### PR TITLE
GroupBy normalization rule maintains parent Projection dependencies

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -5678,6 +5678,14 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: "select sum(x.i) + y.i from mytable as x, mytable as y where x.i = y.i GROUP BY x.i",
+		Expected: []sql.Row{
+			{float64(2)},
+			{float64(4)},
+			{float64(6)},
+		},
+	},
+	{
 		Query:    "SELECT 2.0 + CAST(5 AS DECIMAL)",
 		Expected: []sql.Row{{float64(7)}},
 	},

--- a/sql/analyzer/aggregations.go
+++ b/sql/analyzer/aggregations.go
@@ -75,8 +75,8 @@ func flattenedGroupBy(ctx *sql.Context, projection, grouping []sql.Expression, c
 func replaceAggregatesWithGetFieldProjections(ctx *sql.Context, projection []sql.Expression) (projections, aggregations []sql.Expression, err error) {
 	var newProjection = make([]sql.Expression, len(projection))
 	var newAggregates []sql.Expression
-	allGetFields := make(map[int]sql.Expression, 0)
-	projDeps := make(map[int]struct{}, 0)
+	allGetFields := make(map[int]sql.Expression)
+	projDeps := make(map[int]struct{})
 	for i, p := range projection {
 		var transformed bool
 		e, err := expression.TransformUp(p, func(e sql.Expression) (sql.Expression, error) {


### PR DESCRIPTION
We flatten GroupBy aggregations to isolation agg functions, but in the process lose nested column dependencies. The downstream `qualifyColumns` rule was erroring, but without passthrough projections binary expressions like `Arithemtic(Sum(x.i), y.i)` will fail at execution time without a full set of input dependencies.

For this query:`
```
select sum(x.i) + y.i from mytable as x, mytable as y where x.i = y.i GROUP BY x.i
```

We correctly identify that the GroupBy node has one primary aggregation, Sum, and project the Arithmetic separately.
```
GroupBy -> Sum(x.i) + y.i -> ... TableScan (x,y)
=> 
Project (Arithmetic(sum(x.i) + (y.i)))-> GroupBy(Sum(x.i)) -> ...
```

The `Project` node fails downstream trying to lookup the `y.i` dependency we discarded in the transform. This PR adds dependencies back to cover the new parent `Project` for `GroupBy` flattening.

```
GroupBy -> Sum(x.i) + y.i -> ... TableScan (x,y)
=> 
Project (Arithmetic(sum(x.i) + (y.i)))-> GroupBy(Sum(x.i), y.i) -> ...
```
 