### PR TITLE
Fixed bug in indexed joins

### DIFF
--- a/sql/analyzer/apply_indexes_for_subquery_comparisons.go
+++ b/sql/analyzer/apply_indexes_for_subquery_comparisons.go
@@ -68,7 +68,7 @@ func getIndexedInSubqueryFilter(ctx *sql.Context, a *Analyzer, left, right sql.E
 		return nil
 	}
 	defer indexes.releaseUsedIndexes()
-	idx := indexes.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, gf)...)
+	idx := indexes.IndexByExpression(ctx, ctx.GetCurrentDatabase(), rt.Name(), normalizeExpressions(ctx, tableAliases, gf)...)
 	if idx == nil {
 		return nil
 	}

--- a/sql/analyzer/apply_indexes_from_outer_scope.go
+++ b/sql/analyzer/apply_indexes_from_outer_scope.go
@@ -233,7 +233,7 @@ func getSubqueryIndexes(
 	for _, table := range tablesInScope {
 		indexCols := exprsByTable[table]
 		if indexCols != nil {
-			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(),
+			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), table,
 				normalizeExpressions(ctx, tableAliases, extractComparands(indexCols)...)...)
 			if idx != nil {
 				result[indexCols[0].comparandCol.Table()] = idx

--- a/sql/analyzer/apply_indexes_from_outer_scope.go
+++ b/sql/analyzer/apply_indexes_from_outer_scope.go
@@ -230,13 +230,14 @@ func getSubqueryIndexes(
 	result := make(map[string]sql.Index)
 	// For every predicate involving a table in the outer scope, see if there's an index lookup possible on its comparands
 	// (the tables in this scope)
-	for _, table := range tablesInScope {
-		indexCols := exprsByTable[table]
+	for _, scopeTable := range tablesInScope {
+		indexCols := exprsByTable[scopeTable]
 		if indexCols != nil {
+			table := indexCols[0].comparandCol.Table()
 			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), table,
 				normalizeExpressions(ctx, tableAliases, extractComparands(indexCols)...)...)
 			if idx != nil {
-				result[indexCols[0].comparandCol.Table()] = idx
+				result[table] = idx
 			}
 		}
 	}

--- a/sql/analyzer/index_analyzer.go
+++ b/sql/analyzer/index_analyzer.go
@@ -112,7 +112,7 @@ func (r *indexAnalyzer) IndexesByTable(ctx *sql.Context, db, table string) []sql
 
 // IndexByExpression returns an index by the given expression. It will return nil if no index is found. If more than
 // one expression is given, all of them must match for the index to be matched.
-func (r *indexAnalyzer) IndexByExpression(ctx *sql.Context, db string, expr ...sql.Expression) sql.Index {
+func (r *indexAnalyzer) IndexByExpression(ctx *sql.Context, db string, table string, expr ...sql.Expression) sql.Index {
 	// Multiple expressions may be the same so we filter out duplicates
 	distinctExprs := make(map[string]struct{})
 	var exprStrs []string
@@ -124,11 +124,9 @@ func (r *indexAnalyzer) IndexByExpression(ctx *sql.Context, db string, expr ...s
 		}
 	}
 
-	for _, idxes := range r.indexesByTable {
-		for _, idx := range idxes {
-			if exprListsEqual(idx.Expressions(), exprStrs) {
-				return idx
-			}
+	for _, idx := range r.indexesByTable[table] {
+		if exprListsEqual(idx.Expressions(), exprStrs) {
+			return idx
 		}
 	}
 

--- a/sql/analyzer/index_analyzer.go
+++ b/sql/analyzer/index_analyzer.go
@@ -15,6 +15,8 @@
 package analyzer
 
 import (
+	"strings"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
@@ -124,7 +126,7 @@ func (r *indexAnalyzer) IndexByExpression(ctx *sql.Context, db string, table str
 		}
 	}
 
-	for _, idx := range r.indexesByTable[table] {
+	for _, idx := range r.indexesByTable[strings.ToLower(table)] {
 		if exprListsEqual(idx.Expressions(), exprStrs) {
 			return idx
 		}

--- a/sql/analyzer/index_analyzer.go
+++ b/sql/analyzer/index_analyzer.go
@@ -66,6 +66,8 @@ func getIndexesForNode(ctx *sql.Context, a *Analyzer, n sql.Node) (*indexAnalyze
 					analysisErr = err
 					return false
 				}
+
+				return false
 			case *plan.ResolvedTable:
 				err := indexesForTable(n.Name(), n)
 				if err != nil {

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -723,8 +723,8 @@ func getEqualityIndexes(
 	}
 
 	leftIdx, rightIdx :=
-		ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, cond.Left())...),
-		ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, cond.Right())...)
+		ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), leftCol.col.Table(), normalizeExpressions(ctx, tableAliases, cond.Left())...),
+		ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), rightCol.col.Table(), normalizeExpressions(ctx, tableAliases, cond.Right())...)
 
 	// Figure out which table is on the left and right in the join
 	leftJoinPosition := plan.JoinTypeLeft
