### PR TITLE
Adding support for an `as of` expression in `show columns from table`

### DIFF
--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -976,6 +976,14 @@ var ScriptTests = []ScriptTest{
 					{"v1", "bigint", "NO", "", "200", ""},
 				},
 			},
+			{
+				// as of syntax is supported, but mocked out in test harnesses
+				Query: "DESCRIBE test as of 'version'",
+				Expected: []sql.Row{
+					{"pk", "bigint", "NO", "PRI", "", ""},
+					{"v1", "bigint", "NO", "", "200", ""},
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Passing through `as of` expression in `show columns` statements.

Depends on Vitess support in: https://github.com/dolthub/vitess/pull/150