### PR TITLE
fix panics on CREATE PROCEDURE queries

### DIFF
--- a/enginetest/procedure_queries.go
+++ b/enginetest/procedure_queries.go
@@ -898,39 +898,6 @@ var ProcedureCallTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "use procedure parameter in filter expressions",
-		SetUpScript: []string{
-			"CREATE TABLE inventory (store_id int, product varchar(5))",
-			"INSERT INTO inventory VALUES (1, 'a'), (1, 'b'), (1, 'c'), (1, 'd'), (2, 'e'), (2, 'f'), (1, 'g'), (1, 'h'), (3, 'i')",
-			"CREATE PROCEDURE product_in_stock (IN p_store_id INT) SELECT COUNT(*) FROM inventory WHERE store_id = p_store_id;",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query: "CALL product_in_stock(1)",
-				Expected: []sql.Row{
-					{
-						int64(6),
-					},
-				},
-			},
-			{
-				Query: "CALL product_in_stock(2)",
-				Expected: []sql.Row{
-					{
-						int64(2),
-					},
-				},
-			}, {
-				Query: "CALL product_in_stock(4)",
-				Expected: []sql.Row{
-					{
-						int64(0),
-					},
-				},
-			},
-		},
-	},
-	{
 		Name: "use procedure parameter in filter expressions and multiple statements",
 		SetUpScript: []string{
 			"CREATE TABLE inventory (store_id int, product varchar(5))",

--- a/enginetest/procedure_queries.go
+++ b/enginetest/procedure_queries.go
@@ -930,6 +930,54 @@ var ProcedureCallTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "use procedure parameter in filter expressions and multiple statements",
+		SetUpScript: []string{
+			"CREATE TABLE inventory (store_id int, product varchar(5))",
+			"INSERT INTO inventory VALUES (1, 'a'), (1, 'b'), (1, 'c'), (1, 'd'), (2, 'e'), (2, 'f'), (1, 'g'), (1, 'h'), (3, 'i')",
+			"CREATE PROCEDURE proc1 (IN p_store_id INT) SELECT COUNT(*) FROM inventory WHERE store_id = p_store_id;",
+			"CREATE PROCEDURE proc2 (IN p_store_id INT, OUT p_film_count INT) READS SQL DATA BEGIN SELECT COUNT(*) as counted FROM inventory WHERE store_id = p_store_id; SET p_film_count = 44; END ;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CALL proc1(1)",
+				Expected: []sql.Row{
+					{
+						int64(6),
+					},
+				},
+			},
+			{
+				Query: "CALL proc1(2)",
+				Expected: []sql.Row{
+					{
+						int64(2),
+					},
+				},
+			}, {
+				Query: "CALL proc1(4)",
+				Expected: []sql.Row{
+					{
+						int64(0),
+					},
+				},
+			}, {
+				Query: "CALL proc2(3, @foo)",
+				Expected: []sql.Row{
+					{
+						int64(1),
+					},
+				},
+			}, {
+				Query: "SELECT @foo",
+				Expected: []sql.Row{
+					{
+						int64(44),
+					},
+				},
+			},
+		},
+	},
 }
 
 var ProcedureDropTests = []ScriptTest{

--- a/enginetest/procedure_queries.go
+++ b/enginetest/procedure_queries.go
@@ -897,6 +897,39 @@ var ProcedureCallTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "use procedure parameter in filter expressions",
+		SetUpScript: []string{
+			"CREATE TABLE inventory (store_id int, product varchar(5))",
+			"INSERT INTO inventory VALUES (1, 'a'), (1, 'b'), (1, 'c'), (1, 'd'), (2, 'e'), (2, 'f'), (1, 'g'), (1, 'h'), (3, 'i')",
+			"CREATE PROCEDURE product_in_stock (IN p_store_id INT) SELECT COUNT(*) FROM inventory WHERE store_id = p_store_id;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CALL product_in_stock(1)",
+				Expected: []sql.Row{
+					{
+						int64(6),
+					},
+				},
+			},
+			{
+				Query: "CALL product_in_stock(2)",
+				Expected: []sql.Row{
+					{
+						int64(2),
+					},
+				},
+			}, {
+				Query: "CALL product_in_stock(4)",
+				Expected: []sql.Row{
+					{
+						int64(0),
+					},
+				},
+			},
+		},
+	},
 }
 
 var ProcedureDropTests = []ScriptTest{

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -8613,7 +8613,7 @@ var errorQueries = []QueryErrorTest{
 						LEFT JOIN mytable as t15 ON t14.i = t15.i`,
 		ExpectedErr: sql.ErrUnsupportedJoinFactorCount,
 	},
-	// this query should be allowed, but should return error when this procedure is called
+	// this query should be allowed, instead it should return error when this query is called
 	{
 		Query:       `CREATE PROCEDURE proc1 (OUT out_count INT) READS SQL DATA SELECT COUNT(*) FROM mytable WHERE i = 1 AND s = 'first row' AND func1(i);`,
 		ExpectedErr: sql.ErrFunctionNotFound,

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -8613,7 +8613,7 @@ var errorQueries = []QueryErrorTest{
 						LEFT JOIN mytable as t15 ON t14.i = t15.i`,
 		ExpectedErr: sql.ErrUnsupportedJoinFactorCount,
 	},
-	// this query should be allowed, instead it should return error when this query is called
+	// this query was panicing, but should be allowed and should return error when this query is called
 	{
 		Query:       `CREATE PROCEDURE proc1 (OUT out_count INT) READS SQL DATA SELECT COUNT(*) FROM mytable WHERE i = 1 AND s = 'first row' AND func1(i);`,
 		ExpectedErr: sql.ErrFunctionNotFound,

--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -8613,6 +8613,11 @@ var errorQueries = []QueryErrorTest{
 						LEFT JOIN mytable as t15 ON t14.i = t15.i`,
 		ExpectedErr: sql.ErrUnsupportedJoinFactorCount,
 	},
+	// this query should be allowed, but should return error when this procedure is called
+	{
+		Query:       `CREATE PROCEDURE proc1 (OUT out_count INT) READS SQL DATA SELECT COUNT(*) FROM mytable WHERE i = 1 AND s = 'first row' AND func1(i);`,
+		ExpectedErr: sql.ErrFunctionNotFound,
+	},
 }
 
 // WriteQueryTest is a query test for INSERT, UPDATE, etc. statements. It has a query to run and a select query to

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -1007,11 +1007,8 @@ func containsBindvars(e sql.Expression) bool {
 func containsProcedureParam(e sql.Expression) bool {
 	var result bool
 	sql.Inspect(e, func(e sql.Expression) bool {
-		if _, ok := e.(*expression.ProcedureParam); ok {
-			result = true
-			return false
-		}
-		return true
+		_, result = e.(*expression.ProcedureParam)
+		return !result
 	})
 	return result
 }

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -989,13 +989,25 @@ func containsSubquery(e sql.Expression) bool {
 }
 
 func isEvaluable(e sql.Expression) bool {
-	return !containsColumns(e) && !containsSubquery(e) && !containsBindvars(e)
+	return !containsColumns(e) && !containsSubquery(e) && !containsBindvars(e) && !containsProcedureParam(e)
 }
 
 func containsBindvars(e sql.Expression) bool {
 	var result bool
 	sql.Inspect(e, func(e sql.Expression) bool {
 		if _, ok := e.(*expression.BindVar); ok {
+			result = true
+			return false
+		}
+		return true
+	})
+	return result
+}
+
+func containsProcedureParam(e sql.Expression) bool {
+	var result bool
+	sql.Inspect(e, func(e sql.Expression) bool {
+		if _, ok := e.(*expression.ProcedureParam); ok {
 			result = true
 			return false
 		}

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -811,6 +811,8 @@ func fds(e sql.Expression) int {
 	switch e.(type) {
 	case *expression.UnresolvedColumn:
 		return 1
+	case *expression.UnresolvedFunction:
+		return 1
 	default:
 		return sql.NumColumns(e.Type())
 	}


### PR DESCRIPTION
- Skips evaluating procedure-parameters in the analyzer step
- Added case for handling `UnresolvedFunction` in `fds` to avoid panics
- Fixes issue, https://github.com/dolthub/dolt/issues/3241 (when procedure parameters are used in filter expressions, it needs to be evaluated, but procedure parameters cannot be evaluated without nil reference map)