@@ -775,13 +775,13 @@ func getJoinIndex(
 	indexesByTable := make(joinIndexesByTable)
 	for table, cols := range exprsByTable {
 		exprs := extractExpressions(cols)
-		idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, exprs...)...)
+		idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), table, normalizeExpressions(ctx, tableAliases, exprs...)...)
 		// If we do not find a perfect index, we take the first single column partial index if there is one.
 		// This currently only finds single column indexes. A better search would look for the most complete
 		// index available, covering the columns with the most specificity / highest cardinality.
 		if idx == nil && len(exprs) > 1 {
 			for _, e := range exprs {
-				idx = ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, e)...)
+				idx = ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), table, normalizeExpressions(ctx, tableAliases, e)...)
 				if idx != nil {
 					break
 				}

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -159,11 +159,13 @@ func getIndexes(
 			return nil, nil
 		}
 	case *expression.InTuple:
-		// Take the index of a SOMETHING IN SOMETHING expression only if:
-		// the right branch is evaluable and the indexlookup supports set
-		// operations.
 		if !isEvaluable(e.Left()) && isEvaluable(e.Right()) {
-			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, e.Left())...)
+			gf := extractGetField(e.Left())
+			if gf == nil {
+				return nil, nil
+			}
+
+			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), gf.Table(), normalizeExpressions(ctx, tableAliases, e.Left())...)
 			if idx != nil {
 				value, err := e.Right().Eval(sql.NewEmptyContext(), nil)
 				if err != nil {
@@ -243,7 +245,12 @@ func getIndexes(
 		}
 	case *expression.Between:
 		if !isEvaluable(e.Val) && isEvaluable(e.Upper) && isEvaluable(e.Lower) {
-			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, e.Val)...)
+			gf := extractGetField(e)
+			if gf == nil {
+				return nil, nil
+			}
+
+			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), gf.Table(), normalizeExpressions(ctx, tableAliases, e.Val)...)
 			if idx != nil {
 
 				upper, err := e.Upper.Eval(sql.NewEmptyContext(), nil)
@@ -382,7 +389,12 @@ func getComparisonIndexLookup(
 	}
 
 	if !isEvaluable(left) && isEvaluable(right) {
-		idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, left)...)
+		gf := extractGetField(left)
+		if gf == nil {
+			return nil, nil
+		}
+
+		idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), gf.Table(), normalizeExpressions(ctx, tableAliases, left)...)
 		if idx != nil {
 			value, err := right.Eval(sql.NewEmptyContext(), nil)
 			if err != nil {
@@ -487,7 +499,12 @@ func getNegatedIndexes(
 			return nil, nil
 		}
 
-		idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, left)...)
+		gf := extractGetField(left)
+		if gf == nil {
+			return nil, nil
+		}
+
+		idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), gf.Table(), normalizeExpressions(ctx, tableAliases, left)...)
 		if idx == nil {
 			return nil, nil
 		}
