### PR TITLE
Fix logic with OR operation and add missing nil check to Like

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -111,11 +111,11 @@ func TestQueriesSimple(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleQuery(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 
 	var test enginetest.QueryTest
 	test = enginetest.QueryTest{
-		Query:    `SELECT * FROM datetime_table where date_col = '2020-01-01'`,
+		Query:    `select c1 from jsontable where c1 LIKE ('%' OR NULL)`,
 		Expected: []sql.Row{},
 	}
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -111,11 +111,11 @@ func TestQueriesSimple(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleQuery(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 
 	var test enginetest.QueryTest
 	test = enginetest.QueryTest{
-		Query:    `select c1 from jsontable where c1 LIKE ('%' OR NULL)`,
+		Query:    `SELECT * FROM datetime_table where date_col = '2020-01-01'`,
 		Expected: []sql.Row{},
 	}
 

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -6746,6 +6746,10 @@ var QueryTests = []QueryTest{
 		Query:    `select c1 from jsontable where c1 LIKE ('%' OR NULL)`,
 		Expected: []sql.Row{},
 	},
+	{
+		Query:    `select (('%' || 'dsads') || '%')`,
+		Expected: []sql.Row{{false}},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -6739,8 +6739,12 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:    `select (('%' || 'dsads') || '%')`,
-		Expected: []sql.Row{{false}},
+		Query:    `select c1 from jsontable where c1 LIKE (('%' OR 'dsads') OR '%')`,
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    `select c1 from jsontable where c1 LIKE ('%' OR NULL)`,
+		Expected: []sql.Row{},
 	},
 }
 

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -6747,7 +6747,7 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{},
 	},
 	{
-		Query:    `select (('%' || 'dsads') || '%')`,
+		Query:    `select (('%' OR 'dsads') OR '%')`,
 		Expected: []sql.Row{{false}},
 	},
 }

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -6738,6 +6738,10 @@ var QueryTests = []QueryTest{
 			{1, 1, 0},
 		},
 	},
+	{
+		Query:    `select (('%' || 'dsads') || '%')`,
+		Expected: []sql.Row{{false}},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -110,6 +110,10 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
+	if likeMatcher == nil {
+		return false, nil
+	}
+
 	ok := likeMatcher.Match(left.(string))
 	if !l.cached {
 		likeMatcher.Dispose()

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -145,6 +145,7 @@ func (o *Or) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		}
 	}
 
+	// Can also be triggered by lval and rval not being bool types.
 	if lval == false && rval == false {
 		return false, nil
 	}

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -128,14 +128,10 @@ func (o *Or) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 	if lval != nil {
-		lvalBool, err := sql.ConvertToBool(lval)
-		if err == nil && lvalBool {
+		lval, err = sql.ConvertToBool(lval)
+		if err == nil && lval.(bool) {
 			return true, nil
 		}
-	}
-
-	if lval == true {
-		return true, nil
 	}
 
 	rval, err := o.Right.Eval(ctx, row)
@@ -143,14 +139,10 @@ func (o *Or) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 	if rval != nil {
-		rvalBool, err := sql.ConvertToBool(rval)
-		if err == nil && rvalBool {
+		rval, err = sql.ConvertToBool(rval)
+		if err == nil && rval.(bool) {
 			return true, nil
 		}
-	}
-
-	if rval == true {
-		return true, nil
 	}
 
 	if lval == false && rval == false {

--- a/sql/expression/logic_test.go
+++ b/sql/expression/logic_test.go
@@ -73,6 +73,7 @@ func TestOr(t *testing.T) {
 		{"left is string, right is different string", "abc", "def", false},
 		{"left is string, right is nil", "abc", nil, nil},
 		{"left is nil, right is string", nil, "def", nil},
+		{"left is float, right is string", 2.0, "hello", true},
 	}
 
 	for _, tt := range testCases {

--- a/sql/expression/logic_test.go
+++ b/sql/expression/logic_test.go
@@ -37,6 +37,9 @@ func TestAnd(t *testing.T) {
 		{"both true", true, true, true},
 		{"both false", false, false, false},
 		{"both nil", nil, nil, nil},
+		{"left is string, right is string", "dsdad", "dasa", false},
+		{"left is string, right is nil", "ads", nil, false},
+		{"left is nil, right is string", nil, "dada", false},
 	}
 
 	for _, tt := range testCases {
@@ -67,6 +70,9 @@ func TestOr(t *testing.T) {
 		{"both true", true, true, true},
 		{"both false", false, false, false},
 		{"both null", nil, nil, nil},
+		{"left is string, right is different string", "abc", "def", false},
+		{"left is string, right is nil", "abc", nil, nil},
+		{"left is nil, right is string", nil, "def", nil},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
MySQL has some really weird behavior where the OR of two non bools evaluates too false. Improperly handling this situation was trickling up to a LIKE panic on the new query added to queries.go

```
SELECT "A" OR "A";
+------------+
| "A" OR "A" |
+------------+
|          0 |
+------------+
```