### PR TITLE
Fix: not check tcp6 socket state while ipv6 is disabled

### DIFF
--- a/internal/sockstate/netstat_linux.go
+++ b/internal/sockstate/netstat_linux.go
@@ -243,6 +243,9 @@ func tcpSocks(accept AcceptFn) ([]sockTabEntry, error) {
 		defer func() {
 			_ = f.Close()
 		}()
+		if os.IsNotExist(err) {
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
If ipv6 is disabled on the system, tcp6 will not exist in the `/proc/net` dir.

So open /proc/net/tcp6 will produce the error open /proc/net/tcp6: No such file or directory, we should not always check tcp6 socket state(unless it is opened).