### PR TITLE
Fixing Point method to actually print string

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1250,6 +1250,12 @@ func TestScripts(t *testing.T, harness Harness) {
 	}
 }
 
+func TestSpatialScripts(t *testing.T, harness Harness) {
+	for _, script := range SpatialScriptTests {
+		TestScript(t, harness, script)
+	}
+}
+
 func TestLoadDataPrepared(t *testing.T, harness Harness) {
 	for _, script := range LoadDataScripts {
 		TestScriptPrepared(t, harness, script)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -595,6 +595,10 @@ func TestScripts(t *testing.T) {
 	enginetest.TestScripts(t, enginetest.NewMemoryHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
 }
 
+func TestSpatialScripts(t *testing.T) {
+	enginetest.TestSpatialScripts(t, enginetest.NewMemoryHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
+}
+
 func TestLoadDataPrepared(t *testing.T) {
 	enginetest.TestLoadDataPrepared(t, enginetest.NewMemoryHarness("default", 1, testNumPartitions, true, mergableIndexDriver))
 }

--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -2028,6 +2028,69 @@ var SpatialScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "create geometry table using default point value",
+		SetUpScript: []string{
+			"CREATE TABLE test (i int primary key, g geometry  default point(123.456, 7.89));",
+			"insert into test (i) values (0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select st_aswkt(g) from test",
+				Expected: []sql.Row{{"POINT(123.456 7.89)"}},
+			},
+			{
+				Query:    "show create table test",
+				Expected: []sql.Row{{"test", "CREATE TABLE `test` (\n  `i` int NOT NULL,\n  `g` geometry DEFAULT (POINT(123.456, 7.89)),\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"}},
+			},
+			{
+				Query:    "describe test",
+				Expected: []sql.Row{{"i", "int", "NO", "PRI", "", ""}, {"g", "geometry", "YES", "", "(POINT(123.456, 7.89))", ""}},
+			},
+		},
+	},
+	{
+		Name: "create geometry table using default linestring value",
+		SetUpScript: []string{
+			"CREATE TABLE test (i int primary key, g geometry default linestring(point(1,2), point(3,4)));",
+			"insert into test (i) values (0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select st_aswkt(g) from test",
+				Expected: []sql.Row{{"LINESTRING(1 2,3 4)"}},
+			},
+			{
+				Query:    "show create table test",
+				Expected: []sql.Row{{"test", "CREATE TABLE `test` (\n  `i` int NOT NULL,\n  `g` geometry DEFAULT (LINESTRING(POINT(1, 2),POINT(3, 4))),\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"}},
+			},
+			{
+				Query:    "describe test",
+				Expected: []sql.Row{{"i", "int", "NO", "PRI", "", ""}, {"g", "geometry", "YES", "", "(LINESTRING(POINT(1, 2),POINT(3, 4)))", ""}},
+			},
+		},
+	},
+	{
+		Name: "create geometry table using default polygon value",
+		SetUpScript: []string{
+			"CREATE TABLE test (i int primary key, g geometry default polygon(linestring(point(0,0), point(1,1), point(2,2), point(0,0))));",
+			"insert into test (i) values (0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select st_aswkt(g) from test",
+				Expected: []sql.Row{{"POLYGON((0 0,1 1,2 2,0 0))"}},
+			},
+			{
+				Query:    "show create table test",
+				Expected: []sql.Row{{"test", "CREATE TABLE `test` (\n  `i` int NOT NULL,\n  `g` geometry DEFAULT (POLYGON(LINESTRING(POINT(0, 0),POINT(1, 1),POINT(2, 2),POINT(0, 0)))),\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"}},
+			},
+			{
+				Query:    "describe test",
+				Expected: []sql.Row{{"i", "int", "NO", "PRI", "", ""}, {"g", "geometry", "YES", "", "(POLYGON(LINESTRING(POINT(0, 0),POINT(1, 1),POINT(2, 2),POINT(0, 0))))", ""}},
+			},
+		},
+	},
 }
 
 var CreateCheckConstraintsScripts = []ScriptTest{

--- a/enginetest/script_queries.go
+++ b/enginetest/script_queries.go
@@ -1964,6 +1964,72 @@ var ScriptTests = []ScriptTest{
 	},
 }
 
