### PR TITLE
Added the VALUES() function

### DIFF
--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -415,6 +415,12 @@ var InsertQueries = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{int64(1), "duplicate"}},
 	},
 	{
+		WriteQuery:          "INSERT INTO mytable (i,s) values (1,'mar'), (2,'par') ON DUPLICATE KEY UPDATE s=CONCAT(VALUES(s), 'tial')",
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(4)}},
+		SelectQuery:         "SELECT * FROM mytable WHERE i IN (1,2) ORDER BY i",
+		ExpectedSelect:      []sql.Row{{int64(1), "martial"},{int64(2), "partial"}},
+	},
+	{
 		WriteQuery:          "INSERT INTO mytable (i,s) values (1,'maybe') ON DUPLICATE KEY UPDATE i=VALUES(i)+8000, s=VALUES(s)",
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(2)}},
 		SelectQuery:         "SELECT * FROM mytable WHERE i = 8001",

--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -403,6 +403,24 @@ var InsertQueries = []WriteQueryTest{
 		},
 	},
 	{
+		WriteQuery:          "INSERT INTO mytable (i,s) values (1,'hi') ON DUPLICATE KEY UPDATE s=VALUES(s)",
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(2)}},
+		SelectQuery:         "SELECT * FROM mytable WHERE i = 1",
+		ExpectedSelect:      []sql.Row{{int64(1), "hi"}},
+	},
+	{
+		WriteQuery:          "INSERT INTO mytable (s,i) values ('dup',1) ON DUPLICATE KEY UPDATE s=CONCAT(VALUES(s), 'licate')",
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(2)}},
+		SelectQuery:         "SELECT * FROM mytable WHERE i = 1",
+		ExpectedSelect:      []sql.Row{{int64(1), "duplicate"}},
+	},
+	{
+		WriteQuery:          "INSERT INTO mytable (i,s) values (1,'maybe') ON DUPLICATE KEY UPDATE i=VALUES(i)+8000, s=VALUES(s)",
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(2)}},
+		SelectQuery:         "SELECT * FROM mytable WHERE i = 8001",
+		ExpectedSelect:      []sql.Row{{int64(8001), "maybe"}},
+	},
+	{
 		WriteQuery:          "INSERT INTO auto_increment_tbl (c0) values (44)",
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(1)}},
 		SelectQuery:         "SELECT * FROM auto_increment_tbl ORDER BY pk",

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -3438,6 +3438,14 @@ var QueryTests = []QueryTest{
 			sql.NewRow(2),
 		},
 	},
+	{
+		Query: "SELECT VALUES(i) FROM mytable",
+		Expected: []sql.Row{
+			sql.NewRow(nil),
+			sql.NewRow(nil),
+			sql.NewRow(nil),
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -121,6 +121,7 @@ var Defaults = []sql.Function{
 	sql.Function1{Name: "upper", Fn: NewUpper},
 	sql.NewFunction0("user", NewUser),
 	sql.FunctionN{Name: "week", Fn: NewWeek},
+	sql.Function1{Name: "values", Fn: NewValues},
 	sql.Function1{Name: "weekday", Fn: NewWeekday},
 	sql.Function1{Name: "weekofyear", Fn: NewWeekOfYear},
 	sql.Function1{Name: "year", Fn: NewYear},

--- a/sql/expression/function/values.go
+++ b/sql/expression/function/values.go
@@ -1,0 +1,57 @@
+package function
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+// Values is used in an ON DUPLICATE KEY UPDATE statement to return the value stated in the to-be-inserted column.
+// For example, given the following statement:
+// INSERT INTO table (pk, v1, v2) VALUES (1, 3, 5), (2, 4, 6) ON DUPLICATE KEY UPDATE v2 = values(v1) * 10;
+// the values inserted into v2 would be 30 and 40.
+type Values struct {
+	expression.UnaryExpression
+	Value interface{}
+}
+
+var _ sql.FunctionExpression = (*Values)(nil)
+
+// NewValues creates a new Values function.
+func NewValues(col sql.Expression) sql.Expression {
+	return &Values{
+		UnaryExpression: expression.UnaryExpression{Child: col},
+		Value:           nil,
+	}
+}
+
+// Eval implements sql.FunctionExpression.
+func (v *Values) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	// If Value is never assigned to then it has the nil value. It will only be assigned to in the ON DUPLICATE KEY UPDATE
+	// statement, therefore when used in every other context it will return nil, which is the correct and intended behavior.
+	return v.Value, nil
+}
+
+// FunctionName implements sql.FunctionExpression.
+func (v *Values) FunctionName() string {
+	return "values"
+}
+
+// String implements sql.FunctionExpression.
+func (v *Values) String() string {
+	return fmt.Sprintf("VALUES(%s)", v.Child.String())
+}
+
+// Type implements sql.FunctionExpression.
+func (v *Values) Type() sql.Type {
+	return v.Child.Type()
+}
+
+// WithChildren implements sql.FunctionExpression.
+func (v *Values) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(v, len(children), 1)
+	}
+	return NewValues(children[0]), nil
+}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1731,6 +1731,12 @@ func exprToExpression(ctx *sql.Context, e sqlparser.Expr) (sql.Expression, error
 	case *sqlparser.CollateExpr:
 		// TODO: handle collation
 		return exprToExpression(ctx, v.Expr)
+	case *sqlparser.ValuesFuncExpr:
+		col, err := exprToExpression(ctx, v.Name)
+		if err != nil {
+			return nil, err
+		}
+		return expression.NewUnresolvedFunction("values", false, col), nil
 	}
 }
 


### PR DESCRIPTION
Requested in: https://github.com/dolthub/dolt/issues/1225
`VALUES()` is deprecated in the latest versions of MySQL (as of version 8.0.20, released April 2020), but it is recent enough that I feel its inclusion in the engine is justified.