### PR TITLE
InsertInto Bindvars

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4436,6 +4436,90 @@ func TestVariables(t *testing.T, harness Harness) {
 	}
 }
 
+func TestPreparedInsert(t *testing.T, harness Harness) {
+	myDb := harness.NewDatabase("mydb")
+	databases := []sql.Database{myDb}
+	e := NewEngineWithDbs(t, harness, databases)
+	defer e.Close()
+
+	tests := []struct {
+		Name        string
+		SetUpScript []string
+		Assertions  []QueryTest
+	}{
+		{
+			Name: "Insert on duplicate key",
+			SetUpScript: []string{
+				`CREATE TABLE users (
+  				id varchar(42) PRIMARY KEY
+			)`,
+				`CREATE TABLE nodes (
+			    id varchar(42) PRIMARY KEY,
+			    owner varchar(42),
+			    status varchar(12),
+			    timestamp bigint NOT NULL,
+			    FOREIGN KEY(owner) REFERENCES users(id)
+			)`,
+				"INSERT INTO users values ('milo'), ('dabe')",
+				"INSERT INTO nodes values ('id1', 'milo', 'off', 1)",
+			},
+			Assertions: []QueryTest{
+				{
+					Query: "insert into nodes(id,owner,status,timestamp) values(?, ?, ?, ?) on duplicate key update owner=?,status=?",
+					Bindings: map[string]sql.Expression{
+						"v1": expression.NewLiteral("id1", sql.Text),
+						"v2": expression.NewLiteral("dabe", sql.Text),
+						"v3": expression.NewLiteral("off", sql.Text),
+						"v4": expression.NewLiteral(2, sql.Int64),
+						"v5": expression.NewLiteral("milo", sql.Text),
+						"v6": expression.NewLiteral("on", sql.Text),
+					},
+					Expected: []sql.Row{
+						{sql.OkResult{RowsAffected: 2}},
+					},
+				},
+				{
+					Query: "insert into nodes(id,owner,status,timestamp) values(?, ?, ?, ?) on duplicate key update owner=?,status=?",
+					Bindings: map[string]sql.Expression{
+						"v1": expression.NewLiteral("id2", sql.Text),
+						"v2": expression.NewLiteral("dabe", sql.Text),
+						"v3": expression.NewLiteral("off", sql.Text),
+						"v4": expression.NewLiteral(3, sql.Int64),
+						"v5": expression.NewLiteral("milo", sql.Text),
+						"v6": expression.NewLiteral("on", sql.Text),
+					},
+					Expected: []sql.Row{
+						{sql.OkResult{RowsAffected: 1}},
+					},
+				},
+				{
+					Query: "select * from nodes",
+					Expected: []sql.Row{
+						{"id1", "milo", "on", 1},
+						{"id2", "dabe", "off", 3},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		ctx := NewContextWithEngine(harness, e)
+		for _, statement := range tt.SetUpScript {
+			if sh, ok := harness.(SkippingHarness); ok {
+				if sh.SkipQueryTest(statement) {
+					t.Skip()
+				}
+			}
+
+			RunQuery(t, e, harness, statement)
+		}
+
+		for _, a := range tt.Assertions {
+			TestQueryWithContext(t, ctx, e, a.Query, a.Expected, nil, a.Bindings)
+		}
+	}
+}
+
 func TestVariableErrors(t *testing.T, harness Harness) {
 	e := NewEngine(t, harness)
 	defer e.Close()

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -696,6 +696,10 @@ func TestPersist(t *testing.T) {
 	enginetest.TestPersist(t, enginetest.NewDefaultMemoryHarness(), newSess)
 }
 
+func TestPreparedInsert(t *testing.T) {
+	enginetest.TestPreparedInsert(t, enginetest.NewMemoryHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+}
+
 func mergableIndexDriver(dbs []sql.Database) sql.IndexDriver {
 	return memory.NewIndexDriver("mydb", map[string][]sql.DriverIndex{
 		"mytable": {

--- a/sql/plan/bindvar.go
+++ b/sql/plan/bindvar.go
@@ -47,6 +47,14 @@ func ApplyBindings(n sql.Node, bindings map[string]sql.Expression) (sql.Node, er
 
 	return TransformUpWithOpaque(n, func(node sql.Node) (sql.Node, error) {
 		switch n := node.(type) {
+		case *IndexedJoin:
+			// *plan.IndexedJoin cannot implement sql.Expressioner
+			// because the column indexes get mis-ordered by FixFieldIndexesForExpressions.
+			cond, err := expression.TransformUp(n.Cond, fixBindings)
+			if err != nil {
+				return nil, err
+			}
+			return NewIndexedJoin(n.left, n.right, n.joinType, cond, n.scopeLen), nil
 		case *InsertInto:
 			// Manually apply bindings to [Source] because it is separated
 			// from [Destination].
@@ -54,9 +62,8 @@ func ApplyBindings(n sql.Node, bindings map[string]sql.Expression) (sql.Node, er
 			if err != nil {
 				return nil, err
 			}
-			return n.WithSource(newSource), nil
-		default:
-			return TransformExpressionsUp(node, fixBindings)
+			return TransformExpressionsUp(n.WithSource(newSource), fixBindings)
 		}
+		return TransformExpressionsUp(node, fixBindings)
 	})
 }


### PR DESCRIPTION
InsertInto is special in that [Source] is not a child sql.Node,
so [Source] needs to be traversed separately to touch every expression
in a DFS search.

This fixes a bug in that DFS search missing the non-Source node
children.