### PR TITLE
analyzer doesn't error for invalid value

### DIFF
--- a/enginetest/delete_queries.go
+++ b/enginetest/delete_queries.go
@@ -102,6 +102,12 @@ var DeleteTests = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{int64(1), "first row"}, {int64(2), "second row"}, {int64(3), "third row"}},
 	},
 	{
+		WriteQuery:          "DELETE FROM mytable WHERE i = 'invalid';",
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
+		SelectQuery:         "SELECT * FROM mytable;",
+		ExpectedSelect:      []sql.Row{{int64(1), "first row"}, {int64(2), "second row"}, {int64(3), "third row"}},
+	},
+	{
 		WriteQuery:          "DELETE FROM mytable ORDER BY i ASC LIMIT 2;",
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(2)}},
 		SelectQuery:         "SELECT * FROM mytable;",
@@ -186,9 +192,5 @@ var DeleteErrorTests = []GenericErrorQueryTest{
 	{
 		Name:  "targets subquery alias",
 		Query: "DELETE FROM (SELECT * FROM mytable) mytable WHERE id = 1;",
-	},
-	{
-		Name:  "invalid value for int type",
-		Query: "DELETE FROM mytable WHERE i = 'invalid';",
 	},
 }

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -277,7 +277,9 @@ func (b *IndexBuilder) updateCol(ctx *Context, colExpr string, potentialRanges .
 			newRange, ok, err := currentRange.TryIntersect(potentialRange)
 			if err != nil {
 				b.isInvalid = true
-				b.err = err
+				if !ErrInvalidValue.Is(err) {
+					b.err = err
+				}
 				return
 			}
 			if ok {


### PR DESCRIPTION
re: https://github.com/dolthub/go-mysql-server/issues/815

Originally we were failing to handle an analyzer error. Catching that error exposed a case where we want to manually prevent that error path from bubbling up.