### PR TITLE
Fix JSON string comparison.

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -2689,6 +2689,18 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{"\t2"}},
 	},
 	{
+		Query:    `SELECT JSON_UNQUOTE(JSON_EXTRACT('{"xid":"hello"}', '$.xid')) = "hello"`,
+		Expected: []sql.Row{{true}},
+	},
+	{
+		Query:    `SELECT JSON_EXTRACT('{"xid":"hello"}', '$.xid') = "hello"`,
+		Expected: []sql.Row{{true}},
+	},
+	{
+		Query:    `SELECT JSON_EXTRACT('{"xid":"hello"}', '$.xid') = '"hello"'`,
+		Expected: []sql.Row{{false}},
+	},
+	{
 		Query:    `SELECT CONNECTION_ID()`,
 		Expected: []sql.Row{{uint32(1)}},
 	},

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -2701,6 +2701,10 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{false}},
 	},
 	{
+		Query:    `SELECT JSON_UNQUOTE(JSON_EXTRACT('{"xid":null}', '$.xid'))`,
+		Expected: []sql.Row{{"null"}},
+	},
+	{
 		Query:    `SELECT CONNECTION_ID()`,
 		Expected: []sql.Row{{uint32(1)}},
 	},

--- a/internal/strings/unquote.go
+++ b/internal/strings/unquote.go
@@ -1,0 +1,86 @@
+package strings
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"unicode/utf8"
+)
+
+// The implementation is taken from TiDB
+// https://github.com/pingcap/tidb/blob/a594287e9f402037b06930026906547000006bb6/types/json/binary_functions.go#L89
+func Unquote(s string) (string, error) {
+	ret := new(bytes.Buffer)
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			i++
+			if i == len(s) {
+				return "", fmt.Errorf("Missing a closing quotation mark in string")
+			}
+			switch s[i] {
+			case '"':
+				ret.WriteByte('"')
+			case 'b':
+				ret.WriteByte('\b')
+			case 'f':
+				ret.WriteByte('\f')
+			case 'n':
+				ret.WriteByte('\n')
+			case 'r':
+				ret.WriteByte('\r')
+			case 't':
+				ret.WriteByte('\t')
+			case '\\':
+				ret.WriteByte('\\')
+			case 'u':
+				if i+4 > len(s) {
+					return "", fmt.Errorf("Invalid unicode: %s", s[i+1:])
+				}
+				char, size, err := decodeEscapedUnicode([]byte(s[i+1 : i+5]))
+				if err != nil {
+					return "", err
+				}
+				ret.Write(char[0:size])
+				i += 4
+			default:
+				// For all other escape sequences, backslash is ignored.
+				ret.WriteByte(s[i])
+			}
+		} else {
+			ret.WriteByte(s[i])
+		}
+	}
+
+	str := ret.String()
+	strlen := len(str)
+	// Remove prefix and suffix '"'.
+	if strlen > 1 {
+		head, tail := str[0], str[strlen-1]
+		if head == '"' && tail == '"' {
+			return str[1 : strlen-1], nil
+		}
+	}
+	return str, nil
+}
+
+// decodeEscapedUnicode decodes unicode into utf8 bytes specified in RFC 3629.
+// According RFC 3629, the max length of utf8 characters is 4 bytes.
+// And MySQL use 4 bytes to represent the unicode which must be in [0, 65536).
+// The implementation is taken from TiDB:
+// https://github.com/pingcap/tidb/blob/a594287e9f402037b06930026906547000006bb6/types/json/binary_functions.go#L136
+func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
+	size, err = hex.Decode(char[0:2], s)
+	if err != nil || size != 2 {
+		// The unicode must can be represented in 2 bytes.
+		return char, 0, err
+	}
+	var unicode uint16
+	err = binary.Read(bytes.NewReader(char[0:2]), binary.BigEndian, &unicode)
+	if err != nil {
+		return char, 0, err
+	}
+	size = utf8.RuneLen(rune(unicode))
+	utf8.EncodeRune(char[0:size], rune(unicode))
+	return
+}

--- a/sql/expression/function/json_unquote.go
+++ b/sql/expression/function/json_unquote.go
@@ -15,13 +15,10 @@
 package function
 
 import (
-	"bytes"
-	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"reflect"
-	"unicode/utf8"
 
+	"github.com/dolthub/go-mysql-server/internal/strings"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 )
@@ -78,82 +75,5 @@ func (js *JSONUnquote) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 		return nil, sql.ErrInvalidType.New(reflect.TypeOf(ex).String())
 	}
 
