### PR TITLE
Arithmetic .Type() Perf Improvement

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -5975,6 +5975,10 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
+		Query:    `SELECT ALL - - 20 * - CASE + AVG ( ALL + + 89 ) WHEN - 66 THEN NULL WHEN - 15 THEN 38 * COUNT( * ) * MIN( DISTINCT - + 88 ) - MIN( ALL + 0 ) - - COUNT( * ) + - 0 + - 14 * + ( 98 ) * + 70 * 14 * + 57 * 48 - 53 + + 7 END * + 78 + - 11 * + 29 + + + 46 + + 10 + + ( - 83 ) * - - 74 / - 8 + 18`,
+		Expected: []sql.Row{},
+	},
+	{
 		Query:    "SELECT 1/0 FROM dual",
 		Expected: []sql.Row{{sql.Null}},
 	},

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -5976,7 +5976,7 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query:    `SELECT ALL - - 20 * - CASE + AVG ( ALL + + 89 ) WHEN - 66 THEN NULL WHEN - 15 THEN 38 * COUNT( * ) * MIN( DISTINCT - + 88 ) - MIN( ALL + 0 ) - - COUNT( * ) + - 0 + - 14 * + ( 98 ) * + 70 * 14 * + 57 * 48 - 53 + + 7 END * + 78 + - 11 * + 29 + + + 46 + + 10 + + ( - 83 ) * - - 74 / - 8 + 18`,
-		Expected: []sql.Row{},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 1/0 FROM dual",

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -125,11 +125,13 @@ func (a *Arithmetic) IsNullable() bool {
 // Type returns the greatest type for given operation.
 func (a *Arithmetic) Type() sql.Type {
 	//TODO: what if both BindVars? should be constant folded
-	if sql.IsDeferredType(a.Right.Type()) {
-		return a.Right.Type()
+	rTyp := a.Right.Type()
+	if sql.IsDeferredType(rTyp) {
+		return rTyp
 	}
-	if sql.IsDeferredType(a.Left.Type()) {
-		return a.Left.Type()
+	lTyp := a.Left.Type()
+	if sql.IsDeferredType(lTyp) {
+		return lTyp
 	}
 
 	switch strings.ToLower(a.Op) {
@@ -138,12 +140,12 @@ func (a *Arithmetic) Type() sql.Type {
 			return sql.Datetime
 		}
 
-		if sql.IsTime(a.Left.Type()) && sql.IsTime(a.Right.Type()) {
+		if sql.IsTime(lTyp) && sql.IsTime(rTyp) {
 			return sql.Int64
 		}
 
-		if sql.IsInteger(a.Left.Type()) && sql.IsInteger(a.Right.Type()) {
-			if sql.IsUnsigned(a.Left.Type()) && sql.IsUnsigned(a.Right.Type()) {
+		if sql.IsInteger(lTyp) && sql.IsInteger(rTyp) {
+			if sql.IsUnsigned(lTyp) && sql.IsUnsigned(rTyp) {
 				return sql.Uint64
 			}
 			return sql.Int64
@@ -155,7 +157,7 @@ func (a *Arithmetic) Type() sql.Type {
 		return sql.Uint64
 
 	case sqlparser.BitAndStr, sqlparser.BitOrStr, sqlparser.BitXorStr, sqlparser.IntDivStr, sqlparser.ModStr:
-		if sql.IsUnsigned(a.Left.Type()) && sql.IsUnsigned(a.Right.Type()) {
+		if sql.IsUnsigned(lTyp) && sql.IsUnsigned(rTyp) {
 			return sql.Uint64
 		}
 		return sql.Int64


### PR DESCRIPTION
SQL Logictests were timing out on huge CASE statements with ~40
nodes. This fixes the computational blowup, which I think was
somehow exponential before.