### PR TITLE
Add ISNULL(expr) and compatible with Navicat Premium

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ examples on how to connect to go-mysql-server using them.
 |`IF(expr1, expr2, expr3)`| if `expr1` evaluates to true, retuns `expr2`. Otherwise returns `expr3`. |
 |`INSTR(str1, str2)`| returns the 1-based index of the first occurence of `str2` in `str1`, or 0 if it does not occur. |
 |`IS_BINARY(blob)`| returns whether a `blob` is a binary file or not.|
+|`ISNULL(expr)`| returns whether a `expr` is null or not.|
 |`JSON_EXTRACT(json_doc, path, ...)`| extracts data from a json document using json paths. Extracting a string will result in that string being quoted. To avoid this, use `JSON_UNQUOTE(JSON_EXTRACT(json_doc, path, ...))`.|
 |`JSON_UNQUOTE(json)`| unquotes JSON value and returns the result as a utf8mb4 string.|
 |`LAST(expr)`| returns the last value in a sequence of elements of an aggregation.|

--- a/sql/expression/function/isnull.go
+++ b/sql/expression/function/isnull.go
@@ -1,0 +1,70 @@
+// Copyright 2020-2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+// IsNull is a function that returns whether a value is null or not.
+type IsNull struct {
+	expression.UnaryExpression
+}
+
+var _ sql.FunctionExpression = (*IsNull)(nil)
+
+// NewIsNull creates a new IsNull expression.
+func NewIsNull(e sql.Expression) sql.Expression {
+	return &IsNull{expression.UnaryExpression{Child: e}}
+}
+
+// FunctionName implements sql.FunctionExpression
+func (ib *IsNull) FunctionName() string {
+	return "isnull"
+}
+
+// Eval implements the Expression interface.
+func (ib *IsNull) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	v, err := ib.Child.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if v != nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ib *IsNull) String() string {
+	return fmt.Sprintf("ISNULL(%s)", ib.Child)
+}
+
+// WithChildren implements the Expression interface.
+func (ib *IsNull) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(ib, len(children), 1)
+	}
+	return NewIsNull(children[0]), nil
+}
+
+// Type implements the Expression interface.
+func (ib *IsNull) Type() sql.Type {
+	return sql.Boolean
+}

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -78,6 +78,7 @@ var Defaults = []sql.Function{
 	sql.Function2{Name: "instr", Fn: NewInstr},
 	sql.Function1{Name: "is_binary", Fn: NewIsBinary},
 	sql.Function1{Name: "is_uuid", Fn: NewIsUUID},
+	sql.Function1{Name: "isnull", Fn: NewIsNull},
 	sql.FunctionN{Name: "json_array", Fn: NewJSONArray},
 	sql.Function1{Name: "json_arrayagg", Fn: func(e sql.Expression) sql.Expression { return aggregation.NewJSONArrayAgg(e) }},
 	sql.Function2{Name: "json_objectagg", Fn: aggregation.NewJSONObjectAgg},

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -419,6 +419,7 @@ var partitionSchema = Schema{
 	{Name: "partition_expression", Type: MustCreateStringWithDefaults(sqltypes.VarChar, 2048), Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "subpartition_expression", Type: MustCreateStringWithDefaults(sqltypes.VarChar, 2048), Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "partition_descriptor", Type: LongText, Default: nil, Nullable: true, Source: PartitionsTableName},
+	{Name: "partition_description", Type: LongText, Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "table_rows", Type: Uint64, Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "avg_row_length", Type: Uint64, Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "data_length", Type: Uint64, Default: nil, Nullable: true, Source: PartitionsTableName},

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -418,7 +418,6 @@ var partitionSchema = Schema{
 	{Name: "subpartition_method", Type: MustCreateStringWithDefaults(sqltypes.VarChar, 13), Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "partition_expression", Type: MustCreateStringWithDefaults(sqltypes.VarChar, 2048), Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "subpartition_expression", Type: MustCreateStringWithDefaults(sqltypes.VarChar, 2048), Default: nil, Nullable: true, Source: PartitionsTableName},
-	{Name: "partition_descriptor", Type: LongText, Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "partition_description", Type: LongText, Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "table_rows", Type: Uint64, Default: nil, Nullable: true, Source: PartitionsTableName},
 	{Name: "avg_row_length", Type: Uint64, Default: nil, Nullable: true, Source: PartitionsTableName},


### PR DESCRIPTION
When I use Navicat Premium 15.0.28 to design tables.

Get error: `1105 - function: 'isnull, maybe you mean ifnull?' not found`

After I implement `ISNULL(expr)`.

Get error: `1105 - column "PARTITION_DESCRIPTION" could not be found in any table in scope`

This RP is fixed this problem.