### PR TITLE
Only skip updating defaults when added column has no default value AND is nullable

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2425,20 +2425,6 @@ func TestDropColumn(t *testing.T, harness Harness) {
 	})
 }
 
-func TestAddAndDropColumn(t *testing.T, harness Harness) {
-	e := NewEngine(t, harness)
-	defer e.Close()
-
-	t.Run("column does not retain values after being dropped and re-added", func(t *testing.T) {
-		TestQuery(t, harness, e, "ALTER TABLE mytable ADD COLUMN i2 INT;", []sql.Row(nil), nil, nil)
-		TestQuery(t, harness, e, "UPDATE mytable SET i2 = 1;", []sql.Row{{sql.OkResult{RowsAffected: 3, Info: plan.UpdateInfo{Matched: 3, Updated: 3}}}}, nil, nil)
-		TestQuery(t, harness, e, "ALTER TABLE mytable DROP COLUMN i2;", []sql.Row(nil), nil, nil)
-		TestQuery(t, harness, e, "ALTER TABLE mytable ADD COLUMN i2 INT;", []sql.Row(nil), nil, nil)
-
-		TestQuery(t, harness, e, "SELECT * FROM mytable WHERE i2 = 1", []sql.Row{}, nil, nil)
-	})
-}
-
 func TestCreateDatabase(t *testing.T, harness Harness) {
 	e := NewEngine(t, harness)
 	defer e.Close()

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -549,10 +549,6 @@ func TestDropColumn(t *testing.T) {
 	enginetest.TestDropColumn(t, enginetest.NewDefaultMemoryHarness())
 }
 
-func TestAddAndDropColumn(t *testing.T) {
-	enginetest.TestAddAndDropColumn(t, enginetest.NewDefaultMemoryHarness())
-}
-
 func TestCreateDatabase(t *testing.T) {
 	enginetest.TestCreateDatabase(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -161,11 +161,10 @@ func (a *AddColumn) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) 
 		return nil, err
 	}
 
-	// Prevents an iter of the full table when adding a new column that is not
+	// Prevents an iter of the full table when adding a new column that is
 	// nullable and has no default. This assumes that the underlying backend
-	// does not need to update defaults for every row when adding a column that
-	// is nullable and does not have a default.
-	if !a.column.Nullable && a.column.Default == nil {
+	// does not need to update defaults in this case.
+	if a.column.Nullable && a.column.Default == nil {
 		return sql.RowsToRowIter(), nil
 	}
 

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -161,8 +161,11 @@ func (a *AddColumn) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) 
 		return nil, err
 	}
 
-	// Prevents an iter of the full table when adding a new column with no default.
-	if a.column.Default == nil {
+	// Prevents an iter of the full table when adding a new column that is not
+	// nullable and has no default. This assumes that the underlying backend
+	// does not need to update defaults for every row when adding a column that
+	// is nullable and does not have a default.
+	if !a.column.Nullable && a.column.Default == nil {
 		return sql.RowsToRowIter(), nil
 	}
 


### PR DESCRIPTION
Fix for bad PR #855 which fails the following Dolt test:
http://github.com/dolthub/dolt/blob/51987ab84ef9d07b3c6ceae3ab65b9ca65ab55bd/go/libraries/doltcore/sqle/sqlddl_test.go#L482-L482

Verified this PR passes Dolt tests.

Also, removes `TestAddAndDropColumn` test which will be replaced with an appropriate bat test on Dolt. 

Related to https://github.com/dolthub/dolt/issues/2939