### PR TITLE
sql/analyzer: Split analysis of subqueries so that once-after rules are applied uniformly.

### DIFF
--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -338,6 +338,25 @@ func (a *Analyzer) PopDebugContext() {
 // Analyze applies the transformation rules to the node given. In the case of an error, the last successfully
 // transformed node is returned along with the error.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *Scope) (sql.Node, error) {
+	return a.analyzeWithSelector(ctx, n, scope, func (string) bool { return true })
+}
+
+func (a *Analyzer) analyzeThroughBatch(ctx *sql.Context, n sql.Node, scope *Scope, until string) (sql.Node, error) {
+	stop := false
+	return a.analyzeWithSelector(ctx, n, scope, func(desc string) bool {
+		if stop {
+			return false
+		}
+		if desc == until {
+			stop = true
+		}
+		// we return true even for the matching description; only start
+		// returning false after this batch.
+		return true
+	})
+}
+
+func (a *Analyzer) analyzeWithSelector(ctx *sql.Context, n sql.Node, scope *Scope, selector func (d string) bool) (sql.Node, error) {
 	span, ctx := ctx.Span("analyze", opentracing.Tags{
 		//"plan": , n.String(),
 	})
@@ -345,14 +364,16 @@ func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *Scope) (sql.Node
 	var err error
 	a.Log("starting analysis of node of type: %T", n)
 	for _, batch := range a.Batches {
-		a.PushDebugContext(batch.Desc)
-		n, err = batch.Eval(ctx, a, n, scope)
-		if err != nil {
-			a.Log("Encountered error: %v", err)
+		if selector(batch.Desc) {
+			a.PushDebugContext(batch.Desc)
+			n, err = batch.Eval(ctx, a, n, scope)
+			if err != nil {
+				a.Log("Encountered error: %v", err)
+				a.PopDebugContext()
+				return n, err
+			}
 			a.PopDebugContext()
-			return n, err
 		}
-		a.PopDebugContext()
 	}
 
 	defer func() {
@@ -363,4 +384,17 @@ func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *Scope) (sql.Node
 	}()
 
 	return n, err
+}
+
+func (a *Analyzer) analyzeStartingAtBatch(ctx *sql.Context, n sql.Node, scope *Scope, startAt string) (sql.Node, error) {
+	start := false
+	return a.analyzeWithSelector(ctx, n, scope, func(desc string) bool {
+		if desc == startAt {
+			start = true
+		}
+		if start {
+			return true
+		}
+		return false
+	})
 }

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -338,7 +338,7 @@ func (a *Analyzer) PopDebugContext() {
 // Analyze applies the transformation rules to the node given. In the case of an error, the last successfully
 // transformed node is returned along with the error.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *Scope) (sql.Node, error) {
-	return a.analyzeWithSelector(ctx, n, scope, func (string) bool { return true })
+	return a.analyzeWithSelector(ctx, n, scope, func(string) bool { return true })
 }
 
 func (a *Analyzer) analyzeThroughBatch(ctx *sql.Context, n sql.Node, scope *Scope, until string) (sql.Node, error) {
@@ -356,7 +356,7 @@ func (a *Analyzer) analyzeThroughBatch(ctx *sql.Context, n sql.Node, scope *Scop
 	})
 }
 
-func (a *Analyzer) analyzeWithSelector(ctx *sql.Context, n sql.Node, scope *Scope, selector func (d string) bool) (sql.Node, error) {
+func (a *Analyzer) analyzeWithSelector(ctx *sql.Context, n sql.Node, scope *Scope, selector func(d string) bool) (sql.Node, error) {
 	span, ctx := ctx.Span("analyze", opentracing.Tags{
 		//"plan": , n.String(),
 	})

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -335,10 +335,14 @@ func (a *Analyzer) PopDebugContext() {
 	}
 }
 
+func analyzeAll(batchName string) bool {
+	return true
+}
+
 // Analyze applies the transformation rules to the node given. In the case of an error, the last successfully
 // transformed node is returned along with the error.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *Scope) (sql.Node, error) {
-	return a.analyzeWithSelector(ctx, n, scope, func(string) bool { return true })
+	return a.analyzeWithSelector(ctx, n, scope, analyzeAll)
 }
 
 func (a *Analyzer) analyzeThroughBatch(ctx *sql.Context, n sql.Node, scope *Scope, until string) (sql.Node, error) {

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -27,8 +27,6 @@ func resolveSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) 
 	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
 		case *plan.SubqueryAlias:
