### PR TITLE
Transaction support

### DIFF
--- a/auth/common_test.go
+++ b/auth/common_test.go
@@ -195,7 +195,7 @@ func testAudit(
 	req.NoError(err)
 
 	for _, c := range tests {
-		t.Run(c.user, func(t *testing.T) {
+		t.Run(c.query, func(t *testing.T) {
 			r := require.New(t)
 
 			var db *dsql.DB

--- a/engine.go
+++ b/engine.go
@@ -136,8 +136,8 @@ func (e *Engine) QueryNodeWithBindings(
 ) (sql.Schema, sql.RowIter, error) {
 	var (
 		analyzed sql.Node
-		iter             sql.RowIter
-		err              error
+		iter     sql.RowIter
+		err      error
 	)
 
 	if parsed == nil {

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -173,25 +173,24 @@ func TestOrderByGroupBy(t *testing.T, harness Harness) {
 	db := harness.NewDatabase("db")
 
 	wrapInTransaction(t, db, harness, func() {
-	table, err := harness.NewTable(db, "members", sql.Schema{
-		{Name: "id", Type: sql.Int64, Source: "members", PrimaryKey: true},
-		{Name: "team", Type: sql.Text, Source: "members"},
+		table, err := harness.NewTable(db, "members", sql.Schema{
+			{Name: "id", Type: sql.Int64, Source: "members", PrimaryKey: true},
+			{Name: "team", Type: sql.Text, Source: "members"},
+		})
+		require.NoError(err)
+
+		ctx := harness.NewContext()
+
+		InsertRows(
+			t, ctx, mustInsertableTable(t, table),
+			sql.NewRow(int64(3), "red"),
+			sql.NewRow(int64(4), "red"),
+			sql.NewRow(int64(5), "orange"),
+			sql.NewRow(int64(6), "orange"),
+			sql.NewRow(int64(7), "orange"),
+			sql.NewRow(int64(8), "purple"),
+		)
 	})
-	require.NoError(err)
-
-	ctx := harness.NewContext()
-
-	InsertRows(
-		t, ctx, mustInsertableTable(t, table),
-		sql.NewRow(int64(3), "red"),
-		sql.NewRow(int64(4), "red"),
-		sql.NewRow(int64(5), "orange"),
-		sql.NewRow(int64(6), "orange"),
-		sql.NewRow(int64(7), "orange"),
-		sql.NewRow(int64(8), "purple"),
-	)
-	})
-
 
 	e := sqle.NewDefault()
 	e.AddDatabase(db)
@@ -244,7 +243,6 @@ func TestReadOnly(t *testing.T, harness Harness) {
 		})
 		require.NoError(err)
 	})
-
 
 	catalog := sql.NewCatalog()
 	catalog.AddDatabase(db)
@@ -399,21 +397,21 @@ func TestAmbiguousColumnResolution(t *testing.T, harness Harness) {
 	db := harness.NewDatabase("mydb")
 
 	wrapInTransaction(t, db, harness, func() {
-	table, err := harness.NewTable(db, "foo", sql.Schema{
-		{Name: "a", Type: sql.Int64, Source: "foo", PrimaryKey: true},
-		{Name: "b", Type: sql.Text, Source: "foo"},
-	})
-	require.NoError(err)
+		table, err := harness.NewTable(db, "foo", sql.Schema{
+			{Name: "a", Type: sql.Int64, Source: "foo", PrimaryKey: true},
+			{Name: "b", Type: sql.Text, Source: "foo"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, table), sql.NewRow(int64(1), "foo"), sql.NewRow(int64(2), "bar"), sql.NewRow(int64(3), "baz"))
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, table), sql.NewRow(int64(1), "foo"), sql.NewRow(int64(2), "bar"), sql.NewRow(int64(3), "baz"))
 
-	table2, err := harness.NewTable(db, "bar", sql.Schema{
-		{Name: "b", Type: sql.Text, Source: "bar", PrimaryKey: true},
-		{Name: "c", Type: sql.Int64, Source: "bar"},
-	})
-	require.NoError(err)
+		table2, err := harness.NewTable(db, "bar", sql.Schema{
+			{Name: "b", Type: sql.Text, Source: "bar", PrimaryKey: true},
+			{Name: "c", Type: sql.Int64, Source: "bar"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, table2), sql.NewRow("qux", int64(3)), sql.NewRow("mux", int64(2)), sql.NewRow("pux", int64(1)))
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, table2), sql.NewRow("qux", int64(3)), sql.NewRow("mux", int64(2)), sql.NewRow("pux", int64(1)))
 	})
 
 	e := sqle.NewDefault()
@@ -2302,29 +2300,29 @@ func TestNaturalJoin(t *testing.T, harness Harness) {
 
 	db := harness.NewDatabase("mydb")
 	wrapInTransaction(t, db, harness, func() {
-	t1, err := harness.NewTable(db, "t1", sql.Schema{
-		{Name: "a", Type: sql.Text, Source: "t1", PrimaryKey: true},
-		{Name: "b", Type: sql.Text, Source: "t1"},
-		{Name: "c", Type: sql.Text, Source: "t1"},
-	})
-	require.NoError(err)
+		t1, err := harness.NewTable(db, "t1", sql.Schema{
+			{Name: "a", Type: sql.Text, Source: "t1", PrimaryKey: true},
+			{Name: "b", Type: sql.Text, Source: "t1"},
+			{Name: "c", Type: sql.Text, Source: "t1"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, t1),
-		sql.NewRow("a_1", "b_1", "c_1"),
-		sql.NewRow("a_2", "b_2", "c_2"),
-		sql.NewRow("a_3", "b_3", "c_3"))
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, t1),
+			sql.NewRow("a_1", "b_1", "c_1"),
+			sql.NewRow("a_2", "b_2", "c_2"),
+			sql.NewRow("a_3", "b_3", "c_3"))
 
-	t2, err := harness.NewTable(db, "t2", sql.Schema{
-		{Name: "a", Type: sql.Text, Source: "t2", PrimaryKey: true},
-		{Name: "b", Type: sql.Text, Source: "t2"},
-		{Name: "d", Type: sql.Text, Source: "t2"},
-	})
-	require.NoError(err)
+		t2, err := harness.NewTable(db, "t2", sql.Schema{
+			{Name: "a", Type: sql.Text, Source: "t2", PrimaryKey: true},
+			{Name: "b", Type: sql.Text, Source: "t2"},
+			{Name: "d", Type: sql.Text, Source: "t2"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, t2),
-		sql.NewRow("a_1", "b_1", "d_1"),
-		sql.NewRow("a_2", "b_2", "d_2"),
-		sql.NewRow("a_3", "b_3", "d_3"))
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, t2),
+			sql.NewRow("a_1", "b_1", "d_1"),
+			sql.NewRow("a_2", "b_2", "d_2"),
+			sql.NewRow("a_3", "b_3", "d_3"))
 	})
 
 	e := sqle.NewDefault()
@@ -2342,29 +2340,29 @@ func TestNaturalJoinEqual(t *testing.T, harness Harness) {
 
 	db := harness.NewDatabase("mydb")
 	wrapInTransaction(t, db, harness, func() {
-	t1, err := harness.NewTable(db, "t1", sql.Schema{
-		{Name: "a", Type: sql.Text, Source: "t1", PrimaryKey: true},
-		{Name: "b", Type: sql.Text, Source: "t1"},
-		{Name: "c", Type: sql.Text, Source: "t1"},
-	})
-	require.NoError(err)
+		t1, err := harness.NewTable(db, "t1", sql.Schema{
+			{Name: "a", Type: sql.Text, Source: "t1", PrimaryKey: true},
+			{Name: "b", Type: sql.Text, Source: "t1"},
+			{Name: "c", Type: sql.Text, Source: "t1"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, t1),
-		sql.NewRow("a_1", "b_1", "c_1"),
-		sql.NewRow("a_2", "b_2", "c_2"),
-		sql.NewRow("a_3", "b_3", "c_3"))
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, t1),
+			sql.NewRow("a_1", "b_1", "c_1"),
+			sql.NewRow("a_2", "b_2", "c_2"),
+			sql.NewRow("a_3", "b_3", "c_3"))
 
-	t2, err := harness.NewTable(db, "t2", sql.Schema{
-		{Name: "a", Type: sql.Text, Source: "t2", PrimaryKey: true},
-		{Name: "b", Type: sql.Text, Source: "t2"},
-		{Name: "c", Type: sql.Text, Source: "t2"},
-	})
-	require.NoError(err)
+		t2, err := harness.NewTable(db, "t2", sql.Schema{
+			{Name: "a", Type: sql.Text, Source: "t2", PrimaryKey: true},
+			{Name: "b", Type: sql.Text, Source: "t2"},
+			{Name: "c", Type: sql.Text, Source: "t2"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, t2),
-		sql.NewRow("a_1", "b_1", "c_1"),
-		sql.NewRow("a_2", "b_2", "c_2"),
-		sql.NewRow("a_3", "b_3", "c_3"))
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, t2),
+			sql.NewRow("a_1", "b_1", "c_1"),
+			sql.NewRow("a_2", "b_2", "c_2"),
+			sql.NewRow("a_3", "b_3", "c_3"))
 	})
 
 	e := sqle.NewDefault()
@@ -2382,24 +2380,24 @@ func TestNaturalJoinDisjoint(t *testing.T, harness Harness) {
 
 	db := harness.NewDatabase("mydb")
 	wrapInTransaction(t, db, harness, func() {
-	t1, err := harness.NewTable(db, "t1", sql.Schema{
-		{Name: "a", Type: sql.Text, Source: "t1", PrimaryKey: true},
-	})
-	require.NoError(err)
+		t1, err := harness.NewTable(db, "t1", sql.Schema{
+			{Name: "a", Type: sql.Text, Source: "t1", PrimaryKey: true},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, t1),
-		sql.NewRow("a1"),
-		sql.NewRow("a2"),
-		sql.NewRow("a3"))
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, t1),
+			sql.NewRow("a1"),
+			sql.NewRow("a2"),
+			sql.NewRow("a3"))
 
-	t2, err := harness.NewTable(db, "t2", sql.Schema{
-		{Name: "b", Type: sql.Text, Source: "t2", PrimaryKey: true},
-	})
-	require.NoError(err)
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, t2),
-		sql.NewRow("b1"),
-		sql.NewRow("b2"),
-		sql.NewRow("b3"))
+		t2, err := harness.NewTable(db, "t2", sql.Schema{
+			{Name: "b", Type: sql.Text, Source: "t2", PrimaryKey: true},
+		})
+		require.NoError(err)
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, t2),
+			sql.NewRow("b1"),
+			sql.NewRow("b2"),
+			sql.NewRow("b3"))
 	})
 
 	e := sqle.NewDefault()
