### PR TITLE
Added INOUT/OUT params to procedures & nested procedures

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -194,7 +194,6 @@ func (e *Engine) QueryWithBindings(
 			e.Catalog.Done(ctx.Pid())
 		}
 	}()
-
 	if err != nil {
 		return nil, nil, err
 	}

--- a/memory/table_test.go
+++ b/memory/table_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dolthub/go-mysql-server/memory"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/parse"

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -21,6 +21,7 @@ import (
 // OnceBeforeDefault contains the rules to be applied just once before the
 // DefaultRules.
 var OnceBeforeDefault = []Rule{
+	{"load_stored_procedures", loadStoredProcedures},
 	{"resolve_views", resolveViews},
 	{"resolve_tables", resolveTables},
 	{"resolve_set_variables", resolveSetVariables},

--- a/sql/analyzer/stored_procedures.go
+++ b/sql/analyzer/stored_procedures.go
@@ -18,11 +18,67 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql/parse"
+
+	"gopkg.in/src-d/go-errors.v1"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
+
+// loadStoredProcedures loads stored procedures for all databases on relevant calls.
+func loadStoredProcedures(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
+	if ctx.ProcedureCache.IsPopulating() {
+		return n, nil
+	}
+	hasCall := false
+	plan.Inspect(n, func(n sql.Node) bool {
+		_, ok := n.(*plan.Call)
+		if ok {
+			hasCall = true
+			return false
+		}
+		return true
+	})
+	if !hasCall {
+		return n, nil
+	}
+	ctx.ProcedureCache = sql.NewProcedureCache(true)
+
+	for _, database := range a.Catalog.AllDatabases() {
+		if pdb, ok := database.(sql.StoredProcedureDatabase); ok {
+			procedures, err := pdb.GetStoredProcedures(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, procedure := range procedures {
+				parsedProcedure, err := parse.Parse(ctx, procedure.CreateStatement)
+				if err != nil {
+					return nil, err
+				}
+				cp, ok := parsedProcedure.(*plan.CreateProcedure)
+				if !ok {
+					return nil, sql.ErrProcedureCreateStatementInvalid.New(procedure.CreateStatement)
+				}
+
+				analyzedNode, err := a.Analyze(ctx, cp, nil)
+				if err != nil {
+					return nil, err
+				}
+				analyzedNode = stripQueryProcess(analyzedNode)
+				analyzedCp, ok := analyzedNode.(*plan.CreateProcedure)
+				if !ok {
+					return nil, fmt.Errorf("analyzed node %T and expected *plan.CreateProcedure", analyzedNode)
+				}
+
+				ctx.ProcedureCache.Register(database.Name(), analyzedCp.AsProcedure())
+			}
+		}
+	}
+	return n, nil
+}
 
 // validateStoredProcedure handles CreateProcedure nodes, resolving references to the parameters, along with ensuring
 // that all logic contained within the stored procedure body is valid.
@@ -41,7 +97,37 @@ func validateStoredProcedure(ctx *sql.Context, a *Analyzer, node sql.Node, scope
 		paramNames[paramName] = struct{}{}
 	}
 
-	body, err := plan.TransformExpressions(cp.Body, func(e sql.Expression) (sql.Expression, error) {
+	// For now, we don't support creating any of the following within stored procedures.
+	// These will be removed in the future, but cause issues with the current execution plan.
+	var err error
+	spUnsupportedErr := errors.NewKind("creating %s in stored procedures is currently unsupported " +
+		"and will be added in a future release")
+	plan.Inspect(cp.Body, func(n sql.Node) bool {
+		switch n.(type) {
+		case *plan.CreateTable:
+			err = spUnsupportedErr.New("tables")
+		case *plan.CreateTrigger:
+			err = spUnsupportedErr.New("triggers")
+		case *plan.CreateProcedure:
+			err = spUnsupportedErr.New("procedures")
+		case *plan.CreateDB:
+			err = spUnsupportedErr.New("databases")
+		case *plan.CreateForeignKey:
+			err = spUnsupportedErr.New("foreign keys")
+		case *plan.CreateIndex:
+			err = spUnsupportedErr.New("indexes")
+		case *plan.CreateView:
+			err = spUnsupportedErr.New("views")
+		default:
+			return true
+		}
+		return false
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := plan.TransformExpressionsUp(cp.Body, func(e sql.Expression) (sql.Expression, error) {
 		switch e := e.(type) {
 		case *expression.UnresolvedColumn:
 			if strings.ToLower(e.Table()) == "" {
@@ -79,69 +165,37 @@ func validateStoredProcedure(ctx *sql.Context, a *Analyzer, node sql.Node, scope
 }
 
 func applyProcedures(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
-	//TODO: this should only apply to either CALL statements or statements that may contain CALL statements
-	call, ok := n.(*plan.Call)
-	if !ok {
-		return n, nil
-	}
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
+		call, ok := n.(*plan.Call)
+		if !ok {
+			return n, nil
+		}
 
-	callName := strings.ToLower(call.Name)
-	db := ctx.GetCurrentDatabase()
-	database, err := a.Catalog.Database(db)
-	if err != nil {
-		return nil, err
-	}
+		pRef := expression.NewProcedureParamReference()
+		call = call.WithParamReference(pRef)
 
-	pRef := &expression.ProcedureParamReference{
-		NameToParam: make(map[string]interface{}),
-	}
-	call = call.WithParamReference(pRef)
-
-	if pdb, ok := database.(sql.StoredProcedureDatabase); ok {
-		procedures, err := pdb.GetStoredProcedures(ctx)
+		procedure := ctx.ProcedureCache.Get(ctx.GetCurrentDatabase(), call.Name)
+		if procedure == nil {
+			return nil, sql.ErrStoredProcedureDoesNotExist.New(call.Name)
+		}
+		procedureBody, err := plan.TransformExpressionsUp(procedure.Body, func(e sql.Expression) (sql.Expression, error) {
+			switch expr := e.(type) {
+			case *expression.ProcedureParam:
+				return expr.WithParamReference(pRef), nil
+			default:
+				return e, nil
+			}
+		})
+		if err != nil {
+			return nil, err
+		}
+		procedureBody, err = applyProcedures(ctx, a, procedureBody, scope)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, procedure := range procedures {
-			procName := strings.ToLower(procedure.Name)
-			if procName != callName {
-				continue
-			}
-
-			parsedProcedure, err := parse.Parse(ctx, procedure.CreateStatement)
-			if err != nil {
-				return nil, err
-			}
-			cp, ok := parsedProcedure.(*plan.CreateProcedure)
-			if !ok {
-				return nil, sql.ErrProcedureCreateStatementInvalid.New(procedure.CreateStatement)
-			}
-
-			analyzedNode, err := a.Analyze(ctx, cp, scope)
-			if err != nil {
-				return nil, err
-			}
-			analyzedNode = stripQueryProcess(analyzedNode)
-			analyzedCp, ok := analyzedNode.(*plan.CreateProcedure)
-			if !ok {
-				return nil, fmt.Errorf("analyzed node %T and expected *plan.CreateProcedure", analyzedNode)
-			}
-
-			procedureBody, err := plan.TransformExpressions(analyzedCp.Body, func(e sql.Expression) (sql.Expression, error) {
-				switch expr := e.(type) {
-				case *expression.ProcedureParam:
-					return expr.WithParamReference(pRef), nil
-				default:
-					return e, nil
-				}
-			})
-			analyzedCp.Body = procedureBody
-			call = call.WithProcedure(analyzedCp)
-		}
-	}
-	if !call.HasProcedure() {
-		return nil, sql.ErrStoredProcedureDoesNotExist.New(call.Name)
-	}
-	return call, nil
+		procedure.Body = procedureBody
+		call = call.WithProcedure(procedure)
+		return call, nil
+	})
 }

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -592,16 +592,16 @@ func convertCreateTrigger(ctx *sql.Context, query string, c *sqlparser.DDL) (sql
 }
 
 func convertCreateProcedure(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.Node, error) {
-	var params []plan.ProcedureParam
+	var params []sql.ProcedureParam
 	for _, param := range c.ProcedureSpec.Params {
-		var direction plan.ProcedureParamDirection
+		var direction sql.ProcedureParamDirection
 		switch param.Direction {
 		case sqlparser.ProcedureParamDirection_In:
-			direction = plan.ProcedureParamDirection_In
+			direction = sql.ProcedureParamDirection_In
 		case sqlparser.ProcedureParamDirection_Inout:
-			direction = plan.ProcedureParamDirection_Inout
+			direction = sql.ProcedureParamDirection_Inout
 		case sqlparser.ProcedureParamDirection_Out:
-			direction = plan.ProcedureParamDirection_Out
+			direction = sql.ProcedureParamDirection_Out
 		default:
 			return nil, fmt.Errorf("unknown procedure parameter direction: `%s`", string(param.Direction))
 		}
@@ -609,38 +609,38 @@ func convertCreateProcedure(ctx *sql.Context, query string, c *sqlparser.DDL) (s
 		if err != nil {
 			return nil, err
 		}
-		params = append(params, plan.ProcedureParam{
+		params = append(params, sql.ProcedureParam{
 			Direction: direction,
 			Name:      param.Name,
 			Type:      internalTyp,
 		})
 	}
 
-	var characteristics []plan.Characteristic
-	securityType := plan.ProcedureSecurityType_Definer // Default Security Type
+	var characteristics []sql.Characteristic
+	securityType := sql.ProcedureSecurityContext_Definer // Default Security Context
 	comment := ""
 	for _, characteristic := range c.ProcedureSpec.Characteristics {
 		switch characteristic.Type {
 		case sqlparser.CharacteristicValue_Comment:
 			comment = characteristic.Comment
 		case sqlparser.CharacteristicValue_LanguageSql:
-			characteristics = append(characteristics, plan.Characteristic_LanguageSql)
+			characteristics = append(characteristics, sql.Characteristic_LanguageSql)
 		case sqlparser.CharacteristicValue_Deterministic:
-			characteristics = append(characteristics, plan.Characteristic_Deterministic)
+			characteristics = append(characteristics, sql.Characteristic_Deterministic)
 		case sqlparser.CharacteristicValue_NotDeterministic:
-			characteristics = append(characteristics, plan.Characteristic_NotDeterministic)
+			characteristics = append(characteristics, sql.Characteristic_NotDeterministic)
 		case sqlparser.CharacteristicValue_ContainsSql:
-			characteristics = append(characteristics, plan.Characteristic_ContainsSql)
+			characteristics = append(characteristics, sql.Characteristic_ContainsSql)
 		case sqlparser.CharacteristicValue_NoSql:
-			characteristics = append(characteristics, plan.Characteristic_NoSql)
+			characteristics = append(characteristics, sql.Characteristic_NoSql)
 		case sqlparser.CharacteristicValue_ReadsSqlData:
-			characteristics = append(characteristics, plan.Characteristic_ReadsSqlData)
+			characteristics = append(characteristics, sql.Characteristic_ReadsSqlData)
 		case sqlparser.CharacteristicValue_ModifiesSqlData:
-			characteristics = append(characteristics, plan.Characteristic_ModifiesSqlData)
+			characteristics = append(characteristics, sql.Characteristic_ModifiesSqlData)
 		case sqlparser.CharacteristicValue_SqlSecurityDefiner:
 			// This is already the default value, so this prevents the default switch case
 		case sqlparser.CharacteristicValue_SqlSecurityInvoker:
-			securityType = plan.ProcedureSecurityType_Invoker
+			securityType = sql.ProcedureSecurityContext_Invoker
 		default:
 			return nil, fmt.Errorf("unknown procedure characteristic: `%s`", string(characteristic.Type))
 		}

--- a/sql/plan/ddl_procedure.go
+++ b/sql/plan/ddl_procedure.go
@@ -23,47 +23,14 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
-type ProcedureSecurityType byte
-
-const (
-	ProcedureSecurityType_Definer ProcedureSecurityType = iota
-	ProcedureSecurityType_Invoker
-)
-
-type ProcedureParamDirection byte
-
-const (
-	ProcedureParamDirection_In ProcedureParamDirection = iota
-	ProcedureParamDirection_Inout
-	ProcedureParamDirection_Out
-)
-
-type ProcedureParam struct {
-	Direction ProcedureParamDirection
-	Name      string
-	Type      sql.Type
-}
-
-type Characteristic byte
-
-const (
-	Characteristic_LanguageSql Characteristic = iota
-	Characteristic_Deterministic
-	Characteristic_NotDeterministic
-	Characteristic_ContainsSql
-	Characteristic_NoSql
-	Characteristic_ReadsSqlData
-	Characteristic_ModifiesSqlData
-)
-
 type CreateProcedure struct {
 	Name                  string
 	Definer               string
-	Params                []ProcedureParam
+	Params                []sql.ProcedureParam
 	CreatedAt             time.Time
 	ModifiedAt            time.Time
-	SecurityType          ProcedureSecurityType
-	Characteristics       []Characteristic
+	SecurityContext       sql.ProcedureSecurityContext
+	Characteristics       []sql.Characteristic
 	Comment               string
 	CreateProcedureString string
 	Body                  sql.Node
@@ -79,10 +46,10 @@ var _ sql.DebugStringer = (*CreateProcedure)(nil)
 func NewCreateProcedure(
 	name,
 	definer string,
-	params []ProcedureParam,
+	params []sql.ProcedureParam,
 	createdAt, modifiedAt time.Time,
-	securityType ProcedureSecurityType,
-	characteristics []Characteristic,
+	securityContext sql.ProcedureSecurityContext,
+	characteristics []sql.Characteristic,
 	body sql.Node,
 	comment, createString, bodyString string,
 ) *CreateProcedure {
@@ -92,7 +59,7 @@ func NewCreateProcedure(
 		Params:                params,
 		CreatedAt:             createdAt,
 		ModifiedAt:            modifiedAt,
-		SecurityType:          securityType,
+		SecurityContext:       securityContext,
 		Characteristics:       characteristics,
 		Comment:               comment,
 		CreateProcedureString: createString,
@@ -161,7 +128,7 @@ func (c *CreateProcedure) String() string {
 		characteristics += fmt.Sprintf(" %s", characteristic.String())
 	}
 	return fmt.Sprintf("CREATE%s PROCEDURE %s (%s) %s%s%s %s",
-		definer, c.Name, params, c.SecurityType.String(), comment, characteristics, c.Body.String())
+		definer, c.Name, params, c.SecurityContext.String(), comment, characteristics, c.Body.String())
 }
 
 // DebugString implements the sql.DebugStringer interface.
@@ -186,7 +153,19 @@ func (c *CreateProcedure) DebugString() string {
 		characteristics += fmt.Sprintf(" %s", characteristic.String())
 	}
 	return fmt.Sprintf("CREATE%s PROCEDURE %s (%s) %s%s%s %s",
-		definer, c.Name, params, c.SecurityType.String(), comment, characteristics, sql.DebugString(c.Body))
+		definer, c.Name, params, c.SecurityContext.String(), comment, characteristics, sql.DebugString(c.Body))
+}
+
+// AsProcedure returns this *CreateProcedure as a *sql.Procedure.
+func (c *CreateProcedure) AsProcedure() *sql.Procedure {
+	return sql.NewProcedure(
+		c.Name,
+		c.Definer,
+		c.Params,
+		c.SecurityContext,
+		c.Characteristics,
+		c.CreateProcedureString,
+		c.Body)
 }
 
 // RowIter implements the sql.Node interface.
@@ -237,49 +216,4 @@ func (c *createProcedureIter) Next() (sql.Row, error) {
 // Close implements the sql.RowIter interface.
 func (c *createProcedureIter) Close(ctx *sql.Context) error {
 	return nil
-}
-
-func (pst ProcedureSecurityType) String() string {
-	switch pst {
-	case ProcedureSecurityType_Definer:
-		return "SQL SECURITY DEFINER"
-	case ProcedureSecurityType_Invoker:
-		return "SQL SECURITY INVOKER"
-	default:
-		panic(fmt.Errorf("invalid characteristic value `%d`", byte(pst)))
-	}
-}
-
-func (pp ProcedureParam) String() string {
-	direction := ""
-	switch pp.Direction {
-	case ProcedureParamDirection_In:
-		direction = "IN"
-	case ProcedureParamDirection_Inout:
-		direction = "INOUT"
-	case ProcedureParamDirection_Out:
-		direction = "OUT"
-	}
-	return fmt.Sprintf("%s %s %s", direction, pp.Name, pp.Type.String())
-}
-
-func (c Characteristic) String() string {
-	switch c {
-	case Characteristic_LanguageSql:
-		return "LANGUAGE SQL"
-	case Characteristic_Deterministic:
-		return "DETERMINISTIC"
-	case Characteristic_NotDeterministic:
-		return "NOT DETERMINISTIC"
-	case Characteristic_ContainsSql:
-		return "CONTAINS SQL"
-	case Characteristic_NoSql:
-		return "NO SQL"
-	case Characteristic_ReadsSqlData:
-		return "READS SQL DATA"
-	case Characteristic_ModifiesSqlData:
-		return "MODIFIES SQL DATA"
-	default:
-		panic(fmt.Errorf("invalid characteristic value `%d`", byte(c)))
-	}
 }

--- a/sql/plan/set.go
+++ b/sql/plan/set.go
@@ -91,6 +91,15 @@ func (s *Set) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 			if err != nil {
 				return nil, err
 			}
+		case *expression.ProcedureParam:
+			value, err := setField.Right.Eval(ctx, row)
+			if err != nil {
+				return nil, err
+			}
+			err = left.Set(value, setField.Right.Type())
+			if err != nil {
+				return nil, err
+			}
 		case *expression.GetField:
 			updateExprs = append(updateExprs, setField)
 		default:

--- a/sql/session.go
+++ b/sql/session.go
@@ -309,12 +309,13 @@ type Context struct {
 	Session
 	*IndexRegistry
 	*ViewRegistry
-	Memory    *MemoryManager
-	pid       uint64
-	query     string
-	queryTime time.Time
-	tracer    opentracing.Tracer
-	rootSpan  opentracing.Span
+	ProcedureCache *ProcedureCache
+	Memory         *MemoryManager
+	pid            uint64
+	query          string
+	queryTime      time.Time
+	tracer         opentracing.Tracer
+	rootSpan       opentracing.Span
 }
 
 // ContextOption is a function to configure the context.
@@ -399,7 +400,7 @@ func NewContext(
 	ctx context.Context,
 	opts ...ContextOption,
 ) *Context {
-	c := &Context{ctx, NewBaseSession(), nil, nil, nil, 0, "", ctxNowFunc(), opentracing.NoopTracer{}, nil}
+	c := &Context{ctx, NewBaseSession(), nil, nil, nil, nil, 0, "", ctxNowFunc(), opentracing.NoopTracer{}, nil}
 	for _, opt := range opts {
 		opt(c)
 	}
@@ -410,6 +411,10 @@ func NewContext(
 
 	if c.ViewRegistry == nil {
 		c.ViewRegistry = NewViewRegistry()
+	}
+
+	if c.ProcedureCache == nil {
+		c.ProcedureCache = NewProcedureCache(false)
 	}
 
 	if c.Memory == nil {
@@ -454,16 +459,17 @@ func (c *Context) Span(
 	ctx := opentracing.ContextWithSpan(c.Context, span)
 
 	return span, &Context{
-		Context:       ctx,
-		Session:       c.Session,
-		IndexRegistry: c.IndexRegistry,
-		ViewRegistry:  c.ViewRegistry,
-		Memory:        c.Memory,
-		pid:           c.Pid(),
-		query:         c.Query(),
-		queryTime:     c.queryTime,
-		tracer:        c.tracer,
-		rootSpan:      c.rootSpan,
+		Context:        ctx,
+		Session:        c.Session,
+		IndexRegistry:  c.IndexRegistry,
+		ViewRegistry:   c.ViewRegistry,
+		ProcedureCache: c.ProcedureCache,
+		Memory:         c.Memory,
+		pid:            c.Pid(),
+		query:          c.Query(),
+		queryTime:      c.queryTime,
+		tracer:         c.tracer,
+		rootSpan:       c.rootSpan,
 	}
 }
 
@@ -472,16 +478,17 @@ func (c *Context) Span(
 func (c *Context) NewSubContext() (*Context, context.CancelFunc) {
 	ctx, cancelFunc := context.WithCancel(c.Context)
 	return &Context{
-		Context:       ctx,
-		Session:       c.Session,
-		IndexRegistry: c.IndexRegistry,
-		ViewRegistry:  c.ViewRegistry,
-		Memory:        c.Memory,
-		pid:           c.Pid(),
-		query:         c.Query(),
-		queryTime:     c.queryTime,
-		tracer:        c.tracer,
-		rootSpan:      c.rootSpan,
+		Context:        ctx,
+		Session:        c.Session,
+		IndexRegistry:  c.IndexRegistry,
+		ViewRegistry:   c.ViewRegistry,
+		ProcedureCache: c.ProcedureCache,
+		Memory:         c.Memory,
+		pid:            c.Pid(),
+		query:          c.Query(),
+		queryTime:      c.queryTime,
+		tracer:         c.tracer,
+		rootSpan:       c.rootSpan,
 	}, cancelFunc
 }
 
@@ -493,16 +500,17 @@ func (c *Context) WithCurrentDB(db string) *Context {
 // WithContext returns a new context with the given underlying context.
 func (c *Context) WithContext(ctx context.Context) *Context {
 	return &Context{
-		Context:       ctx,
-		Session:       c.Session,
-		IndexRegistry: c.IndexRegistry,
-		ViewRegistry:  c.ViewRegistry,
-		Memory:        c.Memory,
-		pid:           c.Pid(),
-		query:         c.Query(),
-		queryTime:     c.queryTime,
-		tracer:        c.tracer,
-		rootSpan:      c.rootSpan,
+		Context:        ctx,
+		Session:        c.Session,
+		IndexRegistry:  c.IndexRegistry,
+		ViewRegistry:   c.ViewRegistry,
+		ProcedureCache: c.ProcedureCache,
+		Memory:         c.Memory,
+		pid:            c.Pid(),
+		query:          c.Query(),
+		queryTime:      c.queryTime,
+		tracer:         c.tracer,
+		rootSpan:       c.rootSpan,
 	}
 }
 

--- a/sql/storedprocedure.go
+++ b/sql/storedprocedure.go
@@ -1,0 +1,211 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProcedureSecurityContext determines whether the stored procedure is executed using the privileges of the definer or
+// the invoker.
+type ProcedureSecurityContext byte
+const (
+	// ProcedureSecurityContext_Definer uses the definer's security context.
+	ProcedureSecurityContext_Definer ProcedureSecurityContext = iota
+	// ProcedureSecurityContext_Invoker uses the invoker's security context.
+	ProcedureSecurityContext_Invoker
+)
+
+// ProcedureParamDirection represents the use case of the stored procedure parameter.
+type ProcedureParamDirection byte
+const (
+	// ProcedureParamDirection_In means the parameter passes its contained value to the stored procedure.
+	ProcedureParamDirection_In ProcedureParamDirection = iota
+	// ProcedureParamDirection_Inout means the parameter passes its contained value to the stored procedure, while also
+	// modifying the given variable.
+	ProcedureParamDirection_Inout
+	// ProcedureParamDirection_Out means the parameter variable will be modified, but will not be read from within the
+	// stored procedure.
+	ProcedureParamDirection_Out
+)
+
+// ProcedureParam represents the parameter of a stored procedure.
+type ProcedureParam struct {
+	Direction ProcedureParamDirection // Direction is the direction of the parameter.
+	Name      string // Name is the name of the parameter.
+	Type      Type // Type is the SQL type of the parameter.
+}
+
+// Characteristic represents a characteristic that is defined on either a stored procedure or stored function.
+type Characteristic byte
+const (
+	Characteristic_LanguageSql Characteristic = iota
+	Characteristic_Deterministic
+	Characteristic_NotDeterministic
+	Characteristic_ContainsSql
+	Characteristic_NoSql
+	Characteristic_ReadsSqlData
+	Characteristic_ModifiesSqlData
+)
+
+// ProcedureCache contains all of the stored procedures for each database.
+type ProcedureCache struct {
+	dbToProcedureMap map[string]map[string]*Procedure
+	isPopulating     bool
+}
+
+// NewProcedureCache returns a *ProcedureCache. If you will be adding procedures immediately to the cache, then set
+// the parameter to true.
+func NewProcedureCache(willImmediatelyRegister bool) *ProcedureCache {
+	return &ProcedureCache{
+		dbToProcedureMap: make(map[string]map[string]*Procedure),
+		isPopulating:     willImmediatelyRegister,
+	}
+}
+
+// Get returns the stored procedure with the given name from the given database. All names are case-insensitive. If the
+// procedure does not exist, then this returns nil.
+func (pc *ProcedureCache) Get(dbName, procedureName string) *Procedure {
+	pc.isPopulating = false
+	dbName = strings.ToLower(dbName)
+	procedureName = strings.ToLower(procedureName)
+	if procMap, ok := pc.dbToProcedureMap[dbName]; ok {
+		if procedure, ok := procMap[procedureName]; ok {
+			return procedure
+		}
+	}
+	return nil
+}
+
+// Register adds the given stored procedure to the cache. Will overwrite any procedures that already exist with the
+// same name for the given database name.
+func (pc *ProcedureCache) Register(dbName string, procedure *Procedure) {
+	pc.isPopulating = true
+	dbName = strings.ToLower(dbName)
+	if procMap, ok := pc.dbToProcedureMap[dbName]; ok {
+		procMap[strings.ToLower(procedure.Name)] = procedure
+	} else {
+		pc.dbToProcedureMap[dbName] = map[string]*Procedure{strings.ToLower(procedure.Name): procedure}
+	}
+}
+
+// IsPopulating returns whether the cache is being populated with procedures.
+func (pc *ProcedureCache) IsPopulating() bool {
+	if pc == nil {
+		return false
+	}
+	return pc.isPopulating
+}
+
+// Procedure is a stored procedure that may be executed using the CALL statement.
+type Procedure struct {
+	Name                  string
+	Definer               string
+	Params                []ProcedureParam
+	SecurityContext       ProcedureSecurityContext
+	Characteristics       []Characteristic
+	CreateProcedureString string
+	Body                  Node
+}
+
+// NewProcedure returns a *Procedure. All names contained within are lowercase, and all methods are case-insensitive.
+func NewProcedure(
+	name string,
+	definer string,
+	params []ProcedureParam,
+	securityContext ProcedureSecurityContext,
+	characteristics []Characteristic,
+	createProcedureString string,
+	body Node,
+) *Procedure {
+	lowercasedParams := make([]ProcedureParam, len(params))
+	for i, param := range params {
+		lowercasedParams[i] = ProcedureParam{
+			Direction: param.Direction,
+			Name:      strings.ToLower(param.Name),
+			Type:      param.Type,
+		}
+	}
+	return &Procedure{
+		Name:                  strings.ToLower(name),
+		Definer:               definer,
+		Params:                lowercasedParams,
+		SecurityContext:       securityContext,
+		Characteristics:       characteristics,
+		CreateProcedureString: createProcedureString,
+		Body:                  body,
+	}
+}
+
+// ParamIndex returns the index of the parameter with the given name. The name is case-insensitive. If the parameter
+// does not exist, returns -1.
+func (p *Procedure) ParamIndex(name string) int {
+	name = strings.ToLower(name)
+	for i, param := range p.Params {
+		if param.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// String returns the original SQL representation.
+func (pst ProcedureSecurityContext) String() string {
+	switch pst {
+	case ProcedureSecurityContext_Definer:
+		return "SQL SECURITY DEFINER"
+	case ProcedureSecurityContext_Invoker:
+		return "SQL SECURITY INVOKER"
+	default:
+		panic(fmt.Errorf("invalid security context value `%d`", byte(pst)))
+	}
+}
+
+// String returns the original SQL representation.
+func (pp ProcedureParam) String() string {
+	direction := ""
+	switch pp.Direction {
+	case ProcedureParamDirection_In:
+		direction = "IN"
+	case ProcedureParamDirection_Inout:
+		direction = "INOUT"
+	case ProcedureParamDirection_Out:
+		direction = "OUT"
+	}
+	return fmt.Sprintf("%s %s %s", direction, pp.Name, pp.Type.String())
+}
+
+// String returns the original SQL representation.
+func (c Characteristic) String() string {
+	switch c {
+	case Characteristic_LanguageSql:
+		return "LANGUAGE SQL"
+	case Characteristic_Deterministic:
+		return "DETERMINISTIC"
+	case Characteristic_NotDeterministic:
+		return "NOT DETERMINISTIC"
+	case Characteristic_ContainsSql:
+		return "CONTAINS SQL"
+	case Characteristic_NoSql:
+		return "NO SQL"
+	case Characteristic_ReadsSqlData:
+		return "READS SQL DATA"
+	case Characteristic_ModifiesSqlData:
+		return "MODIFIES SQL DATA"
+	default:
+		panic(fmt.Errorf("invalid characteristic value `%d`", byte(c)))
+	}
+}


### PR DESCRIPTION
Stored procedures now work with `INOUT/OUT` directions for their parameters. Not only is this critical for nested `CALL` statements to work properly, but additional changes were made to handle nested `CALL`s. Stored procedures are now loaded before analyzing the query body.