### PR TITLE
Prevent Creation of Unique Keys

### DIFF
--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1536,13 +1536,17 @@ func convertCreateTable(ctx *sql.Context, c *sqlparser.DDL) (sql.Node, error) {
 		}
 	}
 
+	seenPrimary := false
+	seenUnique := false
 	var idxDefs []*plan.IndexDefinition
 	for _, idxDef := range c.TableSpec.Indexes {
 		constraint := sql.IndexConstraint_None
 		if idxDef.Info.Primary {
 			constraint = sql.IndexConstraint_Primary
+			seenPrimary = true
 		} else if idxDef.Info.Unique {
 			constraint = sql.IndexConstraint_Unique
+			seenUnique = true
 		} else if idxDef.Info.Spatial {
 			constraint = sql.IndexConstraint_Spatial
 		} else if idxDef.Info.Fulltext {
@@ -1585,7 +1589,14 @@ func convertCreateTable(ctx *sql.Context, c *sqlparser.DDL) (sql.Node, error) {
 	}
 
 	for _, colDef := range c.TableSpec.Columns {
+		if colDef.Type.KeyOpt == colKeyFulltextKey {
+			return nil, sql.ErrUnsupportedFeature.New("fulltext keys are unsupported")
+		}
+		if colDef.Type.KeyOpt == colKeyPrimary {
+			seenPrimary = true
+		}
 		if colDef.Type.KeyOpt == colKeyUnique || colDef.Type.KeyOpt == colKeyUniqueKey {
+			seenUnique = true
 			idxDefs = append(idxDefs, &plan.IndexDefinition{
 				IndexName:  "",
 				Using:      sql.IndexUsing_Default,
@@ -1597,6 +1608,11 @@ func convertCreateTable(ctx *sql.Context, c *sqlparser.DDL) (sql.Node, error) {
 				}},
 			})
 		}
+	}
+
+	// can't use unique constraint on keyless tables
+	if seenUnique && !seenPrimary {
+		return nil, sql.ErrUnsupportedFeature.New("unique constraint on keyless tables")
 	}
 
 	qualifier := c.Table.Qualifier.String()

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -3826,6 +3826,9 @@ var fixturesErrors = map[string]*errors.Kind{
 	`KILL CONNECTION 4294967296`:                                sql.ErrUnsupportedFeature,
 	`DROP TABLE IF EXISTS curdb.foo, otherdb.bar`:               sql.ErrUnsupportedFeature,
 	`DROP TABLE curdb.t1, t2`:                                   sql.ErrUnsupportedFeature,
+	`CREATE TABLE test (i int unique)`:                          sql.ErrUnsupportedFeature,
+	`CREATE TABLE test (i int, j int unique)`:                   sql.ErrUnsupportedFeature,
+	`CREATE TABLE test (i int, unique(i))`:                      sql.ErrUnsupportedFeature,
 }
 
 func TestParseOne(t *testing.T) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -3826,6 +3826,7 @@ var fixturesErrors = map[string]*errors.Kind{
 	`KILL CONNECTION 4294967296`:                                sql.ErrUnsupportedFeature,
 	`DROP TABLE IF EXISTS curdb.foo, otherdb.bar`:               sql.ErrUnsupportedFeature,
 	`DROP TABLE curdb.t1, t2`:                                   sql.ErrUnsupportedFeature,
+	`CREATE TABLE test (i int fulltext key)`:                    sql.ErrUnsupportedFeature,
 	`CREATE TABLE test (i int unique)`:                          sql.ErrUnsupportedFeature,
 	`CREATE TABLE test (i int, j int unique)`:                   sql.ErrUnsupportedFeature,
 	`CREATE TABLE test (i int, unique(i))`:                      sql.ErrUnsupportedFeature,


### PR DESCRIPTION
Small fix for preventing the creation of `FULLTEXT` keys as well.

TODO: There should also be a change in Dolt to prevent altering and modifying columns to use `FULLTEXT` keys