+var SpatialScriptTests = []ScriptTest{
+	{
+		Name: "create table using default point value",
+		SetUpScript: []string{
+			"CREATE TABLE test (i int primary key, p point default point(123.456, 7.89));",
+			"insert into test (i) values (0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select st_aswkt(p) from test",
+				Expected: []sql.Row{{"POINT(123.456 7.89)"}},
+			},
+			{
+				Query:    "show create table test",
+				Expected: []sql.Row{{"test", "CREATE TABLE `test` (\n  `i` int NOT NULL,\n  `p` point DEFAULT (POINT(123.456, 7.89)),\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"}},
+			},
+			{
+				Query:    "describe test",
+				Expected: []sql.Row{{"i", "int", "NO", "PRI", "", ""}, {"p", "point", "YES", "", "(POINT(123.456, 7.89))", ""}},
+			},
+		},
+	},
+	{
+		Name: "create table using default linestring value",
+		SetUpScript: []string{
+			"CREATE TABLE test (i int primary key, l linestring default linestring(point(1,2), point(3,4)));",
+			"insert into test (i) values (0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select st_aswkt(l) from test",
+				Expected: []sql.Row{{"LINESTRING(1 2,3 4)"}},
+			},
+			{
+				Query:    "show create table test",
+				Expected: []sql.Row{{"test", "CREATE TABLE `test` (\n  `i` int NOT NULL,\n  `l` linestring DEFAULT (LINESTRING(POINT(1, 2),POINT(3, 4))),\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"}},
+			},
+			{
+				Query:    "describe test",
+				Expected: []sql.Row{{"i", "int", "NO", "PRI", "", ""}, {"l", "linestring", "YES", "", "(LINESTRING(POINT(1, 2),POINT(3, 4)))", ""}},
+			},
+		},
+	},
+	{
+		Name: "create table using default polygon value",
+		SetUpScript: []string{
+			"CREATE TABLE test (i int primary key, p polygon default polygon(linestring(point(0,0), point(1,1), point(2,2), point(0,0))));",
+			"insert into test (i) values (0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select st_aswkt(p) from test",
+				Expected: []sql.Row{{"POLYGON((0 0,1 1,2 2,0 0))"}},
+			},
+			{
+				Query:    "show create table test",
+				Expected: []sql.Row{{"test", "CREATE TABLE `test` (\n  `i` int NOT NULL,\n  `p` polygon DEFAULT (POLYGON(LINESTRING(POINT(0, 0),POINT(1, 1),POINT(2, 2),POINT(0, 0)))),\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"}},
+			},
+			{
+				Query:    "describe test",
+				Expected: []sql.Row{{"i", "int", "NO", "PRI", "", ""}, {"p", "polygon", "YES", "", "(POLYGON(LINESTRING(POINT(0, 0),POINT(1, 1),POINT(2, 2),POINT(0, 0))))", ""}},
+			},
+		},
+	},
+}
+
 var CreateCheckConstraintsScripts = []ScriptTest{
 	{
 		Name: "Run SHOW CREATE TABLE with different types of check constraints",

--- a/sql/expression/function/point.go
+++ b/sql/expression/function/point.go
@@ -64,7 +64,7 @@ func (p *Point) Type() sql.Type {
 }
 
 func (p *Point) String() string {
-	return fmt.Sprintf("POINT(%f, %f)", p.X, p.Y)
+	return fmt.Sprintf("POINT(%s, %s)", p.X.String(), p.Y.String())
 }
 
 // WithChildren implements the Expression interface.


### PR DESCRIPTION
Fix for: https://github.com/dolthub/dolt/issues/3228
Allows the use of `point()`, `linestring()`, and `polygon()` for default values for columns of type `point`, `linestring`, `polygon`, and `geometry`.