### PR TITLE
support handling join table between parentheses

### DIFF
--- a/enginetest/join_queries.go
+++ b/enginetest/join_queries.go
@@ -236,4 +236,24 @@ var JoinQueryTests = []QueryTest{
 			{2, "second row", "third", 1},
 		},
 	},
+	{
+		Query:    "select i.pk, j.v3 from one_pk_two_idx i JOIN one_pk_three_idx j on i.v1 = j.pk;",
+		Expected: []sql.Row{{0, 0}, {1, 1}, {2, 0}, {3, 2}, {4, 0}, {5, 3}, {6, 0}, {7, 4}},
+	},
+	{
+		Query:    "select i.pk, j.v3, k.c1 from one_pk_two_idx i JOIN one_pk_three_idx j on i.v1 = j.pk JOIN one_pk k on j.v3 = k.pk;",
+		Expected: []sql.Row{{0, 0, 0}, {1, 1, 10}, {2, 0, 0}, {3, 2, 20}, {4, 0, 0}, {5, 3, 30}, {6, 0, 0}},
+	},
+	{
+		Query:    "select i.pk, j.v3 from (one_pk_two_idx i JOIN one_pk_three_idx j on((i.v1 = j.pk)));",
+		Expected: []sql.Row{{0, 0}, {1, 1}, {2, 0}, {3, 2}, {4, 0}, {5, 3}, {6, 0}, {7, 4}},
+	},
+	{
+		Query:    "select i.pk, j.v3, k.c1 from ((one_pk_two_idx i JOIN one_pk_three_idx j on ((i.v1 = j.pk))) JOIN one_pk k on((j.v3 = k.pk)));",
+		Expected: []sql.Row{{0, 0, 0}, {1, 1, 10}, {2, 0, 0}, {3, 2, 20}, {4, 0, 0}, {5, 3, 30}, {6, 0, 0}},
+	},
+	{
+		Query:    "select i.pk, j.v3, k.c1 from (one_pk_two_idx i JOIN one_pk_three_idx j on ((i.v1 = j.pk)) JOIN one_pk k on((j.v3 = k.pk)));",
+		Expected: []sql.Row{{0, 0, 0}, {1, 1, 10}, {2, 0, 0}, {3, 2, 20}, {4, 0, 0}, {5, 3, 30}, {6, 0, 0}},
+	},
 }

--- a/enginetest/query_plans.go
+++ b/enginetest/query_plans.go
@@ -2216,6 +2216,65 @@ var PlanTests = []QueryPlanTest{
 			"         └─ IndexedTableAccess(othertable on [othertable.i2])\n" +
 			"",
 	},
