### PR TITLE
CURRENT_USER() -> current_user

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1740,19 +1740,19 @@ var QueryTests = []QueryTest{
 	{
 		Query: `SELECT USER()`,
 		Expected: []sql.Row{
-			{"user"},
+			{"user@%"},
 		},
 	},
 	{
 		Query: `SELECT CURRENT_USER()`,
 		Expected: []sql.Row{
-			{"user"},
+			{"user@%"},
 		},
 	},
 	{
 		Query: `SELECT CURRENT_USER`,
 		Expected: []sql.Row{
-			{"user"},
+			{"user@%"},
 		},
 	},
 	{

--- a/sql/expression/function/system.go
+++ b/sql/expression/function/system.go
@@ -41,35 +41,3 @@ func (c ConnectionID) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 func (c ConnectionID) WithChildren(expressions ...sql.Expression) (sql.Expression, error) {
 	return NoArgFuncWithChildren(c, expressions)
 }
-
-type User struct {
-	NoArgFunc
-}
-
-func userFuncLogic(ctx *sql.Context, _ sql.Row) (interface{}, error) {
-	return ctx.Client().User, nil
-}
-
-var _ sql.FunctionExpression = User{}
-
-func NewUser() sql.Expression {
-	return User{
-		NoArgFunc: NoArgFunc{"user", sql.LongText},
-	}
-}
-
-func NewCurrentUser() sql.Expression {
-	return User{
-		NoArgFunc: NoArgFunc{"current_user", sql.LongText},
-	}
-}
-
-// Eval implements sql.Expression
-func (c User) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	return userFuncLogic(ctx, row)
-}
-
-// WithChildren implements sql.Expression
-func (c User) WithChildren(expressions ...sql.Expression) (sql.Expression, error) {
-	return NoArgFuncWithChildren(c, expressions)
-}

--- a/sql/expression/function/user.go
+++ b/sql/expression/function/user.go
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"fmt"
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
@@ -26,7 +27,11 @@ type User struct {
 var _ sql.FunctionExpression = (*User)(nil)
 
 func userFuncLogic(ctx *sql.Context, _ sql.Row) (interface{}, error) {
-	return ctx.Client().User, nil
+	user := ctx.Client().User
+	if user == "" {
+		return user, nil
+	}
+	return fmt.Sprintf("%s%s", user, "@%"), nil
 }
 
 func NewUser() sql.Expression {

--- a/sql/expression/function/user.go
+++ b/sql/expression/function/user.go
@@ -1,0 +1,80 @@
+// Copyright 2020-2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, User 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// User is a function that returns server user.
+type User struct {
+	NoArgFunc
+}
+
+var _ sql.FunctionExpression = (*User)(nil)
+
+func userFuncLogic(ctx *sql.Context, _ sql.Row) (interface{}, error) {
+	return ctx.Client().User, nil
+}
+
+func NewUser() sql.Expression {
+	return User{
+		NoArgFunc: NoArgFunc{"user", sql.LongText},
+	}
+}
+
+func NewCurrentUser() sql.Expression {
+	return User{
+		NoArgFunc: NoArgFunc{"current_user", sql.LongText},
+	}
+}
+
+// FunctionName implements sql.FunctionExpression
+func (f User) FunctionName() string {
+	return "user"
+}
+
+// Type implements the Expression interface.
+func (f User) Type() sql.Type { return sql.LongText }
+
+// IsNullable implements the Expression interface.
+func (f User) IsNullable() bool {
+	return false
+}
+
+func (f User) String() string {
+	return "current_user"
+}
+
+// WithChildren implements the Expression interface.
+func (f User) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(f, len(children), 0)
+	}
+	return f, nil
+}
+
+// Resolved implements the Expression interface.
+func (f User) Resolved() bool {
+	return true
+}
+
+// Children implements the Expression interface.
+func (f User) Children() []sql.Expression { return nil }
+
+// Eval implements the Expression interface.
+func (f User) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	return userFuncLogic(ctx, row)
+}

--- a/sql/expression/function/user_test.go
+++ b/sql/expression/function/user_test.go
@@ -47,4 +47,7 @@ func TestUser(t *testing.T) {
 	user, err = fn().Eval(ctx, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "", user)
+
+	column := fn().String()
+	assert.Equal(t, "current_user", column)
 }

--- a/sql/expression/function/user_test.go
+++ b/sql/expression/function/user_test.go
@@ -33,14 +33,14 @@ func TestUser(t *testing.T) {
 
 	user, err := fn().Eval(ctx, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "root", user)
+	assert.Equal(t, "root@%", user)
 
 	session = sql.NewSession("server", "client", "someguy", 0)
 	ctx = sql.NewContext(context.TODO(), sql.WithSession(session))
 
 	user, err = fn().Eval(ctx, nil)
 	require.NoError(t, err)
-	assert.Equal(t, "someguy", user)
+	assert.Equal(t, "someguy@%", user)
 
 	ctx = sql.NewEmptyContext()
 


### PR DESCRIPTION
User implements expression interface so I can override `User.String()` method for TonicAI.

Non-empty strings append "@%" at end for tonic.