### PR TITLE
Update some analyzer rules and expression behavior to deal with tuples in a more principled way.

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1194,6 +1194,50 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{1}},
 	},
 	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) = (select 3, 4 from dual where false)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 3, 4 from dual where false) = ((1, 2))",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 3, 4 from dual where false) in ((1, 2))",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) in (select 3, 4 from dual where false)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE null = (select 4 from dual where false)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE null <=> (select 4 from dual where false)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (null, null) <=> (select 1, 4 from dual where false)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 1, 2 from dual) in (select 1, 2 from dual)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 1, 2 from dual where false) in (select 1, 2 from dual)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 1, 2 from dual where false) in (select 1, 2 from dual where false)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 1, 2 from dual) in (select 1, 2 from dual where false)",
+		Expected: []sql.Row{},
+	},
+	{
 		Query:    "SELECT 1 FROM DUAL WHERE (select 5, 6 from dual) in ((1, 2), (2, 3), (3, 4))",
 		Expected: []sql.Row{},
 	},

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1124,6 +1124,120 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{nil}},
 	},
 	{
+		Query:    "SELECT 1 FROM DUAL WHERE 1 in (1)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) in ((1, 2))",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) in ((3, 4), (5, 6), (1, 2))",
+		Expected: []sql.Row{{1}},
+	},
+	// TODO
+	//	{
+	//		Query:    "SELECT 1 FROM DUAL WHERE (1, null) in ((1, null))",
+	//		Expected: []sql.Row{},
+	//	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (true)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) > (0, 1)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) >= (0, 1)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) <= (0, 1)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) < (0, 1)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) != (0, 1)",
+		Expected: []sql.Row{{1}},
+	},
+	// TODO
+	//	{
+	//		Query:    "SELECT 1 FROM DUAL WHERE (1, null) != (0, null)",
+	//		Expected: []sql.Row{},
+	//	},
+	//	{
+	//		Query:    "SELECT 1 FROM DUAL WHERE (0, null) = (0, null)",
+	//		Expected: []sql.Row{},
+	//	},
+	//	{
+	//		Query:    "SELECT 1 FROM DUAL WHERE ('0', 0) = (0, '0')",
+	//		Expected: []sql.Row{{1}},
+	//	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) <=> (0, 1)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, null) <=> (1, null)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 1, 2 from dual) in ((1, 2))",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 3, 4 from dual) in ((1, 2), (2, 3), (3, 4))",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (select 5, 6 from dual) in ((1, 2), (2, 3), (3, 4))",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) in (select 5, 6 from dual)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) in (select 5, 6 from dual union select 1, 2 from dual)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT (((1,2),3)) = (((1,2),3)) from dual",
+		Expected: []sql.Row{{true}},
+	},
+	{
+		Query:    "SELECT (((1,3),2)) = (((1,2),3)) from dual",
+		Expected: []sql.Row{{false}},
+	},
+	{
+		Query:    "SELECT (((1,3),2)) in (((1,2),6), ((1,2),4)) from dual",
+		Expected: []sql.Row{{false}},
+	},
+	{
+		Query:    "SELECT (((1,3),2)) in (((1,2),6), ((1,3),2)) from dual",
+		Expected: []sql.Row{{true}},
+	},
+	{
+		Query:    "SELECT (1, 2) in (select 1, 2 from dual) from dual",
+		Expected: []sql.Row{{true}},
+	},
+	{
+		Query:    "SELECT (1, 2) in (select 2, 3 from dual) from dual",
+		Expected: []sql.Row{{false}},
+	},
+	{
+		Query:    "SELECT (select 1, 2 from dual) in ((1, 2)) from dual",
+		Expected: []sql.Row{{true}},
+	},
+	{
+		Query:    "SELECT (select 2, 3 from dual) in ((1, 2)) from dual",
+		Expected: []sql.Row{{false}},
+	},
+	{
 		Query:    `SELECT 'a' NOT IN ('b','c',null,'d')`,
 		Expected: []sql.Row{{nil}},
 		ExpectedColumns: sql.Schema{
@@ -6207,6 +6321,54 @@ var errorQueries = []QueryErrorTest{
 	{
 		Query:       "SELECT SUM(i) as sum, i FROM mytable GROUP BY i ORDER BY 1+SUM(i) ASC",
 		ExpectedErr: analyzer.ErrAggregationUnsupported,
+	},
+	{
+		Query:       "select ((1, 2)) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (select 1, 2 from dual) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select concat((1, 2)) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (1, 2) = (1) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (1) in (select 1, 2 from dual) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (1, 2) in (select 1, 2, 3 from dual) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (select 1 from dual) in ((1, 2)) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (((1,2),3)) = (((1,2))) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (((1,2),3)) = (((1),2)) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (((1,2),3)) = (((1))) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select (((1,2),3)) = (((1,2),3),(4,5)) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
+	},
+	{
+		Query:       "select ((4,5),((1,2),3)) = ((1,2),(4,5)) from dual",
+		ExpectedErr: sql.ErrInvalidOperandColumns,
 	},
 }
 

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1135,11 +1135,22 @@ var QueryTests = []QueryTest{
 		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) in ((3, 4), (5, 6), (1, 2))",
 		Expected: []sql.Row{{1}},
 	},
-	// TODO
-	//	{
-	//		Query:    "SELECT 1 FROM DUAL WHERE (1, null) in ((1, null))",
-	//		Expected: []sql.Row{},
-	//	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) in ((3, 4), (5, 6))",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) not in ((3, 4), (5, 6))",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) not in ((3, 4), (5, 6), (1, 2))",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) not in ((1, 2))",
+		Expected: []sql.Row{},
+	},
 	{
 		Query:    "SELECT 1 FROM DUAL WHERE (true)",
 		Expected: []sql.Row{{1}},
@@ -1164,19 +1175,6 @@ var QueryTests = []QueryTest{
 		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) != (0, 1)",
 		Expected: []sql.Row{{1}},
 	},
