### PR TITLE
Added support for external stored procedures

### DIFF
--- a/enginetest/external_procedure_queries.go
+++ b/enginetest/external_procedure_queries.go
@@ -1,0 +1,117 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+var ExternalProcedureTests = []ScriptTest{
+	{
+		Name: "INOUT on first param, IN on second param",
+		SetUpScript: []string{
+			"SET @outparam = 5;",
+			"CALL memory_inout_add(@outparam, 11);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT @outparam;",
+				Expected: []sql.Row{{16}},
+			},
+		},
+	},
+	{
+		Name: "Called from standard stored procedure",
+		SetUpScript: []string{
+			"CREATE PROCEDURE p1(x BIGINT) BEGIN CALL memory_inout_add(x, x); SELECT x; END;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "CALL p1(11);",
+				Expected: []sql.Row{{22}},
+			},
+		},
+	},
+	{
+		Name: "Overloaded Name",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "CALL memory_overloaded_mult(1);",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "CALL memory_overloaded_mult(2, 3);",
+				Expected: []sql.Row{{6}},
+			},
+			{
+				Query:    "CALL memory_overloaded_mult(4, 5, 6);",
+				Expected: []sql.Row{{120}},
+			},
+		},
+	},
+	{
+		Name: "Passing in all supported types",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CALL memory_overloaded_type_test(1, 100, 10000, 1000000, 100000000, 3, 300," +
+					"10, 1000, 100000, 10000000, 1000000000, 30, 3000);",
+				Expected: []sql.Row{{1111114444}},
+			},
+			{
+				Query: "CALL memory_overloaded_type_test(false, 'hi', 'A', '2020-02-20 12:00:00', 123.456," +
+					"true, 'bye', 'B', '2022-02-02 12:00:00', 654.32);",
+				Expected: []sql.Row{{`aa:false,ba:true,ab:"hi",bb:"bye",ac:[65],bc:[66],ad:2020-02-20,bd:2022-02-02,ae:123.456,be:654.32`}},
+			},
+		},
+	},
+	{
+		Name: "BOOL and []BYTE INOUT conversions",
+		SetUpScript: []string{
+			"SET @outparam1 = 1;",
+			"SET @outparam2 = 0;",
+			"SET @outparam3 = 'A';",
+			"SET @outparam4 = 'B';",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT @outparam1, @outparam2, @outparam3, @outparam4;",
+				Expected: []sql.Row{{1, 0, "A", "B"}},
+			},
+			{
+				Query:    "CALL memory_inout_bool_byte(@outparam1, @outparam2, @outparam3, @outparam4);",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT @outparam1, @outparam2, @outparam3, @outparam4;",
+				Expected: []sql.Row{{1, 1, "A", "C"}},
+			},
+			{
+				Query:    "CALL memory_inout_bool_byte(@outparam1, @outparam2, @outparam3, @outparam4);",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "SELECT @outparam1, @outparam2, @outparam3, @outparam4;",
+				Expected: []sql.Row{{1, 0, "A", "D"}},
+			},
+		},
+	},
+	{
+		Name: "Errors returned",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CALL memory_error_table_not_found();",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+		},
+	},
+}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -560,6 +560,13 @@ func TestStoredProcedures(t *testing.T) {
 	enginetest.TestStoredProcedures(t, enginetest.NewDefaultMemoryHarness())
 }
 
+func TestExternalProcedures(t *testing.T) {
+	harness := enginetest.NewExternalStoredProcedureMemoryHarness()
+	for _, script := range enginetest.ExternalProcedureTests {
+		enginetest.TestScript(t, harness, script)
+	}
+}
+
 func TestTriggersErrors(t *testing.T) {
 	enginetest.TestTriggerErrors(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/enginetest/memory_harness.go
+++ b/enginetest/memory_harness.go
@@ -218,3 +218,29 @@ func (m *MemoryHarness) NewReadOnlyDatabases(names ...string) []sql.ReadOnlyData
 	}
 	return dbs
 }
+
+type ExternalStoredProcedureMemoryHarness struct {
+	*MemoryHarness
+}
+
+var _ Harness = ExternalStoredProcedureMemoryHarness{}
+
+func NewExternalStoredProcedureMemoryHarness() *ExternalStoredProcedureMemoryHarness {
+	return &ExternalStoredProcedureMemoryHarness{NewDefaultMemoryHarness()}
+}
+
+func (h ExternalStoredProcedureMemoryHarness) NewDatabase(name string) sql.Database {
+	database := memory.NewExternalStoredProcedureDatabase(name)
+	if h.nativeIndexSupport {
+		database.EnablePrimaryKeyIndexes()
+	}
+	return database
+}
+
+func (h ExternalStoredProcedureMemoryHarness) NewDatabases(names ...string) []sql.Database {
+	var dbs []sql.Database
+	for _, name := range names {
+		dbs = append(dbs, h.NewDatabase(name))
+	}
+	return dbs
+}

