### PR TITLE
sql/plan,analyzer: Fix HashLookup for cases where there is a schema prefix not visible to the direct join parent.

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -4930,6 +4930,15 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{float64(8)}},
 	},
 	{
+		Query: `SELECT /*+ JOIN_ORDER(a, c, b, d) */ a.c1, b.c2, c.c3, d.c4 FROM one_pk a JOIN one_pk b ON a.pk = b.pk JOIN one_pk c ON c.pk = b.pk JOIN (select * from one_pk) d ON d.pk = c.pk`,
+		Expected: []sql.Row{
+			{0, 1, 2, 3},
+			{10, 11, 12, 13},
+			{20, 21, 22, 23},
+			{30, 31, 32, 33},
+		},
+	},
+	{
 		Query: "SELECT * FROM people WHERE last_name='doe' and first_name='jane' order by dob",
 		Expected: []sql.Row{
 			sql.NewRow(dob(1990, 2, 21), "jane", "doe", "", int64(68), int64(1)),

--- a/sql/analyzer/apply_hash_lookups.go
+++ b/sql/analyzer/apply_hash_lookups.go
@@ -23,6 +23,10 @@ import (
 func applyHashLookups(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
 	return plan.TransformUpCtx(n, nil, func(c plan.TransformContext) (sql.Node, error) {
 		if c.SchemaPrefix == nil {
+			// If c.SchemaPrefix is nil, it's possible our prefix
+			// isn't Resolved yet. Whatever the case, we cannot
+			// safely apply a hash lookup here without knowing what
+			// our schema actually is.
 			return c.Node, nil
 		}
 

--- a/sql/analyzer/apply_hash_lookups.go
+++ b/sql/analyzer/apply_hash_lookups.go
@@ -21,8 +21,12 @@ import (
 )
 
 func applyHashLookups(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
-	return plan.TransformUpWithParent(n, func(n sql.Node, parent sql.Node, childNum int) (sql.Node, error) {
-		if j, ok := n.(plan.JoinNode); ok {
+	return plan.TransformUpCtx(n, nil, func(c plan.TransformContext) (sql.Node, error) {
+		if c.SchemaPrefix == nil {
+			return c.Node, nil
+		}
+
+		if j, ok := c.Node.(plan.JoinNode); ok {
 			// JoinNodes implement a number of join modes, some of which put all results from the
 			// primary or secondary table in memory. This hash lookup implementation is expecting
 			// multipass mode, so we apply that here if we have a JoinNode whose secondary child
@@ -36,39 +40,36 @@ func applyHashLookups(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (
 					return j.WithMultipassMode(), nil
 				}
 			}
-			return n, nil
+			return c.Node, nil
 		}
 
-		cr, isCachedResults := n.(*plan.CachedResults)
-		pj, _ := parent.(plan.JoinNode)
-		pij, _ := parent.(*plan.IndexedJoin)
+		cr, isCachedResults := c.Node.(*plan.CachedResults)
+		pj, _ := c.Parent.(plan.JoinNode)
+		pij, _ := c.Parent.(*plan.IndexedJoin)
 		var cond sql.Expression
 		var primaryGetter, secondaryGetter func(sql.Expression) sql.Expression
 		if isCachedResults {
 			switch {
-			case pij != nil && childNum == 1:
-				primary := pij.Left()
+			case pij != nil && c.ChildNum == 1:
 				cond = pij.Cond
-				primaryIndex := len(primary.Schema()) + len(scope.Schema())
+				primaryIndex := len(c.SchemaPrefix) + len(scope.Schema())
 				primaryGetter = getFieldIndexRange(0, primaryIndex, 0)
 				secondaryGetter = getFieldIndexRange(primaryIndex, -1, primaryIndex)
-			case pj != nil && pj.JoinType() != plan.JoinTypeRight && childNum == 1:
-				primary := pj.Left()
+			case pj != nil && pj.JoinType() != plan.JoinTypeRight && c.ChildNum == 1:
 				cond = pj.JoinCond()
-				primaryIndex := len(primary.Schema()) + len(scope.Schema())
+				primaryIndex := len(c.SchemaPrefix) + len(scope.Schema())
 				primaryGetter = getFieldIndexRange(0, primaryIndex, 0)
 				secondaryGetter = getFieldIndexRange(primaryIndex, -1, primaryIndex)
-			case pj != nil && pj.JoinType() == plan.JoinTypeRight && childNum == 0:
+			case pj != nil && pj.JoinType() == plan.JoinTypeRight && c.ChildNum == 0:
 				// The columns from the primary row are on the right.
-				secondary := pj.Left()
 				cond = pj.JoinCond()
-				primaryIndex := len(secondary.Schema()) + len(scope.Schema())
+				primaryIndex := len(c.SchemaPrefix) + len(c.Node.Schema()) + len(scope.Schema())
 				primaryGetter = getFieldIndexRange(primaryIndex, -1, primaryIndex)
 				secondaryGetter = getFieldIndexRange(0, primaryIndex, 0)
 			}
 		}
 		if cond == nil {
-			return n, nil
+			return c.Node, nil
 		}
 		// Support expressions of the form (GetField = GetField AND GetField = GetField AND ...)
 		// where every equal comparison has one operand coming from primary and one operand
@@ -114,7 +115,7 @@ func applyHashLookups(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (
 			secondaryTuple := expression.NewTuple(secondaryGetFields...)
 			return plan.NewHashLookup(cr, secondaryTuple, primaryTuple), nil
 		}
-		return n, nil
+		return c.Node, nil
 	})
 }
 

--- a/sql/analyzer/apply_indexes_from_outer_scope.go
+++ b/sql/analyzer/apply_indexes_from_outer_scope.go
@@ -46,8 +46,8 @@ func applyIndexesFromOuterScope(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 		return n, nil
 	}
 
-	childSelector := func(parent sql.Node, child sql.Node, childNum int) bool {
-		switch parent.(type) {
+	childSelector := func(c plan.TransformContext) bool {
+		switch c.Parent.(type) {
 		// We can't push any indexes down a branch that have already had an index pushed down it
 		case *plan.IndexedTableAccess:
 			return false
@@ -57,8 +57,8 @@ func applyIndexesFromOuterScope(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 
 	// replace the tables with possible index lookups with indexed access
 	for _, idxLookup := range indexLookups {
-		n, err = plan.TransformUpWithSelector(n, childSelector, func(n sql.Node) (sql.Node, error) {
-			switch n := n.(type) {
+		n, err = plan.TransformUpCtx(n, childSelector, func(c plan.TransformContext) (sql.Node, error) {
+			switch n := c.Node.(type) {
 			case *plan.IndexedTableAccess:
 				return n, nil
 			case *plan.TableAlias:

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -42,9 +42,9 @@ func constructJoinPlan(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) 
 }
 
 func replaceJoinPlans(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
-	selector := func(parent sql.Node, child sql.Node, childNum int) bool {
+	selector := func(c plan.TransformContext) bool {
 		// We only want the top-most join node, so don't examine anything beneath join nodes
-		switch parent.(type) {
+		switch c.Parent.(type) {
 		case *plan.InnerJoin, *plan.LeftJoin, *plan.RightJoin:
 			return false
 		default:
@@ -54,8 +54,8 @@ func replaceJoinPlans(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (
 
 	var tableAliases TableAliases
 	var joinIndexes joinIndexesByTable
-	newJoin, err := plan.TransformUpWithSelector(n, selector, func(n sql.Node) (sql.Node, error) {
-		switch n := n.(type) {
+	newJoin, err := plan.TransformUpCtx(n, selector, func(c plan.TransformContext) (sql.Node, error) {
+		switch n := c.Node.(type) {
 		case *plan.IndexedJoin:
 			return n, nil
 		case plan.JoinNode:

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -135,16 +135,16 @@ func moveJoinConditionsToFilter(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 
 	// Add a new filter node with all removed predicates above the top level InnerJoin. Or, if there is a filter node
 	// above that, combine into a new filter.
-	selector := func(parent sql.Node, child sql.Node, childNum int) bool {
-		switch parent.(type) {
+	selector := func(c plan.TransformContext) bool {
+		switch c.Parent.(type) {
 		case *plan.Filter:
 			return false
 		}
-		return parent != topJoin
+		return c.Parent != topJoin
 	}
 
-	return plan.TransformUpWithSelector(node, selector, func(node sql.Node) (sql.Node, error) {
-		switch node := node.(type) {
+	return plan.TransformUpCtx(node, selector, func(c plan.TransformContext) (sql.Node, error) {
+		switch node := c.Node.(type) {
 		case *plan.Filter:
 			return plan.NewFilter(
 				expression.JoinAnd(append([]sql.Expression{node.Expression}, nonJoinFilters...)...),

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -101,8 +101,8 @@ func columnsUsedByNode(n sql.Node) usedColumns {
 	return columns
 }
 
-func canPruneChild(parent, child sql.Node, idx int) bool {
-	_, isIndexedJoin := parent.(*plan.IndexedJoin)
+func canPruneChild(c plan.TransformContext) bool {
+	_, isIndexedJoin := c.Parent.(*plan.IndexedJoin)
 	return !isIndexedJoin
 }
 
@@ -223,10 +223,10 @@ func pruneSubqueries(
 	n sql.Node,
 	parentColumns usedColumns,
 ) (sql.Node, error) {
-	return plan.TransformUpWithSelector(n, canPruneChild, func(n sql.Node) (sql.Node, error) {
-		subq, ok := n.(*plan.SubqueryAlias)
+	return plan.TransformUpCtx(n, canPruneChild, func(c plan.TransformContext) (sql.Node, error) {
+		subq, ok := c.Node.(*plan.SubqueryAlias)
 		if !ok {
-			return n, nil
+			return c.Node, nil
 		}
 
 		return pruneSubqueryColumns(ctx, a, subq, parentColumns)
@@ -234,8 +234,8 @@ func pruneSubqueries(
 }
 
 func pruneUnusedColumns(a *Analyzer, n sql.Node, columns usedColumns) (sql.Node, error) {
-	return plan.TransformUpWithSelector(n, canPruneChild, func(n sql.Node) (sql.Node, error) {
-		switch n := n.(type) {
+	return plan.TransformUpCtx(n, canPruneChild, func(c plan.TransformContext) (sql.Node, error) {
+		switch n := c.Node.(type) {
 		case *plan.Project:
 			return pruneProject(a, n, columns), nil
 		case *plan.GroupBy:
@@ -297,8 +297,8 @@ func shouldPruneExpr(e sql.Expression, cols usedColumns) bool {
 }
 
 func fixRemainingFieldsIndexes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
-	return plan.TransformUpWithSelector(n, canPruneChild, func(n sql.Node) (sql.Node, error) {
-		switch n := n.(type) {
+	return plan.TransformUpCtx(n, canPruneChild, func(c plan.TransformContext) (sql.Node, error) {
+		switch n := c.Node.(type) {
 		case *plan.SubqueryAlias:
 			child, err := fixRemainingFieldsIndexes(ctx, a, n.Child, nil)
 			if err != nil {

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -164,19 +164,19 @@ func canDoPushdown(n sql.Node) bool {
 // Pushing down a filter is incompatible with the secondary table in a Left or Right join. If we push a predicate on
 // the secondary table below the join, we end up not evaluating it in all cases (since the secondary table result is
 // sometimes null in these types of joins). It must be evaluated only after the join result is computed.
-func filterPushdownChildSelector(parent sql.Node, child sql.Node, childNum int) bool {
-	switch n := parent.(type) {
+func filterPushdownChildSelector(c plan.TransformContext) bool {
+	switch n := c.Parent.(type) {
 	case *plan.TableAlias:
 		return false
 	case *plan.IndexedJoin:
 		if n.JoinType() == plan.JoinTypeLeft || n.JoinType() == plan.JoinTypeRight {
-			return childNum == 0
+			return c.ChildNum == 0
 		}
 		return true
 	case *plan.LeftJoin:
-		return childNum == 0
+		return c.ChildNum == 0
 	case *plan.RightJoin:
-		return childNum == 1
+		return c.ChildNum == 1
 	}
 	return true
 }
@@ -185,14 +185,14 @@ func filterPushdownChildSelector(parent sql.Node, child sql.Node, childNum int) 
 // (for tables that can't treat the filter as an index lookup or accept it directly). In this case, we want to avoid
 // introducing additional Filter nodes unnecessarily. This means only introducing new filter nodes when they are being
 // pushed below a join or other structure.
-func filterPushdownAboveTablesChildSelector(parent sql.Node, child sql.Node, childNum int) bool {
+func filterPushdownAboveTablesChildSelector(c plan.TransformContext) bool {
 	// All the same restrictions that apply to pushing filters down in general apply here as well
-	if !filterPushdownChildSelector(parent, child, childNum) {
+	if !filterPushdownChildSelector(c) {
 		return false
 	}
-	switch parent.(type) {
+	switch c.Parent.(type) {
 	case *plan.Filter:
-		switch child.(type) {
+		switch c.Node.(type) {
 		// Don't bother pushing filters down above tables if the direct child node is a table. At best this
 		// just splits the predicates into multiple filter nodes, and at worst it breaks other parts of the
 		// analyzer that don't expect this structure in the tree.
@@ -206,8 +206,8 @@ func filterPushdownAboveTablesChildSelector(parent sql.Node, child sql.Node, chi
 
 func transformPushdownFilters(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, tableAliases TableAliases) (sql.Node, error) {
 	applyFilteredTables := func(n *plan.Filter, filters *filterSet) (sql.Node, error) {
-		return plan.TransformUpWithSelector(n, filterPushdownChildSelector, func(node sql.Node) (sql.Node, error) {
-			switch node := node.(type) {
+		return plan.TransformUpCtx(n, filterPushdownChildSelector, func(c plan.TransformContext) (sql.Node, error) {
+			switch node := c.Node.(type) {
 			case *plan.Filter:
 				n, err := removePushedDownPredicates(ctx, a, node, filters)
 				if err != nil {
@@ -227,8 +227,8 @@ func transformPushdownFilters(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 	}
 
 	pushdownAboveTables := func(n sql.Node, filters *filterSet) (sql.Node, error) {
-		return plan.TransformUpWithSelector(n, filterPushdownAboveTablesChildSelector, func(node sql.Node) (sql.Node, error) {
-			switch node := node.(type) {
+		return plan.TransformUpCtx(n, filterPushdownAboveTablesChildSelector, func(c plan.TransformContext) (sql.Node, error) {
+			switch node := c.Node.(type) {
 			case *plan.Filter:
 				n, err := removePushedDownPredicates(ctx, a, node, filters)
 				if err != nil {
@@ -274,8 +274,8 @@ func transformPushdownSubqueryAliasFilters(ctx *sql.Context, a *Analyzer, n sql.
 	var filters *filterSet
 
 	transformFilterNode := func(n *plan.Filter) (sql.Node, error) {
-		return plan.TransformUpWithSelector(n, filterPushdownChildSelector, func(node sql.Node) (sql.Node, error) {
-			switch node := node.(type) {
+		return plan.TransformUpCtx(n, filterPushdownChildSelector, func(c plan.TransformContext) (sql.Node, error) {
+			switch node := c.Node.(type) {
 			case *plan.Filter:
 				return removePushedDownPredicates(ctx, a, node, filters)
 			case *plan.SubqueryAlias:
@@ -308,14 +308,14 @@ func convertFiltersToIndexedAccess(
 	scope *Scope,
 	indexes indexLookupsByTable,
 ) (sql.Node, error) {
-	childSelector := func(parent sql.Node, child sql.Node, childNum int) bool {
-		switch child.(type) {
+	childSelector := func(c plan.TransformContext) bool {
+		switch c.Node.(type) {
 		// We can't push any indexes down to a table has already had an index pushed down it
 		case *plan.IndexedTableAccess:
 			return false
 		}
 
-		switch parent.(type) {
+		switch c.Parent.(type) {
 		// For IndexedJoins, if we are already using indexed access during query execution for the secondary table,
 		// replacing the secondary table with an indexed lookup will have no effect on the result of the join, but
 		// *will* inappropriately remove the filter from the predicate.
@@ -323,11 +323,11 @@ func convertFiltersToIndexedAccess(
 		case *plan.IndexedJoin:
 			// Left and right joins can push down indexes for the primary table, but not the secondary. See comment
 			// on transformPushdownFilters
-			return childNum == 0
+			return c.ChildNum == 0
 		case *plan.LeftJoin:
-			return childNum == 0
+			return c.ChildNum == 0
 		case *plan.RightJoin:
-			return childNum == 1
+			return c.ChildNum == 1
 		case *plan.TableAlias:
 			// For a TableAlias, we apply this pushdown to the
 			// TableAlias, but not to the resolved table directly
@@ -337,8 +337,8 @@ func convertFiltersToIndexedAccess(
 		return true
 	}
 
-	node, err := plan.TransformUpWithSelector(n, childSelector, func(node sql.Node) (sql.Node, error) {
-		switch node := node.(type) {
+	node, err := plan.TransformUpCtx(n, childSelector, func(c plan.TransformContext) (sql.Node, error) {
+		switch node := c.Node.(type) {
 		// TODO: some indexes, once pushed down, can be safely removed from the filter. But not all of them, as currently
 		//  implemented -- some indexes return more values than strictly match.
 		case *plan.TableAlias:
@@ -601,8 +601,8 @@ func transformPushdownProjections(ctx *sql.Context, a *Analyzer, n sql.Node, sco
 	usedFieldsByTable := make(fieldsByTable)
 	fieldsByTable := getFieldsByTable(ctx, n)
 
-	selector := func(parent sql.Node, child sql.Node, childNum int) bool {
-		switch parent.(type) {
+	selector := func(c plan.TransformContext) bool {
+		switch c.Parent.(type) {
 		case *plan.TableAlias:
 			// When we hit a table alias, we don't want to descend farther into the tree for expression matches, which
 			// would give us the original (unaliased) names of columns
@@ -612,12 +612,12 @@ func transformPushdownProjections(ctx *sql.Context, a *Analyzer, n sql.Node, sco
 		}
 	}
 
-	node, err := plan.TransformUpWithSelector(n, selector, func(node sql.Node) (sql.Node, error) {
+	node, err := plan.TransformUpCtx(n, selector, func(c plan.TransformContext) (sql.Node, error) {
 		var nameable NameableNode
 
-		switch node.(type) {
+		switch c.Node.(type) {
 		case *plan.TableAlias, *plan.ResolvedTable, *plan.IndexedTableAccess:
-			nameable = node.(NameableNode)
+			nameable = c.Node.(NameableNode)
 		}
 
 		if nameable != nil {
@@ -627,7 +627,7 @@ func transformPushdownProjections(ctx *sql.Context, a *Analyzer, n sql.Node, sco
 			}
 			return FixFieldIndexesForExpressions(ctx, a, table, scope)
 		} else {
-			return FixFieldIndexesForExpressions(ctx, a, node, scope)
+			return FixFieldIndexesForExpressions(ctx, a, c.Node, scope)
 		}
 	})
 

--- a/sql/analyzer/stored_procedures.go
+++ b/sql/analyzer/stored_procedures.go
@@ -368,10 +368,10 @@ func applyProceduresCall(ctx *sql.Context, a *Analyzer, call *plan.Call, scope *
 		return nil, err
 	}
 
-	transformedProcedure, err = plan.TransformUpWithParent(transformedProcedure, func(n sql.Node, parent sql.Node, childNum int) (sql.Node, error) {
-		rt, ok := n.(*plan.ResolvedTable)
+	transformedProcedure, err = plan.TransformUpCtx(transformedProcedure, nil, func(c plan.TransformContext) (sql.Node, error) {
+		rt, ok := c.Node.(*plan.ResolvedTable)
 		if !ok {
-			return n, nil
+			return c.Node, nil
 		}
 		return plan.NewProcedureResolvedTable(rt), nil
 	})

--- a/sql/plan/transform.go
+++ b/sql/plan/transform.go
@@ -91,14 +91,6 @@ func transformUpCtx(c TransformContext, s TransformSelector, f Transformer) (sql
 	return f(TransformContext{node, c.Parent, c.ChildNum, c.SchemaPrefix})
 }
 
-type ExpressionTransformContext struct {
-	TransformContext
-	Expr       sql.Expression
-	ParentExpr sql.Expression
-}
-
-type ExprTransformer func(ExpressionTransformContext) (sql.Expression, error)
-
 // TransformUp applies a transformation function to the given tree from the
 // bottom up.
 func TransformUp(node sql.Node, f sql.TransformNodeFunc) (sql.Node, error) {
@@ -118,8 +110,8 @@ func TransformExpressionsUpWithNode(node sql.Node, f expression.TransformExprWit
 // TransformExpressionsUp applies a transformation function to all expressions
 // on the given tree from the bottom up.
 func TransformExpressionsUp(node sql.Node, f sql.TransformExprFunc) (sql.Node, error) {
-	return TransformUp(node, func(n sql.Node) (sql.Node, error) {
-		return TransformExpressions(n, f)
+	return TransformExpressionsUpWithNode(node, func(n sql.Node, e sql.Expression) (sql.Expression, error) {
+		return f(e)
 	})
 }
 

--- a/sql/plan/transform.go
+++ b/sql/plan/transform.go
@@ -102,20 +102,8 @@ type ExprTransformer func(ExpressionTransformContext) (sql.Expression, error)
 // TransformUp applies a transformation function to the given tree from the
 // bottom up.
 func TransformUp(node sql.Node, f sql.TransformNodeFunc) (sql.Node, error) {
-	return TransformUpWithParent(node, func(n sql.Node, parent sql.Node, num int) (sql.Node, error) {
-		return f(n)
-	})
-}
-
-// TransformNodeWithParentFunc is an analog to sql.TransformNodeFunc that also includes the parent of the node being
-// transformed. The parent is for inspection only, and cannot be altered.
-type TransformNodeWithParentFunc func(n sql.Node, parent sql.Node, childNum int) (sql.Node, error)
-
-// TransformUpWithParent applies a transformation function to the given tree from the bottom up, with the additional
-// context of the parent node of the node under inspection.
-func TransformUpWithParent(node sql.Node, f TransformNodeWithParentFunc) (sql.Node, error) {
 	return TransformUpCtx(node, nil, func(c TransformContext) (sql.Node, error) {
-		return f(c.Node, c.Parent, c.ChildNum)
+		return f(c.Node)
 	})
 }
 

--- a/sql/plan/transform.go
+++ b/sql/plan/transform.go
@@ -19,33 +19,72 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 )
 
-// TransformUp applies a transformation function to the given tree from the
-// bottom up.
-func TransformUp(node sql.Node, f sql.TransformNodeFunc) (sql.Node, error) {
-	if o, ok := node.(sql.OpaqueNode); ok && o.Opaque() {
-		return f(node)
+type TransformContext struct {
+	Node         sql.Node
+	Parent       sql.Node
+	ChildNum     int
+	SchemaPrefix sql.Schema
+}
+
+type Transformer func(TransformContext) (sql.Node, error)
+type TransformSelector func(TransformContext) bool
+
+func TransformUpCtx(n sql.Node, s TransformSelector, f Transformer) (sql.Node, error) {
+	return transformUpCtx(TransformContext{n, nil, -1, sql.Schema{}}, s, f)
+}
+
+func transformUpCtx(c TransformContext, s TransformSelector, f Transformer) (sql.Node, error) {
+	if o, ok := c.Node.(sql.OpaqueNode); ok && o.Opaque() {
+		return f(c)
 	}
 
-	children := node.Children()
+	children := c.Node.Children()
 	if len(children) == 0 {
-		return f(node)
+		return f(c)
 	}
 
+	childPrefix := append(sql.Schema{}, c.SchemaPrefix...)
 	newChildren := make([]sql.Node, len(children))
-	for i, c := range children {
-		c, err := TransformUp(c, f)
-		if err != nil {
-			return nil, err
+	for i, child := range children {
+		cc := TransformContext{child, c.Node, i, childPrefix}
+		if s == nil || s(cc) {
+			var err error
+			child, err = transformUpCtx(cc, s, f)
+			if err != nil {
+				return nil, err
+			}
 		}
-		newChildren[i] = c
+		newChildren[i] = child
+		if child.Resolved() && childPrefix != nil {
+			cs := child.Schema()
+			childPrefix = append(childPrefix, cs...)
+		} else {
+			childPrefix = nil
+		}
 	}
 
-	node, err := node.WithChildren(newChildren...)
+	node, err := c.Node.WithChildren(newChildren...)
 	if err != nil {
 		return nil, err
 	}
 
-	return f(node)
+	return f(TransformContext{node, c.Parent, c.ChildNum, c.SchemaPrefix})
+}
+
+type ExpressionTransformContext struct {
+	TransformContext
+	Expr       sql.Expression
+	ParentExpr sql.Expression
+}
+
+type ExprTransformer func(ExpressionTransformContext) (sql.Expression, error)
+
+// TransformUp applies a transformation function to the given tree from the
+// bottom up.
+func TransformUp(node sql.Node, f sql.TransformNodeFunc) (sql.Node, error) {
+	return TransformUpWithParent(node, func(n sql.Node, parent sql.Node, num int) (sql.Node, error) {
+		return f(n)
+	})
 }
 
 // TransformNodeWithParentFunc is an analog to sql.TransformNodeFunc that also includes the parent of the node being
@@ -55,35 +94,9 @@ type TransformNodeWithParentFunc func(n sql.Node, parent sql.Node, childNum int)
 // TransformUpWithParent applies a transformation function to the given tree from the bottom up, with the additional
 // context of the parent node of the node under inspection.
 func TransformUpWithParent(node sql.Node, f TransformNodeWithParentFunc) (sql.Node, error) {
-	return transformUpWithParent(node, nil, -1, f)
-}
-
-// transformUpWithParent is the internal implementation of TransformUpWithParent that allows passing a parent node.
-func transformUpWithParent(node sql.Node, parent sql.Node, childNum int, f TransformNodeWithParentFunc) (sql.Node, error) {
-	if o, ok := node.(sql.OpaqueNode); ok && o.Opaque() {
-		return f(node, parent, childNum)
-	}
-
-	children := node.Children()
-	if len(children) == 0 {
-		return f(node, parent, childNum)
-	}
-
-	newChildren := make([]sql.Node, len(children))
-	for i, c := range children {
-		c, err := transformUpWithParent(c, node, i, f)
-		if err != nil {
-			return nil, err
-		}
-		newChildren[i] = c
-	}
-
-	node, err := node.WithChildren(newChildren...)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(node, parent, childNum)
+	return TransformUpCtx(node, nil, func(c TransformContext) (sql.Node, error) {
+		return f(c.Node, c.Parent, c.ChildNum)
+	})
 }
 
 // ChildSelector is a func that returns whether the child of a parent node should be walked as part of a transformation.
@@ -92,117 +105,35 @@ type ChildSelector func(parent sql.Node, child sql.Node, childNum int) bool
 
 // TransformUpWithSelector works like TransformUp, but allows the caller to decide which children of a node are walked.
 func TransformUpWithSelector(node sql.Node, selector ChildSelector, f sql.TransformNodeFunc) (sql.Node, error) {
-	if o, ok := node.(sql.OpaqueNode); ok && o.Opaque() {
-		return f(node)
-	}
-
-	children := node.Children()
-	if len(children) == 0 {
-		return f(node)
-	}
-
-	newChildren := make([]sql.Node, len(children))
-	for i, c := range children {
-		if selector(node, c, i) {
-			c, err := TransformUpWithSelector(c, selector, f)
-			if err != nil {
-				return nil, err
-			}
-			newChildren[i] = c
-		} else {
-			newChildren[i] = c
-		}
-	}
-
-	node, err := node.WithChildren(newChildren...)
-	if err != nil {
-		return nil, err
-	}
-
-	return f(node)
+	return TransformUpCtx(node, func(c TransformContext) bool {
+		return selector(c.Parent, c.Node, c.ChildNum)
+	}, func (c TransformContext) (sql.Node, error) {
+		return f(c.Node)
+	})
 }
 
 // TransformExpressionsUp applies a transformation function to all expressions
 // on the given tree from the bottom up.
 func TransformExpressionsUpWithNode(node sql.Node, f expression.TransformExprWithNodeFunc) (sql.Node, error) {
-	if o, ok := node.(sql.OpaqueNode); ok && o.Opaque() {
-		return TransformExpressionsWithNode(node, f)
-	}
-
-	children := node.Children()
-	if len(children) == 0 {
-		return TransformExpressionsWithNode(node, f)
-	}
-
-	newChildren := make([]sql.Node, len(children))
-	for i, c := range children {
-		c, err := TransformExpressionsUpWithNode(c, f)
-		if err != nil {
-			return nil, err
-		}
-		newChildren[i] = c
-	}
-
-	node, err := node.WithChildren(newChildren...)
-	if err != nil {
-		return nil, err
-	}
-
-	return TransformExpressionsWithNode(node, f)
+	return TransformUp(node, func(n sql.Node) (sql.Node, error) {
+		return TransformExpressionsWithNode(n, f)
+	})
 }
 
 // TransformExpressionsUp applies a transformation function to all expressions
 // on the given tree from the bottom up.
 func TransformExpressionsUp(node sql.Node, f sql.TransformExprFunc) (sql.Node, error) {
-	if o, ok := node.(sql.OpaqueNode); ok && o.Opaque() {
-		return TransformExpressions(node, f)
-	}
-
-	children := node.Children()
-	if len(children) == 0 {
-		return TransformExpressions(node, f)
-	}
-
-	newChildren := make([]sql.Node, len(children))
-	for i, c := range children {
-		c, err := TransformExpressionsUp(c, f)
-		if err != nil {
-			return nil, err
-		}
-		newChildren[i] = c
-	}
-
-	node, err := node.WithChildren(newChildren...)
-	if err != nil {
-		return nil, err
-	}
-
-	return TransformExpressions(node, f)
+	return TransformUp(node, func(n sql.Node) (sql.Node, error) {
+		return TransformExpressions(n, f)
+	})
 }
 
 // TransformExpressions applies a transformation function to all expressions
 // on the given node.
 func TransformExpressions(node sql.Node, f sql.TransformExprFunc) (sql.Node, error) {
-	e, ok := node.(sql.Expressioner)
-	if !ok {
-		return node, nil
-	}
-
-	exprs := e.Expressions()
-	if len(exprs) == 0 {
-		return node, nil
-	}
-
-	newExprs := make([]sql.Expression, len(exprs))
-	for i, e := range exprs {
-		e, err := expression.TransformUp(e, f)
-		if err != nil {
-			return nil, err
-		}
-		newExprs[i] = e
-	}
-
-	return e.WithExpressions(newExprs...)
+	return TransformExpressionsWithNode(node, func(n sql.Node, e sql.Expression) (sql.Expression, error) {
+		return f(e)
+	})
 }
 
 // TransformExpressions applies a transformation function to all expressions

--- a/sql/plan/transform.go
+++ b/sql/plan/transform.go
@@ -119,19 +119,6 @@ func TransformUpWithParent(node sql.Node, f TransformNodeWithParentFunc) (sql.No
 	})
 }
 
-// ChildSelector is a func that returns whether the child of a parent node should be walked as part of a transformation.
-// If not, that child and its portion of the subtree is skipped.
-type ChildSelector func(parent sql.Node, child sql.Node, childNum int) bool
-
-// TransformUpWithSelector works like TransformUp, but allows the caller to decide which children of a node are walked.
-func TransformUpWithSelector(node sql.Node, selector ChildSelector, f sql.TransformNodeFunc) (sql.Node, error) {
-	return TransformUpCtx(node, func(c TransformContext) bool {
-		return selector(c.Parent, c.Node, c.ChildNum)
-	}, func (c TransformContext) (sql.Node, error) {
-		return f(c.Node)
-	})
-}
-
 // TransformExpressionsUp applies a transformation function to all expressions
 // on the given tree from the bottom up.
 func TransformExpressionsUpWithNode(node sql.Node, f expression.TransformExprWithNodeFunc) (sql.Node, error) {

--- a/sql/plan/trigger.go
+++ b/sql/plan/trigger.go
@@ -96,12 +96,12 @@ type triggerIter struct {
 // prependRowInPlanForTriggerExecution returns a transformation function that prepends the row given to any row source in a query
 // plan. Any source of rows, as well as any node that alters the schema of its children, will be wrapped so that its
 // result rows are prepended with the row given.
-func prependRowInPlanForTriggerExecution(row sql.Row) func(n, parent sql.Node, childNum int) (sql.Node, error) {
-	return func(n, parent sql.Node, childNum int) (sql.Node, error) {
-		switch n := n.(type) {
+func prependRowInPlanForTriggerExecution(row sql.Row) func(c TransformContext) (sql.Node, error) {
+	return func(c TransformContext) (sql.Node, error) {
+		switch n := c.Node.(type) {
 		case *Project:
 			// Only prepend rows for projects that aren't the input to inserts and other triggers
-			switch parent.(type) {
+			switch c.Parent.(type) {
 			case *InsertInto, *TriggerExecutor:
 				return n, nil
 			default:
@@ -128,7 +128,7 @@ func (t *triggerIter) Next() (row sql.Row, returnErr error) {
 	}
 
 	// Wrap the execution logic with the current child row before executing it.
-	logic, err := TransformUpWithParent(t.executionLogic, prependRowInPlanForTriggerExecution(childRow))
+	logic, err := TransformUpCtx(t.executionLogic, nil, prependRowInPlanForTriggerExecution(childRow))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds a `TransformUpCtx` function that passes along a `SchemaPrefix` in the `TransformContext` if the schema prefix is scrutable from resolved children at that point in the analysis. `apply_hash_lookup` makes use of this to make the transformed expressions in the `HashLookup` lookup node refer to the right place, even when `JoinNode.Left().Schema()` doesn't have the whole prefix.

This schema prefix is probably useful in other places and I am exploring rationalizing certain places where the analyzer makes use of the schema by using it or something like it.

In the mean time, converted some of the more obscure transform variants (UpWithParent, UpWithSelector) to use TransformUpCtx as well. Held off on moving TransformUp to TransformUpCtx.

Very open to suggestions on names for TransformUpCtx.