### PR TITLE
fix `BETWEEN` function of missing inclusive logic

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -2698,6 +2698,14 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{int64(3)}},
 	},
 	{
+		Query:    "SELECT 2 BETWEEN NULL AND 2",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT NOT 2 BETWEEN NULL AND 2",
+		Expected: []sql.Row{{nil}},
+	},
+	{
 		Query: "SELECT DISTINCT * FROM (values row(7,31,27), row(79,17,38), row(78,59,26)) a (col0, col1, col2) WHERE ( + col1 + + col2 ) NOT BETWEEN NULL AND col1",
 		Expected: []sql.Row{{7, 31, 27},
 			{79, 17, 38},

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -115,14 +115,14 @@ func (b *Between) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	if lower != nil && upper == nil {
-		if cmpLower > 0 {
+		if cmpLower >= 0 {
 			return nil, nil
 		} else {
 			return false, nil
 		}
 	}
 	if upper != nil && lower == nil {
-		if cmpUpper < 0 {
+		if cmpUpper <= 0 {
 			return nil, nil
 		} else {
 			return false, nil

--- a/sql/expression/between_test.go
+++ b/sql/expression/between_test.go
@@ -36,8 +36,10 @@ func TestBetween(t *testing.T) {
 		err      bool
 	}{
 		{"val is null", sql.NewRow(nil, 1, 2), nil, false},
-		{"lower is null", sql.NewRow(1, nil, 2), nil, false},
-		{"upper is null", sql.NewRow(1, 2, nil), false, false},
+		{"lower is null, out of range", sql.NewRow(1, nil, 2), nil, false},
+		{"lower is null, in range", sql.NewRow(2, nil, 2), nil, false},
+		{"upper is null, out of range", sql.NewRow(1, 2, nil), false, false},
+		{"upper is null, in range", sql.NewRow(2, 2, nil), nil, false},
 		{"val is lower", sql.NewRow(1, 1, 3), true, false},
 		{"val is upper", sql.NewRow(3, 1, 3), true, false},
 		{"val is between lower and upper", sql.NewRow(2, 1, 3), true, false},
@@ -177,8 +179,10 @@ func TestNotBetween(t *testing.T) {
 		err      bool
 	}{
 		{"val is null", sql.NewRow(nil, 1, 2), nil, false},
-		{"lower is null", sql.NewRow(1, nil, 2), nil, false},
-		{"upper is null", sql.NewRow(1, 2, nil), true, false},
+		{"lower is null, out of range", sql.NewRow(1, nil, 2), nil, false},
+		{"lower is null, in range", sql.NewRow(2, nil, 2), nil, false},
+		{"upper is null, out of range", sql.NewRow(1, 2, nil), true, false},
+		{"upper is null, in range", sql.NewRow(2, 2, nil), nil, false},
 		{"val is lower", sql.NewRow(1, 1, 3), false, false},
 		{"val is upper", sql.NewRow(3, 1, 3), false, false},
 		{"val is between lower and upper", sql.NewRow(2, 1, 3), false, false},


### PR DESCRIPTION
`BETWEEN()` does inclusive check including checks with NULL value