-	return unquote(str)
-}
-
-// The implementation is taken from TiDB
-// https://github.com/pingcap/tidb/blob/a594287e9f402037b06930026906547000006bb6/types/json/binary_functions.go#L89
-func unquote(s string) (string, error) {
-	ret := new(bytes.Buffer)
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\\' {
-			i++
-			if i == len(s) {
-				return "", fmt.Errorf("Missing a closing quotation mark in string")
-			}
-			switch s[i] {
-			case '"':
-				ret.WriteByte('"')
-			case 'b':
-				ret.WriteByte('\b')
-			case 'f':
-				ret.WriteByte('\f')
-			case 'n':
-				ret.WriteByte('\n')
-			case 'r':
-				ret.WriteByte('\r')
-			case 't':
-				ret.WriteByte('\t')
-			case '\\':
-				ret.WriteByte('\\')
-			case 'u':
-				if i+4 > len(s) {
-					return "", fmt.Errorf("Invalid unicode: %s", s[i+1:])
-				}
-				char, size, err := decodeEscapedUnicode([]byte(s[i+1 : i+5]))
-				if err != nil {
-					return "", err
-				}
-				ret.Write(char[0:size])
-				i += 4
-			default:
-				// For all other escape sequences, backslash is ignored.
-				ret.WriteByte(s[i])
-			}
-		} else {
-			ret.WriteByte(s[i])
-		}
-	}
-
-	str := ret.String()
-	strlen := len(str)
-	// Remove prefix and suffix '"'.
-	if strlen > 1 {
-		head, tail := str[0], str[strlen-1]
-		if head == '"' && tail == '"' {
-			return str[1 : strlen-1], nil
-		}
-	}
-	return str, nil
-}
-
-// decodeEscapedUnicode decodes unicode into utf8 bytes specified in RFC 3629.
-// According RFC 3629, the max length of utf8 characters is 4 bytes.
-// And MySQL use 4 bytes to represent the unicode which must be in [0, 65536).
-// The implementation is taken from TiDB:
-// https://github.com/pingcap/tidb/blob/a594287e9f402037b06930026906547000006bb6/types/json/binary_functions.go#L136
-func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
-	size, err = hex.Decode(char[0:2], s)
-	if err != nil || size != 2 {
-		// The unicode must can be represented in 2 bytes.
-		return char, 0, err
-	}
-	var unicode uint16
-	err = binary.Read(bytes.NewReader(char[0:2]), binary.BigEndian, &unicode)
-	if err != nil {
-		return char, 0, err
-	}
-	size = utf8.RuneLen(rune(unicode))
-	utf8.EncodeRune(char[0:size], rune(unicode))
-	return
+	return strings.Unquote(str)
 }

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -268,11 +268,7 @@ func (t stringType) Convert(v interface{}) (interface{}, error) {
 			return nil, nil
 		}
 		val = s.Decimal.String()
-	case JSONDocument:
-		if s.Val == nil {
-			return "", nil
-		}
-
+	case JSONValue:
 		str, err := s.ToString(nil)
 		if err != nil {
 			return nil, err

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -26,6 +26,7 @@ import (
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/internal/regex"
+	istrings "github.com/dolthub/go-mysql-server/internal/strings"
 )
 
 const (
@@ -272,7 +273,15 @@ func (t stringType) Convert(v interface{}) (interface{}, error) {
 			return "", nil
 		}
 
-		return s.ToString(nil)
+		str, err := s.ToString(nil)
+		if err != nil {
+			return nil, err
+		}
+
+		val, err = istrings.Unquote(str)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, ErrConvertToSQL.New(t)
 	}

--- a/sql/stringtype_test.go
+++ b/sql/stringtype_test.go
@@ -316,6 +316,7 @@ func TestStringConvert(t *testing.T) {
 		{MustCreateStringWithDefaults(sqltypes.Text, 3), strings.Repeat("𒁏", int(tinyTextBlobMax/Collation_Default.CharacterSet().MaxLength())+1), nil, true},
 		{MustCreateBinary(sqltypes.VarBinary, 3), []byte{01, 02, 03, 04}, nil, true},
 		{MustCreateStringWithDefaults(sqltypes.VarChar, 3), []byte("abcd"), nil, true},
+		{MustCreateStringWithDefaults(sqltypes.Char, 20), JSONDocument{Val: nil}, "null", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fix when a JSON is compared with a string, and apply
unquote as MySQL does.

Fixes #474 

Signed-off-by: Antonio Navarro Perez <antnavper@gmail.com>