### PR TITLE
Add uint types to LiteralToInt

### DIFF
--- a/sql/expression/common.go
+++ b/sql/expression/common.go
@@ -139,6 +139,16 @@ func LiteralToInt(e sql.Expression) (int, error) {
 		offset = int(e)
 	case int64:
 		offset = int(e)
+	case uint:
+		offset = int(e)
+	case uint8:
+		offset = int(e)
+	case uint16:
+		offset = int(e)
+	case uint32:
+		offset = int(e)
+	case uint64:
+		offset = int(e)
 	default:
 		return 0, ErrInvalidOffset.New(e)
 	}


### PR DESCRIPTION
Re: issue https://github.com/dolthub/go-mysql-server/issues/799

This database and this query were parsing 128 as a uint8, which my type switch missed:
```SQL
$ dolt clone https://doltremoteapi.dolthub.com/post-no-preference/stocks
$ cd stocks
$ dolt sql
stocks> select date, act_symbol, avg(close) OVER (PARTITION BY act_symbol ORDER BY date ROWS BETWEEN 128 PRECEDING AND CURRENT ROW) AS ma200 FROM ohlcv WHERE act_symbol='AAPL' having date = '2022-02-11';
offset must be a non-negative integer; found: 128
```

After fix:
```SQL
select date, act_symbol, avg(close) OVER (PARTITION BY act_symbol ORDER BY date ROWS BETWEEN 128 PRECEDING AND CURRENT ROW) AS ma200 FROM ohlcv WHERE act_symbol='AAPL' having date = '2022-02-11';
+-------------------------------+------------+--------------------+
| date                          | act_symbol | ma200              |
+-------------------------------+------------+--------------------+
| 2022-02-11 00:00:00 +0000 UTC | AAPL       | 158.29837209302272 |
+-------------------------------+------------+--------------------+
```

I haven't been able to create a testing database with the same type parsing behavior yet. Something about the `stocks` database or that specific query is yielding a types.Value with value=128 and type=sql.Uint8.