### PR TITLE
Basic CREATE USER implementation

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1003,6 +1003,12 @@ func TestScripts(t *testing.T, harness Harness) {
 	}
 }
 
+func TestUsersAndPrivileges(t *testing.T, harness Harness) {
+	for _, script := range UserPrivTests {
+		TestScript(t, harness, script)
+	}
+}
+
 func TestComplexIndexQueries(t *testing.T, harness Harness) {
 	for _, script := range ComplexIndexQueries {
 		TestScript(t, harness, script)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -422,6 +422,10 @@ func TestScripts(t *testing.T) {
 	enginetest.TestScripts(t, enginetest.NewMemoryHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
 }
 
+func TestUsersAndPrivileges(t *testing.T) {
+	enginetest.TestUsersAndPrivileges(t, enginetest.NewMemoryHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+}
+
 func TestComplexIndexQueries(t *testing.T) {
 	harness := enginetest.NewMemoryHarness("default", 1, testNumPartitions, true, mergableIndexDriver)
 	enginetest.TestComplexIndexQueries(t, harness)

--- a/enginetest/user_priv_queries.go
+++ b/enginetest/user_priv_queries.go
@@ -1,0 +1,111 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	"time"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// UserPrivTests test the user, authentication, and privilege systems.
+var UserPrivTests = []ScriptTest{
+	{
+		Name: "Basic user creation",
+		SetUpScript: []string{
+			"CREATE USER testuser@`127.0.0.1`;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CREATE USER testuser@`127.0.0.1`;",
+				ExpectedErr: sql.ErrUserCreationFailure,
+			},
+			{
+				Query:    "CREATE USER IF NOT EXISTS testuser@`127.0.0.1`;",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
+			},
+			{
+				Query:    "INSERT INTO mysql.user (Host, User, ssl_cipher, x509_issuer, x509_subject) VALUES ('localhost', 'testuser2', '', '', '');",
+				Expected: []sql.Row{{sql.NewOkResult(1)}},
+			},
+			{
+				Query: "SELECT * FROM mysql.user WHERE User = 'root';",
+				Expected: []sql.Row{
+					{
+						"localhost",             // Host
+						"root",                  // User
+						"Y",                     // Select_priv
+						"Y",                     // Insert_priv
+						"Y",                     // Update_priv
+						"Y",                     // Delete_priv
+						"Y",                     // Create_priv
+						"Y",                     // Drop_priv
+						"Y",                     // Reload_priv
+						"Y",                     // Shutdown_priv
+						"Y",                     // Process_priv
+						"Y",                     // File_priv
+						"Y",                     // Grant_priv
+						"Y",                     // References_priv
+						"Y",                     // Index_priv
+						"Y",                     // Alter_priv
+						"Y",                     // Show_db_priv
+						"Y",                     // Super_priv
+						"Y",                     // Create_tmp_table_priv
+						"Y",                     // Lock_tables_priv
+						"Y",                     // Execute_priv
+						"Y",                     // Repl_slave_priv
+						"Y",                     // Repl_client_priv
+						"Y",                     // Create_view_priv
+						"Y",                     // Show_view_priv
+						"Y",                     // Create_routine_priv
+						"Y",                     // Alter_routine_priv
+						"Y",                     // Create_user_priv
+						"Y",                     // Event_priv
+						"Y",                     // Trigger_priv
+						"Y",                     // Create_tablespace_priv
+						"",                      // ssl_type
+						"",                      // ssl_cipher
+						"",                      // x509_issuer
+						"",                      // x509_subject
+						0,                       // max_questions
+						0,                       // max_updates
+						0,                       // max_connections
+						0,                       // max_user_connections
+						"caching_sha2_password", // plugin
+						nil,                     // authentication_string
+						"N",                     // password_expired
+						time.Unix(0, 0).UTC(),   // password_last_changed
+						nil,                     // password_lifetime
+						"N",                     // account_locked
+						"Y",                     // Create_role_priv
+						"Y",                     // Drop_role_priv
+						nil,                     // Password_reuse_history
+						nil,                     // Password_reuse_time
+						nil,                     // Password_require_current
+						nil,                     // User_attributes
+					},
+				},
+			},
+			{
+				Query: "SELECT Host, User FROM mysql.user;",
+				Expected: []sql.Row{
+					{"localhost", "root"},
+					{"localhost", "testuser2"},
+					{"127.0.0.1", "testuser"},
+				},
+			},
+		},
+	},
+}

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -264,7 +264,7 @@ type Analyzer struct {
 	// Batches of Rules to apply.
 	Batches []*Batch
 	// Catalog of databases and registered functions.
-	Catalog sql.Catalog
+	Catalog *Catalog
 	// ProcedureCache is a cache of stored procedures.
 	ProcedureCache *ProcedureCache
 }

--- a/sql/analyzer/catalog_locks_test.go
+++ b/sql/analyzer/catalog_locks_test.go
@@ -55,5 +55,5 @@ func TestCatalogLockTable(t *testing.T) {
 		},
 	}
 
-	require.Equal(expected, c.(*Catalog).locks)
+	require.Equal(expected, c.locks)
 }

--- a/sql/analyzer/privileges.go
+++ b/sql/analyzer/privileges.go
@@ -1,0 +1,24 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+// checkPrivileges verifies the given statement (node n) by checking that the calling user has the necessary privileges
+// to execute it.
+func checkPrivileges(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
+	//TODO: implement this
+	return n, nil
+}

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -21,6 +21,7 @@ import (
 // OnceBeforeDefault contains the rules to be applied just once before the
 // DefaultRules.
 var OnceBeforeDefault = []Rule{
+	{"check_privileges", checkPrivileges},
 	{"validate_offset_and_limit", validateLimitAndOffset},
 	{"validate_create_table", validateCreateTable},
 	{"load_stored_procedures", loadStoredProcedures},

--- a/sql/core.go
+++ b/sql/core.go
@@ -273,17 +273,6 @@ type SchemaTarget interface {
 	WithTargetSchema(Schema) (Node, error)
 }
 
-// Partition represents a partition from a SQL table.
-type Partition interface {
-	Key() []byte
-}
-
-// PartitionIter is an iterator that retrieves partitions.
-type PartitionIter interface {
-	Closer
-	Next(*Context) (Partition, error)
-}
-
 // Table represents the backend of a SQL table.
 type Table interface {
 	Nameable

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -380,8 +380,11 @@ var (
 	// ErrUnknownConstraintDefinition is returned when an unknown constraint type is used
 	ErrUnknownConstraintDefinition = errors.NewKind("unknown constraint definition: %s, %T")
 
-	// ErrInvalidCheckConstraint is returned when a  check constraint is defined incorrectly
+	// ErrInvalidCheckConstraint is returned when a check constraint is defined incorrectly
 	ErrInvalidCheckConstraint = errors.NewKind("invalid constraint definition: %s")
+
+	// ErrUserCreationFailure is returned when attempting to create a user and it fails for any reason.
+	ErrUserCreationFailure = errors.NewKind("Operation CREATE USER failed for %s")
 )
 
 func CastSQLError(err error) (*mysql.SQLError, error, bool) {

--- a/sql/expression/function/time_format.go
+++ b/sql/expression/function/time_format.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lestrrat-go/strftime"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/lestrrat-go/strftime"
 )
 
 var mysqlTimeFormatSpec = strftime.NewSpecificationSet()

--- a/sql/expression/function/time_format_test.go
+++ b/sql/expression/function/time_format_test.go
@@ -18,9 +18,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTimeFormatting(t *testing.T) {

--- a/sql/grant_tables/grant_table.go
+++ b/sql/grant_tables/grant_table.go
@@ -1,0 +1,99 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant_tables
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/in_mem_table"
+)
+
+type grantTable struct {
+	name string
+	sch  sql.Schema
+	data *in_mem_table.InMemTableData
+}
+
+var _ sql.Table = (*grantTable)(nil)
+var _ sql.InsertableTable = (*grantTable)(nil)
+var _ sql.UpdatableTable = (*grantTable)(nil)
+var _ sql.DeletableTable = (*grantTable)(nil)
+var _ sql.ReplaceableTable = (*grantTable)(nil)
+var _ sql.TruncateableTable = (*grantTable)(nil)
+
+// newGrantTable returns a new Grant Table with the given schema and keys.
+func newGrantTable(name string, sch sql.Schema, primaryKey in_mem_table.InMemTableDataKey, secondaryKeys ...in_mem_table.InMemTableDataKey) *grantTable {
+	return &grantTable{
+		name: name,
+		sch:  sch,
+		data: in_mem_table.NewInMemTableData(sch, primaryKey, secondaryKeys),
+	}
+}
+
+// Name implements the interface sql.Table.
+func (g *grantTable) Name() string {
+	return g.name
+}
+
+// String implements the interface sql.Table.
+func (g *grantTable) String() string {
+	return g.name
+}
+
+// Schema implements the interface sql.Table.
+func (g *grantTable) Schema() sql.Schema {
+	return g.sch.Copy()
+}
+
+// Partitions implements the interface sql.Table.
+func (g *grantTable) Partitions(ctx *sql.Context) (sql.PartitionIter, error) {
+	return sql.PartitionsToPartitionIter(dummyPartition{}), nil
+}
+
+// PartitionRows implements the interface sql.Table.
+func (g *grantTable) PartitionRows(ctx *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+	return g.data.ToRowIter(), nil
+}
+
+// Inserter implements the interface sql.InsertableTable.
+func (g *grantTable) Inserter(ctx *sql.Context) sql.RowInserter {
+	return in_mem_table.NewInMemTableDataEditor(g.data)
+}
+
+// Updater implements the interface sql.UpdatableTable.
+func (g *grantTable) Updater(ctx *sql.Context) sql.RowUpdater {
+	return in_mem_table.NewInMemTableDataEditor(g.data)
+}
+
+// Deleter implements the interface sql.DeletableTable.
+func (g *grantTable) Deleter(ctx *sql.Context) sql.RowDeleter {
+	return in_mem_table.NewInMemTableDataEditor(g.data)
+}
+
+// Replacer implements the interface sql.ReplaceableTable.
+func (g *grantTable) Replacer(ctx *sql.Context) sql.RowReplacer {
+	return in_mem_table.NewInMemTableDataEditor(g.data)
+}
+
+// Truncate implements the interface sql.TruncateableTable.
+func (g *grantTable) Truncate(ctx *sql.Context) (int, error) {
+	count := g.data.Count()
+	g.data.Clear()
+	return int(count), nil
+}
+
+// Data returns the in-memory table data for the grant table.
+func (g *grantTable) Data() *in_mem_table.InMemTableData {
+	return g.data
+}

--- a/sql/grant_tables/grant_table_test.go
+++ b/sql/grant_tables/grant_table_test.go
@@ -1,0 +1,147 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant_tables
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/in_mem_table"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrantTableData(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	testTable := newGrantTable(
+		"test",
+		sql.Schema{
+			&sql.Column{
+				Name:       "pk",
+				Type:       sql.Int64,
+				Default:    nil,
+				Nullable:   false,
+				Source:     "test",
+				PrimaryKey: true,
+			},
+			&sql.Column{
+				Name:       "val1",
+				Type:       sql.Int64,
+				Default:    nil,
+				Nullable:   false,
+				Source:     "test",
+				PrimaryKey: true,
+			},
+			&sql.Column{
+				Name:       "val2",
+				Type:       sql.Int64,
+				Default:    nil,
+				Nullable:   false,
+				Source:     "test",
+				PrimaryKey: true,
+			},
+		},
+		testPK{},
+		testSK{},
+	)
+
+	inserter := testTable.Inserter(ctx)
+	updater := inserter.(sql.RowUpdater)
+	deleter := inserter.(sql.RowDeleter)
+
+	row1 := sql.Row{int64(1), int64(1), int64(2)}
+	row2a := sql.Row{int64(2), int64(3), int64(4)}
+	row2b := sql.Row{int64(2), int64(7), int64(8)}
+	row3 := sql.Row{int64(3), int64(5), int64(6)}
+	row4 := sql.Row{int64(4), int64(9), int64(0)}
+	row5 := sql.Row{int64(5), int64(10), int64(11)}
+	row6 := sql.Row{int64(6), int64(12), int64(13)}
+	row7 := sql.Row{int64(7), int64(14), int64(15)}
+	row8 := sql.Row{int64(8), int64(14), int64(15)}
+
+	require.NoError(t, inserter.Insert(ctx, row1))
+	require.NoError(t, inserter.Insert(ctx, row4))
+	require.NoError(t, inserter.Insert(ctx, row2a))
+	require.NoError(t, inserter.Insert(ctx, row3))
+	require.NoError(t, updater.Update(ctx, row2a, row2b))
+	require.NoError(t, deleter.Delete(ctx, row4))
+	require.Error(t, inserter.Insert(ctx, row1))
+
+	rows, err := sql.RowIterToRows(ctx, testTable.data.ToRowIter())
+	require.NoError(t, err)
+	require.ElementsMatch(t, []sql.Row{row1, row2b, row3}, rows)
+
+	require.NoError(t, testTable.data.Put(row5))
+	require.NoError(t, testTable.data.Put(row6))
+	require.NoError(t, testTable.data.Put(row7))
+	require.NoError(t, testTable.data.Put(row8))
+
+	require.Equal(t, []sql.Row{row5}, testTable.data.Get(testPK{5}))
+	require.True(t, testTable.data.Has(row6))
+	require.ElementsMatch(t, []sql.Row{row7, row8}, testTable.data.Get(testSK{15, 14}))
+	require.NoError(t, testTable.data.Remove(testSK{15, 14}, nil))
+	require.False(t, testTable.data.Has(row7))
+	require.False(t, testTable.data.Has(row8))
+	require.NoError(t, testTable.data.Remove(nil, row5))
+	require.False(t, testTable.data.Has(row5))
+}
+
+type testPK struct {
+	val int64
+}
+
+var _ in_mem_table.InMemTableDataKey = testPK{}
+
+func (tpk testPK) AssignValues(vals ...interface{}) (in_mem_table.InMemTableDataKey, error) {
+	if len(vals) != 1 {
+		return tpk, fmt.Errorf("wrong number of values")
+	}
+	val, ok := vals[0].(int64)
+	if !ok {
+		return tpk, fmt.Errorf("value is not int64")
+	}
+	return testPK{val}, nil
+}
+
+func (tpk testPK) RepresentedColumns() []uint16 {
+	return []uint16{0}
+}
+
+type testSK struct {
+	val2 int64
+	val1 int64
+}
+
+var _ in_mem_table.InMemTableDataKey = testSK{}
+
+func (tsk testSK) AssignValues(vals ...interface{}) (in_mem_table.InMemTableDataKey, error) {
+	if len(vals) != 2 {
+		return tsk, fmt.Errorf("wrong number of values")
+	}
+	val2, ok := vals[0].(int64)
+	if !ok {
+		return tsk, fmt.Errorf("value is not int64")
+	}
+	val1, ok := vals[1].(int64)
+	if !ok {
+		return tsk, fmt.Errorf("value is not int64")
+	}
+	return testSK{val2, val1}, nil
+}
+
+func (tsk testSK) RepresentedColumns() []uint16 {
+	return []uint16{2, 1}
+}

--- a/sql/grant_tables/grant_tables.go
+++ b/sql/grant_tables/grant_tables.go
@@ -1,0 +1,110 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant_tables
+
+import (
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// GrantTables are the collection of tables that are used with any user or privilege-related operations.
+// https://dev.mysql.com/doc/refman/8.0/en/grant-tables.html
+type GrantTables struct {
+	user *grantTable
+	//TODO: add the rest of these tables
+	//db               *grantTable
+	//global_grants    *grantTable
+	//tables_priv      *grantTable
+	//columns_priv     *grantTable
+	//procs_priv       *grantTable
+	//proxies_priv     *grantTable
+	//default_roles    *grantTable
+	//role_edges       *grantTable
+	//password_history *grantTable
+}
+
+var _ sql.Database = (*GrantTables)(nil)
+
+// CreateEmptyGrantTables returns a collection of Grant Tables that do not contain any data.
+func CreateEmptyGrantTables() *GrantTables {
+	grantTables := &GrantTables{
+		user: newGrantTable(userTblName, userTblSchema, UserPrimaryKey{}),
+	}
+	addDefaultRootUser(grantTables.user)
+	return grantTables
+}
+
+// Name implements the interface sql.Database.
+func (g *GrantTables) Name() string {
+	return "mysql"
+}
+
+// GetTableInsensitive implements the interface sql.Database.
+func (g *GrantTables) GetTableInsensitive(ctx *sql.Context, tblName string) (sql.Table, bool, error) {
+	switch strings.ToLower(tblName) {
+	case "user":
+		return g.user, true, nil
+	default:
+		return nil, false, nil
+	}
+}
+
+// GetTableNames implements the interface sql.Database.
+func (g *GrantTables) GetTableNames(ctx *sql.Context) ([]string, error) {
+	return []string{"user"}, nil
+}
+
+// Persist passes along all changes to the integrator.
+func (g *GrantTables) Persist(ctx *sql.Context) error {
+	//TODO: add the UserPersist interface, using this as a stand-in so I won't forget to put it where it needs to go
+	return nil
+}
+
+// UserTable returns the user table.
+func (g *GrantTables) UserTable() *grantTable {
+	return g.user
+}
+
+// columnTemplate takes in a column as a template, and returns a new column with a different name based on the given
+// template.
+func columnTemplate(name string, source string, isPk bool, template *sql.Column) *sql.Column {
+	newCol := *template
+	if newCol.Default != nil {
+		newCol.Default = &(*newCol.Default)
+	}
+	newCol.Name = name
+	newCol.Source = source
+	newCol.PrimaryKey = isPk
+	return &newCol
+}
+
+// mustDefault enforces that no error occurred when constructing the column default value.
+func mustDefault(expr sql.Expression, outType sql.Type, representsLiteral bool, mayReturnNil bool) *sql.ColumnDefaultValue {
+	colDef, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, mayReturnNil)
+	if err != nil {
+		panic(err)
+	}
+	return colDef
+}
+
+type dummyPartition struct{}
+
+var _ sql.Partition = dummyPartition{}
+
+// Key implements the interface sql.Partition.
+func (d dummyPartition) Key() []byte {
+	return nil
+}

--- a/sql/grant_tables/user.go
+++ b/sql/grant_tables/user.go
@@ -1,0 +1,253 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grant_tables
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/in_mem_table"
+
+	"github.com/dolthub/vitess/go/sqltypes"
+)
+
+const userTblName = "user"
+
+var (
+	userPkCols      = []uint16{0, 1}
+	errUserPkAssign = fmt.Errorf("the primary key for the `user` table expects a host and user string")
+
+	userTblSchema sql.Schema
+)
+
+// UserPrimaryKey is a key that represents the primary key for the "user" Grant Table.
+type UserPrimaryKey struct {
+	Host string
+	User string
+}
+
+var _ in_mem_table.InMemTableDataKey = UserPrimaryKey{}
+
+// AssignValues implements the interface in_mem_table.InMemTableDataKey.
+func (u UserPrimaryKey) AssignValues(vals ...interface{}) (in_mem_table.InMemTableDataKey, error) {
+	if len(vals) != 2 {
+		return u, errUserPkAssign
+	}
+	host, ok := vals[0].(string)
+	if !ok {
+		return u, errUserPkAssign
+	}
+	user, ok := vals[1].(string)
+	if !ok {
+		return u, errUserPkAssign
+	}
+	return UserPrimaryKey{
+		Host: host,
+		User: user,
+	}, nil
+}
+
+// RepresentedColumns implements the interface in_mem_table.InMemTableDataKey.
+func (u UserPrimaryKey) RepresentedColumns() []uint16 {
+	return userPkCols
+}
+
+// init creates the schema for the "user" Grant Table.
+func init() {
+	// Types
+	char32_utf8_bin := sql.MustCreateString(sqltypes.Char, 32, sql.Collation_utf8_bin)
+	char64_utf8_bin := sql.MustCreateString(sqltypes.Char, 64, sql.Collation_utf8_bin)
+	char255_ascii_general_ci := sql.MustCreateString(sqltypes.Char, 255, sql.Collation_ascii_general_ci)
+	enum_ANY_X509_SPECIFIED_utf8_general_ci := sql.MustCreateEnumType([]string{"", "ANY", "X509", "SPECIFIED"}, sql.Collation_utf8_general_ci)
+	enum_N_Y_utf8_general_ci := sql.MustCreateEnumType([]string{"N", "Y"}, sql.Collation_utf8_general_ci)
+	text_utf8_bin := sql.CreateText(sql.Collation_utf8_bin)
+
+	// Column Templates
+	blob_not_null_default_nil := &sql.Column{
+		Type:     sql.Blob,
+		Default:  nil,
+		Nullable: false,
+	}
+	char32_utf8_bin_not_null_default_empty := &sql.Column{
+		Type:     char32_utf8_bin,
+		Default:  mustDefault(expression.NewLiteral("", char32_utf8_bin), char32_utf8_bin, true, false),
+		Nullable: false,
+	}
+	char64_utf8_bin_not_null_default_caching_sha2_password := &sql.Column{
+		Type:     char64_utf8_bin,
+		Default:  mustDefault(expression.NewLiteral("caching_sha2_password", char64_utf8_bin), char64_utf8_bin, true, false),
+		Nullable: false,
+	}
+	char255_ascii_general_ci_not_null_default_empty := &sql.Column{
+		Type:     char255_ascii_general_ci,
+		Default:  mustDefault(expression.NewLiteral("", char255_ascii_general_ci), char255_ascii_general_ci, true, false),
+		Nullable: false,
+	}
+	enum_ANY_X509_SPECIFIED_utf8_general_ci_not_null_default_empty := &sql.Column{
+		Type:     enum_ANY_X509_SPECIFIED_utf8_general_ci,
+		Default:  mustDefault(expression.NewLiteral("", enum_ANY_X509_SPECIFIED_utf8_general_ci), enum_ANY_X509_SPECIFIED_utf8_general_ci, true, false),
+		Nullable: false,
+	}
+	enum_N_Y_utf8_general_ci_not_null_default_N := &sql.Column{
+		Type:     enum_N_Y_utf8_general_ci,
+		Default:  mustDefault(expression.NewLiteral("N", enum_N_Y_utf8_general_ci), enum_N_Y_utf8_general_ci, true, false),
+		Nullable: false,
+	}
+	enum_N_Y_utf8_general_ci_nullable_default_nil := &sql.Column{
+		Type:     enum_N_Y_utf8_general_ci,
+		Default:  nil,
+		Nullable: true,
+	}
+	int_unsigned_not_null_default_0 := &sql.Column{
+		Type:     sql.Uint32,
+		Default:  mustDefault(expression.NewLiteral(uint32(0), sql.Uint32), sql.Uint32, true, false),
+		Nullable: false,
+	}
+	json_nullable_default_nil := &sql.Column{
+		Type:     sql.JSON,
+		Default:  nil,
+		Nullable: true,
+	}
+	smallint_unsigned_nullable_default_nil := &sql.Column{
+		Type:     sql.Uint16,
+		Default:  nil,
+		Nullable: true,
+	}
+	text_utf8_bin_nullable_default_nil := &sql.Column{
+		Type:     text_utf8_bin,
+		Default:  nil,
+		Nullable: true,
+	}
+	timestamp_nullable_default_nil := &sql.Column{
+		Type:     sql.Timestamp,
+		Default:  nil,
+		Nullable: true,
+	}
+
+	userTblSchema = sql.Schema{
+		columnTemplate("Host", userTblName, true, char255_ascii_general_ci_not_null_default_empty),
+		columnTemplate("User", userTblName, true, char32_utf8_bin_not_null_default_empty),
+		columnTemplate("Select_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Insert_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Update_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Delete_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Create_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Drop_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Reload_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Shutdown_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Process_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("File_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Grant_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("References_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Index_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Alter_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Show_db_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Super_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Create_tmp_table_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Lock_tables_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Execute_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Repl_slave_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Repl_client_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Create_view_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Show_view_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Create_routine_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Alter_routine_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Create_user_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Event_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Trigger_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Create_tablespace_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("ssl_type", userTblName, false, enum_ANY_X509_SPECIFIED_utf8_general_ci_not_null_default_empty),
+		columnTemplate("ssl_cipher", userTblName, false, blob_not_null_default_nil),
+		columnTemplate("x509_issuer", userTblName, false, blob_not_null_default_nil),
+		columnTemplate("x509_subject", userTblName, false, blob_not_null_default_nil),
+		columnTemplate("max_questions", userTblName, false, int_unsigned_not_null_default_0),
+		columnTemplate("max_updates", userTblName, false, int_unsigned_not_null_default_0),
+		columnTemplate("max_connections", userTblName, false, int_unsigned_not_null_default_0),
+		columnTemplate("max_user_connections", userTblName, false, int_unsigned_not_null_default_0),
+		columnTemplate("plugin", userTblName, false, char64_utf8_bin_not_null_default_caching_sha2_password),
+		columnTemplate("authentication_string", userTblName, false, text_utf8_bin_nullable_default_nil),
+		columnTemplate("password_expired", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("password_last_changed", userTblName, false, timestamp_nullable_default_nil),
+		columnTemplate("password_lifetime", userTblName, false, smallint_unsigned_nullable_default_nil),
+		columnTemplate("account_locked", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Create_role_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Drop_role_priv", userTblName, false, enum_N_Y_utf8_general_ci_not_null_default_N),
+		columnTemplate("Password_reuse_history", userTblName, false, smallint_unsigned_nullable_default_nil),
+		columnTemplate("Password_reuse_time", userTblName, false, smallint_unsigned_nullable_default_nil),
+		columnTemplate("Password_require_current", userTblName, false, enum_N_Y_utf8_general_ci_nullable_default_nil),
+		columnTemplate("User_attributes", userTblName, false, json_nullable_default_nil),
+	}
+}
+
+func addDefaultRootUser(userTable *grantTable) {
+	err := userTable.Data().Put(sql.Row{
+		"localhost",             // 00: Host
+		"root",                  // 01: User
+		"Y",                     // 02: Select_priv
+		"Y",                     // 03: Insert_priv
+		"Y",                     // 04: Update_priv
+		"Y",                     // 05: Delete_priv
+		"Y",                     // 06: Create_priv
+		"Y",                     // 07: Drop_priv
+		"Y",                     // 08: Reload_priv
+		"Y",                     // 09: Shutdown_priv
+		"Y",                     // 10: Process_priv
+		"Y",                     // 11: File_priv
+		"Y",                     // 12: Grant_priv
+		"Y",                     // 13: References_priv
+		"Y",                     // 14: Index_priv
+		"Y",                     // 15: Alter_priv
+		"Y",                     // 16: Show_db_priv
+		"Y",                     // 17: Super_priv
+		"Y",                     // 18: Create_tmp_table_priv
+		"Y",                     // 19: Lock_tables_priv
+		"Y",                     // 20: Execute_priv
+		"Y",                     // 21: Repl_slave_priv
+		"Y",                     // 22: Repl_client_priv
+		"Y",                     // 23: Create_view_priv
+		"Y",                     // 24: Show_view_priv
+		"Y",                     // 25: Create_routine_priv
+		"Y",                     // 26: Alter_routine_priv
+		"Y",                     // 27: Create_user_priv
+		"Y",                     // 28: Event_priv
+		"Y",                     // 29: Trigger_priv
+		"Y",                     // 30: Create_tablespace_priv
+		"",                      // 31: ssl_type
+		"",                      // 32: ssl_cipher
+		"",                      // 33: x509_issuer
+		"",                      // 34: x509_subject
+		0,                       // 35: max_questions
+		0,                       // 36: max_updates
+		0,                       // 37: max_connections
+		0,                       // 38: max_user_connections
+		"caching_sha2_password", // 39: plugin
+		nil,                     // 40: authentication_string //TODO: figure out what this password should be
+		"N",                     // 41: password_expired
+		time.Unix(0, 0).UTC(),   // 42: password_last_changed
+		nil,                     // 43: password_lifetime
+		"N",                     // 44: account_locked
+		"Y",                     // 45: Create_role_priv
+		"Y",                     // 46: Drop_role_priv
+		nil,                     // 47: Password_reuse_history
+		nil,                     // 48: Password_reuse_time
+		nil,                     // 49: Password_require_current
+		nil,                     // 50: User_attributes
+	})
+	if err != nil {
+		panic(err) // Insertion should never fail so this should never be reached
+	}
+}

--- a/sql/in_mem_table/inmem_table_data.go
+++ b/sql/in_mem_table/inmem_table_data.go
@@ -1,0 +1,311 @@
+// Copyright 2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package in_mem_table
+
+import (
+	"reflect"
+	"sync"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// Eventually these structures should be replaced by memory tables, however at the time of writing this file, the
+// memory tables strive for correctness rather than speed (as they're primarily used for testing functionality rather
+// than for actual usage). They are also not built with concurrency in mind. Rather than rewriting them, these
+// structures were made. For internal tables that need to quickly access data, such as the Grant Tables, this provides
+// a more optimized alternative to the memory tables for rapid access (such as verifying every statement for the
+// correct privileges). Although alteration is supported, it is not the focus.
+//
+// For clarification, these are "in-memory tables", which are different from the "memory tables". The "memory tables"
+// reside in a folder in the project's root, under `/memory`. It contains a full table implementation, from auto-
+// incrementing columns to foreign key support. For now, "in-memory tables" are to be used for tables that exist outside
+// of an integrator's domain, while requiring alteration. This is unlike the information_schema tables, which do not
+// allow any kind of direct alteration.
+
+// InMemTableDataKey represents a key that will be matched in order to retrieve a row. All implementations of this
+// interface must NOT be a pointer, as pointers have different rules for determining equality.
+type InMemTableDataKey interface {
+	// AssignValues returns a new key with the given values. These values will be in the same order as their represented
+	// columns (as returned by RepresentedColumns). The new key's type is expected to match the calling key's type.
+	AssignValues(vals ...interface{}) (InMemTableDataKey, error)
+	// RepresentedColumns returns the index positions of the columns that represent this key, based on the table's schema.
+	RepresentedColumns() []uint16
+}
+
+// InMemTableData is used for in-memory tables to store their row data in a way that may be quickly retrieved for queries.
+type InMemTableData struct {
+	sch                 sql.Schema
+	mutex               *sync.RWMutex
+	count               int64
+	primaryReferenceKey InMemTableDataKey
+	otherReferenceKeys  []InMemTableDataKey
+	data                map[reflect.Type]map[InMemTableDataKey][]sql.Row
+}
+
+// NewInMemTableData returns a new *InMemTableData. A primary key must be given, with additional keys (secondary)
+// optional. If a key is given, it must not be defined as a pointer type.
+func NewInMemTableData(sch sql.Schema, primaryKey InMemTableDataKey, secondaryKeys []InMemTableDataKey) *InMemTableData {
+	if primaryKey == nil {
+		panic("in memory table primary key cannot be nil")
+	}
+	if reflect.TypeOf(primaryKey).Kind() == reflect.Ptr {
+		panic("in memory table primary key must not be a pointer type")
+	}
+	for _, secondaryKey := range secondaryKeys {
+		if secondaryKey == nil {
+			panic("in memory table secondary keys cannot be nil")
+		}
+		if reflect.TypeOf(secondaryKey).Kind() == reflect.Ptr {
+			panic("in memory table secondary keys must not be a pointer types")
+		}
+	}
+	return &InMemTableData{
+		sch,
+		&sync.RWMutex{},
+		0,
+		primaryKey,
+		secondaryKeys,
+		make(map[reflect.Type]map[InMemTableDataKey][]sql.Row),
+	}
+}
+
+// Count returns this table's number of rows.
+func (imtd *InMemTableData) Count() int64 {
+	imtd.mutex.RLock()
+	defer imtd.mutex.RUnlock()
+	return imtd.count
+}
+
+// Get returns the rows matching the given key.
+func (imtd *InMemTableData) Get(key InMemTableDataKey) []sql.Row {
+	imtd.mutex.RLock()
+	defer imtd.mutex.RUnlock()
+	keyType := reflect.TypeOf(key)
+	indexedData, ok := imtd.data[keyType]
+	if !ok {
+		return nil
+	}
+	return indexedData[key]
+}
+
+// Has returns whether the given row is found in the table.
+func (imtd *InMemTableData) Has(row sql.Row) bool {
+	imtd.mutex.RLock()
+	defer imtd.mutex.RUnlock()
+	rowIndexes := imtd.primaryReferenceKey.RepresentedColumns()
+	vals := make([]interface{}, len(rowIndexes))
+	for i, rowIndex := range rowIndexes {
+		vals[i] = row[rowIndex]
+	}
+	key, err := imtd.primaryReferenceKey.AssignValues(vals...)
+	if err != nil {
+		return false
+	}
+
+	keyType := reflect.TypeOf(key)
+	indexedData, ok := imtd.data[keyType]
+	if !ok {
+		return false
+	}
+	rows, ok := indexedData[key]
+	if !ok {
+		return false
+	}
+	for _, ourRow := range rows {
+		if ok, err := ourRow.Equals(row, imtd.sch); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Put adds the given row to the data.
+func (imtd *InMemTableData) Put(row sql.Row) error {
+	imtd.mutex.Lock()
+	defer imtd.mutex.Unlock()
+	row = row.Copy()
+	isDuplicateRow := true
+	for _, referenceKey := range append(imtd.otherReferenceKeys, imtd.primaryReferenceKey) {
+		rowIndexes := referenceKey.RepresentedColumns()
+		vals := make([]interface{}, len(rowIndexes))
+		for i, rowIndex := range rowIndexes {
+			vals[i] = row[rowIndex]
+		}
+		key, err := referenceKey.AssignValues(vals...)
+		if err != nil {
+			return err
+		}
+
+		keyType := reflect.TypeOf(key)
+		indexedData, ok := imtd.data[keyType]
+		if !ok {
+			indexedData = make(map[InMemTableDataKey][]sql.Row)
+			imtd.data[keyType] = indexedData
+			indexedData[key] = []sql.Row{row}
+		} else {
+			existingRows := indexedData[key]
+			found := false
+			for _, existingRow := range existingRows {
+				if ok, err := existingRow.Equals(row, imtd.sch); err != nil {
+					return err
+				} else if ok {
+					found = true
+					break
+				}
+			}
+			if !found {
+				indexedData[key] = append(indexedData[key], row)
+				isDuplicateRow = false
+			}
+		}
+	}
+	if !isDuplicateRow {
+		imtd.count++
+	}
+	return nil
+}
+
+// Remove will completely remove the given key and/or row. If the given key is not nil, then all matching rows are
+// found and removed. If the given row is not nil, then only that row is removed.
+func (imtd *InMemTableData) Remove(key InMemTableDataKey, row sql.Row) error {
+	if key != nil {
+		existingRows := imtd.Get(key)
+		for _, existingRow := range existingRows {
+			if err := imtd.Remove(nil, existingRow); err != nil {
+				return err
+			}
+		}
+	}
+	if row != nil {
+		imtd.mutex.Lock()
+		defer imtd.mutex.Unlock()
+		rowExisted := false
+		for _, referenceKey := range append(imtd.otherReferenceKeys, imtd.primaryReferenceKey) {
+			rowIndexes := referenceKey.RepresentedColumns()
+			vals := make([]interface{}, len(rowIndexes))
+			for i, rowIndex := range rowIndexes {
+				vals[i] = row[rowIndex]
+			}
+			key, err := referenceKey.AssignValues(vals...)
+			if err != nil {
+				return err
+			}
+
+			keyType := reflect.TypeOf(key)
+			indexedData, ok := imtd.data[keyType]
+			if ok {
+				existingRows, ok := indexedData[key]
+				if ok {
+					for i, existingRow := range existingRows {
+						if ok, err := existingRow.Equals(row, imtd.sch); err != nil {
+							return err
+						} else if ok {
+							indexedData[key] = append(existingRows[:i], existingRows[i+1:]...)
+							rowExisted = true
+							break
+						}
+					}
+				}
+			}
+		}
+		if rowExisted {
+			imtd.count--
+		}
+	}
+	return nil
+}
+
+// Clear removes all rows.
+func (imtd *InMemTableData) Clear() {
+	imtd.mutex.Lock()
+	defer imtd.mutex.Unlock()
+	imtd.count = 0
+	imtd.data = make(map[reflect.Type]map[InMemTableDataKey][]sql.Row)
+}
+
+// ToRowIter returns a RowIter containing all of this table's rows.
+func (imtd *InMemTableData) ToRowIter() sql.RowIter {
+	imtd.mutex.RLock()
+	defer imtd.mutex.RUnlock()
+	var rows []sql.Row
+	for _, indexedData := range imtd.data {
+		for _, ourRows := range indexedData {
+			for _, ourRow := range ourRows {
+				rows = append(rows, ourRow.Copy())
+			}
+		}
+		break
+	}
+	return sql.RowsToRowIter(rows...)
+}
+
+// InMemTableDataEditor allows for a table to process alteration statements on its data.
+type InMemTableDataEditor struct {
+	data *InMemTableData
+}
+
+var _ sql.RowInserter = (*InMemTableDataEditor)(nil)
+var _ sql.RowUpdater = (*InMemTableDataEditor)(nil)
+var _ sql.RowDeleter = (*InMemTableDataEditor)(nil)
+var _ sql.RowReplacer = (*InMemTableDataEditor)(nil)
+
+// NewInMemTableDataEditor returns a new *InMemTableDataEditor.
+func NewInMemTableDataEditor(data *InMemTableData) *InMemTableDataEditor {
+	return &InMemTableDataEditor{data}
+}
+
+// StatementBegin implements the TableEditor interface.
+func (editor *InMemTableDataEditor) StatementBegin(ctx *sql.Context) {
+	//TODO: implement this
+}
+
+// DiscardChanges implements the TableEditor interface.
+func (editor *InMemTableDataEditor) DiscardChanges(ctx *sql.Context, errorEncountered error) error {
+	//TODO: implement this
+	return nil
+}
+
+// StatementComplete implements the TableEditor interface.
+func (editor *InMemTableDataEditor) StatementComplete(ctx *sql.Context) error {
+	//TODO: implement this
+	return nil
+}
+
+// Insert implements the RowInserter interface.
+func (editor *InMemTableDataEditor) Insert(ctx *sql.Context, row sql.Row) error {
+	if editor.data.Has(row) {
+		return sql.ErrPrimaryKeyViolation.New()
+	}
+	return editor.data.Put(row)
+}
+
+// Update implements the RowUpdater interface.
+func (editor *InMemTableDataEditor) Update(ctx *sql.Context, old sql.Row, new sql.Row) error {
+	err := editor.data.Remove(nil, old)
+	if err != nil {
+		return err
+	}
+	return editor.data.Put(new)
+}
+
+// Delete implements the RowDeleter interface.
+func (editor *InMemTableDataEditor) Delete(ctx *sql.Context, row sql.Row) error {
+	return editor.data.Remove(nil, row)
+}
+
+// Close implements the Closer interface.
+func (editor *InMemTableDataEditor) Close(ctx *sql.Context) error {
+	return nil
+}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2054,6 +2054,7 @@ func convertCreateUser(ctx *sql.Context, n *sqlparser.CreateUser) (*plan.CreateU
 		PasswordOptions: passwordOptions,
 		Locked:          n.Locked,
 		Attribute:       n.Attribute,
+		GrantTables:     sql.UnresolvedDatabase("mysql"),
 	}, nil
 }
 

--- a/sql/partition.go
+++ b/sql/partition.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import "io"
+
+// Partition represents a partition from a SQL table.
+type Partition interface {
+	Key() []byte
+}
+
+// PartitionIter is an iterator that retrieves partitions.
+type PartitionIter interface {
+	Closer
+	Next(*Context) (Partition, error)
+}
+
+// PartitionsToPartitionIter creates a PartitionIter that iterates over the given partitions.
+func PartitionsToPartitionIter(partitions ...Partition) PartitionIter {
+	return &slicePartitionIter{partitions: partitions}
+}
+
+type slicePartitionIter struct {
+	partitions []Partition
+	idx        int
+}
+
+func (i *slicePartitionIter) Next(*Context) (Partition, error) {
+	if i.idx >= len(i.partitions) {
+		return nil, io.EOF
+	}
+	i.idx++
+	return i.partitions[i.idx-1], nil
+}
+func (i *slicePartitionIter) Close(*Context) error {
+	i.partitions = nil
+	return nil
+}

--- a/sql/plan/create_user.go
+++ b/sql/plan/create_user.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/grant_tables"
 )
 
 // CreateUser represents the statement CREATE USER.
@@ -31,9 +32,11 @@ type CreateUser struct {
 	PasswordOptions *PasswordOptions
 	Locked          bool
 	Attribute       string
+	GrantTables     sql.Database
 }
 
 var _ sql.Node = (*CreateUser)(nil)
+var _ sql.Databaser = (*CreateUser)(nil)
 
 // Schema implements the interface sql.Node.
 func (n *CreateUser) Schema() sql.Schema {
@@ -53,9 +56,22 @@ func (n *CreateUser) String() string {
 	return fmt.Sprintf("CreateUser(%s%s)", ifNotExists, strings.Join(users, ", "))
 }
 
+// Database implements the interface sql.Databaser.
+func (n *CreateUser) Database() sql.Database {
+	return n.GrantTables
+}
+
+// WithDatabase implements the interface sql.Databaser.
+func (n *CreateUser) WithDatabase(db sql.Database) (sql.Node, error) {
+	nn := *n
+	nn.GrantTables = db
+	return &nn, nil
+}
+
 // Resolved implements the interface sql.Node.
 func (n *CreateUser) Resolved() bool {
-	return true
+	_, ok := n.GrantTables.(sql.UnresolvedDatabase)
+	return !ok
 }
 
 // Children implements the interface sql.Node.
@@ -73,5 +89,84 @@ func (n *CreateUser) WithChildren(children ...sql.Node) (sql.Node, error) {
 
 // RowIter implements the interface sql.Node.
 func (n *CreateUser) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	grantTables, ok := n.GrantTables.(*grant_tables.GrantTables)
+	if !ok {
+		return nil, sql.ErrDatabaseNotFound.New("mysql")
+	}
+	userTableData := grantTables.UserTable().Data()
+	for _, user := range n.Users {
+		userPk := grant_tables.UserPrimaryKey{
+			Host: user.UserName.Host,
+			User: user.UserName.Name,
+		}
+		existingRows := userTableData.Get(userPk)
+		if len(existingRows) > 0 {
+			if n.IfNotExists {
+				continue
+			}
+			return nil, sql.ErrUserCreationFailure.New(user.UserName.StringWithQuote("'", ""))
+		}
+		//TODO: validate all of the data
+		err := userTableData.Put(sql.Row{
+			user.UserName.Host,      // 00: Host
+			user.UserName.Name,      // 01: User
+			"N",                     // 02: Select_priv
+			"N",                     // 03: Insert_priv
+			"N",                     // 04: Update_priv
+			"N",                     // 05: Delete_priv
+			"N",                     // 06: Create_priv
+			"N",                     // 07: Drop_priv
+			"N",                     // 08: Reload_priv
+			"N",                     // 09: Shutdown_priv
+			"N",                     // 10: Process_priv
+			"N",                     // 11: File_priv
+			"N",                     // 12: Grant_priv
+			"N",                     // 13: References_priv
+			"N",                     // 14: Index_priv
+			"N",                     // 15: Alter_priv
+			"N",                     // 16: Show_db_priv
+			"N",                     // 17: Super_priv
+			"N",                     // 18: Create_tmp_table_priv
+			"N",                     // 19: Lock_tables_priv
+			"N",                     // 20: Execute_priv
+			"N",                     // 21: Repl_slave_priv
+			"N",                     // 22: Repl_client_priv
+			"N",                     // 23: Create_view_priv
+			"N",                     // 24: Show_view_priv
+			"N",                     // 25: Create_routine_priv
+			"N",                     // 26: Alter_routine_priv
+			"N",                     // 27: Create_user_priv
+			"N",                     // 28: Event_priv
+			"N",                     // 29: Trigger_priv
+			"N",                     // 30: Create_tablespace_priv
+			"",                      // 31: ssl_type
+			"",                      // 32: ssl_cipher
+			"",                      // 33: x509_issuer
+			"",                      // 34: x509_subject
+			0,                       // 35: max_questions
+			0,                       // 36: max_updates
+			0,                       // 37: max_connections
+			0,                       // 38: max_user_connections
+			"caching_sha2_password", // 39: plugin
+			nil,                     // 40: authentication_string
+			"N",                     // 41: password_expired
+			nil,                     // 42: password_last_changed
+			nil,                     // 43: password_lifetime
+			"N",                     // 44: account_locked
+			"N",                     // 45: Create_role_priv
+			"N",                     // 46: Drop_role_priv
+			nil,                     // 47: Password_reuse_history
+			nil,                     // 48: Password_reuse_time
+			nil,                     // 49: Password_require_current
+			nil,                     // 50: User_attributes
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	err := grantTables.Persist(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return sql.RowsToRowIter(sql.Row{sql.NewOkResult(0)}), nil
 }

--- a/sql/schema.go
+++ b/sql/schema.go
@@ -53,12 +53,13 @@ func (s Schema) CheckRow(row Row) error {
 // Copy returns a deep copy of this schema, making a copy of all columns
 func (s Schema) Copy() Schema {
 	ns := make(Schema, len(s))
-
 	for i, col := range s {
 		nc := *col
+		if nc.Default != nil {
+			nc.Default = &(*nc.Default)
+		}
 		ns[i] = &nc
 	}
-
 	return ns
 }
 


### PR DESCRIPTION
This adds the minimum for the `CREATE USER` statement to work, in that we have an in-memory representation of the grant tables, which may be accessed either directly (by the `mysql` database) or through the user statements (of which we only have `CREATE USER` for now).