### PR TITLE
Fix IndexedTableAccess WithChildren

### DIFF
--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -124,6 +124,13 @@ func (i *IndexedTableAccess) DebugString() string {
 	return fmt.Sprintf("IndexedTableAccess(%s, using fields %s)", i.Name(), strings.Join(keyExprs, ", "))
 }
 
+func (i *IndexedTableAccess) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(i, len(children), 0)
+	}
+	return i, nil
+}
+
 // Expressions implements sql.Expressioner
 func (i *IndexedTableAccess) Expressions() []sql.Expression {
 	return i.keyExprs


### PR DESCRIPTION
@reltuk I noticed that IndexedTableAccess.WithChildren was returning a ResolvedTable, not an IndexedTableAccess. This seems like the wrong behavior (which I introduced in the first place) and I'm sorry I didn't catch it earlier.