### PR TITLE
have methods for dolt to call to parse check expression

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -16,15 +16,14 @@ package sqle
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"os"
-
-	"github.com/dolthub/go-mysql-server/sql/grant_tables"
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
+	"github.com/dolthub/go-mysql-server/sql/grant_tables"
 	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )

--- a/engine.go
+++ b/engine.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"os"
 
 	"github.com/dolthub/go-mysql-server/sql/grant_tables"
@@ -591,4 +592,23 @@ func ResolveDefaults(tableName string, schema []*ColumnWithRawDefault) (sql.Sche
 	}
 
 	return analyzedCreateTable.CreateSchema.Schema, nil
+}
+
+// ColumnsFromCheckDefinition retrieves the Column Names referenced by a CheckDefinition
+func ColumnsFromCheckDefinition(ctx *sql.Context, def *sql.CheckDefinition) ([]string, error) {
+	// Evaluate the CheckDefinition to get evaluated Expression
+	c, err := analyzer.ConvertCheckDefToConstraint(ctx, def)
+	if err != nil {
+		return nil, err
+	}
+	// Look for any column references in the evaluated Expression
+	var cols []string
+	sql.Inspect(c.Expr, func(expr sql.Expression) bool {
+		if c, ok := expr.(*expression.UnresolvedColumn); ok {
+			cols = append(cols, c.Name())
+			return false
+		}
+		return true
+	})
+	return cols, nil
 }

--- a/sql/analyzer/check_constraints.go
+++ b/sql/analyzer/check_constraints.go
@@ -264,7 +264,7 @@ func loadChecksFromTable(ctx *sql.Context, table sql.Table) ([]*sql.CheckConstra
 			return nil, err
 		}
 		for _, ch := range checks {
-			constraint, err := convertCheckDefToConstraint(ctx, &ch)
+			constraint, err := ConvertCheckDefToConstraint(ctx, &ch)
 			if err != nil {
 				return nil, err
 			}
@@ -274,7 +274,7 @@ func loadChecksFromTable(ctx *sql.Context, table sql.Table) ([]*sql.CheckConstra
 	return loadedChecks, nil
 }
 
-func convertCheckDefToConstraint(ctx *sql.Context, check *sql.CheckDefinition) (*sql.CheckConstraint, error) {
+func ConvertCheckDefToConstraint(ctx *sql.Context, check *sql.CheckDefinition) (*sql.CheckConstraint, error) {
 	parseStr := fmt.Sprintf("select %s", check.CheckExpression)
 	parsed, err := sqlparser.Parse(parseStr)
 	if err != nil {


### PR DESCRIPTION
To properly merge check constraints, Dolt needs to partially parse their expression strings.
This PR gives Dolt access to some helper methods, to complete this operation. Should have no functional effect on GMS.