--- a/enginetest/procedure_queries.go
+++ b/enginetest/procedure_queries.go
@@ -748,6 +748,14 @@ BEGIN
 END;`,
 		ExpectedErr: sql.ErrDeclareConditionNotFound,
 	},
+	{
+		Name: "Duplicate procedure name",
+		SetUpScript: []string{
+			"CREATE PROCEDURE test_proc(x DOUBLE, y DOUBLE) SELECT x*y",
+		},
+		Query:       "CREATE PROCEDURE test_proc(z VARCHAR(20)) SELECT z",
+		ExpectedErr: sql.ErrStoredProcedureAlreadyExists,
+	},
 }
 
 var ProcedureCallTests = []ScriptTest{

--- a/memory/external_sp_db.go
+++ b/memory/external_sp_db.go
@@ -1,0 +1,145 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memory
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+var (
+	externalSPSchemaInt = sql.Schema{&sql.Column{
+		Name: "a",
+		Type: sql.Int64,
+	}}
+	externalSPSchemaText = sql.Schema{&sql.Column{
+		Name: "a",
+		Type: sql.LongText,
+	}}
+)
+
+// ExternalStoredProcedureDatabase is an implementation of sql.ExternalStoredProcedureDatabase for the memory db.
+type ExternalStoredProcedureDatabase struct {
+	*HistoryDatabase
+}
+
+var _ sql.ExternalStoredProcedureDatabase = ExternalStoredProcedureDatabase{}
+
+// NewExternalStoredProcedureDatabase returns a new ExternalStoredProcedureDatabase.
+func NewExternalStoredProcedureDatabase(name string) ExternalStoredProcedureDatabase {
+	return ExternalStoredProcedureDatabase{NewHistoryDatabase(name)}
+}
+
+// GetExternalStoredProcedures implements the interface sql.ExternalStoredProcedureDatabase.
+func (e ExternalStoredProcedureDatabase) GetExternalStoredProcedures(ctx *sql.Context) ([]sql.ExternalStoredProcedureDetails, error) {
+	return []sql.ExternalStoredProcedureDetails{
+		{
+			Name:     "memory_inout_add",
+			Schema:   nil,
+			Function: e.inout_add,
+		},
+		{
+			Name:     "memory_overloaded_mult",
+			Schema:   externalSPSchemaInt,
+			Function: e.overloaded_mult1,
+		},
+		{
+			Name:     "memory_overloaded_mult",
+			Schema:   externalSPSchemaInt,
+			Function: e.overloaded_mult2,
+		},
+		{
+			Name:     "memory_overloaded_mult",
+			Schema:   externalSPSchemaInt,
+			Function: e.overloaded_mult3,
+		},
+		{
+			Name:     "memory_overloaded_type_test",
+			Schema:   externalSPSchemaInt,
+			Function: e.overloaded_type_test1,
+		},
+		{
+			Name:     "memory_overloaded_type_test",
+			Schema:   externalSPSchemaInt,
+			Function: e.overloaded_type_test2,
+		},
+		{
+			Name:     "memory_inout_bool_byte",
+			Schema:   nil,
+			Function: e.inout_bool_byte,
+		},
+		{
+			Name:     "memory_error_table_not_found",
+			Schema:   nil,
+			Function: e.error_table_not_found,
+		},
+	}, nil
+}
+
+func (e ExternalStoredProcedureDatabase) inout_add(ctx *sql.Context, a *int64, b int64) (sql.RowIter, error) {
+	*a = *a + b
+	return sql.RowsToRowIter(), nil
+}
+
+func (e ExternalStoredProcedureDatabase) overloaded_mult1(ctx *sql.Context, a int8) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{int64(a)}), nil
+}
+func (e ExternalStoredProcedureDatabase) overloaded_mult2(ctx *sql.Context, a int16, b int32) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{int64(a) * int64(b)}), nil
+}
+func (e ExternalStoredProcedureDatabase) overloaded_mult3(ctx *sql.Context, a int8, b int32, c int64) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{int64(a) * int64(b) * c}), nil
+}
+
+func (e ExternalStoredProcedureDatabase) overloaded_type_test1(
+	ctx *sql.Context,
+	aa int8, ab int16, ac int, ad int32, ae int64, af float32, ag float64,
+	ba *int8, bb *int16, bc *int, bd *int32, be *int64, bf *float32, bg *float64,
+) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{
+		int64(aa) + int64(ab) + int64(ac) + int64(ad) + int64(ae) + int64(af) + int64(ag) +
+			int64(*ba) + int64(*bb) + int64(*bc) + int64(*bd) + int64(*be) + int64(*bf) + int64(*bg),
+	}), nil
+}
+func (e ExternalStoredProcedureDatabase) overloaded_type_test2(
+	ctx *sql.Context,
+	aa bool, ab string, ac []byte, ad time.Time, ae decimal.Decimal,
+	ba *bool, bb *string, bc *[]byte, bd *time.Time, be *decimal.Decimal,
+) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{
+		fmt.Sprintf(`aa:%v,ba:%v,ab:"%s",bb:"%s",ac:%v,bc:%v,ad:%s,bd:%s,ae:%s,be:%s`,
+			aa, *ba, ab, *bb, ac, *bc, ad.Format("2006-01-02"), (*bd).Format("2006-01-02"), ae.String(), (*be).String()),
+	}), nil
+}
+
+func (e ExternalStoredProcedureDatabase) inout_bool_byte(ctx *sql.Context, a bool, b *bool, c []byte, d *[]byte) (sql.RowIter, error) {
+	a = !a
+	*b = !*b
+	for i := range c {
+		c[i] = c[i] + 1
+	}
+	for i := range *d {
+		(*d)[i] = (*d)[i] + 1
+	}
+	return nil, nil
+}
+
+func (e ExternalStoredProcedureDatabase) error_table_not_found(ctx *sql.Context) (sql.RowIter, error) {
+	return nil, sql.ErrTableNotFound.New("non_existent_table")
+}

--- a/sql/analyzer/procedure_cache.go
+++ b/sql/analyzer/procedure_cache.go
@@ -18,62 +18,87 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
 // ProcedureCache contains all of the stored procedures for each database.
 type ProcedureCache struct {
-	dbToProcedureMap map[string]map[string]*plan.Procedure
+	dbToProcedureMap map[string]map[string]map[int]*plan.Procedure
 	IsPopulating     bool
 }
 
 // NewProcedureCache returns a *ProcedureCache.
 func NewProcedureCache() *ProcedureCache {
 	return &ProcedureCache{
-		dbToProcedureMap: make(map[string]map[string]*plan.Procedure),
+		dbToProcedureMap: make(map[string]map[string]map[int]*plan.Procedure),
 		IsPopulating:     false,
 	}
 }
 
 // Get returns the stored procedure with the given name from the given database. All names are case-insensitive. If the
-// procedure does not exist, then this returns nil.
-func (pc *ProcedureCache) Get(dbName, procedureName string) *plan.Procedure {
+// procedure does not exist, then this returns nil. If the number of parameters do not match any given procedure, then
+// returns the procedure with the largest number of parameters.
+func (pc *ProcedureCache) Get(dbName, procedureName string, numOfParams int) *plan.Procedure {
 	dbName = strings.ToLower(dbName)
 	procedureName = strings.ToLower(procedureName)
 	if procMap, ok := pc.dbToProcedureMap[dbName]; ok {
-		if procedure, ok := procMap[procedureName]; ok {
-			return procedure
+		if procedures, ok := procMap[procedureName]; ok {
+			if procedure, ok := procedures[numOfParams]; ok {
+				return procedure
+			}
+
+			var largestParamProc *plan.Procedure
+			for _, procedure := range procedures {
+				if len(procedure.Params) == numOfParams {
+					return procedure
+				}
+				if largestParamProc == nil || len(largestParamProc.Params) < len(procedure.Params) {
+					largestParamProc = procedure
+				}
+			}
+			return largestParamProc
 		}
 	}
 	return nil
 }
 
-// AllForDatabase returns all of the stored procedures for the given database, sorted by name ascending. The database
-// name is case-insensitive.
+// AllForDatabase returns all of the stored procedures for the given database, sorted by name and parameter count
+// ascending. The database name is case-insensitive.
 func (pc *ProcedureCache) AllForDatabase(dbName string) []*plan.Procedure {
 	dbName = strings.ToLower(dbName)
-	var procedures []*plan.Procedure
+	var proceduresForDb []*plan.Procedure
 	if procMap, ok := pc.dbToProcedureMap[dbName]; ok {
-		procedures = make([]*plan.Procedure, len(procMap))
-		i := 0
-		for _, procedure := range procMap {
-			procedures[i] = procedure
-			i++
+		for _, procedures := range procMap {
+			for _, procedure := range procedures {
+				proceduresForDb = append(proceduresForDb, procedure)
+			}
 		}
-		sort.Slice(procedures, func(i, j int) bool {
-			return procedures[i].Name < procedures[j].Name
+		sort.Slice(proceduresForDb, func(i, j int) bool {
+			if proceduresForDb[i].Name != proceduresForDb[j].Name {
+				return proceduresForDb[i].Name < proceduresForDb[j].Name
+			}
+			return len(proceduresForDb[i].Params) < len(proceduresForDb[j].Params)
 		})
 	}
-	return procedures
+	return proceduresForDb
 }
 
 // Register adds the given stored procedure to the cache. Will overwrite any procedures that already exist with the
-// same name for the given database name.
-func (pc *ProcedureCache) Register(dbName string, procedure *plan.Procedure) {
+// same name and same number of parameters for the given database name.
+func (pc *ProcedureCache) Register(dbName string, procedure *plan.Procedure) error {
 	dbName = strings.ToLower(dbName)
 	if procMap, ok := pc.dbToProcedureMap[dbName]; ok {
-		procMap[strings.ToLower(procedure.Name)] = procedure
+		if procedures, ok := procMap[strings.ToLower(procedure.Name)]; ok {
+			if _, ok := procedures[len(procedure.Params)]; ok {
+				return sql.ErrExternalProcedureAmbiguousOverload.New(procedure.Name, len(procedure.Params))
+			}
+			procedures[len(procedure.Params)] = procedure
+		} else {
+			procMap[strings.ToLower(procedure.Name)] = map[int]*plan.Procedure{len(procedure.Params): procedure}
+		}
 	} else {
-		pc.dbToProcedureMap[dbName] = map[string]*plan.Procedure{strings.ToLower(procedure.Name): procedure}
+		pc.dbToProcedureMap[dbName] = map[string]map[int]*plan.Procedure{strings.ToLower(procedure.Name): {len(procedure.Params): procedure}}
 	}
+	return nil
 }

--- a/sql/analyzer/resolve_external_stored_procedures.go
+++ b/sql/analyzer/resolve_external_stored_procedures.go
@@ -1,0 +1,158 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+)
+
+var (
+	// ctxType is the reflect.Type of a *sql.Context.
+	ctxType = reflect.TypeOf((*sql.Context)(nil))
+	// ctxType is the reflect.Type of a sql.RowIter.
+	rowIterType = reflect.TypeOf((*sql.RowIter)(nil)).Elem()
+	// ctxType is the reflect.Type of an error.
+	errorType = reflect.TypeOf((*error)(nil)).Elem()
+	// externalStoredProcedurePointerTypes maps a non-pointer type to a sql.Type for external stored procedures.
+	externalStoredProcedureTypes = map[reflect.Type]sql.Type{
+		reflect.TypeOf(int(0)):            sql.Int64,
+		reflect.TypeOf(int8(0)):           sql.Int8,
+		reflect.TypeOf(int16(0)):          sql.Int16,
+		reflect.TypeOf(int32(0)):          sql.Int32,
+		reflect.TypeOf(int64(0)):          sql.Int64,
+		reflect.TypeOf(uint(0)):           sql.Uint64,
+		reflect.TypeOf(uint8(0)):          sql.Uint8,
+		reflect.TypeOf(uint16(0)):         sql.Uint16,
+		reflect.TypeOf(uint32(0)):         sql.Uint32,
+		reflect.TypeOf(uint64(0)):         sql.Uint64,
+		reflect.TypeOf(float32(0)):        sql.Float32,
+		reflect.TypeOf(float64(0)):        sql.Float64,
+		reflect.TypeOf(bool(false)):       sql.Int8,
+		reflect.TypeOf(string("")):        sql.LongText,
+		reflect.TypeOf([]byte{}):          sql.LongBlob,
+		reflect.TypeOf(time.Time{}):       sql.Datetime,
+		reflect.TypeOf(decimal.Decimal{}): sql.InternalDecimalType,
+	}
+	// externalStoredProcedurePointerTypes maps a pointer type to a sql.Type for external stored procedures.
+	externalStoredProcedurePointerTypes = map[reflect.Type]sql.Type{
+		reflect.TypeOf((*int)(nil)):             sql.Int64,
+		reflect.TypeOf((*int8)(nil)):            sql.Int8,
+		reflect.TypeOf((*int16)(nil)):           sql.Int16,
+		reflect.TypeOf((*int32)(nil)):           sql.Int32,
+		reflect.TypeOf((*int64)(nil)):           sql.Int64,
+		reflect.TypeOf((*uint)(nil)):            sql.Uint64,
+		reflect.TypeOf((*uint8)(nil)):           sql.Uint8,
+		reflect.TypeOf((*uint16)(nil)):          sql.Uint16,
+		reflect.TypeOf((*uint32)(nil)):          sql.Uint32,
+		reflect.TypeOf((*uint64)(nil)):          sql.Uint64,
+		reflect.TypeOf((*float32)(nil)):         sql.Float32,
+		reflect.TypeOf((*float64)(nil)):         sql.Float64,
+		reflect.TypeOf((*bool)(nil)):            sql.Int8,
+		reflect.TypeOf((*string)(nil)):          sql.LongText,
+		reflect.TypeOf((*[]byte)(nil)):          sql.LongBlob,
+		reflect.TypeOf((*time.Time)(nil)):       sql.Datetime,
+		reflect.TypeOf((*decimal.Decimal)(nil)): sql.InternalDecimalType,
+	}
+)
+
+func init() {
+	if strconv.IntSize == 32 {
+		externalStoredProcedureTypes[reflect.TypeOf(int(0))] = sql.Int32
+		externalStoredProcedureTypes[reflect.TypeOf(uint(0))] = sql.Uint32
+		externalStoredProcedurePointerTypes[reflect.TypeOf((*int)(nil))] = sql.Int32
+		externalStoredProcedurePointerTypes[reflect.TypeOf((*uint)(nil))] = sql.Uint32
+	}
+}
+
+// resolveExternalStoredProcedure resolves external stored procedures, converting them to the format expected of
+// normal stored procedures.
+func resolveExternalStoredProcedure(ctx *sql.Context, dbName string, externalProcedure sql.ExternalStoredProcedureDetails) (*plan.Procedure, error) {
+	funcVal := reflect.ValueOf(externalProcedure.Function)
+	funcType := funcVal.Type()
+	if funcType.Kind() != reflect.Func {
+		return nil, sql.ErrExternalProcedureNonFunction.New(externalProcedure.Function)
+	}
+	if funcType.NumIn() == 0 {
+		return nil, sql.ErrExternalProcedureMissingContextParam.New()
+	}
+	if funcType.NumIn() > 27 {
+		return nil, sql.ErrExternalProcedureTooManyParams.New()
+	}
+	if funcType.NumOut() != 2 {
+		return nil, sql.ErrExternalProcedureReturnTypes.New()
+	}
+	if funcType.In(0) != ctxType {
+		return nil, sql.ErrExternalProcedureMissingContextParam.New()
+	}
+	if funcType.Out(0) != rowIterType {
+		return nil, sql.ErrExternalProcedureFirstReturn.New()
+	}
+	if funcType.Out(1) != errorType {
+		return nil, sql.ErrExternalProcedureSecondReturn.New()
+	}
+
+	paramDefinitions := make([]plan.ProcedureParam, funcType.NumIn()-1)
+	paramReferences := make([]*expression.ProcedureParam, len(paramDefinitions))
+	for i := 0; i < len(paramDefinitions); i++ {
+		funcParamType := funcType.In(i + 1)
+		paramName := string([]byte{byte(i) + 65}) // Names will be "A", "B", "C", etc.
+
+		if sqlType, ok := externalStoredProcedureTypes[funcParamType]; ok {
+			paramDefinitions[i] = plan.ProcedureParam{
+				Direction: plan.ProcedureParamDirection_In,
+				Name:      paramName,
+				Type:      sqlType,
+			}
+			paramReferences[i] = expression.NewProcedureParam(paramName)
+		} else if sqlType, ok = externalStoredProcedurePointerTypes[funcParamType]; ok {
+			paramDefinitions[i] = plan.ProcedureParam{
+				Direction: plan.ProcedureParamDirection_Inout,
+				Name:      paramName,
+				Type:      sqlType,
+			}
+			paramReferences[i] = expression.NewProcedureParam(paramName)
+		} else {
+			return nil, sql.ErrExternalProcedureInvalidParamType.New(funcParamType.String())
+		}
+	}
+
+	comment := fmt.Sprintf("External stored procedure defined by %s", dbName)
+	procedure := plan.NewProcedure(
+		externalProcedure.Name,
+		"root",
+		paramDefinitions,
+		plan.ProcedureSecurityContext_Definer,
+		comment,
+		nil,
+		comment,
+		&plan.ExternalProcedure{
+			ExternalStoredProcedureDetails: externalProcedure,
+			ParamDefinitions:               paramDefinitions,
+			Params:                         paramReferences,
+		},
+		time.Unix(1, 0),
+		time.Unix(1, 0),
+	)
+	return procedure, nil
+}

--- a/sql/core.go
+++ b/sql/core.go
@@ -972,6 +972,37 @@ type StoredProcedureDetails struct {
 	ModifiedAt      time.Time // The time of the last modification to the stored procedure.
 }
 
+// ExternalStoredProcedureDetails are the details of an external stored procedure. Compared to standard stored
+// procedures, external ones are considered "built-in", in that they're not created by the user, and may not be modified
+// or deleted by a user. In addition, they're implemented as a function taking standard parameters, compared to stored
+// procedures being implemented as expressions.
+type ExternalStoredProcedureDetails struct {
+	// Name is the name of the external stored procedure. If two external stored procedures share a name, then they're
+	// considered overloaded. Standard stored procedures do not support overloading.
+	Name string
+	// Schema describes the row layout of the RowIter returned from Function.
+	Schema Schema
+	// Function is the implementation of the external stored procedure. All functions should have the following definition:
+	// `func(*Context, <PARAMETERS>) (RowIter, error)`. The <PARAMETERS> may be any of the following types: `bool`,
+	// `string`, `[]byte`, `int8`-`int64`, `uint8`-`uint64`, `float32`, `float64`, `time.Time`, or `decimal`
+	// (shopspring/decimal). The architecture-dependent types `int` and `uint` (without a number) are also supported.
+	// It is valid to return a nil RowIter if there are no rows to be returned.
+	//
+	// Each parameter, by default, is an IN parameter. If the parameter type is a pointer, e.g. `*int32`, then it
+	// becomes an INOUT parameter. There is no way to set a parameter as an OUT parameter.
+	//
+	// Values are converted to their nearest type before being passed in, following the conversion rules of their
+	// related SQL types. The exceptions are `time.Time` (treated as a `DATETIME`), string (treated as a `LONGTEXT` with the
+	// default collation) and decimal (treated with a larger precision and scale). Take extra care when using decimal
+	// for an INOUT parameter, to ensure that the returned value fits the original's precision and scale, else an error
+	// will occur.
+	//
+	// As functions support overloading, each variant must have a completely unique function signature to prevent
+	// ambiguity. Uniqueness is determined by the number of parameters. If two functions are returned that have the same
+	// name and same number of parameters, then an error is thrown.
+	Function interface{}
+}
+
 // StoredProcedureDatabase is a database that supports the creation and execution of stored procedures. The engine will
 // handle all parsing and execution logic for stored procedures. Integrators only need to store and retrieve
 // StoredProcedureDetails, while verifying that all stored procedures have a unique name without regard to
@@ -988,6 +1019,16 @@ type StoredProcedureDatabase interface {
 
 	// DropStoredProcedure removes the StoredProcedureDetails with the matching name from the database.
 	DropStoredProcedure(ctx *Context, name string) error
+}
+
+// ExternalStoredProcedureDatabase is a database that implements its own stored procedures as a function, rather than as
+// a SQL statement. The returned stored procedures are treated as "built-in", in that they cannot be modified nor
+// deleted.
+type ExternalStoredProcedureDatabase interface {
+	StoredProcedureDatabase
+
+	// GetExternalStoredProcedures returns all ExternalStoredProcedureDetails for the database.
+	GetExternalStoredProcedures(ctx *Context) ([]ExternalStoredProcedureDetails, error)
 }
 
 // EvaluateCondition evaluates a condition, which is an expression whose value

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -177,6 +177,34 @@ var (
 	// ErrProcedureInvalidBodyStatement is returned when a stored procedure has a statement that is invalid inside of procedures.
 	ErrProcedureInvalidBodyStatement = errors.NewKind("`%s` statements are invalid inside of stored procedures")
 
+	// ErrExternalProcedureAmbiguousOverload is returned when an external stored procedure is overloaded and has two
+	// functions with the same number of parameters.
+	ErrExternalProcedureAmbiguousOverload = errors.NewKind("overloaded stored procedure `%s` may only have a single variant with `%d` parameters")
+
+	// ErrExternalProcedureNonFunction is returned when an external stored procedure is given something other than the
+	// expected function type.
+	ErrExternalProcedureNonFunction = errors.NewKind("received `%T` in place of a function for an external stored procedure")
+
+	// ErrExternalProcedureMissingContextParam is returned when an external stored procedure's first parameter is not
+	// the context.
+	ErrExternalProcedureMissingContextParam = errors.NewKind("external stored procedures require the first parameter to be the context")
+
+	// ErrExternalProcedureTooManyParams is returned when an external stored procedure has too many parameters.
+	ErrExternalProcedureTooManyParams = errors.NewKind("external stored procedures may have a max of 27 parameters")
+
+	// ErrExternalProcedureReturnTypes is returned when an external stored procedure's return types are incorrect.
+	ErrExternalProcedureReturnTypes = errors.NewKind("external stored procedures must return a RowIter and error")
+
+	// ErrExternalProcedureFirstReturn is returned when an external stored procedure's first return type is incorrect.
+	ErrExternalProcedureFirstReturn = errors.NewKind("external stored procedures require the first return value to be the RowIter")
+
+	// ErrExternalProcedureSecondReturn is returned when an external stored procedure's second return type is incorrect.
+	ErrExternalProcedureSecondReturn = errors.NewKind("external stored procedures require the second return value to be the error")
+
+	// ErrExternalProcedureInvalidParamType is returned when one of an external stored procedure's parameters have an
+	// invalid type.
+	ErrExternalProcedureInvalidParamType = errors.NewKind("external stored procedures do not support parameters with type `%s`")
+
 	// ErrCallIncorrectParameterCount is returned when a CALL statement has the incorrect number of parameters.
 	ErrCallIncorrectParameterCount = errors.NewKind("`%s` expected `%d` parameters but got `%d`")
 

--- a/sql/grant_tables/privileged_database_provider.go
+++ b/sql/grant_tables/privileged_database_provider.go
@@ -105,6 +105,7 @@ var _ sql.TableDropper = PrivilegedDatabase{}
 var _ sql.TableRenamer = PrivilegedDatabase{}
 var _ sql.TriggerDatabase = PrivilegedDatabase{}
 var _ sql.StoredProcedureDatabase = PrivilegedDatabase{}
+var _ sql.ExternalStoredProcedureDatabase = PrivilegedDatabase{}
 var _ sql.TableCopierDatabase = PrivilegedDatabase{}
 var _ sql.ReadOnlyDatabase = PrivilegedDatabase{}
 var _ sql.TemporaryTableDatabase = PrivilegedDatabase{}
@@ -296,6 +297,14 @@ func (pdb PrivilegedDatabase) DropStoredProcedure(ctx *sql.Context, name string)
 		return db.DropStoredProcedure(ctx, name)
 	}
 	return sql.ErrStoredProceduresNotSupported.New(pdb.db.Name())
+}
+
+// GetExternalStoredProcedures implements the interface sql.ExternalStoredProcedureDatabase.
+func (pdb PrivilegedDatabase) GetExternalStoredProcedures(ctx *sql.Context) ([]sql.ExternalStoredProcedureDetails, error) {
+	if db, ok := pdb.db.(sql.ExternalStoredProcedureDatabase); ok {
+		return db.GetExternalStoredProcedures(ctx)
+	}
+	return nil, nil
 }
 
 // CopyTableData implements the interface sql.TableCopierDatabase.

--- a/sql/plan/external_procedure.go
+++ b/sql/plan/external_procedure.go
@@ -1,0 +1,188 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+var (
+	boolType      = reflect.TypeOf(bool(false))
+	byteSliceType = reflect.TypeOf([]byte{})
+	intType       = reflect.TypeOf(int(0))
+	uintType      = reflect.TypeOf(uint(0))
+	decimalType   = reflect.TypeOf(decimal.Decimal{})
+)
+
+// ExternalProcedure is the sql.Node container for sql.ExternalStoredProcedureDetails.
+type ExternalProcedure struct {
+	sql.ExternalStoredProcedureDetails
+	ParamDefinitions []ProcedureParam
+	Params           []*expression.ProcedureParam
+}
+
+var _ sql.Node = (*ExternalProcedure)(nil)
+var _ sql.Expressioner = (*ExternalProcedure)(nil)
+
+// Resolved implements the interface sql.Node.
+func (n *ExternalProcedure) Resolved() bool {
+	return true
+}
+
+// String implements the interface sql.Node.
+func (n *ExternalProcedure) String() string {
+	return n.ExternalStoredProcedureDetails.Name
+}
+
+// Schema implements the interface sql.Node.
+func (n *ExternalProcedure) Schema() sql.Schema {
+	return n.ExternalStoredProcedureDetails.Schema
+}
+
+// Children implements the interface sql.Node.
+func (n *ExternalProcedure) Children() []sql.Node {
+	return nil
+}
+
+// WithChildren implements the interface sql.Node.
+func (n *ExternalProcedure) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(n, len(children), 0)
+	}
+	return n, nil
+}
+
+// Expressions implements the interface sql.Expressioner.
+func (n *ExternalProcedure) Expressions() []sql.Expression {
+	exprs := make([]sql.Expression, len(n.Params))
+	for i, param := range n.Params {
+		exprs[i] = param
+	}
+	return exprs
+}
+
+// WithExpressions implements the interface sql.Expressioner.
+func (n *ExternalProcedure) WithExpressions(expressions ...sql.Expression) (sql.Node, error) {
+	if len(expressions) != len(n.Params) {
+		return nil, sql.ErrInvalidExpressionNumber.New(n, len(expressions), len(n.Params))
+	}
+	newParams := make([]*expression.ProcedureParam, len(expressions))
+	for i, expr := range expressions {
+		newParams[i] = expr.(*expression.ProcedureParam)
+	}
+	nn := *n
+	nn.Params = newParams
+	return &nn, nil
+}
+
+// CheckPrivileges implements the interface sql.Node.
+func (n *ExternalProcedure) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
+	//TODO: when DEFINER is implemented for stored procedures then this should be added
+	return true
+}
+
+// RowIter implements the interface sql.Node.
+func (n *ExternalProcedure) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	// The function's structure has been verified by the analyzer, so no need to double-check any of it here
+	funcVal := reflect.ValueOf(n.Function)
+	funcType := funcVal.Type()
+	// The first parameter is always the context, but it doesn't exist as far as the stored procedures are concerned, so
+	// we prepend it here
+	funcParams := make([]reflect.Value, len(n.Params)+1)
+	funcParams[0] = reflect.ValueOf(ctx)
+
+	for i, exprParam := range n.Params {
+		funcParamType := funcType.In(i + 1)
+		// Grab the passed-in variable and convert it to the type we expect
+		exprParamVal, err := exprParam.Eval(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+		exprParamVal, err = n.ParamDefinitions[i].Type.Convert(exprParamVal)
+		if err != nil {
+			return nil, err
+		}
+
+		funcParamCompType := funcParamType
+		if funcParamType.Kind() == reflect.Ptr {
+			funcParamCompType = funcParamType.Elem()
+		}
+		// Convert to bool, []byte, int, and uint as they differ from their sql.Type value
+		switch funcParamCompType {
+		case boolType:
+			val := false
+			if exprParamVal.(int8) != 0 {
+				val = true
+			}
+			exprParamVal = val
+		case byteSliceType:
+			exprParamVal = []byte(exprParamVal.(string))
+		case intType:
+			if strconv.IntSize == 32 {
+				exprParamVal = int(exprParamVal.(int32))
+			} else {
+				exprParamVal = int(exprParamVal.(int64))
+			}
+		case uintType:
+			if strconv.IntSize == 64 {
+				exprParamVal = int(exprParamVal.(uint32))
+			} else {
+				exprParamVal = int(exprParamVal.(uint64))
+			}
+		case decimalType:
+			exprParamVal, err = decimal.NewFromString(exprParamVal.(string))
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if funcParamType.Kind() == reflect.Ptr { // Coincides with INOUT
+			funcParamVal := reflect.New(funcParamType.Elem())
+			funcParamVal.Elem().Set(reflect.ValueOf(exprParamVal))
+			funcParams[i+1] = funcParamVal
+		} else { // Coincides with IN
+			funcParamVal := reflect.New(funcParamType)
+			funcParamVal.Elem().Set(reflect.ValueOf(exprParamVal))
+			funcParams[i+1] = funcParamVal.Elem()
+		}
+	}
+	out := funcVal.Call(funcParams)
+
+	// Again, these types are enforced in the analyzer, so it's safe to assume their types here
+	if err, ok := out[1].Interface().(error); ok { // Only evaluates to true when error is not nil
+		return nil, err
+	}
+	for i, paramDefinition := range n.ParamDefinitions {
+		if paramDefinition.Direction == ProcedureParamDirection_Inout || paramDefinition.Direction == ProcedureParamDirection_Out {
+			exprParam := n.Params[i]
+			funcParamVal := funcParams[i+1].Elem().Interface()
+			err := exprParam.Set(funcParamVal, exprParam.Type())
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	// It's not invalid to return a nil RowIter, as having no rows to return is expected of many stored procedures.
+	if rowIter, ok := out[0].Interface().(sql.RowIter); ok {
+		return rowIter, nil
+	}
+	return sql.RowsToRowIter(), nil
+}


### PR DESCRIPTION
This adds support for hooking functions into the stored procedure system.

There were two considerations for the implementation, and I felt this implementation is superior (using the `reflect` package). The other primary consideration was to expect a specific function signature that takes a `map[string]interface{}` representing each parameter, and there'd be another `map[string]sql.Type` returned in the loading function that specifies the type of each parameter. I didn't like that the types were interfaces, and their definitions declared elsewhere, as I'd rather the engine handle as much as possible. I'd prefer to have this all statically-enforced, but Go's type system is sadly not flexible enough, so this is the next best thing.

The reflection logic is fairly straightforward, and there are many comments, so I'm not too concerned with this being hard to maintain at all.