### PR TITLE
Add a very basic from_unixtime function.

### DIFF
--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -152,3 +152,14 @@ func TestUnixTimestamp(t *testing.T) {
 	require.NoError(err)
 	require.Equal(expected, result)
 }
+
+func TestFromUnixtime(t *testing.T) {
+	require := require.New(t)
+
+	ctx := sql.NewEmptyContext()
+	_, err := NewUnixTimestamp(ctx, expression.NewLiteral(0, sql.Int64))
+	require.NoError(err)
+
+	_, err = NewUnixTimestamp(ctx, expression.NewLiteral(1447430881, sql.Int64))
+	require.NoError(err)
+}

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -171,6 +171,7 @@ var Defaults = []sql.Function{
 	sql.Function1{Name: "ucase", Fn: NewUpper},
 	sql.Function1{Name: "unhex", Fn: NewUnhex},
 	sql.FunctionN{Name: "unix_timestamp", Fn: NewUnixTimestamp},
+	sql.Function1{Name: "from_unixtime", Fn: NewFromUnixtime},
 	sql.Function1{Name: "upper", Fn: NewUpper},
 	sql.NewFunction0("user", NewUser),
 	sql.FunctionN{Name: "utc_timestamp", Fn: NewUTCTimestamp},


### PR DESCRIPTION
The function does the basic conversion but (a) doesn't support passing floats and (b) doesn't support the format param.

Is this something you'd be interested in?  I could probably find some time to extend it further.

Signed-off-by: Tom Wilkie <tom@grafana.com>