### PR TITLE
Fixing return types for spatial functions

### DIFF
--- a/sql/expression/function/dimension.go
+++ b/sql/expression/function/dimension.go
@@ -50,7 +50,7 @@ func (p *Dimension) IsNullable() bool {
 
 // Type implements the sql.Expression interface.
 func (p *Dimension) Type() sql.Type {
-	return p.Child.Type()
+	return sql.Int32
 }
 
 func (p *Dimension) String() string {

--- a/sql/expression/function/dimension_test.go
+++ b/sql/expression/function/dimension_test.go
@@ -90,8 +90,12 @@ func TestDimension(t *testing.T) {
 	t.Run("check return type", func(t *testing.T) {
 		require := require.New(t)
 		f := NewDimension(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.NumberType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }

--- a/sql/expression/function/dimension_test.go
+++ b/sql/expression/function/dimension_test.go
@@ -86,4 +86,12 @@ func TestDimension(t *testing.T) {
 		require.NoError(err)
 		require.Equal(nil, v)
 	})
+
+	t.Run("check return type", func(t *testing.T) {
+		require := require.New(t)
+		f := NewDimension(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+		typ := f.Type()
+		_, ok := typ.(sql.NumberType)
+		require.True(ok)
+	})
 }

--- a/sql/expression/function/geojson_test.go
+++ b/sql/expression/function/geojson_test.go
@@ -255,8 +255,11 @@ func TestGeomFromGeoJSON(t *testing.T) {
 		f, err := NewAsGeoJSON(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
 		typ := f.Type()
-		_, ok := typ.(sql.JsonType)
-		require.True(ok)
+
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }

--- a/sql/expression/function/geojson_test.go
+++ b/sql/expression/function/geojson_test.go
@@ -250,7 +250,7 @@ func TestGeomFromGeoJSON(t *testing.T) {
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.Equal(sql.Polygon{SRID: 0, Lines: []sql.Linestring{{0, []sql.Point{{0, 0, 0}, {0, 1, 1}, {0, 0, 1}, {0, 0, 0}}}}}, v)
 	})
-	t.Run("convert point to geojson", func(t *testing.T) {
+	t.Run("check return type", func(t *testing.T) {
 		require := require.New(t)
 		f, err := NewAsGeoJSON(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
 		require.NoError(err)

--- a/sql/expression/function/geojson_test.go
+++ b/sql/expression/function/geojson_test.go
@@ -250,4 +250,13 @@ func TestGeomFromGeoJSON(t *testing.T) {
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.Equal(sql.Polygon{SRID: 0, Lines: []sql.Linestring{{0, []sql.Point{{0, 0, 0}, {0, 1, 1}, {0, 0, 1}, {0, 0, 0}}}}}, v)
 	})
+	t.Run("convert point to geojson", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewAsGeoJSON(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.JsonType)
+		require.True(ok)
+	})
 }

--- a/sql/expression/function/srid_test.go
+++ b/sql/expression/function/srid_test.go
@@ -182,4 +182,25 @@ func TestSRID(t *testing.T) {
 		require.NoError(err)
 		require.Equal(sql.Geometry{Inner: sql.Polygon{SRID: 4326, Lines: []sql.Linestring{{SRID: 4326, Points: []sql.Point{{SRID: 4326, X: 0, Y: 0}, {SRID: 4326, X: 0, Y: 1}, {SRID: 4326, X: 1, Y: 1}, {SRID: 4326, X: 0, Y: 0}}}}}}, v)
 	})
+
+	t.Run("return type with one argument", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSRID(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.NumberType)
+		require.True(ok)
+	})
+
+	t.Run("return type with two arguments", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSRID(expression.NewLiteral(sql.Linestring{Points: []sql.Point{{X: 1, Y: 2}, {X: 3, Y: 4}}}, sql.LinestringType{}),
+			expression.NewLiteral(4326, sql.Int32))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.LinestringType)
+		require.True(ok)
+	})
 }

--- a/sql/expression/function/srid_test.go
+++ b/sql/expression/function/srid_test.go
@@ -188,9 +188,12 @@ func TestSRID(t *testing.T) {
 		f, err := NewSRID(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.NumberType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 
 	t.Run("return type with two arguments", func(t *testing.T) {
@@ -199,8 +202,11 @@ func TestSRID(t *testing.T) {
 			expression.NewLiteral(4326, sql.Int32))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.LinestringType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }

--- a/sql/expression/function/swapxy_test.go
+++ b/sql/expression/function/swapxy_test.go
@@ -86,4 +86,13 @@ func TestSwapXY(t *testing.T) {
 		require.NoError(err)
 		require.Equal(sql.Geometry{Inner: sql.Polygon{Lines: []sql.Linestring{{Points: []sql.Point{{X: 0, Y: 0}, {X: 1, Y: 1}, {X: 1, Y: 0}, {X: 0, Y: 0}}}}}}, v)
 	})
+
+	t.Run("check return type", func(t *testing.T) {
+		require := require.New(t)
+		f := NewSwapXY(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+
+		typ := f.Type()
+		_, ok := typ.(sql.PointType)
+		require.True(ok)
+	})
 }

--- a/sql/expression/function/swapxy_test.go
+++ b/sql/expression/function/swapxy_test.go
@@ -91,8 +91,11 @@ func TestSwapXY(t *testing.T) {
 		require := require.New(t)
 		f := NewSwapXY(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.PointType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }

--- a/sql/expression/function/wkb.go
+++ b/sql/expression/function/wkb.go
@@ -53,7 +53,7 @@ func (a *AsWKB) IsNullable() bool {
 
 // Type implements the sql.Expression interface.
 func (a *AsWKB) Type() sql.Type {
-	return a.Child.Type()
+	return sql.LongBlob
 }
 
 func (a *AsWKB) String() string {

--- a/sql/expression/function/wkb_test.go
+++ b/sql/expression/function/wkb_test.go
@@ -79,6 +79,15 @@ func TestAsWKB(t *testing.T) {
 		_, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.Error(err)
 	})
+
+	t.Run("check return type", func(t *testing.T) {
+		require := require.New(t)
+		f := NewAsWKB(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+
+		typ := f.Type()
+		_, ok := typ.(sql.JsonType)
+		require.True(ok)
+	})
 }
 
 func TestGeomFromWKB(t *testing.T) {

--- a/sql/expression/function/wkb_test.go
+++ b/sql/expression/function/wkb_test.go
@@ -84,9 +84,12 @@ func TestAsWKB(t *testing.T) {
 		require := require.New(t)
 		f := NewAsWKB(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.JsonType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }
 

--- a/sql/expression/function/wkt.go
+++ b/sql/expression/function/wkt.go
@@ -52,7 +52,7 @@ func (p *AsWKT) IsNullable() bool {
 
 // Type implements the sql.Expression interface.
 func (p *AsWKT) Type() sql.Type {
-	return p.Child.Type()
+	return sql.LongText
 }
 
 func (p *AsWKT) String() string {

--- a/sql/expression/function/wkt.go
+++ b/sql/expression/function/wkt.go
@@ -169,7 +169,8 @@ func (g *GeomFromText) Description() string {
 
 // Type implements the sql.Expression interface.
 func (g *GeomFromText) Type() sql.Type {
-	return sql.PointType{}
+	// TODO: return type is determined after Eval, use Geometry for now?
+	return sql.GeometryType{}
 }
 
 func (g *GeomFromText) String() string {

--- a/sql/expression/function/wkt_test.go
+++ b/sql/expression/function/wkt_test.go
@@ -64,11 +64,19 @@ func TestAsWKT(t *testing.T) {
 		require.Equal(nil, v)
 	})
 
-	t.Run("wrong type", func(t *testing.T) {
+	t.Run("provide wrong type", func(t *testing.T) {
 		require := require.New(t)
 		f := NewAsWKT(expression.NewLiteral("notageometry", sql.Blob))
 		_, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.Error(err)
+	})
+
+	t.Run("check return type", func(t *testing.T) {
+		require := require.New(t)
+		f := NewAsWKT(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+		typ := f.Type()
+		_, ok := typ.(sql.StringType)
+		require.True(ok)
 	})
 }
 
@@ -319,5 +327,14 @@ func TestGeomFromText(t *testing.T) {
 		v, err := f.Eval(sql.NewEmptyContext(), nil)
 		require.NoError(err)
 		require.Equal(sql.Polygon{SRID: 4230, Lines: []sql.Linestring{{SRID: 4230, Points: []sql.Point{{SRID: 4230, X: 0, Y: 0}, {SRID: 4230, X: 1, Y: 0}, {SRID: 4230, X: 0, Y: 1}, {SRID: 4230, X: 0, Y: 0}}}}}, v)
+	})
+
+	t.Run("check return type", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewGeomFromWKT(expression.NewLiteral("POINT(1 2)", sql.Blob))
+		require.NoError(err)
+		typ := f.Type()
+		_, ok := typ.(sql.GeometryType)
+		require.True(ok)
 	})
 }

--- a/sql/expression/function/wkt_test.go
+++ b/sql/expression/function/wkt_test.go
@@ -74,9 +74,12 @@ func TestAsWKT(t *testing.T) {
 	t.Run("check return type", func(t *testing.T) {
 		require := require.New(t)
 		f := NewAsWKT(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.StringType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }
 

--- a/sql/expression/function/x_y_latitude_longitude_test.go
+++ b/sql/expression/function/x_y_latitude_longitude_test.go
@@ -85,6 +85,27 @@ func TestSTX(t *testing.T) {
 		_, err = f.Eval(sql.NewEmptyContext(), nil)
 		require.Error(err)
 	})
+
+	t.Run("check return type with one argument", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTX(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.NumberType)
+		require.True(ok)
+	})
+
+	t.Run("check return type with two arguments", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTX(expression.NewLiteral(sql.Point{X: 0, Y: 0}, sql.PointType{}),
+			expression.NewLiteral(123.456, sql.Float64))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.PointType)
+		require.True(ok)
+	})
 }
 
 func TestSTY(t *testing.T) {
@@ -148,6 +169,27 @@ func TestSTY(t *testing.T) {
 
 		_, err = f.Eval(sql.NewEmptyContext(), nil)
 		require.Error(err)
+	})
+
+	t.Run("check return type with one argument", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTY(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.NumberType)
+		require.True(ok)
+	})
+
+	t.Run("check return type with two arguments", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewSTY(expression.NewLiteral(sql.Point{X: 0, Y: 0}, sql.PointType{}),
+			expression.NewLiteral(123.456, sql.Float64))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.PointType)
+		require.True(ok)
 	})
 }
 
@@ -234,6 +276,27 @@ func TestLongitude(t *testing.T) {
 		_, err = f.Eval(sql.NewEmptyContext(), nil)
 		require.Error(err)
 	})
+
+	t.Run("check return type with one argument", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewLongitude(expression.NewLiteral(sql.Point{SRID: 4326, X: 1, Y: 2}, sql.PointType{}))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.NumberType)
+		require.True(ok)
+	})
+
+	t.Run("check return type with two arguments", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewLongitude(expression.NewLiteral(sql.Point{SRID: 4326, X: 0, Y: 0}, sql.PointType{}),
+			expression.NewLiteral(123.456, sql.Float64))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.PointType)
+		require.True(ok)
+	})
 }
 
 func TestLatitude(t *testing.T) {
@@ -318,5 +381,26 @@ func TestLatitude(t *testing.T) {
 
 		_, err = f.Eval(sql.NewEmptyContext(), nil)
 		require.Error(err)
+	})
+
+	t.Run("check return type with one argument", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewLatitude(expression.NewLiteral(sql.Point{SRID: 4326, X: 1, Y: 2}, sql.PointType{}))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.NumberType)
+		require.True(ok)
+	})
+
+	t.Run("check return type with two arguments", func(t *testing.T) {
+		require := require.New(t)
+		f, err := NewLatitude(expression.NewLiteral(sql.Point{SRID: 4326, X: 0, Y: 0}, sql.PointType{}),
+			expression.NewLiteral(12.3456, sql.Float64))
+		require.NoError(err)
+
+		typ := f.Type()
+		_, ok := typ.(sql.PointType)
+		require.True(ok)
 	})
 }

