### PR TITLE
Add support for inserting empty value tuples

### DIFF
--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -26,6 +26,18 @@ import (
 
 var InsertQueries = []WriteQueryTest{
 	{
+		WriteQuery:          "INSERT INTO keyless VALUES ();",
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(1)}},
+		SelectQuery:         "SELECT * FROM keyless WHERE c0 IS NULL;",
+		ExpectedSelect:      []sql.Row{{nil, nil}},
+	},
+	{
+		WriteQuery:          "INSERT INTO keyless () VALUES ();",
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(1)}},
+		SelectQuery:         "SELECT * FROM keyless WHERE c0 IS NULL;",
+		ExpectedSelect:      []sql.Row{{nil, nil}},
+	},
+	{
 		WriteQuery:          "INSERT INTO mytable (s, i) VALUES ('x', '10.0');",
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(1)}},
 		SelectQuery:         "SELECT i FROM mytable WHERE s = 'x';",
@@ -1024,6 +1036,14 @@ var InsertScripts = []ScriptTest{
 }
 
 var InsertErrorTests = []GenericErrorQueryTest{
+	{
+		Name:  "try to insert empty into col without default value",
+		Query: "INSERT INTO mytable VALUES ();",
+	},
+	{
+		Name:  "try to insert empty into col without default value",
+		Query: "INSERT INTO mytable () VALUES ();",
+	},
 	{
 		Name:  "too few values",
 		Query: "INSERT INTO mytable (s, i) VALUES ('x');",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20211112215933-1feb51c6c461
+	github.com/dolthub/vitess v0.0.0-20211119212027-006e9b3d2f89
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20211119212027-006e9b3d2f89
+	github.com/dolthub/vitess v0.0.0-20211119232752-ab01038d96f6
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/dolthub/vitess v0.0.0-20211112215933-1feb51c6c461 h1:LpF6eRWczB7YtF9T
 github.com/dolthub/vitess v0.0.0-20211112215933-1feb51c6c461/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/dolthub/vitess v0.0.0-20211119212027-006e9b3d2f89 h1:/btJm+LT4rBY1AaW2mSeRk1TKuCW2r2EVxHfcC0RZSY=
 github.com/dolthub/vitess v0.0.0-20211119212027-006e9b3d2f89/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
+github.com/dolthub/vitess v0.0.0-20211119232752-ab01038d96f6 h1:L3trszochUwuHUssg8dV7/zHi/nhS/xFw9k43B3noh0=
+github.com/dolthub/vitess v0.0.0-20211119232752-ab01038d96f6/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9X
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
 github.com/dolthub/vitess v0.0.0-20211112215933-1feb51c6c461 h1:LpF6eRWczB7YtF9T69K219Ddq/I6/n1S3b/t9Bj4+40=
 github.com/dolthub/vitess v0.0.0-20211112215933-1feb51c6c461/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
+github.com/dolthub/vitess v0.0.0-20211119212027-006e9b3d2f89 h1:/btJm+LT4rBY1AaW2mSeRk1TKuCW2r2EVxHfcC0RZSY=
+github.com/dolthub/vitess v0.0.0-20211119212027-006e9b3d2f89/go.mod h1:hUE8oSk2H5JZnvtlLBhJPYC8WZCA5AoSntdLTcBvdBM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -114,8 +114,7 @@ func existsNonZeroValueCount(values sql.Node) bool {
 			}
 		}
 	default:
-		// TODO: what to do for non values?
-		return false
+		return true
 	}
 	return false
 }

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -70,13 +70,15 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) 
 
 		dstSchema := insertable.Schema()
 
-		// If no columns are given, use the full schema
+
+		// normalize the column name
 		columnNames := make([]string, len(insert.ColumnNames))
 		for i, name := range insert.ColumnNames {
-			columnNames[i] = strings.ToLower(name) // normalize the column name
+			columnNames[i] = strings.ToLower(name)
 		}
 
-		if len(columnNames) == 0 {
+		// If no columns are given and value tuples are not all empty, use the full schema
+		if len(columnNames) == 0 && existsNonZeroValueCount(source) {
 			columnNames = make([]string, len(dstSchema))
 			for i, f := range dstSchema {
 				columnNames[i] = f.Name
@@ -100,6 +102,22 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) 
 
 		return insert.WithSource(project), nil
 	})
+}
+
+// Ensures that the number of elements in each Value tuple is empty
+func existsNonZeroValueCount(values sql.Node) bool {
+	switch node := values.(type) {
+	case *plan.Values:
+		for _, exprTuple := range node.ExpressionTuples {
+			if len(exprTuple) != 0 {
+				return true
+			}
+		}
+	default:
+		// TODO: what to do for non values?
+		return false
+	}
+	return false
 }
 
 // wrapRowSource wraps the original row source in a projection so that its schema matches the full schema of the


### PR DESCRIPTION
There was an edge case where if columns were not provided, it required there to be exactly num columns for value tuples, even if there are default values for those columns. 
Added a helper function `existsNonZeroValues` to avoid this.