### PR TITLE
Fix InTuple optimizer bug

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -1779,6 +1779,14 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{},
 	},
 	{
+		Query:    "SELECT * FROM one_pk where pk in (1) and c1 = 10",
+		Expected: []sql.Row{{1, 10, 11, 12, 13, 14}},
+	},
+	{
+		Query:    "SELECT * FROM one_pk where pk in (1)",
+		Expected: []sql.Row{{1, 10, 11, 12, 13, 14}},
+	},
+	{
 		Query:    "SELECT 1 FROM DUAL WHERE (1, 2) not in ((3, 4), (5, 6))",
 		Expected: []sql.Row{{1}},
 	},

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -743,10 +743,12 @@ func getMultiColumnIndexForExpressions(
 						return nil, err
 					}
 					values, ok := value.([]interface{})
-					if !ok {
-						return nil, errInvalidInRightEvaluation.New(value)
+					if ok {
+						indexBuilder = indexBuilder.Equals(ctx, expr.col.String(), values...)
+					} else {
+						// For single length tuples, we don't return []interface{}, just the first element
+						indexBuilder = indexBuilder.Equals(ctx, expr.col.String(), value)
 					}
-					indexBuilder = indexBuilder.Equals(ctx, expr.col.String(), values...)
 				} else {
 					return nil, nil
 				}


### PR DESCRIPTION
Last week we fixed a dropped optimizer error return that was masking a
tuple bug. We expected a slice of interfaces, but single element tuples
return one value. We catch this in most circumstances, but missed the
multicolumn case triggered by an AND expression. The error was passing
logictests because we still return correct results even if we fail to
push a filter into a table scan.