### PR TITLE
Naive/hacky show grants

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -89,7 +89,7 @@ func TestSingleQuery(t *testing.T) {
 
 	var test enginetest.QueryTest
 	test = enginetest.QueryTest{
-		Query:    "SELECT i from mytable where 4 = :foo * 2 order by 1",
+		Query: "SELECT i from mytable where 4 = :foo * 2 order by 1",
 		Expected: []sql.Row{
 			{1},
 			{2},

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1691,6 +1691,10 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{"mydb"}, {"foo"}, {"information_schema"}},
 	},
 	{
+		Query:    `SHOW GRANTS`,
+		Expected: []sql.Row{{"GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION"}},
+	},
+	{
 		Query: `SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA`,
 		Expected: []sql.Row{
 			{"information_schema", "utf8mb4", "utf8mb4_0900_ai_ci"},

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -287,7 +287,7 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:    "SELECT :foo * 2",
+		Query: "SELECT :foo * 2",
 		Expected: []sql.Row{
 			{2},
 		},
@@ -296,7 +296,7 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:    "SELECT i from mytable where i in (:foo, :bar) order by 1",
+		Query: "SELECT i from mytable where i in (:foo, :bar) order by 1",
 		Expected: []sql.Row{
 			{1},
 			{2},
@@ -307,7 +307,7 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:    "SELECT i from mytable where i = :foo * 2",
+		Query: "SELECT i from mytable where i = :foo * 2",
 		Expected: []sql.Row{
 			{2},
 		},
@@ -316,7 +316,7 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:    "SELECT i from mytable where 4 = :foo * 2 order by 1",
+		Query: "SELECT i from mytable where 4 = :foo * 2 order by 1",
 		Expected: []sql.Row{
 			{1},
 			{2},

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -17,6 +17,7 @@ package parse
 import (
 	"bufio"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/memory"
 	"io"
 	"io/ioutil"
 	"regexp"
@@ -304,6 +305,11 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 			sql.UnresolvedDatabase(s.Table.Qualifier.String()),
 			s.Table.Name.String(),
 		), nil
+	case "grants":
+		table := plan.NewResolvedTable(memory.NewTable(
+			"foo", sql.Schema{{Name: "a", Source: "foo", Type: sql.Text, PrimaryKey: true}},
+			))
+		return plan.NewShowGrants(table), nil
 	case "triggers":
 		var dbName string
 		var filter sql.Expression

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -17,7 +17,6 @@ package parse
 import (
 	"bufio"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/memory"
 	"io"
 	"io/ioutil"
 	"regexp"
@@ -306,10 +305,7 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 			s.Table.Name.String(),
 		), nil
 	case "grants":
-		table := plan.NewResolvedTable(memory.NewTable(
-			"foo", sql.Schema{{Name: "a", Source: "foo", Type: sql.Text, PrimaryKey: true}},
-			))
-		return plan.NewShowGrants(table), nil
+		return plan.NewShowGrants(), nil
 	case "triggers":
 		var dbName string
 		var filter sql.Expression

--- a/sql/plan/showgrants.go
+++ b/sql/plan/showgrants.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Dolthub, Inc.
+// Copyright 2021 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sql/plan/showgrants.go
+++ b/sql/plan/showgrants.go
@@ -35,7 +35,7 @@ func NewShowGrants() *ShowGrants {
 // Schema implements the sql.Node interface.
 func (s *ShowGrants) Schema() sql.Schema {
 	return sql.Schema{{
-		Name: "Grants for root@",
+		Name: "Grants for root@%",
 		Type: sql.LongText,
 	}}
 }

--- a/sql/plan/showgrants.go
+++ b/sql/plan/showgrants.go
@@ -1,0 +1,73 @@
+// Copyright 2020-2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// ShowGrants shows the columns details of a table.
+type ShowGrants struct {
+	UnaryNode
+}
+
+var (
+	showGrantsSchema = sql.Schema{
+		{Name: "Grants for root@", Type: sql.LongText},
+	}
+
+)
+
+// NewShowGrants creates a new ShowGrants node.
+func NewShowGrants(child sql.Node) *ShowGrants {
+	return &ShowGrants{UnaryNode: UnaryNode{Child: child}}
+}
+
+var _ sql.Node = (*ShowGrants)(nil)
+
+// Schema implements the sql.Node interface.
+func (s *ShowGrants) Schema() sql.Schema {
+    return sql.Schema{{
+        Name: "Grants for root@",
+        Type: sql.LongText,
+    }}
+}
+
+// RowIter creates a new ShowGrants node.
+func (s *ShowGrants) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	span, _ := ctx.Span("plan.ShowGrants")
+
+	rows := []sql.Row{
+		sql.Row{"GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION"},
+	}
+
+	return sql.NewSpanIter(span, sql.RowsToRowIter(rows...)), nil
+}
+
+// WithChildren implements the Node interface.
+func (s *ShowGrants) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
+	}
+
+    return NewShowGrants(children[0]), nil
+}
+
+func (s *ShowGrants) String() string {
+	p := sql.NewTreePrinter()
+    _ = p.WriteNode("ShowGrants")
+	_ = p.WriteChildren(s.Child.String())
+	return p.String()
+}

--- a/sql/plan/showgrants.go
+++ b/sql/plan/showgrants.go
@@ -19,30 +19,25 @@ import (
 )
 
 // ShowGrants shows the columns details of a table.
-type ShowGrants struct {
-	UnaryNode
-}
+type ShowGrants struct{}
 
 var (
 	showGrantsSchema = sql.Schema{
 		{Name: "Grants for root@", Type: sql.LongText},
 	}
-
 )
 
 // NewShowGrants creates a new ShowGrants node.
-func NewShowGrants(child sql.Node) *ShowGrants {
-	return &ShowGrants{UnaryNode: UnaryNode{Child: child}}
+func NewShowGrants() *ShowGrants {
+	return &ShowGrants{}
 }
-
-var _ sql.Node = (*ShowGrants)(nil)
 
 // Schema implements the sql.Node interface.
 func (s *ShowGrants) Schema() sql.Schema {
-    return sql.Schema{{
-        Name: "Grants for root@",
-        Type: sql.LongText,
-    }}
+	return sql.Schema{{
+		Name: "Grants for root@",
+		Type: sql.LongText,
+	}}
 }
 
 // RowIter creates a new ShowGrants node.
@@ -58,16 +53,19 @@ func (s *ShowGrants) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error)
 
 // WithChildren implements the Node interface.
 func (s *ShowGrants) WithChildren(children ...sql.Node) (sql.Node, error) {
-	if len(children) != 1 {
-		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 1)
-	}
-
-    return NewShowGrants(children[0]), nil
+	return NewShowGrants(), nil
 }
 
 func (s *ShowGrants) String() string {
 	p := sql.NewTreePrinter()
-    _ = p.WriteNode("ShowGrants")
-	_ = p.WriteChildren(s.Child.String())
+	_ = p.WriteNode("ShowGrants")
 	return p.String()
+}
+
+func (s *ShowGrants) Children() []sql.Node {
+	return nil
+}
+
+func (s *ShowGrants) Resolved() bool {
+	return true
 }

--- a/sql/plan/showgrants_test.go
+++ b/sql/plan/showgrants_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020-2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan_test
+
+import (
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/sql/parse"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	. "github.com/dolthub/go-mysql-server/sql/plan"
+)
+
+func TestShowGrants(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	table := NewResolvedTable(memory.NewTable("foo", sql.Schema{
+		{Name: "a", Source: "foo", Type: sql.Text, PrimaryKey: true},
+		{Name: "b", Source: "foo", Type: sql.Int64, Nullable: true},
+		{Name: "c", Source: "foo", Type: sql.Int64, Default: parse.MustStringToColumnDefaultValue(ctx, "1", sql.Int64, false)},
+	}))
+
+	iter, err := NewShowGrants(table).RowIter(ctx, nil)
+	require.NoError(err)
+
+	rows, err := sql.RowIterToRows(iter)
+	require.NoError(err)
+
+	expected := []sql.Row{
+		{"GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION"},
+	}
+
+	require.Equal(expected, rows)
+}

--- a/sql/plan/showgrants_test.go
+++ b/sql/plan/showgrants_test.go
@@ -15,8 +15,6 @@
 package plan_test
 
 import (
-	"github.com/dolthub/go-mysql-server/memory"
-	"github.com/dolthub/go-mysql-server/sql/parse"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,13 +27,7 @@ func TestShowGrants(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
-	table := NewResolvedTable(memory.NewTable("foo", sql.Schema{
-		{Name: "a", Source: "foo", Type: sql.Text, PrimaryKey: true},
-		{Name: "b", Source: "foo", Type: sql.Int64, Nullable: true},
-		{Name: "c", Source: "foo", Type: sql.Int64, Default: parse.MustStringToColumnDefaultValue(ctx, "1", sql.Int64, false)},
-	}))
-
-	iter, err := NewShowGrants(table).RowIter(ctx, nil)
+	iter, err := NewShowGrants().RowIter(ctx, nil)
 	require.NoError(err)
 
 	rows, err := sql.RowIterToRows(iter)


### PR DESCRIPTION
hard-coded `SHOW GRANTS` handling:
```
> dolt sql -q "show grants for current_user"
+-------------------------------------------------------------+
| Grants for root@%                                            |
+-------------------------------------------------------------+
| GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION |
+-------------------------------------------------------------+

```