### PR TITLE
allow NULL value for geometry types

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -72,6 +72,20 @@ func TestSpatialQueries(t *testing.T, harness Harness) {
 	for _, tt := range SpatialQueryTests {
 		TestQuery(t, harness, engine, tt.Query, tt.Expected, tt.ExpectedColumns, tt.Bindings)
 	}
+
+	t.Run("create table with NULL default values for geometry types", func(t *testing.T) {
+		ctx := NewContext(harness)
+
+		TestQuery(t, harness, engine, "CREATE TABLE null_default (pk int NOT NULL PRIMARY KEY, v1 geometry DEFAULT NULL, v2 linestring DEFAULT NULL, v3 point DEFAULT NULL, v4 polygon DEFAULT NULL)",
+			[]sql.Row{}, nil, nil)
+		db, err := engine.Analyzer.Catalog.Database(ctx, "mydb")
+		require.NoError(t, err)
+
+		_, ok, err := db.GetTableInsensitive(ctx, "null_default")
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
 }
 
 // Tests join queries against a provided harness.

--- a/sql/geometry.go
+++ b/sql/geometry.go
@@ -63,6 +63,9 @@ func (t GeometryType) Compare(a any, b any) (int, error) {
 
 // Convert implements Type interface.
 func (t GeometryType) Convert(v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
 	// Must be a one of the Spatial Types
 	switch this := v.(type) {
 	case Point:

--- a/sql/linestring.go
+++ b/sql/linestring.go
@@ -86,6 +86,9 @@ func (t LinestringType) Compare(a interface{}, b interface{}) (int, error) {
 
 // Convert implements Type interface.
 func (t LinestringType) Convert(v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
 	// Must be a Linestring, fail otherwise
 	if v, ok := v.(Linestring); ok {
 		return v, nil

--- a/sql/point.go
+++ b/sql/point.go
@@ -73,6 +73,9 @@ func (t PointType) Compare(a interface{}, b interface{}) (int, error) {
 
 // Convert implements Type interface.
 func (t PointType) Convert(v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
 	// Must be a Point, fail otherwise
 	if v, ok := v.(Point); ok {
 		return v, nil

--- a/sql/polygon.go
+++ b/sql/polygon.go
@@ -86,6 +86,9 @@ func (t PolygonType) Compare(a interface{}, b interface{}) (int, error) {
 
 // Convert implements Type interface.
 func (t PolygonType) Convert(v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
 	// Must be a Polygon, fail otherwise
 	if v, ok := v.(Polygon); ok {
 		return v, nil


### PR DESCRIPTION
Allow handling null values some geometry data types. For these types, DEFAULT NULL values should be allowed