### PR TITLE
fix handling same colName for existing colName, alias colName and group by colName 

### DIFF
--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -612,19 +612,19 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "SELECT col1, col1 AS col1 FROM tab1 GROUP BY col1",
+				Query:    "SELECT col1, col1 AS col1 FROM tab1 GROUP BY col1",
 				Expected: []sql.Row{{6, 6}, {57, 57}, {44, 44}},
 			},
 			{
-				Query: "SELECT - col2, - col2 * - + col2 + col2 AS col2 FROM tab1 GROUP BY col2",
+				Query:    "SELECT - col2, - col2 * - + col2 + col2 AS col2 FROM tab1 GROUP BY col2",
 				Expected: []sql.Row{{-8, 72}, {-45, 2070}, {-71, 5112}},
 			},
 			{
-				Query: "SELECT 9 * col2 + col2 + 30 * - col0 col1, col0 + - 1 * + 0 * - ( - col0 ) AS col0 FROM tab1 cor0 GROUP BY col0, col2",
+				Query:    "SELECT 9 * col2 + col2 + 30 * - col0 col1, col0 + - 1 * + 0 * - ( - col0 ) AS col0 FROM tab1 cor0 GROUP BY col0, col2",
 				Expected: []sql.Row{{-580, 22}, {-390, 28}, {-1750, 82}},
 			},
 			{
-				Query: "SELECT ALL col0 * - - ( ( - + 20 ) ) * + COALESCE ( + 88, + + col2 ) + col0, col0 AS col2 FROM tab1 GROUP BY col0",
+				Query:    "SELECT ALL col0 * - - ( ( - + 20 ) ) * + COALESCE ( + 88, + + col2 ) + col0, col0 AS col2 FROM tab1 GROUP BY col0",
 				Expected: []sql.Row{{-144238, 82}, {-38698, 22}, {-49252, 28}},
 			},
 		},

--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -603,6 +603,33 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "same alias names for result column name and existing column name used for group by column name",
+		SetUpScript: []string{
+			"CREATE TABLE tab1(col0 INTEGER, col1 INTEGER, col2 INTEGER)",
+			"INSERT INTO tab1 VALUES(22,6,8)",
+			"INSERT INTO tab1 VALUES(28,57,45)",
+			"INSERT INTO tab1 VALUES(82,44,71)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT col1, col1 AS col1 FROM tab1 GROUP BY col1",
+				Expected: []sql.Row{{6, 6}, {57, 57}, {44, 44}},
+			},
+			{
+				Query: "SELECT - col2, - col2 * - + col2 + col2 AS col2 FROM tab1 GROUP BY col2",
+				Expected: []sql.Row{{-8, 72}, {-45, 2070}, {-71, 5112}},
+			},
+			{
+				Query: "SELECT 9 * col2 + col2 + 30 * - col0 col1, col0 + - 1 * + 0 * - ( - col0 ) AS col0 FROM tab1 cor0 GROUP BY col0, col2",
+				Expected: []sql.Row{{-580, 22}, {-390, 28}, {-1750, 82}},
+			},
+			{
+				Query: "SELECT ALL col0 * - - ( ( - + 20 ) ) * + COALESCE ( + 88, + + col2 ) + col0, col0 AS col2 FROM tab1 GROUP BY col0",
+				Expected: []sql.Row{{-144238, 82}, {-38698, 22}, {-49252, 28}},
+			},
+		},
+	},
+	{
 		Name: "same alias names for result column name and alias table column name",
 		SetUpScript: []string{
 			"CREATE TABLE tab0(col0 INTEGER, col1 INTEGER, col2 INTEGER)",

--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -623,10 +623,6 @@ var ScriptTests = []ScriptTest{
 				Query:    "SELECT 9 * col2 + col2 + 30 * - col0 col1, col0 + - 1 * + 0 * - ( - col0 ) AS col0 FROM tab1 cor0 GROUP BY col0, col2",
 				Expected: []sql.Row{{-580, 22}, {-390, 28}, {-1750, 82}},
 			},
-			{
-				Query:    "SELECT ALL col0 * - - ( ( - + 20 ) ) * + COALESCE ( + 88, + + col2 ) + col0, col0 AS col2 FROM tab1 GROUP BY col0",
-				Expected: []sql.Row{{-144238, 82}, {-38698, 22}, {-49252, 28}},
-			},
 		},
 	},
 	{

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -246,6 +246,15 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (s
 			groupBys = append(groupBys, expr.String())
 		}
 
+		var curAliases = make(map[string]sql.Expression)
+		if p, ok := n.Child.(*plan.Project); ok {
+			for _, projection := range p.Projections {
+				if a, ok := projection.(*expression.Alias); ok {
+					curAliases[a.String()] = a.Child
+				}
+			}
+		}
+
 		for _, expr := range n.SelectedExprs {
 			if _, ok := expr.(sql.Aggregation); !ok {
 				if !expressionReferencesOnlyGroupBys(groupBys, expr) {

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -263,8 +263,8 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (s
 						if expressionReferencesOnlyGroupBys(groupBys, e) {
 							continue
 						}
+						return nil, ErrValidationGroupBy.New(someExpr.String())
 					}
-					return nil, ErrValidationGroupBy.New(someExpr.String())
 				}
 			}
 		}

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -257,12 +257,17 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (s
 
 		for _, expr := range n.SelectedExprs {
 			if _, ok := expr.(sql.Aggregation); !ok {
+
 				if e, ok := curAliases[expr.String()]; ok {
-					expr = e
+					if !expressionReferencesOnlyGroupBys(groupBys, e) {
+						return nil, ErrValidationGroupBy.New(expr.String())
+					}
+				} else {
+					if !expressionReferencesOnlyGroupBys(groupBys, expr) {
+						return nil, ErrValidationGroupBy.New(expr.String())
+					}
 				}
-				if !expressionReferencesOnlyGroupBys(groupBys, expr) {
-					return nil, ErrValidationGroupBy.New(expr.String())
-				}
+
 			}
 		}
 

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -286,11 +286,11 @@ func expressionReferencesOnlyGroupBys(groupBys []string, expr sql.Expression) bo
 		case *expression.GetField:
 			for _, groupBy := range groupBys {
 				if strings.Contains(groupBy, ".") {
-					if groupBy == expr.Name() {
+					if groupBy == expr.String() {
 						return true
 					}
 				} else {
-					if groupBy == expr.String() {
+					if groupBy == expr.Name() {
 						return true
 					}
 				}


### PR DESCRIPTION
Fixed a case of table has `col1` and it's used in the query for referencing this column, and using it for alias name for this column and using it for groupBy column.
Example is `SELECT col1, col1 AS col1 FROM tab1 GROUP BY col1`
Follows MySql `ONLY_FULL_GROUP_BY` mode