### PR TITLE
Changing UserVar to return its correct type

### DIFF
--- a/enginetest/variable_queries.go
+++ b/enginetest/variable_queries.go
@@ -276,6 +276,28 @@ var VariableQueries = []ScriptTest{
 		},
 	},
 	{
+		Name: "uninitialized user vars",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT @doesNotExist;",
+				Expected: []sql.Row{{nil}},
+			},
+			{
+				Query:    "SELECT @doesNotExist is NULL;",
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    "SELECT @doesNotExist='';",
+				Expected: []sql.Row{{nil}},
+			},
+			{
+				Query:    "SELECT @doesNotExist < 123;",
+				Expected: []sql.Row{{nil}},
+			},
+		},
+	},
+
+	{
 		Name: "eval string user var",
 		SetUpScript: []string{
 			"set @stringVar = 'abc'",

--- a/enginetest/variable_queries.go
+++ b/enginetest/variable_queries.go
@@ -276,6 +276,30 @@ var VariableQueries = []ScriptTest{
 		},
 	},
 	{
+		Name: "eval string user var",
+		SetUpScript: []string{
+			"set @stringVar = 'abc'",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT @stringVar='abc'",
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    "SELECT @stringVar='abcd';",
+				Expected: []sql.Row{{false}},
+			},
+			{
+				Query:    "SELECT @stringVar=123;",
+				Expected: []sql.Row{{false}},
+			},
+			{
+				Query:    "SELECT @stringVar is null;",
+				Expected: []sql.Row{{false}},
+			},
+		},
+	},
+	{
 		Name: "set transaction",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/sql/analyzer/resolve_variables.go
+++ b/sql/analyzer/resolve_variables.go
@@ -231,8 +231,12 @@ func resolveSystemOrUserVariable(ctx *sql.Context, a *Analyzer, col column) (sql
 		a.Log("resolved column %s to session system variable", col)
 		return expression.NewSystemVar(varName, sql.SystemVariableScope_Session), true, nil
 	case sqlparser.SetScope_User:
+		t, _, err := ctx.GetUserVariable(ctx, varName)
+		if err != nil {
+			return nil, false, err
+		}
 		a.Log("resolved column %s to user variable", col)
-		return expression.NewUserVar(varName), true, nil
+		return expression.NewUserVarWithType(varName, t), true, nil
 	default: // shouldn't happen
 		return nil, false, fmt.Errorf("unknown set scope %v", scope)
 	}

--- a/sql/analyzer/resolve_variables_test.go
+++ b/sql/analyzer/resolve_variables_test.go
@@ -145,8 +145,11 @@ func TestResolveBarewordSetVariables(t *testing.T) {
 func TestResolveColumnsSession(t *testing.T) {
 	require := require.New(t)
 
+	fooBarValue := int64(42)
+	fooBarType := sql.ApproximateTypeFromValue(fooBarValue)
+
 	ctx := sql.NewContext(context.Background(), sql.WithSession(sql.NewBaseSession()))
-	err := ctx.SetUserVariable(ctx, "foo_bar", int64(42))
+	err := ctx.SetUserVariable(ctx, "foo_bar", fooBarValue)
 	require.NoError(err)
 	err = ctx.SetSessionVariable(ctx, "autocommit", true)
 	require.NoError(err)
@@ -166,7 +169,7 @@ func TestResolveColumnsSession(t *testing.T) {
 
 	expected := plan.NewProject(
 		[]sql.Expression{
-			expression.NewUserVar("foo_bar"),
+			expression.NewUserVarWithType("foo_bar", fooBarType),
 			expression.NewUserVar("bar_baz"),
 			expression.NewSystemVar("autocommit", sql.SystemVariableScope_Session),
 			expression.NewUserVar("myvar"),

--- a/sql/expression/variables.go
+++ b/sql/expression/variables.go
@@ -92,12 +92,21 @@ func (v *SystemVar) WithChildren(children ...sql.Expression) (sql.Expression, er
 // UserVar is an expression that returns the value of a user variable. It's also used as the expression on the left hand
 // side of a SET statement for a user var.
 type UserVar struct {
-	Name string
+	Name     string
+	exprType sql.Type
 }
 
-// NewUserVar creates a new UserVar expression.
+// NewUserVar creates a UserVar with a name, but no type information, for use as the left-hand value
+// in a SetField assignment Expression. This method should not be used when the user variable is
+// being used as a value, since the correct type information will not be available.
 func NewUserVar(name string) *UserVar {
-	return &UserVar{name}
+	return &UserVar{name, sql.Null}
+}
+
+// NewUserVarWithType creates a UserVar with its type resolved, so that it can be used as a value
+// in other expressions.
+func NewUserVarWithType(name string, t sql.Type) *UserVar {
+	return &UserVar{name, t}
 }
 
 // Children implements the sql.Expression interface.
@@ -105,16 +114,20 @@ func (v *UserVar) Children() []sql.Expression { return nil }
 
 // Eval implements the sql.Expression interface.
 func (v *UserVar) Eval(ctx *sql.Context, _ sql.Row) (interface{}, error) {
-	_, val, err := ctx.GetUserVariable(ctx, v.Name)
+	t, val, err := ctx.GetUserVariable(ctx, v.Name)
 	if err != nil {
 		return nil, err
 	}
+
+	v.exprType = t
+
 	return val, nil
 }
 
 // Type implements the sql.Expression interface.
-// TODO: type checking based on type of user var
-func (v *UserVar) Type() sql.Type { return sql.Boolean }
+func (v *UserVar) Type() sql.Type {
+	return v.exprType
+}
 
 // IsNullable implements the sql.Expression interface.
 func (v *UserVar) IsNullable() bool { return true }


### PR DESCRIPTION
Changing UserVar to return its correct type, when used as a value in an expression. 

Resolves: https://github.com/dolthub/go-mysql-server/issues/790