@@ -2423,44 +2421,44 @@ func TestInnerNestedInNaturalJoins(t *testing.T, harness Harness) {
 
 	db := harness.NewDatabase("mydb")
 	wrapInTransaction(t, db, harness, func() {
-	table1, err := harness.NewTable(db, "table1", sql.Schema{
-		{Name: "i", Type: sql.Int32, Source: "table1"},
-		{Name: "f", Type: sql.Float64, Source: "table1"},
-		{Name: "t", Type: sql.Text, Source: "table1"},
-	})
-	require.NoError(err)
+		table1, err := harness.NewTable(db, "table1", sql.Schema{
+			{Name: "i", Type: sql.Int32, Source: "table1"},
+			{Name: "f", Type: sql.Float64, Source: "table1"},
+			{Name: "t", Type: sql.Text, Source: "table1"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, table1),
-		sql.NewRow(int32(1), float64(2.1), "table1"),
-		sql.NewRow(int32(1), float64(2.1), "table1"),
-		sql.NewRow(int32(10), float64(2.1), "table1"),
-	)
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, table1),
+			sql.NewRow(int32(1), float64(2.1), "table1"),
+			sql.NewRow(int32(1), float64(2.1), "table1"),
+			sql.NewRow(int32(10), float64(2.1), "table1"),
+		)
 
-	table2, err := harness.NewTable(db, "table2", sql.Schema{
-		{Name: "i2", Type: sql.Int32, Source: "table2"},
-		{Name: "f2", Type: sql.Float64, Source: "table2"},
-		{Name: "t2", Type: sql.Text, Source: "table2"},
-	})
-	require.NoError(err)
+		table2, err := harness.NewTable(db, "table2", sql.Schema{
+			{Name: "i2", Type: sql.Int32, Source: "table2"},
+			{Name: "f2", Type: sql.Float64, Source: "table2"},
+			{Name: "t2", Type: sql.Text, Source: "table2"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, table2),
-		sql.NewRow(int32(1), float64(2.2), "table2"),
-		sql.NewRow(int32(1), float64(2.2), "table2"),
-		sql.NewRow(int32(20), float64(2.2), "table2"),
-	)
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, table2),
+			sql.NewRow(int32(1), float64(2.2), "table2"),
+			sql.NewRow(int32(1), float64(2.2), "table2"),
+			sql.NewRow(int32(20), float64(2.2), "table2"),
+		)
 
-	table3, err := harness.NewTable(db, "table3", sql.Schema{
-		{Name: "i", Type: sql.Int32, Source: "table3"},
-		{Name: "f2", Type: sql.Float64, Source: "table3"},
-		{Name: "t3", Type: sql.Text, Source: "table3"},
-	})
-	require.NoError(err)
+		table3, err := harness.NewTable(db, "table3", sql.Schema{
+			{Name: "i", Type: sql.Int32, Source: "table3"},
+			{Name: "f2", Type: sql.Float64, Source: "table3"},
+			{Name: "t3", Type: sql.Text, Source: "table3"},
+		})
+		require.NoError(err)
 
-	InsertRows(t, NewContext(harness), mustInsertableTable(t, table3),
-		sql.NewRow(int32(1), float64(2.2), "table3"),
-		sql.NewRow(int32(2), float64(2.2), "table3"),
-		sql.NewRow(int32(30), float64(2.2), "table3"),
-	)
+		InsertRows(t, NewContext(harness), mustInsertableTable(t, table3),
+			sql.NewRow(int32(1), float64(2.2), "table3"),
+			sql.NewRow(int32(2), float64(2.2), "table3"),
+			sql.NewRow(int32(30), float64(2.2), "table3"),
+		)
 	})
 
 	e := sqle.NewDefault()

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1689,8 +1689,6 @@ func TestDropDatabase(t *testing.T, harness Harness) {
 		TestQueryWithContext(t, ctx, e, "DROP DATABASE mydb", []sql.Row{{sql.OkResult{RowsAffected: 1}}}, nil, nil)
 		AssertWarningAndTestQuery(t, e, ctx, harness, "DROP DATABASE IF EXISTS mydb", []sql.Row{{sql.OkResult{RowsAffected: 0}}}, nil, mysql.ERDbDropExists)
 
-		e.Analyzer.Verbose = true
-		e.Analyzer.Debug = true
 		TestQueryWithContext(t, ctx, e, "CREATE DATABASE testdb", []sql.Row{{sql.OkResult{RowsAffected: 1}}}, nil, nil)
 
 		_, err := e.Catalog.Database("testdb")

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -252,7 +252,7 @@ func TestReadOnly(t *testing.T, harness Harness) {
 		`CREATE INDEX foo USING BTREE ON mytable (i, s)`,
 		`DROP INDEX foo ON mytable`,
 		`INSERT INTO mytable (i, s) VALUES(42, 'yolo')`,
-		`CREATE VIEW myview AS SELECT i FROM mytable`,
+		`CREATE VIEW myview3 AS SELECT i FROM mytable`,
 		`DROP VIEW myview`,
 	}
 

--- a/enginetest/harness.go
+++ b/enginetest/harness.go
@@ -31,7 +31,7 @@ type Harness interface {
 	// harnesses should generally dispatch to enginetest.NewContext(harness), rather than calling this method themselves.
 	NewContext() *sql.Context
 	// NewSession returns a context with a new Session, rather than reusing an existing session from previous calls to
-	// NewContext() 
+	// NewContext()
 	NewSession() *sql.Context
 }
 

--- a/enginetest/harness.go
+++ b/enginetest/harness.go
@@ -30,6 +30,9 @@ type Harness interface {
 	// additional information (e.g. current DB) set uniformly. To replicated the behavior of tests during setup,
 	// harnesses should generally dispatch to enginetest.NewContext(harness), rather than calling this method themselves.
 	NewContext() *sql.Context
+	// NewSession returns a context with a new Session, rather than reusing an existing session from previous calls to
+	// NewContext() 
+	NewSession() *sql.Context
 }
 
 // SkippingHarness provides a way for integrators to skip tests that are known to be broken. E.g., integrators that

--- a/enginetest/memoryharness.go
+++ b/enginetest/memoryharness.go
@@ -33,6 +33,10 @@ type MemoryHarness struct {
 	session                sql.Session
 }
 
+func (m *MemoryHarness) NewSession() *sql.Context {
+	return m.NewContext()
+}
+
 const testNumPartitions = 5
 
 func NewMemoryHarness(name string, parallelism int, numTablePartitions int, useNativeIndexes bool, indexDriverInitalizer IndexDriverInitalizer) *MemoryHarness {

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -39,428 +39,454 @@ func includeTable(includedTables []string, tableName string) bool {
 	return false
 }
 
+func wrapInTransaction(t *testing.T, db sql.Database, harness Harness, fn func()) {
+	if tdb, ok := db.(sql.TransactionDatabase); ok {
+		ctx := NewContext(harness)
+		tx, err := tdb.StartTransaction(ctx)
+		require.NoError(t, err)
+		ctx.SetTransaction(tx)
+	}
+
+	fn()
+
+	if tdb, ok := db.(sql.TransactionDatabase); ok {
+		ctx := NewContext(harness)
+		err := tdb.CommitTransaction(ctx, ctx.GetTransaction())
+		require.NoError(t, err)
+		ctx.SetTransaction(nil)
+	}
+}
+
 // createSubsetTestData creates test tables and data. Passing a non-nil slice for includedTables will restrict the
 // table creation to just those tables named.
 func CreateSubsetTestData(t *testing.T, harness Harness, includedTables []string) []sql.Database {
 	myDb := harness.NewDatabase("mydb")
 	foo := harness.NewDatabase("foo")
-	var table sql.Table
-	var err error
 
-	if includeTable(includedTables, "mytable") {
-		table, err = harness.NewTable(myDb, "mytable", sql.Schema{
-			{Name: "i", Type: sql.Int64, Source: "mytable", PrimaryKey: true},
-			{Name: "s", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20), Source: "mytable", Comment: "column s"},
-		})
+	// This is a bit odd, but because this setup doesn't interact with the engine.Query path, we need to do transaction
+	// management here, instead. If we don't, then any Query-based setup will wipe out our work by starting a new
+	// transaction without commiting the work done so far.
+	// The secondary foo database doesn't have this problem because we don't mix and match query and non-query setup
+	// when adding data to it
+	wrapInTransaction(t, myDb, harness, func() {
+		var table sql.Table
+		var err error
 
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(1), "first row"),
-				sql.NewRow(int64(2), "second row"),
-				sql.NewRow(int64(3), "third row"))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "mytable", err)
-		}
-	}
+		if includeTable(includedTables, "mytable") {
+			table, err = harness.NewTable(myDb, "mytable", sql.Schema{
+				{Name: "i", Type: sql.Int64, Source: "mytable", PrimaryKey: true},
+				{Name: "s", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20), Source: "mytable", Comment: "column s"},
+			})
 
