### PR TITLE
log: Remove unused V function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2
-	github.com/golang/glog v0.0.0-20210429001901-424d2337a529
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/lestrrat-go/strftime v1.0.4
@@ -28,6 +27,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/golang/glog v0.0.0-20210429001901-424d2337a529 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/log.go
+++ b/log.go
@@ -16,7 +16,6 @@ package sqle
 
 import (
 	vtlog "github.com/dolthub/vitess/go/vt/log"
-	"github.com/golang/glog"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,23 +23,6 @@ const ConnectionIdLogField = "connectionID"
 const ConnectTimeLogKey = "connectTime"
 
 func init() {
-	// V quickly checks if the logging verbosity meets a threshold.
-	vtlog.V = func(level glog.Level) glog.Verbose {
-		lvl := logrus.GetLevel()
-		switch int32(level) {
-		case 0:
-			return glog.Verbose(lvl == logrus.InfoLevel)
-		case 1:
-			return glog.Verbose(lvl == logrus.WarnLevel)
-		case 2:
-			return glog.Verbose(lvl == logrus.ErrorLevel)
-		case 3:
-			return glog.Verbose(lvl == logrus.FatalLevel)
-		default:
-			return glog.Verbose(false)
-		}
-	}
-
 	// Flush ensures any pending I/O is written.
 	vtlog.Flush = func() {}
 


### PR DESCRIPTION
This function does not seem to be used, and as it import "golang/glog"
it can conflict with other packages using the "-v" flag globally.