### PR TITLE
server/handler.go: Have ComPrepare correctly return null result schema metadata for write statements.

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -133,11 +133,13 @@ func (s *SessionManager) NewContext(conn *mysql.Conn) (*sql.Context, error) {
 
 func (s *SessionManager) getOrCreateSession(ctx context.Context, conn *mysql.Conn) (sql.Session, *sql.IndexRegistry, *sql.ViewRegistry, error) {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	sess, ok := s.sessions[conn.ConnectionID]
-	s.mu.Unlock()
 
 	if !ok {
+		s.mu.Unlock()
 		err := s.NewSession(ctx, conn)
+		s.mu.Lock()
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -92,6 +92,9 @@ func (h *Handler) ComPrepare(c *mysql.Conn, query string) ([]*query.Field, error
 	if err != nil {
 		return nil, err
 	}
+	if sql.IsOkResultSchema(schema) {
+		return nil, nil
+	}
 	return schemaToFields(schema), nil
 }
 

--- a/sql/ok_result.go
+++ b/sql/ok_result.go
@@ -39,6 +39,10 @@ var OkResultSchema = Schema{
 	},
 }
 
+func IsOkResultSchema(schema Schema) bool {
+	return len(schema) == 1 && schema[0] == OkResultSchema[0]
+}
+
 // NewOkResult returns a new OkResult with the given number of rows affected.
 func NewOkResult(rowsAffected int) OkResult {
 	return OkResult{RowsAffected: uint64(rowsAffected)}


### PR DESCRIPTION
This fixes our server's interaction with clients which expect the result
metadata for a write statement to be NULL. One such client is RMariaDB. See:
https://github.com/dolthub/dolt/issues/2084.