-	if includeTable(includedTables, "one_pk") {
-		table, err = harness.NewTable(myDb, "one_pk", sql.Schema{
-			{Name: "pk", Type: sql.Int8, Source: "one_pk", PrimaryKey: true},
-			{Name: "c1", Type: sql.Int8, Source: "one_pk"},
-			{Name: "c2", Type: sql.Int8, Source: "one_pk"},
-			{Name: "c3", Type: sql.Int8, Source: "one_pk"},
-			{Name: "c4", Type: sql.Int8, Source: "one_pk"},
-			{Name: "c5", Type: sql.Int8, Source: "one_pk"},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(0, 0, 1, 2, 3, 4),
-				sql.NewRow(1, 10, 11, 12, 13, 14),
-				sql.NewRow(2, 20, 21, 22, 23, 24),
-				sql.NewRow(3, 30, 31, 32, 33, 34))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "one_pk", err)
-		}
-	}
-
-	if includeTable(includedTables, "two_pk") {
-		table, err = harness.NewTable(myDb, "two_pk", sql.Schema{
-			{Name: "pk1", Type: sql.Int8, Source: "two_pk", PrimaryKey: true},
-			{Name: "pk2", Type: sql.Int8, Source: "two_pk", PrimaryKey: true},
-			{Name: "c1", Type: sql.Int8, Source: "two_pk"},
-			{Name: "c2", Type: sql.Int8, Source: "two_pk"},
-			{Name: "c3", Type: sql.Int8, Source: "two_pk"},
-			{Name: "c4", Type: sql.Int8, Source: "two_pk"},
-			{Name: "c5", Type: sql.Int8, Source: "two_pk"},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(0, 0, 0, 1, 2, 3, 4),
-				sql.NewRow(0, 1, 10, 11, 12, 13, 14),
-				sql.NewRow(1, 0, 20, 21, 22, 23, 24),
-				sql.NewRow(1, 1, 30, 31, 32, 33, 34))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "two_pk", err)
-		}
-	}
-
-	if includeTable(includedTables, "othertable") {
-		table, err = harness.NewTable(myDb, "othertable", sql.Schema{
-			{Name: "s2", Type: sql.Text, Source: "othertable"},
-			{Name: "i2", Type: sql.Int64, Source: "othertable", PrimaryKey: true},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow("first", int64(3)),
-				sql.NewRow("second", int64(2)),
-				sql.NewRow("third", int64(1)))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "othertable", err)
-		}
-	}
-
-	if includeTable(includedTables, "tabletest") {
-		table, err = harness.NewTable(myDb, "tabletest", sql.Schema{
-			{Name: "i", Type: sql.Int32, Source: "tabletest", PrimaryKey: true},
-			{Name: "s", Type: sql.Text, Source: "tabletest"},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(1), "first row"),
-				sql.NewRow(int64(2), "second row"),
-				sql.NewRow(int64(3), "third row"))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "tabletest", err)
-		}
-	}
-
-	if includeTable(includedTables, "emptytable") {
-		table, err = harness.NewTable(myDb, "emptytable", sql.Schema{
-			{Name: "i", Type: sql.Int32, Source: "emptytable", PrimaryKey: true},
-			{Name: "s", Type: sql.Text, Source: "emptytable"},
-		})
-
-		if err != nil {
-			t.Logf("Warning: could not create table %s: %s", "tabletest", err)
-		}
-	}
-
-	if includeTable(includedTables, "other_table") {
-		table, err = harness.NewTable(foo, "other_table", sql.Schema{
-			{Name: "text", Type: sql.Text, Source: "other_table", PrimaryKey: true},
-			{Name: "number", Type: sql.Int32, Source: "other_table"},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow("a", int32(4)),
-				sql.NewRow("b", int32(2)),
-				sql.NewRow("c", int32(0)))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "other_table", err)
-		}
-	}
-
-	if includeTable(includedTables, "bigtable") {
-		table, err = harness.NewTable(myDb, "bigtable", sql.Schema{
-			{Name: "t", Type: sql.Text, Source: "bigtable", PrimaryKey: true},
-			{Name: "n", Type: sql.Int64, Source: "bigtable"},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow("a", int64(1)),
-				sql.NewRow("s", int64(2)),
-				sql.NewRow("f", int64(3)),
-				sql.NewRow("g", int64(1)),
-				sql.NewRow("h", int64(2)),
-				sql.NewRow("j", int64(3)),
-				sql.NewRow("k", int64(1)),
-				sql.NewRow("l", int64(2)),
-				sql.NewRow("ñ", int64(4)),
-				sql.NewRow("z", int64(5)),
-				sql.NewRow("x", int64(6)),
-				sql.NewRow("c", int64(7)),
-				sql.NewRow("v", int64(8)),
-				sql.NewRow("b", int64(9)))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "bigtable", err)
-		}
-	}
-
-	if includeTable(includedTables, "floattable") {
-		table, err = harness.NewTable(myDb, "floattable", sql.Schema{
-			{Name: "i", Type: sql.Int64, Source: "floattable", PrimaryKey: true},
-			{Name: "f32", Type: sql.Float32, Source: "floattable"},
-			{Name: "f64", Type: sql.Float64, Source: "floattable"},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(1), float32(1.0), float64(1.0)),
-				sql.NewRow(int64(2), float32(1.5), float64(1.5)),
-				sql.NewRow(int64(3), float32(2.0), float64(2.0)),
-				sql.NewRow(int64(4), float32(2.5), float64(2.5)),
-				sql.NewRow(int64(-1), float32(-1.0), float64(-1.0)),
-				sql.NewRow(int64(-2), float32(-1.5), float64(-1.5)))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "floattable", err)
-		}
-	}
-
-	if includeTable(includedTables, "people") {
-		table, err = harness.NewTable(myDb, "people", sql.Schema{
-			{Name: "dob", Type: sql.Date, Source: "people", PrimaryKey: true},
-			{Name: "first_name", Type: sql.Text, Source: "people", PrimaryKey: true},
-			{Name: "last_name", Type: sql.Text, Source: "people", PrimaryKey: true},
-			{Name: "middle_name", Type: sql.Text, Source: "people", PrimaryKey: true},
-			{Name: "height_inches", Type: sql.Int64, Source: "people", Nullable: false},
-			{Name: "gender", Type: sql.Int64, Source: "people", Nullable: false},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(dob(1970, 12, 1), "jon", "smith", "", int64(72), int64(0)),
-				sql.NewRow(dob(1980, 1, 11), "jon", "smith", "", int64(67), int64(0)),
-				sql.NewRow(dob(1990, 2, 21), "jane", "doe", "", int64(68), int64(1)),
-				sql.NewRow(dob(2000, 12, 31), "frank", "franklin", "", int64(70), int64(2)),
-				sql.NewRow(dob(2010, 3, 15), "jane", "doe", "", int64(69), int64(1)))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "niltable", err)
-		}
-	}
-
-	if includeTable(includedTables, "niltable") {
-		table, err = harness.NewTable(myDb, "niltable", sql.Schema{
-			{Name: "i", Type: sql.Int64, Source: "niltable", PrimaryKey: true},
-			{Name: "i2", Type: sql.Int64, Source: "niltable", Nullable: true},
-			{Name: "b", Type: sql.Boolean, Source: "niltable", Nullable: true},
-			{Name: "f", Type: sql.Float64, Source: "niltable", Nullable: true},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(1), nil, nil, nil),
-				sql.NewRow(int64(2), int64(2), 1, nil),
-				sql.NewRow(int64(3), nil, 0, nil),
-				sql.NewRow(int64(4), int64(4), nil, float64(4)),
-				sql.NewRow(int64(5), nil, 1, float64(5)),
-				sql.NewRow(int64(6), int64(6), 0, float64(6)))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "niltable", err)
-		}
-	}
-
-	if includeTable(includedTables, "newlinetable") {
-		table, err = harness.NewTable(myDb, "newlinetable", sql.Schema{
-			{Name: "i", Type: sql.Int64, Source: "newlinetable", PrimaryKey: true},
-			{Name: "s", Type: sql.Text, Source: "newlinetable"},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(1), "\nthere is some text in here"),
-				sql.NewRow(int64(2), "there is some\ntext in here"),
-				sql.NewRow(int64(3), "there is some text\nin here"),
-				sql.NewRow(int64(4), "there is some text in here\n"),
-				sql.NewRow(int64(5), "there is some text in here"))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "newlinetable", err)
-		}
-	}
-
-	if includeTable(includedTables, "typestable") {
-		table, err = harness.NewTable(myDb, "typestable", sql.Schema{
-			{Name: "id", Type: sql.Int64, Source: "typestable", PrimaryKey: true},
-			{Name: "i8", Type: sql.Int8, Source: "typestable", Nullable: true},
-			{Name: "i16", Type: sql.Int16, Source: "typestable", Nullable: true},
-			{Name: "i32", Type: sql.Int32, Source: "typestable", Nullable: true},
-			{Name: "i64", Type: sql.Int64, Source: "typestable", Nullable: true},
-			{Name: "u8", Type: sql.Uint8, Source: "typestable", Nullable: true},
-			{Name: "u16", Type: sql.Uint16, Source: "typestable", Nullable: true},
-			{Name: "u32", Type: sql.Uint32, Source: "typestable", Nullable: true},
-			{Name: "u64", Type: sql.Uint64, Source: "typestable", Nullable: true},
-			{Name: "f32", Type: sql.Float32, Source: "typestable", Nullable: true},
-			{Name: "f64", Type: sql.Float64, Source: "typestable", Nullable: true},
-			{Name: "ti", Type: sql.Timestamp, Source: "typestable", Nullable: true},
-			{Name: "da", Type: sql.Date, Source: "typestable", Nullable: true},
-			{Name: "te", Type: sql.Text, Source: "typestable", Nullable: true},
-			{Name: "bo", Type: sql.Boolean, Source: "typestable", Nullable: true},
-			{Name: "js", Type: sql.JSON, Source: "typestable", Nullable: true},
-			{Name: "bl", Type: sql.Blob, Source: "typestable", Nullable: true},
-		})
-
-		if err == nil {
-			t1, err := time.Parse(time.RFC3339, "2019-12-31T12:00:00Z")
-			require.NoError(t, err)
-			t2, err := time.Parse(time.RFC3339, "2019-12-31T00:00:00Z")
-			require.NoError(t, err)
-
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(
-					int64(1),
-					int8(2),
-					int16(3),
-					int32(4),
-					int64(5),
-					uint8(6),
-					uint16(7),
-					uint32(8),
-					uint64(9),
-					float32(10),
-					float64(11),
-					t1,
-					t2,
-					"fourteen",
-					0,
-					nil,
-					nil,
-				))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "typestable", err)
-		}
-	}
-
-	if includeTable(includedTables, "stringandtable") {
-		table, err = harness.NewTable(myDb, "stringandtable", sql.Schema{
-			{Name: "k", Type: sql.Int64, Source: "stringandtable", PrimaryKey: true},
-			{Name: "i", Type: sql.Int64, Source: "stringandtable", Nullable: true},
-			{Name: "v", Type: sql.Text, Source: "stringandtable", Nullable: true},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(0), int64(0), "0"),
-				sql.NewRow(int64(1), int64(1), "1"),
-				sql.NewRow(int64(2), int64(2), ""),
-				sql.NewRow(int64(3), int64(3), "true"),
-				sql.NewRow(int64(4), int64(4), "false"),
-				sql.NewRow(int64(5), int64(5), nil),
-				sql.NewRow(int64(6), nil, "2"))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "stringandtable", err)
-		}
-	}
-
-	if includeTable(includedTables, "reservedWordsTable") {
-		table, err = harness.NewTable(myDb, "reservedWordsTable", sql.Schema{
-			{Name: "Timestamp", Type: sql.Text, Source: "reservedWordsTable", PrimaryKey: true},
-			{Name: "and", Type: sql.Text, Source: "reservedWordsTable", Nullable: true},
-			{Name: "or", Type: sql.Text, Source: "reservedWordsTable", Nullable: true},
-			{Name: "select", Type: sql.Text, Source: "reservedWordsTable", Nullable: true},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow("1", "1.1", "aaa", "create"))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "reservedWordsTable", err)
-		}
-	}
-
-	if includeTable(includedTables, "fk_tbl") {
-		table, err = harness.NewTable(myDb, "fk_tbl", sql.Schema{
-			{Name: "pk", Type: sql.Int64, Source: "fk_tbl", PrimaryKey: true},
-			{Name: "a", Type: sql.Int64, Source: "fk_tbl", Nullable: true},
-			{Name: "b", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20), Source: "fk_tbl", Nullable: true},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(1, 1, "first row"),
-				sql.NewRow(2, 2, "second row"),
-				sql.NewRow(3, 3, "third row"),
-			)
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "fk_tbl", err)
-		}
-	}
-
-	if includeTable(includedTables, "auto_increment_tbl") {
-		table, err = harness.NewTable(myDb, "auto_increment_tbl", sql.Schema{
-			{Name: "pk", Type: sql.Int64, Source: "auto_increment_tbl", PrimaryKey: true, AutoIncrement: true, Extra: "auto_increment"},
-			{Name: "c0", Type: sql.Int64, Source: "auto_increment_tbl", Nullable: true},
-		})
-
-		autoTbl, ok := table.(sql.AutoIncrementTable)
-
-		if err == nil && ok {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, autoTbl),
-				sql.NewRow(1, 11),
-				sql.NewRow(2, 22),
-				sql.NewRow(3, 33),
-			)
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "auto_increment_tbl", err)
-		}
-	}
-
-	if versionedHarness, ok := harness.(VersionedDBHarness); ok &&
-		includeTable(includedTables, "myhistorytable") {
-		versionedDb, ok := myDb.(sql.VersionedDatabase)
-		if !ok {
-			panic("VersionedDbTestHarness must provide a VersionedDatabase implementation")
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(1), "first row"),
+					sql.NewRow(int64(2), "second row"),
+					sql.NewRow(int64(3), "third row"))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "mytable", err)
+			}
 		}
 
