### PR TITLE
Reduced index range complexity, removed range overlapping

### DIFF
--- a/sql/index.go
+++ b/sql/index.go
@@ -39,13 +39,12 @@ type Index interface {
 	// IsGenerated returns whether this index was generated. Generated indexes
 	// are used for index access, but are not displayed (such as with SHOW INDEXES).
 	IsGenerated() bool
-	// NewLookup returns a new IndexLookup for the ranges given. Ranges represent filters over columns (RangeColumns),
-	// and it is possible for ranges to overlap (however they will not be subsets of one another). Each Range
-	// is ordered by the column expressions (as returned by Expressions) with the RangeColumn representing the
-	// searchable area for each column expression. Multiple RangeColumnExprs per RangeColumn are equivalent to the union
-	// of those RangeColumnExprs, e.g. (x < 1 OR x > 10) will return two RangeColumnExprs, where matching either is
-	// valid for the column "x". If an integrator is unable to process the given ranges, then a nil may be returned. An
-	// error should be returned only in the event that an error occurred.
+	// NewLookup returns a new IndexLookup for the ranges given. Ranges represent filters over columns. Each Range
+	// is ordered by the column expressions (as returned by Expressions) with the RangeColumnExpr representing the
+	// searchable area for each column expression. Each Range given will not overlap with any other ranges. Additionally,
+	// all ranges will have the same length, and may represent a partial index (matching a prefix rather than the entire
+	// index). If an integrator is unable to process the given ranges, then a nil may be returned. An error should be
+	// returned only in the event that an error occurred.
 	NewLookup(ctx *Context, ranges ...Range) (IndexLookup, error)
 	// ColumnExpressionTypes returns each expression and its associated Type. Each expression string should exactly
 	// match the string returned from Index.Expressions().

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -31,7 +31,7 @@ type IndexBuilder struct {
 	isInvalid    bool
 	err          error
 	colExprTypes map[string]Type
-	ranges       map[string]RangeColumn
+	ranges       map[string][]RangeColumnExpr
 }
 
 // NewIndexBuilder returns a new IndexBuilder. Used internally to construct a range that will later be passed to
@@ -46,7 +46,7 @@ func NewIndexBuilder(ctx *Context, idx Index) *IndexBuilder {
 		isInvalid:    false,
 		err:          nil,
 		colExprTypes: colExprTypes,
-		ranges:       make(map[string]RangeColumn),
+		ranges:       make(map[string][]RangeColumnExpr),
 	}
 }
 
@@ -154,12 +154,12 @@ func (b *IndexBuilder) LessOrEqual(ctx *Context, colExpr string, key interface{}
 	return b
 }
 
-// Range returns the range for this index builder. If the builder is invalid for any reason then this returns nil.
-func (b *IndexBuilder) Range() Range {
+// Ranges returns all ranges for this index builder. If the builder is invalid for any reason then this returns nil.
+func (b *IndexBuilder) Ranges() RangeCollection {
 	if b.err != nil || b.isInvalid {
 		return nil
 	}
-	var rangeCollection Range
+	var allColumns [][]RangeColumnExpr
 	for _, colExpr := range b.idx.Expressions() {
 		ranges, ok := b.ranges[colExpr]
 		if !ok {
@@ -167,9 +167,34 @@ func (b *IndexBuilder) Range() Range {
 			// not have an entry for then we've hit all the ranges.
 			break
 		}
-		rangeCollection = append(rangeCollection, ranges)
+		allColumns = append(allColumns, ranges)
 	}
-	return rangeCollection
+
+	// In the builder ranges map we store multiple column expressions per column, however we want all permutations to
+	// be their own range, so here we're creating a new range for every permutation.
+	colCounts := make([]int, len(allColumns))
+	permutation := make([]int, len(allColumns))
+	for i, rangeColumn := range allColumns {
+		colCounts[i] = len(rangeColumn)
+	}
+	var ranges []Range
+	exit := false
+	for !exit {
+		exit = true
+		currentRange := make(Range, len(allColumns))
+		for colIdx, exprCount := range colCounts {
+			permutation[colIdx] = (permutation[colIdx] + 1) % exprCount
+			if permutation[colIdx] != 0 {
+				exit = false
+				break
+			}
+		}
+		for colIdx, exprIdx := range permutation {
+			currentRange[colIdx] = allColumns[colIdx][exprIdx]
+		}
+		ranges = append(ranges, currentRange)
+	}
+	return ranges
 }
 
 // Build constructs a new IndexLookup based on the ranges that have been built internally by this builder.
@@ -179,11 +204,11 @@ func (b *IndexBuilder) Build(ctx *Context) (IndexLookup, error) {
 	} else if b.isInvalid {
 		return nil, nil
 	} else {
-		rang := b.Range()
-		if len(rang) == 0 {
+		ranges := b.Ranges()
+		if len(ranges) == 0 {
 			return nil, nil
 		}
-		return b.idx.NewLookup(ctx, rang)
+		return b.idx.NewLookup(ctx, ranges...)
 	}
 }
 

--- a/sql/range.go
+++ b/sql/range.go
@@ -14,15 +14,14 @@
 
 package sql
 
+import "strings"
+
 // RangeCollection is a collection of ranges that represent different (non-overlapping) filter expressions.
 type RangeCollection []Range
 
 // Range is a collection of RangeColumns that are ordered by the column expressions as returned by their parent
 // index. A single range represents a set of values intended for iteration by an integrator's index.
-type Range []RangeColumn
-
-// RangeColumn is a slice of RangeColumnExprs meant to represent a set of discrete, non-overlapping RangeColumnExprs.
-type RangeColumn []RangeColumnExpr
+type Range []RangeColumnExpr
 
 // Intersect attempts to intersect the given RangeCollection with the calling RangeCollection. This ensures that each
 // Range belonging to the same collection is treated as a union with respect to that same collection, rather than
@@ -40,7 +39,7 @@ func (ranges RangeCollection) Intersect(otherRanges RangeCollection) (RangeColle
 			}
 		}
 	}
