### PR TITLE
`GroupBy` window framing refactor

### DIFF
--- a/sql/expression/function/aggregation/avg.go
+++ b/sql/expression/function/aggregation/avg.go
@@ -86,6 +86,16 @@ func (a *Avg) NewBuffer() (sql.AggregationBuffer, error) {
 	return &avgBuffer{sum, rows, bufferChild}, nil
 }
 
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (a *Avg) NewWindowFunction() (sql.WindowFunction, error) {
+	c, err := expression.Clone(a.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewAvgAgg(c), nil
+}
+
 type avgBuffer struct {
 	sum  float64
 	rows int64

--- a/sql/expression/function/aggregation/count.go
+++ b/sql/expression/function/aggregation/count.go
@@ -30,9 +30,11 @@ type Count struct {
 
 var _ sql.FunctionExpression = (*Count)(nil)
 var _ sql.Aggregation = (*Count)(nil)
+var _ sql.WindowAdaptableExpression = (*Count)(nil)
 
 var _ sql.FunctionExpression = (*CountDistinct)(nil)
 var _ sql.Aggregation = (*CountDistinct)(nil)
+var _ sql.WindowAdaptableExpression = (*CountDistinct)(nil)
 
 // NewCount creates a new Count node.
 func NewCount(e sql.Expression) *Count {
@@ -56,6 +58,15 @@ func (c *Count) NewBuffer() (sql.AggregationBuffer, error) {
 		return nil, err
 	}
 	return &countBuffer{0, bufferChild}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (c *Count) NewWindowFunction() (sql.WindowFunction, error) {
+	child, err := expression.Clone(c.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewCountAgg(child), nil
 }
 
 // Type returns the type of the result.
@@ -107,6 +118,15 @@ func NewCountDistinct(e sql.Expression) *CountDistinct {
 // NewBuffer creates a new buffer for the aggregation.
 func (c *CountDistinct) NewBuffer() (sql.AggregationBuffer, error) {
 	return &countDistinctBuffer{make(map[uint64]struct{}), c.Child}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (c *CountDistinct) NewWindowFunction() (sql.WindowFunction, error) {
+	child, err := expression.Clone(c.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewCountAgg(expression.NewDistinctExpression(child)), nil
 }
 
 // Type returns the type of the result.

--- a/sql/expression/function/aggregation/first.go
+++ b/sql/expression/function/aggregation/first.go
@@ -29,6 +29,7 @@ type First struct {
 
 var _ sql.FunctionExpression = (*First)(nil)
 var _ sql.Aggregation = (*First)(nil)
+var _ sql.WindowAdaptableExpression = (*First)(nil)
 
 // NewFirst returns a new First node.
 func NewFirst(e sql.Expression) *First {
@@ -69,6 +70,15 @@ func (f *First) NewBuffer() (sql.AggregationBuffer, error) {
 		return nil, err
 	}
 	return &firstBuffer{nil, bufferChild}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (f *First) NewWindowFunction() (sql.WindowFunction, error) {
+	c, err := expression.Clone(f.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewFirstAgg(c), nil
 }
 
 // Eval implements the Expresion interface.

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -36,6 +36,7 @@ type GroupConcat struct {
 
 var _ sql.FunctionExpression = &GroupConcat{}
 var _ sql.Aggregation = &GroupConcat{}
+var _ sql.WindowAdaptableExpression = (*GroupConcat)(nil)
 
 func NewEmptyGroupConcat() sql.Expression {
 	return &GroupConcat{}
@@ -60,6 +61,11 @@ func (g *GroupConcat) NewBuffer() (sql.AggregationBuffer, error) {
 	var rows []sql.Row
 	distinctSet := make(map[string]bool)
 	return &groupConcatBuffer{g, rows, distinctSet}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (g *GroupConcat) NewWindowFunction() (sql.WindowFunction, error) {
+	return NewGroupConcatAgg(g), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/aggregation/json_agg.go
+++ b/sql/expression/function/aggregation/json_agg.go
@@ -39,8 +39,9 @@ type JSONArrayAgg struct {
 	expression.UnaryExpression
 }
 
-var _ sql.FunctionExpression = &JSONArrayAgg{}
-var _ sql.Aggregation = &JSONArrayAgg{}
+var _ sql.FunctionExpression = (*JSONArrayAgg)(nil)
+var _ sql.Aggregation = (*JSONArrayAgg)(nil)
+var _ sql.WindowAdaptableExpression = (*JSONArrayAgg)(nil)
 
 // NewJSONArrayAgg creates a new JSONArrayAgg function.
 func NewJSONArrayAgg(arg sql.Expression) *JSONArrayAgg {
@@ -57,15 +58,15 @@ func (j *JSONArrayAgg) Description() string {
 	return "returns result set as a single JSON array."
 }
 
-// IsUnsupported implements sql.FunctionExpression
-func (j *JSONArrayAgg) IsUnsupported() bool {
-	return true
-}
-
 // NewBuffer creates a new buffer for the aggregation.
 func (j *JSONArrayAgg) NewBuffer() (sql.AggregationBuffer, error) {
 	var row []interface{}
 	return &jsonArrayBuffer{row, j}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (j *JSONArrayAgg) NewWindowFunction() (sql.WindowFunction, error) {
+	return NewJSONArrayAgg2(j), nil
 }
 
 // Type returns the type of the result.
@@ -153,55 +154,51 @@ type JSONObjectAgg struct {
 	value sql.Expression
 }
 
-var _ sql.FunctionExpression = JSONObjectAgg{}
-var _ sql.Aggregation = JSONObjectAgg{}
+var _ sql.FunctionExpression = (*JSONObjectAgg)(nil)
+var _ sql.Aggregation = (*JSONObjectAgg)(nil)
+var _ sql.WindowAdaptableExpression = (*JSONObjectAgg)(nil)
 
 // NewJSONObjectAgg creates a new JSONArrayAgg function.
 func NewJSONObjectAgg(key, value sql.Expression) sql.Expression {
-	return JSONObjectAgg{key: key, value: value}
+	return &JSONObjectAgg{key: key, value: value}
 }
 
 // FunctionName implements sql.FunctionExpression
-func (j JSONObjectAgg) FunctionName() string {
+func (j *JSONObjectAgg) FunctionName() string {
 	return "json_objectagg"
 }
 
 // Description implements sql.FunctionExpression
-func (j JSONObjectAgg) Description() string {
+func (j *JSONObjectAgg) Description() string {
 	return "returns result set as a single JSON object."
 }
 
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONObjectAgg) IsUnsupported() bool {
-	return true
-}
-
 // Resolved implements the Expression interface.
-func (j JSONObjectAgg) Resolved() bool {
+func (j *JSONObjectAgg) Resolved() bool {
 	return j.key.Resolved() && j.value.Resolved()
 }
 
-func (j JSONObjectAgg) String() string {
+func (j *JSONObjectAgg) String() string {
 	return fmt.Sprintf("JSON_OBJECTAGG(%s, %s)", j.key, j.value)
 }
 
 // Type implements the Expression interface.
-func (j JSONObjectAgg) Type() sql.Type {
+func (j *JSONObjectAgg) Type() sql.Type {
 	return sql.JSON
 }
 
 // IsNullable implements the Expression interface.
-func (j JSONObjectAgg) IsNullable() bool {
+func (j *JSONObjectAgg) IsNullable() bool {
 	return false
 }
 
 // Children implements the Expression interface.
-func (j JSONObjectAgg) Children() []sql.Expression {
+func (j *JSONObjectAgg) Children() []sql.Expression {
 	return []sql.Expression{j.key, j.value}
 }
 
 // WithChildren implements the Expression interface.
-func (j JSONObjectAgg) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+func (j *JSONObjectAgg) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 2 {
 		return nil, sql.ErrInvalidChildrenNumber.New(j, len(children), 2)
 	}
@@ -210,13 +207,18 @@ func (j JSONObjectAgg) WithChildren(children ...sql.Expression) (sql.Expression,
 }
 
 // NewBuffer implements the Aggregation interface.
-func (j JSONObjectAgg) NewBuffer() (sql.AggregationBuffer, error) {
+func (j *JSONObjectAgg) NewBuffer() (sql.AggregationBuffer, error) {
 	row := make(map[string]interface{})
-	return &jsonObjectBuffer{row, &j}, nil
+	return &jsonObjectBuffer{row, j}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (j *JSONObjectAgg) NewWindowFunction() (sql.WindowFunction, error) {
+	return NewJSONObjectAgg2(j), nil
 }
 
 // Eval implements the Expression interface.
-func (j JSONObjectAgg) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+func (j *JSONObjectAgg) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return nil, ErrEvalUnsupportedOnAggregation.New("JSONObjectAgg")
 }
 

--- a/sql/expression/function/aggregation/last.go
+++ b/sql/expression/function/aggregation/last.go
@@ -29,6 +29,7 @@ type Last struct {
 
 var _ sql.FunctionExpression = (*Last)(nil)
 var _ sql.Aggregation = (*Last)(nil)
+var _ sql.WindowAdaptableExpression = (*Last)(nil)
 
 // NewLast returns a new Last node.
 func NewLast(e sql.Expression) *Last {
@@ -69,6 +70,15 @@ func (l *Last) NewBuffer() (sql.AggregationBuffer, error) {
 		return nil, err
 	}
 	return &lastBuffer{nil, bufferChild}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (l *Last) NewWindowFunction() (sql.WindowFunction, error) {
+	c, err := expression.Clone(l.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewLastAgg(c), nil
 }
 
 // Eval implements the sql.Expression interface.

--- a/sql/expression/function/aggregation/max.go
+++ b/sql/expression/function/aggregation/max.go
@@ -30,6 +30,7 @@ type Max struct {
 
 var _ sql.FunctionExpression = (*Max)(nil)
 var _ sql.Aggregation = (*Max)(nil)
+var _ sql.WindowAdaptableExpression = (*Max)(nil)
 
 // NewMax returns a new Max node.
 func NewMax(e sql.Expression) *Max {
@@ -79,6 +80,15 @@ func (m *Max) NewBuffer() (sql.AggregationBuffer, error) {
 		return nil, err
 	}
 	return &maxBuffer{nil, bufferChild}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (m *Max) NewWindowFunction() (sql.WindowFunction, error) {
+	c, err := expression.Clone(m.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewMaxAgg(c), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/aggregation/min.go
+++ b/sql/expression/function/aggregation/min.go
@@ -30,6 +30,7 @@ type Min struct {
 
 var _ sql.FunctionExpression = (*Min)(nil)
 var _ sql.Aggregation = (*Min)(nil)
+var _ sql.WindowAdaptableExpression = (*Min)(nil)
 
 // NewMin creates a new Min node.
 func NewMin(e sql.Expression) *Min {
@@ -75,6 +76,15 @@ func (m *Min) NewBuffer() (sql.AggregationBuffer, error) {
 		return nil, err
 	}
 	return &minBuffer{nil, bufferChild}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (m *Min) NewWindowFunction() (sql.WindowFunction, error) {
+	c, err := expression.Clone(m.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewMinAgg(c), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/aggregation/sum.go
+++ b/sql/expression/function/aggregation/sum.go
@@ -29,6 +29,7 @@ type Sum struct {
 
 var _ sql.FunctionExpression = (*Sum)(nil)
 var _ sql.Aggregation = (*Sum)(nil)
+var _ sql.WindowAdaptableExpression = (*Sum)(nil)
 
 // NewSum returns a new Sum node.
 func NewSum(e sql.Expression) *Sum {
@@ -69,6 +70,15 @@ func (m *Sum) NewBuffer() (sql.AggregationBuffer, error) {
 		return nil, err
 	}
 	return &sumBuffer{true, 0, bufferChild}, nil
+}
+
+// NewWindowFunctionAggregation implements sql.WindowAdaptableExpression
+func (m *Sum) NewWindowFunction() (sql.WindowFunction, error) {
+	c, err := expression.Clone(m.UnaryExpression.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewSumAgg(c), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/aggregation/window_block.go
+++ b/sql/expression/function/aggregation/window_block.go
@@ -1,0 +1,334 @@
+// Copyright 2022 DoltHub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"errors"
+	"io"
+	"sort"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+var ErrNoPartitions = errors.New("no partitions")
+
+type Aggregation struct {
+	fn     sql.WindowFunction
+	framer sql.WindowFramer
+}
+
+func NewAggregation(a sql.WindowFunction, f sql.WindowFramer) *Aggregation {
+	return &Aggregation{fn: a, framer: f}
+}
+
+type windowBlockIter struct {
+	ctx   *sql.Context
+	pos   int
+	child sql.RowIter
+
+	partitionBy []sql.Expression
+	sortBy      sql.SortFields
+	aggs        []*Aggregation
+
+	partitions       []sql.WindowInterval
+	currentPartition sql.WindowInterval
+	partitionIdx     int
+	done             bool
+
+	input, output     sql.WindowBuffer
+	outputOrdering    []int
+	outputIdx         []int
+	outputOrderingPos int
+}
+
+var _ sql.RowIter = (*windowBlockIter)(nil)
+var _ sql.Disposable = (*windowBlockIter)(nil)
+
+func NewWindowBlockIter(partitionBy []sql.Expression, sortBy sql.SortFields, aggs []*Aggregation, child sql.RowIter) *windowBlockIter {
+	return &windowBlockIter{
+		partitionBy:  partitionBy,
+		sortBy:       sortBy,
+		aggs:         aggs,
+		child:        child,
+		partitionIdx: -1,
+	}
+}
+
+func (i *windowBlockIter) Close(ctx *sql.Context) error {
+	i.Dispose()
+	i.input = nil
+	return i.child.Close(ctx)
+}
+
+func (i *windowBlockIter) Dispose() {
+	for _, a := range i.aggs {
+		a.fn.Dispose()
+	}
+}
+
+func (i *windowBlockIter) Next(ctx *sql.Context) (sql.Row, error) {
+	var err error
+	if i.output == nil {
+		i.input, i.outputOrdering, err = i.materializeInput(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		i.partitions, err = i.initializePartitions(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		i.output, err = i.materializeOutput(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		err = i.sortAndFilterOutput()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if i.pos > len(i.output)-1 {
+		return nil, io.EOF
+	}
+
+	defer func() { i.pos++ }()
+
+	return i.output[i.pos], nil
+}
+
+// materializeInput empties the child iterator int a buffer and sorts by (WPK, WSK). Returns
+// a sorted sql.WindowBuffer and a list of original row indices for resorting.
+func (i *windowBlockIter) materializeInput(ctx *sql.Context) (sql.WindowBuffer, []int, error) {
+	input := make(sql.WindowBuffer, 0)
+	j := 0
+	for {
+		row, err := i.child.Next(ctx)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, nil, err
+		}
+		input = append(input, append(row, j))
+		j++
+	}
+
+	if len(input) == 0 {
+		return nil, nil, nil
+	}
+
+	// sort all rows by partition
+	sorter := &expression.Sorter{
+		SortFields: append(partitionsToSortFields(i.partitionBy), i.sortBy...),
+		Rows:       input,
+		Ctx:        ctx,
+	}
+	sort.Stable(sorter)
+
+	// maintain output sort ordering
+	// TODO: push sort above aggregation, makes this code unnecessarily complex
+	outputOrdering := make([]int, len(input))
+	outputIdx := len(input[0]) - 1
+	for k, row := range input {
+		outputOrdering[k], input[k] = row[outputIdx].(int), row[:outputIdx]
+	}
+
+	return input, outputOrdering, nil
+}
+
+// initializePartitions walks the [i.input] buffer using [i.partitionBy] and
+// returns a list of sql.WindowInterval [partition]s.
+func (i *windowBlockIter) initializePartitions(ctx *sql.Context) ([]sql.WindowInterval, error) {
+	if len(i.input) == 0 {
+		// Some conditions require a default output for nil input rows. The
+		// empty partition lets window framing pass through one io.EOF to
+		// provide a default result before stopping for these cases.
+		return []sql.WindowInterval{{Start: 0, End: 0}}, nil
+	}
+
+	partitions := make([]sql.WindowInterval, 0)
+	startIdx := 0
+	var lastRow sql.Row
+	for j, row := range i.input {
+		newPart, err := isNewPartition(ctx, i.partitionBy, lastRow, row)
+		if err != nil {
+			return nil, err
+		}
+		if newPart && j > startIdx {
+			partitions = append(partitions, sql.WindowInterval{Start: startIdx, End: j})
+			startIdx = j
+		}
+		lastRow = row
+	}
+
+	if startIdx < len(i.input) {
+		partitions = append(partitions, sql.WindowInterval{Start: startIdx, End: len(i.input)})
+	}
+
+	return partitions, nil
+}
+
+// materializeOutput evaluates and collects all aggregation results into an output sql.WindowBuffer.
+// At this stage, result rows are appended with the original row index for resorting. The size of
+// [i.output] will be smaller than [i.input] if the outer sql.Node is a plan.GroupBy with fewer partitions than rows.
+func (i *windowBlockIter) materializeOutput(ctx *sql.Context) (sql.WindowBuffer, error) {
+	// handle nil input specially if no partition clause
+	// ex: COUNT(*) on nil rows returns 0, not nil
+	if len(i.input) == 0 && len(i.partitionBy) > 0 {
+		return nil, io.EOF
+	}
+
+	output := make(sql.WindowBuffer, 0, len(i.input))
+	var row sql.Row
+	var err error
+	for {
+		row, err = i.compute(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		output = append(output, row)
+	}
+
+	return output, nil
+}
+
+// compute evaluates each function in [i.aggs], returning the result as an sql.Row with
+// the outputOrdering index appended, or an io.EOF error if we are finished iterating.
+func (i *windowBlockIter) compute(ctx *sql.Context) (sql.Row, error) {
+	var row = make(sql.Row, len(i.aggs)+1)
+
+	// each [agg] has its own [agg.framer] that is globally positioned
+	// but updated independently. This allows aggregations with the same
+	// partition and sorting to have different framing behavior.
+	for j, agg := range i.aggs {
+		interval, err := agg.framer.Next()
+		if errors.Is(err, io.EOF) {
+			err = i.nextPartition(ctx)
+			if err != nil {
+				return nil, err
+			}
+			interval, err = agg.framer.Next()
+			if err != nil {
+				return nil, err
+			}
+		}
+		row[j] = agg.fn.Compute(ctx, interval, i.input)
+	}
+
+	// TODO: move sort by above aggregation
+	if i.outputOrdering != nil {
+		row[len(i.aggs)] = i.outputOrdering[i.outputOrderingPos]
+	}
+	i.outputOrderingPos++
+	return row, nil
+}
+
+// sortAndFilterOutput in-place sorts the [i.output] buffer using the last
+// value in every row as the sort index.
+func (i *windowBlockIter) sortAndFilterOutput() error {
+	// TODO: move sort by above aggregations
+	// we could cycle sort this for windows (not group by, unless number
+	// of group by partitions = number of rows)
+	if len(i.output) == 0 {
+		return nil
+	}
+
+	originalOrderIdx := len(i.output[0]) - 1
+	sort.SliceStable(i.output, func(j, k int) bool {
+		return i.output[j][originalOrderIdx].(int) < i.output[k][originalOrderIdx].(int)
+	})
+
+	for j, row := range i.output {
+		i.output[j] = row[:originalOrderIdx]
+	}
+
+	return nil
+}
+
+func (i *windowBlockIter) nextPartition(ctx *sql.Context) error {
+	if len(i.partitions) == 0 {
+		return ErrNoPartitions
+	}
+
+	if i.partitionIdx < 0 {
+		i.partitionIdx = 0
+	} else {
+		i.partitionIdx++
+	}
+
+	if i.partitionIdx > len(i.partitions)-1 {
+		return io.EOF
+	}
+
+	i.currentPartition = i.partitions[i.partitionIdx]
+	i.outputOrderingPos = i.currentPartition.Start
+
+	for _, a := range i.aggs {
+		err := a.fn.StartPartition(ctx, i.currentPartition, i.input)
+		if err != nil {
+			return err
+		}
+		a.framer = a.framer.NewFramer(i.currentPartition)
+	}
+
+	return nil
+}
+
+func partitionsToSortFields(partitionExprs []sql.Expression) sql.SortFields {
+	sfs := make(sql.SortFields, len(partitionExprs))
+	for i, expr := range partitionExprs {
+		sfs[i] = sql.SortField{
+			Column: expr,
+			Order:  sql.Ascending,
+		}
+	}
+	return sfs
+}
+
+func isNewPartition(ctx *sql.Context, partitionBy []sql.Expression, last sql.Row, row sql.Row) (bool, error) {
+	if len(last) == 0 {
+		return true, nil
+	}
+
+	if len(partitionBy) == 0 {
+		return false, nil
+	}
+
+	lastExp, _, err := evalExprs(ctx, partitionBy, last)
+	if err != nil {
+		return false, err
+	}
+
+	thisExp, _, err := evalExprs(ctx, partitionBy, row)
+	if err != nil {
+		return false, err
+	}
+
+	for i, expr := range partitionBy {
+		cmp, err := expr.Type().Compare(lastExp[i], thisExp[i])
+		if err != nil {
+			return false, err
+		}
+		return cmp != 0, nil
+	}
+
+	return false, nil
+}

--- a/sql/expression/function/aggregation/window_block_test.go
+++ b/sql/expression/function/aggregation/window_block_test.go
@@ -1,0 +1,154 @@
+// Copyright 2022 DoltHub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+func TestWindowBlockIter(t *testing.T) {
+
+	tests := []struct {
+		Name     string
+		Iter     windowBlockIter
+		Expected []sql.Row
+	}{
+		{
+			Name: "group by",
+			Iter: windowBlockIter{
+				partitionBy: []sql.Expression{
+					expression.NewGetFieldWithTable(1, sql.Text, "a", "x", false),
+				},
+				sortBy: sql.SortFields{
+					{
+						Column: expression.NewGetFieldWithTable(0, sql.Int64, "a", "w", false),
+					},
+				},
+				aggs: []*Aggregation{
+					NewAggregation(
+						NewLastAgg(expression.NewGetField(1, sql.Text, "x", true)),
+						NewGroupByFramer(),
+					),
+					NewAggregation(
+						NewFirstAgg(expression.NewGetField(2, sql.Text, "y", true)),
+						NewGroupByFramer(),
+					),
+					NewAggregation(
+						NewSumAgg(expression.NewGetField(3, sql.Int64, "z", true)),
+						NewGroupByFramer(),
+					),
+				},
+				partitionIdx: -1,
+			},
+			Expected: []sql.Row{
+				{"forest", "leaf", float64(27)},
+				{"desert", "sand", float64(23)},
+			},
+		},
+		{
+			Name: "partition level desc",
+			Iter: windowBlockIter{
+				partitionBy: []sql.Expression{
+					expression.NewGetFieldWithTable(1, sql.Text, "a", "x", false),
+				},
+				sortBy: sql.SortFields{
+					{
+						Column: expression.NewGetFieldWithTable(0, sql.Int64, "a", "w", false),
+						Order:  sql.Descending,
+					},
+				},
+				aggs: []*Aggregation{
+					NewAggregation(
+						NewLastAgg(expression.NewGetField(1, sql.Text, "x", true)),
+						NewPartitionFramer(),
+					),
+					NewAggregation(
+						NewFirstAgg(expression.NewGetField(2, sql.Text, "y", true)),
+						NewPartitionFramer(),
+					),
+					NewAggregation(
+						NewSumAgg(expression.NewGetField(3, sql.Int64, "z", true)),
+						NewPartitionFramer(),
+					),
+				},
+				partitionIdx: -1,
+			},
+			Expected: []sql.Row{
+				{"forest", "wildflower", float64(27)},
+				{"forest", "wildflower", float64(27)},
+				{"forest", "wildflower", float64(27)},
+				{"forest", "wildflower", float64(27)},
+				{"forest", "wildflower", float64(27)},
+				{"desert", "mummy", float64(23)},
+				{"desert", "mummy", float64(23)},
+				{"desert", "mummy", float64(23)},
+				{"desert", "mummy", float64(23)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			ctx := sql.NewEmptyContext()
+			tt.Iter.child = newRowIter(t, ctx)
+			res, err := sql.RowIterToRows(ctx, &tt.Iter)
+			require.NoError(t, err)
+			require.Equal(t, tt.Expected, res)
+		})
+	}
+}
+
+func newRowIter(t *testing.T, ctx *sql.Context) sql.RowIter {
+	childSchema := sql.NewPrimaryKeySchema(sql.Schema{
+		{Name: "w", Type: sql.Int64, Nullable: true},
+		{Name: "x", Type: sql.Text, Nullable: true},
+		{Name: "y", Type: sql.Text, Nullable: true},
+		{Name: "z", Type: sql.Int32, Nullable: true},
+	})
+	table := memory.NewTable("test", childSchema)
+
+	rows := []sql.Row{
+		{int64(1), "forest", "leaf", 4},
+		{int64(2), "forest", "bark", 4},
+		{int64(3), "forest", "canopy", 6},
+		{int64(4), "forest", "bug", 3},
+		{int64(5), "forest", "wildflower", 10},
+		{int64(6), "desert", "sand", 4},
+		{int64(7), "desert", "cactus", 6},
+		{int64(8), "desert", "scorpion", 8},
+		{int64(9), "desert", "mummy", 5},
+	}
+
+	for _, r := range rows {
+		assert.NoError(t, table.Insert(sql.NewEmptyContext(), r))
+	}
+
+	pIter, err := table.Partitions(ctx)
+	require.NoError(t, err)
+
+	p, err := pIter.Next(ctx)
+	require.NoError(t, err)
+
+	child, err := table.PartitionRows(ctx, p)
+	require.NoError(t, err)
+	return child
+}

--- a/sql/expression/function/aggregation/window_framers.go
+++ b/sql/expression/function/aggregation/window_framers.go
@@ -1,0 +1,232 @@
+// Copyright 2022 DoltHub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"errors"
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+var ErrPartitionNotSet = errors.New("attempted to general a window frame interval before framer partition was set")
+
+var _ sql.WindowFramer = (*RowFramer)(nil)
+var _ sql.WindowFramer = (*PartitionFramer)(nil)
+var _ sql.WindowFramer = (*GroupByFramer)(nil)
+
+func NewUnboundedPrecedingToCurrentRowFramer() *RowFramer {
+	return &RowFramer{
+		unboundedPreceding: true,
+		followingOffset:    0,
+		frameEnd:           -1,
+		frameStart:         -1,
+		partitionStart:     -1,
+		partitionEnd:       -1,
+	}
+}
+
+type RowFramer struct {
+	idx                          int
+	partitionStart, partitionEnd int
+	frameStart, frameEnd         int
+	partitionSet                 bool
+
+	followingOffset, precedingOffset       int
+	unboundedPreceding, unboundedFollowing bool
+}
+
+func (f *RowFramer) Close() {
+	panic("implement me")
+}
+
+func (f *RowFramer) NewFramer(interval sql.WindowInterval) sql.WindowFramer {
+	return &RowFramer{
+		idx:            interval.Start,
+		partitionStart: interval.Start,
+		partitionEnd:   interval.End,
+		frameStart:     -1,
+		frameEnd:       -1,
+		partitionSet:   true,
+		// pass through parent state
+		unboundedPreceding: f.unboundedPreceding,
+		unboundedFollowing: f.unboundedFollowing,
+		followingOffset:    f.followingOffset,
+		precedingOffset:    f.precedingOffset,
+	}
+}
+
+func (f *RowFramer) Next() (sql.WindowInterval, error) {
+	if f.idx != 0 && f.idx >= f.partitionEnd || !f.partitionSet {
+		return sql.WindowInterval{}, io.EOF
+	}
+
+	newStart := f.idx - f.precedingOffset
+	if f.unboundedPreceding || newStart < f.partitionStart {
+		newStart = f.partitionStart
+	}
+
+	newEnd := f.idx + f.followingOffset + 1
+	if f.unboundedFollowing || newEnd > f.partitionEnd {
+		newEnd = f.partitionEnd
+	}
+
+	f.frameStart = newStart
+	f.frameEnd = newEnd
+
+	f.idx++
+	return f.Interval()
+}
+
+func (f *RowFramer) FirstIdx() int {
+	return f.frameEnd
+}
+
+func (f *RowFramer) LastIdx() int {
+	return f.frameStart
+}
+
+func (f *RowFramer) Interval() (sql.WindowInterval, error) {
+	if !f.partitionSet {
+		return sql.WindowInterval{}, ErrPartitionNotSet
+	}
+	return sql.WindowInterval{Start: f.frameStart, End: f.frameEnd}, nil
+}
+
+func (f *RowFramer) SlidingInterval(ctx sql.Context) (sql.WindowInterval, sql.WindowInterval, sql.WindowInterval) {
+	panic("implement me")
+}
+
+type PartitionFramer struct {
+	idx                          int
+	partitionStart, partitionEnd int
+
+	followOffset, precOffset int
+	frameStart, frameEnd     int
+	partitionSet             bool
+}
+
+func NewPartitionFramer() *PartitionFramer {
+	return &PartitionFramer{
+		idx:            -1,
+		frameEnd:       -1,
+		frameStart:     -1,
+		partitionStart: -1,
+		partitionEnd:   -1,
+	}
+}
+
+func (f *PartitionFramer) NewFramer(interval sql.WindowInterval) sql.WindowFramer {
+	return &PartitionFramer{
+		idx:            interval.Start,
+		frameEnd:       interval.End,
+		frameStart:     interval.Start,
+		partitionStart: interval.Start,
+		partitionEnd:   interval.End,
+		partitionSet:   true,
+	}
+}
+
+func (f *PartitionFramer) Next() (sql.WindowInterval, error) {
+	if !f.partitionSet {
+		return sql.WindowInterval{}, io.EOF
+	}
+	if f.idx == 0 || (0 < f.idx && f.idx < f.partitionEnd) {
+		f.idx++
+		return f.Interval()
+	}
+	return sql.WindowInterval{}, io.EOF
+}
+
+func (f *PartitionFramer) FirstIdx() int {
+	return f.frameStart
+}
+
+func (f *PartitionFramer) LastIdx() int {
+	return f.frameEnd
+}
+
+func (f *PartitionFramer) Interval() (sql.WindowInterval, error) {
+	if !f.partitionSet {
+		return sql.WindowInterval{}, ErrPartitionNotSet
+	}
+	return sql.WindowInterval{Start: f.frameStart, End: f.frameEnd}, nil
+}
+
+func (f *PartitionFramer) SlidingInterval(ctx sql.Context) (sql.WindowInterval, sql.WindowInterval, sql.WindowInterval) {
+	panic("implement me")
+}
+
+func (f *PartitionFramer) Close() {
+	panic("implement me")
+}
+
+func NewGroupByFramer() *GroupByFramer {
+	return &GroupByFramer{
+		frameEnd:       -1,
+		frameStart:     -1,
+		partitionStart: -1,
+		partitionEnd:   -1,
+	}
+}
+
+type GroupByFramer struct {
+	evaluated                    bool
+	partitionStart, partitionEnd int
+
+	frameStart, frameEnd int
+	partitionSet         bool
+}
+
+func (f *GroupByFramer) NewFramer(interval sql.WindowInterval) sql.WindowFramer {
+	return &GroupByFramer{
+		evaluated:      false,
+		frameEnd:       interval.End,
+		frameStart:     interval.Start,
+		partitionStart: interval.Start,
+		partitionEnd:   interval.End,
+		partitionSet:   true,
+	}
+}
+
+func (f *GroupByFramer) Next() (sql.WindowInterval, error) {
+	if !f.partitionSet {
+		return sql.WindowInterval{}, io.EOF
+	}
+	if !f.evaluated {
+		f.evaluated = true
+		return f.Interval()
+	}
+	return sql.WindowInterval{}, io.EOF
+}
+
+func (f *GroupByFramer) FirstIdx() int {
+	return f.frameStart
+}
+
+func (f *GroupByFramer) LastIdx() int {
+	return f.frameEnd
+}
+
+func (f *GroupByFramer) Interval() (sql.WindowInterval, error) {
+	if !f.partitionSet {
+		return sql.WindowInterval{}, ErrPartitionNotSet
+	}
+	return sql.WindowInterval{Start: f.frameStart, End: f.frameEnd}, nil
+}
+
+func (f *GroupByFramer) SlidingInterval(ctx sql.Context) (sql.WindowInterval, sql.WindowInterval, sql.WindowInterval) {
+	panic("implement me")
+}

--- a/sql/expression/function/aggregation/window_framers_test.go
+++ b/sql/expression/function/aggregation/window_framers_test.go
@@ -1,0 +1,105 @@
+// Copyright 2022 DoltHub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+func TestWindowFramers(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Framer   sql.WindowFramer
+		Expected []sql.WindowInterval
+	}{
+		{
+			Name:   "partition framer",
+			Framer: NewPartitionFramer(),
+			Expected: []sql.WindowInterval{
+				{},
+				{End: 2},
+				{End: 2},
+				{Start: 2, End: 6},
+				{Start: 2, End: 6},
+				{Start: 2, End: 6},
+				{Start: 2, End: 6},
+				{Start: 6, End: 9},
+				{Start: 6, End: 9},
+				{Start: 6, End: 9},
+			},
+		},
+		{
+			Name:   "group by framer",
+			Framer: NewGroupByFramer(),
+			Expected: []sql.WindowInterval{
+				{},
+				{End: 2},
+				{Start: 2, End: 6},
+				{Start: 6, End: 9},
+			},
+		},
+		{
+			Name:   "rows unbounded preceeding to current row framer",
+			Framer: NewUnboundedPrecedingToCurrentRowFramer(),
+			Expected: []sql.WindowInterval{
+				{},
+				{Start: 0, End: 1},
+				{Start: 0, End: 2},
+				{Start: 2, End: 3},
+				{Start: 2, End: 4},
+				{Start: 2, End: 5},
+				{Start: 2, End: 6},
+				{Start: 6, End: 7},
+				{Start: 6, End: 8},
+				{Start: 6, End: 9},
+			},
+		},
+	}
+
+	partitions := []sql.WindowInterval{
+		{}, // check nil row behavior, wouldn't happen normally
+		{Start: 0, End: 2},
+		{Start: 2, End: 6},
+		{Start: 6, End: 9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			_, err := tt.Framer.Interval()
+			require.Error(t, err)
+			require.Equal(t, err, ErrPartitionNotSet)
+
+			var res []sql.WindowInterval
+			var frame sql.WindowInterval
+			for _, p := range partitions {
+				tt.Framer = tt.Framer.NewFramer(p)
+				for {
+					frame, err = tt.Framer.Next()
+					if errors.Is(err, io.EOF) {
+						break
+					}
+					res = append(res, frame)
+				}
+			}
+			require.Equal(t, tt.Expected, res)
+		})
+	}
+}

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -1,0 +1,658 @@
+// Copyright 2022 DoltHub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+var _ sql.WindowFunction = (*SumAgg)(nil)
+var _ sql.WindowFunction = (*MaxAgg)(nil)
+var _ sql.WindowFunction = (*MinAgg)(nil)
+var _ sql.WindowFunction = (*AvgAgg)(nil)
+var _ sql.WindowFunction = (*LastAgg)(nil)
+var _ sql.WindowFunction = (*FirstAgg)(nil)
+var _ sql.WindowFunction = (*CountAgg)(nil)
+var _ sql.WindowFunction = (*GroupConcatAgg)(nil)
+var _ sql.WindowFunction = (*WindowedJSONArrayAgg)(nil)
+var _ sql.WindowFunction = (*WindowedJSONObjectAgg)(nil)
+
+var _ sql.Disposable = (*SumAgg)(nil)
+
+type SumAgg struct {
+	partitionStart, partitionEnd int
+	expr                         sql.Expression
+
+	// use prefix sums to quickly calculate arbitrary frame sum within partition
+	prefixSum []float64
+}
+
+func NewSumAgg(e sql.Expression) *SumAgg {
+	return &SumAgg{
+		partitionStart: -1,
+		partitionEnd:   -1,
+		expr:           e,
+	}
+}
+
+func (a *SumAgg) Dispose() {
+	expression.Dispose(a.expr)
+}
+
+func (a *SumAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	a.partitionStart, a.partitionEnd = interval.Start, interval.End
+	a.Dispose()
+	var err error
+	a.prefixSum, _, err = floatPrefixSum(ctx, interval, buf, a.expr)
+	return err
+}
+
+func (a *SumAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *SumAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) interface{} {
+	if interval.End-interval.Start < 1 {
+		return nil
+	}
+	return computePrefixSum(interval, a.partitionStart, a.prefixSum)
+}
+
+func floatPrefixSum(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer, e sql.Expression) ([]float64, []int, error) {
+	intervalLen := interval.End - interval.Start
+	sums := make([]float64, intervalLen)
+	nulls := make([]int, intervalLen)
+	var last float64
+	var nullCnt int
+	for i := 0; i < intervalLen; i++ {
+		v, err := e.Eval(ctx, buf[interval.Start+i])
+		if err != nil {
+			continue
+		}
+		val, err := sql.Float64.Convert(v)
+		if err != nil || val == nil {
+			val = float64(0)
+			nullCnt += 1
+		}
+		last += val.(float64)
+		sums[i] = last
+		nulls[i] = nullCnt
+	}
+	return sums, nulls, nil
+}
+
+func computePrefixSum(interval sql.WindowInterval, partitionStart int, prefixSum []float64) float64 {
+	startIdx := interval.Start - partitionStart - 1
+	endIdx := interval.End - partitionStart - 1
+
+	var sum float64
+	if endIdx >= 0 {
+		sum = prefixSum[endIdx]
+	}
+	if startIdx >= 0 {
+		sum -= prefixSum[startIdx]
+	}
+	return sum
+}
+
+type AvgAgg struct {
+	partitionStart, partitionEnd int
+	expr                         sql.Expression
+
+	// use prefix sums to quickly calculate arbitrary frame sum within partition
+	prefixSum []float64
+	// exclude nulls in average denominator
+	nullCnt []int
+}
+
+func NewAvgAgg(e sql.Expression) *AvgAgg {
+	return &AvgAgg{
+		expr: e,
+	}
+}
+
+func (a *AvgAgg) Dispose() {
+	expression.Dispose(a.expr)
+}
+
+func (a *AvgAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	a.Dispose()
+	a.partitionStart = interval.Start
+	a.partitionEnd = interval.End
+	var err error
+	a.prefixSum, a.nullCnt, err = floatPrefixSum(ctx, interval, buf, a.expr)
+	return err
+}
+
+func (a *AvgAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *AvgAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) interface{} {
+	startIdx := interval.Start - a.partitionStart - 1
+	endIdx := interval.End - a.partitionStart - 1
+
+	var nonNullCnt int
+	if endIdx >= 0 {
+		nonNullCnt += endIdx + 1
+		nonNullCnt -= a.nullCnt[endIdx]
+	}
+	if startIdx >= 0 {
+		nonNullCnt -= startIdx + 1
+		nonNullCnt += a.nullCnt[startIdx]
+	}
+	return computePrefixSum(interval, a.partitionStart, a.prefixSum) / float64(nonNullCnt)
+}
+
+type MaxAgg struct {
+	expr sql.Expression
+}
+
+func NewMaxAgg(e sql.Expression) *MaxAgg {
+	return &MaxAgg{
+		expr: e,
+	}
+}
+
+func (a *MaxAgg) Dispose() {
+	expression.Dispose(a.expr)
+}
+
+func (a *MaxAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
+	a.Dispose()
+	return nil
+}
+
+func (a *MaxAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *MaxAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) interface{} {
+	var max interface{}
+	for i := interval.Start; i < interval.End; i++ {
+		row := buffer[i]
+		v, err := a.expr.Eval(ctx, row)
+		if err != nil {
+			return err
+		}
+
+		if v == nil {
+			continue
+		}
+
+		if max == nil {
+			max = v
+		}
+
+		cmp, err := a.expr.Type().Compare(v, max)
+		if err != nil {
+			return err
+		}
+		if cmp == 1 {
+			max = v
+		}
+	}
+	return max
+}
+
+type MinAgg struct {
+	expr sql.Expression
+}
+
+func NewMinAgg(e sql.Expression) *MinAgg {
+	return &MinAgg{
+		expr: e,
+	}
+}
+
+func (a *MinAgg) Dispose() {
+	expression.Dispose(a.expr)
+}
+
+func (a *MinAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
+	a.Dispose()
+	return nil
+}
+
+func (a *MinAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *MinAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) interface{} {
+	var min interface{}
+	for _, row := range buf[interval.Start:interval.End] {
+		v, err := a.expr.Eval(ctx, row)
+		if err != nil {
+			return err
+		}
+
+		if v == nil {
+			continue
+		}
+
+		if min == nil {
+			min = v
+			continue
+		}
+
+		cmp, err := a.expr.Type().Compare(v, min)
+		if err != nil {
+			return err
+		}
+		if cmp == -1 {
+			min = v
+		}
+	}
+	return min
+}
+
+type LastAgg struct {
+	expr sql.Expression
+}
+
+func NewLastAgg(e sql.Expression) *LastAgg {
+	return &LastAgg{
+		expr: e,
+	}
+}
+
+func (a *LastAgg) Dispose() {
+	expression.Dispose(a.expr)
+}
+
+func (a *LastAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
+	a.Dispose()
+	return nil
+}
+
+func (a *LastAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *LastAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) interface{} {
+	if interval.End-interval.Start < 1 {
+		return nil
+	}
+	row := buffer[interval.End-1]
+	v, err := a.expr.Eval(ctx, row)
+	if err != nil {
+		return err
+	}
+	return v
+}
+
+type FirstAgg struct {
+	partitionStart, partitionEnd int
+	expr                         sql.Expression
+}
+
+func NewFirstAgg(e sql.Expression) *FirstAgg {
+	return &FirstAgg{
+		expr: e,
+	}
+}
+
+func (a *FirstAgg) Dispose() {
+	expression.Dispose(a.expr)
+}
+
+func (a *FirstAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) error {
+	a.Dispose()
+	a.partitionStart, a.partitionEnd = interval.Start, interval.End
+	return nil
+}
+
+func (a *FirstAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *FirstAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buffer sql.WindowBuffer) interface{} {
+	if interval.End-interval.Start < 1 {
+		return nil
+	}
+	row := buffer[interval.Start]
+	v, err := a.expr.Eval(ctx, row)
+	if err != nil {
+		return err
+	}
+	return v
+}
+
+type CountAgg struct {
+	partitionStart, partitionEnd int
+	expr                         sql.Expression
+
+	// use prefix sums to quickly calculate arbitrary a frame's row cnt within partition
+	prefixSum []float64
+}
+
+func NewCountAgg(e sql.Expression) *CountAgg {
+	return &CountAgg{
+		partitionStart: -1,
+		partitionEnd:   -1,
+		expr:           e,
+	}
+}
+
+func (a *CountAgg) Dispose() {
+	expression.Dispose(a.expr)
+}
+
+func (a *CountAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	a.Dispose()
+	a.partitionStart, a.partitionEnd = interval.Start, interval.End
+	var err error
+	a.prefixSum, err = countPrefixSum(ctx, interval, buf, a.expr)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a *CountAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *CountAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) interface{} {
+	return int64(computePrefixSum(interval, a.partitionStart, a.prefixSum))
+}
+
+func countPrefixSum(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer, expr sql.Expression) ([]float64, error) {
+	intervalLen := interval.End - interval.Start
+	sums := make([]float64, intervalLen)
+	var last float64
+	for i := 0; i < intervalLen; i++ {
+		row := buf[interval.Start+i]
+		var inc bool
+		if _, ok := expr.(*expression.Star); ok {
+			inc = true
+		} else {
+			v, err := expr.Eval(ctx, row)
+			if v != nil {
+				inc = true
+			}
+
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if inc {
+			last += 1
+		}
+		sums[i] = last
+	}
+	return sums, nil
+}
+
+type GroupConcatAgg struct {
+	gc *GroupConcat
+	// hash map to deduplicate values
+	// TODO make this more efficient, ideally with sliding window and hashes
+	distinct map[string]struct{}
+	// original row order used for optional result sorting
+	rows []sql.Row
+}
+
+func NewGroupConcatAgg(gc *GroupConcat) *GroupConcatAgg {
+	return &GroupConcatAgg{
+		gc: gc,
+	}
+}
+
+func (a *GroupConcatAgg) Dispose() {
+	expression.Dispose(a.gc)
+}
+
+func (a *GroupConcatAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	a.Dispose()
+	var err error
+	a.rows, a.distinct, err = a.filterToDistinct(ctx, buf[interval.Start:interval.End])
+	return err
+}
+
+func (a *GroupConcatAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *GroupConcatAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) interface{} {
+	rows := a.rows
+
+	if len(rows) == 0 {
+		return nil
+	}
+
+	// Execute the order operation if it exists.
+	if a.gc.sf != nil {
+		sorter := &expression.Sorter{
+			SortFields: a.gc.sf,
+			Rows:       rows,
+			Ctx:        ctx,
+		}
+
+		sort.Stable(sorter)
+		if sorter.LastError != nil {
+			return nil
+		}
+	}
+
+	sb := strings.Builder{}
+	for i, row := range rows {
+		lastIdx := len(row) - 1
+		if i == 0 {
+			sb.WriteString(row[lastIdx].(string))
+		} else {
+			sb.WriteString(a.gc.separator)
+			sb.WriteString(row[lastIdx].(string))
+		}
+
+		// Don't allow the string to cross maxlen
+		if sb.Len() >= a.gc.maxLen {
+			break
+		}
+	}
+
+	ret := sb.String()
+
+	// There might be a couple of character differences even if we broke early in the loop
+	if len(ret) > a.gc.maxLen {
+		ret = ret[:a.gc.maxLen]
+	}
+
+	// Add this to handle any one off errors.
+	return ret
+}
+
+func (a *GroupConcatAgg) filterToDistinct(ctx *sql.Context, buf sql.WindowBuffer) ([]sql.Row, map[string]struct{}, error) {
+	rows := make([]sql.Row, 0)
+	distinct := make(map[string]struct{}, 0)
+	for _, row := range buf {
+		evalRow, retType, err := evalExprs(ctx, a.gc.selectExprs, row)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		a.gc.returnType = retType
+
+		// Skip if this is a null row
+		if evalRow == nil {
+			continue
+		}
+
+		var v interface{}
+		if retType == sql.Blob {
+			v, err = sql.Blob.Convert(evalRow[0])
+		} else {
+			v, err = sql.LongText.Convert(evalRow[0])
+		}
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if v == nil {
+			continue
+		}
+
+		vs := v.(string)
+
+		// Get the current array of rows and the map
+		// Check if distinct is active if so look at and update our map
+		if a.gc.distinct != "" {
+			// If this value exists go ahead and return nil
+			if _, ok := distinct[vs]; ok {
+				continue
+			} else {
+				distinct[vs] = struct{}{}
+			}
+		}
+
+		// Append the current value to the end of the row. We want to preserve the row's original structure for
+		// for sort ordering in the final step.
+		rows = append(rows, append(row, nil, vs))
+	}
+	return rows, distinct, nil
+}
+
+type WindowedJSONArrayAgg struct {
+	j *JSONArrayAgg
+}
+
+func NewJSONArrayAgg2(j *JSONArrayAgg) *WindowedJSONArrayAgg {
+	return &WindowedJSONArrayAgg{
+		j: j,
+	}
+}
+
+func (a *WindowedJSONArrayAgg) Dispose() {
+	expression.Dispose(a.j)
+}
+
+func (a *WindowedJSONArrayAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	a.Dispose()
+	return nil
+}
+
+func (a *WindowedJSONArrayAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *WindowedJSONArrayAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) interface{} {
+	res, err := a.aggregateVals(ctx, interval, buf)
+	if err != nil {
+		return nil
+	}
+	return sql.JSONDocument{Val: res}
+}
+
+func (a *WindowedJSONArrayAgg) aggregateVals(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) ([]interface{}, error) {
+	vals := make([]interface{}, 0, interval.End-interval.Start)
+	for _, row := range buf[interval.Start:interval.End] {
+		v, err := a.j.Child.Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+
+		// unwrap JSON values
+		if js, ok := v.(sql.JSONValue); ok {
+			doc, err := js.Unmarshall(ctx)
+			if err != nil {
+				return nil, err
+			}
+			v = doc.Val
+		}
+
+		vals = append(vals, v)
+	}
+
+	return vals, nil
+}
+
+type WindowedJSONObjectAgg struct {
+	j *JSONObjectAgg
+	// we need to eval the partition before Compute to return nil key errors
+	vals map[string]interface{}
+}
+
+func NewJSONObjectAgg2(j *JSONObjectAgg) *WindowedJSONObjectAgg {
+	return &WindowedJSONObjectAgg{
+		j: j,
+	}
+}
+
+func (a *WindowedJSONObjectAgg) Dispose() {
+	expression.Dispose(a.j)
+}
+
+func (a *WindowedJSONObjectAgg) StartPartition(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) error {
+	a.Dispose()
+	var err error
+	a.vals, err = a.aggregateVals(ctx, interval, buf)
+	return err
+}
+
+func (a *WindowedJSONObjectAgg) NewSlidingFrameInterval(added, dropped sql.WindowInterval) {
+	panic("sliding window interface not implemented yet")
+}
+
+func (a *WindowedJSONObjectAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) interface{} {
+	if len(a.vals) == 0 {
+		return nil
+	}
+	return sql.JSONDocument{Val: a.vals}
+}
+
+func (a *WindowedJSONObjectAgg) aggregateVals(ctx *sql.Context, interval sql.WindowInterval, buf sql.WindowBuffer) (map[string]interface{}, error) {
+	vals := make(map[string]interface{}, 0)
+	for _, row := range buf[interval.Start:interval.End] {
+		key, err := a.j.key.Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+
+		// An error occurs if any key name is NULL
+		if key == nil {
+			return nil, sql.ErrJSONObjectAggNullKey.New()
+		}
+
+		val, err := a.j.value.Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+
+		// unwrap JSON values
+		if js, ok := val.(sql.JSONValue); ok {
+			doc, err := js.Unmarshall(ctx)
+			if err != nil {
+				return nil, err
+			}
+			val = doc.Val
+		}
+
+		// Update the map.
+		keyAsString, err := sql.LongText.Convert(key)
+		if err != nil {
+			continue
+		}
+		vals[keyAsString.(string)] = val
+
+	}
+
+	return vals, nil
+}

--- a/sql/expression/function/aggregation/window_functions_test.go
+++ b/sql/expression/function/aggregation/window_functions_test.go
@@ -1,0 +1,267 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+func TestAggFuncs(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Agg      sql.WindowFunction
+		Expected sql.Row
+	}{
+		{
+			Name:     "count star",
+			Agg:      NewCountAgg(expression.NewStar()),
+			Expected: sql.Row{int64(4), int64(4), int64(6)},
+		},
+		{
+			Name:     "count without nulls",
+			Agg:      NewCountAgg(expression.NewGetField(1, sql.LongText, "x", true)),
+			Expected: sql.Row{int64(4), int64(4), int64(6)},
+		},
+		{
+			Name:     "count with nulls",
+			Agg:      NewCountAgg(expression.NewGetField(0, sql.LongText, "x", true)),
+			Expected: sql.Row{int64(3), int64(3), int64(4)},
+		},
+		{
+			Name:     "max ints",
+			Agg:      NewMaxAgg(expression.NewGetField(1, sql.LongText, "x", true)),
+			Expected: sql.Row{4, 4, 6},
+		},
+		{
+			Name:     "max int64",
+			Agg:      NewMaxAgg(expression.NewGetField(2, sql.LongText, "x", true)),
+			Expected: sql.Row{int64(3), int64(3), int64(5)},
+		},
+		{
+			Name:     "max w/ nulls",
+			Agg:      NewMaxAgg(expression.NewGetField(0, sql.LongText, "x", true)),
+			Expected: sql.Row{4, 4, 6},
+		},
+		{
+			Name:     "max w/ float",
+			Agg:      NewMaxAgg(expression.NewGetField(3, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(4), float64(4), float64(6)},
+		},
+		{
+			Name:     "min ints",
+			Agg:      NewMinAgg(expression.NewGetField(1, sql.LongText, "x", true)),
+			Expected: sql.Row{1, 1, 1},
+		},
+		{
+			Name:     "min int64",
+			Agg:      NewMinAgg(expression.NewGetField(2, sql.LongText, "x", true)),
+			Expected: sql.Row{int64(1), int64(1), int64(1)},
+		},
+		{
+			Name:     "min w/ nulls",
+			Agg:      NewMinAgg(expression.NewGetField(0, sql.LongText, "x", true)),
+			Expected: sql.Row{1, 1, 1},
+		},
+		{
+			Name:     "min w/ float",
+			Agg:      NewMinAgg(expression.NewGetField(3, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(1), float64(1), float64(1)},
+		},
+		{
+			Name:     "avg nulls",
+			Agg:      NewAvgAgg(expression.NewGetField(0, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(8) / float64(3), float64(8) / float64(3), float64(14) / float64(4)},
+		},
+		{
+			Name:     "avg int",
+			Agg:      NewAvgAgg(expression.NewGetField(1, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(10) / float64(4), float64(10) / float64(4), float64(21) / float64(6)},
+		},
+		{
+			Name:     "avg int64",
+			Agg:      NewAvgAgg(expression.NewGetField(2, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(8) / float64(4), float64(8) / float64(4), float64(17) / float64(6)},
+		},
+		{
+			Name:     "avg float",
+			Agg:      NewAvgAgg(expression.NewGetField(3, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(10) / float64(4), float64(10) / float64(4), float64(21) / float64(6)},
+		},
+		{
+			Name:     "sum nulls",
+			Agg:      NewSumAgg(expression.NewGetField(0, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(8), float64(8), float64(14)},
+		},
+		{
+			Name:     "sum ints",
+			Agg:      NewSumAgg(expression.NewGetField(1, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(10), float64(10), float64(21)},
+		},
+		{
+			Name:     "sum int64",
+			Agg:      NewSumAgg(expression.NewGetField(2, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(8), float64(8), float64(17)},
+		},
+		{
+			Name:     "sum float64",
+			Agg:      NewSumAgg(expression.NewGetField(3, sql.LongText, "x", true)),
+			Expected: sql.Row{float64(10), float64(10), float64(21)},
+		},
+		{
+			Name:     "first",
+			Agg:      NewFirstAgg(expression.NewGetField(0, sql.LongText, "x", true)),
+			Expected: sql.Row{1, 1, 1},
+		},
+		{
+			Name:     "last",
+			Agg:      NewLastAgg(expression.NewGetField(0, sql.LongText, "x", true)),
+			Expected: sql.Row{4, 4, 6},
+		},
+		// list aggregations
+		{
+			Name:     "group concat null",
+			Agg:      NewGroupConcatAgg(mustNewGroupByConcat("", nil, ",", []sql.Expression{expression.NewGetField(0, sql.LongText, "x", true)}, 1042)),
+			Expected: sql.Row{"1,3,4", "1,3,4", "1,2,5,6"},
+		},
+		{
+			Name:     "group concat int",
+			Agg:      NewGroupConcatAgg(mustNewGroupByConcat("", nil, ",", []sql.Expression{expression.NewGetField(1, sql.LongText, "x", true)}, 1042)),
+			Expected: sql.Row{"1,2,3,4", "1,2,3,4", "1,2,3,4,5,6"},
+		},
+		{
+			Name:     "group concat float",
+			Agg:      NewGroupConcatAgg(mustNewGroupByConcat("", nil, ",", []sql.Expression{expression.NewGetField(3, sql.LongText, "x", true)}, 1042)),
+			Expected: sql.Row{"1,2,3,4", "1,2,3,4", "1,2,3,4,5,6"},
+		},
+		{
+			Name: "json array null",
+			Agg:  NewJSONArrayAgg2(NewJSONArrayAgg(expression.NewGetField(0, sql.LongText, "x", true))),
+			Expected: sql.Row{
+				sql.JSONDocument{Val: []interface{}{1, nil, 3, 4}},
+				sql.JSONDocument{Val: []interface{}{1, nil, 3, 4}},
+				sql.JSONDocument{Val: []interface{}{1, 2, nil, nil, 5, 6}},
+			},
+		},
+		{
+			Name: "json array int",
+			Agg:  NewJSONArrayAgg2(NewJSONArrayAgg(expression.NewGetField(1, sql.LongText, "x", true))),
+			Expected: sql.Row{
+				sql.JSONDocument{Val: []interface{}{1, 2, 3, 4}},
+				sql.JSONDocument{Val: []interface{}{1, 2, 3, 4}},
+				sql.JSONDocument{Val: []interface{}{1, 2, 3, 4, 5, 6}},
+			},
+		},
+		{
+			Name: "json array float",
+			Agg:  NewJSONArrayAgg2(NewJSONArrayAgg(expression.NewGetField(3, sql.LongText, "x", true))),
+			Expected: sql.Row{
+				sql.JSONDocument{Val: []interface{}{float64(1), float64(2), float64(3), float64(4)}},
+				sql.JSONDocument{Val: []interface{}{float64(1), float64(2), float64(3), float64(4)}},
+				sql.JSONDocument{Val: []interface{}{float64(1), float64(2), float64(3), float64(4), float64(5), float64(6)}},
+			},
+		},
+		{
+			Name: "json object null",
+			Agg: NewJSONObjectAgg2(
+				NewJSONObjectAgg(
+					expression.NewGetField(1, sql.LongText, "x", true),
+					expression.NewGetField(0, sql.LongText, "y", true),
+				).(*JSONObjectAgg),
+			),
+			Expected: sql.Row{
+				sql.JSONDocument{Val: map[string]interface{}{"1": 1, "2": nil, "3": 3, "4": 4}},
+				sql.JSONDocument{Val: map[string]interface{}{"1": 1, "2": nil, "3": 3, "4": 4}},
+				sql.JSONDocument{Val: map[string]interface{}{"1": 1, "2": 2, "3": nil, "4": nil, "5": 5, "6": 6}},
+			},
+		},
+		{
+			Name: "json object int",
+			Agg: NewJSONObjectAgg2(
+				NewJSONObjectAgg(
+					expression.NewGetField(1, sql.LongText, "x", true),
+					expression.NewGetField(0, sql.LongText, "x", true),
+				).(*JSONObjectAgg),
+			),
+			Expected: sql.Row{
+				sql.JSONDocument{Val: map[string]interface{}{"1": 1, "2": nil, "3": 3, "4": 4}},
+				sql.JSONDocument{Val: map[string]interface{}{"1": 1, "2": nil, "3": 3, "4": 4}},
+				sql.JSONDocument{Val: map[string]interface{}{"1": 1, "2": 2, "3": nil, "4": nil, "5": 5, "6": 6}},
+			},
+		},
+		{
+			Name: "json object float",
+			Agg: NewJSONObjectAgg2(
+				NewJSONObjectAgg(
+					expression.NewGetField(1, sql.LongText, "x", true),
+					expression.NewGetField(3, sql.LongText, "x", true),
+				).(*JSONObjectAgg),
+			),
+			Expected: sql.Row{
+				sql.JSONDocument{Val: map[string]interface{}{"1": float64(1), "2": float64(2), "3": float64(3), "4": float64(4)}},
+				sql.JSONDocument{Val: map[string]interface{}{"1": float64(1), "2": float64(2), "3": float64(3), "4": float64(4)}},
+				sql.JSONDocument{Val: map[string]interface{}{"1": float64(1), "2": float64(2), "3": float64(3), "4": float64(4), "5": float64(5), "6": float64(6)}},
+			},
+		},
+	}
+
+	buf := []sql.Row{
+		{1, 1, int64(1), float64(1), 1},
+		{nil, 2, int64(2), float64(2), 1},
+		{3, 3, int64(3), float64(3), 1},
+		{4, 4, int64(2), float64(4), 1},
+		{1, 1, int64(1), float64(1), 2},
+		{nil, 2, int64(2), float64(2), 2},
+		{3, 3, int64(3), float64(3), 2},
+		{4, 4, int64(2), float64(4), 2},
+		{1, 1, int64(1), float64(1), 3},
+		{2, 2, int64(2), float64(2), 3},
+		{nil, 3, int64(3), float64(3), 3},
+		{nil, 4, int64(4), float64(4), 3},
+		{5, 5, int64(5), float64(5), 3},
+		{6, 6, int64(2), float64(6), 3},
+	}
+
+	partitions := []sql.WindowInterval{
+		{Start: 0, End: 4},
+		{Start: 4, End: 8},
+		{Start: 8, End: 14},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			ctx := sql.NewEmptyContext()
+			res := make(sql.Row, len(partitions))
+			for i, p := range partitions {
+				err := tt.Agg.StartPartition(ctx, p, buf)
+				require.NoError(t, err)
+				res[i] = tt.Agg.Compute(ctx, p, buf)
+			}
+			require.Equal(t, tt.Expected, res)
+		})
+	}
+}
+
+func mustNewGroupByConcat(distinct string, orderBy sql.SortFields, separator string, selectExprs []sql.Expression, maxLen int) *GroupConcat {
+	gc, err := NewGroupConcat(distinct, orderBy, separator, selectExprs, maxLen)
+	if err != nil {
+		panic(err)
+	}
+	return gc
+}

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -16,10 +16,8 @@ package plan
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
-	"github.com/cespare/xxhash"
 	opentracing "github.com/opentracing/opentracing-go"
 	errors "gopkg.in/src-d/go-errors.v1"
 
@@ -97,12 +95,24 @@ func (g *GroupBy) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 		return nil, err
 	}
 
-	var iter sql.RowIter
-	if len(g.GroupByExprs) == 0 {
-		iter = newGroupByIter(g.SelectedExprs, i)
-	} else {
-		iter = newGroupByGroupingIter(ctx, g.SelectedExprs, g.GroupByExprs, i)
+	aggs := make([]*aggregation.Aggregation, len(g.SelectedExprs))
+	for i, e := range g.SelectedExprs {
+		switch a := e.(type) {
+		case sql.WindowAdaptableExpression:
+			fn, err := a.NewWindowFunction()
+			if err != nil {
+				return nil, err
+			}
+			aggs[i] = aggregation.NewAggregation(fn, aggregation.NewGroupByFramer())
+		default:
+			fn, err := aggregation.NewLast(a).NewWindowFunction()
+			if err != nil {
+				return nil, err
+			}
+			aggs[i] = aggregation.NewAggregation(fn, aggregation.NewGroupByFramer())
+		}
 	}
+	iter := aggregation.NewWindowBlockIter(g.GroupByExprs, nil, aggs, i)
 
 	return sql.NewSpanIter(span, iter), nil
 }
@@ -182,247 +192,4 @@ func (g *GroupBy) Expressions() []sql.Expression {
 	exprs = append(exprs, g.SelectedExprs...)
 	exprs = append(exprs, g.GroupByExprs...)
 	return exprs
-}
-
-type groupByIter struct {
-	selectedExprs []sql.Expression
-	child         sql.RowIter
-	ctx           *sql.Context
-	buf           []sql.AggregationBuffer
-	done          bool
-}
-
-func newGroupByIter(selectedExprs []sql.Expression, child sql.RowIter) *groupByIter {
-	return &groupByIter{
-		selectedExprs: selectedExprs,
-		child:         child,
-		buf:           make([]sql.AggregationBuffer, len(selectedExprs)),
-	}
-}
-
-func (i *groupByIter) Next(ctx *sql.Context) (sql.Row, error) {
-	if i.done {
-		return nil, io.EOF
-	}
-
-	i.done = true
-
-	var err error
-	for j, a := range i.selectedExprs {
-		i.buf[j], err = newAggregationBuffer(a)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for {
-		row, err := i.child.Next(ctx)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, err
-		}
-
-		if err := updateBuffers(ctx, i.buf, row); err != nil {
-			return nil, err
-		}
-	}
-
-	return evalBuffers(ctx, i.buf)
-}
-
-func (i *groupByIter) Close(ctx *sql.Context) error {
-	i.Dispose()
-	i.buf = nil
-	return i.child.Close(ctx)
-}
-
-func (i *groupByIter) Dispose() {
-	for _, b := range i.buf {
-		b.Dispose()
-	}
-}
-
-type groupByGroupingIter struct {
-	selectedExprs []sql.Expression
-	groupByExprs  []sql.Expression
-	aggregations  sql.KeyValueCache
-	keys          []uint64
-	pos           int
-	child         sql.RowIter
-	dispose       sql.DisposeFunc
-}
-
-func newGroupByGroupingIter(
-	ctx *sql.Context,
-	selectedExprs, groupByExprs []sql.Expression,
-	child sql.RowIter,
-) *groupByGroupingIter {
-	return &groupByGroupingIter{
-		selectedExprs: selectedExprs,
-		groupByExprs:  groupByExprs,
-		child:         child,
-	}
-}
-
-func (i *groupByGroupingIter) Next(ctx *sql.Context) (sql.Row, error) {
-	if i.aggregations == nil {
-		i.aggregations, i.dispose = ctx.Memory.NewHistoryCache()
-		if err := i.compute(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	if i.pos >= len(i.keys) {
-		return nil, io.EOF
-	}
-
-	buffers, err := i.get(i.keys[i.pos])
-	if err != nil {
-		return nil, err
-	}
-	i.pos++
-	return evalBuffers(ctx, buffers)
-}
-
-func (i *groupByGroupingIter) compute(ctx *sql.Context) error {
-	for {
-		row, err := i.child.Next(ctx)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return err
-		}
-
-		key, err := groupingKey(ctx, i.groupByExprs, row)
-		if err != nil {
-			return err
-		}
-
-		b, err := i.get(key)
-		if sql.ErrKeyNotFound.Is(err) {
-			b = make([]sql.AggregationBuffer, len(i.selectedExprs))
-			for j, a := range i.selectedExprs {
-				b[j], err = newAggregationBuffer(a)
-				if err != nil {
-					return err
-				}
-			}
-
-			if err := i.aggregations.Put(key, b); err != nil {
-				return err
-			}
-
-			i.keys = append(i.keys, key)
-		} else if err != nil {
-			return err
-		}
-
-		err = updateBuffers(ctx, b, row)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (i *groupByGroupingIter) get(key uint64) ([]sql.AggregationBuffer, error) {
-	v, err := i.aggregations.Get(key)
-	if err != nil {
-		return nil, err
-	}
-	if v == nil {
-		return nil, nil
-	}
-	return v.([]sql.AggregationBuffer), err
-}
-
-func (i *groupByGroupingIter) put(key uint64, val []sql.AggregationBuffer) error {
-	return i.aggregations.Put(key, val)
-}
-
-func (i *groupByGroupingIter) Close(ctx *sql.Context) error {
-	i.Dispose()
-	i.aggregations = nil
-	if i.dispose != nil {
-		i.dispose()
-		i.dispose = nil
-	}
-
-	return i.child.Close(ctx)
-}
-
-func (i *groupByGroupingIter) Dispose() {
-	for _, k := range i.keys {
-		bs, _ := i.get(k)
-		if bs != nil {
-			for _, b := range bs {
-				b.Dispose()
-			}
-		}
-	}
-}
-
-func groupingKey(
-	ctx *sql.Context,
-	exprs []sql.Expression,
-	row sql.Row,
-) (uint64, error) {
-	hash := xxhash.New()
-	for _, expr := range exprs {
-		v, err := expr.Eval(ctx, row)
-		if err != nil {
-			return 0, err
-		}
-		_, err = hash.Write(([]byte)(fmt.Sprintf("%#v,", v)))
-		if err != nil {
-			return 0, err
-		}
-	}
-
-	return hash.Sum64(), nil
-}
-
-func newAggregationBuffer(expr sql.Expression) (sql.AggregationBuffer, error) {
-	switch n := expr.(type) {
-	case sql.Aggregation:
-		return n.NewBuffer()
-	default:
-		// The semantics for a non-aggregation in a group by node is Last.
-		return aggregation.NewLast(expr).NewBuffer()
-	}
-}
-
-func updateBuffers(
-	ctx *sql.Context,
-	buffers []sql.AggregationBuffer,
-	row sql.Row,
-) error {
-	for _, b := range buffers {
-		if err := b.Update(ctx, row); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func evalBuffers(
-	ctx *sql.Context,
-	buffers []sql.AggregationBuffer,
-) (sql.Row, error) {
-	var row = make(sql.Row, len(buffers))
-
-	var err error
-	for i, b := range buffers {
-		row[i], err = b.Eval(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return row, nil
 }

--- a/sql/plan/group_by_test.go
+++ b/sql/plan/group_by_test.go
@@ -111,17 +111,6 @@ func TestGroupByRowIter(t *testing.T) {
 	require.Equal(sql.NewRow("col1_2", int64(4444)), rows[1])
 }
 
-func TestGroupByEvalEmptyBuffer(t *testing.T) {
-	require := require.New(t)
-	ctx := sql.NewEmptyContext()
-
-	b, err := newAggregationBuffer(expression.NewGetField(0, sql.LongText, "col1", true))
-	require.NoError(err)
-	r, err := b.Eval(ctx)
-	require.NoError(err)
-	require.Nil(r)
-}
-
 func TestGroupByAggregationGrouping(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()


### PR DESCRIPTION
This PR adds:
- design for window framing
- new agg functions for window frames
- `GroupBy` refactor using framing (frame = partition)

`Aggregations` will have two execution paths while I am swapping out the `Window` execution layer:
- In `GroupBy` node, agg functions will use window frame setup
- In `Window` nodes, agg functions will continue to use `AggregationBuffer`

Other:
- The `aggregation` package is a bit of a mess right now. I will delete all of the old aggregation and window code during the window refactor.
- I was 50/50 on whether or not we should use a special iterator for groupBy. It was not too hard to extend the `windowBlockIterator`, which should drop-in work for regular windows.