### PR TITLE
Initial percent_rank fn

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2338,6 +2338,16 @@ func TestWindowAgg(t *testing.T, harness Harness) {
 		{4, 0.0},
 		{5, 0.0},
 	}, nil, nil)
+
+	// no order by clause -> all rows are peers
+	TestQuery(t, harness, e, `SELECT a, percent_rank() over (partition by b) FROM t1 order by a`, []sql.Row{
+		{0, 0.0},
+		{1, 0.0},
+		{2, 0.0},
+		{3, 0.0},
+		{4, 0.0},
+		{5, 0.0},
+	}, nil, nil)
 }
 func TestNaturalJoin(t *testing.T, harness Harness) {
 	require := require.New(t)

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2295,6 +2295,50 @@ func TestDropConstraints(t *testing.T, harness Harness) {
 	AssertErr(t, e, harness, "ALTER TABLE t1 DROP CONSTRAINT fk1", sql.ErrUnknownConstraint)
 }
 
+func TestWindowAgg(t *testing.T, harness Harness) {
+	//require := require.New(t)
+
+	e := NewEngine(t, harness)
+
+	RunQuery(t, e, harness, "CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER, c integer)")
+	RunQuery(t, e, harness, "INSERT INTO t1 VALUES (0,0,0), (1,1,1), (2,2,0), (3,0,0), (4,1,0), (5,3,0)")
+
+	TestQuery(t, harness, e, `SELECT a, percent_rank() over (order by b) FROM t1 order by a`, []sql.Row{
+		{0, 0.0},
+		{1, 0.4},
+		{2, 0.8},
+		{3, 0.0},
+		{4, 0.4},
+		{5, 1.0},
+	}, nil, nil)
+
+	TestQuery(t, harness, e, `SELECT a, percent_rank() over (order by b desc) FROM t1 order by a`, []sql.Row{
+		{0, 0.8},
+		{1, 0.4},
+		{2, 0.2},
+		{3, 0.8},
+		{4, 0.4},
+		{5, 0.0},
+	}, nil, nil)
+
+	TestQuery(t, harness, e, `SELECT a, percent_rank() over (partition by c order by b) FROM t1 order by a`, []sql.Row{
+		{0, 0.0},
+		{1, 0.0},
+		{2, 0.75},
+		{3, 0.0},
+		{4, 0.5},
+		{5, 1.0},
+	}, nil, nil)
+
+	TestQuery(t, harness, e, `SELECT a, percent_rank() over (partition by b order by c) FROM t1 order by a`, []sql.Row{
+		{0, 0.0},
+		{1, 1.0},
+		{2, 0.0},
+		{3, 0.0},
+		{4, 0.0},
+		{5, 0.0},
+	}, nil, nil)
+}
 func TestNaturalJoin(t *testing.T, harness Harness) {
 	require := require.New(t)
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -493,6 +493,10 @@ func TestNaturalJoin(t *testing.T) {
 	enginetest.TestNaturalJoin(t, enginetest.NewDefaultMemoryHarness())
 }
 
+func TestTestWindowAggregations(t *testing.T) {
+	enginetest.TestWindowAgg(t, enginetest.NewDefaultMemoryHarness())
+}
+
 func TestNaturalJoinEqual(t *testing.T) {
 	enginetest.TestNaturalJoinEqual(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/sql/core.go
+++ b/sql/core.go
@@ -73,13 +73,6 @@ type FunctionExpression interface {
 	FunctionName() string
 }
 
-// WindowExpression is an Expression that represents a window aggregation
-type WindowExpression interface {
-	Expression
-	Window() *Window
-	IsNewPartition(ctx *Context, last Row, row Row) (bool, error)
-}
-
 // NonDeterministicExpression allows a way for expressions to declare that they are non-deterministic, which will
 // signal the engine to not cache their results when this would otherwise appear to be safe.
 type NonDeterministicExpression interface {
@@ -110,7 +103,9 @@ type Aggregation interface {
 // WindowAggregation is expected to track its input rows in the order received, and to return the value for the row
 // index given on demand.
 type WindowAggregation interface {
-	WindowExpression
+	Expression
+	// Window returns this expression's window
+	Window() *Window
 	// WithWindow returns a version of this window aggregation with the window given
 	WithWindow(window *Window) (WindowAggregation, error)
 	// NewBuffer creates a new buffer and returns it as a Row. This buffer will be provided for all further operations.

--- a/sql/core.go
+++ b/sql/core.go
@@ -73,6 +73,13 @@ type FunctionExpression interface {
 	FunctionName() string
 }
 
+// WindowExpression is an Expression that represents a window aggregation
+type WindowExpression interface {
+	Expression
+	Window() *Window
+	IsNewPartition(ctx *Context, last Row, row Row) (bool, error)
+}
+
 // NonDeterministicExpression allows a way for expressions to declare that they are non-deterministic, which will
 // signal the engine to not cache their results when this would otherwise appear to be safe.
 type NonDeterministicExpression interface {
@@ -103,7 +110,7 @@ type Aggregation interface {
 // WindowAggregation is expected to track its input rows in the order received, and to return the value for the row
 // index given on demand.
 type WindowAggregation interface {
-	Expression
+	WindowExpression
 	// WithWindow returns a version of this window aggregation with the window given
 	WithWindow(window *Window) (WindowAggregation, error)
 	// NewBuffer creates a new buffer and returns it as a Row. This buffer will be provided for all further operations.

--- a/sql/expression/function/aggregation/window/percent_rank.go
+++ b/sql/expression/function/aggregation/window/percent_rank.go
@@ -1,0 +1,209 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"sort"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+type PercentRank struct {
+	window *sql.Window
+	pos    int
+}
+
+var _ sql.FunctionExpression = (*PercentRank)(nil)
+var _ sql.WindowAggregation = (*PercentRank)(nil)
+
+func NewPercentRank() sql.Expression {
+	return &PercentRank{}
+}
+
+// Window implements sql.WindowExpression
+func (p *PercentRank) Window() *sql.Window {
+	return p.window
+}
+
+// IsNullable implements sql.Expression
+func (p *PercentRank) Resolved() bool {
+	return windowResolved(p.window)
+}
+
+func (p *PercentRank) NewBuffer() sql.Row {
+	return sql.NewRow(make([]sql.Row, 0))
+}
+
+func (p *PercentRank) String() string {
+	sb := strings.Builder{}
+	sb.WriteString("percent_rank()")
+	if p.window != nil {
+		sb.WriteString(" ")
+		sb.WriteString(p.window.String())
+	}
+	return sb.String()
+}
+
+func (p *PercentRank) DebugString() string {
+	sb := strings.Builder{}
+	sb.WriteString("percent_rank()")
+	if p.window != nil {
+		sb.WriteString(" ")
+		sb.WriteString(sql.DebugString(p.window))
+	}
+	return sb.String()
+}
+
+// FunctionName implements sql.FunctionExpression
+func (p *PercentRank) FunctionName() string {
+	return "PERCENT_RANK"
+}
+
+// Type implements sql.Expression
+func (p *PercentRank) Type() sql.Type {
+	return sql.Float64
+}
+
+// IsNullable implements sql.Expression
+func (p *PercentRank) IsNullable() bool {
+	return false
+}
+
+// Eval implements sql.Expression
+func (p *PercentRank) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	panic("eval called on window function")
+}
+
+// Children implements sql.Expression
+func (p *PercentRank) Children() []sql.Expression {
+	return p.window.ToExpressions()
+}
+
+// WithChildren implements sql.Expression
+func (p *PercentRank) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	window, err := p.window.FromExpressions(children)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.WithWindow(window)
+}
+
+// WithWindow implements sql.WindowAggregation
+func (p *PercentRank) WithWindow(window *sql.Window) (sql.WindowAggregation, error) {
+	nr := *p
+	nr.window = window
+	return &nr, nil
+}
+
+// Add implements sql.WindowAggregation
+func (p *PercentRank) Add(ctx *sql.Context, buffer, row sql.Row) error {
+	rows := buffer[0].([]sql.Row)
+	// order -> row, partitionCount, rowIndex, originalIndex
+	buffer[0] = append(rows, append(row, nil, nil, p.pos))
+	p.pos++
+	return nil
+}
+
+// Finish implements sql.WindowAggregation
+func (p *PercentRank) Finish(ctx *sql.Context, buffer sql.Row) error {
+	rows := buffer[0].([]sql.Row)
+	if len(rows) > 0 && p.window != nil && p.window.OrderBy != nil {
+		sorter := &expression.Sorter{
+			SortFields: append(partitionsToSortFields(p.Window().PartitionBy), p.Window().OrderBy...),
+			Rows:       rows,
+			Ctx:        ctx,
+		}
+		sort.Stable(sorter)
+		if sorter.LastError != nil {
+			return sorter.LastError
+		}
+
+		// Now that we have the rows in sorted order, number them
+		partitionCountIdx := len(rows[0]) - 3
+		rowNumIdx := len(rows[0]) - 2
+		originalIdx := len(rows[0]) - 1
+		partitionCounts := make([]int, 0)
+		var last sql.Row
+		var err error
+		var isNew bool
+		rowNum := 0
+		partitionCnt := 0
+		for _, row := range rows {
+			// every time we encounter a new partition, start the count over
+			isNew, err = p.IsNewPartition(ctx, last, row)
+			if err != nil {
+				return err
+			}
+			if isNew {
+				if partitionCnt > 0 {
+					partitionCounts = append(partitionCounts, partitionCnt)
+				}
+				partitionCnt = 1
+				rowNum = 1
+			} else {
+				// only bump row num when we have unique order by columns
+				isNew, err = isNewOrderValue(ctx, p, last, row)
+				if err != nil {
+					return err
+				}
+				partitionCnt++
+				if isNew {
+					rowNum = partitionCnt
+				}
+			}
+
+			row[rowNumIdx] = rowNum
+
+			last = row
+		}
+		partitionCounts = append(partitionCounts, partitionCnt)
+
+		// set partition counts
+		currentPartitionIdx := 0
+		for _, row := range rows {
+			if row[rowNumIdx].(int) == 0 && currentPartitionIdx != 0 {
+				currentPartitionIdx += 1
+			}
+			row[partitionCountIdx] = partitionCounts[currentPartitionIdx]
+		}
+
+		// And finally sort again by the original order
+		sort.SliceStable(rows, func(i, j int) bool {
+			return rows[i][originalIdx].(int) < rows[j][originalIdx].(int)
+		})
+	}
+	return nil
+}
+
+// EvalRow implements sql.WindowAggregation
+func (p *PercentRank) EvalRow(i int, buffer sql.Row) (interface{}, error) {
+	rows := buffer[0].([]sql.Row)
+
+	partitionCountIdx := len(rows[0]) - 3
+	partitionCount := rows[i][partitionCountIdx].(int)
+
+	rowNumIdx := len(rows[0]) - 2
+	rowNum := rows[i][rowNumIdx].(int)
+
+	return float64(rowNum-1) / float64(partitionCount-1), nil
+}
+
+// IsNewPartition implements sql.WindowExpression
+func (p *PercentRank) IsNewPartition(ctx *sql.Context, last sql.Row, row sql.Row) (bool, error) {
+	return isNewPartition(ctx, p, last, row)
+}

--- a/sql/expression/function/aggregation/window/percent_rank.go
+++ b/sql/expression/function/aggregation/window/percent_rank.go
@@ -15,9 +15,10 @@
 package window
 
 import (
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"sort"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/expression/function/aggregation/window/row_number.go
+++ b/sql/expression/function/aggregation/window/row_number.go
@@ -140,7 +140,7 @@ func (r *RowNumber) Finish(ctx *sql.Context, buffer sql.Row) error {
 		var rowNum int
 		for _, row := range rows {
 			// every time we encounter a new partition, start the count over
-			isNew, err := r.IsNewPartition(ctx, last, row)
+			isNew, err := isNewPartition(ctx, r.window.PartitionBy, last, row)
 			if err != nil {
 				return err
 			}
@@ -166,8 +166,4 @@ func (r *RowNumber) Finish(ctx *sql.Context, buffer sql.Row) error {
 func (r *RowNumber) EvalRow(i int, buffer sql.Row) (interface{}, error) {
 	rows := buffer[0].([]sql.Row)
 	return rows[i][len(rows[i])-2], nil
-}
-
-func (r *RowNumber) IsNewPartition(ctx *sql.Context, last sql.Row, row sql.Row) (bool, error) {
-	return isNewPartition(ctx, r, last, row)
 }

--- a/sql/expression/function/aggregation/window/row_number.go
+++ b/sql/expression/function/aggregation/window/row_number.go
@@ -15,9 +15,10 @@
 package window
 
 import (
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"sort"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/expression/function/aggregation/window/window.go
+++ b/sql/expression/function/aggregation/window/window.go
@@ -1,0 +1,102 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+func windowResolved(window *sql.Window) bool {
+	if window == nil {
+		return true
+	}
+	return expression.ExpressionsResolved(append(window.OrderBy.ToExpressions(), window.PartitionBy...)...)
+}
+
+func partitionsToSortFields(partitionExprs []sql.Expression) sql.SortFields {
+	sfs := make(sql.SortFields, len(partitionExprs))
+	for i, expr := range partitionExprs {
+		sfs[i] = sql.SortField{
+			Column: expr,
+			Order:  sql.Ascending,
+		}
+	}
+	return sfs
+}
+
+func evalExprs(ctx *sql.Context, exprs []sql.Expression, row sql.Row) (sql.Row, error) {
+	result := make(sql.Row, len(exprs))
+	for i, expr := range exprs {
+		var err error
+		result[i], err = expr.Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}
+
+func isNewPartition(ctx *sql.Context, window sql.WindowExpression, last sql.Row, row sql.Row) (bool, error) {
+	if len(last) == 0 {
+		return true, nil
+	}
+
+	if len(window.Window().PartitionBy) == 0 {
+		return false, nil
+	}
+
+	lastExp, err := evalExprs(ctx, window.Window().PartitionBy, last)
+	if err != nil {
+		return false, err
+	}
+
+	thisExp, err := evalExprs(ctx, window.Window().PartitionBy, row)
+	if err != nil {
+		return false, err
+	}
+
+	for i := range lastExp {
+		if lastExp[i] != thisExp[i] {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func isNewOrderValue(ctx *sql.Context, window sql.WindowExpression, last sql.Row, row sql.Row) (bool, error) {
+	if len(last) == 0 {
+		return true, nil
+	}
+
+	lastExp, err := evalExprs(ctx, window.Window().OrderBy.ToExpressions(), last)
+	if err != nil {
+		return false, err
+	}
+
+	thisExp, err := evalExprs(ctx, window.Window().OrderBy.ToExpressions(), row)
+	if err != nil {
+		return false, err
+	}
+
+	for i := range lastExp {
+		if lastExp[i] != thisExp[i] {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -144,6 +144,7 @@ var Defaults = []sql.Function{
 	sql.FunctionN{Name: "round", Fn: NewRound},
 	sql.Function0{Name: "row_count", Fn: NewRowCount},
 	sql.Function0{Name: "row_number", Fn: window.NewRowNumber},
+	sql.Function0{Name: "percent_rank", Fn: window.NewPercentRank},
 	sql.FunctionN{Name: "rpad", Fn: NewPadFunc(rPadType)},
 	sql.Function1{Name: "rtrim", Fn: NewTrimFunc(rTrimType)},
 	sql.Function1{Name: "second", Fn: NewSecond},


### PR DESCRIPTION
- percent_rank function implemented, which is basically the step function quantile of column-sorted rows within a partition.
- moved helpers to `window/window.go`
- created `WindowExpression` interface to facilitate helper function re-use (there are multiple ways of doing that, extra interface isn't super necessary but made sense to me at the time)

todo:
- bats with great expectation specific query