### PR TITLE
Fix for hanging joins when the secondary table is empty using an in-memory strategy

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -97,7 +97,7 @@ func TestSingleQuery(t *testing.T) {
 
 	var test enginetest.QueryTest
 	test = enginetest.QueryTest{
-		Query:           "select * from mytable t1 join mytable t2 on t2.i = t1.i where t2.i > 10",
+		Query:    "select * from mytable t1 join mytable t2 on t2.i = t1.i where t2.i > 10",
 		Expected: []sql.Row{},
 	}
 	fmt.Sprintf("%v", test)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -97,10 +97,8 @@ func TestSingleQuery(t *testing.T) {
 
 	var test enginetest.QueryTest
 	test = enginetest.QueryTest{
-		Query: "CREATE DATABASE testdb",
-		Expected: []sql.Row{
-			{"second row"},
-		},
+		Query:           "select * from mytable t1 join mytable t2 on t2.i = t1.i where t2.i > 10",
+		Expected: []sql.Row{},
 	}
 	fmt.Sprintf("%v", test)
 

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -401,12 +401,12 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:           "select * from mytable t1 join mytable t2 on t2.i = t1.i where t2.i > 10",
-		Expected:        []sql.Row{},
+		Query:    "select * from mytable t1 join mytable t2 on t2.i = t1.i where t2.i > 10",
+		Expected: []sql.Row{},
 	},
 	{
-		Query:           "select * from tabletest t1 join tabletest t2 on t2.s = t1.s where t2.i > 10",
-		Expected:        []sql.Row{},
+		Query:    "select * from tabletest t1 join tabletest t2 on t2.s = t1.s where t2.i > 10",
+		Expected: []sql.Row{},
 	},
 	{
 		Query: "WITH mt as (select i,s FROM mytable) SELECT s,i FROM mt;",

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -401,6 +401,14 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query:           "select * from mytable t1 join mytable t2 on t2.i = t1.i where t2.i > 10",
+		Expected:        []sql.Row{},
+	},
+	{
+		Query:           "select * from tabletest t1 join tabletest t2 on t2.s = t1.s where t2.i > 10",
+		Expected:        []sql.Row{},
+	},
+	{
 		Query: "WITH mt as (select i,s FROM mytable) SELECT s,i FROM mt;",
 		Expected: []sql.Row{
 			{"first row", int64(1)},

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -546,6 +546,10 @@ func (i *joinIter) loadSecondary() (row sql.Row, err error) {
 	if i.mode == memoryMode {
 		if len(i.secondaryRows.Get()) == 0 {
 			if err = i.loadSecondaryInMemory(); err != nil {
+				if err == io.EOF {
+					i.primaryRow = nil
+					i.pos = 0
+				}
 				return nil, err
 			}
 		}


### PR DESCRIPTION
This fixes #222 