### PR TITLE
Regression test case for https://github.com/dolthub/dolt/issues/3247

### DIFF
--- a/enginetest/queries.go
+++ b/enginetest/queries.go
@@ -8239,6 +8239,11 @@ type QueryErrorTest struct {
 
 var errorQueries = []QueryErrorTest{
 	{
+		// Test for: https://github.com/dolthub/dolt/issues/3247
+		Query:       "select * from dual where foo() and true;",
+		ExpectedErr: sql.ErrFunctionNotFound,
+	},
+	{
 		Query:       "select * from mytable where (i = 1, i = 0 or i = 2) and (i > -1)",
 		ExpectedErr: sql.ErrInvalidOperandColumns,
 	},


### PR DESCRIPTION
https://github.com/dolthub/dolt/issues/3247 reported a panic that our test cases didn't cover. Another commit (https://github.com/dolthub/go-mysql-server/commit/324e43b896d344f745be0b52935640335e9fd546) already fixed the panic, so this PR just adds a quick test to ensure we don't regress with the same bug. 
