### PR TITLE
Fix for joins on columns that are not a prefix to an index

### DIFF
--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -1295,6 +1295,21 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "JOIN on non-index-prefix columns do not panic (Dolt Issue #2366)",
+		SetUpScript: []string{
+			"CREATE TABLE `player_season_stat_totals` (`player_id` int NOT NULL, `team_id` int NOT NULL, `season_id` int NOT NULL, `minutes` int, `games_started` int, `games_played` int, `2pm` int, `2pa` int, `3pm` int, `3pa` int, `ftm` int, `fta` int, `ast` int, `stl` int, `blk` int, `tov` int, `pts` int, `orb` int, `drb` int, `trb` int, `pf` int, `season_type_id` int NOT NULL, `league_id` int NOT NULL DEFAULT 0, PRIMARY KEY (`player_id`,`team_id`,`season_id`,`season_type_id`,`league_id`));",
+			"CREATE TABLE `team_seasons` (`team_id` int NOT NULL, `league_id` int NOT NULL, `season_id` int NOT NULL, `prefix` varchar(100), `nickname` varchar(100), `abbreviation` varchar(100), `city` varchar(100), `state` varchar(100), `country` varchar(100), PRIMARY KEY (`team_id`,`league_id`,`season_id`));",
+			"INSERT INTO player_season_stat_totals VALUES (1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);",
+			"INSERT INTO team_seasons VALUES (1,1,1,'','','','','','');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT stats.* FROM player_season_stat_totals stats LEFT JOIN team_seasons ON team_seasons.team_id = stats.team_id AND team_seasons.season_id = stats.season_id;",
+				Expected: []sql.Row{{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}},
+			},
+		},
+	},
 }
 
 var CreateCheckConstraintsScripts = []ScriptTest{

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -819,13 +819,13 @@ func getJoinIndex(
 	for table, cols := range exprsByTable {
 		exprs := extractExpressions(cols)
 		idx := ia.MatchingIndex(ctx, ctx.GetCurrentDatabase(), table, normalizeExpressions(ctx, tableAliases, exprs...)...)
-		// If we do not find a perfect index, we take the first single column partial index if there is one.
-		// This currently only finds single column indexes. A better search would look for the most complete
-		// index available, covering the columns with the most specificity / highest cardinality.
+		// If we do not find a full or partial matching index, we take the first single column index if there is one.
+		// A better search would look for the most complete index available, covering the columns with the most
+		// specificity / highest cardinality.
 		if idx == nil && len(exprs) > 1 {
 			for _, e := range exprs {
 				idx = ia.MatchingIndex(ctx, ctx.GetCurrentDatabase(), table, normalizeExpressions(ctx, tableAliases, e)...)
-				if idx != nil {
+				if idx != nil && len(idx.Expressions()) == 1 {
 					break
 				}
 			}

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -179,7 +179,11 @@ func (b *IndexBuilder) Build(ctx *Context) (IndexLookup, error) {
 	} else if b.isInvalid {
 		return nil, nil
 	} else {
-		return b.idx.NewLookup(ctx, b.Range())
+		rang := b.Range()
+		if len(rang) == 0 {
+			return nil, nil
+		}
+		return b.idx.NewLookup(ctx, rang)
 	}
 }
 


### PR DESCRIPTION
As we now natively support partial indexes in GMS, we had a case where we'd match a single column to a partial index. We would then attempt to use the full index's column expressions which later failed as the columns were not a prefix to the index. Now we enforce that, when we start looking for single column matches, we only find indexes over a single column.

Also, the index builder assumed it would be used if it was created, and therefore could return an range of length 0, so that has been fixed as well. It should only be hit in erroneous cases like the preceding one, but this should prevent panics in other circumstances as well.