### PR TITLE
plan,analyzer: Implement a TopRowsNode.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2921,7 +2921,7 @@ func TestTracing(t *testing.T, harness Harness) {
 	spans := tracer.Spans
 	var expectedSpans = []string{
 		"plan.Limit",
-		"plan.Sort",
+		"plan.TopN",
 		"plan.Distinct",
 		"plan.Project",
 		"plan.Filter",

--- a/enginetest/query_plans.go
+++ b/enginetest/query_plans.go
@@ -715,6 +715,27 @@ var PlanTests = []QueryPlanTest{
 			"",
 	},
 	{
+		Query: `SELECT * FROM datetime_table ORDER BY date_col ASC`,
+		ExpectedPlan: "Sort(datetime_table.date_col ASC)\n" +
+			" └─ Projected table access on [i date_col datetime_col timestamp_col]\n" +
+			"     └─ Table(datetime_table)\n",
+	},
+	{
+		Query: `SELECT * FROM datetime_table ORDER BY date_col ASC LIMIT 100`,
+		ExpectedPlan: "Limit(100)\n" +
+			" └─ TopN(Limit: [100]; datetime_table.date_col ASC)\n" +
+			"     └─ Projected table access on [i date_col datetime_col timestamp_col]\n" +
+			"         └─ Table(datetime_table)\n",
+	},
+	{
+		Query: `SELECT * FROM datetime_table ORDER BY date_col ASC LIMIT 100 OFFSET 100`,
+		ExpectedPlan: "Limit(100)\n" +
+			" └─ Offset(100)\n" +
+			"     └─ TopN(Limit: [(100 + 100)]; datetime_table.date_col ASC)\n" +
+			"         └─ Projected table access on [i date_col datetime_col timestamp_col]\n" +
+			"             └─ Table(datetime_table)\n",
+	},
+	{
 		Query: `SELECT * FROM datetime_table where date_col = '2020-01-01'`,
 		ExpectedPlan: "Filter(datetime_table.date_col = \"2020-01-01\")\n" +
 			" └─ Projected table access on [i date_col datetime_col timestamp_col]\n" +

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -90,6 +90,7 @@ var OnceAfterDefault = []Rule{
 	{"pushdown_projections", pushdownProjections},
 	{"set_join_scope_len", setJoinScopeLen},
 	{"erase_projection", eraseProjection},
+	{"insert_topn", insertTopNNodes},
 	// One final pass at analyzing subqueries to handle rewriting field indexes after changes to outer scope by
 	// previous rules.
 	{"resolve_subquery_exprs", resolveSubqueryExpressions},

--- a/sql/analyzer/topn.go
+++ b/sql/analyzer/topn.go
@@ -1,0 +1,60 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	//"fmt"
+
+        "github.com/dolthub/go-mysql-server/sql"
+        "github.com/dolthub/go-mysql-server/sql/plan"
+        "github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+// insertTopNNodes replaces Limit(Sort(...)) and Limit(Offset(Sort(...))) with
+// a TopN node.
+func insertTopNNodes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
+	var updateCalcFoundRows bool
+	return plan.TransformUpCtx(n, nil, func(tc plan.TransformContext) (sql.Node, error) {
+		if o, ok := tc.Node.(*plan.Offset); ok {
+			parentLimit, ok := tc.Parent.(*plan.Limit)
+			if !ok {
+				return tc.Node, nil
+			}
+			childSort, ok := o.UnaryNode.Child.(*plan.Sort)
+			if !ok {
+				return tc.Node, nil
+			}
+			topn := plan.NewTopN(childSort.SortFields, expression.NewPlus(parentLimit.Limit, o.Offset), childSort.UnaryNode.Child)
+			topn = topn.WithCalcFoundRows(parentLimit.CalcFoundRows)
+			updateCalcFoundRows = true
+			return o.WithChildren(topn)
+		} else if l, ok := tc.Node.(*plan.Limit); ok {
+			childSort, ok := l.UnaryNode.Child.(*plan.Sort)
+			if !ok {
+				if updateCalcFoundRows {
+					updateCalcFoundRows = false
+					//return nil, fmt.Errorf("toggling off CalcFoundRows: %v", sql.DebugString(l))
+					return l.WithCalcFoundRows(false), nil
+				}
+				// return nil, fmt.Errorf("child of limit is not sort: %v", sql.DebugString(l))
+				return tc.Node, nil
+			}
+			topn := plan.NewTopN(childSort.SortFields, l.Limit, childSort.UnaryNode.Child)
+			topn = topn.WithCalcFoundRows(l.CalcFoundRows)
+			return l.WithCalcFoundRows(false).WithChildren(topn)
+		}
+		return tc.Node, nil
+	})
+}

--- a/sql/analyzer/topn.go
+++ b/sql/analyzer/topn.go
@@ -15,8 +15,6 @@
 package analyzer
 
 import (
-	//"fmt"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -45,10 +43,8 @@ func insertTopNNodes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (s
 			if !ok {
 				if updateCalcFoundRows {
 					updateCalcFoundRows = false
-					//return nil, fmt.Errorf("toggling off CalcFoundRows: %v", sql.DebugString(l))
 					return l.WithCalcFoundRows(false), nil
 				}
-				// return nil, fmt.Errorf("child of limit is not sort: %v", sql.DebugString(l))
 				return tc.Node, nil
 			}
 			topn := plan.NewTopN(childSort.SortFields, l.Limit, childSort.UnaryNode.Child)

--- a/sql/analyzer/topn.go
+++ b/sql/analyzer/topn.go
@@ -17,9 +17,9 @@ package analyzer
 import (
 	//"fmt"
 
-        "github.com/dolthub/go-mysql-server/sql"
-        "github.com/dolthub/go-mysql-server/sql/plan"
-        "github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
 // insertTopNNodes replaces Limit(Sort(...)) and Limit(Offset(Sort(...))) with

--- a/sql/expression/sort.go
+++ b/sql/expression/sort.go
@@ -107,14 +107,14 @@ func (h *TopRowsHeap) Pop() interface{} {
 	old := h.Sorter.Rows
 	n := len(old)
 	res := old[n-1]
-	h.Sorter.Rows = old[0:n-1]
+	h.Sorter.Rows = old[0 : n-1]
 	return res
 }
 
 func (h *TopRowsHeap) Rows() ([]sql.Row, error) {
 	l := h.Len()
 	res := make([]sql.Row, l)
-	for i := l-1; i >= 0; i-- {
+	for i := l - 1; i >= 0; i-- {
 		res[i] = heap.Pop(h).(sql.Row)
 	}
 	return res, h.LastError

--- a/sql/plan/limit.go
+++ b/sql/plan/limit.go
@@ -58,6 +58,11 @@ func (l *Limit) Resolved() bool {
 	return l.UnaryNode.Child.Resolved() && l.Limit.Resolved()
 }
 
+func (l Limit) WithCalcFoundRows(v bool) *Limit {
+	l.CalcFoundRows = v
+	return &l
+}
+
 // RowIter implements the Node interface.
 func (l *Limit) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	span, ctx := ctx.Span("plan.Limit", opentracing.Tag{Key: "limit", Value: l.Limit})

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"container/heap"
 	"fmt"
 	"io"
 	"sort"
@@ -191,4 +192,197 @@ func (i *sortIter) computeSortedRows() error {
 	}
 	i.sortedRows = rows
 	return nil
+}
+
+// TopN was a sort node that has a limit. It doesn't need to buffer everything,
+// but can calculate the top n on the fly.
+type TopN struct {
+	UnaryNode
+	Limit         sql.Expression
+	SortFields    []sql.SortField
+	CalcFoundRows bool
+}
+
+// NewTopN creates a new TopN node.
+func NewTopN(sortFields []sql.SortField, limit sql.Expression, child sql.Node) *TopN {
+	return &TopN{
+		UnaryNode:  UnaryNode{child},
+		Limit:      limit,
+		SortFields: sortFields,
+	}
+}
+
+var _ sql.Expressioner = (*TopN)(nil)
+
+// Resolved implements the Resolvable interface.
+func (n *TopN) Resolved() bool {
+	for _, f := range n.SortFields {
+		if !f.Column.Resolved() {
+			return false
+		}
+	}
+	return n.Child.Resolved()
+}
+
+func (n TopN) WithCalcFoundRows(v bool) *TopN {
+	n.CalcFoundRows = v
+	return &n
+}
+
+// RowIter implements the Node interface.
+func (n *TopN) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	span, ctx := ctx.Span("plan.TopN")
+	i, err := n.UnaryNode.Child.RowIter(ctx, row)
+	if err != nil {
+		span.Finish()
+		return nil, err
+	}
+
+	limit, err := getInt64Value(ctx, n.Limit)
+	if err != nil {
+		return nil, err
+	}
+	return sql.NewSpanIter(span, newTopRowsIter(ctx, n, limit, i)), nil
+}
+
+func (n *TopN) String() string {
+	pr := sql.NewTreePrinter()
+	var fields = make([]string, len(n.SortFields))
+	for i, f := range n.SortFields {
+		fields[i] = fmt.Sprintf("%s %s", f.Column, f.Order)
+	}
+	_ = pr.WriteNode("TopN(Limit: [%s]; %s)", n.Limit.String(), strings.Join(fields, ", "))
+	_ = pr.WriteChildren(n.Child.String())
+	return pr.String()
+}
+
+func (n *TopN) DebugString() string {
+	pr := sql.NewTreePrinter()
+	var fields = make([]string, len(n.SortFields))
+	for i, f := range n.SortFields {
+		fields[i] = sql.DebugString(f)
+	}
+	_ = pr.WriteNode("TopN(Limit: [%s]; %s)", sql.DebugString(n.Limit), strings.Join(fields, ", "))
+	_ = pr.WriteChildren(sql.DebugString(n.Child))
+	return pr.String()
+}
+
+// Expressions implements the Expressioner interface.
+func (n *TopN) Expressions() []sql.Expression {
+	var exprs = make([]sql.Expression, len(n.SortFields))
+	for i, f := range n.SortFields {
+		exprs[i] = f.Column
+	}
+	return exprs
+}
+
+// WithChildren implements the Node interface.
+func (n *TopN) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 1)
+	}
+
+	topn := NewTopN(n.SortFields, n.Limit, children[0])
+	topn.CalcFoundRows = n.CalcFoundRows
+	return topn, nil
+}
+
+// WithExpressions implements the Expressioner interface.
+func (n *TopN) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
+	if len(exprs) != len(n.SortFields) {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(exprs), len(n.SortFields))
+	}
+
+	var fields = make([]sql.SortField, len(n.SortFields))
+	for i, expr := range exprs {
+		fields[i] = sql.SortField{
+			Column:       expr,
+			NullOrdering: n.SortFields[i].NullOrdering,
+			Order:        n.SortFields[i].Order,
+		}
+	}
+
+	topn := NewTopN(fields, n.Limit, n.Child)
+	topn.CalcFoundRows = n.CalcFoundRows
+	return topn, nil
+}
+
+type topRowsIter struct {
+	ctx          *sql.Context
+	n            *TopN
+	childIter    sql.RowIter
+	limit        int64
+	topRows      []sql.Row
+	numFoundRows int64
+	idx          int
+}
+
+func newTopRowsIter(ctx *sql.Context, n *TopN, limit int64, child sql.RowIter) *topRowsIter {
+	return &topRowsIter{
+		ctx:       ctx,
+		n:         n,
+		limit:     limit,
+		childIter: child,
+		idx:       -1,
+	}
+}
+
+func (i *topRowsIter) Next() (sql.Row, error) {
+	if i.idx == -1 {
+		err := i.computeTopRows()
+		if err != nil {
+			return nil, err
+		}
+		i.idx = 0
+	}
+
+	if i.idx >= len(i.topRows) {
+		return nil, io.EOF
+	}
+	row := i.topRows[i.idx]
+	i.idx++
+	return row, nil
+}
+
+func (i *topRowsIter) Close(ctx *sql.Context) error {
+	i.topRows = nil
+
+	if i.n.CalcFoundRows {
+		ctx.SetLastQueryInfo(sql.FoundRows, i.numFoundRows)
+	}
+
+	return i.childIter.Close(ctx)
+}
+
+func (i *topRowsIter) computeTopRows() error {
+	topRowsHeap := &expression.TopRowsHeap{
+		expression.Sorter{
+			SortFields: i.n.SortFields,
+			Rows:       []sql.Row{},
+			LastError:  nil,
+			Ctx:        i.ctx,
+		},
+	}
+	for {
+		row, err := i.childIter.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		i.numFoundRows++
+
+		heap.Push(topRowsHeap, row)
+		if int64(topRowsHeap.Len()) > i.limit {
+			heap.Pop(topRowsHeap)
+		}
+		if topRowsHeap.LastError != nil {
+			return topRowsHeap.LastError
+		}
+	}
+
+	var err error
+	i.topRows, err = topRowsHeap.Rows()
+	return err
 }


### PR DESCRIPTION
For a query like:

`SELECT * FROM table ORDER BY id LIMIT 100 OFFSET 100`

we do not need to materialize the entire sorted result. We can use a heap to
compute a streaming TopN and output the results when the child iterator is EOF.

* Add a simple implementation of TopN based on container/heap and
  sql/expression.Sorter.

* Add a TopRowsNode and topRowIter.

* Add a simple analyzer rule to replace a Sort node with a TopRows node when it
  sits directly underneath a Limit() or directly underneath a Limit(Offset()).
  Some care is required to keep `sql_calc_found_rows` operating as expected.