### PR TITLE
Allow arbitrary parameter count for external stored procedures

### DIFF
--- a/enginetest/external_procedure_queries.go
+++ b/enginetest/external_procedure_queries.go
@@ -114,4 +114,71 @@ var ExternalProcedureTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Variadic parameter",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "CALL memory_variadic_add();",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "CALL memory_variadic_add(1);",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "CALL memory_variadic_add(1, 2);",
+				Expected: []sql.Row{{3}},
+			},
+			{
+				Query:    "CALL memory_variadic_add(1, 2, 3);",
+				Expected: []sql.Row{{6}},
+			},
+			{
+				Query:    "CALL memory_variadic_add(1, 2, 3, 4);",
+				Expected: []sql.Row{{10}},
+			},
+		},
+	},
+	{
+		Name: "Variadic byte slices",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "CALL memory_variadic_byte_slice();",
+				Expected: []sql.Row{{""}},
+			},
+			{
+				Query:    "CALL memory_variadic_byte_slice('A');",
+				Expected: []sql.Row{{"A"}},
+			},
+			{
+				Query:    "CALL memory_variadic_byte_slice('A', 'B');",
+				Expected: []sql.Row{{"AB"}},
+			},
+		},
+	},
+	{
+		Name: "Variadic overloading",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CALL memory_variadic_overload();",
+				ExpectedErr: sql.ErrCallIncorrectParameterCount,
+			},
+			{
+				Query:       "CALL memory_variadic_overload('A');",
+				ExpectedErr: sql.ErrCallIncorrectParameterCount,
+			},
+			{
+				Query:    "CALL memory_variadic_overload('A', 'B');",
+				Expected: []sql.Row{{"A-B"}},
+			},
+			{
+				Query:       "CALL memory_variadic_overload('A', 'B', 'C');",
+				ExpectedErr: sql.ErrInvalidValue,
+			},
+			{
+				Query:    "CALL memory_variadic_overload('A', 'B', 5);",
+				Expected: []sql.Row{{"A,B,[5]"}},
+			},
+		},
+	},
 }

--- a/memory/external_sp_db.go
+++ b/memory/external_sp_db.go
@@ -16,6 +16,7 @@ package memory
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -76,7 +77,7 @@ func (e ExternalStoredProcedureDatabase) GetExternalStoredProcedures(ctx *sql.Co
 		},
 		{
 			Name:     "memory_overloaded_type_test",
-			Schema:   externalSPSchemaInt,
+			Schema:   externalSPSchemaText,
 			Function: e.overloaded_type_test2,
 		},
 		{
@@ -88,6 +89,26 @@ func (e ExternalStoredProcedureDatabase) GetExternalStoredProcedures(ctx *sql.Co
 			Name:     "memory_error_table_not_found",
 			Schema:   nil,
 			Function: e.error_table_not_found,
+		},
+		{
+			Name:     "memory_variadic_add",
+			Schema:   externalSPSchemaInt,
+			Function: e.variadic_add,
+		},
+		{
+			Name:     "memory_variadic_byte_slice",
+			Schema:   externalSPSchemaText,
+			Function: e.variadic_byte_slice,
+		},
+		{
+			Name:     "memory_variadic_overload",
+			Schema:   externalSPSchemaText,
+			Function: e.variadic_overload1,
+		},
+		{
+			Name:     "memory_variadic_overload",
+			Schema:   externalSPSchemaText,
+			Function: e.variadic_overload2,
 		},
 	}, nil
 }
@@ -142,4 +163,28 @@ func (e ExternalStoredProcedureDatabase) inout_bool_byte(ctx *sql.Context, a boo
 
 func (e ExternalStoredProcedureDatabase) error_table_not_found(ctx *sql.Context) (sql.RowIter, error) {
 	return nil, sql.ErrTableNotFound.New("non_existent_table")
+}
+
+func (e ExternalStoredProcedureDatabase) variadic_add(ctx *sql.Context, vals ...int) (sql.RowIter, error) {
+	sum := int64(0)
+	for _, val := range vals {
+		sum += int64(val)
+	}
+	return sql.RowsToRowIter(sql.Row{sum}), nil
+}
+
+func (e ExternalStoredProcedureDatabase) variadic_byte_slice(ctx *sql.Context, vals ...[]byte) (sql.RowIter, error) {
+	sb := strings.Builder{}
+	for _, val := range vals {
+		sb.Write(val)
+	}
+	return sql.RowsToRowIter(sql.Row{sb.String()}), nil
+}
+
+func (e ExternalStoredProcedureDatabase) variadic_overload1(ctx *sql.Context, a string, b string) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{fmt.Sprintf("%s-%s", a, b)}), nil
+}
+
+func (e ExternalStoredProcedureDatabase) variadic_overload2(ctx *sql.Context, a string, b string, vals ...uint8) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{fmt.Sprintf("%s,%s,%v", a, b, vals)}), nil
 }

