### PR TITLE
Editing test data to work around failures with new Dolt storage format

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -7165,9 +7165,9 @@ var VersionedQueries = []QueryTest{
 	{
 		Query: "SELECT *  FROM myhistorytable ORDER BY i",
 		Expected: []sql.Row{
-			{int64(1), "first row, 2", "1"},
-			{int64(2), "second row, 2", "2"},
-			{int64(3), "third row, 2", "3"},
+			{int64(1), "first row, 3", "1"},
+			{int64(2), "second row, 3", "2"},
+			{int64(3), "third row, 3", "3"},
 		},
 	},
 	{
@@ -8571,17 +8571,17 @@ var VersionedViewTests = []QueryTest{
 	{
 		Query: "SELECT * FROM myview1 ORDER BY i",
 		Expected: []sql.Row{
-			sql.NewRow(int64(1), "first row, 2", "1"),
-			sql.NewRow(int64(2), "second row, 2", "2"),
-			sql.NewRow(int64(3), "third row, 2", "3"),
+			sql.NewRow(int64(1), "first row, 3", "1"),
+			sql.NewRow(int64(2), "second row, 3", "2"),
+			sql.NewRow(int64(3), "third row, 3", "3"),
 		},
 	},
 	{
 		Query: "SELECT t.* FROM myview1 AS t ORDER BY i",
 		Expected: []sql.Row{
-			sql.NewRow(int64(1), "first row, 2", "1"),
-			sql.NewRow(int64(2), "second row, 2", "2"),
-			sql.NewRow(int64(3), "third row, 2", "3"),
+			sql.NewRow(int64(1), "first row, 3", "1"),
+			sql.NewRow(int64(2), "second row, 3", "2"),
+			sql.NewRow(int64(3), "third row, 3", "3"),
 		},
 	},
 	{
@@ -8603,7 +8603,7 @@ var VersionedViewTests = []QueryTest{
 	{
 		Query: "SELECT * FROM myview2",
 		Expected: []sql.Row{
-			sql.NewRow(int64(1), "first row, 2", "1"),
+			sql.NewRow(int64(1), "first row, 3", "1"),
 		},
 	},
 	{
@@ -8621,13 +8621,13 @@ var VersionedViewTests = []QueryTest{
 	{
 		Query: "SELECT myview2.* FROM myview2",
 		Expected: []sql.Row{
-			sql.NewRow(int64(1), "first row, 2", "1"),
+			sql.NewRow(int64(1), "first row, 3", "1"),
 		},
 	},
 	{
 		Query: "SELECT t.* FROM myview2 as t",
 		Expected: []sql.Row{
-			sql.NewRow(int64(1), "first row, 2", "1"),
+			sql.NewRow(int64(1), "first row, 3", "1"),
 		},
 	},
 	{

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -804,9 +804,9 @@ func createSubsetTestData(t *testing.T, harness Harness, includedTables []string
 				column := sql.Column{Name: "c", Type: sql.Text}
 				AddColumn(t, NewContext(harness), mustAlterableTable(t, table), &column)
 				InsertRows(t, NewContext(harness), mustInsertableTable(t, table),
-					sql.NewRow(int64(1), "first row, 2", "1"),
-					sql.NewRow(int64(2), "second row, 2", "2"),
-					sql.NewRow(int64(3), "third row, 2", "3"))
+					sql.NewRow(int64(1), "first row, 3", "1"),
+					sql.NewRow(int64(2), "second row, 3", "2"),
+					sql.NewRow(int64(3), "third row, 3", "3"))
 			}
 		})
 


### PR DESCRIPTION
Without changing the test data, the new Dolt storage format doesn't recognize that there is any change and it errors out with "nothing to commit" during testdata setup.

Editing the test data allows the testdata setup to complete successfully on the old Dolt storage format and on the new Dolt storage format. TestVersionedQueries is now configured to be skipped on the new Dolt storage format. 