### PR TITLE
server/handler.go: Migrate doQuery rows loop to errgroup.

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -339,6 +339,8 @@ func (h *Handler) doQuery(
 		}
 	}()
 
+	eg, ctx := ctx.NewErrgroup()
+
 	schema, rows, err := h.e.QueryNodeWithBindings(ctx, query, parsed, sqlBindings)
 	if err != nil {
 		ctx.GetLogger().WithError(err).Warn("error running query")
@@ -350,10 +352,34 @@ func (h *Handler) doQuery(
 
 	// Reads rows from the row reading goroutine
 	rowChan := make(chan sql.Row)
-	// To send errors from the two goroutines to the main one
-	errChan := make(chan error)
-	// To close the goroutines
-	quit := make(chan struct{})
+
+	eg.Go(func() error {
+		defer close(rowChan)
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			default:
+				row, err := rows.Next()
+				if err != nil {
+					if err == io.EOF {
+						return nil
+					}
+					return err
+				}
+				select {
+				case rowChan <- row:
+				case <-ctx.Done():
+					return nil
+				}
+			}
+		}
+	})
+
+	pollCtx, cancelF := ctx.NewSubContext()
+	eg.Go(func() error {
+		return h.pollForClosedConnection(pollCtx, c)
+	})
 
 	// Default waitTime is one minute if there is no timeout configured, in which case
 	// it will loop to iterate again unless the socket died by the OS timeout or other problems.