-		table = versionedHarness.NewTableAsOf(versionedDb, "myhistorytable", sql.Schema{
-			{Name: "i", Type: sql.Int64, Source: "myhistorytable", PrimaryKey: true},
-			{Name: "s", Type: sql.Text, Source: "myhistorytable"},
-		}, "2019-01-01")
+		if includeTable(includedTables, "one_pk") {
+			table, err = harness.NewTable(myDb, "one_pk", sql.Schema{
+				{Name: "pk", Type: sql.Int8, Source: "one_pk", PrimaryKey: true},
+				{Name: "c1", Type: sql.Int8, Source: "one_pk"},
+				{Name: "c2", Type: sql.Int8, Source: "one_pk"},
+				{Name: "c3", Type: sql.Int8, Source: "one_pk"},
+				{Name: "c4", Type: sql.Int8, Source: "one_pk"},
+				{Name: "c5", Type: sql.Int8, Source: "one_pk"},
+			})
 
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(1), "first row, 1"),
-				sql.NewRow(int64(2), "second row, 1"),
-				sql.NewRow(int64(3), "third row, 1"))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "myhistorytable", err)
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(0, 0, 1, 2, 3, 4),
+					sql.NewRow(1, 10, 11, 12, 13, 14),
+					sql.NewRow(2, 20, 21, 22, 23, 24),
+					sql.NewRow(3, 30, 31, 32, 33, 34))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "one_pk", err)
+			}
 		}
 
-		require.NoError(t, versionedHarness.SnapshotTable(versionedDb, "myhistorytable", "2019-01-01"))
+		if includeTable(includedTables, "two_pk") {
+			table, err = harness.NewTable(myDb, "two_pk", sql.Schema{
+				{Name: "pk1", Type: sql.Int8, Source: "two_pk", PrimaryKey: true},
+				{Name: "pk2", Type: sql.Int8, Source: "two_pk", PrimaryKey: true},
+				{Name: "c1", Type: sql.Int8, Source: "two_pk"},
+				{Name: "c2", Type: sql.Int8, Source: "two_pk"},
+				{Name: "c3", Type: sql.Int8, Source: "two_pk"},
+				{Name: "c4", Type: sql.Int8, Source: "two_pk"},
+				{Name: "c5", Type: sql.Int8, Source: "two_pk"},
+			})
 
-		table = versionedHarness.NewTableAsOf(versionedDb, "myhistorytable", sql.Schema{
-			{Name: "i", Type: sql.Int64, Source: "myhistorytable", PrimaryKey: true},
-			{Name: "s", Type: sql.Text, Source: "myhistorytable"},
-		}, "2019-01-02")
-
-		if err == nil {
-			DeleteRows(t, NewContext(harness), mustDeletableTable(t, table),
-				sql.NewRow(int64(1), "first row, 1"),
-				sql.NewRow(int64(2), "second row, 1"),
-				sql.NewRow(int64(3), "third row, 1"))
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(1), "first row, 2"),
-				sql.NewRow(int64(2), "second row, 2"),
-				sql.NewRow(int64(3), "third row, 2"))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "myhistorytable", err)
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(0, 0, 0, 1, 2, 3, 4),
+					sql.NewRow(0, 1, 10, 11, 12, 13, 14),
+					sql.NewRow(1, 0, 20, 21, 22, 23, 24),
+					sql.NewRow(1, 1, 30, 31, 32, 33, 34))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "two_pk", err)
+			}
 		}
 