--- a/sql/expression/function/x_y_latitude_longitude_test.go
+++ b/sql/expression/function/x_y_latitude_longitude_test.go
@@ -91,9 +91,12 @@ func TestSTX(t *testing.T) {
 		f, err := NewSTX(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.NumberType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
@@ -102,9 +105,12 @@ func TestSTX(t *testing.T) {
 			expression.NewLiteral(123.456, sql.Float64))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.PointType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }
 
@@ -176,9 +182,12 @@ func TestSTY(t *testing.T) {
 		f, err := NewSTY(expression.NewLiteral(sql.Point{X: 1, Y: 2}, sql.PointType{}))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.NumberType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
@@ -282,9 +291,12 @@ func TestLongitude(t *testing.T) {
 		f, err := NewLongitude(expression.NewLiteral(sql.Point{SRID: 4326, X: 1, Y: 2}, sql.PointType{}))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.NumberType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
@@ -293,9 +305,12 @@ func TestLongitude(t *testing.T) {
 			expression.NewLiteral(123.456, sql.Float64))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.PointType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }
 
@@ -388,9 +403,12 @@ func TestLatitude(t *testing.T) {
 		f, err := NewLatitude(expression.NewLiteral(sql.Point{SRID: 4326, X: 1, Y: 2}, sql.PointType{}))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.NumberType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 
 	t.Run("check return type with two arguments", func(t *testing.T) {
@@ -399,8 +417,11 @@ func TestLatitude(t *testing.T) {
 			expression.NewLiteral(12.3456, sql.Float64))
 		require.NoError(err)
 
+		v, err := f.Eval(sql.NewEmptyContext(), nil)
+		require.NoError(err)
+
 		typ := f.Type()
-		_, ok := typ.(sql.PointType)
-		require.True(ok)
+		_, err = typ.Convert(v)
+		require.NoError(err)
 	})
 }


### PR DESCRIPTION
Fix for: https://github.com/dolthub/dolt/issues/3279

Adding tests that check the return type for functions
 - `st_asgeojson`
 - `st_aswkb`
 - `st_aswkt`
 - `st_astext`
 - `st_dimension`
 - `st_latitude`
 - `st_longitude`
 - `st_swapxy`
 - `st_x`
 - `st_y`
