### PR TITLE
added warnings for some syntaxes of ALTER TABLE and CREATE DATABASE statements

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2498,6 +2498,14 @@ func TestCreateDatabase(t *testing.T, harness Harness) {
 	})
 
 	t.Run("CREATE DATABASE error handling", func(t *testing.T) {
+		AssertWarningAndTestQuery(t, e, ctx, harness, "CREATE DATABASE newtestdb CHARACTER SET utf8mb4 ENCRYPTION='N'",
+			[]sql.Row{sql.Row{sql.OkResult{RowsAffected: 1, InsertID: 0, Info: nil}}}, nil, mysql.ERNotSupportedYet, 1,
+			"", false)
+
+		AssertWarningAndTestQuery(t, e, ctx, harness, "CREATE DATABASE newtest1db DEFAULT COLLATE binary ENCRYPTION='Y'",
+			[]sql.Row{sql.Row{sql.OkResult{RowsAffected: 1, InsertID: 0, Info: nil}}}, nil, mysql.ERNotSupportedYet, 1,
+			"", false)
+
 		AssertErr(t, e, harness, "CREATE DATABASE mydb", sql.ErrDatabaseExists)
 
 		AssertWarningAndTestQuery(t, e, nil, harness, "CREATE DATABASE IF NOT EXISTS mydb",
@@ -4852,6 +4860,16 @@ func TestAlterTable(t *testing.T, harness Harness) {
 				Enforced:        true,
 			},
 		}, checks)
+	})
+
+	t.Run("Add column invalid after", func(t *testing.T) {
+		ctx := NewContext(harness)
+		AssertWarningAndTestQuery(t, e, ctx, harness, "ALTER TABLE t33 DISABLE KEYS",
+			[]sql.Row{}, nil, mysql.ERNotSupportedYet, 1,
+			"", false)
+		AssertWarningAndTestQuery(t, e, ctx, harness, "ALTER TABLE t33 ENABLE KEYS",
+			[]sql.Row{}, nil, mysql.ERNotSupportedYet, 1,
+			"", false)
 	})
 }
 

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -18,12 +18,12 @@ import (
 	"encoding/hex"
 	goerrors "errors"
 	"fmt"
-	"github.com/dolthub/vitess/go/mysql"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
 
+	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/opentracing/opentracing-go"
 	"gopkg.in/src-d/go-errors.v1"

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -909,7 +909,7 @@ func convertDBDDL(ctx *sql.Context, c *sqlparser.DBDDL) (sql.Node, error) {
 			ctx.Session.Warn(&sql.Warning{
 				Level:   "Warning",
 				Code:    mysql.ERNotSupportedYet,
-				Message: fmt.Sprintf("Setting CHARACTER SET, COLLATION and ENCRYPTION feature is not supported yet"),
+				Message: fmt.Sprintf("Setting CHARACTER SET, COLLATION and ENCRYPTION are not supported yet"),
 			})
 		}
 		return plan.NewCreateDatabase(c.DBName, c.IfNotExists), nil

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	goerrors "errors"
 	"fmt"
+	"github.com/dolthub/vitess/go/mysql"
 	"strconv"
 	"strings"
 	"time"
@@ -181,7 +182,7 @@ func convert(ctx *sql.Context, stmt sqlparser.Statement, query string) (sql.Node
 	case *sqlparser.MultiAlterDDL:
 		return convertMultiAlterDDL(ctx, query, n)
 	case *sqlparser.DBDDL:
-		return convertDBDDL(n)
+		return convertDBDDL(ctx, n)
 	case *sqlparser.Explain:
 		return convertExplain(ctx, n)
 	case *sqlparser.Insert:
@@ -901,9 +902,16 @@ func convertMultiAlterDDL(ctx *sql.Context, query string, c *sqlparser.MultiAlte
 	return plan.NewBlock(statements), nil
 }
 
-func convertDBDDL(c *sqlparser.DBDDL) (sql.Node, error) {
+func convertDBDDL(ctx *sql.Context, c *sqlparser.DBDDL) (sql.Node, error) {
 	switch strings.ToLower(c.Action) {
 	case sqlparser.CreateStr:
+		if len(c.CharsetCollate) > 0 {
+			ctx.Session.Warn(&sql.Warning{
+				Level:   "Warning",
+				Code:    mysql.ERNotSupportedYet,
+				Message: fmt.Sprintf("Setting CHARACTER SET, COLLATION and ENCRYPTION feature is not supported yet"),
+			})
+		}
 		return plan.NewCreateDatabase(c.DBName, c.IfNotExists), nil
 	case sqlparser.DropStr:
 		return plan.NewDropDatabase(c.DBName, c.IfExists), nil
@@ -1306,6 +1314,10 @@ func convertAlterIndex(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
 		return plan.NewAlterDropIndex(table, ddl.IndexSpec.ToName.String()), nil
 	case sqlparser.RenameStr:
 		return plan.NewAlterRenameIndex(table, ddl.IndexSpec.FromName.String(), ddl.IndexSpec.ToName.String()), nil
+	case "disable":
+		return plan.NewAlterDisableEnableKeys(table, true), nil
+	case "enable":
+		return plan.NewAlterDisableEnableKeys(table, false), nil
 	default:
 		return nil, sql.ErrUnsupportedFeature.New(sqlparser.String(ddl))
 	}

--- a/sql/plan/alter_index.go
+++ b/sql/plan/alter_index.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"fmt"
+	"github.com/dolthub/vitess/go/mysql"
 	"strings"
 
 	"gopkg.in/src-d/go-errors.v1"
@@ -40,6 +41,7 @@ const (
 	IndexAction_Create IndexAction = iota
 	IndexAction_Drop
 	IndexAction_Rename
+	IndexAction_DisableEnableKeys
 )
 
 type AlterIndex struct {
@@ -59,6 +61,8 @@ type AlterIndex struct {
 	Columns []sql.IndexColumn
 	// Comment is the comment that was left at index creation, if any
 	Comment string
+	// DisableKeys determines whether to DISABLE KEYS if true or ENABLE KEYS if false
+	DisableKeys bool
 }
 
 func NewAlterCreateIndex(table sql.Node, indexName string, using sql.IndexUsing, constraint sql.IndexConstraint, columns []sql.IndexColumn, comment string) *AlterIndex {
@@ -87,6 +91,14 @@ func NewAlterRenameIndex(table sql.Node, fromIndexName, toIndexName string) *Alt
 		Table:             table,
 		IndexName:         toIndexName,
 		PreviousIndexName: fromIndexName,
+	}
+}
+
+func NewAlterDisableEnableKeys(table sql.Node, disableKeys bool) *AlterIndex {
+	return &AlterIndex{
+		Action:      IndexAction_DisableEnableKeys,
+		Table:       table,
+		DisableKeys: disableKeys,
 	}
 }
 
@@ -154,6 +166,13 @@ func (p *AlterIndex) Execute(ctx *sql.Context) error {
 		return indexable.DropIndex(ctx, p.IndexName)
 	case IndexAction_Rename:
 		return indexable.RenameIndex(ctx, p.PreviousIndexName, p.IndexName)
+	case IndexAction_DisableEnableKeys:
+		ctx.Session.Warn(&sql.Warning{
+			Level:   "Warning",
+			Code:    mysql.ERNotSupportedYet,
+			Message: fmt.Sprintf("'disable/enable keys' feature is not supported yet"),
+		})
+		return nil
 	default:
 		return ErrIndexActionNotImplemented.New(p.Action)
 	}
@@ -181,6 +200,8 @@ func (p *AlterIndex) WithChildren(children ...sql.Node) (sql.Node, error) {
 		return NewAlterDropIndex(children[0], p.IndexName), nil
 	case IndexAction_Rename:
 		return NewAlterRenameIndex(children[0], p.PreviousIndexName, p.IndexName), nil
+	case IndexAction_DisableEnableKeys:
+		return NewAlterDisableEnableKeys(children[0], p.DisableKeys), nil
 	default:
 		return nil, ErrIndexActionNotImplemented.New(p.Action)
 	}

--- a/sql/plan/alter_index.go
+++ b/sql/plan/alter_index.go
@@ -16,9 +16,9 @@ package plan
 
 import (
 	"fmt"
-	"github.com/dolthub/vitess/go/mysql"
 	"strings"
 
+	"github.com/dolthub/vitess/go/mysql"
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"

--- a/sql/system_variables.go
+++ b/sql/system_variables.go
@@ -986,6 +986,14 @@ var systemVars = map[string]SystemVariable{
 		Type:              NewSystemBoolType("inmemory_joins"),
 		Default:           int8(0),
 	},
+	"innodb_stats_auto_recalc": {
+		Name:              "inmemory_joins",
+		Scope:             SystemVariableScope_Global,
+		Dynamic:           true,
+		SetVarHintApplies: false,
+		Type:              NewSystemBoolType("innodb_stats_auto_recalc"),
+		Default:           int8(1),
+	},
 	"interactive_timeout": {
 		Name:              "interactive_timeout",
 		Scope:             SystemVariableScope_Both,


### PR DESCRIPTION
- Added a warning for using `CHARACTER SET`, `COLLATE` or `ENCRYPTION` syntaxes when creating database. The database is still created.
- Added a warning for using `DISABLE KEYS` or  `ENABLE KEYS` options for alter table statement. Nothing changes for the table being altered.
- Added a system variable that mysqldump uses, `innodb_stats_auto_recalc`