### PR TITLE
fix non_unique column value definition in `information_schema.statistics` table

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -7956,8 +7956,8 @@ var InfoSchemaScripts = []ScriptTest{
 			{
 				Query: "SELECT * FROM information_schema.statistics where table_name='mytable'",
 				Expected: []sql.Row{
-					{"def", "mydb", "mytable", 0, "mydb", "myindex", 1, "test_score", "A", uint64(2), nil, nil, "YES", "BTREE", "", "", "YES", nil},
-					{"def", "mydb", "mytable", 1, "mydb", "PRIMARY", 1, "pk", "A", uint64(2), nil, nil, "", "BTREE", "", "", "YES", nil},
+					{"def", "mydb", "mytable", 1, "mydb", "myindex", 1, "test_score", "A", uint64(2), nil, nil, "YES", "BTREE", "", "", "YES", nil},
+					{"def", "mydb", "mytable", 0, "mydb", "PRIMARY", 1, "pk", "A", uint64(2), nil, nil, "", "BTREE", "", "", "YES", nil},
 				},
 			},
 		},

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -995,9 +995,9 @@ func statisticsRowIter(ctx *Context, c Catalog) (RowIter, error) {
 					)
 					indexName = index.ID()
 					if index.IsUnique() {
-						nonUnique = 1
-					} else {
 						nonUnique = 0
+					} else {
+						nonUnique = 1
 					}
 					indexType := index.IndexType()
 					indexComment = index.Comment()


### PR DESCRIPTION
fix non_unique being assigned incorrect value. Verified with Mysql docs, "0 if the index cannot contain duplicates (which .IsUnique() is true), 1 if it can."