### PR TITLE
add engine tests for dateparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ examples on how to connect to go-mysql-server using them.
 |`SOUNDEX(str)`| returns the soundex of a string.|
 |`SPLIT(str,sep)`| returns the parts of the string `str` split by the separator `sep` as a JSON array of strings.|
 |`SQRT(X)`| returns the square root of a nonnegative number `X`.|
+| `STR_TO_DATE(date_str, format_str)`| parses the date/datetime/timestamp expression according to the format specifier. |
 |`SUBSTR(str, pos, [len])`| returns a substring from the string `str` starting at `pos` with a length of `len` characters. If no `len` is provided, all characters from `pos` until the end will be taken.|
 |`SUBSTRING(str, pos, [len])`| returns a substring from the string `str` starting at `pos` with a length of `len` characters. If no `len` is provided, all characters from `pos` until the end will be taken.|
 |`SUBSTRING_INDEX(str, delim, count)` | Returns a substring after `count` appearances of `delim`. If `count` is negative, counts from the right side of the string. |

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3173,6 +3173,13 @@ func (c customFunc) WithChildren(ctx *sql.Context, children ...sql.Expression) (
 	return &customFunc{expression.UnaryExpression{children[0]}}, nil
 }
 
+func TestDateParse(t *testing.T, harness Harness) {
+	engine := NewEngine(t, harness)
+	for _, tt := range DateParseQueries {
+		TestQuery(t, harness, engine, tt.Query, tt.Expected, nil, nil)
+	}
+}
+
 func TestColumnDefaults(t *testing.T, harness Harness) {
 	require := require.New(t)
 	e := NewEngine(t, harness)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -480,6 +480,10 @@ func TestColumnDefaults(t *testing.T) {
 	enginetest.TestColumnDefaults(t, enginetest.NewDefaultMemoryHarness())
 }
 
+func TestDateParse(t *testing.T) {
+	enginetest.TestDateParse(t, enginetest.NewDefaultMemoryHarness())
+}
+
 func TestJsonScripts(t *testing.T) {
 	enginetest.TestJsonScripts(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -5446,6 +5446,29 @@ var VersionedQueries = []QueryTest{
 	},
 }
 
+var DateParseQueries = []QueryTest{
+	{
+		Query:    "SELECT STR_TO_DATE('Jan 3, 2000', '%b %e, %Y')",
+		Expected: []sql.Row{{time.Date(2000, time.January, 3, 0, 0, 0, 0, time.Local)}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('May 3, 10:23:00 PM 2000', '%b %e, %H:%i:%s %p %Y')",
+		Expected: []sql.Row{{time.Date(2000, time.May, 3, 22, 23, 0, 0, time.Local)}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('01/02/99 314', '%m/%e/%y %f')",
+		Expected: []sql.Row{{time.Date(1999, time.January, 2, 0, 0, 0, 314000, time.Local)}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('01/02/99 05:14:12 PM', '%m/%e/%y %r')",
+		Expected: []sql.Row{{time.Date(1999, time.January, 2, 17, 14, 12, 0, time.Local)}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('invalid', 'notvalid')",
+		Expected: []sql.Row{{sql.Null}},
+	},
+}
+
 var InfoSchemaQueries = []QueryTest{
 	{
 		Query: "SHOW TABLES",


### PR DESCRIPTION
Follow-up to https://github.com/dolthub/go-mysql-server/pull/523