### PR TITLE
Wrote proper number conversion logic

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -6201,11 +6201,11 @@ var errorQueries = []QueryErrorTest{
 	},
 	{
 		Query:          `select JSON_EXTRACT('{"id":"abc"}', '$.id')-1;`,
-		ExpectedErrStr: "unable to cast \"abc\" of type string to float64",
+		ExpectedErrStr: `error: 'abc' is not a valid value for 'DOUBLE'`,
 	},
 	{
 		Query:          `select JSON_EXTRACT('{"id":{"a": "abc"}}', '$.id')-1;`,
-		ExpectedErrStr: `unable to cast map[string]interface {}{"a":"abc"} of type map[string]interface {} to float64`,
+		ExpectedErrStr: `error: 'map[string]interface {}' is not a valid value type for 'DOUBLE'`,
 	},
 	{
 		Query:       `alter table mytable add primary key (s)`,

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/sanity-io/litter v1.2.0
 	github.com/shopspring/decimal v0.0.0-20191130220710-360f2bc03045
 	github.com/sirupsen/logrus v1.4.2
-	github.com/spf13/cast v1.3.0
 	github.com/src-d/go-oniguruma v1.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tebeka/strftime v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190830154057-c17b040389b9 h1:5/jaG/gKlo3xxvUn85ReNyTlN7BvlPPsxC6sHZKjGEE=
 golang.org/x/tools v0.0.0-20190830154057-c17b040389b9/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474/go.mod h1:kMz7uXOXq4qRriCEyZ/LUeTqraLJCjf0WVZcUi6TxUY=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20210802203534-01de666843ce h1:NNoKBTOCFRslRQyn0Zko/1Aq1A+bpuktdXVip/dY47w=
-github.com/dolthub/vitess v0.0.0-20210802203534-01de666843ce/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/dolthub/vitess v0.0.0-20210823180838-e36a9ec06b90 h1:bHYET3IPb3XwK8qqo7gmSeQUQ5DARrXSYapLha0Jnu8=
 github.com/dolthub/vitess v0.0.0-20210823180838-e36a9ec06b90/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -76,8 +74,6 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
-github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/src-d/go-oniguruma v1.1.0 h1:EG+Nm5n2JqWUaCjtM0NtutPxU7ZN5Tp50GWrrV8bTww=
 github.com/src-d/go-oniguruma v1.1.0/go.mod h1:chVbff8kcVtmrhxtZ3yBVLLquXbzCS6DrxQaAK/CeqM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -129,7 +125,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/tools v0.0.0-20190830154057-c17b040389b9 h1:5/jaG/gKlo3xxvUn85ReNyTlN7BvlPPsxC6sHZKjGEE=
 golang.org/x/tools v0.0.0-20190830154057-c17b040389b9/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -313,6 +313,12 @@ var (
 
 	// ErrImmutableDatabaseProvider is returned when attempting to edit an immutable database databaseProvider.
 	ErrImmutableDatabaseProvider = errors.NewKind("error: can't modify database databaseProvider")
+
+	// ErrInvalidValue is returned when a given value does not match what is expected.
+	ErrInvalidValue = errors.NewKind(`error: '%v' is not a valid value for '%v'`)
+
+	// ErrInvalidValueType is returned when a given value's type does not match what is expected.
+	ErrInvalidValueType = errors.NewKind(`error: '%T' is not a valid value type for '%v'`)
 )
 
 func CastSQLError(err error) (*mysql.SQLError, bool) {

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -16,7 +16,6 @@ package expression
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -215,46 +214,14 @@ func convertValue(val interface{}, castTo string) (interface{}, error) {
 	case ConvertToUnsigned:
 		num, err := sql.Uint64.Convert(val)
 		if err != nil {
-			num = handleUnsignedErrors(err, val)
+			num, err = sql.Int64.Convert(val)
+			if err != nil {
+				return sql.Uint64.Zero(), nil
+			}
+			return uint64(num.(int64)), nil
 		}
-
 		return num, nil
 	default:
 		return nil, nil
 	}
-}
-
-func handleUnsignedErrors(err error, val interface{}) uint64 {
-	if err.Error() == "unable to cast negative value" {
-		return castSignedToUnsigned(val)
-	}
-
-	if strings.Contains(err.Error(), "strconv.ParseUint") {
-		signedNum, err := strconv.ParseInt(val.(string), 0, 64)
-		if err != nil {
-			return uint64(0)
-		}
-
-		return castSignedToUnsigned(signedNum)
-	}
-
-	return uint64(0)
-}
-
-func castSignedToUnsigned(val interface{}) uint64 {
-	var unsigned uint64
-	switch num := val.(type) {
-	case int:
-		unsigned = uint64(num)
-	case int8:
-		unsigned = uint64(num)
-	case int16:
-		unsigned = uint64(num)
-	case int32:
-		unsigned = uint64(num)
-	case int64:
-		unsigned = uint64(num)
-	}
-
-	return unsigned
 }

--- a/sql/numbertype_test.go
+++ b/sql/numbertype_test.go
@@ -179,6 +179,7 @@ func TestNumberConvert(t *testing.T) {
 		{Uint24, 36.756, uint32(36), false},
 		{Uint32, uint8(37), uint32(37), false},
 		{Uint64, time.Date(2009, 1, 2, 3, 4, 5, 0, time.UTC), uint64(time.Date(2009, 1, 2, 3, 4, 5, 0, time.UTC).Unix()), false},
+		{Uint64, "01000", uint64(1000), false},
 		{Float32, "22.25", float32(22.25), false},
 		{Float64, float32(893.875), float64(893.875), false},
 


### PR DESCRIPTION
Previously we were relying on the `cast` library, which had a few issues with how we expect SQL numbers to function. One such issue was how number strings were handled (such as interpreting `"01000"` as a binary number rather than in decimal). There have been more issues in the past that have gone undocumented, but this should fix them (or allow for an easy fix since it's all custom logic now).