+	{
+		Query: `select i.pk, j.v3 from one_pk_two_idx i JOIN one_pk_three_idx j on i.v1 = j.pk;`,
+		ExpectedPlan: "Project(i.pk, j.v3)\n" +
+			" └─ IndexedJoin(i.v1 = j.pk)\n" +
+			"     ├─ TableAlias(i)\n" +
+			"     │   └─ Table(one_pk_two_idx)\n" +
+			"     └─ TableAlias(j)\n" +
+			"         └─ IndexedTableAccess(one_pk_three_idx on [one_pk_three_idx.pk])\n" +
+			"",
+	},
+	{
+		Query: `select i.pk, j.v3, k.c1 from one_pk_two_idx i JOIN one_pk_three_idx j on i.v1 = j.pk JOIN one_pk k on j.v3 = k.pk;`,
+		ExpectedPlan: "Project(i.pk, j.v3, k.c1)\n" +
+			" └─ IndexedJoin(j.v3 = k.pk)\n" +
+			"     ├─ TableAlias(k)\n" +
+			"     │   └─ Table(one_pk)\n" +
+			"     └─ IndexedJoin(i.v1 = j.pk)\n" +
+			"         ├─ TableAlias(i)\n" +
+			"         │   └─ Table(one_pk_two_idx)\n" +
+			"         └─ TableAlias(j)\n" +
+			"             └─ IndexedTableAccess(one_pk_three_idx on [one_pk_three_idx.pk])\n" +
+			"",
+	},
+	{
+		Query: `select i.pk, j.v3 from (one_pk_two_idx i JOIN one_pk_three_idx j on((i.v1 = j.pk)));`,
+		ExpectedPlan: "Project(i.pk, j.v3)\n" +
+			" └─ IndexedJoin(i.v1 = j.pk)\n" +
+			"     ├─ TableAlias(i)\n" +
+			"     │   └─ Table(one_pk_two_idx)\n" +
+			"     └─ TableAlias(j)\n" +
+			"         └─ IndexedTableAccess(one_pk_three_idx on [one_pk_three_idx.pk])\n" +
+			"",
+	},
+	{
+		Query: `select i.pk, j.v3, k.c1 from ((one_pk_two_idx i JOIN one_pk_three_idx j on ((i.v1 = j.pk))) JOIN one_pk k on((j.v3 = k.pk)));`,
+		ExpectedPlan: "Project(i.pk, j.v3, k.c1)\n" +
+			" └─ IndexedJoin(j.v3 = k.pk)\n" +
+			"     ├─ TableAlias(k)\n" +
+			"     │   └─ Table(one_pk)\n" +
+			"     └─ IndexedJoin(i.v1 = j.pk)\n" +
+			"         ├─ TableAlias(i)\n" +
+			"         │   └─ Table(one_pk_two_idx)\n" +
+			"         └─ TableAlias(j)\n" +
+			"             └─ IndexedTableAccess(one_pk_three_idx on [one_pk_three_idx.pk])\n" +
+			"",
+	},
+	{
+		Query: `select i.pk, j.v3, k.c1 from (one_pk_two_idx i JOIN one_pk_three_idx j on ((i.v1 = j.pk)) JOIN one_pk k on((j.v3 = k.pk)))`,
+		ExpectedPlan: "Project(i.pk, j.v3, k.c1)\n" +
+			" └─ IndexedJoin(j.v3 = k.pk)\n" +
+			"     ├─ TableAlias(k)\n" +
+			"     │   └─ Table(one_pk)\n" +
+			"     └─ IndexedJoin(i.v1 = j.pk)\n" +
+			"         ├─ TableAlias(i)\n" +
+			"         │   └─ Table(one_pk_two_idx)\n" +
+			"         └─ TableAlias(j)\n" +
+			"             └─ IndexedTableAccess(one_pk_three_idx on [one_pk_three_idx.pk])\n" +
+			"",
+	},
 }
 
 var ScriptQueryPlanTest = []ScriptTest{}

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -278,7 +278,7 @@ func createSubsetTestData(t *testing.T, harness Harness, includedTables []string
 					sql.NewRow(3, "row three", sql.JSONDocument{Val: []interface{}{5, 6}}, sql.JSONDocument{Val: map[string]interface{}{"c": 2}}),
 					sql.NewRow(4, "row four", sql.JSONDocument{Val: []interface{}{7, 8}}, sql.JSONDocument{Val: map[string]interface{}{"d": 2}}))
 			} else {
-				t.Logf("Warning: could not create table %s: %s", "one_pk", err)
+				t.Logf("Warning: could not create table %s: %s", "json", err)
 			}
 		})
 	}

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -278,7 +278,7 @@ func createSubsetTestData(t *testing.T, harness Harness, includedTables []string
 					sql.NewRow(3, "row three", sql.JSONDocument{Val: []interface{}{5, 6}}, sql.JSONDocument{Val: map[string]interface{}{"c": 2}}),
 					sql.NewRow(4, "row four", sql.JSONDocument{Val: []interface{}{7, 8}}, sql.JSONDocument{Val: map[string]interface{}{"d": 2}}))
 			} else {
-				t.Logf("Warning: could not create table %s: %s", "json", err)
+				t.Logf("Warning: could not create table %s: %s", "jsontable", err)
 			}
 		})
 	}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2484,45 +2484,61 @@ func tableExprToTable(
 		return expression.NewUnresolvedTableFunction(t.Name, exprs), nil
 
 	case *sqlparser.JoinTableExpr:
-		// TODO: add support for using, once we have proper table
-		// qualification of fields
-		if len(t.Condition.Using) > 0 {
-			return nil, sql.ErrUnsupportedFeature.New("USING clause on join")
-		}
+		return handleJoinTableExpr(ctx, t)
 
-		left, err := tableExprToTable(ctx, t.LeftExpr)
-		if err != nil {
-			return nil, err
+	case *sqlparser.ParenTableExpr:
+		if len(t.Exprs) == 1 {
+			switch j := t.Exprs[0].(type) {
+			default:
+				return nil, sql.ErrUnsupportedSyntax.New(sqlparser.String(t))
+			case *sqlparser.JoinTableExpr:
+				return handleJoinTableExpr(ctx, j)
+			}
+		} else {
+			return nil, sql.ErrUnsupportedSyntax.New(sqlparser.String(t))
 		}
+	}
+}
 
