### PR TITLE
Prevent invalidating table check constraints when altering table schema

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1686,7 +1686,6 @@ func TestRenameColumn(t *testing.T, harness Harness) {
 	}, tbl.Schema())
 
 	RunQuery(t, e, harness, "ALTER TABLE mytable RENAME COLUMN i TO i2, RENAME COLUMN s TO s2")
-
 	tbl, ok, err = db.GetTableInsensitive(NewContext(harness), "mytable")
 	require.NoError(err)
 	require.True(ok)
@@ -1699,6 +1698,21 @@ func TestRenameColumn(t *testing.T, harness Harness) {
 		[]sql.Row{
 			{1, "first row"},
 		}, nil, nil)
+
+	// Test column rename behavior when a table check constraint is involved
+	RunQuery(t, e, harness, "ALTER TABLE mytable ADD CONSTRAINT test_check CHECK (i2 < 12345)")
+	AssertErr(t, e, harness, "ALTER TABLE mytable RENAME COLUMN i2 TO i3", sql.ErrCheckConstraintInvalidatedByColumnAlter)
+	RunQuery(t, e, harness, "ALTER TABLE mytable RENAME COLUMN s2 TO s3")
+	tbl, ok, err = db.GetTableInsensitive(NewContext(harness), "mytable")
+	require.NoError(err)
+	require.True(ok)
+	checkTable, ok := tbl.(sql.CheckTable)
+	require.True(ok)
+	checks, err := checkTable.GetChecks(harness.NewContext())
+	require.NoError(err)
+	require.Equal(1, len(checks))
+	require.Equal("test_check", checks[0].Name)
+	require.Equal("(i2 < 12345)", checks[0].CheckExpression)
 }
 
 func assertSchemasEqualWithDefaults(t *testing.T, expected, actual sql.Schema) bool {
@@ -1970,6 +1984,22 @@ func TestDropColumn(t *testing.T, harness Harness) {
 
 		TestQueryWithContext(t, ctx, e, "ALTER TABLE mydb.tabletest DROP COLUMN s", []sql.Row(nil), nil, nil)
 	})
