### PR TITLE
Add IGNORE behavior for CHECK CONSTRAINTS and on duplicate key

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2948,9 +2948,6 @@ func TestChecksOnInsert(t *testing.T, harness Harness) {
 	// Check that INSERT IGNORE correctly drops errors with check constraints and does not update the actual table.
 	RunQuery(t, e, harness, "INSERT IGNORE INTO t1 VALUES (5,2, 'abc')")
 	TestQuery(t, harness, e, `SELECT count(*) FROM t1 where a = 5`, []sql.Row{{0}}, nil, nil)
-
-	RunQuery(t, e, harness, "INSERT IGNORE INTO t1 VALUES (2,2, 'abc') ON DUPLICATE KEY UPDATE b = 1000") // violates b > 10 constraint
-	TestQuery(t, harness, e, `SELECT * FROM t1 where a = 2`, []sql.Row{{2, 2, nil}}, nil, nil)
 }
 
 func TestChecksOnUpdate(t *testing.T, harness Harness) {

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2948,6 +2948,12 @@ func TestChecksOnInsert(t *testing.T, harness Harness) {
 	// Check that INSERT IGNORE correctly drops errors with check constraints and does not update the actual table.
 	RunQuery(t, e, harness, "INSERT IGNORE INTO t1 VALUES (5,2, 'abc')")
 	TestQuery(t, harness, e, `SELECT count(*) FROM t1 where a = 5`, []sql.Row{{0}}, nil, nil)
+
+	// One value is correctly accepted and the other value is not accepted due to a check constraint violation.
+	// The accepted value is correctly added to the table.
+	RunQuery(t, e, harness, "INSERT IGNORE INTO t1 VALUES (4,4, null), (5,2, 'abc')")
+	TestQuery(t, harness, e, `SELECT count(*) FROM t1 where a = 5`, []sql.Row{{0}}, nil, nil)
+	TestQuery(t, harness, e, `SELECT count(*) FROM t1 where a = 4`, []sql.Row{{1}}, nil, nil)
 }
 
 func TestChecksOnUpdate(t *testing.T, harness Harness) {

--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -1237,6 +1237,7 @@ var InsertIgnoreScripts = []ScriptTest{
 			"CREATE TABLE t1 (id INT PRIMARY KEY, v int);",
 			"INSERT INTO t1 VALUES (1,1)",
 			"CREATE TABLE t2 (pk int primary key, v2 varchar(1))",
+			"ALTER TABLE t2 ADD CONSTRAINT cx CHECK (pk < 100)",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1258,6 +1259,16 @@ var InsertIgnoreScripts = []ScriptTest{
 					{sql.OkResult{RowsAffected: 1}},
 				},
 				ExpectedWarning: mysql.ERUnknownError,
+			},
+			{
+				Query: "SELECT * FROM t2",
+				Expected: []sql.Row{
+					{1, "a"},
+				},
+			},
+			{
+				Query:    "INSERT IGNORE INTO t2 VALUES (1, 's') ON DUPLICATE KEY UPDATE pk = 1000", // violates constraint
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 0}}},
 			},
 			{
 				Query: "SELECT * FROM t2",

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -58,6 +58,7 @@ var IgnorableErrors = []*errors.Kind{sql.ErrInsertIntoNonNullableProvidedNull,
 	sql.ErrForeignKeyParentViolation,
 	sql.ErrDuplicateEntry,
 	sql.ErrUniqueKeyViolation,
+	sql.ErrCheckConstraintViolated,
 }
 
 // InsertInto is the top level node for INSERT INTO statements. It has a source for rows and a destination to insert
@@ -349,7 +350,7 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 		}
 
 		if sql.IsFalse(res) {
-			return nil, sql.NewWrappedInsertError(row, sql.ErrCheckConstraintViolated.New(check.Name))
+			return nil, i.warnOnIgnorableError(ctx, row, sql.ErrCheckConstraintViolated.New(check.Name))
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where INSERT IGNORE was not correctly ignoring check constraints