### PR TITLE
sql/analyzer: Fix reresolveTables to not drop IndexedTableAccess and DeferredAsOfTable nodes on its transform.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -166,6 +166,17 @@ func TestQueriesPrepared(t *testing.T, harness Harness) {
 	}
 }
 
+func TestPreparedStaticIndexQuery(t *testing.T, harness Harness) {
+	engine := NewEngine(t, harness)
+	ctx := NewContextWithEngine(harness, engine)
+
+	RunQueryWithContext(t, engine, ctx, "CREATE TABLE squares (i bigint primary key, square bigint);")
+	engine.PrepareQuery(ctx, "select * from squares where i = 1")
+	RunQueryWithContext(t, engine, ctx, "INSERT INTO squares VALUES (0, 0), (1, 1), (2, 4), (3, 9);")
+	TestQueryWithContext(t, ctx, engine, "select * from squares where i = 1",
+		[]sql.Row{{1, 1}}, sql.Schema{{Name: "i", Type: sql.Int64}, {Name: "square", Type: sql.Int64}}, nil)
+}
+
 // Runs the query tests given after setting up the engine. Useful for testing out a smaller subset of queries during
 // debugging.
 func RunQueryTests(t *testing.T, harness Harness, queries []QueryTest) {

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -142,6 +142,10 @@ func TestSpatialQueriesSimple(t *testing.T) {
 	enginetest.TestSpatialQueries(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
 }
 
+func TestPreparedStaticIndexQuerySimple(t *testing.T) {
+	enginetest.TestPreparedStaticIndexQuery(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
+}
+
 // TestQueriesSimple runs the canonical test queries against a single threaded index enabled harness.
 func TestQueriesSimple(t *testing.T) {
 	enginetest.TestQueries(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -214,7 +214,7 @@ func getNodeAvailableNames(n sql.Node, scope *Scope) availableNames {
 	for i, n := range append(append(([]sql.Node)(nil), n), scope.InnerToOuter()...) {
 		transform.Inspect(n, func(n sql.Node) bool {
 			switch n := n.(type) {
-			case *plan.SubqueryAlias, *plan.ResolvedTable, *plan.ValueDerivedTable, *plan.RecursiveTable, *plan.RecursiveCte, *information_schema.ColumnsTable:
+			case *plan.SubqueryAlias, *plan.ResolvedTable, *plan.ValueDerivedTable, *plan.RecursiveTable, *plan.RecursiveCte, *information_schema.ColumnsTable, *plan.IndexedTableAccess:
 				name := strings.ToLower(n.(sql.Nameable).Name())
 				names.indexTable(name, name, i)
 				return false

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -292,9 +292,8 @@ func reresolveTables(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 			if err != nil {
 				return nil, transform.SameTree, err
 			}
-			new := *n
-			new.ResolvedTable = transferProjections(from, to.(*plan.ResolvedTable))
-			return &new, transform.NewTree, nil
+			new := transferProjections(from, to.(*plan.ResolvedTable))
+			return new, transform.NewTree, nil
 		default:
 		}
 		if err != nil {

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -287,7 +287,6 @@ func (i IndexedTableAccess) WithTable(table sql.Table) (*IndexedTableAccess, err
 	if err != nil {
 		return nil, err
 	}
-
 	i.ResolvedTable = nrt
 	return &i, nil
 }


### PR DESCRIPTION
enginetest: Add a test to assert IndexedTableAccess in a prepared statement
behaves correctly when querying a table that has been modified since the
prepare.