### PR TITLE
sql/analyzer/validation_rules.go: Add a validation rule to assert that a subquery expression was successfully analyzed in the last pass.

### DIFF
--- a/sql/analyzer/common_test.go
+++ b/sql/analyzer/common_test.go
@@ -148,6 +148,7 @@ type analyzerFnTestCase struct {
 	scope    *Scope
 	expected sql.Node
 	err      *errors.Kind
+	postF    func(*testing.T, sql.Node) sql.Node
 }
 
 func runTestCases(t *testing.T, ctx *sql.Context, testCases []analyzerFnTestCase, a *Analyzer, f Rule) {
@@ -168,6 +169,10 @@ func runTestCases(t *testing.T, ctx *sql.Context, testCases []analyzerFnTestCase
 			expected := tt.expected
 			if expected == nil {
 				expected = tt.node
+			}
+
+			if tt.postF != nil {
+				result = tt.postF(t, result)
 			}
 
 			assertNodesEqualWithDiff(t, expected, result)

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -114,12 +114,12 @@ func resolveSubqueryExpressions(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 			//  recover the actual error in the validation step.
 			if ErrValidationResolved.Is(err) || sql.ErrTableColumnNotFound.Is(err) || sql.ErrColumnNotFound.Is(err) {
 				// keep the work we have and defer remainder of analysis of this subquery until a later pass
-				return s.WithQuery(analyzed), nil
+				return s.WithQuery(analyzed).WithLastErr(err), nil
 			}
 			return nil, err
 		}
 
-		return s.WithQuery(stripQueryProcess(analyzed)), nil
+		return s.WithQuery(stripQueryProcess(analyzed)).WithLastErr(nil), nil
 	})
 }
 

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -30,6 +30,8 @@ type Subquery struct {
 	Query sql.Node
 	// The original verbatim select statement for this subquery
 	QueryString string
+	// lastErr is the last analysis error that the analyzer saw. By the time the query is fully analyzed, this should be nil.
+	lastErr error
 	// Whether it's safe to cache result values for this subquery
 	canCacheResults bool
 	// Whether results have been cached
@@ -366,6 +368,16 @@ func (s *Subquery) WithQuery(node sql.Node) *Subquery {
 	ns := *s
 	ns.Query = node
 	return &ns
+}
+
+func (s *Subquery) WithLastErr(err error) *Subquery {
+	ns := *s
+	ns.lastErr = err
+	return &ns
+}
+
+func (s *Subquery) LastErr() error {
+	return s.lastErr
 }
 
 func (s *Subquery) IsNonDeterministic() bool {


### PR DESCRIPTION
The analyzer steps that analyzes subqueries allows that analysis to fail with
an error and a partial result. The idea is that it is going to happen
iteratively while the scope and table and alias names are worked out from later
analysis steps. On later iterations of the subquery analysis, the subquery will
analyze successfully.

The problem is that after the subquery has analyzed successfully, a later
transformation of plan tree (combined with bugs or unsupported features in our
engine) could cause the subquery to stop analyzing successfully.

This code change adds a validation step to the analyzer to assert that the last
run of the subquery analysis on any plan.Subquery nodes did not return any
errors, even errors that would have been tolerated by the analyzer during
default-rules iteration for example.