### PR TITLE
add nil check in json_unquote function as LongText.Convert() can retu…

### DIFF
--- a/sql/expression/function/json_unquote.go
+++ b/sql/expression/function/json_unquote.go
@@ -70,6 +70,9 @@ func (js *JSONUnquote) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
+	if ex == nil {
+		return nil, nil
+	}
 	str, ok := ex.(string)
 	if !ok {
 		return nil, sql.ErrInvalidType.New(reflect.TypeOf(ex).String())


### PR DESCRIPTION
…rn nil,nil

This fixes an issue that can trigger a panic in master with: 
```sql
SELECT json_unquote(json_extract('{"hi":"there"}', '$.nope'))
```
When json_extract returns with a path that is not resolved in the result, json_unquote will blow up while producing an error.