-	newRanges, err := SimplifyRanges(newRanges...)
+	newRanges, err := RemoveOverlappingRanges(newRanges...)
 	if err != nil {
 		return nil, err
 	}
@@ -50,46 +49,137 @@ func (ranges RangeCollection) Intersect(otherRanges RangeCollection) (RangeColle
 	return newRanges, nil
 }
 
+// String returns this RangeCollection as a string for display purposes.
+func (ranges RangeCollection) String() string {
+	sb := strings.Builder{}
+	sb.WriteByte('[')
+	for i, rang := range ranges {
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(rang.String())
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+// DebugString returns this RangeCollection as a string for debugging purposes.
+func (ranges RangeCollection) DebugString() string {
+	sb := strings.Builder{}
+	sb.WriteByte('[')
+	for i, rang := range ranges {
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(rang.DebugString())
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
 // AsEmpty returns a Range full of empty RangeColumns with the same types as the calling Range.
 func (rang Range) AsEmpty() Range {
 	emptyRange := make(Range, len(rang))
 	for i := range rang {
-		emptyRange[i] = RangeColumn{EmptyRangeColumnExpr(rang[i][0].typ)}
+		emptyRange[i] = EmptyRangeColumnExpr(rang[i].typ)
 	}
 	return emptyRange
 }
 
-// RangesByColumnExpression returns the RangeColumn that belongs to the given column expression. If an index does not
-// contain the given column expression then a nil is returned.
-func (rang Range) RangesByColumnExpression(idx Index, colExpr string) RangeColumn {
+// Copy returns a duplicate of this Range.
+func (rang Range) Copy() Range {
+	newRange := make(Range, len(rang))
+	for i, colExpr := range rang {
+		newRange[i] = colExpr // RangeColumnExpr and all of its members are non-pointer types, so they're copied
+	}
+	return newRange
+}
+
+// ExpressionByColumnName returns the RangeColumnExpr that belongs to the given column expression. If an index does not
+// contain the column expression then false is returned.
+func (rang Range) ExpressionByColumnName(idx Index, colExpr string) (RangeColumnExpr, bool) {
 	for i, idxColExpr := range idx.Expressions() {
 		if idxColExpr == colExpr {
 			if i < len(rang) {
-				return rang[i]
+				return rang[i], true
 			}
 			break
 		}
 	}
-	return nil
+	return RangeColumnExpr{}, false
 }
 
-// Intersect attempts to intersect the given Range with the calling Range.
+// Equals evaluates whether the calling Range is equivalent to the given Range.
+func (rang Range) Equals(otherRange Range) (bool, error) {
+	if len(rang) != len(otherRange) {
+		return false, nil
+	}
+	for i := range rang {
+		if ok, err := rang[i].Equals(otherRange[i]); err != nil || !ok {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// Intersect intersects the given Range with the calling Range.
 func (rang Range) Intersect(otherRange Range) (Range, error) {
 	if len(rang) != len(otherRange) {
 		return nil, nil
 	}
 	newRangeCollection := make(Range, len(rang))
 	for i := range rang {
-		intersectedRanges, ok, err := rang[i].TryIntersect(otherRange[i])
+		intersectedRange, ok, err := rang[i].TryIntersect(otherRange[i])
 		if err != nil {
 			return nil, err
 		}
 		if !ok {
 			return rang.AsEmpty(), nil
 		}
-		newRangeCollection[i] = intersectedRanges
+		newRangeCollection[i] = intersectedRange
 	}
 	return newRangeCollection, nil
+}
+
+// TryMerge attempts to merge the given Range with the calling Range. This can only do a merge if one Range is a subset
+// of the other, or if all columns except for one are equivalent, upon which a union is attempted on that column.
+// Returns true if the merge was successful.
+func (rang Range) TryMerge(otherRange Range) (Range, bool, error) {
+	if len(rang) != len(otherRange) {
+		return nil, false, nil
+	}
+	if ok, err := rang.IsSupersetOf(otherRange); err != nil {
+		return nil, false, err
+	} else if ok {
+		return rang, true, nil
+	}
+	if ok, err := otherRange.IsSupersetOf(rang); err != nil {
+		return nil, false, err
+	} else if ok {
+		return otherRange, true, nil
+	}
+
+	indexToMerge := -1
+	// The superset checks will cover if every column expr is equivalent
+	for i := 0; i < len(rang); i++ {
+		if ok, err := rang[i].Equals(otherRange[i]); err != nil {
+			return nil, false, err
+		} else if !ok {
+			// Only one column may not equal another
+			if indexToMerge == -1 {
+				indexToMerge = i
+			} else {
+				return nil, false, nil
+			}
+		}
+	}
+	mergedLastExpr, ok, err := rang[indexToMerge].TryUnion(otherRange[indexToMerge])
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	mergedRange := rang.Copy()
+	mergedRange[indexToMerge] = mergedLastExpr
+	return mergedRange, true, nil
 }
 
 // IsSubsetOf evaluates whether the calling Range is fully encompassed by the given Range.
@@ -111,64 +201,153 @@ func (rang Range) IsSupersetOf(otherRange Range) (bool, error) {
 	return otherRange.IsSubsetOf(rang)
 }
 
-// Equals returns whether the calling RangeColumn is equal to the given RangeColumn.
-func (rc RangeColumn) Equals(other RangeColumn) (bool, error) {
-	if len(rc) != len(other) {
+// IsConnected returns whether the calling Range and given Range have overlapping values, which would result in the same
+// values being returned from some subset of both ranges.
+func (rang Range) IsConnected(otherRange Range) (bool, error) {
+	if len(rang) != len(otherRange) {
 		return false, nil
 	}
-	for i := range rc {
-		if ok, err := rc[i].Equals(other[i]); err != nil || !ok {
+	for i := range rang {
+		_, ok, err := rang[i].Overlaps(otherRange[i])
+		if err != nil || !ok {
 			return false, err
 		}
 	}
 	return true, nil
 }
 
-// TryIntersect attempts to intersect the calling RangeColumn with the given RangeColumn. If the intersection fails or
-// results in an empty RangeColumn then nil and false are returned.
-func (rc RangeColumn) TryIntersect(other RangeColumn) (RangeColumn, bool, error) {
-	var newRangeColumn []RangeColumnExpr
-	var err error
-	for _, rr := range rc {
-		for _, or := range other {
-			newRange, ok, err := rr.TryIntersect(or)
-			if err != nil {
-				return nil, false, err
-			}
-			if ok {
-				newRangeColumn = append(newRangeColumn, newRange)
-			}
-		}
+// Overlaps returns whether the calling Range and given Range have overlapping values, which would result in the same
+// values being returned from some subset of both ranges.
+func (rang Range) Overlaps(otherRange Range) (bool, error) {
+	if len(rang) != len(otherRange) {
+		return false, nil
 	}
-	newRangeColumn, err = SimplifyRangeColumn(newRangeColumn...)
-	if err != nil || len(newRangeColumn) == 0 {
-		return nil, false, err
-	}
-	return newRangeColumn, true, nil
-}
-
-// IsSubsetOf evaluates whether the calling RangeColumn is fully encompassed by the given RangeColumn.
-func (rc RangeColumn) IsSubsetOf(other RangeColumn) (bool, error) {
-	for _, rce := range rc {
-		isSubset := false
-		for _, otherRCE := range other {
-			if ok, err := rce.IsSubsetOf(otherRCE); err != nil {
-				return false, err
-			} else if ok {
-				isSubset = true
-				break
-			}
-		}
-		if !isSubset {
-			return false, nil
+	for i := range rang {
+		_, ok, err := rang[i].Overlaps(otherRange[i])
+		if err != nil || !ok {
+			return false, err
 		}
 	}
 	return true, nil
 }
 
-// IsSupersetOf evaluates whether the calling RangeColumn fully encompasses the given RangeColumn.
-func (rc RangeColumn) IsSupersetOf(other RangeColumn) (bool, error) {
-	return other.IsSubsetOf(rc)
+// RemoveOverlap removes any overlap that the given Range may have with the calling Range. If the two ranges do not
+// overlap and are not mergeable then they're both returned. If one is a subset of the other or is mergeable then only
+// one Range is returned. Otherwise, this returns a collection of ranges that do not overlap with each other, and covers
+// the entirety of the original ranges (and nothing more). If the two ranges do not overlap and are not mergeable then
+// false is returned, otherwise returns true.
+func (rang Range) RemoveOverlap(otherRange Range) (RangeCollection, bool, error) {
+	// An explanation on why overlapping ranges may return more than one range, and why they can't just be merged as-is.
+	// Let's start with a Range that has a single RangeColumnExpression (a one-dimensional range). Imagine this as a
+	// number line with contiguous sections defined as the range. If you have any two sections that overlap, then you
+	// can simply take the lowest and highest bounds between both of those sections to create a single, larger range
+	// that fully encompasses both (while not including any elements that were not in the original ranges).
+	//
+	// Now let's look at a Range that has two RangeColumnExpressions (a two-dimensional range). Imagine this as a sheet
+	// of paper on a table (for easier visualization). If these two sheet overlap then we can't just take the lowest
+	// and highest bounds of these sheets as that may include areas outside either sheet of paper. Instead, we can cut
+	// the sheets so that we get smaller sheets of paper, with one "sub sheet" perfectly overlapping the other. This
+	// may be done with two cuts on each sheet, giving us a total of 8 smaller sheets overall. Of course the perfectly
+	// overlapping sheets can be combined, so we throw one of them away. From there we're back to our original Range
+	// example with only one dimension, as now this overlapping subsheet will differ from the sheets on its edges by
+	// only a single dimension (the sheet to the left, for example, will be the same height but extending further left).
+	// We can then combine it with its edge-adjacent sheets until we have a collection of sheets that do not overlap
+	// and all have different widths and heights.
+	//
+	// The great thing about this example with two dimensions is that it can be used for N dimensions, where we break
+	// down the ranges until we get a perfectly overlapping range, and then merge (a single dimension at a time) all
+	// edge-adjacent ranges until we arrive at a set of ranges that do not overlap and cannot be combined.
+
+	// If the two ranges may be merged then we just do that and return.
+	// Also allows us to not have to worry about the case where every column is equivalent.
+	if mergedRange, ok, err := rang.TryMerge(otherRange); err != nil {
+		return nil, false, err
+	} else if ok {
+		return []Range{mergedRange}, true, nil
+	}
+	// We check for overlapping after checking for merge as two ranges may not overlap but may be mergeable.
+	// This would occur if all other columns are equivalent except for one column that is overlapping or adjacent.
+	if ok, err := rang.Overlaps(otherRange); err != nil || !ok {
+		return []Range{rang, otherRange}, false, err
+	}
+
+	var ranges []Range
+	for i := range rang {
+		if ok, err := rang[i].Equals(otherRange[i]); err != nil {
+			return nil, false, err
+		} else if ok {
+			continue
+		}
+		// Get the RangeColumnExpr that overlaps both RangeColumnExprs
+		overlapExpr, _, err := rang[i].Overlaps(otherRange[i])
+		if err != nil {
+			return nil, false, err
+		}
+		// Subtract the overlapping range from each existing range.
+		// This will give us a collection of ranges that do not have any overlap.
+		range1Subtracted, err := rang[i].Subtract(overlapExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		for _, newColExpr := range range1Subtracted {
+			ranges = append(ranges, rang.replace(i, newColExpr))
+		}
+		range2Subtracted, err := otherRange[i].Subtract(overlapExpr)
+		if err != nil {
+			return nil, false, err
+		}
+		for _, newColExpr := range range2Subtracted {
+			ranges = append(ranges, otherRange.replace(i, newColExpr))
+		}
+		// Create two ranges that replace each respective RangeColumnExpr with the overlapping one, giving us two
+		// ranges that are guaranteed to overlap (and are a subset of the originals). We can then recursively call this
+		// function on the new overlapping ranges which will eventually return a set of non-overlapping ranges.
+		newRanges, _, err := rang.replace(i, overlapExpr).RemoveOverlap(otherRange.replace(i, overlapExpr))
+		if err != nil {
+			return nil, false, err
+		}
+		ranges = append(ranges, newRanges...)
+		break
+	}
+
+	return ranges, true, nil
+}
+
+// String returns this Range as a string for display purposes.
+func (rang Range) String() string {
+	sb := strings.Builder{}
+	sb.WriteByte('{')
+	for i, colExpr := range rang {
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(colExpr.String())
+	}
+	sb.WriteByte('}')
+	return sb.String()
+}
+
+// DebugString returns this Range as a string for debugging purposes.
+func (rang Range) DebugString() string {
+	sb := strings.Builder{}
+	sb.WriteByte('{')
+	for i, colExpr := range rang {
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(colExpr.DebugString())
+	}
+	sb.WriteByte('}')
+	return sb.String()
+}
+
+// replace returns a new Range with the column at the given index replaced by the given RangeColumnExpr. Does NOT
+// perform any validation checks such as the index being within the bounds of the Range or the RangeColumnExpr having
+// the same type as the other columns, so use with caution.
+func (rang Range) replace(i int, colExpr RangeColumnExpr) Range {
+	newRange := rang.Copy()
+	newRange[i] = colExpr
+	return newRange
 }
 
 // IntersectRanges intersects each Range for each column expression. If a RangeColumnExpr ends up with no valid ranges
@@ -208,62 +387,34 @@ func IntersectRanges(ranges ...Range) Range {
 	return rang
 }
 
-// SimplifyRanges operates differently depending on whether the given RangeCollection represent a single RangeColumn or
-// multiple RangeColumns, as they have different rules. If the collections contain a single RangeColumn then they are
-// all unioned together. If the collections contain multiple RangeColumns then all RangeColumns that are a subset of
-// another RangeColumn are removed.
-//
-// This difference is because a Range that contains multiple RangeColumns was constructed with an AND restriction
-// between each column, therefore a union between only RangeColumnExprs would result in valid results according to the
-// RangeColumn that are invalid according to the filter itself.
-func SimplifyRanges(ranges ...Range) (RangeCollection, error) {
+// RemoveOverlappingRanges removes all overlap between all ranges.
+func RemoveOverlappingRanges(ranges ...Range) (RangeCollection, error) {
 	if len(ranges) == 0 {
 		return nil, nil
 	}
 
-	if len(ranges[0]) == 1 {
-		var allRangeColExprs []RangeColumnExpr
-		returnAllRange := true
-		for _, rangeCollection := range ranges {
-			if len(rangeCollection) != 1 {
-				returnAllRange = false
+	// There are more efficient ways to do these comparisons, but this is just a simple implementation for now
+	var newRanges RangeCollection
+	for i := 0; i < len(ranges); i++ {
+		hadOverlap := false
+		for nri := 0; nri < len(newRanges); nri++ {
+			if resultingRanges, ok, err := ranges[i].RemoveOverlap(newRanges[nri]); err != nil {
+				return nil, err
+			} else if ok {
+				hadOverlap = true
+				// Remove the overlapping Range from newRanges
+				nrLast := len(newRanges) - 1
+				newRanges[nri], newRanges[nrLast] = newRanges[nrLast], newRanges[nri]
+				newRanges = newRanges[:nrLast]
+				// Add the new ranges to the end of the given slice allowing us to compare those against everything else.
+				ranges = append(ranges, resultingRanges...)
 				break
 			}
-			allRangeColExprs = append(allRangeColExprs, rangeCollection[0]...)
 		}
-		if returnAllRange {
-			var err error
-			allRangeColExprs, err = SimplifyRangeColumn(allRangeColExprs...)
-			if err != nil {
-				return nil, err
-			}
-			if len(allRangeColExprs) == 0 {
-				return []Range{{RangeColumn{EmptyRangeColumnExpr(ranges[0][0][0].typ)}}}, nil
-			}
-			return []Range{{allRangeColExprs}}, nil
+		if !hadOverlap {
+			newRanges = append(newRanges, ranges[i])
 		}
 	}
 
-	var discreteRanges []Range
-	for _, rang := range ranges {
-		shouldAdd := true
-		for dcIndex := 0; dcIndex < len(discreteRanges); dcIndex++ {
-			discreteCollection := discreteRanges[dcIndex]
-			if ok, err := discreteCollection.IsSupersetOf(rang); err != nil {
-				return nil, err
-			} else if ok {
-				shouldAdd = false
-				break
-			} else if ok, err = rang.IsSupersetOf(discreteCollection); err != nil {
-				return nil, err
-			} else if ok {
-				discreteRanges = append(discreteRanges[:dcIndex], discreteRanges[dcIndex+1:]...)
-				dcIndex--
-			}
-		}
-		if shouldAdd {
-			discreteRanges = append(discreteRanges, rang)
-		}
-	}
-	return discreteRanges, nil
+	return newRanges, nil
 }

--- a/sql/range_cut.go
+++ b/sql/range_cut.go
@@ -22,7 +22,7 @@ import (
 type RangeCut interface {
 	// Compare returns an integer stating the relative position of the calling RangeCut to the given RangeCut.
 	Compare(RangeCut, Type) (int, error)
-	// String returns the RangeCut as a string for debugging purposes. Will panic on errors.
+	// String returns the RangeCut as a string for display purposes.
 	String() string
 	// TypeAsLowerBound returns the bound type if the calling RangeCut is the lower bound of a range.
 	TypeAsLowerBound() RangeBoundType
@@ -55,6 +55,36 @@ func GetRangeCutKey(c RangeCut) interface{} {
 	default:
 		panic(fmt.Errorf("need to check the RangeCut type before calling GetRangeCutKey, used on `%T`", c))
 	}
+}
+
+// GetRangeCutMax returns the RangeCut with the highest value.
+func GetRangeCutMax(typ Type, cuts ...RangeCut) (RangeCut, error) {
+	maxCut := cuts[0]
+	for i := 1; i < len(cuts); i++ {
+		comp, err := maxCut.Compare(cuts[i], typ)
+		if err != nil {
+			return maxCut, err
+		}
+		if comp == -1 {
+			maxCut = cuts[i]
+		}
+	}
+	return maxCut, nil
+}
+
+// GetRangeCutMin returns the RangeCut with the lowest value.
+func GetRangeCutMin(typ Type, cuts ...RangeCut) (RangeCut, error) {
+	minCut := cuts[0]
+	for i := 1; i < len(cuts); i++ {
+		comp, err := minCut.Compare(cuts[i], typ)
+		if err != nil {
+			return minCut, err
+		}
+		if comp == 1 {
+			minCut = cuts[i]
+		}
+	}
+	return minCut, nil
 }
 
 // Above represents the position immediately above the contained key.
@@ -122,12 +152,12 @@ func (AboveAll) String() string {
 
 // TypeAsLowerBound implements RangeCut.
 func (AboveAll) TypeAsLowerBound() RangeBoundType {
-	panic("AboveAll TypeAsLowerBound should be unreachable")
+	return Open
 }
 
 // TypeAsUpperBound implements RangeCut.
 func (AboveAll) TypeAsUpperBound() RangeBoundType {
-	panic("AboveAll TypeAsUpperBound should be unreachable")
+	return Open
 }
 
 // Below represents the position immediately below the contained key.
@@ -195,10 +225,10 @@ func (BelowAll) String() string {
 
 // TypeAsLowerBound implements RangeCut.
 func (BelowAll) TypeAsLowerBound() RangeBoundType {
-	panic("BelowAll TypeAsLowerBound should be unreachable")
+	return Open
 }
 
 // TypeAsUpperBound implements RangeCut.
 func (BelowAll) TypeAsUpperBound() RangeBoundType {
-	panic("BelowAll TypeAsUpperBound should be unreachable")
+	return Open
 }

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -1,0 +1,365 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+var rangeType = sql.Uint8
+
+func TestRangeOverlapTwoColumns(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	x, y, _, values2, _ := setup()
+
+	tests := []struct {
+		reference sql.Expression
+		ranges    sql.RangeCollection
+	}{
+		{
+			or(
+				and(lt(x, 2), gt(y, 5)),
+				and(gt(x, 8), gt(y, 5)),
+				and(gt(x, 5), gt(y, 8)),
+			),
+			sql.RangeCollection{
+				r(rlt(2), rgt(5)),
+				r(rgt(8), rgt(5)),
+				r(rgt(5), rgt(8)),
+			},
+		},
+		{
+			or(
+				and(lt(x, 2), gt(y, 5)),
+				and(gt(x, 8), gt(y, 5)),
+				and(gt(x, 5), lt(y, 8)),
+			),
+			sql.RangeCollection{
+				r(rlt(2), rgt(5)),
+				r(rgt(8), rgt(5)),
+				r(rgt(5), rlt(8)),
+			},
+		},
+		{
+			or(
+				and(gt(x, 1), gt(y, 1)),
+				and(gt(x, 2), gt(y, 2)),
+				and(gt(x, 3), gt(y, 3)),
+				and(gt(x, 4), gt(y, 4)),
+				and(gt(x, 5), gt(y, 5)),
+				and(gt(x, 6), gt(y, 6)),
+				and(gt(x, 7), gt(y, 7)),
+				and(gt(x, 8), gt(y, 8)),
+				and(gt(x, 9), gt(y, 9)),
+				and(lt(x, 1), lt(y, 1)),
+				and(lt(x, 2), lt(y, 2)),
+				and(lt(x, 3), lt(y, 3)),
+				and(lt(x, 4), lt(y, 4)),
+				and(lt(x, 5), lt(y, 5)),
+				and(lt(x, 6), lt(y, 6)),
+				and(lt(x, 7), lt(y, 7)),
+				and(lt(x, 8), lt(y, 8)),
+				and(lt(x, 9), lt(y, 9)),
+			),
+			sql.RangeCollection{
+				r(rgt(1), rgt(1)),
+				r(rgt(2), rgt(2)),
+				r(rgt(3), rgt(3)),
+				r(rgt(4), rgt(4)),
+				r(rgt(5), rgt(5)),
+				r(rgt(6), rgt(6)),
+				r(rgt(7), rgt(7)),
+				r(rgt(8), rgt(8)),
+				r(rgt(9), rgt(9)),
+				r(rlt(1), rlt(1)),
+				r(rlt(2), rlt(2)),
+				r(rlt(3), rlt(3)),
+				r(rlt(4), rlt(4)),
+				r(rlt(5), rlt(5)),
+				r(rlt(6), rlt(6)),
+				r(rlt(7), rlt(7)),
+				r(rlt(8), rlt(8)),
+				r(rlt(9), rlt(9)),
+			},
+		},
+		{
+			or(
+				and(gt(x, 2), gt(y, 2)),
+				and(eq(x, 4), eq(y, 4)),
+				and(lt(x, 9), lt(y, 9)),
+				and(eq(x, 6), eq(y, 6)),
+				and(eq(x, 8), eq(y, 8)),
+			),
+			sql.RangeCollection{
+				r(rgt(2), rgt(2)),
+				r(req(4), req(4)),
+				r(rlt(9), rlt(9)),
+				r(req(6), req(6)),
+				r(req(8), req(8)),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Expr:  %s\nRange: %s", test.reference.String(), test.ranges.DebugString()), func(t *testing.T) {
+			discreteRanges, err := sql.RemoveOverlappingRanges(test.ranges...)
+			require.NoError(t, err)
+			for _, row := range values2 {
+				referenceBool, err := test.reference.Eval(ctx, row)
+				require.NoError(t, err)
+				rangeBool := evalRanges(t, discreteRanges, row)
+				assert.Equal(t, referenceBool, rangeBool, fmt.Sprintf("%v: DiscreteRanges: %s", row, discreteRanges.DebugString()))
+			}
+		})
+	}
+}
+
+func TestRangeOverlapThreeColumns(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	x, y, z, _, values3 := setup()
+
+	tests := []struct {
+		reference sql.Expression
+		ranges    sql.RangeCollection
+	}{
+		{
+			or(
+				and(gt(x, 2), gt(y, 2), gt(z, 2)),
+				and(lt(x, 8), lt(y, 8), lt(z, 8)),
+			),
+			sql.RangeCollection{
+				r(rgt(2), rgt(2), rgt(2)),
+				r(rlt(8), rlt(8), rlt(8)),
+			},
+		},
+		{
+			or(
+				and(gte(x, 3), gte(y, 3), gte(z, 3)),
+				and(lte(x, 5), lte(y, 5), lte(z, 5)),
+			),
+			sql.RangeCollection{
+				r(rgte(3), rgte(3), rgte(3)),
+				r(rlte(5), rlte(5), rlte(5)),
+			},
+		},
+		{
+			or(
+				and(gte(x, 3), gte(y, 4), gt(z, 5)),
+				and(lte(x, 6), lt(y, 7), lte(z, 8)),
+			),
+			sql.RangeCollection{
+				r(rgte(3), rgte(4), rgt(5)),
+				r(rlte(6), rlt(7), rlte(8)),
+			},
+		},
+		{
+			or(
+				and(gte(x, 4), gte(y, 4), gte(z, 3)),
+				and(lte(x, 4), lte(y, 4), lte(z, 5)),
+			),
+			sql.RangeCollection{
+				r(rgte(4), rgte(4), rgte(3)),
+				r(rlte(4), rlte(4), rlte(5)),
+			},
+		},
+		{
+			or(
+				and(gte(x, 4), gte(y, 3), gte(z, 4)),
+				and(lte(x, 4), lte(y, 5), lte(z, 4)),
+			),
+			sql.RangeCollection{
+				r(rgte(4), rgte(3), rgte(4)),
+				r(rlte(4), rlte(5), rlte(4)),
+			},
+		},
+		{
+			or(
+				and(gte(x, 3), gte(y, 4), gte(z, 4)),
+				and(lte(x, 5), lte(y, 4), lte(z, 4)),
+			),
+			sql.RangeCollection{
+				r(rgte(3), rgte(4), rgte(4)),
+				r(rlte(5), rlte(4), rlte(4)),
+			},
+		},
+		{
+			or(
+				and(lt(x, 4), gte(y, 3), lt(z, 4)),
+				and(gt(x, 4), lte(y, 5), gt(z, 4)),
+			),
+			sql.RangeCollection{
+				r(rlt(4), rgte(3), rlt(4)),
+				r(rgt(4), rlte(5), rgt(4)),
+			},
+		},
+		{
+			or(
+				and(gt(x, 3), gt(y, 2), eq(z, 2)),
+				and(lt(x, 4), gte(y, 7), lte(z, 2)),
+				and(lte(x, 9), gt(y, 5), gt(z, 1)),
+			),
+			sql.RangeCollection{
+				r(rgt(3), rgt(2), req(2)),
+				r(rlt(4), rgte(7), rlte(2)),
+				r(rlte(9), rgt(5), rgt(1)),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Expr:  %s\nRange: %s", test.reference.String(), test.ranges.DebugString()), func(t *testing.T) {
+			discreteRanges, err := sql.RemoveOverlappingRanges(test.ranges...)
+			require.NoError(t, err)
+			for _, row := range values3 {
+				referenceBool, err := test.reference.Eval(ctx, row)
+				require.NoError(t, err)
+				rangeBool := evalRanges(t, discreteRanges, row)
+				assert.Equal(t, referenceBool, rangeBool, fmt.Sprintf("%v: DiscreteRanges: %s", row, discreteRanges.DebugString()))
+			}
+		})
+	}
+}
+
+func setup() (x, y, z sql.Expression, values2, values3 [][]interface{}) {
+	values2 = make([][]interface{}, 0, 100)
+	values3 = make([][]interface{}, 0, 1000)
+	for i := byte(1); i <= 10; i++ {
+		for j := byte(1); j <= 10; j++ {
+			for k := byte(1); k <= 10; k++ {
+				values3 = append(values3, []interface{}{i, j, k})
+			}
+			values2 = append(values2, []interface{}{i, j})
+		}
+	}
+	x = expression.NewGetField(0, rangeType, "x", true)
+	y = expression.NewGetField(1, rangeType, "y", true)
+	z = expression.NewGetField(2, rangeType, "z", true)
+	return
+}
+
+func evalRanges(t *testing.T, ranges []sql.Range, row []interface{}) bool {
+	found := false
+	for _, rang := range ranges {
+		if evalRange(t, rang, row) {
+			if !found {
+				found = true
+			} else {
+				assert.FailNow(t, "overlap in ranges")
+			}
+		}
+	}
+	return found
+}
+
+func evalRange(t *testing.T, rang sql.Range, row []interface{}) bool {
+	rowRange := make(sql.Range, len(rang))
+	for i, val := range row {
+		rowRange[i] = sql.ClosedRangeColumnExpr(val, val, rangeType)
+	}
+	ok, err := rang.IsSupersetOf(rowRange)
+	require.NoError(t, err)
+	return ok
+}
+
+func eq(field sql.Expression, val uint8) sql.Expression {
+	return expression.NewNullSafeEquals(field, expression.NewLiteral(val, rangeType))
+}
+
+func lt(field sql.Expression, val uint8) sql.Expression {
+	return expression.NewNullSafeLessThan(field, expression.NewLiteral(val, rangeType))
+}
+
+func lte(field sql.Expression, val uint8) sql.Expression {
+	return expression.NewNullSafeLessThanOrEqual(field, expression.NewLiteral(val, rangeType))
+}
+
+func gt(field sql.Expression, val uint8) sql.Expression {
+	return expression.NewNullSafeGreaterThan(field, expression.NewLiteral(val, rangeType))
+}
+
+func gte(field sql.Expression, val uint8) sql.Expression {
+	return expression.NewNullSafeGreaterThanOrEqual(field, expression.NewLiteral(val, rangeType))
+}
+
+func not(field sql.Expression, val uint8) sql.Expression {
+	return expression.NewNot(eq(field, val))
+}
+
+func r(colExprs ...sql.RangeColumnExpr) sql.Range {
+	return colExprs
+}
+
+func req(val byte) sql.RangeColumnExpr {
+	return sql.ClosedRangeColumnExpr(val, val, rangeType)
+}
+
+func rlt(val byte) sql.RangeColumnExpr {
+	return sql.LessThanRangeColumnExpr(val, rangeType)
+}
+
+func rlte(val byte) sql.RangeColumnExpr {
+	return sql.LessOrEqualRangeColumnExpr(val, rangeType)
+}
+
+func rgt(val byte) sql.RangeColumnExpr {
+	return sql.GreaterThanRangeColumnExpr(val, rangeType)
+}
+
+func rgte(val byte) sql.RangeColumnExpr {
+	return sql.GreaterOrEqualRangeColumnExpr(val, rangeType)
+}
+
+func rcc(lowerbound, upperbound byte) sql.RangeColumnExpr {
+	return sql.CustomRangeColumnExpr(lowerbound, upperbound, sql.Closed, sql.Closed, rangeType)
+}
+
+func rco(lowerbound, upperbound byte) sql.RangeColumnExpr {
+	return sql.CustomRangeColumnExpr(lowerbound, upperbound, sql.Closed, sql.Open, rangeType)
+}
+
+func roc(lowerbound, upperbound byte) sql.RangeColumnExpr {
+	return sql.CustomRangeColumnExpr(lowerbound, upperbound, sql.Open, sql.Closed, rangeType)
+}
+
+func roo(lowerbound, upperbound byte) sql.RangeColumnExpr {
+	return sql.CustomRangeColumnExpr(lowerbound, upperbound, sql.Open, sql.Open, rangeType)
+}
+
+func or(expressions ...sql.Expression) sql.Expression {
+	if len(expressions) == 1 {
+		return expressions[0]
+	}
+	if expressions[0] == nil {
+		return or(expressions[1:]...)
+	}
+	return expression.NewOr(expressions[0], or(expressions[1:]...))
+}
+
+func and(expressions ...sql.Expression) sql.Expression {
+	if len(expressions) == 1 {
+		return expressions[0]
+	}
+	if expressions[0] == nil {
+		return and(expressions[1:]...)
+	}
+	return expression.NewAnd(expressions[0], and(expressions[1:]...))
+}


### PR DESCRIPTION
All Ranges now only have a single column expression per range. Ranges no longer overlap. Additional comment changes and whatnot to facilitate both of these changes.