### PR TITLE
sql/analyzer: indexed_joins: Keep searching for usable indexes when there are NOT(? = ?) and NOT(? <=> ?) clauses in a join conjunction.

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -389,6 +389,30 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: `SELECT i, s, i2, s2 FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT (s2 <=> s)`,
+		Expected: []sql.Row{
+			{1, "first row", 1, "third"},
+			{2, "second row", 2, "second"},
+			{3, "third row", 3, "first"},
+		},
+	},
+	{
+		Query: `SELECT i, s, i2, s2 FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT (s2 = s)`,
+		Expected: []sql.Row{
+			{1, "first row", 1, "third"},
+			{2, "second row", 2, "second"},
+			{3, "third row", 3, "first"},
+		},
+	},
+	{
+		Query: `SELECT i, s, i2, s2 FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND CONCAT(s, s2) IS NOT NULL`,
+		Expected: []sql.Row{
+			{1, "first row", 1, "third"},
+			{2, "second row", 2, "second"},
+			{3, "third row", 3, "first"},
+		},
+	},
+	{
 		Query: `SELECT * FROM mytable mt JOIN othertable ot ON ot.i2 = (SELECT i2 FROM othertable WHERE s2 = "second") AND mt.i = ot.i2 JOIN mytable mt2 ON mt.i = mt2.i`,
 		Expected: []sql.Row{
 			{2, "second row", "second", 2, 2, "second row"},

--- a/enginetest/query_plans.go
+++ b/enginetest/query_plans.go
@@ -319,6 +319,45 @@ var PlanTests = []QueryPlanTest{
 			"",
 	},
 	{
+		Query: `SELECT * FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT (s2 <=> s)`,
+		ExpectedPlan: "IndexedJoin((mytable.i = othertable.i2) AND (NOT((othertable.s2 <=> mytable.s))))\n" +
+			" ├─ Table(mytable)\n" +
+			" └─ IndexedTableAccess(othertable on [othertable.i2])\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT (s2 = s)`,
+		ExpectedPlan: "IndexedJoin((mytable.i = othertable.i2) AND (NOT((othertable.s2 = mytable.s))))\n" +
+			" ├─ Table(mytable)\n" +
+			" └─ IndexedTableAccess(othertable on [othertable.i2])\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND CONCAT(s, s2) IS NOT NULL`,
+		ExpectedPlan: "IndexedJoin((mytable.i = othertable.i2) AND (NOT(concat(mytable.s, othertable.s2) IS NULL)))\n" +
+			" ├─ Table(mytable)\n" +
+			" └─ IndexedTableAccess(othertable on [othertable.i2])\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND s > s2`,
+		ExpectedPlan: "InnerJoin((mytable.i = othertable.i2) AND (mytable.s > othertable.s2))\n" +
+			" ├─ Projected table access on [i s]\n" +
+			" │   └─ Table(mytable)\n" +
+			" └─ Projected table access on [s2 i2]\n" +
+			"     └─ Table(othertable)\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT(s > s2)`,
+		ExpectedPlan: "InnerJoin((mytable.i = othertable.i2) AND (NOT((mytable.s > othertable.s2))))\n" +
+			" ├─ Projected table access on [i s]\n" +
+			" │   └─ Table(mytable)\n" +
+			" └─ Projected table access on [s2 i2]\n" +
+			"     └─ Table(othertable)\n" +
+			"",
+	},
+	{
 		Query: `SELECT /*+ JOIN_ORDER(mytable, othertable) */ s2, i2, i FROM mytable INNER JOIN (SELECT * FROM othertable) othertable ON i2 = i`,
 		ExpectedPlan: "Project(othertable.s2, othertable.i2, mytable.i)\n" +
 			" └─ InnerJoin(othertable.i2 = mytable.i)\n" +

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -636,7 +636,9 @@ func getJoinIndexes(
 			switch e := expr.(type) {
 			case *expression.Equals, *expression.NullSafeEquals, *expression.IsNull:
 			case *expression.Not:
-				if _, ok := e.Child.(*expression.IsNull); !ok {
+				switch e.Child.(type) {
+				case *expression.Equals, *expression.NullSafeEquals, *expression.IsNull:
+				default:
 					return nil
 				}
 			default:


### PR DESCRIPTION
The indexed join logic is perfectly happy to go forward with a join plan if it
doesn't find a perfect index, or even a usable index at all, for one or more
table factors in the join. This logic is probably left over from when that was
not the case, but for now we make it a little more liberal to cover some cases
we need to cover for a customer.