### PR TITLE
fix `ROLLBACK;` fail with no database selected

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3972,6 +3972,9 @@ func TestNoDatabaseSelected(t *testing.T, harness Harness) {
 	AssertErrWithCtx(t, e, ctx, "create table a (b int primary key)", sql.ErrNoDatabaseSelected)
 	AssertErrWithCtx(t, e, ctx, "show tables", sql.ErrNoDatabaseSelected)
 	AssertErrWithCtx(t, e, ctx, "show triggers", sql.ErrNoDatabaseSelected)
+
+	_, _, err := e.Query(ctx, "ROLLBACK")
+	require.NoError(t, err)
 }
 
 func TestSessionSelectLimit(t *testing.T, harness Harness) {

--- a/sql/analyzer/resolve_database.go
+++ b/sql/analyzer/resolve_database.go
@@ -62,7 +62,7 @@ func validateDatabaseSet(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope
 	plan.Inspect(n, func(node sql.Node) bool {
 		switch n.(type) {
 		// TODO: there are probably other kinds of nodes that need this too
-		case *plan.ShowTables, *plan.ShowTriggers, *plan.CreateTable:
+		case *plan.ShowTables, *plan.ShowTriggers, *plan.CreateTable, *plan.Rollback:
 			n := n.(sql.Databaser)
 			if _, ok := n.Database().(sql.UnresolvedDatabase); ok {
 				err = sql.ErrNoDatabaseSelected.New()

--- a/sql/analyzer/resolve_database.go
+++ b/sql/analyzer/resolve_database.go
@@ -62,7 +62,7 @@ func validateDatabaseSet(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope
 	plan.Inspect(n, func(node sql.Node) bool {
 		switch n.(type) {
 		// TODO: there are probably other kinds of nodes that need this too
-		case *plan.ShowTables, *plan.ShowTriggers, *plan.CreateTable, *plan.Rollback:
+		case *plan.ShowTables, *plan.ShowTriggers, *plan.CreateTable:
 			n := n.(sql.Databaser)
 			if _, ok := n.Database().(sql.UnresolvedDatabase); ok {
 				err = sql.ErrNoDatabaseSelected.New()

--- a/sql/plan/transaction.go
+++ b/sql/plan/transaction.go
@@ -311,8 +311,9 @@ func (r *Rollback) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpe
 
 // Resolved implements the sql.Node interface.
 func (r *Rollback) Resolved() bool {
-	_, ok := r.db.(sql.UnresolvedDatabase)
-	return !ok
+	return true
+	//_, ok := r.db.(sql.UnresolvedDatabase)
+	//return !ok
 }
 
 // Children implements the sql.Node interface.

--- a/sql/plan/transaction.go
+++ b/sql/plan/transaction.go
@@ -311,9 +311,11 @@ func (r *Rollback) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpe
 
 // Resolved implements the sql.Node interface.
 func (r *Rollback) Resolved() bool {
-	return true
-	//_, ok := r.db.(sql.UnresolvedDatabase)
-	//return !ok
+	if r.db.Name() == "" {
+		return true
+	}
+	_, ok := r.db.(sql.UnresolvedDatabase)
+	return !ok
 }
 
 // Children implements the sql.Node interface.


### PR DESCRIPTION
MySQL lets `ROLLBACK` when no database is selected