### PR TITLE
Foreign keys now allow limited type changing

### DIFF
--- a/memory/table.go
+++ b/memory/table.go
@@ -745,7 +745,7 @@ func (t *Table) ModifyColumn(ctx *sql.Context, columnName string, column *sql.Co
 		for i, expr := range memIndex.Exprs {
 			getField := expr.(*expression.GetField)
 			if strings.ToLower(getField.Name()) == nameLowercase {
-				memIndex.Exprs[i] = expression.NewGetFieldWithTable(i, getField.Type(), getField.Table(), column.Name, getField.IsNullable())
+				memIndex.Exprs[i] = expression.NewGetFieldWithTable(newIdx, column.Type, getField.Table(), column.Name, column.Nullable)
 			}
 		}
 	}

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -243,7 +243,7 @@ func ResolveForeignKey(ctx *sql.Context, tbl sql.ForeignKeyTable, refTbl sql.For
 	for i := range fkDef.Columns {
 		col := cols[strings.ToLower(fkDef.Columns[i])]
 		parentCol := parentCols[strings.ToLower(fkDef.ParentColumns[i])]
-		if !col.Type.Equals(parentCol.Type) {
+		if !foreignKeyComparableTypes(ctx, col.Type, parentCol.Type) {
 			return sql.ErrForeignKeyColumnTypeMismatch.New(fkDef.Columns[i], fkDef.ParentColumns[i])
 		}
 		sqlParserType := col.Type.Type()
@@ -496,9 +496,8 @@ func FindForeignKeyColMapping(
 			return nil, nil, fmt.Errorf("index column `%s` in foreign key `%s` cannot be found",
 				destFKCols[fkIdx], fkName)
 		}
-		//TODO: add equality checks to types
-		if indexTypeMap[destFkCol] != expectedType {
-			return nil, nil, fmt.Errorf("mismatched types")
+		if !foreignKeyComparableTypes(ctx, indexTypeMap[destFkCol], expectedType) {
+			return nil, nil, sql.ErrForeignKeyColumnTypeMismatch.New(colName, destFkCol)
 		}
 		indexPositions[indexPos] = localRowPos
 	}
@@ -573,6 +572,30 @@ func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexedTable, prefixCols []st
 		sortedIndexes[i] = indexesWithLen[i].Index
 	}
 	return sortedIndexes[0], true, nil
+}
+
+// foreignKeyComparableTypes returns whether the two given types are able to be used as parent/child columns in a
+// foreign key.
+func foreignKeyComparableTypes(ctx *sql.Context, type1 sql.Type, type2 sql.Type) bool {
+	if !type1.Equals(type2) {
+		// There seems to be a special case where CHAR/VARCHAR/BINARY/VARBINARY can have unequal lengths.
+		// Have not tested every type nor combination, but this seems specific to those 4 types.
+		if type1.Type() == type2.Type() {
+			switch type1.Type() {
+			case sqltypes.Char, sqltypes.VarChar, sqltypes.Binary, sqltypes.VarBinary:
+				type1String := type1.(sql.StringType)
+				type2String := type2.(sql.StringType)
+				if type1String.Collation() != type2String.Collation() {
+					return false
+				}
+			default:
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
 }
 
 // TODO: copy of analyzer.exprsAreIndexSubset, need to shift stuff around to eliminate import cycle


### PR DESCRIPTION
It seems that, specifically when using the string types, you may lengthen a field, but you may not change any other properties (cannot change character set or collation). Non-string types don't seem to allow lengthening, as you can't change an `INT` to a `BIGINT`.

The implemented behavior is actually an approximation of MySQL's, as you cannot cross some length thresholds due to how MySQL stores strings. From what I can gather for MySQL, as long as the on-disk data does not change **AND** does not need to be checked, it is allowed. I'm sure more type changes are allowed, but it's not documented, and therefore would require _a ton_ of trial and error, so just shipping this for now.