### PR TITLE
sql/plan: Defer returning error from IndexedInSubqueryFilter.RowIter until the Next() call.

### DIFF
--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -205,7 +205,7 @@ func (s *Subquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 func prependRowInPlan(row sql.Row) func(n sql.Node) (sql.Node, error) {
 	return func(n sql.Node) (sql.Node, error) {
 		switch n := n.(type) {
-		case *Project, *GroupBy, *Having, *SubqueryAlias, *Window, sql.Table, *ValueDerivedTable:
+		case *Project, *GroupBy, *Having, *SubqueryAlias, *Window, sql.Table, *ValueDerivedTable, *Union:
 			return &prependNode{
 				UnaryNode: UnaryNode{Child: n},
 				row:       row,


### PR DESCRIPTION
Fixes some interactions between INSERT IGNORE INTO and expressions which will
fail on evaluation.

This might be a credible strategy everywhere we .Eval within RowIter, for
example, in indexed_table_access.