### PR TITLE
Fixing a race condition by no longer updating the UserVar's type during Eval

### DIFF
--- a/sql/expression/variables.go
+++ b/sql/expression/variables.go
@@ -114,12 +114,10 @@ func (v *UserVar) Children() []sql.Expression { return nil }
 
 // Eval implements the sql.Expression interface.
 func (v *UserVar) Eval(ctx *sql.Context, _ sql.Row) (interface{}, error) {
-	t, val, err := ctx.GetUserVariable(ctx, v.Name)
+	_, val, err := ctx.GetUserVariable(ctx, v.Name)
 	if err != nil {
 		return nil, err
 	}
-
-	v.exprType = t
 
 	return val, nil
 }


### PR DESCRIPTION
The type was being set when retrieved in Eval for completeness, but it shouldn't be needed. 

When used as a value, the analyzer was already using the NewUserVarWithType method that explicitly loaded and set the type. The NewUserVar method (which doesn't set type) should only be used when the user var is the left hand side of a set var operation. 