### PR TITLE
update `create view` parsing and added `definer` var for `create trigger` stmt

### DIFF
--- a/enginetest/procedure_queries.go
+++ b/enginetest/procedure_queries.go
@@ -972,7 +972,7 @@ var ProcedureShowStatus = []ScriptTest{
 						"mydb",                // Db
 						"p2",                  // Name
 						"PROCEDURE",           // Type
-						"user",                // Definer
+						"`user`@`%`",          // Definer
 						time.Unix(0, 0).UTC(), // Modified
 						time.Unix(0, 0).UTC(), // Created
 						"INVOKER",             // Security_type
@@ -1003,7 +1003,7 @@ var ProcedureShowStatus = []ScriptTest{
 						"mydb",                // Db
 						"p2",                  // Name
 						"PROCEDURE",           // Type
-						"user",                // Definer
+						"`user`@`%`",          // Definer
 						time.Unix(0, 0).UTC(), // Modified
 						time.Unix(0, 0).UTC(), // Created
 						"INVOKER",             // Security_type
@@ -1051,7 +1051,7 @@ var ProcedureShowStatus = []ScriptTest{
 						"mydb",                // Db
 						"p2",                  // Name
 						"PROCEDURE",           // Type
-						"user",                // Definer
+						"`user`@`%`",          // Definer
 						time.Unix(0, 0).UTC(), // Modified
 						time.Unix(0, 0).UTC(), // Created
 						"INVOKER",             // Security_type
@@ -1113,7 +1113,7 @@ var ProcedureShowStatus = []ScriptTest{
 						"mydb",                // Db
 						"p2",                  // Name
 						"PROCEDURE",           // Type
-						"user",                // Definer
+						"`user`@`%`",          // Definer
 						time.Unix(0, 0).UTC(), // Modified
 						time.Unix(0, 0).UTC(), // Created
 						"INVOKER",             // Security_type

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -8083,6 +8083,21 @@ var InfoSchemaScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "information_schema.triggers create trigger definer defined",
+		SetUpScript: []string{
+			"CREATE TABLE aa (x INT PRIMARY KEY)",
+			"CREATE DEFINER=`dolt`@`localhost` TRIGGER trigger1 BEFORE INSERT ON aa FOR EACH ROW SET NEW.x = NEW.x + 1",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT trigger_name, event_object_table, definer FROM INFORMATION_SCHEMA.TRIGGERS WHERE trigger_name = 'trigger1'",
+				Expected: []sql.Row{
+					{"trigger1", "aa", "`dolt`@`localhost`"},
+				},
+			},
+		},
+	},
+	{
 		Name: "information_schema.statistics shows non unique index",
 		SetUpScript: []string{
 			"CREATE TABLE mytable (pk int primary key, test_score int, height int)",
@@ -8122,7 +8137,7 @@ var InfoSchemaScripts = []ScriptTest{
 						nil, "SQL", "SQL", "", "", nil, "DEFINER", "SQL", "hi", "", "utf8mb4", "utf8mb4_0900_bin",
 						"utf8mb4_0900_bin"},
 					{"p2", "def", "mydb", "p2", "PROCEDURE", "", nil, nil, nil, nil, nil, nil, nil, "", "SQL",
-						nil, "SQL", "SQL", "", "", nil, "INVOKER", "SQL", "", "user", "utf8mb4", "utf8mb4_0900_bin",
+						nil, "SQL", "SQL", "", "", nil, "INVOKER", "SQL", "", "`user`@`%`", "utf8mb4", "utf8mb4_0900_bin",
 						"utf8mb4_0900_bin"},
 					{"p12", "def", "somedb", "p12", "PROCEDURE", "", nil, nil, nil, nil, nil, nil, nil, "", "SQL",
 						nil, "SQL", "SQL", "", "", nil, "DEFINER", "SQL", "hello", "", "utf8mb4", "utf8mb4_0900_bin",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20220404164553-6944b106018c
+	github.com/dolthub/vitess v0.0.0-20220405181441-4764d69e0e9f
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/dolthub/vitess v0.0.0-20220330190824-c23b568183c5 h1:66HHMuSkaCV3S7bN
 github.com/dolthub/vitess v0.0.0-20220330190824-c23b568183c5/go.mod h1:jxgvpEvrTNw2i4BKlwT75E775eUXBeMv5MPeQkIb9zI=
 github.com/dolthub/vitess v0.0.0-20220404164553-6944b106018c h1:D0U6mDvtWx4NCikNZVMHVywQbMhGEiZMw3SQnuhEYPI=
 github.com/dolthub/vitess v0.0.0-20220404164553-6944b106018c/go.mod h1:jxgvpEvrTNw2i4BKlwT75E775eUXBeMv5MPeQkIb9zI=
+github.com/dolthub/vitess v0.0.0-20220405181441-4764d69e0e9f h1:PJ3/KnDI7xHpzoeXcUMtCpa7sRXDOYMEwEp30fwUNIM=
+github.com/dolthub/vitess v0.0.0-20220405181441-4764d69e0e9f/go.mod h1:jxgvpEvrTNw2i4BKlwT75E775eUXBeMv5MPeQkIb9zI=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1211,7 +1211,7 @@ func triggersRowIter(ctx *Context, c Catalog) (RowIter, error) {
 						"NEW",                   // action_reference_new_row
 						triggerPlan.CreatedAt,   // created
 						"",                      // sql_mode
-						"",                      // definer
+						triggerPlan.Definer,     // definer
 						characterSetClient,      // character_set_client
 						collationConnection,     // collation_connection
 						collationServer,         // database_collation

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -921,7 +921,7 @@ func convertDDL(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.Node, err
 		if c.ProcedureSpec != nil {
 			return convertCreateProcedure(ctx, query, c)
 		}
-		if !c.View.IsEmpty() {
+		if c.ViewSpec != nil {
 			return convertCreateView(ctx, query, c)
 		}
 		return convertCreateTable(ctx, c)
@@ -1014,6 +1014,7 @@ func convertCreateTrigger(ctx *sql.Context, query string, c *sqlparser.DDL) (sql
 		query,
 		bodyStr,
 		ctx.QueryTime(),
+		c.TriggerSpec.Definer,
 	), nil
 }
 
@@ -1704,9 +1705,9 @@ func convertReferenceAction(action sqlparser.ReferenceAction) sql.ForeignKeyRefe
 }
 
 func convertCreateView(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.Node, error) {
-	selectStatement, ok := c.ViewExpr.(sqlparser.SelectStatement)
+	selectStatement, ok := c.ViewSpec.ViewExpr.(sqlparser.SelectStatement)
 	if !ok {
-		return nil, sql.ErrUnsupportedSyntax.New(sqlparser.String(c.ViewExpr))
+		return nil, sql.ErrUnsupportedSyntax.New(sqlparser.String(c.ViewSpec.ViewExpr))
 	}
 
 	queryNode, err := convertSelectStatement(ctx, selectStatement)
@@ -1715,10 +1716,10 @@ func convertCreateView(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.No
 	}
 
 	selectStr := query[c.SubStatementPositionStart:c.SubStatementPositionEnd]
-	queryAlias := plan.NewSubqueryAlias(c.View.Name.String(), selectStr, queryNode)
+	queryAlias := plan.NewSubqueryAlias(c.ViewSpec.ViewName.Name.String(), selectStr, queryNode)
 
 	return plan.NewCreateView(
-		sql.UnresolvedDatabase(""), c.View.Name.String(), []string{}, queryAlias, c.OrReplace), nil
+		sql.UnresolvedDatabase(""), c.ViewSpec.ViewName.Name.String(), []string{}, queryAlias, c.OrReplace), nil
 }
 
 func convertDropView(ctx *sql.Context, c *sqlparser.DDL) (sql.Node, error) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -3694,6 +3694,7 @@ var triggerFixtures = map[string]sql.Node{
 		 INSERT INTO zzz (a,b) VALUES (old.a, old.b);
    END`,
 		time.Unix(0, 0),
+		"",
 	),
 	`CREATE TRIGGER myTrigger BEFORE UPDATE ON foo FOR EACH ROW INSERT INTO zzz (a,b) VALUES (old.a, old.b)`: plan.NewCreateTrigger(sql.UnresolvedDatabase(""),
 		"myTrigger", "before", "update", nil,
@@ -3706,6 +3707,7 @@ var triggerFixtures = map[string]sql.Node{
 		`CREATE TRIGGER myTrigger BEFORE UPDATE ON foo FOR EACH ROW INSERT INTO zzz (a,b) VALUES (old.a, old.b)`,
 		`INSERT INTO zzz (a,b) VALUES (old.a, old.b)`,
 		time.Unix(0, 0),
+		"",
 	),
 	`CREATE TRIGGER myTrigger BEFORE UPDATE ON foo FOR EACH ROW FOLLOWS yourTrigger INSERT INTO zzz (a,b) VALUES (old.a, old.b)`: plan.NewCreateTrigger(sql.UnresolvedDatabase(""),
 		"myTrigger", "before", "update",
@@ -3719,6 +3721,7 @@ var triggerFixtures = map[string]sql.Node{
 		`CREATE TRIGGER myTrigger BEFORE UPDATE ON foo FOR EACH ROW FOLLOWS yourTrigger INSERT INTO zzz (a,b) VALUES (old.a, old.b)`,
 		`INSERT INTO zzz (a,b) VALUES (old.a, old.b)`,
 		time.Unix(0, 0),
+		"",
 	),
 }
 

--- a/sql/plan/ddl_trigger.go
+++ b/sql/plan/ddl_trigger.go
@@ -39,6 +39,7 @@ type CreateTrigger struct {
 	CreateTriggerString string
 	BodyString          string
 	CreatedAt           time.Time
+	Definer             string
 }
 
 func NewCreateTrigger(triggerDb sql.Database,
@@ -50,7 +51,8 @@ func NewCreateTrigger(triggerDb sql.Database,
 	body sql.Node,
 	createTriggerString,
 	bodyString string,
-	createdAt time.Time) *CreateTrigger {
+	createdAt time.Time,
+	definer string) *CreateTrigger {
 	return &CreateTrigger{
 		ddlNode:             ddlNode{db: triggerDb},
 		TriggerName:         triggerName,
@@ -62,6 +64,7 @@ func NewCreateTrigger(triggerDb sql.Database,
 		BodyString:          bodyString,
 		CreateTriggerString: createTriggerString,
 		CreatedAt:           createdAt,
+		Definer:             definer,
 	}
 }
 


### PR DESCRIPTION
Updated `CREATE VIEW` parsing supporting `algorithm`, `definer`, `security` syntaxes, but does not support the functionality or affect `create view` query statement.
Added Definer variable to Trigger.
Added and updated engine tests covering these changes