### PR TITLE
sql/analyzer: Make column resolution more reliable when a subquery alias is under a table alias node.

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -465,6 +465,24 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: `WITH common_table AS (SELECT cec.id, cec.strength FROM (SELECT 1 as id, 12 as strength) cec) SELECT strength FROM common_table cte`,
+		Expected: []sql.Row{
+			{12},
+		},
+	},
+	{
+		Query: `WITH common_table AS (SELECT cec.id id, cec.strength FROM (SELECT 1 as id, 12 as strength) cec) SELECT strength FROM common_table cte`,
+		Expected: []sql.Row{
+			{12},
+		},
+	},
+	{
+		Query: `WITH common_table AS (SELECT cec.id AS id, cec.strength FROM (SELECT 1 as id, 12 as strength) cec) SELECT strength FROM common_table cte`,
+		Expected: []sql.Row{
+			{12},
+		},
+	},
+	{
 		Query: "SELECT s, (select i from mytable mt where sub.i = mt.i) as subi FROM (select i,s,'hello' FROM mytable where s = 'first row') as sub;",
 		Expected: []sql.Row{
 			{"first row", int64(1)},

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -103,9 +103,7 @@ func columnsUsedByNode(n sql.Node) usedColumns {
 
 func canPruneChild(parent, child sql.Node, idx int) bool {
 	_, isIndexedJoin := parent.(*plan.IndexedJoin)
-	_, parentIsTableAlias := parent.(*plan.TableAlias)
-	_, childIsSubqueryAlias := child.(*plan.SubqueryAlias)
-	return !isIndexedJoin && !(parentIsTableAlias && childIsSubqueryAlias)
+	return !isIndexedJoin
 }
 
 func pruneSubqueryColumns(

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -103,7 +103,9 @@ func columnsUsedByNode(n sql.Node) usedColumns {
 
 func canPruneChild(parent, child sql.Node, idx int) bool {
 	_, isIndexedJoin := parent.(*plan.IndexedJoin)
-	return !isIndexedJoin
+	_, parentIsTableAlias := parent.(*plan.TableAlias)
+	_, childIsSubqueryAlias := child.(*plan.SubqueryAlias)
+	return !isIndexedJoin && !(parentIsTableAlias && childIsSubqueryAlias)
 }
 
 func pruneSubqueryColumns(

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -43,6 +43,7 @@ var DefaultRules = []Rule{
 	{"resolve_natural_joins", resolveNaturalJoins},
 	{"resolve_orderby_literals", resolveOrderByLiterals},
 	{"resolve_functions", resolveFunctions},
+	{"flatten_table_aliases", flattenTableAliases},
 	{"pushdown_sort", pushdownSort},
 	{"pushdown_groupby_aliases", pushdownGroupByAliases},
 	{"qualify_columns", qualifyColumns},

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -76,6 +76,11 @@ func (n *SubqueryAlias) WithChildren(children ...sql.Node) (sql.Node, error) {
 	return &nn, nil
 }
 
+func (n SubqueryAlias) WithName(name string) *SubqueryAlias {
+	n.name = name
+	return &n
+}
+
 // Opaque implements the OpaqueNode interface.
 func (n *SubqueryAlias) Opaque() bool {
 	return true

--- a/sql/plan/tablealias.go
+++ b/sql/plan/tablealias.go
@@ -93,3 +93,8 @@ func (t TableAlias) DebugString() string {
 	_ = pr.WriteChildren(sql.DebugString(t.Child))
 	return pr.String()
 }
+
+func (t TableAlias) WithName(name string) *TableAlias {
+	t.name = name
+	return &t
+}


### PR DESCRIPTION
Using a common table expression (and probably using a view), you can alias a common table expression. Some analyzer steps, and in particular `prune_columns`, assume the subquery alias is the name that the parent schema sees. This adds an analyzer pass that flattens nested table aliases and a table alias on a subquery alias into the bottom-most node.