### PR TITLE
added alter table auto_increment support

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -72,6 +72,7 @@ var infoSchemaTables = []string{
 	"newlinetable",
 	"other_table",
 	"fk_tbl",
+	"auto_increment_tbl",
 }
 
 // Runs tests of the information_schema database.

--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -415,7 +415,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{10}, {20}, {30}, {31}, {40}, {41},
 				},
@@ -432,7 +432,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{11},
 				},
@@ -451,7 +451,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1, 10}, {2, 20}, {3, 30},
 				},
@@ -472,7 +472,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1,10}, {2,20}, {3,30}, {9,90},
 				},
@@ -493,7 +493,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1,10}, {2,20}, {3,30}, {19,190},
 				},
@@ -508,7 +508,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1},{10},{11},
 				},
@@ -523,7 +523,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1},{10},{11},
 				},
@@ -538,7 +538,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1},{10},{11},
 				},
@@ -553,7 +553,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1},{10},{11},
 				},
@@ -568,7 +568,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{1},{10},{11},
 				},
@@ -583,7 +583,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{uint64(1)},{uint64(10)},{uint64(11)},
 				},
@@ -598,7 +598,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{uint64(1)},{uint64(10)},{uint64(11)},
 				},
@@ -613,7 +613,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{uint64(1)},{uint64(10)},{uint64(11)},
 				},
@@ -628,7 +628,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{uint64(1)},{uint64(10)},{uint64(11)},
 				},
@@ -643,7 +643,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{uint64(1)},{uint64(10)},{uint64(11)},
 				},
@@ -658,7 +658,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{float64(1)},{float64(10)},{float64(11)},
 				},
@@ -673,7 +673,7 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto",
+				Query: "select * from auto order by 1",
 				Expected: []sql.Row{
 					{float64(1)},{float64(10)},{float64(11)},
 				},

