### PR TITLE
sql/plan: {update,insert,update,process}.go: Fix some potential issues with context lifecycle and reuse.

### DIFF
--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -1,8 +1,6 @@
 package plan
 
 import (
-	"io"
-
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
@@ -242,19 +240,16 @@ func (i *trackedIndexKeyValueIter) done() {
 }
 
 func (i *trackedIndexKeyValueIter) Close() (err error) {
-	i.done()
 	if i.iter != nil {
 		err = i.iter.Close()
 	}
+	i.done()
 	return err
 }
 
 func (i *trackedIndexKeyValueIter) Next() ([]interface{}, []byte, error) {
 	v, k, err := i.iter.Next()
 	if err != nil {
-		if err == io.EOF {
-			i.done()
-		}
 		return nil, nil, err
 	}
 

--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -177,9 +177,6 @@ func (i *trackedRowIter) done() {
 func (i *trackedRowIter) Next() (sql.Row, error) {
 	row, err := i.iter.Next()
 	if err != nil {
-		if err == io.EOF {
-			i.done()
-		}
 		return nil, err
 	}
 
@@ -191,8 +188,9 @@ func (i *trackedRowIter) Next() (sql.Row, error) {
 }
 
 func (i *trackedRowIter) Close() error {
+	err := i.iter.Close()
 	i.done()
-	return i.iter.Close()
+	return err
 }
 
 type trackedPartitionIndexKeyValueIter struct {

--- a/sql/plan/process_test.go
+++ b/sql/plan/process_test.go
@@ -148,6 +148,7 @@ func TestProcessIndexableTable(t *testing.T) {
 		for {
 			v, _, err := kviter.Next()
 			if err == io.EOF {
+				kviter.Close()
 				break
 			}
 			values = append(values, v)

--- a/sql/table_iter.go
+++ b/sql/table_iter.go
@@ -1,7 +1,6 @@
 package sql
 
 import (
-	"context"
 	"io"
 )
 
@@ -20,10 +19,8 @@ func NewTableRowIter(ctx *Context, table Table, partitions PartitionIter) *Table
 }
 
 func (i *TableRowIter) Next() (Row, error) {
-	select {
-	case <-i.ctx.Done():
-		return nil, context.Canceled
-	default:
+	if i.ctx.Err() != nil {
+		return nil, i.ctx.Err()
 	}
 
 	if i.partition == nil {

--- a/sql/viewregistry_test.go
+++ b/sql/viewregistry_test.go
@@ -1,6 +1,7 @@
 package sql
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -116,7 +117,7 @@ func TestViewsInDatabase(t *testing.T) {
 
 	for _, db := range databases {
 		for i := 0; i < db.numViews; i++ {
-			view := NewView(viewName+string(i), nil, "")
+			view := NewView(viewName+fmt.Sprint(i), nil, "")
 			err := registry.Register(db.name, view)
 			require.NoError(err)
 		}


### PR DESCRIPTION
* insert, update, delete: Only call underlying table editors with our captured
  context once when we are Close(). Return a `nil` error after that.

* process: Change to only call `onDone` when the rowTrackingIter is Closed.

* process: Change to call childIter.Close() before `onDone` is called. Child
  iterators have a right to Close() before the context in which they are
  running is canceled.