### PR TITLE
support more than 1 byte characters to insert for char()/varchar() types

### DIFF
--- a/enginetest/insert_queries.go
+++ b/enginetest/insert_queries.go
@@ -1223,6 +1223,18 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "INSERT string with exact char length but extra byte length",
+		SetUpScript: []string{
+			"CREATE TABLE city (id int PRIMARY KEY, district char(20) NOT NULL DEFAULT '');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "INSERT INTO city VALUES (1,'San Pedro de Macorís');",
+				Expected: []sql.Row{{sql.NewOkResult(1)}},
+			},
+		},
+	},
+	{
 		Name: "Insert on duplicate key",
 		SetUpScript: []string{
 			`CREATE TABLE users (

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -295,7 +295,8 @@ func (t stringType) Convert(v interface{}) (interface{}, error) {
 			}
 		} else {
 			//TODO: this should count the string's length properly according to the character set
-			if int64(len(val)) > t.charLength {
+			//convert 'val' string to rune to count the character length, not byte length
+			if int64(len([]rune(val))) > t.charLength {
 				return nil, ErrLengthBeyondLimit.New()
 			}
 		}


### PR DESCRIPTION
Allows inserting strings with 'exact number of character but consists of more bytes' values to char() or varchar() types
Fixes https://github.com/dolthub/dolt/issues/3233