@@ -368,79 +394,62 @@ func (h *Handler) doQuery(
 	defer timer.Stop()
 
 	// Read rows off the row iterator and send them to the row channel.
-	go func() {
+	eg.Go(func() error {
+		defer cancelF()
 		for {
+			if r == nil {
+				r = &sqltypes.Result{Fields: schemaToFields(schema)}
+			}
+
+			if r.RowsAffected == rowsBatch {
+				if err := callback(r, more); err != nil {
+					return err
+				}
+				r = nil
+				proccesedAtLeastOneBatch = true
+				continue
+			}
+
 			select {
-			case <-quit:
-				return
-			default:
-				row, err := rows.Next()
+			case <-ctx.Done():
+				return nil
+			case row, ok := <-rowChan:
+				if !ok {
+					return nil
+				}
+				if sql.IsOkResult(row) {
+					if len(r.Rows) > 0 {
+						panic("Got OkResult mixed with RowResult")
+					}
+					r = resultFromOkResult(row[0].(sql.OkResult))
+					continue
+				}
+
+				outputRow, err := rowToSQL(schema, row)
 				if err != nil {
-					errChan <- err
-					return
+					return err
 				}
-				rowChan <- row
-			}
-		}
-	}()
 
-	go h.pollForClosedConnection(ctx, c, errChan, quit)
-
-rowLoop:
-	for {
-		if r == nil {
-			r = &sqltypes.Result{Fields: schemaToFields(schema)}
-		}
-
-		if r.RowsAffected == rowsBatch {
-			if err := callback(r, more); err != nil {
-				close(quit)
-				return remainder, err
-			}
-
-			r = nil
-			proccesedAtLeastOneBatch = true
-			continue
-		}
-
-		select {
-		case err = <-errChan:
-			if err == io.EOF {
-				break rowLoop
-			}
-
-			ctx.GetLogger().WithError(err).Warn("error running query")
-			close(quit)
-			return remainder, err
-		case row := <-rowChan:
-			if sql.IsOkResult(row) {
-				if len(r.Rows) > 0 {
-					panic("Got OkResult mixed with RowResult")
+				ctx.GetLogger().Tracef("spooling result row %s", outputRow)
+				r.Rows = append(r.Rows, outputRow)
+				r.RowsAffected++
+			case <-timer.C:
+				if h.readTimeout != 0 {
+					// Cancel and return so Vitess can call the CloseConnection callback
+					ctx.GetLogger().Tracef("connection timeout")
+					return ErrRowTimeout.New()
 				}
-				r = resultFromOkResult(row[0].(sql.OkResult))
-				break rowLoop
 			}
-
-			outputRow, err := rowToSQL(schema, row)
-			if err != nil {
-				close(quit)
-				return remainder, err
-			}
-
-			ctx.GetLogger().Tracef("spooling result row %s", outputRow)
-			r.Rows = append(r.Rows, outputRow)
-			r.RowsAffected++
-		case <-timer.C:
-			if h.readTimeout != 0 {
-				// Cancel and return so Vitess can call the CloseConnection callback
-				ctx.GetLogger().Tracef("connection timeout")
-				close(quit)
-				return remainder, ErrRowTimeout.New()
-			}
+			timer.Reset(waitTime)
 		}
-		timer.Reset(waitTime)
+	})
+
+	err = eg.Wait()
+	if err != nil {
+		rows.Close(ctx)
+		ctx.GetLogger().WithError(err).Warn("error running query")
+		return remainder, err
 	}
-	close(quit)
 
 	err = rows.Close(ctx)
 	if err != nil {
@@ -467,11 +476,8 @@ rowLoop:
 
 	ctx.GetLogger().Debugf("Query took %dms", time.Since(start).Milliseconds())
 
-	// TODO(andy): logic doesn't match comment?
-	// Even if r.RowsAffected = 0, the callback must be
-	// called to update the state in the go-vitess' listener
-	// and avoid returning errors when the query doesn't
-	// produce any results.
+	// processedAtLeastOneBatch means we already called callback() at least
+	// once, so no need to call it if RowsAffected == 0.
 	if r != nil && (r.RowsAffected == 0 && proccesedAtLeastOneBatch) {
 		return remainder, nil
 	}
@@ -554,14 +560,14 @@ func (h *Handler) errorWrappedDoQuery(
 	}
 }
 
-// Periodically polls the connection socket to determine if it is has been closed by the client, sending an error on
-// the supplied error channel if it has. Meant to be run in a separate goroutine from the query handler routine.
-// Returns immediately on platforms that can't support TCP socket checks.
-func (h *Handler) pollForClosedConnection(ctx *sql.Context, c *mysql.Conn, errChan chan error, quit chan struct{}) {
+// Periodically polls the connection socket to determine if it is has been closed by the client, returning an error
+// if it has been. Meant to be run in an errgroup from the query handler routine. Returns immediately with no error
+// on platforms that can't support TCP socket checks.
+func (h *Handler) pollForClosedConnection(ctx *sql.Context, c *mysql.Conn) error {
 	tcpConn, ok := maybeGetTCPConn(c.Conn)
 	if !ok {
 		ctx.GetLogger().Trace("Connection checker exiting, connection isn't TCP")
-		return
+		return nil
 	}
 
 	inode, err := sockstate.GetConnInode(tcpConn)
@@ -569,19 +575,19 @@ func (h *Handler) pollForClosedConnection(ctx *sql.Context, c *mysql.Conn, errCh
 		if !sockstate.ErrSocketCheckNotImplemented.Is(err) {
 			ctx.GetLogger().Trace("Connection checker exiting, connection isn't TCP")
 		}
-		return
+		return nil
 	}
 
 	t, ok := tcpConn.LocalAddr().(*net.TCPAddr)
 	if !ok {
 		ctx.GetLogger().Trace("Connection checker exiting, could not get local port")
-		return
+		return nil
 	}
 
 	for {
 		select {
-		case <-quit:
-			return
+		case <-ctx.Done():
+			return nil
 		default:
 		}
 
@@ -589,11 +595,10 @@ func (h *Handler) pollForClosedConnection(ctx *sql.Context, c *mysql.Conn, errCh
 		switch st {
 		case sockstate.Broken:
 			ctx.GetLogger().Warn("socket state is broken, returning error")
-			errChan <- ErrConnectionWasClosed.New()
-			return
+			return ErrConnectionWasClosed.New()
 		case sockstate.Error:
 			ctx.GetLogger().WithError(err).Warn("Connection checker exiting, got err checking sockstate")
-			return
+			return nil
 		default: // Established
 			// (juanjux) this check is not free, each iteration takes about 9 milliseconds to run on my machine
 			// thus the small wait between checks

--- a/server/handler.go
+++ b/server/handler.go
@@ -55,6 +55,7 @@ var ErrUnsupportedOperation = errors.NewKind("unsupported operation")
 
 // TODO parametrize
 const rowsBatch = 100
+
 var tcpCheckerSleepDuration time.Duration = 1 * time.Second
 
 type MultiStmtMode int

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -368,7 +368,7 @@ func TestOkClosedConnection(t *testing.T) {
 	c := newConn(1)
 	h.NewConnection(c)
 
-	q := fmt.Sprintf("SELECT SLEEP(%d)", tcpCheckerSleepTime*4)
+	q := fmt.Sprintf("SELECT SLEEP(%d)", (tcpCheckerSleepDuration*4/time.Second))
 	h.ComInitDB(c, "test")
 	err = h.ComQuery(c, q, func(res *sqltypes.Result, more bool) error {
 		return nil

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -368,7 +368,7 @@ func TestOkClosedConnection(t *testing.T) {
 	c := newConn(1)
 	h.NewConnection(c)
 
-	q := fmt.Sprintf("SELECT SLEEP(%d)", (tcpCheckerSleepDuration*4/time.Second))
+	q := fmt.Sprintf("SELECT SLEEP(%d)", (tcpCheckerSleepDuration * 4 / time.Second))
 	h.ComInitDB(c, "test")
 	err = h.ComQuery(c, q, func(res *sqltypes.Result, more bool) error {
 		return nil


### PR DESCRIPTION
Previously this used  a |quit| signaling channel and an |errChan| to
communicate any errors. We didn't get context cancelation in all cases and our
call to |rows.Close()| raced with the background thread's call to
|rows.Next()|.