-	// TODO
-	//	{
-	//		Query:    "SELECT 1 FROM DUAL WHERE (1, null) != (0, null)",
-	//		Expected: []sql.Row{},
-	//	},
-	//	{
-	//		Query:    "SELECT 1 FROM DUAL WHERE (0, null) = (0, null)",
-	//		Expected: []sql.Row{},
-	//	},
-	//	{
-	//		Query:    "SELECT 1 FROM DUAL WHERE ('0', 0) = (0, '0')",
-	//		Expected: []sql.Row{{1}},
-	//	},
 	{
 		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) <=> (0, 1)",
 		Expected: []sql.Row{},
@@ -1220,6 +1218,10 @@ var QueryTests = []QueryTest{
 	{
 		Query:    "SELECT 1 FROM DUAL WHERE (null, null) <=> (select 1, 4 from dual where false)",
 		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (null, null) <=> (select null, null from dual)",
+		Expected: []sql.Row{{1}},
 	},
 	{
 		Query:    "SELECT 1 FROM DUAL WHERE (select 1, 2 from dual) in (select 1, 2 from dual)",
@@ -5538,6 +5540,28 @@ var BrokenQueries = []QueryTest{
 				Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20),
 			},
 		},
+	},
+	// Null-safe and type conversion tuple comparison is not correctly
+	// implemented yet.
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, null) in ((1, null))",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (1, null) != (0, null)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (0, null) = (0, null)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE ('0', 0) = (0, '0')",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "SELECT 1 FROM DUAL WHERE (null, null) = (select null, null from dual)",
+		Expected: []sql.Row{},
 	},
 }
 