--- a/sql/core.go
+++ b/sql/core.go
@@ -992,14 +992,18 @@ type ExternalStoredProcedureDetails struct {
 	// becomes an INOUT parameter. There is no way to set a parameter as an OUT parameter.
 	//
 	// Values are converted to their nearest type before being passed in, following the conversion rules of their
-	// related SQL types. The exceptions are `time.Time` (treated as a `DATETIME`), string (treated as a `LONGTEXT` with the
-	// default collation) and decimal (treated with a larger precision and scale). Take extra care when using decimal
+	// related SQL types. The exceptions are `time.Time` (treated as a `DATETIME`), string (treated as a `LONGTEXT` with
+	// the default collation) and decimal (treated with a larger precision and scale). Take extra care when using decimal
 	// for an INOUT parameter, to ensure that the returned value fits the original's precision and scale, else an error
 	// will occur.
 	//
 	// As functions support overloading, each variant must have a completely unique function signature to prevent
 	// ambiguity. Uniqueness is determined by the number of parameters. If two functions are returned that have the same
-	// name and same number of parameters, then an error is thrown.
+	// name and same number of parameters, then an error is thrown. If the last parameter is variadic, then the stored
+	// procedure functions as though it has the integer-max number of parameters. When an exact match is not found for
+	// overloaded functions, the largest function is used (which in this case will be the variadic function). Also, due
+	// to the usage of the integer-max for the parameter count, only one variadic function is allowed per function name.
+	// The type of the variadic parameter may not have a pointer type.
 	Function interface{}
 }
 

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -189,8 +189,8 @@ var (
 	// the context.
 	ErrExternalProcedureMissingContextParam = errors.NewKind("external stored procedures require the first parameter to be the context")
 
-	// ErrExternalProcedureTooManyParams is returned when an external stored procedure has too many parameters.
-	ErrExternalProcedureTooManyParams = errors.NewKind("external stored procedures may have a max of 27 parameters")
+	// ErrExternalProcedurePointerVariadic is returned when an external stored procedure's variadic parameter has a pointer type.
+	ErrExternalProcedurePointerVariadic = errors.NewKind("an external stored procedures's variadiac parameter may not have a pointer type")
 
 	// ErrExternalProcedureReturnTypes is returned when an external stored procedure's return types are incorrect.
 	ErrExternalProcedureReturnTypes = errors.NewKind("external stored procedures must return a RowIter and error")

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1040,6 +1040,7 @@ func convertCreateProcedure(ctx *sql.Context, query string, c *sqlparser.DDL) (s
 			Direction: direction,
 			Name:      param.Name,
 			Type:      internalTyp,
+			Variadic:  false,
 		})
 	}
 

--- a/sql/plan/procedure.go
+++ b/sql/plan/procedure.go
@@ -16,8 +16,11 @@ package plan
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )
@@ -52,6 +55,7 @@ type ProcedureParam struct {
 	Direction ProcedureParamDirection // Direction is the direction of the parameter.
 	Name      string                  // Name is the name of the parameter.
 	Type      sql.Type                // Type is the SQL type of the parameter.
+	Variadic  bool                    // Variadic states whether the parameter is variadic.
 }
 
 // Characteristic represents a characteristic that is defined on either a stored procedure or stored function.
@@ -103,6 +107,7 @@ func NewProcedure(
 			Direction: param.Direction,
 			Name:      strings.ToLower(param.Name),
 			Type:      param.Type,
+			Variadic:  param.Variadic,
 		}
 	}
 	return &Procedure{
@@ -163,6 +168,55 @@ func (p *Procedure) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOp
 // RowIter implements the sql.Node interface.
 func (p *Procedure) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	return p.Body.RowIter(ctx, row)
+}
+
+// ExtendVariadic returns a new procedure that has the variadic parameter extended to match the CALL's parameter count.
+func (p *Procedure) ExtendVariadic(ctx *sql.Context, length int) *Procedure {
+	if !p.HasVariadicParameter() {
+		return p
+	}
+	np := *p
+	body := p.Body.(*ExternalProcedure)
+	newBody := *body
+	np.Body = &newBody
+
+	newParamDefinitions := make([]ProcedureParam, length)
+	newParams := make([]*expression.ProcedureParam, length)
+	if length < len(p.Params) {
+		newParamDefinitions = p.Params[:len(p.Params)-1]
+		newParams = body.Params[:len(body.Params)-1]
+	} else {
+		for i := range p.Params {
+			newParamDefinitions[i] = p.Params[i]
+			newParams[i] = body.Params[i]
+		}
+		if length >= len(p.Params) {
+			variadicParam := p.Params[len(p.Params)-1]
+			for i := len(p.Params); i < length; i++ {
+				paramName := "A" + strconv.FormatInt(int64(i), 10)
+				newParamDefinitions[i] = ProcedureParam{
+					Direction: variadicParam.Direction,
+					Name:      paramName,
+					Type:      variadicParam.Type,
+					Variadic:  variadicParam.Variadic,
+				}
+				newParams[i] = expression.NewProcedureParam(paramName)
+			}
+		}
+	}
+
+	newBody.ParamDefinitions = newParamDefinitions
+	newBody.Params = newParams
+	np.Params = newParamDefinitions
+	return &np
+}
+
+// HasVariadicParameter returns if the last parameter is variadic.
+func (p *Procedure) HasVariadicParameter() bool {
+	if len(p.Params) > 0 {
+		return p.Params[len(p.Params)-1].Variadic
+	}
+	return false
 }
 
 // String returns the original SQL representation.


### PR DESCRIPTION
If an overloaded function contains a variadic variant, that variant is only used if an exact match is not found.