-		require.NoError(t, versionedHarness.SnapshotTable(versionedDb, "myhistorytable", "2019-01-02"))
-	}
+		if includeTable(includedTables, "othertable") {
+			table, err = harness.NewTable(myDb, "othertable", sql.Schema{
+				{Name: "s2", Type: sql.Text, Source: "othertable"},
+				{Name: "i2", Type: sql.Int64, Source: "othertable", PrimaryKey: true},
+			})
 
-	if keyless, ok := harness.(KeylessTableHarness); ok &&
-		keyless.SupportsKeylessTables() &&
-		includeTable(includedTables, "keyless") {
-		table, err = harness.NewTable(myDb, "keyless", sql.Schema{
-			{Name: "c0", Type: sql.Int64, Source: "keyless", Nullable: true},
-			{Name: "c1", Type: sql.Int64, Source: "keyless", Nullable: true},
-		})
-
-		if err == nil {
-			InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-				sql.NewRow(int64(0), int64(0)),
-				sql.NewRow(int64(1), int64(1)),
-				sql.NewRow(int64(1), int64(1)),
-				sql.NewRow(int64(2), int64(2)))
-		} else {
-			t.Logf("Warning: could not create table %s: %s", "keyless", err)
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow("first", int64(3)),
+					sql.NewRow("second", int64(2)),
+					sql.NewRow("third", int64(1)))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "othertable", err)
+			}
 		}
