### PR TITLE
Prevent pushing SortBy below window

### DIFF
--- a/sql/analyzer/resolve_orderby.go
+++ b/sql/analyzer/resolve_orderby.go
@@ -169,12 +169,7 @@ func pushSortDown(sort *plan.Sort) (sql.Node, error) {
 			child.GroupByExprs,
 			plan.NewSort(sort.SortFields, child.Child),
 		), nil
-	case *plan.Window:
-		return plan.NewWindow(
-			child.SelectExprs,
-			plan.NewSort(sort.SortFields, child.Child),
-		), nil
-	case *plan.ResolvedTable:
+	case *plan.ResolvedTable, plan.JoinNode:
 		return sort, nil
 	default:
 		children := child.Children()

--- a/sql/analyzer/resolve_orderby_test.go
+++ b/sql/analyzer/resolve_orderby_test.go
@@ -244,7 +244,7 @@ func TestPushdownSortWindow(t *testing.T) {
 			),
 		},
 		{
-			name: "push sort below window, with alias",
+			name: "don't push sort below window, with alias",
 			node: plan.NewSort(
 				[]sql.SortField{
 					{Column: expression.NewUnresolvedColumn("a")},
@@ -268,32 +268,9 @@ func TestPushdownSortWindow(t *testing.T) {
 					plan.NewResolvedTable(table, nil, nil),
 				),
 			),
-			expected: plan.NewWindow(
-				[]sql.Expression{
-					expression.NewAlias("x", expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false)),
-					mustExpr(window.NewRowNumber().(*window.RowNumber).WithWindow(
-						sql.NewWindow(
-							[]sql.Expression{
-								expression.NewGetFieldWithTable(0, sql.Int64, "foo", "b", false),
-							},
-							sql.SortFields{
-								{
-									Column: expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
-								},
-							},
-						),
-					)),
-				},
-				plan.NewSort(
-					[]sql.SortField{
-						{Column: expression.NewUnresolvedColumn("a")},
-					},
-					plan.NewResolvedTable(table, nil, nil),
-				),
-			),
 		},
 		{
-			name: "push sort below window, missing field",
+			name: "don't push sort below window, missing field",
 			node: plan.NewSort(
 				[]sql.SortField{
 					{Column: expression.NewUnresolvedColumn("a")},
@@ -313,29 +290,6 @@ func TestPushdownSortWindow(t *testing.T) {
 								},
 							),
 						)),
-					},
-					plan.NewResolvedTable(table, nil, nil),
-				),
-			),
-			expected: plan.NewWindow(
-				[]sql.Expression{
-					expression.NewGetFieldWithTable(0, sql.Int64, "foo", "b", false),
-					mustExpr(window.NewRowNumber().(*window.RowNumber).WithWindow(
-						sql.NewWindow(
-							[]sql.Expression{
-								expression.NewGetFieldWithTable(0, sql.Int64, "foo", "b", false),
-							},
-							sql.SortFields{
-								{
-									Column: expression.NewGetFieldWithTable(0, sql.Int64, "foo", "a", false),
-								},
-							},
-						),
-					)),
-				},
-				plan.NewSort(
-					[]sql.SortField{
-						{Column: expression.NewUnresolvedColumn("a")},
 					},
 					plan.NewResolvedTable(table, nil, nil),
 				),


### PR DESCRIPTION
Windows are sorted and partition by an Over clause before outputs are computed. Pushing a SortBy node below a Window wastes work (the sorting was unnecessary), and forces the Window to remember the original sort order, before finally sorting the output again to maintain the original SortBy constraint.  Putting the SortBy above the Window is easier and more efficient. 

This PR enforces the ordering and nests SortBy -> Window with necessary Project nodes to expose SortBy columns.