--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -459,6 +459,27 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "alter auto_increment value",
+		SetUpScript: []string{
+			`create table auto (
+				pk int auto_increment,
+				c0 int,
+				primary key(pk)
+			);`,
+			"insert into auto values (NULL,10), (NULL,20), (NULL,30)",
+			"alter table auto auto_increment = 9;",
+			"insert into auto values (NULL,90)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from auto",
+				Expected: []sql.Row{
+					{1,10}, {2,20}, {3,30}, {9,90},
+				},
+			},
+		},
+	},
+	{
 		Name: "auto increment on tinyint",
 		SetUpScript: []string{
 			"create table auto (pk tinyint primary key auto_increment)",

--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -467,7 +467,7 @@ var InsertScripts = []ScriptTest{
 				primary key(pk)
 			);`,
 			"insert into auto values (NULL,10), (NULL,20), (NULL,30)",
-			"alter table auto auto_increment = 9;",
+			"alter table auto auto_increment 9;",
 			"insert into auto values (NULL,90)",
 		},
 		Assertions: []ScriptTestAssertion{
@@ -475,6 +475,27 @@ var InsertScripts = []ScriptTest{
 				Query: "select * from auto",
 				Expected: []sql.Row{
 					{1,10}, {2,20}, {3,30}, {9,90},
+				},
+			},
+		},
+	},
+	{
+		Name: "alter auto_increment value to float",
+		SetUpScript: []string{
+			`create table auto (
+				pk int auto_increment,
+				c0 int,
+				primary key(pk)
+			);`,
+			"insert into auto values (NULL,10), (NULL,20), (NULL,30)",
+			"alter table auto auto_increment = 19.9;",
+			"insert into auto values (NULL,190)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from auto",
+				Expected: []sql.Row{
+					{1,10}, {2,20}, {3,30}, {19,190},
 				},
 			},
 		},

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -3298,6 +3298,7 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		`SHOW TABLE STATUS FROM mydb`,
 		[]sql.Row{
+			{"auto_increment_tbl", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
@@ -3328,6 +3329,7 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		`SHOW TABLE STATUS`,
 		[]sql.Row{
+			{"auto_increment_tbl", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 			{"mytable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 			{"othertable", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
 			{"tabletest", "InnoDB", "10", "Fixed", int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), int64(0), nil, nil, nil, "utf8mb4_0900_ai_ci", nil, nil},
@@ -3341,6 +3343,7 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		"SHOW TABLES",
 		[]sql.Row{
+			{"auto_increment_tbl"},
 			{"bigtable"},
 			{"floattable"},
 			{"fk_tbl"},
@@ -3355,6 +3358,7 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		"SHOW FULL TABLES",
 		[]sql.Row{
+			{"auto_increment_tbl", "BASE TABLE"},
 			{"bigtable", "BASE TABLE"},
 			{"fk_tbl", "BASE TABLE"},
 			{"floattable", "BASE TABLE"},
@@ -3470,6 +3474,7 @@ var InfoSchemaQueries = []QueryTest{
 		ORDER BY 1
 		`,
 		[]sql.Row{
+			{"auto_increment_tbl"},
 			{"bigtable"},
 			{"floattable"},
 			{"fk_tbl"},
@@ -3597,6 +3602,22 @@ var InfoSchemaQueries = []QueryTest{
 				"  PRIMARY KEY (`pk`),\n" +
 				"  CONSTRAINT `fk1` FOREIGN KEY (`a`,`b`) REFERENCES `mytable` (`i`,`s`) ON DELETE CASCADE\n" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"},
+		},
+	},
+	{
+
+		"SELECT table_name, `auto_increment` FROM information_schema.tables " +
+			"WHERE TABLE_SCHEMA='mydb' AND TABLE_TYPE='BASE TABLE' ORDER BY 1",
+		[]sql.Row{
+			{"auto_increment_tbl", 4},
+			{"bigtable", nil},
+			{"fk_tbl", nil},
+			{"floattable", nil},
+			{"mytable", nil},
+			{"newlinetable", nil},
+			{"niltable", nil},
+			{"othertable", nil},
+			{"tabletest", nil},
 		},
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/cespare/xxhash v1.1.0
-	github.com/dolthub/vitess v0.0.0-20201030211154-aac4fea7230f
+	github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
 	github.com/go-kit/kit v0.9.0
 	github.com/go-sql-driver/mysql v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/cespare/xxhash v1.1.0
-	github.com/dolthub/vitess v0.0.0-20201105222715-09545a377901
+	github.com/dolthub/vitess v0.0.0-20201105231317-8886950f2053
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
 	github.com/go-kit/kit v0.9.0
 	github.com/go-sql-driver/mysql v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/cespare/xxhash v1.1.0
-	github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e
+	github.com/dolthub/vitess v0.0.0-20201105222715-09545a377901
 	github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 // indirect
 	github.com/go-kit/kit v0.9.0
 	github.com/go-sql-driver/mysql v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e h1:rhF84t4aRMtVuj/J
 github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/dolthub/vitess v0.0.0-20201105222715-09545a377901 h1:lszgRBIWYyAVdBtSGFbhC70OrVH8XffNhecCUuiGIE0=
 github.com/dolthub/vitess v0.0.0-20201105222715-09545a377901/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
+github.com/dolthub/vitess v0.0.0-20201105231317-8886950f2053 h1:d1IcMtRAas14KQWTLG3vh6hWhYTwZYvdtp1bUwVfdIU=
+github.com/dolthub/vitess v0.0.0-20201105231317-8886950f2053/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 h1:Ghm4eQYC0nEPnSJdVkTrXpu9KtoVCSo1hg7mtI7G9KU=

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dolthub/vitess v0.0.0-20201030211154-aac4fea7230f h1:My5J2+UejT0tivbgBYBePhr+7Xc5FoOW5ENU5ZwmKf8=
 github.com/dolthub/vitess v0.0.0-20201030211154-aac4fea7230f/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
+github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e h1:rhF84t4aRMtVuj/J/duNrX1iJg53MrZSxeaV7PJDqsU=
+github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 h1:Ghm4eQYC0nEPnSJdVkTrXpu9KtoVCSo1hg7mtI7G9KU=

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/dolthub/vitess v0.0.0-20201030211154-aac4fea7230f h1:My5J2+UejT0tivbg
 github.com/dolthub/vitess v0.0.0-20201030211154-aac4fea7230f/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e h1:rhF84t4aRMtVuj/J/duNrX1iJg53MrZSxeaV7PJDqsU=
 github.com/dolthub/vitess v0.0.0-20201105214225-3cc7392ffe3e/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
+github.com/dolthub/vitess v0.0.0-20201105222715-09545a377901 h1:lszgRBIWYyAVdBtSGFbhC70OrVH8XffNhecCUuiGIE0=
+github.com/dolthub/vitess v0.0.0-20201105222715-09545a377901/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fastly/go-utils v0.0.0-20180712184237-d95a45783239 h1:Ghm4eQYC0nEPnSJdVkTrXpu9KtoVCSo1hg7mtI7G9KU=

--- a/memory/table.go
+++ b/memory/table.go
@@ -430,6 +430,10 @@ func (t *tableEditor) Insert(ctx *sql.Context, row sql.Row) error {
 
 func increment(v interface{}) interface{} {
 	switch val := v.(type) {
+	case int:
+		return val + 1
+	case uint:
+		return val + 1
 	case int8:
 		return val + 1
 	case int16:

--- a/sql/core.go
+++ b/sql/core.go
@@ -339,11 +339,20 @@ type RowDeleter interface {
 	Closer
 }
 
-// AutoIncrementTable is a table that supports an AUTO_INCREMENT column
+// AutoIncrementTable is a table that supports an AUTO_INCREMENT column.
 type AutoIncrementTable interface {
 	Table
-	// GetAutoIncrementValue gets the last AUTO_INCREMENT value
+	// GetAutoIncrementValue gets the last AUTO_INCREMENT value.
 	GetAutoIncrementValue(*Context) (interface{}, error)
+	// AutoIncrementSetter returns an AutoIncrementSetter.
+	AutoIncrementSetter(*Context) AutoIncrementSetter
+}
+
+type AutoIncrementSetter interface {
+	// SetAutoIncrementValue sets a new AUTO_INCREMENT value.
+	SetAutoIncrementValue(*Context, interface{}) error
+	// Close finalizes the set operation, persisting the result.
+	Closer
 }
 
 type Closer interface {

--- a/sql/core.go
+++ b/sql/core.go
@@ -339,15 +339,22 @@ type RowDeleter interface {
 	Closer
 }
 
-// AutoIncrementTable is a table that supports an AUTO_INCREMENT column.
+// AutoIncrementTable is a table that supports AUTO_INCREMENT.
+// Getter and Setter methods access the table's AUTO_INCREMENT
+// sequence. These methods should only be used for tables with
+// and AUTO_INCREMENT column in their schema.
 type AutoIncrementTable interface {
 	Table
-	// GetAutoIncrementValue gets the last AUTO_INCREMENT value.
+	// GetAutoIncrementValue gets the next AUTO_INCREMENT value.
+	// Implementations are responsible for updating their
+	// state to provide the correct values.
 	GetAutoIncrementValue(*Context) (interface{}, error)
 	// AutoIncrementSetter returns an AutoIncrementSetter.
 	AutoIncrementSetter(*Context) AutoIncrementSetter
 }
 
+// AutoIncrementSetter provides support for altering a table's
+// AUTO_INCREMENT sequence, eg 'ALTER TABLE t AUTO_INCREMENT = 10;'
 type AutoIncrementSetter interface {
 	// SetAutoIncrementValue sets a new AUTO_INCREMENT value.
 	SetAutoIncrementValue(*Context, interface{}) error

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -36,6 +36,11 @@ func NewPlus(left, right sql.Expression) *Arithmetic {
 	return NewArithmetic(left, right, sqlparser.PlusStr)
 }
 
+func NewIncrement(left sql.Expression) *Arithmetic {
+	one := NewLiteral(sql.NumericUnaryValue(left.Type()), left.Type())
+	return NewArithmetic(left, one, sqlparser.PlusStr)
+}
+
 // NewMinus creates a new Arithmetic - sql.Expression.
 func NewMinus(left, right sql.Expression) *Arithmetic {
 	return NewArithmetic(left, right, sqlparser.MinusStr)

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -374,6 +374,8 @@ func tablesRowIter(ctx *Context, cat *Catalog) (RowIter, error) {
 
 		y2k, _ := Timestamp.Convert("2000-01-01 00:00:00")
 		err := DBTableIter(ctx, db, func(t Table) (cont bool, err error) {
+
+			autoVal := getAutoIncremnetValue(ctx, t)
 			rows = append(rows, Row{
 				"def",                      // table_catalog
 				db.Name(),                  // table_schema
@@ -388,7 +390,7 @@ func tablesRowIter(ctx *Context, cat *Catalog) (RowIter, error) {
 				nil,                        // max_data_length
 				nil,                        // max_data_length
 				nil,                        // data_free
-				nil,                        // auto_increment
+				autoVal,                    // auto_increment
 				y2k,                        // create_time
 				y2k,                        // update_time
 				nil,                        // check_time
@@ -824,4 +826,15 @@ func printTable(name string, tableSchema Schema) string {
 
 func partitionKey(tableName string) []byte {
 	return []byte(InformationSchemaDatabaseName + "." + tableName)
+}
+
+func getAutoIncremnetValue(ctx *Context, t Table) (val interface{}) {
+	for _, c := range t.Schema() {
+		if c.AutoIncrement {
+			val, _ = t.(AutoIncrementTable).GetAutoIncrementValue(ctx)
+			// ignore errors
+			break
+		}
+	}
+	return
 }

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -375,7 +375,7 @@ func tablesRowIter(ctx *Context, cat *Catalog) (RowIter, error) {
 		y2k, _ := Timestamp.Convert("2000-01-01 00:00:00")
 		err := DBTableIter(ctx, db, func(t Table) (cont bool, err error) {
 
-			autoVal := getAutoIncremnetValue(ctx, t)
+			autoVal := getAutoIncrementValue(ctx, t)
 			rows = append(rows, Row{
 				"def",                      // table_catalog
 				db.Name(),                  // table_schema
@@ -828,7 +828,7 @@ func partitionKey(tableName string) []byte {
 	return []byte(InformationSchemaDatabaseName + "." + tableName)
 }
 
-func getAutoIncremnetValue(ctx *Context, t Table) (val interface{}) {
+func getAutoIncrementValue(ctx *Context, t Table) (val interface{}) {
 	for _, c := range t.Schema() {
 		if c.AutoIncrement {
 			val, _ = t.(AutoIncrementTable).GetAutoIncrementValue(ctx)

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -710,10 +710,7 @@ func convertAlterAutoIncrement(ddl *sqlparser.DDL) (sql.Node, error) {
 		return nil, ErrInvalidSQLValType.New(ddl.AutoIncSpec.Value)
 	}
 
-	return plan.NewAlterAutoIncrement(
-		plan.NewUnresolvedTable(ddl.Table.Name.String(), ddl.Table.Qualifier.String()),
-		autoVal,
-	), nil
+	return plan.NewAlterAutoIncrement(tableNameToUnresolvedTable(ddl.Table), autoVal), nil
 }
 
 func convertExternalCreateIndex(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {

--- a/sql/plan/alter_auto_increment.go
+++ b/sql/plan/alter_auto_increment.go
@@ -1,0 +1,60 @@
+package plan
+
+import (
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+type AlterAutoIncrement struct {
+	UnaryNode
+	autoVal int64
+}
+
+func NewAlterAutoIncrement(table sql.Node, autoVal int64) *AlterAutoIncrement {
+	return &AlterAutoIncrement{
+		UnaryNode: UnaryNode{Child: table},
+		autoVal:     autoVal,
+	}
+}
+
+// Execute inserts the rows in the database.
+func (p *AlterAutoIncrement) Execute(ctx *sql.Context) error {
+	insertable, err := GetInsertable(p.UnaryNode.Child)
+	if err != nil {
+		return err
+	}
+
+	autoTbl, ok := insertable.(sql.AutoIncrementTable)
+	if !ok {
+		return ErrAutoIncrementNotSupported.New(insertable.Name())
+	}
+
+	return autoTbl.AutoIncrementSetter(ctx).SetAutoIncrementValue(ctx, p.autoVal)
+}
+
+// RowIter implements the Node interface.
+func (p *AlterAutoIncrement) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter, error) {
+	err := p.Execute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return sql.RowsToRowIter(), nil
+}
+
+// WithChildren implements the Node interface.
+func (p *AlterAutoIncrement) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(p, len(children), 1)
+	}
+	return NewAlterAutoIncrement(children[0], p.autoVal), nil
+}
+
+func (p *AlterAutoIncrement) Schema() sql.Schema   { return nil }
+
+func (p AlterAutoIncrement) String() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("AlterAutoIncrement(%d)", p.autoVal)
+	_ = pr.WriteChildren(fmt.Sprintf("Table(%s)", p.UnaryNode.Child.String()))
+	return pr.String()
+}


### PR DESCRIPTION
This PR changes the semantics of `AutoIncrementTable.GetAutoIncrementValue()` to return the current value of the sequence, ie the next `AUTO_INCREMENT` id. 
Previously the semantics were to return the last used id. The return value of the function should now match what would be seen in MySQL's `information_schema.table` table