-	}
+
+		if includeTable(includedTables, "tabletest") {
+			table, err = harness.NewTable(myDb, "tabletest", sql.Schema{
+				{Name: "i", Type: sql.Int32, Source: "tabletest", PrimaryKey: true},
+				{Name: "s", Type: sql.Text, Source: "tabletest"},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(1), "first row"),
+					sql.NewRow(int64(2), "second row"),
+					sql.NewRow(int64(3), "third row"))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "tabletest", err)
+			}
+		}
+
+		if includeTable(includedTables, "emptytable") {
+			table, err = harness.NewTable(myDb, "emptytable", sql.Schema{
+				{Name: "i", Type: sql.Int32, Source: "emptytable", PrimaryKey: true},
+				{Name: "s", Type: sql.Text, Source: "emptytable"},
+			})
+
+			if err != nil {
+				t.Logf("Warning: could not create table %s: %s", "tabletest", err)
+			}
+		}
+
+		if includeTable(includedTables, "other_table") {
+			table, err = harness.NewTable(foo, "other_table", sql.Schema{
+				{Name: "text", Type: sql.Text, Source: "other_table", PrimaryKey: true},
+				{Name: "number", Type: sql.Int32, Source: "other_table"},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow("a", int32(4)),
+					sql.NewRow("b", int32(2)),
+					sql.NewRow("c", int32(0)))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "other_table", err)
+			}
+		}
+
+		if includeTable(includedTables, "bigtable") {
+			table, err = harness.NewTable(myDb, "bigtable", sql.Schema{
+				{Name: "t", Type: sql.Text, Source: "bigtable", PrimaryKey: true},
+				{Name: "n", Type: sql.Int64, Source: "bigtable"},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow("a", int64(1)),
+					sql.NewRow("s", int64(2)),
+					sql.NewRow("f", int64(3)),
+					sql.NewRow("g", int64(1)),
+					sql.NewRow("h", int64(2)),
+					sql.NewRow("j", int64(3)),
+					sql.NewRow("k", int64(1)),
+					sql.NewRow("l", int64(2)),
+					sql.NewRow("ñ", int64(4)),
+					sql.NewRow("z", int64(5)),
+					sql.NewRow("x", int64(6)),
+					sql.NewRow("c", int64(7)),
+					sql.NewRow("v", int64(8)),
+					sql.NewRow("b", int64(9)))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "bigtable", err)
+			}
+		}
+
+		if includeTable(includedTables, "floattable") {
+			table, err = harness.NewTable(myDb, "floattable", sql.Schema{
+				{Name: "i", Type: sql.Int64, Source: "floattable", PrimaryKey: true},
+				{Name: "f32", Type: sql.Float32, Source: "floattable"},
+				{Name: "f64", Type: sql.Float64, Source: "floattable"},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(1), float32(1.0), float64(1.0)),
+					sql.NewRow(int64(2), float32(1.5), float64(1.5)),
+					sql.NewRow(int64(3), float32(2.0), float64(2.0)),
+					sql.NewRow(int64(4), float32(2.5), float64(2.5)),
+					sql.NewRow(int64(-1), float32(-1.0), float64(-1.0)),
+					sql.NewRow(int64(-2), float32(-1.5), float64(-1.5)))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "floattable", err)
+			}
+		}
+
+		if includeTable(includedTables, "people") {
+			table, err = harness.NewTable(myDb, "people", sql.Schema{
+				{Name: "dob", Type: sql.Date, Source: "people", PrimaryKey: true},
+				{Name: "first_name", Type: sql.Text, Source: "people", PrimaryKey: true},
+				{Name: "last_name", Type: sql.Text, Source: "people", PrimaryKey: true},
+				{Name: "middle_name", Type: sql.Text, Source: "people", PrimaryKey: true},
+				{Name: "height_inches", Type: sql.Int64, Source: "people", Nullable: false},
+				{Name: "gender", Type: sql.Int64, Source: "people", Nullable: false},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(dob(1970, 12, 1), "jon", "smith", "", int64(72), int64(0)),
+					sql.NewRow(dob(1980, 1, 11), "jon", "smith", "", int64(67), int64(0)),
+					sql.NewRow(dob(1990, 2, 21), "jane", "doe", "", int64(68), int64(1)),
+					sql.NewRow(dob(2000, 12, 31), "frank", "franklin", "", int64(70), int64(2)),
+					sql.NewRow(dob(2010, 3, 15), "jane", "doe", "", int64(69), int64(1)))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "niltable", err)
+			}
+		}
+
+		if includeTable(includedTables, "niltable") {
+			table, err = harness.NewTable(myDb, "niltable", sql.Schema{
+				{Name: "i", Type: sql.Int64, Source: "niltable", PrimaryKey: true},
+				{Name: "i2", Type: sql.Int64, Source: "niltable", Nullable: true},
+				{Name: "b", Type: sql.Boolean, Source: "niltable", Nullable: true},
+				{Name: "f", Type: sql.Float64, Source: "niltable", Nullable: true},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(1), nil, nil, nil),
+					sql.NewRow(int64(2), int64(2), 1, nil),
+					sql.NewRow(int64(3), nil, 0, nil),
+					sql.NewRow(int64(4), int64(4), nil, float64(4)),
+					sql.NewRow(int64(5), nil, 1, float64(5)),
+					sql.NewRow(int64(6), int64(6), 0, float64(6)))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "niltable", err)
+			}
+		}
+
+		if includeTable(includedTables, "newlinetable") {
+			table, err = harness.NewTable(myDb, "newlinetable", sql.Schema{
+				{Name: "i", Type: sql.Int64, Source: "newlinetable", PrimaryKey: true},
+				{Name: "s", Type: sql.Text, Source: "newlinetable"},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(1), "\nthere is some text in here"),
+					sql.NewRow(int64(2), "there is some\ntext in here"),
+					sql.NewRow(int64(3), "there is some text\nin here"),
+					sql.NewRow(int64(4), "there is some text in here\n"),
+					sql.NewRow(int64(5), "there is some text in here"))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "newlinetable", err)
+			}
+		}
+
+		if includeTable(includedTables, "typestable") {
+			table, err = harness.NewTable(myDb, "typestable", sql.Schema{
+				{Name: "id", Type: sql.Int64, Source: "typestable", PrimaryKey: true},
+				{Name: "i8", Type: sql.Int8, Source: "typestable", Nullable: true},
+				{Name: "i16", Type: sql.Int16, Source: "typestable", Nullable: true},
+				{Name: "i32", Type: sql.Int32, Source: "typestable", Nullable: true},
+				{Name: "i64", Type: sql.Int64, Source: "typestable", Nullable: true},
+				{Name: "u8", Type: sql.Uint8, Source: "typestable", Nullable: true},
+				{Name: "u16", Type: sql.Uint16, Source: "typestable", Nullable: true},
+				{Name: "u32", Type: sql.Uint32, Source: "typestable", Nullable: true},
+				{Name: "u64", Type: sql.Uint64, Source: "typestable", Nullable: true},
+				{Name: "f32", Type: sql.Float32, Source: "typestable", Nullable: true},
+				{Name: "f64", Type: sql.Float64, Source: "typestable", Nullable: true},
+				{Name: "ti", Type: sql.Timestamp, Source: "typestable", Nullable: true},
+				{Name: "da", Type: sql.Date, Source: "typestable", Nullable: true},
+				{Name: "te", Type: sql.Text, Source: "typestable", Nullable: true},
+				{Name: "bo", Type: sql.Boolean, Source: "typestable", Nullable: true},
+				{Name: "js", Type: sql.JSON, Source: "typestable", Nullable: true},
+				{Name: "bl", Type: sql.Blob, Source: "typestable", Nullable: true},
+			})
+
+			if err == nil {
+				t1, err := time.Parse(time.RFC3339, "2019-12-31T12:00:00Z")
+				require.NoError(t, err)
+				t2, err := time.Parse(time.RFC3339, "2019-12-31T00:00:00Z")
+				require.NoError(t, err)
+
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(
+						int64(1),
+						int8(2),
+						int16(3),
+						int32(4),
+						int64(5),
+						uint8(6),
+						uint16(7),
+						uint32(8),
+						uint64(9),
+						float32(10),
+						float64(11),
+						t1,
+						t2,
+						"fourteen",
+						0,
+						nil,
+						nil,
+					))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "typestable", err)
+			}
+		}
+
+		if includeTable(includedTables, "stringandtable") {
+			table, err = harness.NewTable(myDb, "stringandtable", sql.Schema{
+				{Name: "k", Type: sql.Int64, Source: "stringandtable", PrimaryKey: true},
+				{Name: "i", Type: sql.Int64, Source: "stringandtable", Nullable: true},
+				{Name: "v", Type: sql.Text, Source: "stringandtable", Nullable: true},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(0), int64(0), "0"),
+					sql.NewRow(int64(1), int64(1), "1"),
+					sql.NewRow(int64(2), int64(2), ""),
+					sql.NewRow(int64(3), int64(3), "true"),
+					sql.NewRow(int64(4), int64(4), "false"),
+					sql.NewRow(int64(5), int64(5), nil),
+					sql.NewRow(int64(6), nil, "2"))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "stringandtable", err)
+			}
+		}
+
+		if includeTable(includedTables, "reservedWordsTable") {
+			table, err = harness.NewTable(myDb, "reservedWordsTable", sql.Schema{
+				{Name: "Timestamp", Type: sql.Text, Source: "reservedWordsTable", PrimaryKey: true},
+				{Name: "and", Type: sql.Text, Source: "reservedWordsTable", Nullable: true},
+				{Name: "or", Type: sql.Text, Source: "reservedWordsTable", Nullable: true},
+				{Name: "select", Type: sql.Text, Source: "reservedWordsTable", Nullable: true},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow("1", "1.1", "aaa", "create"))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "reservedWordsTable", err)
+			}
+		}
+
+		if includeTable(includedTables, "fk_tbl") {
+			table, err = harness.NewTable(myDb, "fk_tbl", sql.Schema{
+				{Name: "pk", Type: sql.Int64, Source: "fk_tbl", PrimaryKey: true},
+				{Name: "a", Type: sql.Int64, Source: "fk_tbl", Nullable: true},
+				{Name: "b", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20), Source: "fk_tbl", Nullable: true},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(1, 1, "first row"),
+					sql.NewRow(2, 2, "second row"),
+					sql.NewRow(3, 3, "third row"),
+				)
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "fk_tbl", err)
+			}
+		}
+
+		if includeTable(includedTables, "auto_increment_tbl") {
+			table, err = harness.NewTable(myDb, "auto_increment_tbl", sql.Schema{
+				{Name: "pk", Type: sql.Int64, Source: "auto_increment_tbl", PrimaryKey: true, AutoIncrement: true, Extra: "auto_increment"},
+				{Name: "c0", Type: sql.Int64, Source: "auto_increment_tbl", Nullable: true},
+			})
+
+			autoTbl, ok := table.(sql.AutoIncrementTable)
+
+			if err == nil && ok {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, autoTbl),
+					sql.NewRow(1, 11),
+					sql.NewRow(2, 22),
+					sql.NewRow(3, 33),
+				)
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "auto_increment_tbl", err)
+			}
+		}
+
+		if versionedHarness, ok := harness.(VersionedDBHarness); ok &&
+			includeTable(includedTables, "myhistorytable") {
+			versionedDb, ok := myDb.(sql.VersionedDatabase)
+			if !ok {
+				panic("VersionedDbTestHarness must provide a VersionedDatabase implementation")
+			}
+
+			table = versionedHarness.NewTableAsOf(versionedDb, "myhistorytable", sql.Schema{
+				{Name: "i", Type: sql.Int64, Source: "myhistorytable", PrimaryKey: true},
+				{Name: "s", Type: sql.Text, Source: "myhistorytable"},
+			}, "2019-01-01")
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(1), "first row, 1"),
+					sql.NewRow(int64(2), "second row, 1"),
+					sql.NewRow(int64(3), "third row, 1"))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "myhistorytable", err)
+			}
+
+			require.NoError(t, versionedHarness.SnapshotTable(versionedDb, "myhistorytable", "2019-01-01"))
+
+			table = versionedHarness.NewTableAsOf(versionedDb, "myhistorytable", sql.Schema{
+				{Name: "i", Type: sql.Int64, Source: "myhistorytable", PrimaryKey: true},
+				{Name: "s", Type: sql.Text, Source: "myhistorytable"},
+			}, "2019-01-02")
+
+			if err == nil {
+				DeleteRows(t, NewContext(harness), mustDeletableTable(t, table),
+					sql.NewRow(int64(1), "first row, 1"),
+					sql.NewRow(int64(2), "second row, 1"),
+					sql.NewRow(int64(3), "third row, 1"))
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(1), "first row, 2"),
+					sql.NewRow(int64(2), "second row, 2"),
+					sql.NewRow(int64(3), "third row, 2"))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "myhistorytable", err)
+			}
+
+			require.NoError(t, versionedHarness.SnapshotTable(versionedDb, "myhistorytable", "2019-01-02"))
+		}
+
+		if keyless, ok := harness.(KeylessTableHarness); ok &&
+			keyless.SupportsKeylessTables() &&
+			includeTable(includedTables, "keyless") {
+			table, err = harness.NewTable(myDb, "keyless", sql.Schema{
+				{Name: "c0", Type: sql.Int64, Source: "keyless", Nullable: true},
+				{Name: "c1", Type: sql.Int64, Source: "keyless", Nullable: true},
+			})
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					sql.NewRow(int64(0), int64(0)),
+					sql.NewRow(int64(1), int64(1)),
+					sql.NewRow(int64(1), int64(1)),
+					sql.NewRow(int64(2), int64(2)))
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "keyless", err)
+			}
+		}
+	})
 
 	return []sql.Database{myDb, foo}
 }

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -65,7 +65,7 @@ func CreateSubsetTestData(t *testing.T, harness Harness, includedTables []string
 
 	// This is a bit odd, but because this setup doesn't interact with the engine.Query path, we need to do transaction
 	// management here, instead. If we don't, then any Query-based setup will wipe out our work by starting a new
-	// transaction without commiting the work done so far.
+	// transaction without committing the work done so far.
 	// The secondary foo database doesn't have this problem because we don't mix and match query and non-query setup
 	// when adding data to it
 	wrapInTransaction(t, myDb, harness, func() {

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -39,6 +39,8 @@ func includeTable(includedTables []string, tableName string) bool {
 	return false
 }
 
+// wrapInTransaction runs the function given surrounded in a transaction. If the db provided doesn't implement
+// sql.TransactionDatabase, then the function is simply run and the transaction logic is a no-op.
 func wrapInTransaction(t *testing.T, db sql.Database, harness Harness, fn func()) {
 	if tdb, ok := db.(sql.TransactionDatabase); ok {
 		ctx := NewContext(harness)

--- a/enginetest/transaction_queries.go
+++ b/enginetest/transaction_queries.go
@@ -53,7 +53,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 						{2, 2},
@@ -70,7 +70,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 						{2, 2},
@@ -104,7 +104,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 					},
@@ -120,7 +120,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 					},
@@ -136,7 +136,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 						{2, 2},
@@ -153,7 +153,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 						{3, 3},
@@ -163,7 +163,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 						{2, 2},
@@ -180,7 +180,24 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
+					Expected:        []sql.Row{
+						{1, 1},
+						{2, 2},
+					},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "start transaction",
+					Expected:        []sql.Row{},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 						{2, 2},
@@ -191,7 +208,7 @@ var TransactionTests = []TransactionTest{
 			{
 				Client:              "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a",
+					Query:           "select * from a order by b",
 					Expected:        []sql.Row{
 						{1, 1},
 						{2, 2},

--- a/enginetest/transaction_queries.go
+++ b/enginetest/transaction_queries.go
@@ -80,4 +80,125 @@ var TransactionTests = []TransactionTest{
 			},
 		},
 	},
+	{
+		Name:        "autocommit off",
+		SetUpScript: []string {
+			"create table a (b int primary key, c int)",
+			"insert into a values (1, 1)",
+		},
+		Assertions:  []TransactionTestAssertion{
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "set autocommit = off",
+					Expected:        []sql.Row{{}},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "set autocommit = off",
+					Expected:        []sql.Row{{}},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+					},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "insert into a values (2, 2)",
+					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+				},
+			},
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+					},
+				},
+			},
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "insert into a values (3,3)",
+					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+						{2, 2},
+					},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "commit",
+					Expected:        []sql.Row{},
+				},
+			},
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+						{3, 3},
+					},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+						{2, 2},
+					},
+				},
+			},
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "commit",
+					Expected:        []sql.Row{},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+						{2, 2},
+						{3, 3},
+					},
+				},
+			},
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+						{2, 2},
+						{3, 3},
+					},
+				},
+			},
+		},
+	},
 }