-		right, err := tableExprToTable(ctx, t.RightExpr)
-		if err != nil {
-			return nil, err
-		}
+func handleJoinTableExpr(ctx *sql.Context, t *sqlparser.JoinTableExpr) (sql.Node, error) {
+	// TODO: add support for using, once we have proper table
+	// qualification of fields
+	if len(t.Condition.Using) > 0 {
+		return nil, sql.ErrUnsupportedFeature.New("USING clause on join")
+	}
 
-		if t.Join == sqlparser.NaturalJoinStr {
-			return plan.NewNaturalJoin(left, right), nil
-		}
+	left, err := tableExprToTable(ctx, t.LeftExpr)
+	if err != nil {
+		return nil, err
+	}
 
-		if t.Condition.On == nil {
-			return plan.NewCrossJoin(left, right), nil
-		}
+	right, err := tableExprToTable(ctx, t.RightExpr)
+	if err != nil {
+		return nil, err
+	}
 
-		cond, err := ExprToExpression(ctx, t.Condition.On)
-		if err != nil {
-			return nil, err
-		}
+	if t.Join == sqlparser.NaturalJoinStr {
+		return plan.NewNaturalJoin(left, right), nil
+	}
 
-		switch strings.ToLower(t.Join) {
-		case sqlparser.JoinStr:
-			return plan.NewInnerJoin(left, right, cond), nil
-		case sqlparser.LeftJoinStr:
-			return plan.NewLeftJoin(left, right, cond), nil
-		case sqlparser.RightJoinStr:
-			return plan.NewRightJoin(left, right, cond), nil
-		default:
-			return nil, sql.ErrUnsupportedFeature.New("Join type " + t.Join)
-		}
+	if t.Condition.On == nil {
+		return plan.NewCrossJoin(left, right), nil
+	}
+
+	cond, err := ExprToExpression(ctx, t.Condition.On)
+	if err != nil {
+		return nil, err
+	}
+
+	switch strings.ToLower(t.Join) {
+	case sqlparser.JoinStr:
+		return plan.NewInnerJoin(left, right, cond), nil
+	case sqlparser.LeftJoinStr:
+		return plan.NewLeftJoin(left, right, cond), nil
+	case sqlparser.RightJoinStr:
+		return plan.NewRightJoin(left, right, cond), nil
+	default:
+		return nil, sql.ErrUnsupportedFeature.New("Join type " + t.Join)
 	}
 }
 

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2484,15 +2484,15 @@ func tableExprToTable(
 		return expression.NewUnresolvedTableFunction(t.Name, exprs), nil
 
 	case *sqlparser.JoinTableExpr:
-		return handleJoinTableExpr(ctx, t)
+		return joinTableExpr(ctx, t)
 
 	case *sqlparser.ParenTableExpr:
 		if len(t.Exprs) == 1 {
 			switch j := t.Exprs[0].(type) {
+			case *sqlparser.JoinTableExpr:
+				return joinTableExpr(ctx, j)
 			default:
 				return nil, sql.ErrUnsupportedSyntax.New(sqlparser.String(t))
-			case *sqlparser.JoinTableExpr:
-				return handleJoinTableExpr(ctx, j)
 			}
 		} else {
 			return nil, sql.ErrUnsupportedSyntax.New(sqlparser.String(t))
@@ -2500,7 +2500,7 @@ func tableExprToTable(
 	}
 }
 
-func handleJoinTableExpr(ctx *sql.Context, t *sqlparser.JoinTableExpr) (sql.Node, error) {
+func joinTableExpr(ctx *sql.Context, t *sqlparser.JoinTableExpr) (sql.Node, error) {
 	// TODO: add support for using, once we have proper table
 	// qualification of fields
 	if len(t.Condition.Using) > 0 {


### PR DESCRIPTION
Allow handling join tables in parentheses. It causes the JoinTableExpr to be wrapped in ParenTableExpr in the parser, so it needs to be unwrapped to get the JoinTableExpr inside
Fixes https://github.com/dolthub/dolt/issues/3254