### PR TITLE
Don't apply defaults to all rows when the added column has no default

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2425,6 +2425,20 @@ func TestDropColumn(t *testing.T, harness Harness) {
 	})
 }
 
+func TestAddAndDropColumn(t *testing.T, harness Harness) {
+	e := NewEngine(t, harness)
+	defer e.Close()
+
+	t.Run("column does not retain values after being dropped and re-added", func(t *testing.T) {
+		TestQuery(t, harness, e, "ALTER TABLE mytable ADD COLUMN i2 INT;", []sql.Row(nil), nil, nil)
+		TestQuery(t, harness, e, "UPDATE mytable SET i2 = 1;", []sql.Row{{sql.OkResult{RowsAffected: 3, Info: plan.UpdateInfo{Matched: 3, Updated: 3}}}}, nil, nil)
+		TestQuery(t, harness, e, "ALTER TABLE mytable DROP COLUMN i2;", []sql.Row(nil), nil, nil)
+		TestQuery(t, harness, e, "ALTER TABLE mytable ADD COLUMN i2 INT;", []sql.Row(nil), nil, nil)
+
+		TestQuery(t, harness, e, "SELECT * FROM mytable WHERE i2 = 1", []sql.Row{}, nil, nil)
+	})
+}
+
 func TestCreateDatabase(t *testing.T, harness Harness) {
 	e := NewEngine(t, harness)
 	defer e.Close()

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -549,6 +549,10 @@ func TestDropColumn(t *testing.T) {
 	enginetest.TestDropColumn(t, enginetest.NewDefaultMemoryHarness())
 }
 
+func TestAddAndDropColumn(t *testing.T) {
+	enginetest.TestAddAndDropColumn(t, enginetest.NewDefaultMemoryHarness())
+}
+
 func TestCreateDatabase(t *testing.T) {
 	enginetest.TestCreateDatabase(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -161,6 +161,11 @@ func (a *AddColumn) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) 
 		return nil, err
 	}
 
+	// Prevents an iter of the full table when adding a new column with no default.
+	if a.column.Default == nil {
+		return sql.RowsToRowIter(), nil
+	}
+
 	return sql.RowsToRowIter(), a.updateRowsWithDefaults(ctx, row)
 }
 


### PR DESCRIPTION
Related to https://github.com/dolthub/dolt/issues/2939

When a user was working with a large table, adding a column with no default caused an OOM crash. The crash is a result of the `ADD COLUMN` sql statement causing every row to be modified in the table. This is not-expected and a bug. We expect adding a column with no default to only modify the schema and not any Dolt row. 

The fix is to skip applying defaults to table if the added column has no default. We can call this a "fast" add column since only the schema has to be modified.

In the future, we may also add a "fast" drop column where only the schema is modified. Currently, we modify every row for a `DROP COLUMN` statement. In the "fast" drop scenario, it might be important to ensure values aren't retained across `ADD COLUMN` and `DROP COLUMN` statements with the same column name. This PR also adds tests to ensure this.

