### PR TITLE
Fix explicit DEFAULT value in insert query

### DIFF
--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -865,6 +865,27 @@ var InsertScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "explicit DEFAULT with multiple values",
+		SetUpScript: []string{
+			"CREATE TABLE mytable(id int PRIMARY KEY, v2 int NOT NULL DEFAULT '2')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "INSERT INTO mytable (id, v2)values (1, DEFAULT), (2, DEFAULT)",
+				Expected: []sql.Row{
+					{sql.OkResult{RowsAffected: 2}},
+				},
+			},
+			{
+				Query: "SELECT * FROM mytable",
+				Expected: []sql.Row{
+					{1, 2},
+					{2, 2},
+				},
+			},
+		},
+	},
 }
 
 var InsertErrorTests = []GenericErrorQueryTest{

--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -845,6 +845,26 @@ var InsertScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "explicit DEFAULT",
+		SetUpScript: []string{
+			"CREATE TABLE mytable(id int PRIMARY KEY, v2 int NOT NULL DEFAULT '2')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "INSERT INTO mytable (id, v2)values (1, DEFAULT)",
+				Expected: []sql.Row{
+					{sql.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "SELECT * FROM mytable",
+				Expected: []sql.Row{
+					{1, 2},
+				},
+			},
+		},
+	},
 }
 
 var InsertErrorTests = []GenericErrorQueryTest{

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1471,10 +1471,14 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 	}
 
 	var columns []string
-	for i, c := range columnsToStrings(i.Columns) {
-		if _, found := columnWithDefaultValues[i]; !found {
-			columns = append(columns, c)
+	if len(columnWithDefaultValues) > 0 {
+		for i, c := range columnsToStrings(i.Columns) {
+			if _, found := columnWithDefaultValues[i]; !found {
+				columns = append(columns, c)
+			}
 		}
+	} else {
+		columns = columnsToStrings(i.Columns)
 	}
 
 	return plan.NewInsertInto(sql.UnresolvedDatabase(i.Table.Qualifier.String()), tableNameToUnresolvedTable(i.Table), src, isReplace, columns, onDupExprs, ignore), nil

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1455,18 +1455,22 @@ func convertInsert(ctx *sql.Context, i *sqlparser.Insert) (sql.Node, error) {
 	columnWithDefaultValues := make(map[int]bool)
 
 	if e, ok := src.(*plan.Values); ok {
-		var needCols []sql.Expression
-		for i, s := range e.ExpressionTuples[0] {
-			if _, ok := s.(*expression.DefaultColumn); ok {
-				columnWithDefaultValues[i] = true
-			} else {
-				needCols = append(needCols, s)
+		for i, tuple := range e.ExpressionTuples {
+			var needCols []sql.Expression
+			for j, s := range tuple {
+				if _, ok := s.(*expression.DefaultColumn); ok {
+					columnWithDefaultValues[j] = true
+				} else {
+					needCols = append(needCols, s)
+				}
 			}
-		}
 
-		// Only re-assign if found column with default values
-		if len(columnWithDefaultValues) > 0 {
-			e.ExpressionTuples[0] = needCols
+			// Only re-assign if found column with default values
+			if len(columnWithDefaultValues) == 0 {
+				break
+			}
+
+			e.ExpressionTuples[i] = needCols
 		}
 	}
 

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1503,6 +1503,9 @@ CREATE TABLE t2
 	`INSERT INTO t1 VALUES (b'0111')`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
 		expression.NewLiteral(uint64(7), sql.Uint64),
 	}}), false, []string{}, []sql.Expression{}, false),
+	`INSERT INTO t1 (col1, col2) VALUES ('a', DEFAULT)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+		expression.NewLiteral("a", sql.LongText),
+	}}), false, []string{"col1"}, []sql.Expression{}, false),
 	`UPDATE t1 SET col1 = ?, col2 = ? WHERE id = ?`: plan.NewUpdate(
 		plan.NewFilter(
 			expression.NewEquals(expression.NewUnresolvedColumn("id"), expression.NewBindVar("v3")),


### PR DESCRIPTION
It seems that `go-mysql-server` is not compatible with insert query like:

```sql
INSERT INTO `users` (`id`, `deleted`) VALUES (1, DEFAULT)
```

Whereas `DEFAULT` is just to specify `deleted` columns should use column [default value explicitly](https://dev.mysql.com/doc/refman/8.0/en/insert.html).

The issue could be demostrated using below code:
```go
package main

import (
	dbsql "database/sql"

	sqle "github.com/dolthub/go-mysql-server"
	"github.com/dolthub/go-mysql-server/auth"
	"github.com/dolthub/go-mysql-server/memory"
	"github.com/dolthub/go-mysql-server/server"
	_ "github.com/go-sql-driver/mysql"
)

func main() {
	db, _ := dbsql.Open("mysql", "root:@tcp(127.0.0.1:3307)/test")
	defer db.Close()

	query := `CREATE TABLE users (
  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  deleted tinyint(1) unsigned NOT NULL DEFAULT '0',
  PRIMARY KEY (id)
) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4`

	stmt, _ := db.Prepare(query)
	stmt.Exec()

	_, err := db.Exec("INSERT INTO `users` (`id`, `deleted`) VALUES (1, DEFAULT)")
	if err != nil {
		panic(err.Error())
	}

	stmtOut, _ := db.Prepare("SELECT `deleted` FROM `users` WHERE `id` = 1")
	defer stmtOut.Close()

	deleted := true
	err = stmtOut.QueryRow().Scan(&deleted)
	if err != nil {
		panic(err.Error())
	}

	if deleted == true {
		panic("Wrong deleted value")
	}
}

var engine *sqle.Engine

func init() {
	engine = sqle.NewDefault()
	db := memory.NewDatabase("test")
	engine.AddDatabase(db)

	config := server.Config{
		Protocol: "tcp",
		Address:  "localhost:3307",
		Auth:     auth.NewNativeSingle("root", "", auth.AllPermissions),
	}

	s, _ := server.NewDefaultServer(config, engine)

	go s.Start()
}
```

```
`db.Exec("INSERT INTO `users` (`id`, `deleted`) VALUES (1, DEFAULT)")` will result in error:

Error 1105: plan is not resolved because of node '*plan.Values'
```

This pull request should avoid such issue by turning explicit `DEFAULT` in insert query to implicit.