--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -840,7 +840,7 @@ var ScriptTests = []ScriptTest{
 			},
 			{
 				Query:       `SELECT group_concat((SELECT * FROM t LIMIT 1)) from t`,
-				ExpectedErr: sql.ErrSubqueryMultipleColumns,
+				ExpectedErr: sql.ErrInvalidOperandColumns,
 			},
 			{
 				Query:       `SELECT group_concat((SELECT * FROM x)) from t`,

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
@@ -32,7 +33,7 @@ const (
 	validateOrderByRule           = "validate_order_by"
 	validateGroupByRule           = "validate_group_by"
 	validateSchemaSourceRule      = "validate_schema_source"
-	validateProjectTuplesRule     = "validate_project_tuples"
+	validateOperandsRule          = "validate_operands_rule"
 	validateIndexCreationRule     = "validate_index_creation"
 	validateCaseResultTypesRule   = "validate_case_result_types"
 	validateIntervalUsageRule     = "validate_interval_usage"
@@ -54,9 +55,6 @@ var (
 	// ErrValidationSchemaSource is returned when there is any column source
 	// that does not match the table name.
 	ErrValidationSchemaSource = errors.NewKind("one or more schema sources are empty")
-	// ErrProjectTuple is returned when there is a tuple of more than 1 column
-	// inside a projection.
-	ErrProjectTuple = errors.NewKind("selected field %d should have 1 column, but has %d")
 	// ErrUnknownIndexColumns is returned when there are columns in the expr
 	// to index that are unknown in the table.
 	ErrUnknownIndexColumns = errors.NewKind("unknown columns to index for table %q: %s")
@@ -106,8 +104,8 @@ var DefaultValidationRules = []Rule{
 	{validateOrderByRule, validateOrderBy},
 	{validateGroupByRule, validateGroupBy},
 	{validateSchemaSourceRule, validateSchemaSource},
-	{validateProjectTuplesRule, validateProjectTuples},
 	{validateIndexCreationRule, validateIndexCreation},
+	{validateOperandsRule, validateOperands},
 	{validateCaseResultTypesRule, validateCaseResultTypes},
 	{validateIntervalUsageRule, validateIntervalUsage},
 	{validateExplodeUsageRule, validateExplodeUsage},
@@ -384,36 +382,6 @@ func validateUnionSchemasMatch(ctx *sql.Context, a *Analyzer, n sql.Node, scope 
 	return n, nil
 }
 
-func findProjectTuples(n sql.Node) (sql.Node, error) {
-	if n == nil {
-		return n, nil
-	}
-
-	switch n := n.(type) {
-	case *plan.Project, *plan.GroupBy, *plan.Window:
-		for i, e := range n.(sql.Expressioner).Expressions() {
-			if sql.IsTuple(e.Type()) {
-				return nil, ErrProjectTuple.New(i+1, sql.NumColumns(e.Type()))
-			}
-		}
-	default:
-		for _, ch := range n.Children() {
-			_, err := findProjectTuples(ch)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return n, nil
-}
-
-func validateProjectTuples(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
-	span, _ := ctx.Span("validate_project_tuples")
-	defer span.Finish()
-	return findProjectTuples(n)
-}
-
 func validateCaseResultTypes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
 	span, ctx := ctx.Span("validate_case_result_types")
 	defer span.Finish()
@@ -504,25 +472,84 @@ func validateExplodeUsage(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scop
 	return n, nil
 }
 
-func validateSubqueryColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
+func validateOperands(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
+	// Validate that the number of columns in an operand or a top level
+	// expression are as expected. The currently rules are:
+	// * Every top level expression of a node must have 1 column.
+	// * The following expression nodes are allowed to have `n` columns as
+	// long as `n` matches:
+	//   * *plan.InSubquery, *expression.{Equals,NullSafeEquals,GreaterThan,LessThan,GreaterThanOrEqual,LessThanOrEqual}
+	// * *expression.InTuple must have a tuple on the right side, the # of
+	// columns for each element of the tuple must match the number of
+	// columns of the expression on the left.
+	// * Every other expression with operands must have NumColumns == 1.
 
-	// First validate that every subquery expression returns a single column
-	valid := true
-	plan.InspectExpressions(n, func(e sql.Expression) bool {
-		s, ok := e.(*plan.Subquery)
-		if ok && len(s.Query.Schema()) != 1 {
-			valid = false
+	var err error
+	plan.Inspect(n, func(n sql.Node) bool {
+		if n == nil {
 			return false
 		}
-
-		return true
+		if er, ok := n.(sql.Expressioner); ok {
+			for _, e := range er.Expressions() {
+				nc := sql.NumColumns(e.Type())
+				if nc != 1 {
+					err = sql.ErrInvalidOperandColumns.New(1, nc)
+					return false
+				}
+				sql.Inspect(e, func(e sql.Expression) bool {
+					if e == nil {
+						return err == nil
+					}
+					if err != nil {
+						return false
+					}
+					switch e.(type) {
+					case *plan.InSubquery, *expression.Equals, *expression.NullSafeEquals, *expression.GreaterThan,
+						*expression.LessThan, *expression.GreaterThanOrEqual, *expression.LessThanOrEqual:
+						err = sql.ErrIfMismatchedColumns(e.Children()[0].Type(), e.Children()[1].Type())
+					case *expression.InTuple:
+						t, ok := e.Children()[1].(expression.Tuple)
+						if ok && len(t.Children()) == 1 {
+							// A single element Tuple treats itself like the element it contains.
+							err = sql.ErrIfMismatchedColumns(e.Children()[0].Type(), e.Children()[1].Type())
+						} else {
+							err = sql.ErrIfMismatchedColumnsInTuple(e.Children()[0].Type(), e.Children()[1].Type())
+						}
+					case *aggregation.Count, *aggregation.CountDistinct, *aggregation.JSONArrayAgg:
+						if _, s := e.Children()[0].(*expression.Star); s {
+							return false
+						}
+						for _, e := range e.Children() {
+							nc := sql.NumColumns(e.Type())
+							if nc != 1 {
+								err = sql.ErrInvalidOperandColumns.New(1, nc)
+							}
+						}
+					case expression.Tuple:
+						// Tuple expressions can contain tuples...
+					default:
+						for _, e := range e.Children() {
+							nc := sql.NumColumns(e.Type())
+							if nc != 1 {
+								err = sql.ErrInvalidOperandColumns.New(1, nc)
+							}
+						}
+					}
+					return err == nil
+				})
+			}
+		}
+		return err == nil
 	})
-
-	if !valid {
-		return nil, sql.ErrSubqueryMultipleColumns.New()
+	if err != nil {
+		return nil, err
 	}
+	return n, nil
+}
 
+func validateSubqueryColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
 	// Then validate that every subquery has field indexes within the correct range
+	// TODO: Why is this only for subqueries?
 	var outOfRangeIndexExpression sql.Expression
 	var outOfRangeColumns int
 	plan.InspectExpressionsWithNode(n, func(n sql.Node, e sql.Expression) bool {
@@ -531,22 +558,38 @@ func validateSubqueryColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *S
 			return true
 		}
 
-		outerScopeRowLen := len(schemas(n.Children()))
-		plan.InspectExpressionsWithNode(s.Query, func(n sql.Node, e sql.Expression) bool {
-			if gf, ok := e.(*expression.GetField); ok {
-				if gf.Index() >= outerScopeRowLen+len(schemas(n.Children())) {
-					outOfRangeIndexExpression = gf
-					outOfRangeColumns = outerScopeRowLen + len(schemas(n.Children()))
-					return false
+		outerScopeRowLen := len(scope.Schema()) + len(schemas(n.Children()))
+		plan.Inspect(s.Query, func(n sql.Node) bool {
+			if n == nil {
+				return true
+			}
+			// TODO: the schema of the rows seen by children of
+			// these nodes are not reflected in the schema
+			// calculations here. This needs to be rationalized
+			// across the analyzer.
+			switch n.(type) {
+			case *plan.IndexedJoin, *plan.IndexedInSubqueryFilter:
+				return false
+			}
+			if es, ok := n.(sql.Expressioner); ok {
+				childSchemaLen := len(schemas(n.Children()))
+				for _, e := range es.Expressions() {
+					sql.Inspect(e, func(e sql.Expression) bool {
+						if gf, ok := e.(*expression.GetField); ok {
+							if gf.Index() >= outerScopeRowLen+childSchemaLen {
+								outOfRangeIndexExpression = gf
+								outOfRangeColumns = outerScopeRowLen + childSchemaLen
+							}
+						}
+						return outOfRangeIndexExpression == nil
+					})
 				}
 			}
-			return true
+			return outOfRangeIndexExpression == nil
 		})
-
 		return outOfRangeIndexExpression == nil
 	})
-
-	if !valid {
+	if outOfRangeIndexExpression != nil {
 		return nil, ErrSubqueryFieldIndex.New(outOfRangeIndexExpression, outOfRangeColumns)
 	}
 

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -474,7 +474,7 @@ func validateExplodeUsage(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scop
 
 func validateOperands(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
 	// Validate that the number of columns in an operand or a top level
-	// expression are as expected. The currently rules are:
+	// expression are as expected. The current rules are:
 	// * Every top level expression of a node must have 1 column.
 	// * The following expression nodes are allowed to have `n` columns as
 	// long as `n` matches:
@@ -484,6 +484,8 @@ func validateOperands(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (
 	// columns of the expression on the left.
 	// * Every other expression with operands must have NumColumns == 1.
 
+	// We do not use plan.InspectExpressions here because we're treating
+	// top-level expressions of sql.Node differently from subexpressions.
 	var err error
 	plan.Inspect(n, func(n sql.Node) bool {
 		if n == nil {

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -365,7 +365,7 @@ func TestValidateUnionSchemasMatch(t *testing.T) {
 	}
 }
 
-func TestValidateProjectTuples(t *testing.T) {
+func TestValidateOperands(t *testing.T) {
 	testCases := []struct {
 		name string
 		node sql.Node
@@ -447,9 +447,22 @@ func TestValidateProjectTuples(t *testing.T) {
 			}, nil, nil),
 			false,
 		},
+		{
+			"validate subquery columns",
+			plan.NewProject([]sql.Expression{
+				plan.NewSubquery(plan.NewProject(
+					[]sql.Expression{
+						lit(1),
+						lit(2),
+					},
+					dummyNode{true},
+				), "select 1, 2"),
+			}, dummyNode{true}),
+			false,
+		},
 	}
 
-	rule := getValidationRule(validateProjectTuplesRule)
+	rule := getValidationRule(validateOperandsRule)
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
@@ -458,7 +471,7 @@ func TestValidateProjectTuples(t *testing.T) {
 				require.NoError(err)
 			} else {
 				require.Error(err)
-				require.True(ErrProjectTuple.Is(err))
+				require.True(sql.ErrInvalidOperandColumns.Is(err))
 			}
 		})
 	}
@@ -835,20 +848,6 @@ func TestValidateSubqueryColumns(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
 
-	node := plan.NewProject([]sql.Expression{
-		plan.NewSubquery(plan.NewProject(
-			[]sql.Expression{
-				lit(1),
-				lit(2),
-			},
-			dummyNode{true},
-		), "select 1, 2"),
-	}, dummyNode{true})
-
-	_, err := validateSubqueryColumns(ctx, nil, node, nil)
-	require.Error(err)
-	require.True(sql.ErrSubqueryMultipleColumns.Is(err))
-
 	table := memory.NewTable("test", sql.Schema{
 		{Name: "foo", Type: sql.Text},
 	})
@@ -856,6 +855,7 @@ func TestValidateSubqueryColumns(t *testing.T) {
 		{Name: "bar", Type: sql.Text},
 	})
 
+	var node sql.Node
 	node = plan.NewProject([]sql.Expression{
 		plan.NewSubquery(plan.NewFilter(expression.NewGreaterThan(
 			expression.NewGetField(0, sql.Boolean, "foo", false),
@@ -868,7 +868,7 @@ func TestValidateSubqueryColumns(t *testing.T) {
 		)), "select bar from subtest where foo > 1"),
 	}, plan.NewResolvedTable(table, nil, nil))
 
-	_, err = validateSubqueryColumns(ctx, nil, node, nil)
+	_, err := validateSubqueryColumns(ctx, nil, node, nil)
 	require.NoError(err)
 
 	node = plan.NewProject([]sql.Expression{
@@ -884,7 +884,8 @@ func TestValidateSubqueryColumns(t *testing.T) {
 	}, plan.NewResolvedTable(table, nil, nil))
 
 	_, err = validateSubqueryColumns(ctx, nil, node, nil)
-	require.NoError(err)
+	require.Error(err)
+	require.True(ErrSubqueryFieldIndex.Is(err))
 
 	node = plan.NewProject([]sql.Expression{
 		plan.NewSubquery(plan.NewProject(

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -243,11 +243,6 @@ var (
 	// more than 1 row without an attached IN clause.
 	ErrExpectedSingleRow = errors.NewKind("the subquery returned more than 1 row")
 
-	// ErrSubqueryMultipleColumns is returned when an expression subquery returns
-	// more than a single column.
-	ErrSubqueryMultipleColumns = errors.NewKind(
-		"operand contains more than one column",
-	)
 	// ErrUnknownConstraint is returned when a DROP CONSTRAINT statement refers to a constraint that doesn't exist
 	ErrUnknownConstraint = errors.NewKind("Constraint %q does not exist")
 
@@ -319,6 +314,12 @@ var (
 
 	// ErrInvalidValueType is returned when a given value's type does not match what is expected.
 	ErrInvalidValueType = errors.NewKind(`error: '%T' is not a valid value type for '%v'`)
+
+	// ErrInvalidOperandColumns is returned when the columns in the left
+	// operand and the elements of the right operand don't match. Also
+	// returned for invalid number of columns in projections, filters,
+	// joins, etc.
+	ErrInvalidOperandColumns = errors.NewKind("operand should have %d columns, but has %d")
 )
 
 func CastSQLError(err error) (*mysql.SQLError, bool) {
@@ -339,7 +340,7 @@ func CastSQLError(err error) (*mysql.SQLError, bool) {
 		code = mysql.ERDbCreateExists
 	case ErrExpectedSingleRow.Is(err):
 		code = mysql.ERSubqueryNo1Row
-	case ErrSubqueryMultipleColumns.Is(err):
+	case ErrInvalidOperandColumns.Is(err):
 		code = mysql.EROperandColumns
 	case ErrInsertIntoNonNullableProvidedNull.Is(err):
 		code = mysql.ERBadNullError

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -609,7 +609,4 @@ var (
 	// ErrUnsupportedInOperand is returned when there is an invalid righthand
 	// operand in an IN operator.
 	ErrUnsupportedInOperand = errors.NewKind("right operand in IN operation must be tuple, but is %T")
-	// ErrInvalidOperandColumns is returned when the columns in the left operand
-	// and the elements of the right operand don't match.
-	ErrInvalidOperandColumns = errors.NewKind("operand should have %d columns, but has %d")
 )

--- a/sql/expression/function/concat.go
+++ b/sql/expression/function/concat.go
@@ -50,10 +50,6 @@ func NewConcat(ctx *sql.Context, args ...sql.Expression) (sql.Expression, error)
 		if len(args) > 1 && sql.IsArray(arg.Type()) {
 			return nil, ErrConcatArrayWithOthers.New()
 		}
-
-		if sql.IsTuple(arg.Type()) {
-			return nil, sql.ErrInvalidType.New("tuple")
-		}
 	}
 
 	return &Concat{args}, nil

--- a/sql/expression/function/concat_test.go
+++ b/sql/expression/function/concat_test.go
@@ -75,10 +75,6 @@ func TestNewConcat(t *testing.T) {
 	require.Error(err)
 	require.True(ErrConcatArrayWithOthers.Is(err))
 
-	_, err = NewConcat(sql.NewEmptyContext(), expression.NewLiteral(nil, sql.CreateTuple(sql.LongText, sql.LongText)))
-	require.Error(err)
-	require.True(sql.ErrInvalidType.Is(err))
-
 	_, err = NewConcat(sql.NewEmptyContext(),
 		expression.NewLiteral(nil, sql.LongText),
 		expression.NewLiteral(nil, sql.Boolean),

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -77,7 +77,7 @@ func (in *InTuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	case Tuple:
 		for _, el := range right {
 			if sql.NumColumns(el.Type()) != leftElems {
-				return nil, ErrInvalidOperandColumns.New(leftElems, sql.NumColumns(el.Type()))
+				return nil, sql.ErrInvalidOperandColumns.New(leftElems, sql.NumColumns(el.Type()))
 			}
 		}
 

--- a/sql/expression/in_test.go
+++ b/sql/expression/in_test.go
@@ -56,7 +56,7 @@ func TestInTuple(t *testing.T) {
 			),
 			nil,
 			nil,
-			expression.ErrInvalidOperandColumns,
+			sql.ErrInvalidOperandColumns,
 		},
 		{
 			"right is an unsupported operand",
@@ -139,7 +139,7 @@ func TestNotInTuple(t *testing.T) {
 			),
 			nil,
 			nil,
-			expression.ErrInvalidOperandColumns,
+			sql.ErrInvalidOperandColumns,
 		},
 		{
 			"right is an unsupported operand",

--- a/sql/expression/tuple.go
+++ b/sql/expression/tuple.go
@@ -71,7 +71,7 @@ func (t Tuple) DebugString() string {
 	for i, e := range t {
 		exprs[i] = sql.DebugString(e)
 	}
-	return fmt.Sprintf("TUPLE(%s)[%s]", strings.Join(exprs, ", "), t.Type().String())
+	return fmt.Sprintf("TUPLE(%s)", strings.Join(exprs, ", "))
 }
 
 // Resolved implements the Expression interface.

--- a/sql/expression/tuple.go
+++ b/sql/expression/tuple.go
@@ -66,6 +66,14 @@ func (t Tuple) String() string {
 	return fmt.Sprintf("(%s)", strings.Join(exprs, ", "))
 }
 
+func (t Tuple) DebugString() string {
+	var exprs = make([]string, len(t))
+	for i, e := range t {
+		exprs[i] = sql.DebugString(e)
+	}
+	return fmt.Sprintf("TUPLE(%s)[%s]", strings.Join(exprs, ", "), t.Type().String())
+}
+
 // Resolved implements the Expression interface.
 func (t Tuple) Resolved() bool {
 	for _, e := range t {

--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -45,7 +45,6 @@ var nilKey, _ = sql.HashOf(sql.NewRow(nil))
 // Eval implements the Expression interface.
 func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	typ := in.Left.Type().Promote()
-	leftElems := sql.NumColumns(typ)
 	left, err := in.Left.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -65,11 +64,6 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	switch right := in.Right.(type) {
 	case *Subquery:
-		if leftElems > 1 {
-			// TODO: support more than one element in IN
-			return nil, expression.ErrInvalidOperandColumns.New(leftElems, 1)
-		}
-
 		typ := right.Type()
 		values, err := right.HashMultiple(ctx, row)
 		if err != nil {

--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -64,7 +64,12 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	switch right := in.Right.(type) {
 	case *Subquery:
+		if sql.NumColumns(typ) != sql.NumColumns(right.Type()) {
+			return nil, sql.ErrInvalidOperandColumns.New(sql.NumColumns(typ), sql.NumColumns(right.Type()))
+		}
+
 		typ := right.Type()
+
 		values, err := right.HashMultiple(ctx, row)
 		if err != nil {
 			return nil, err

--- a/sql/plan/insubquery_test.go
+++ b/sql/plan/insubquery_test.go
@@ -71,7 +71,7 @@ func TestInSubquery(t *testing.T) {
 			),
 			nil,
 			nil,
-			expression.ErrInvalidOperandColumns,
+			sql.ErrInvalidOperandColumns,
 		},
 		{
 			"left is in right",
@@ -159,7 +159,7 @@ func TestNotInSubquery(t *testing.T) {
 			),
 			nil,
 			nil,
-			expression.ErrInvalidOperandColumns,
+			sql.ErrInvalidOperandColumns,
 		},
 		{
 			"left is in right",

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -205,7 +205,7 @@ func (s *Subquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 func prependRowInPlan(row sql.Row) func(n sql.Node) (sql.Node, error) {
 	return func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
-		case *Project, *GroupBy, *Having, *SubqueryAlias, *Window, sql.Table, *ValueDerivedTable:
+		case *Project, *GroupBy, *Having, *SubqueryAlias, *Window, sql.Table, *ValueDerivedTable, *Union:
 			return &prependNode{
 				UnaryNode: UnaryNode{Child: n},
 				row:       row,
@@ -254,6 +254,8 @@ func (s *Subquery) evalMultiple(ctx *sql.Context, row sql.Row) ([]interface{}, e
 		return nil, err
 	}
 
+	returnsTuple := len(s.Query.Schema()) > 1
+
 	// Reduce the result row to the size of the expected schema. This means chopping off the first len(row) columns.
 	col := len(row)
 	var result []interface{}
@@ -267,7 +269,11 @@ func (s *Subquery) evalMultiple(ctx *sql.Context, row sql.Row) ([]interface{}, e
 			return nil, err
 		}
 
-		result = append(result, row[col])
+		if returnsTuple {
+			result = append(result, append([]interface{}{}, row[col:]...))
+		} else {
+			result = append(result, row[col])
+		}
 	}
 
 	if err := iter.Close(ctx); err != nil {
@@ -344,8 +350,15 @@ func (s *Subquery) Resolved() bool {
 
 // Type implements the Expression interface.
 func (s *Subquery) Type() sql.Type {
-	// TODO: handle row results (more than one column)
-	return s.Query.Schema()[0].Type
+	qs := s.Query.Schema()
+	if len(qs) == 1 {
+		return s.Query.Schema()[0].Type
+	}
+	ts := make([]sql.Type, len(qs))
+	for i, c := range qs {
+		ts[i] = c.Type
+	}
+	return sql.CreateTuple(ts...)
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -332,7 +332,7 @@ func putAllRows(cache sql.KeyValueCache, vals []interface{}) error {
 
 // IsNullable implements the Expression interface.
 func (s *Subquery) IsNullable() bool {
-	return s.Query.Schema()[0].Nullable
+	return true
 }
 
 func (s *Subquery) String() string {

--- a/sql/tupletype.go
+++ b/sql/tupletype.go
@@ -30,6 +30,10 @@ func CreateTuple(types ...Type) Type {
 }
 
 func (t tupleType) Compare(a, b interface{}) (int, error) {
+	if hasNulls, res := compareNulls(a, b); hasNulls {
+		return res, nil
+	}
+
 	a, err := t.Convert(a)
 	if err != nil {
 		return 0, err
@@ -57,6 +61,9 @@ func (t tupleType) Compare(a, b interface{}) (int, error) {
 }
 
 func (t tupleType) Convert(v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
 	if vals, ok := v.([]interface{}); ok {
 		if len(vals) != len(t) {
 			return nil, ErrInvalidColumnNumber.New(len(t), len(vals))


### PR DESCRIPTION
Subquery expression nodes can now return tuples.

InSubquery expression nodes can work with tuples as expected.

An analyzer validation step now returns operand errors in more cases, expecting
almost all expressions to return one column, but special casing certain
operators and functions which support tuples.

Added some TODO tests for cases where our tuple comparisons are still not
behaving as we want them to. In particular, null safe vs. non-null safe
comparisons and type coercion of tuple subtypes in comparisons still need work.