+
+	// Test drop column behavior when a table check constraint is involved
+	RunQuery(t, e, harness, "ALTER TABLE mytable ADD COLUMN j int, ADD COLUMN k int")
+	RunQuery(t, e, harness, "ALTER TABLE mytable ADD CONSTRAINT test_check CHECK (j < 12345)")
+	AssertErr(t, e, harness, "ALTER TABLE mytable DROP COLUMN j", sql.ErrCheckConstraintInvalidatedByColumnAlter)
+	RunQuery(t, e, harness, "ALTER TABLE mytable DROP COLUMN k")
+	tbl, ok, err = db.GetTableInsensitive(NewContext(harness), "mytable")
+	require.NoError(err)
+	require.True(ok)
+	checkTable, ok := tbl.(sql.CheckTable)
+	require.True(ok)
+	checks, err := checkTable.GetChecks(harness.NewContext())
+	require.NoError(err)
+	require.Equal(1, len(checks))
+	require.Equal("test_check", checks[0].Name)
+	require.Equal("(j < 12345)", checks[0].CheckExpression)
 }
 
 func TestCreateDatabase(t *testing.T, harness Harness) {

--- a/sql/analyzer/check_constraints.go
+++ b/sql/analyzer/check_constraints.go
@@ -16,8 +16,6 @@ package analyzer
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -29,6 +27,8 @@ import (
 
 // validateCreateCheck legal expressions for CREATE CHECK statements, including those embedded in CREATE TABLE
 // statements
+// TODO: validateCreateCheck doesn't currently do any type validation on the check and will allow you to create
+//       checks that will never evaluate correctly.
 func validateCreateCheck(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, error) {
 	switch n := n.(type) {
 	case *plan.CreateCheck:
@@ -142,8 +142,9 @@ func loadChecks(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.No
 
 			return &nn, nil
 		case *plan.Update:
-			rtable := getResolvedTable(node)
+			nn := *node
 
+			rtable := getResolvedTable(node)
 			if rtable == nil {
 				return node, nil
 			}
@@ -154,7 +155,6 @@ func loadChecks(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.No
 			}
 
 			var err error
-			nn := *node
 			nn.Checks, err = loadChecksFromTable(ctx, table)
 			if err != nil {
 				return nil, err
@@ -162,8 +162,9 @@ func loadChecks(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.No
 
 			return &nn, nil
 		case *plan.ShowCreateTable:
-			rtable := getResolvedTable(node)
+			nn := *node
 
+			rtable := getResolvedTable(node)
 			if rtable == nil {
 				return node, nil
 			}
@@ -174,21 +175,17 @@ func loadChecks(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.No
 			}
 
 			var err error
-			nn := *node
 			checks, err := loadChecksFromTable(ctx, table)
 			if err != nil {
 				return nil, err
 			}
 
+			// To match MySQL output format, transform the column names and wrap with backticks
 			transformedChecks := make(sql.CheckConstraints, len(checks))
-
 			for i, check := range checks {
 				newExpr, err := expression.TransformUp(check.Expr, func(e sql.Expression) (sql.Expression, error) {
 					if t, ok := e.(*expression.UnresolvedColumn); ok {
-						name := t.Name()
-						strings.Replace(name, "`", "", -1) // remove any preexisting backticks
-
-						return expression.NewUnresolvedColumn(fmt.Sprintf("`%s`", name)), nil
+						return expression.NewUnresolvedColumn(fmt.Sprintf("`%s`", t.Name())), nil
 					}
 
 					return e, nil
@@ -201,16 +198,56 @@ func loadChecks(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.No
 				check.Expr = newExpr
 				transformedChecks[i] = check
 			}
-
 			nn.Checks = transformedChecks
 
 			return &nn, nil
 
-		// TODO: throw an error if an ALTER TABLE would invalidate a check constraint, or fix them up automatically
-		//  when possible
-		//case *plan.DropColumn:
-		//case *plan.RenameColumn:
-		//case *plan.ModifyColumn:
+		case *plan.DropColumn:
+			nn := *node
+
+			rtable := getResolvedTable(node)
+			if rtable == nil {
+				return node, nil
+			}
+
+			table, ok := rtable.Table.(sql.CheckTable)
+			if !ok {
+				return node, nil
+			}
+
+			var err error
+			nn.Checks, err = loadChecksFromTable(ctx, table)
+			if err != nil {
+				return nil, err
+			}
+
+			return &nn, nil
+
+		case *plan.RenameColumn:
+			nn := *node
+
+			rtable := getResolvedTable(node)
+			if rtable == nil {
+				return node, nil
+			}
+
+			table, ok := rtable.Table.(sql.CheckTable)
+			if !ok {
+				return node, nil
+			}
+
+			var err error
+			nn.Checks, err = loadChecksFromTable(ctx, table)
+			if err != nil {
+				return nil, err
+			}
+
+			return &nn, nil
+
+		// TODO: ModifyColumn can also invalidate table check constraints (e.g. by changing the column's type).
+		//       Ideally, we should also load checks for ModifyColumn and error out if they would be invalidated.
+		// case *plan.ModifyColumn:
+
 		default:
 			return node, nil
 		}

--- a/sql/analyzer/check_constraints.go
+++ b/sql/analyzer/check_constraints.go
@@ -16,6 +16,7 @@ package analyzer
 
 import (
 	"fmt"
+
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -15,8 +15,9 @@
 package analyzer
 
 import (
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -206,10 +206,11 @@ var (
 	// ErrInvalidConstraintSubqueryNotSupported is returned when a CONSTRAINT CHECK is called with a sub-query expression.
 	ErrInvalidConstraintSubqueryNotSupported = errors.NewKind("Invalid constraint expression, sub-queries not supported: %s")
 
-	ErrCheckConstraintViolatedFmtStr = "Check constraint %q violated"
-
 	// ErrCheckConstraintViolated is returned when a CONSTRAINT CHECK is called with a sub-query expression.
-	ErrCheckConstraintViolated = errors.NewKind(ErrCheckConstraintViolatedFmtStr)
+	ErrCheckConstraintViolated = errors.NewKind("Check constraint %q violated")
+
+	// ErrCheckConstraintInvalidatedByColumnAlter is returned when an alter column statement would invalidate a check constraint.
+	ErrCheckConstraintInvalidatedByColumnAlter = errors.NewKind("can't alter column %q because it would invalidate check constraint %q")
 
 	// ErrColumnCountMismatch is returned when a view, derived table or common table expression has a declared column
 	// list with a different number of columns than the schema of the table.

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -313,6 +313,7 @@ type DropColumn struct {
 	ddlNode
 	UnaryNode
 	Column       string
+	Checks       sql.CheckConstraints
 	targetSchema sql.Schema
 }
 
@@ -436,6 +437,7 @@ type RenameColumn struct {
 	UnaryNode
 	ColumnName    string
 	NewColumnName string
+	Checks        sql.CheckConstraints
 	targetSchema  sql.Schema
 }
 


### PR DESCRIPTION
Updated logic for dropping and renaming columns to ensure that no table checks are referenced.

Further improvements should eventually be made to ensure that table check constraints aren't modified by other schema alterations, such as modifying a column's type.
