### PR TITLE
adding 1 second to trigger creation time

### DIFF
--- a/enginetest/trigger_queries.go
+++ b/enginetest/trigger_queries.go
@@ -1399,7 +1399,7 @@ end;`,
 						nil,                     // action_reference_new_table
 						"OLD",                   // action_reference_old_row
 						"NEW",                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),   // created
+						time.Unix(1, 0).UTC(),   // created
 						"",                      // sql_mode
 						"",                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client
@@ -1423,7 +1423,7 @@ end;`,
 						nil,                     // action_reference_new_table
 						"OLD",                   // action_reference_old_row
 						"NEW",                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),   // created
+						time.Unix(1, 0).UTC(),   // created
 						"",                      // sql_mode
 						"",                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client
@@ -1447,7 +1447,7 @@ end;`,
 						nil,                     // action_reference_new_table
 						"OLD",                   // action_reference_old_row
 						"NEW",                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),   // created
+						time.Unix(1, 0).UTC(),   // created
 						"",                      // sql_mode
 						"",                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client
@@ -1471,7 +1471,7 @@ end;`,
 						nil,                     // action_reference_new_table
 						"OLD",                   // action_reference_old_row
 						"NEW",                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),   // created
+						time.Unix(1, 0).UTC(),   // created
 						"",                      // sql_mode
 						"",                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client
@@ -1495,7 +1495,7 @@ end;`,
 						nil,                                     // action_reference_new_table
 						"OLD",                                   // action_reference_old_row
 						"NEW",                                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),                   // created
+						time.Unix(1, 0).UTC(),                   // created
 						"",                                      // sql_mode
 						"",                                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client
@@ -1519,7 +1519,7 @@ end;`,
 						nil,                                     // action_reference_new_table
 						"OLD",                                   // action_reference_old_row
 						"NEW",                                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),                   // created
+						time.Unix(1, 0).UTC(),                   // created
 						"",                                      // sql_mode
 						"",                                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client
@@ -1543,7 +1543,7 @@ end;`,
 						nil,                                     // action_reference_new_table
 						"OLD",                                   // action_reference_old_row
 						"NEW",                                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),                   // created
+						time.Unix(1, 0).UTC(),                   // created
 						"",                                      // sql_mode
 						"",                                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client
@@ -1567,7 +1567,7 @@ end;`,
 						nil,                                     // action_reference_new_table
 						"OLD",                                   // action_reference_old_row
 						"NEW",                                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),                   // created
+						time.Unix(1, 0).UTC(),                   // created
 						"",                                      // sql_mode
 						"",                                      // definer
 						sql.Collation_Default.CharacterSet().String(), // character_set_client

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1170,7 +1170,7 @@ func triggersRowIter(ctx *Context, c Catalog) (RowIter, error) {
 						nil,                     // action_reference_new_table
 						"OLD",                   // action_reference_old_row
 						"NEW",                   // action_reference_new_row
-						time.Unix(0, 0).UTC(),   // created
+						time.Unix(1, 0).UTC(),   // created
 						"",                      // sql_mode
 						"",                      // definer
 						characterSetClient,      // character_set_client

--- a/sql/plan/show_triggers.go
+++ b/sql/plan/show_triggers.go
@@ -96,7 +96,7 @@ func (s *ShowTriggers) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, erro
 			tableName,             // Table
 			trigger.BodyString,    // Statement
 			triggerTime,           // Timing
-			time.Unix(0, 0).UTC(), // Created
+			time.Unix(1, 0).UTC(), // Created
 			"",                    // sql_mode
 			"",                    // Definer
 			characterSetClient,    // character_set_client


### PR DESCRIPTION
Fix for this issue: https://github.com/dolthub/dolt/issues/3047


Triggers weren't showing up in TablePlus because the creation time for triggers is always 0 in unix time, which is out of TablePlus supported timestamp range (for some reason). So this PR just makes the trigger creation time 1 second after the start of all time, which TablePlus considers valid.