@@ -526,7 +543,12 @@ func getNegatedIndexes(
 		// the right branch is evaluable and the indexlookup supports set
 		// operations.
 		if !isEvaluable(e.Left()) && isEvaluable(e.Right()) {
-			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, e.Left())...)
+			gf := extractGetField(e.Left())
+			if gf == nil {
+				return nil ,nil
+			}
+
+			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), gf.Table(), normalizeExpressions(ctx, tableAliases, e.Left())...)
 			if idx != nil {
 				nidx, ok := idx.(sql.NegateIndex)
 				if !ok {
@@ -686,7 +708,7 @@ func getMultiColumnIndexes(
 				continue
 			}
 
-			lookup, err := getMultiColumnIndexForExpressions(ctx, a, ia, selected, exps, tableAliases)
+			lookup, err := getMultiColumnIndexForExpressions(ctx, a, ia, table, selected, exps, tableAliases)
 			if err != nil {
 				return nil, err
 			}
@@ -717,15 +739,16 @@ func getMultiColumnIndexes(
 }
 
 func getMultiColumnIndexForExpressions(
-	ctx *sql.Context,
-	a *Analyzer,
-	ia *indexAnalyzer,
-	selected []sql.Expression,
-	exprs []joinColExpr,
-	tableAliases TableAliases,
+		ctx *sql.Context,
+		a *Analyzer,
+		ia *indexAnalyzer,
+		table string,
+		selected []sql.Expression,
+		exprs []joinColExpr,
+		tableAliases TableAliases,
 ) (*indexLookup, error) {
 
-	index := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), normalizeExpressions(ctx, tableAliases, selected...)...)
+	index := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), table, normalizeExpressions(ctx, tableAliases, selected...)...)
 	if index == nil {
 		return nil, nil
 	}

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -545,7 +545,7 @@ func getNegatedIndexes(
 		if !isEvaluable(e.Left()) && isEvaluable(e.Right()) {
 			gf := extractGetField(e.Left())
 			if gf == nil {
-				return nil ,nil
+				return nil, nil
 			}
 
 			idx := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), gf.Table(), normalizeExpressions(ctx, tableAliases, e.Left())...)
@@ -739,13 +739,13 @@ func getMultiColumnIndexes(
 }
 
 func getMultiColumnIndexForExpressions(
-		ctx *sql.Context,
-		a *Analyzer,
-		ia *indexAnalyzer,
-		table string,
-		selected []sql.Expression,
-		exprs []joinColExpr,
-		tableAliases TableAliases,
+	ctx *sql.Context,
+	a *Analyzer,
+	ia *indexAnalyzer,
+	table string,
+	selected []sql.Expression,
+	exprs []joinColExpr,
+	tableAliases TableAliases,
 ) (*indexLookup, error) {
 
 	index := ia.IndexByExpression(ctx, ctx.GetCurrentDatabase(), table, normalizeExpressions(ctx, tableAliases, selected...)...)

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -307,6 +307,8 @@ func convertExplain(ctx *sql.Context, n *sqlparser.Explain) (sql.Node, error) {
 	switch strings.ToLower(n.ExplainFormat) {
 	case "", sqlparser.TreeStr:
 	// tree format, do nothing
+	case "debug":
+		explainFmt = "debug"
 	default:
 		return nil, errInvalidDescribeFormat.New(
 			n.ExplainFormat,

--- a/sql/plan/describe.go
+++ b/sql/plan/describe.go
@@ -128,7 +128,6 @@ func (d *DescribeQuery) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, err
 		formatString = d.child.String()
 	}
 
-
 	for _, l := range strings.Split(formatString, "\n") {
 		if strings.TrimSpace(l) != "" {
 			rows = append(rows, sql.NewRow(l))

--- a/sql/plan/describe.go
+++ b/sql/plan/describe.go
@@ -121,7 +121,15 @@ func (d *DescribeQuery) Schema() sql.Schema {
 // RowIter implements the Node interface.
 func (d *DescribeQuery) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	var rows []sql.Row
-	for _, l := range strings.Split(d.child.String(), "\n") {
+	var formatString string
+	if d.Format == "debug" {
+		formatString = sql.DebugString(d.child)
+	} else {
+		formatString = d.child.String()
+	}
+
+
+	for _, l := range strings.Split(formatString, "\n") {
 		if strings.TrimSpace(l) != "" {
 			rows = append(rows, sql.NewRow(l))
 		}
@@ -132,7 +140,11 @@ func (d *DescribeQuery) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, err
 func (d *DescribeQuery) String() string {
 	pr := sql.NewTreePrinter()
 	_ = pr.WriteNode("DescribeQuery(format=%s)", d.Format)
-	_ = pr.WriteChildren(d.child.String())
+	if d.Format == "debug" {
+		_ = pr.WriteChildren(sql.DebugString(d.child))
+	} else {
+		_ = pr.WriteChildren(d.child.String())
+	}
 	return pr.String()
 }
 


### PR DESCRIPTION
When a query had two copies of the same table, and it could use an index to join them, it was non-deterministic which of the tables' (identical) indexes would be used. This choice doesn't matter for some implementations or even most queries, but in Dolt, if a query involves the same table at two different revisions (because of AS OF), it was arbitrary which table's index got returned. Because the dolt index implementation gets its data from its parent table, if it chose the wrong index it got the wrong data.

This change restricts the choice of index to a single table name.

Need tests demonstrating the bug, but those will have to live in Dolt for the time being.