### PR TITLE
Fixed a bug in join planning for Inserts.

### DIFF
--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -357,6 +357,32 @@ var InsertQueries = []WriteQueryTest{
 		},
 	},
 	{
+		WriteQuery: `INSERT INTO mytable (i,s) SELECT sub.i + 10, ot.s2 
+				FROM othertable ot INNER JOIN 
+					(SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub 
+				ON sub.i = ot.i2 order by 1`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         "SELECT * FROM mytable where i > 10 ORDER BY i, s",
+		ExpectedSelect: []sql.Row{
+			{11,"third"},
+			{12,"second"},
+			{13,"first"},
+		},
+
+	},
+	{
+		WriteQuery: `INSERT INTO mytable (i,s) SELECT sub.i + 10, ot.s2 
+				FROM (SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub
+				INNER JOIN othertable ot ON sub.i = ot.i2 order by 1`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         "SELECT * FROM mytable where i > 10 ORDER BY i, s",
+		ExpectedSelect: []sql.Row{
+			{11,"third"},
+			{12,"second"},
+			{13,"first"},
+		},
+	},
+	{
 		WriteQuery:          "INSERT INTO mytable (i,s) values (1, 'hello') ON DUPLICATE KEY UPDATE s='hello'",
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(2)}},
 		SelectQuery:         "SELECT * FROM mytable WHERE i = 1",

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -88,17 +88,14 @@ func TestSingleQuery(t *testing.T) {
 
 	var test enginetest.QueryTest
 	test = enginetest.QueryTest{
-		Query: `SELECT * FROM tabletest, mytable mt INNER JOIN othertable ot ON mt.i = ot.i2`,
+		Query: `SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2 
+				FROM othertable ot INNER JOIN 
+					(SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub 
+				ON sub.i = ot.i2 order by 1`,
 		Expected: []sql.Row{
-			{int64(1), "first row", int64(1), "first row", "third", int64(1)},
-			{int64(1), "first row", int64(2), "second row", "second", int64(2)},
-			{int64(1), "first row", int64(3), "third row", "first", int64(3)},
-			{int64(2), "second row", int64(1), "first row", "third", int64(1)},
-			{int64(2), "second row", int64(2), "second row", "second", int64(2)},
-			{int64(2), "second row", int64(3), "third row", "first", int64(3)},
-			{int64(3), "third row", int64(1), "first row", "third", int64(1)},
-			{int64(3), "third row", int64(2), "second row", "second", int64(2)},
-			{int64(3), "third row", int64(3), "third row", "first", int64(3)},
+			{1,1,"third",1,"third"},
+			{2,2,"second",2,"second"},
+			{3,3,"first",3,"first"},
 		},
 	}
 	fmt.Sprintf("%v", test)

--- a/enginetest/memoryharness.go
+++ b/enginetest/memoryharness.go
@@ -45,7 +45,7 @@ func NewMemoryHarness(name string, parallelism int, numTablePartitions int, useN
 }
 
 func NewDefaultMemoryHarness() *MemoryHarness {
-	return NewMemoryHarness("default", 1, testNumPartitions, false, nil)
+	return NewMemoryHarness("default", 1, testNumPartitions, true, nil)
 }
 
 func NewSkippingMemoryHarness() *SkippingMemoryHarness {

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -2311,6 +2311,28 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: `SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2 
+				FROM othertable ot INNER JOIN 
+					(SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub 
+				ON sub.i = ot.i2 order by 1`,
+		Expected: []sql.Row{
+			{1,1,"third",1,"third"},
+			{2,2,"second",2,"second"},
+			{3,3,"first",3,"first"},
+		},
+	},
+	{
+		Query: `SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2 
+				FROM (SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub
+				INNER JOIN othertable ot 
+				ON sub.i = ot.i2 order by 1`,
+		Expected: []sql.Row{
+			{1,1,"third",1,"third"},
+			{2,2,"second",2,"second"},
+			{3,3,"first",3,"first"},
+		},
+	},
+	{
 		Query:    `SELECT CHAR_LENGTH('áé'), LENGTH('àè')`,
 		Expected: []sql.Row{{int32(2), int32(4)}},
 	},

--- a/enginetest/query_plans.go
+++ b/enginetest/query_plans.go
@@ -118,6 +118,19 @@ var PlanTests = []QueryPlanTest{
 			"",
 	},
 	{
+		Query: "SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2 FROM othertable ot INNER JOIN (SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub ON sub.i = ot.i2",
+		ExpectedPlan: "Project(sub.i, sub.i2, sub.s2, ot.i2, ot.s2)\n" +
+			" └─ IndexedJoin(sub.i = ot.i2)\n" +
+			"     ├─ SubqueryAlias(sub)\n" +
+			"     │   └─ Project(mytable.i, othertable.i2, othertable.s2)\n" +
+			"     │       └─ IndexedJoin(mytable.i = othertable.i2)\n" +
+			"     │           ├─ Table(mytable)\n" +
+			"     │           └─ IndexedTableAccess(othertable on [othertable.i2])\n" +
+			"     └─ TableAlias(ot)\n" +
+			"         └─ IndexedTableAccess(othertable on [othertable.i2])\n" +
+			"",
+	},
+	{
 		Query: "SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2",
 		ExpectedPlan: "Project(othertable.s2, othertable.i2, mytable.i)\n" +
 			" └─ IndexedJoin(mytable.i = othertable.i2)\n" +

--- a/sql/analyzer/fix_field_indexes.go
+++ b/sql/analyzer/fix_field_indexes.go
@@ -133,21 +133,30 @@ func FixFieldIndexesForExpressions(node sql.Node, scope *Scope) (sql.Node, error
 			return nil, err
 		}
 
-		n = plan.NewInnerJoin(j.Left(), j.Right(), cond)
+		n, err = j.WithExpressions(cond)
+		if err != nil {
+			return nil, err
+		}
 	case *plan.RightJoin:
 		cond, err := FixFieldIndexes(scope, j.Schema(), j.Cond)
 		if err != nil {
 			return nil, err
 		}
 
-		n = plan.NewRightJoin(j.Left(), j.Right(), cond)
+		n, err = j.WithExpressions(cond)
+		if err != nil {
+			return nil, err
+		}
 	case *plan.LeftJoin:
 		cond, err := FixFieldIndexes(scope, j.Schema(), j.Cond)
 		if err != nil {
 			return nil, err
 		}
 
-		n = plan.NewLeftJoin(j.Left(), j.Right(), cond)
+		n, err = j.WithExpressions(cond)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return n, nil

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -109,18 +109,18 @@ func moveJoinConditionsToFilter(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 			return n, nil
 		}
 
-		left, right := join.Left(), join.Right()
-
 		if len(condFilters) > 0 {
-			topJoin = plan.NewInnerJoin(
-				left, right,
-				expression.JoinAnd(condFilters...),
-			)
+			var err error
+			topJoin, err = join.WithExpressions(expression.JoinAnd(condFilters...))
+			if err != nil {
+				return nil, err
+			}
+
 			return topJoin, nil
 		}
 
 		// if there are no cond filters left we can just convert it to a cross join
-		topJoin = plan.NewCrossJoin(left, right)
+		topJoin = plan.NewCrossJoin(join.Left(), join.Right())
 		return topJoin, nil
 	})
 

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -130,6 +130,7 @@ func canDoPushdown(n sql.Node) bool {
 	}
 
 	// don't do pushdown on certain queries
+	// TODO: we should definitely do pushdown to the SELECT of an INSERT if there is one
 	switch n.(type) {
 	case *plan.InsertInto, *plan.CreateIndex, *plan.CreateTrigger:
 		return false

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -145,7 +145,7 @@ func (j *InnerJoin) String() string {
 
 func (j *InnerJoin) DebugString() string {
 	pr := sql.NewTreePrinter()
-	_ = pr.WriteNode("InnerJoin(%s)", sql.DebugString(j.Cond))
+	_ = pr.WriteNode("InnerJoin(%s), comment=%s", sql.DebugString(j.Cond), j.Comment())
 	_ = pr.WriteChildren(sql.DebugString(j.left), sql.DebugString(j.right))
 	return pr.String()
 }


### PR DESCRIPTION
Table reordering was leaving nodes above the join with incorrect field indexes. This was getting fixed by other analyzer steps for some top-level nodes, but not Inserts.