### PR TITLE
Added Means To Make This Work on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ _example/*.exe
 test-server
 
 .idea/*
+
+# OSX Files
+.DS_Store


### PR DESCRIPTION
This change has the netstat ability of the MySQL server assume that if it can't access `/proc/sys/kernel/osrelease`, then it'll be unlikely to be able to access any other `/proc` files such as `/proc/net/tcp` and `/proc/net/tcp6`.

For a more specific check for Android, one can check if the `getprop` command exists in the PATH environment as getprop is an Android specific command to check the build properties for the system.