### PR TITLE
fix `SHOW INDEXES FROM otherdb.tab` fails as database is initialized incorrectly in parsing

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -226,6 +226,21 @@ func TestIndexQueryPlans(t *testing.T, harness Harness) {
 			TestQueryPlan(t, NewContextWithEngine(harness, engine), engine, harness, tt.Query, tt.ExpectedPlan)
 		})
 	}
+
+	t.Run("no database selected", func(t *testing.T) {
+		ctx := NewContext(harness)
+		ctx.SetCurrentDatabase("")
+
+		RunQuery(t, engine, harness, "CREATE DATABASE otherdb")
+		RunQuery(t, engine, harness, `CREATE TABLE otherdb.a (x int, y int)`)
+		RunQuery(t, engine, harness, `CREATE INDEX idx1 ON otherdb.a (y);`)
+		//otherdb, err := engine.Analyzer.Catalog.Database(ctx, "otherdb")
+
+		TestQueryWithContext(t, ctx, engine, "SHOW INDEXES FROM otherdb.a", []sql.Row{
+			{"a", 1, "idx1", 1, "y", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil},
+		}, nil, nil)
+
+	})
 }
 
 // Tests a variety of queries against databases and tables provided by the given harness.

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -234,7 +234,6 @@ func TestIndexQueryPlans(t *testing.T, harness Harness) {
 		RunQuery(t, engine, harness, "CREATE DATABASE otherdb")
 		RunQuery(t, engine, harness, `CREATE TABLE otherdb.a (x int, y int)`)
 		RunQuery(t, engine, harness, `CREATE INDEX idx1 ON otherdb.a (y);`)
-		//otherdb, err := engine.Analyzer.Catalog.Database(ctx, "otherdb")
 
 		TestQueryWithContext(t, ctx, engine, "SHOW INDEXES FROM otherdb.a", []sql.Row{
 			{"a", 1, "idx1", 1, "y", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil},

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -113,7 +113,7 @@ func (e *ColumnDefaultValue) Resolved() bool {
 func (e *ColumnDefaultValue) String() string {
 	//TODO: currently (2+2)/2 will, when output as a string, give (2 + 2 / 2), which is clearly wrong
 	if e == nil {
-		return ""
+		return "NULL"
 	}
 
 	// https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -113,7 +113,7 @@ func (e *ColumnDefaultValue) Resolved() bool {
 func (e *ColumnDefaultValue) String() string {
 	//TODO: currently (2+2)/2 will, when output as a string, give (2 + 2 / 2), which is clearly wrong
 	if e == nil {
-		return "NULL"
+		return ""
 	}
 
 	// https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -872,6 +872,7 @@ func columnsRowIter(ctx *Context, cat Catalog) (RowIter, error) {
 					charName   interface{}
 					collName   interface{}
 					ordinalPos uint64
+					colDefault string
 				)
 				if c.Nullable {
 					nullable = "YES"
@@ -883,13 +884,17 @@ func columnsRowIter(ctx *Context, cat Catalog) (RowIter, error) {
 					collName = Collation_Default.String()
 				}
 				ordinalPos = uint64(i + 1)
+				colDefault = c.Default.String()
+				if c.Default == nil {
+					colDefault = "NULL"
+				}
 				rows = append(rows, Row{
 					"def",                            // table_catalog
 					db.Name(),                        // table_schema
 					t.Name(),                         // table_name
 					c.Name,                           // column_name
 					ordinalPos,                       // ordinal_position
-					c.Default.String(),               // column_default
+					colDefault,                       // column_default
 					nullable,                         // is_nullable
 					strings.ToLower(c.Type.String()), // data_type
 					nil,                              // character_maximum_length

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -868,9 +868,10 @@ func columnsRowIter(ctx *Context, cat Catalog) (RowIter, error) {
 		err := DBTableIter(ctx, db, func(t Table) (cont bool, err error) {
 			for i, c := range t.Schema() {
 				var (
-					nullable string
-					charName interface{}
-					collName interface{}
+					nullable   string
+					charName   interface{}
+					collName   interface{}
+					ordinalPos uint64
 				)
 				if c.Nullable {
 					nullable = "YES"
@@ -881,12 +882,13 @@ func columnsRowIter(ctx *Context, cat Catalog) (RowIter, error) {
 					charName = Collation_Default.CharacterSet().String()
 					collName = Collation_Default.String()
 				}
+				ordinalPos = uint64(i + 1)
 				rows = append(rows, Row{
 					"def",                            // table_catalog
 					db.Name(),                        // table_schema
 					t.Name(),                         // table_name
 					c.Name,                           // column_name
-					uint64(i),                        // ordinal_position
+					ordinalPos,                       // ordinal_position
 					c.Default.String(),               // column_default
 					nullable,                         // is_nullable
 					strings.ToLower(c.Type.String()), // data_type

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -528,7 +528,7 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 		}
 		return node, nil
 	case "index":
-		return plan.NewShowIndexes(plan.NewUnresolvedTable(s.Table.Name.String(), s.Database)), nil
+		return plan.NewShowIndexes(plan.NewUnresolvedTable(s.Table.Name.String(), s.Table.Qualifier.String())), nil
 	case sqlparser.KeywordString(sqlparser.VARIABLES):
 		var likepattern string
 		if s.Filter != nil {


### PR DESCRIPTION
Before Show Index statement was initializing the Database incorrectly as it would set it to either empty or current database. This was an issue for using the statement for database that user is not currently on. 
This PR also fixes couple of info schema table inconsistencies against Mysql.