### PR TITLE
Fix JSON Extract on structs.

### DIFF
--- a/sql/json.go
+++ b/sql/json.go
@@ -54,7 +54,8 @@ func (t jsonType) Convert(v interface{}) (doc interface{}, err error) {
 		err = json.Unmarshal(v, &doc)
 	case string:
 		err = json.Unmarshal([]byte(v), &doc)
-	case []string, []int, []uint16, []uint32, []uint64, []int16, []int32, []int64, []float32, []float64, []bool:
+	case []string, []int, []uint16, []uint32, []uint64, []int16, []int32, []int64, []float32, []float64, []bool,
+		map[string]string, map[string]int, map[string]uint16, map[string]uint32, map[string]uint64, map[string]int16, map[string]int32, map[string]int64, map[string]float32, map[string]float64:
 		doc = v
 	default:
 		// if |v| can be marshalled, it contains

--- a/sql/json.go
+++ b/sql/json.go
@@ -54,11 +54,13 @@ func (t jsonType) Convert(v interface{}) (doc interface{}, err error) {
 		err = json.Unmarshal(v, &doc)
 	case string:
 		err = json.Unmarshal([]byte(v), &doc)
+	case []string, []int, []uint16, []uint32, []uint64, []int16, []int32, []int64, []float32, []float64, []bool:
+		doc = v
 	default:
 		// if |v| can be marshalled, it contains
 		// a valid JSON document representation
-		if _, err = json.Marshal(v); err == nil {
-			return JSONDocument{Val: v}, nil
+		if b, berr := json.Marshal(v); berr == nil {
+			err = json.Unmarshal(b, &doc)
 		}
 	}
 	if err != nil {

--- a/sql/json_test.go
+++ b/sql/json_test.go
@@ -94,6 +94,9 @@ func TestJsonCompare(t *testing.T) {
 }
 
 func TestJsonConvert(t *testing.T) {
+	type testStruct struct {
+		Field string `json:"field"`
+	}
 	tests := []struct {
 		val         interface{}
 		expectedVal interface{}
@@ -102,6 +105,9 @@ func TestJsonConvert(t *testing.T) {
 		{`""`, MustJSON(`""`), false},
 		{[]int{1, 2}, JSONDocument{Val: []int{1, 2}}, false},
 		{`{"a": true, "b": 3}`, MustJSON(`{"a":true,"b":3}`), false},
+		{[]byte(`{"a": true, "b": 3}`), MustJSON(`{"a":true,"b":3}`), false},
+		{testStruct{Field: "test"}, MustJSON(`{"field":"test"}`), false},
+		{MustJSON(`{"field":"test"}`), MustJSON(`{"field":"test"}`), false},
 	}
 
 	for _, test := range tests {

--- a/sql/json_value.go
+++ b/sql/json_value.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/oliveagle/jsonpath"
+	"github.com/pkg/errors"
 )
 
 // JSONValue is an integrator specific implementation of a JSON field value.
@@ -94,7 +95,10 @@ func (doc JSONDocument) Extract(ctx *Context, path string) (JSONValue, error) {
 	}
 
 	// TODO(andy) handle error
-	val, _ := c.Lookup(doc.Val) // err ignored
+	val, err := c.Lookup(doc.Val) // err ignored
+	if err != nil {
+		return nil, errors.Wrap(err, "json extract")
+	}
 
 	return JSONDocument{Val: val}, nil
 }


### PR DESCRIPTION
It was broken because the jsonpath library fails whenever the given object is not a slice or a map. Structs must thus be converted to map[string]interface{} JSON representation prior to jsonpath.Lookup being called.