### PR TITLE
Driver improvements for Dolt

### DIFF
--- a/driver/context.go
+++ b/driver/context.go
@@ -6,12 +6,15 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
+// A ContextBuilder creates SQL contexts.
 type ContextBuilder interface {
 	NewContext(context.Context, *Conn, ...sql.ContextOption) (*sql.Context, error)
 }
 
+// DefaultContextBuilder creates basic SQL contexts.
 type DefaultContextBuilder struct{}
 
+// NewContext calls sql.NewContext.
 func (DefaultContextBuilder) NewContext(ctx context.Context, conn *Conn, opts ...sql.ContextOption) (*sql.Context, error) {
 	return sql.NewContext(ctx, opts...), nil
 }

--- a/driver/context.go
+++ b/driver/context.go
@@ -1,0 +1,17 @@
+package driver
+
+import (
+	"context"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+type ContextBuilder interface {
+	NewContext(context.Context, *Conn, ...sql.ContextOption) (*sql.Context, error)
+}
+
+type DefaultContextBuilder struct{}
+
+func (DefaultContextBuilder) NewContext(ctx context.Context, conn *Conn, opts ...sql.ContextOption) (*sql.Context, error) {
+	return sql.NewContext(ctx, opts...), nil
+}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -51,21 +51,22 @@ const (
 	ScanAsStored
 )
 
-// Options for the driver
+// Options for the driver.
 type Options struct {
 	// JSON indicates how JSON row values should be scanned
 	JSON ScanKind
 }
 
-// Provider resolves SQL catalogs
+// A Provider resolves SQL catalogs.
 type Provider interface {
 	Resolve(name string, options *Options) (string, *sql.Catalog, error)
 }
 
-// Driver exposes an engine as a stdlib SQL driver.
+// A Driver exposes an engine as a stdlib SQL driver.
 type Driver struct {
 	provider Provider
 	options  Options
+	sessions SessionBuilder
 
 	mu       sync.Mutex
 	catalogs map[*sql.Catalog]*catalog
@@ -73,9 +74,16 @@ type Driver struct {
 
 // New returns a driver using the specified provider.
 func New(provider Provider, options Options) *Driver {
+	sessions, ok := provider.(SessionBuilder)
+	if !ok {
+		sessions = DefaultSessionBuilder{}
+	}
+
 	return &Driver{
 		provider: provider,
 		options:  options,
+		sessions: sessions,
+		catalogs: map[*sql.Catalog]*catalog{},
 	}
 }
 
@@ -125,9 +133,6 @@ func (d *Driver) OpenConnector(dsn string) (driver.Connector, error) {
 		anlz := analyzer.NewDefault(sqlCat)
 		engine := sqle.New(sqlCat, anlz, nil)
 		cat = &catalog{engine: engine}
-		if d.catalogs == nil {
-			d.catalogs = map[*sql.Catalog]*catalog{}
-		}
 		d.catalogs[sqlCat] = cat
 	}
 	d.mu.Unlock()
@@ -173,15 +178,23 @@ type Connector struct {
 }
 
 // Driver returns the driver.
-func (c *Connector) Driver() driver.Driver {
-	return c.driver
-}
+func (c *Connector) Driver() driver.Driver { return c.driver }
+
+// Server returns the server name.
+func (c *Connector) Server() string { return c.server }
+
+// Catalog returns the SQL catalog.
+func (c *Connector) Catalog() *sql.Catalog { return c.catalog.engine.Catalog }
 
 // Connect returns a connection to the database.
-func (c *Connector) Connect(context.Context) (driver.Conn, error) {
+func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	id := c.catalog.nextConnectionID()
 
-	session := sql.NewSession(c.server, fmt.Sprintf("#%d", id), "", id)
+	session, err := c.driver.sessions.NewSession(ctx, id, c)
+	if err != nil {
+		return nil, err
+	}
+
 	indexes := sql.NewIndexRegistry()
 	views := sql.NewViewRegistry()
 	return &Conn{

--- a/driver/session.go
+++ b/driver/session.go
@@ -1,0 +1,21 @@
+package driver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// A SessionBuilder creates SQL sessions.
+type SessionBuilder interface {
+	NewSession(ctx context.Context, id uint32, conn *Connector) (sql.Session, error)
+}
+
+// DefaultSessionBuilder creates basic SQL sessions.
+type DefaultSessionBuilder struct{}
+
+// NewSession calls sql.NewSession.
+func (DefaultSessionBuilder) NewSession(ctx context.Context, id uint32, conn *Connector) (sql.Session, error) {
+	return sql.NewSession(conn.Server(), fmt.Sprintf("#%d", id), "", id), nil
+}

--- a/driver/stmt.go
+++ b/driver/stmt.go
@@ -86,7 +86,11 @@ func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 }
 
 func (s *Stmt) exec(ctx context.Context, bindings map[string]sql.Expression) (driver.Result, error) {
-	qctx := s.conn.newContextWithQuery(ctx, s.queryStr)
+	qctx, err := s.conn.newContextWithQuery(ctx, s.queryStr)
+	if err != nil {
+		return nil, err
+	}
+
 	_, rows, err := s.conn.catalog.engine.QueryWithBindings(qctx, s.queryStr, bindings)
 	if err != nil {
 		return nil, err
@@ -103,7 +107,11 @@ func (s *Stmt) exec(ctx context.Context, bindings map[string]sql.Expression) (dr
 }
 
 func (s *Stmt) query(ctx context.Context, bindings map[string]sql.Expression) (driver.Rows, error) {
-	qctx := s.conn.newContextWithQuery(ctx, s.queryStr)
+	qctx, err := s.conn.newContextWithQuery(ctx, s.queryStr)
+	if err != nil {
+		return nil, err
+	}
+
 	cols, rows, err := s.conn.catalog.engine.QueryWithBindings(qctx, s.queryStr, bindings)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It turns out Dolt needs to have control over how `sql.Session`s are created, and it needs to modify the `*sql.Context` prior to query execution. This MR adds two interfaces:

- `driver.SessionBuilder`
- `driver.ContextBuilder`

When a driver is created, with `driver.New`, if the provider implements either of these interfaces, then the provider's implementation will be used for creating sessions/contexts. Otherwise, a default implementation is used. The Dolt provider can then implement those two interfaces and do the necessary work to setup the session/context:

- New SQL session
  - Create a dolt session (wrapping a sql session)
  - For each Dolt database in the SQL catalog:
    - Call `doltSession.AddDB`
- New SQL context
  - Create a sql context
  - For each Dolt database in the SQL catalog:
    - Get the working root of the corresponding Dolt env
    - Call `doltDatabase.SetRoot`
    - Call `sqle.RegisterSchemaFragments`

Prior to adding `SessionBuilder`, attempting to execute a query would panic, when Dolt attempts to coerce the session into a Dolt session. Prior to adding `ContextBuilder`, some features would not work - for example, queries had no access to uncommitted changes.

For reference, [this](https://gitlab.com/ethan.reesor/vscode-notebooks/querypad/-/tree/main/src/dolt) is the Dolt driver implementation I'm working on.