### PR TITLE
recursive CTEs

### DIFF
--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -676,7 +676,57 @@ func createSubsetTestData(t *testing.T, harness Harness, includedTables []string
 					sql.NewRow(2, 0, 1),
 				)
 			} else {
-				t.Logf("Warning: could not create table %s: %s", "auto_increment_tbl", err)
+				t.Logf("Warning: could not create table %s: %s", "invert_pk", err)
+			}
+		})
+	}
+
+	if includeTable(includedTables, "parts") {
+		wrapInTransaction(t, myDb, harness, func() {
+			table, err = harness.NewTable(myDb, "parts", sql.NewPrimaryKeySchema(sql.Schema{
+				{Name: "part", Type: sql.Text, Source: "parts", PrimaryKey: true},
+				{Name: "sub_part", Type: sql.Text, Source: "parts", PrimaryKey: true},
+				{Name: "quantity", Type: sql.Int64, Source: "parts"},
+			}))
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					[]sql.Row{
+						{"pie", "crust", 1},
+						{"pie", "filling", 2},
+						{"crust", "flour", 20},
+						{"crust", "sugar", 2},
+						{"crust", "butter", 15},
+						{"crust", "salt", 15},
+						{"filling", "sugar", 5},
+						{"filling", "fruit", 9},
+						{"filling", "salt", 3},
+						{"filling", "butter", 3},
+					}...)
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "parts", err)
+			}
+		})
+	}
+
+	if includeTable(includedTables, "bus_routes") {
+		wrapInTransaction(t, myDb, harness, func() {
+			table, err = harness.NewTable(myDb, "bus_routes", sql.NewPrimaryKeySchema(sql.Schema{
+				{Name: "origin", Type: sql.Text, Source: "bus_routes", PrimaryKey: true},
+				{Name: "dst", Type: sql.Text, Source: "bus_routes", PrimaryKey: true},
+			}))
+
+			if err == nil {
+				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
+					[]sql.Row{
+						{"New York", "Boston"},
+						{"Boston", "New York"},
+						{"New York", "Washington"},
+						{"Washington", "Boston"},
+						{"Washington", "Raleigh"},
+					}...)
+			} else {
+				t.Logf("Warning: could not create table %s: %s", "bus_routes", err)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20220126232952-c2e6dea44fb6
+	github.com/dolthub/vitess v0.0.0-20220201170722-4a7e0eaee5e2
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474/go.mod h1:kMz7uXOXq4qRriCEyZ/LUeTqraLJCjf0WVZcUi6TxUY=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20220126232952-c2e6dea44fb6 h1:Irm0MreHGRv2J8V/YPvbB11+HzfQve4e7CFS3AA2EFI=
-github.com/dolthub/vitess v0.0.0-20220126232952-c2e6dea44fb6/go.mod h1:3LlyaD0O/75GPrH1go90tUD7dhdcSF9HsHgs5vuUsac=
+github.com/dolthub/vitess v0.0.0-20220201170722-4a7e0eaee5e2 h1:Dkr1LwyGUYHLBy8eOQXJ29ffJvD66GKQfJgQUO+hSXo=
+github.com/dolthub/vitess v0.0.0-20220201170722-4a7e0eaee5e2/go.mod h1:qpZ4j0dval04OgZJ5fyKnlniSFUosTH280pdzUjUJig=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/memory/index_lookup.go
+++ b/memory/index_lookup.go
@@ -123,5 +123,6 @@ func (u *indexValIter) initValues() error {
 }
 
 func (u *indexValIter) Close(_ *sql.Context) error {
+	u.values = nil
 	return nil
 }

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -88,6 +88,18 @@ func pruneColumnsIsSafe(n sql.Node) bool {
 		}
 		return isSafe
 	})
+	if !isSafe {
+		return false
+	}
+	// We cannot eliminate projections in RecursiveCte's,
+	// they are used implicitly in the recursive execution
+	// if not explicitly in the outer scope.
+	plan.Inspect(n, func(n sql.Node) bool {
+		if _, ok := n.(*plan.RecursiveCte); ok {
+			isSafe = false
+		}
+		return isSafe
+	})
 	return isSafe
 }
 

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -330,6 +330,10 @@ func convertFiltersToIndexedAccess(
 		// We can't push any indexes down to a table has already had an index pushed down it
 		case *plan.IndexedTableAccess:
 			return false
+		case *plan.RecursiveCte:
+			// TODO: fix memory IndexLookup bugs that are not reproduceable in Dolt
+			// this probably fails for *plan.Union also, we just don't have tests for it
+			return false
 		}
 
 		switch c.Parent.(type) {

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -212,13 +212,13 @@ func getNodeAvailableNames(n sql.Node, scope *Scope) availableNames {
 	for i, n := range append(append(([]sql.Node)(nil), n), scope.InnerToOuter()...) {
 		plan.Inspect(n, func(n sql.Node) bool {
 			switch n := n.(type) {
-			case *plan.SubqueryAlias, *plan.ResolvedTable, *plan.ValueDerivedTable:
+			case *plan.SubqueryAlias, *plan.ResolvedTable, *plan.ValueDerivedTable, *plan.RecursiveTable, *plan.RecursiveCte:
 				name := strings.ToLower(n.(sql.Nameable).Name())
 				names.indexTable(name, name, i)
 				return false
 			case *plan.TableAlias:
 				switch t := n.Child.(type) {
-				case *plan.ResolvedTable, *plan.UnresolvedTable, *plan.SubqueryAlias:
+				case *plan.ResolvedTable, *plan.UnresolvedTable, *plan.SubqueryAlias, *plan.RecursiveTable:
 					name := strings.ToLower(t.(sql.Nameable).Name())
 					alias := strings.ToLower(n.Name())
 					names.indexTable(alias, name, i)
@@ -351,7 +351,7 @@ func getColumnsInNodes(nodes []sql.Node, names availableNames, nestingLevel int)
 
 	for _, node := range nodes {
 		switch n := node.(type) {
-		case *plan.TableAlias, *plan.ResolvedTable, *plan.SubqueryAlias, *plan.ValueDerivedTable:
+		case *plan.TableAlias, *plan.ResolvedTable, *plan.SubqueryAlias, *plan.ValueDerivedTable, *plan.RecursiveTable:
 			for _, col := range n.Schema() {
 				names.indexColumn(col.Source, col.Name, nestingLevel)
 			}

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -29,6 +29,7 @@ var OnceBeforeDefault = []Rule{
 	{"resolve_views", resolveViews},
 	{"lift_common_table_expressions", liftCommonTableExpressions},
 	{"resolve_common_table_expressions", resolveCommonTableExpressions},
+	{"lift_recursive_ctes", liftRecursiveCte},
 	{"resolve_databases", resolveDatabases},
 	{"resolve_tables", resolveTables},
 	{"set_target_schemas", setTargetSchemas},

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -413,6 +413,18 @@ var (
 
 	// ErrShowGrantsUserDoesNotExist is returned when a user does not exist when attempting to show their grants.
 	ErrShowGrantsUserDoesNotExist = errors.NewKind("There is no such grant defined for user '%s' on host '%s'")
+
+	// ErrInvalidRecursiveCteUnion is returned when a recursive CTE is not a UNION or UNION ALL node.
+	ErrInvalidRecursiveCteUnion = errors.NewKind("recursive cte top-level query must be a union; found: %v")
+
+	// ErrInvalidRecursiveCteInitialQuery is returned when the recursive CTE base clause is not supported.
+	ErrInvalidRecursiveCteInitialQuery = errors.NewKind("recursive cte initial query must be non-recursive projection; found: %v")
+
+	// ErrInvalidRecursiveCteRecursiveQuery is returned when the recursive CTE recursion clause is not supported.
+	ErrInvalidRecursiveCteRecursiveQuery = errors.NewKind("recursive cte recursive query must be a recursive projection; found: %v")
+
+	// ErrCteRecursionLimitExceeded is returned when a recursive CTE's execution stack depth exceeds the static limit.
+	ErrCteRecursionLimitExceeded = errors.NewKind("WITH RECURSIVE iteration limit exceeded")
 )
 
 func CastSQLError(err error) (*mysql.SQLError, error, bool) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -3023,164 +3023,163 @@ CREATE TABLE t2
 		},
 		plan.NewUnresolvedTable("foo", ""),
 	),
-	// TODO: these pass, after implementing ranges remove error check
-	//`SELECT row_number() over (partition by x RANGE CURRENT ROW) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE CURRENT ROW)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeCurrentRowToCurrentRowFrame(),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE 2 PRECEDING) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE 2 PRECEDING)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeNPrecedingToCurrentRowFrame(
-	//					expression.NewLiteral(int8(2), sql.Int8),
-	//				),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE UNBOUNDED PRECEDING) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE UNBOUNDED PRECEDING)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeUnboundedPrecedingToCurrentRowFrame(),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE interval 5 DAY PRECEDING) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE interval 5 DAY PRECEDING)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeNPrecedingToCurrentRowFrame(
-	//					expression.NewInterval(
-	//						expression.NewLiteral(int8(5), sql.Int8),
-	//						"DAY",
-	//					),
-	//				),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeNPrecedingToCurrentRowFrame(
-	//					expression.NewInterval(
-	//						expression.NewLiteral("2:30", sql.LongText),
-	//						"MINUTE_SECOND",
-	//					),
-	//				),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeNPrecedingToNFollowingFrame(
-	//					expression.NewLiteral(int8(1), sql.Int8),
-	//					expression.NewLiteral(int8(1), sql.Int8),
-	//				),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeCurrentRowToCurrentRowFrame(),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeCurrentRowToNFollowingFrame(
-	//					expression.NewLiteral(int8(1), sql.Int8),
-	//				),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeNPrecedingToCurrentRowFrame(
-	//					expression.NewInterval(
-	//						expression.NewLiteral(int8(5), sql.Int8),
-	//						"DAY",
-	//					),
-	//				),
-	//			),
-	//			)),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
-	//`SELECT row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW) from foo`: plan.NewWindow(
-	//	[]sql.Expression{
-	//		expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)",
-	//			expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
-	//				expression.NewUnresolvedColumn("x"),
-	//			},
-	//				nil,
-	//				plan.NewRangeNPrecedingToCurrentRowFrame(
-	//					expression.NewInterval(
-	//						expression.NewLiteral("2:30", sql.LongText),
-	//						"MINUTE_SECOND",
-	//					),
-	//				),
-	//			)),
-	//		),
-	//	},
-	//	plan.NewUnresolvedTable("foo", ""),
-	//),
+	`SELECT row_number() over (partition by x RANGE CURRENT ROW) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE CURRENT ROW)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeCurrentRowToCurrentRowFrame(),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE 2 PRECEDING) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE 2 PRECEDING)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewLiteral(int8(2), sql.Int8),
+					),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE UNBOUNDED PRECEDING) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE UNBOUNDED PRECEDING)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeUnboundedPrecedingToCurrentRowFrame(),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE interval 5 DAY PRECEDING) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE interval 5 DAY PRECEDING)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral(int8(5), sql.Int8),
+							"DAY",
+						),
+					),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral("2:30", sql.LongText),
+							"MINUTE_SECOND",
+						),
+					),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeNPrecedingToNFollowingFrame(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(1), sql.Int8),
+					),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeCurrentRowToCurrentRowFrame(),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeCurrentRowToNFollowingFrame(
+						expression.NewLiteral(int8(1), sql.Int8),
+					),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral(int8(5), sql.Int8),
+							"DAY",
+						),
+					),
+				),
+				)),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
+	`SELECT row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW) from foo`: plan.NewWindow(
+		[]sql.Expression{
+			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)",
+				expression.NewUnresolvedFunction("row_number", true, sql.NewWindow([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				},
+					nil,
+					plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral("2:30", sql.LongText),
+							"MINUTE_SECOND",
+						),
+					),
+				)),
+			),
+		},
+		plan.NewUnresolvedTable("foo", ""),
+	),
 	`with cte1 as (select a from b) select * from cte1`: plan.NewWith(
 		plan.NewProject(
 			[]sql.Expression{
@@ -3200,6 +3199,48 @@ CREATE TABLE t2
 				[]string{},
 			),
 		},
+		false,
+	),
+	`with recursive cte1 as (select 1 union select n+1 from cte1 where n < 10) select * from cte1`: plan.NewWith(
+		plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewUnresolvedTable("cte1", "")),
+		[]*plan.CommonTableExpression{
+			plan.NewCommonTableExpression(
+				plan.NewSubqueryAlias("cte1", "select 1 from dual union select n + 1 from cte1 where n < 10",
+					plan.NewDistinct(
+						plan.NewUnion(
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewLiteral(int8(1), sql.Int8),
+								},
+								plan.NewUnresolvedTable("dual", ""),
+							),
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewArithmetic(
+										expression.NewUnresolvedColumn("n"),
+										expression.NewLiteral(int8(1), sql.Int8),
+										sqlparser.PlusStr,
+									),
+								},
+								plan.NewFilter(
+									expression.NewLessThan(
+										expression.NewUnresolvedColumn("n"),
+										expression.NewLiteral(int8(10), sql.Int8),
+									),
+									plan.NewUnresolvedTable("cte1", ""),
+								),
+							),
+						),
+					),
+				),
+				[]string{},
+			),
+		},
+		true,
 	),
 	`with cte1 as (select a from b), cte2 as (select c from d) select * from cte1`: plan.NewWith(
 		plan.NewProject(
@@ -3231,6 +3272,7 @@ CREATE TABLE t2
 				[]string{},
 			),
 		},
+		false,
 	),
 	`with cte1 (x) as (select a from b), cte2 (y,z) as (select c from d) select * from cte1`: plan.NewWith(
 		plan.NewProject(
@@ -3262,6 +3304,7 @@ CREATE TABLE t2
 				[]string{"y", "z"},
 			),
 		},
+		false,
 	),
 	`with cte1 as (select a from b) select c, (with cte2 as (select c from d) select e from cte2) from cte1`: plan.NewWith(
 		plan.NewProject(
@@ -3288,6 +3331,7 @@ CREATE TABLE t2
 									[]string{},
 								),
 							},
+							false,
 						),
 						"with cte2 as (select c from d) select e from cte2",
 					),
@@ -3308,6 +3352,7 @@ CREATE TABLE t2
 				[]string{},
 			),
 		},
+		false,
 	),
 	`SELECT -128, 127, 255, -32768, 32767, 65535, -2147483648, 2147483647, 4294967295, -9223372036854775808, 9223372036854775807, 18446744073709551615`: plan.NewProject(
 		[]sql.Expression{

--- a/sql/plan/recursive_cte.go
+++ b/sql/plan/recursive_cte.go
@@ -1,0 +1,344 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+const cteRecursionLimit = 1000
+
+// RecursiveCte is defined by two subqueries
+// connected with a union:
+//   ex => WITH RECURSIVE [name]([Columns]) as ([Init] UNION [Rec]) ...
+// [Init] is a non-recursive select statement, and [Rec] selects from
+// the recursive relation [name] until exhaustion. Note that if [Rec] is
+// not recursive, the optimizer will fold the RecursiveCte into a
+// SubqueryAlias.
+//
+// The node is executed as follows:
+//   1. First, iterate the [Init] subquery.
+//   2. Collect the outputs of [Init] in a [temporary] buffer.
+//   3. When the iterator is exhausted, populate the recursive
+//      [working] table with the [temporary] buffer.
+//   4. Iterate [Rec], collecting outputs in the [temporary] buffer.
+//   5. Repeat steps (3) and (4) until [temporary] is empty.
+//
+// A RecursiveCte, its [Init], and its [Rec] have the same
+// projection count and types. [Init] will be resolved before
+// [Rec] or [RecursiveCte] to share schema types.
+type RecursiveCte struct {
+	// non-recursive projection
+	Init sql.Node
+	// optionally recursive projection
+	Rec sql.Node
+	// if set, use a hashmap to skip tuples seen more than once
+	Deduplicate bool
+	// Columns used to name lazily-loaded schema fields
+	Columns []string
+	// schema will match the types of [Init.Schema()], names of [Columns]
+	schema sql.Schema
+	// working is a handle to our refreshable intermediate table
+	working *RecursiveTable
+	name    string
+}
+
+var _ sql.Node = (*RecursiveCte)(nil)
+var _ sql.Nameable = (*RecursiveCte)(nil)
+
+func NewRecursiveCte(initial, recursive sql.Node, name string, outputCols []string, deduplicate bool) *RecursiveCte {
+	return &RecursiveCte{
+		Init:        initial,
+		Rec:         recursive,
+		Columns:     outputCols,
+		Deduplicate: deduplicate,
+		name:        name,
+	}
+}
+
+// Name implements sql.Nameable
+func (r *RecursiveCte) Name() string {
+	return r.name
+}
+
+// WithSchema inherits [Init]'s schema at resolve time
+func (r *RecursiveCte) WithSchema(s sql.Schema) *RecursiveCte {
+	nr := *r
+	nr.schema = s
+	return &nr
+}
+
+// WithWorking populates the [working] table with a common schema
+func (r *RecursiveCte) WithWorking(t *RecursiveTable) *RecursiveCte {
+	nr := *r
+	nr.working = t
+	return &nr
+}
+
+// Schema implements sql.Node
+func (r *RecursiveCte) Schema() sql.Schema {
+	return r.schema
+}
+
+// RowIter implements sql.Node
+func (r *RecursiveCte) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	return &recursiveCteIter{
+		init:        r.Init,
+		rec:         r.Rec,
+		row:         row,
+		working:     r.working,
+		temp:        make([]sql.Row, 0),
+		deduplicate: r.Deduplicate,
+	}, nil
+}
+
+// Children implements sql.Node
+func (r *RecursiveCte) Children() []sql.Node {
+	return []sql.Node{r.Init, r.Rec}
+}
+
+// WithChildren implements sql.Node
+func (r *RecursiveCte) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), 2)
+	}
+	nn := *r
+	nn.Init = children[0]
+	nn.Rec = children[1]
+	return &nn, nil
+}
+
+// Resolved implements sql.Node
+func (r *RecursiveCte) Resolved() bool {
+	return r.Init.Resolved() && r.Rec.Resolved()
+}
+
+// String implements sql.Node
+func (r *RecursiveCte) String() string {
+	var union string
+	if r.Deduplicate {
+		union = "UNION"
+	} else {
+		union = "UNION ALL"
+	}
+	return fmt.Sprintf("(%s %s %s)", r.Init, union, r.Rec)
+}
+
+// Type implements sql.Node
+func (r *RecursiveCte) Type() sql.Type {
+	cols := r.schema
+	if len(cols) == 1 {
+		return cols[0].Type
+	}
+	ts := make([]sql.Type, len(cols))
+	for i, c := range cols {
+		ts[i] = c.Type
+	}
+	return sql.CreateTuple(ts...)
+}
+
+// IsNullable implements sql.Node
+func (r *RecursiveCte) IsNullable() bool {
+	return true
+}
+
+// recursiveCteIter exhaustively executes a recursive
+// relation [rec] populated by an [init] base case.
+// Refer to RecursiveCte for more details.
+type recursiveCteIter struct {
+	// base sql.Project
+	init sql.Node
+	// recursive sql.Project
+	rec sql.Node
+	// anchor to recursive table to repopulate with [temp]
+	working *RecursiveTable
+	// true if UNION, false if UNION ALL
+	deduplicate bool
+	// parent iter initialization state
+	row sql.Row
+
+	// active iterator, either [init].RowIter or [rec].RowIter
+	iter sql.RowIter
+	// number of recursive iterations finished
+	cycle int
+	// buffer to collect intermediate results for next recursion
+	temp []sql.Row
+	// duplicate lookup if [deduplicated] set
+	cache sql.KeyValueCache
+}
+
+var _ sql.RowIter = (*recursiveCteIter)(nil)
+
+// Next implements sql.RowIter
+func (r *recursiveCteIter) Next(ctx *sql.Context) (sql.Row, error) {
+	if r.iter == nil {
+		// start with [Init].RowIter
+		var err error
+		if r.deduplicate {
+			r.cache = sql.NewMapCache()
+
+		}
+		r.iter, err = r.init.RowIter(ctx, r.row)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var row sql.Row
+	for {
+		var err error
+		row, err = r.iter.Next(ctx)
+		if errors.Is(err, io.EOF) && len(r.temp) > 0 {
+			// reset [Rec].RowIter
+			err = r.resetIter(ctx)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+
+		var key uint64
+		if r.deduplicate {
+			key, _ = sql.HashOf(row)
+			if k, _ := r.cache.Get(key); k != nil {
+				// skip duplicate
+				continue
+			}
+		}
+		r.store(row, key)
+		if err != nil {
+			return nil, err
+		}
+		break
+	}
+	return row, nil
+}
+
+// store saves a row to the [temp] buffer, and hashes if [deduplicated] = true
+func (r *recursiveCteIter) store(row sql.Row, key uint64) {
+	if r.deduplicate {
+		r.cache.Put(key, struct{}{})
+	}
+	r.temp = append(r.temp, row)
+	return
+}
+
+// resetIter creates a new [Rec].RowIter after refreshing the [working] RecursiveTable
+func (r *recursiveCteIter) resetIter(ctx *sql.Context) error {
+	if len(r.temp) == 0 {
+		return io.EOF
+	}
+	r.cycle++
+	if r.cycle > cteRecursionLimit {
+		return sql.ErrCteRecursionLimitExceeded.New()
+	}
+
+	if r.working != nil {
+		r.working.buf = r.temp
+		r.temp = make([]sql.Row, 0)
+	}
+
+	err := r.iter.Close(ctx)
+	if err != nil {
+		return err
+	}
+	r.iter, err = r.rec.RowIter(ctx, r.row)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close implements sql.RowIter
+func (r *recursiveCteIter) Close(ctx *sql.Context) error {
+	r.working.buf = nil
+	r.temp = nil
+	if r.iter != nil {
+		return r.iter.Close(ctx)
+	}
+	return nil
+}
+
+func NewRecursiveTable(n string, s sql.Schema) *RecursiveTable {
+	return &RecursiveTable{
+		name:   n,
+		schema: s,
+	}
+}
+
+// RecursiveTable is a thin wrapper around an in memory
+// buffer for use with recursiveCteIter.
+type RecursiveTable struct {
+	name   string
+	schema sql.Schema
+	buf    []sql.Row
+}
+
+func (r *RecursiveTable) Resolved() bool {
+	return true
+}
+
+func (r *RecursiveTable) Name() string {
+	return r.name
+}
+
+func (r *RecursiveTable) String() string {
+	return r.name
+}
+
+func (r *RecursiveTable) Schema() sql.Schema {
+	return r.schema
+}
+
+func (r *RecursiveTable) Children() []sql.Node {
+	return nil
+}
+
+func (r *RecursiveTable) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	return &recursiveTableIter{buf: r.buf}, nil
+}
+
+func (r *RecursiveTable) WithChildren(node ...sql.Node) (sql.Node, error) {
+	return r, nil
+}
+
+var _ sql.Node = (*RecursiveTable)(nil)
+
+// TODO a queue is probably more optimal
+type recursiveTableIter struct {
+	pos int
+	buf []sql.Row
+}
+
+var _ sql.RowIter = (*recursiveTableIter)(nil)
+
+func (r *recursiveTableIter) Next(ctx *sql.Context) (sql.Row, error) {
+	if r.buf == nil || r.pos >= len(r.buf) {
+		return nil, io.EOF
+	}
+	r.pos++
+	return r.buf[r.pos-1], nil
+}
+
+func (r *recursiveTableIter) Close(ctx *sql.Context) error {
+	r.buf = nil
+	return nil
+}


### PR DESCRIPTION
RecursiveCte node impl with tests for joins, group by, and subquery
aliasing.

RecursiveCte's are not supported in DML statements. Nested recursive
CTE's and nested subqueries are not supported yet. Aliasing is not
neatly split down the middle on either side for RCte unions; only the
dual table can have alias clashes on either side of the CTE for now.
Cyclical recursion will timeout at depth 20. This will likely need a
rewrite with better global aliasing to support infinitely nestable
RecursiveCte's.

Indexed table lookups are not applied to RecursiveCte tables currently
because of a bug in the memory impl.