--- a/enginetest/transaction_queries.go
+++ b/enginetest/transaction_queries.go
@@ -1,0 +1,83 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+// TransactionTest is a script to test transaction correctness. It's similar to ScriptTest, but its assertions name
+// clients that participate
+type TransactionTest struct {
+	// Name of the script test
+	Name string
+	// The sql statements to execute as setup, in order. Results are not checked, but statements must not error.
+	// Setup scripts are run as a distinct client separate from the client used in any assertions.
+	SetUpScript []string
+	// The set of assertions to make after setup, in order
+	Assertions []TransactionTestAssertion
+}
+
+type TransactionTestAssertion struct {
+	// Client the name of the client executing the assertions. If the client name hasn't been seen before during this
+	// script, a new session is created for them. Otherwise, the existing session for them will be reused.
+	Client      string
+	ScriptTestAssertion
+}
+
+var TransactionTests = []TransactionTest{
+	{
+		Name:        "autocommit on",
+		SetUpScript: []string {
+			"create table a (b int primary key, c int)",
+			"insert into a values (1, 1)",
+		},
+		Assertions:  []TransactionTestAssertion{
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "insert into a values (2, 2)",
+					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+						{2, 2},
+					},
+				},
+			},
+			{
+				Client:              "b",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "insert into a values (3, 3)",
+					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+				},
+			},
+			{
+				Client:              "a",
+				ScriptTestAssertion: ScriptTestAssertion{
+					Query:           "select * from a",
+					Expected:        []sql.Row{
+						{1, 1},
+						{2, 2},
+						{3, 3},
+					},
+				},
+			},
+		},
+	},
+}

