### PR TITLE
Changed FILTER expressions to consider ENUM/SET types

### DIFF
--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -1141,6 +1141,35 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "WHERE clause considers ENUM/SET types for comparisons",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 ENUM('a', 'b', 'c'), v2 SET('a', 'b', 'c'));",
+			"INSERT INTO test VALUES (1, 2, 2), (2, 1, 1);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT * FROM test;",
+				Expected: []sql.Row{{1, "b", "b"}, {2, "a", "a"}},
+			},
+			{
+				Query:    "UPDATE test SET v1 = 3 WHERE v1 = 2;",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1, InsertID: 0, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}}},
+			},
+			{
+				Query:    "SELECT * FROM test;",
+				Expected: []sql.Row{{1, "c", "b"}, {2, "a", "a"}},
+			},
+			{
+				Query:    "UPDATE test SET v2 = 3 WHERE 2 = v2;",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1, InsertID: 0, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}}},
+			},
+			{
+				Query:    "SELECT * FROM test;",
+				Expected: []sql.Row{{1, "c", "a,b"}, {2, "a", "a"}},
+			},
+		},
+	},
 }
 
 var CreateCheckConstraintsScripts = []ScriptTest{


### PR DESCRIPTION
Previously a statement such as `UPDATE test SET col = 2 WHERE col = 1;` would fail for `ENUM` and `SET` types. For the `FILTER` node, we only consider the values for comparison, but the aforementioned types can match `'horse'` with the number 50, so we have to consider the column type.

Now this PR only affects `ENUM` and `SET`, although it's probably correct that _all_ types should be used, with direct literal comparisons being used only when no other type can be derived from a column or variable. However, either MySQL has context-aware comparisons (my guess), or our comparison logic is wrong for other types, so I'm leaving those alone for now.