-			a.Log("found subquery %q with child of type %T", n.Name(), n.Child)
-
 			// subqueries do not have access to outer scope
 			child, err := a.analyzeThroughBatch(ctx, n.Child, nil, "default-rules")
 			if err != nil {
@@ -56,8 +54,6 @@ func finalizeSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope)
 	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
 		case *plan.SubqueryAlias:
-			a.Log("found subquery %q with child of type %T", n.Name(), n.Child)
-
 			// subqueries do not have access to outer scope
 			child, err := a.analyzeStartingAtBatch(ctx, n.Child, nil, "default-rules")
 			if err != nil {

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -30,7 +30,36 @@ func resolveSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) 
 			a.Log("found subquery %q with child of type %T", n.Name(), n.Child)
 
 			// subqueries do not have access to outer scope
-			child, err := a.Analyze(ctx, n.Child, nil)
+			child, err := a.analyzeThroughBatch(ctx, n.Child, nil, "default-rules")
+			if err != nil {
+				return nil, err
+			}
+
+			if len(n.Columns) > 0 {
+				schemaLen := schemaLength(n.Child)
+				if schemaLen != len(n.Columns) {
+					return nil, sql.ErrColumnCountMismatch.New()
+				}
+			}
+
+			return n.WithChildren(stripQueryProcess(child))
+		default:
+			return n, nil
+		}
+	})
+}
+
+func finalizeSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
+	span, ctx := ctx.Span("finalize_subqueries")
+	defer span.Finish()
+
+	return plan.TransformUp(n, func(n sql.Node) (sql.Node, error) {
+		switch n := n.(type) {
+		case *plan.SubqueryAlias:
+			a.Log("found subquery %q with child of type %T", n.Name(), n.Child)
+
+			// subqueries do not have access to outer scope
+			child, err := a.analyzeStartingAtBatch(ctx, n.Child, nil, "default-rules")
 			if err != nil {
 				return nil, err
 			}

--- a/sql/analyzer/resolve_subqueries_test.go
+++ b/sql/analyzer/resolve_subqueries_test.go
@@ -110,7 +110,18 @@ func TestResolveSubqueries(t *testing.T) {
 	ctx := sql.NewContext(context.Background(),
 		sql.WithIndexRegistry(sql.NewIndexRegistry()),
 		sql.WithViewRegistry(sql.NewViewRegistry())).WithCurrentDB("mydb")
-	runTestCases(t, ctx, testCases, a, getRule("resolve_subqueries"))
+	resolveSubqueries := getRule("resolve_subqueries")
+	finalizeSubqueries := getRule("finalize_subqueries")
+	runTestCases(t, ctx, testCases, a, Rule{
+		Name: "subqueries",
+		Apply: func(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
+			n, err := resolveSubqueries.Apply(ctx, a, n, scope)
+			if err != nil {
+				return nil, err
+			}
+			return finalizeSubqueries.Apply(ctx, a, n, scope)
+		},
+	})
 }
 
 func TestResolveSubqueryExpressions(t *testing.T) {

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -68,6 +68,8 @@ var DefaultRules = []Rule{
 // OnceAfterDefault contains the rules to be applied just once after the
 // DefaultRules.
 var OnceAfterDefault = []Rule{
+	{"finalize_subqueries", finalizeSubqueries},
+	{"finalize_unions", finalizeUnions},
 	{"load_triggers", loadTriggers},
 	{"process_truncate", processTruncate},
 	{"resolve_column_defaults", resolveColumnDefaults},


### PR DESCRIPTION
This makes is so that rules through default-rules get applied as part of
analyzing the subquery. Later, early in the once-after phase, union and
subquery queries get their own once-after processing.

This allows us to keep the node tree in a state where we can apply
transformations and optimizations across Opaque node boundaries, and come back
for further processing later.