--- a/enginetest/transaction_queries.go
+++ b/enginetest/transaction_queries.go
@@ -31,47 +31,47 @@ type TransactionTest struct {
 type TransactionTestAssertion struct {
 	// Client the name of the client executing the assertions. If the client name hasn't been seen before during this
 	// script, a new session is created for them. Otherwise, the existing session for them will be reused.
-	Client      string
+	Client string
 	ScriptTestAssertion
 }
 
 var TransactionTests = []TransactionTest{
 	{
-		Name:        "autocommit on",
-		SetUpScript: []string {
+		Name: "autocommit on",
+		SetUpScript: []string{
 			"create table a (b int primary key, c int)",
 			"insert into a values (1, 1)",
 		},
-		Assertions:  []TransactionTestAssertion{
+		Assertions: []TransactionTestAssertion{
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "insert into a values (2, 2)",
-					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+					Query:    "insert into a values (2, 2)",
+					Expected: []sql.Row{{sql.NewOkResult(1)}},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 					},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "insert into a values (3, 3)",
-					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+					Query:    "insert into a values (3, 3)",
+					Expected: []sql.Row{{sql.NewOkResult(1)}},
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 						{3, 3},
@@ -81,124 +81,124 @@ var TransactionTests = []TransactionTest{
 		},
 	},
 	{
-		Name:        "autocommit off",
-		SetUpScript: []string {
+		Name: "autocommit off",
+		SetUpScript: []string{
 			"create table a (b int primary key, c int)",
 			"insert into a values (1, 1)",
 		},
-		Assertions:  []TransactionTestAssertion{
+		Assertions: []TransactionTestAssertion{
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "set autocommit = off",
-					Expected:        []sql.Row{{}},
+					Query:    "set autocommit = off",
+					Expected: []sql.Row{{}},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "set autocommit = off",
-					Expected:        []sql.Row{{}},
+					Query:    "set autocommit = off",
+					Expected: []sql.Row{{}},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 					},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "insert into a values (2, 2)",
-					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+					Query:    "insert into a values (2, 2)",
+					Expected: []sql.Row{{sql.NewOkResult(1)}},
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 					},
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "insert into a values (3,3)",
-					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+					Query:    "insert into a values (3,3)",
+					Expected: []sql.Row{{sql.NewOkResult(1)}},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 					},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "commit",
-					Expected:        []sql.Row{},
+					Query:    "commit",
+					Expected: []sql.Row{},
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{3, 3},
 					},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 					},
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "commit",
-					Expected:        []sql.Row{},
+					Query:    "commit",
+					Expected: []sql.Row{},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 					},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "start transaction",
-					Expected:        []sql.Row{},
+					Query:    "start transaction",
+					Expected: []sql.Row{},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 						{3, 3},
@@ -206,10 +206,10 @@ var TransactionTests = []TransactionTest{
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 						{3, 3},
@@ -219,45 +219,45 @@ var TransactionTests = []TransactionTest{
 		},
 	},
 	{
-		Name:        "autocommit on with explicit transactions",
-		SetUpScript: []string {
+		Name: "autocommit on with explicit transactions",
+		SetUpScript: []string{
 			"create table a (b int primary key, c int)",
 			"insert into a values (1, 1)",
 		},
-		Assertions:  []TransactionTestAssertion{
+		Assertions: []TransactionTestAssertion{
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "start transaction",
-					Expected:        []sql.Row{},
+					Query:    "start transaction",
+					Expected: []sql.Row{},
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "insert into a values (2, 2)",
-					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+					Query:    "insert into a values (2, 2)",
+					Expected: []sql.Row{{sql.NewOkResult(1)}},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{{1, 1}},
+					Query:    "select * from a order by b",
+					Expected: []sql.Row{{1, 1}},
 				},
 			},
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "commit",
-					Expected:        []sql.Row{},
+					Query:    "commit",
+					Expected: []sql.Row{},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 					},
@@ -265,17 +265,17 @@ var TransactionTests = []TransactionTest{
 			},
 			// After commit, autocommit turns back on
 			{
-				Client:              "a",
+				Client: "a",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "insert into a values (3, 3)",
-					Expected:        []sql.Row{{sql.NewOkResult(1)}},
+					Query:    "insert into a values (3, 3)",
+					Expected: []sql.Row{{sql.NewOkResult(1)}},
 				},
 			},
 			{
-				Client:              "b",
+				Client: "b",
 				ScriptTestAssertion: ScriptTestAssertion{
-					Query:           "select * from a order by b",
-					Expected:        []sql.Row{
+					Query: "select * from a order by b",
+					Expected: []sql.Row{
 						{1, 1},
 						{2, 2},
 						{3, 3},

--- a/server/handler.go
+++ b/server/handler.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/netutil"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -38,6 +37,7 @@ import (
 	"github.com/dolthub/go-mysql-server/internal/sockstate"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
@@ -630,7 +630,6 @@ func schemaToFields(s sql.Schema) []*query.Field {
 
 	return fields
 }
-
 
 var (
 	// QueryCounter describes a metric that accumulates number of queries monotonically.

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -181,7 +181,7 @@ func TestHandlerKill(t *testing.T) {
 	require.NoError(err)
 	ctx1, err := handler.sm.NewContextWithQuery(conn1, "SELECT 1")
 	require.NoError(err)
-	ctx1, err = handler.e.Catalog.AddProcess(ctx1, sql.QueryProcess, "SELECT 1")
+	ctx1, err = handler.e.Catalog.AddProcess(ctx1, "SELECT 1")
 	require.NoError(err)
 
 	err = handler.ComQuery(conn2, "KILL "+fmt.Sprint(ctx1.ID()), func(res *sqltypes.Result) error {

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -34,7 +34,7 @@ func constructJoinPlan(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) 
 		return n, nil
 	}
 
-	if plan.IsDdlNode(n) {
+	if plan.IsNoRowNode(n) {
 		return n, nil
 	}
 

--- a/sql/analyzer/parallelize.go
+++ b/sql/analyzer/parallelize.go
@@ -36,7 +36,7 @@ func shouldParallelize(node sql.Node, scope *Scope) bool {
 	}
 
 	// Do not try to parallelize DDL or descriptive operations
-	return !plan.IsDdlNode(node)
+	return !plan.IsNoRowNode(node)
 }
 
 func parallelize(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope) (sql.Node, error) {

--- a/sql/analyzer/process_test.go
+++ b/sql/analyzer/process_test.go
@@ -40,7 +40,7 @@ func TestTrackProcess(t *testing.T) {
 	)
 
 	ctx := sql.NewContext(context.Background(), sql.WithPid(1))
-	ctx, err := catalog.AddProcess(ctx, sql.QueryProcess, "SELECT foo")
+	ctx, err := catalog.AddProcess(ctx, "SELECT foo")
 	require.NoError(err)
 
 	result, err := rule.Apply(ctx, a, node, nil)
@@ -49,7 +49,6 @@ func TestTrackProcess(t *testing.T) {
 	processes := catalog.Processes()
 	require.Len(processes, 1)
 	require.Equal("SELECT foo", processes[0].Query)
-	require.Equal(sql.QueryProcess, processes[0].Type)
 	require.Equal(
 		map[string]sql.TableProgress{
 			"foo": sql.TableProgress{

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -147,7 +147,7 @@ func canDoPushdown(n sql.Node) bool {
 		return false
 	}
 
-	if plan.IsDdlNode(n) {
+	if plan.IsNoRowNode(n) {
 		return false
 	}
 

--- a/sql/core.go
+++ b/sql/core.go
@@ -169,12 +169,6 @@ type OpaqueNode interface {
 	Opaque() bool
 }
 
-// AsyncNode is a node that can be executed asynchronously.
-type AsyncNode interface {
-	// IsAsync reports whether the node is async or not.
-	IsAsync() bool
-}
-
 // Expressioner is a node that contains expressions.
 type Expressioner interface {
 	// Expressions returns the list of expressions contained by the node.

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -81,10 +81,11 @@ var (
 	ErrDuplicateAliasOrTable = errors.NewKind("Not unique table/alias: %s")
 
 	// ErrPrimaryKeyViolation is returned when a primary key constraint is violated
-	// TODO: This should be a ErDupEntry instead
-	ErrPrimaryKeyViolation = errors.NewKind("duplicate primary key given: %s")
+	// This is meant to wrap a sql.UniqueKey error, which provides the key string
+	ErrPrimaryKeyViolation = errors.NewKind("duplicate primary key given")
 
 	// ErrUniqueKeyViolation is returned when a unique key constraint is violated
+	// This is meant to wrap a sql.UniqueKey error, which provides the key string
 	ErrUniqueKeyViolation = errors.NewKind("duplicate unique key given")
 
 	// ErrMisusedAlias is returned when a alias is defined and used in the same projection.
@@ -346,9 +347,5 @@ func NewUniqueKeyErr(keyStr string, isPK bool, existing Row) error {
 }
 
 func (ue UniqueKeyError) Error() string {
-	if ue.IsPK {
-		return fmt.Sprintf("duplicate primary key given: %s", ue.keyStr)
-	} else {
-		return fmt.Sprintf("duplicate unique key given: %s", ue.keyStr)
-	}
+	return fmt.Sprintf("%s", ue.keyStr)
 }

--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -66,7 +66,7 @@ func getQueryType(child sql.Node) queryType {
 	// TODO: behavior of CALL is not specified in the docs. Needs investigation
 	var queryType queryType = queryTypeSelect
 	Inspect(child, func(node sql.Node) bool {
-		if IsDdlNode(node) {
+		if IsNoRowNode(node) {
 			queryType = queryTypeDdl
 			return false
 		}
@@ -409,9 +409,13 @@ func partitionName(p sql.Partition) string {
 	return string(p.Key())
 }
 
-// IsDdlNode returns whether the node given is a DDL operation, which includes things like SHOW commands. In general,
-// these are nodes that interact only with schema and the catalog, not with any table rows.
-func IsDdlNode(node sql.Node) bool {
+// IsNoRowNode returns whether this are node interacts only with schema and the catalog, not with any table
+// rows.
+func IsNoRowNode(node sql.Node) bool {
+	return IsDDLNode(node) || IsShowNode(node)
+}
+
+func IsDDLNode(node sql.Node) bool {
 	switch node.(type) {
 	case *CreateTable, *DropTable, *Truncate,
 		*AddColumn, *ModifyColumn, *DropColumn,
@@ -421,8 +425,16 @@ func IsDdlNode(node sql.Node) bool {
 		*CreateProcedure, *DropProcedure,
 		*CreateForeignKey, *DropForeignKey,
 		*CreateCheck, *DropCheck,
-		*CreateTrigger, *DropTrigger,
-		*ShowTables, *ShowCreateTable,
+		*CreateTrigger, *DropTrigger:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsShowNode(node sql.Node) bool {
+	switch node.(type) {
+	case *ShowTables, *ShowCreateTable,
 		*ShowTriggers, *ShowCreateTrigger,
 		*ShowDatabases, *ShowCreateDatabase,
 		*ShowColumns, *ShowIndexes,

--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -421,6 +421,7 @@ func IsDDLNode(node sql.Node) bool {
 		*AddColumn, *ModifyColumn, *DropColumn,
 		*CreateDB, *DropDB,
 		*RenameTable, *RenameColumn,
+		*CreateView, *DropView,
 		*CreateIndex, *AlterIndex, *DropIndex,
 		*CreateProcedure, *DropProcedure,
 		*CreateForeignKey, *DropForeignKey,

--- a/sql/plan/processlist.go
+++ b/sql/plan/processlist.go
@@ -120,7 +120,7 @@ func (p *ShowProcessList) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, e
 			user:    proc.User,
 			time:    int64(proc.Seconds()),
 			state:   strings.Join(status, ""),
-			command: proc.Type.String(),
+			command: "Query",
 			host:    ctx.Session.Client().Address,
 			info:    proc.Query,
 			db:      p.Database,

--- a/sql/plan/processlist_test.go
+++ b/sql/plan/processlist_test.go
@@ -61,7 +61,7 @@ func TestShowProcessList(t *testing.T) {
 	require.NoError(err)
 
 	expected := []sql.Row{
-		{int64(1), "foo", addr, "foo", "query", int64(0),
+		{int64(1), "foo", addr, "foo", "Query", int64(0),
 			`
 a (4/5 partitions)
  ├─ a-1 (7/? rows)
@@ -69,7 +69,7 @@ a (4/5 partitions)
 
 b (2/6 partitions)
 `, "SELECT foo"},
-		{int64(1), "foo", addr, "foo", "create_index", int64(0), "\nfoo (1/2 partitions)\n", "SELECT bar"},
+		{int64(1), "foo", addr, "foo", "Query", int64(0), "\nfoo (1/2 partitions)\n", "SELECT bar"},
 	}
 
 	require.ElementsMatch(expected, rows)

--- a/sql/plan/processlist_test.go
+++ b/sql/plan/processlist_test.go
@@ -33,14 +33,14 @@ func TestShowProcessList(t *testing.T) {
 	sess := sql.NewSession("0.0.0.0:3306", addr, "foo", 1)
 	ctx := sql.NewContext(context.Background(), sql.WithPid(1), sql.WithSession(sess))
 
-	ctx, err := p.AddProcess(ctx, sql.QueryProcess, "SELECT foo")
+	ctx, err := p.AddProcess(ctx, "SELECT foo")
 	require.NoError(err)
 
 	p.AddTableProgress(ctx.Pid(), "a", 5)
 	p.AddTableProgress(ctx.Pid(), "b", 6)
 
 	ctx = sql.NewContext(context.Background(), sql.WithPid(2), sql.WithSession(sess))
-	ctx, err = p.AddProcess(ctx, sql.CreateIndexProcess, "SELECT bar")
+	ctx, err = p.AddProcess(ctx, "SELECT bar")
 	require.NoError(err)
 
 	p.AddTableProgress(ctx.Pid(), "foo", 2)

--- a/sql/processlist_test.go
+++ b/sql/processlist_test.go
@@ -28,7 +28,7 @@ func TestProcessList(t *testing.T) {
 	p := NewProcessList()
 	sess := NewSession("0.0.0.0:3306", "127.0.0.1:34567", "foo", 1)
 	ctx := NewContext(context.Background(), WithPid(1), WithSession(sess))
-	ctx, err := p.AddProcess(ctx, QueryProcess, "SELECT foo")
+	ctx, err := p.AddProcess(ctx, "SELECT foo")
 	require.NoError(err)
 
 	require.Equal(uint64(1), ctx.Pid())
@@ -40,7 +40,6 @@ func TestProcessList(t *testing.T) {
 	expectedProcess := &Process{
 		Pid:        1,
 		Connection: 1,
-		Type:       QueryProcess,
 		Progress: map[string]TableProgress{
 			"a": {Progress{Name: "a", Done: 0, Total: 5}, map[string]PartitionProgress{}},
 			"b": {Progress{Name: "b", Done: 0, Total: 6}, map[string]PartitionProgress{}},
@@ -71,7 +70,7 @@ func TestProcessList(t *testing.T) {
 	require.Equal(expectedProgress, p.procs[ctx.Pid()].Progress)
 
 	ctx = NewContext(context.Background(), WithPid(2), WithSession(sess))
-	ctx, err = p.AddProcess(ctx, CreateIndexProcess, "SELECT bar")
+	ctx, err = p.AddProcess(ctx, "SELECT bar")
 	require.NoError(err)
 
 	p.AddTableProgress(ctx.Pid(), "foo", 2)
@@ -133,7 +132,6 @@ func TestKillConnection(t *testing.T) {
 
 		_, err := pl.AddProcess(
 			NewContext(context.Background(), WithPid(i), WithSession(s)),
-			QueryProcess,
 			"foo",
 		)
 		require.NoError(t, err)

--- a/sql/session.go
+++ b/sql/session.go
@@ -87,11 +87,6 @@ type Session interface {
 	DelLock(lockName string) error
 	// IterLocks iterates through all locks owned by this user
 	IterLocks(cb func(name string) error) error
-	// GetQueriedDatabase represents the database the user is running a query on that is NOT the current database.
-	// Should only be used internally by the engine.
-	GetQueriedDatabase() string
-	// SetQueriedDatabase sets the queried database. Should only be used internally by the engine.
-	SetQueriedDatabase(dbName string)
 	// SetLastQueryInfo sets session-level query info for the key given, applying to the query just executed.
 	SetLastQueryInfo(key string, value int64)
 	// GetLastQueryInfo returns the session-level query info for the key given, for the query most recently executed.

--- a/sql/system_variables.go
+++ b/sql/system_variables.go
@@ -294,7 +294,7 @@ var systemVars = map[string]SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              NewSystemBoolType("autocommit"),
-		Default:           int8(0),
+		Default:           int8(1),
 	},
 	"automatic_sp_privileges": {
 		Name:              "automatic_sp_privileges",


### PR DESCRIPTION
This change:
* Moves a bunch of transaction and other session management code out of Handler into Engine
* Introduces a new set of tests around transactions
* Fixes the error message for duplicate key violations
* Removes AsyncNode and related code
* Eliminates duplicate query parsing