### PR TITLE
Moving transaction initialization before query analysis 

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -236,6 +236,16 @@ func (e *Engine) QueryNodeWithBindings(
 // created autocommit transaction. This enables the next request to have an autocommit transaction
 // correctly started.
 func clearAutocommitTransaction(ctx *sql.Context) error {
+	// The GetignoreAutoCommit property essentially says the current transaction is an explicit,
+	// user-created transaction and we should not process autocommit. So, if it's set, then we
+	// don't need to do anything here to clear implicit transaction state.
+	//
+	// TODO: This logic would probably read more clearly if we could just ask the session/ctx if the
+	//       current transaction is automatically created or explicitly created by the caller.
+	if ctx.GetIgnoreAutoCommit() {
+		return nil
+	}
+
 	autocommit, err := plan.IsSessionAutocommit(ctx)
 	if err != nil {
 		return err

--- a/engine.go
+++ b/engine.go
@@ -174,16 +174,23 @@ func (e *Engine) QueryNodeWithBindings(
 		err      error
 	)
 
+	if parsed == nil {
+		parsed, err = parse.Parse(ctx, query)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	_, err = e.beginTransaction(ctx, parsed)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if p, ok := e.preparedDataForSession(ctx.Session); ok && p.Query == query {
 		analyzed, err = e.analyzePreparedQuery(ctx, query, bindings)
 	} else {
 		analyzed, err = e.analyzeQuery(ctx, query, parsed, bindings)
 	}
-	if err != nil {
-		return nil, nil, err
-	}
-
-	_, err = e.beginTransaction(ctx, analyzed)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/engine.go
+++ b/engine.go
@@ -236,7 +236,7 @@ func (e *Engine) QueryNodeWithBindings(
 // created autocommit transaction. This enables the next request to have an autocommit transaction
 // correctly started.
 func clearAutocommitTransaction(ctx *sql.Context) error {
-	// The GetignoreAutoCommit property essentially says the current transaction is an explicit,
+	// The GetIgnoreAutoCommit property essentially says the current transaction is an explicit,
 	// user-created transaction and we should not process autocommit. So, if it's set, then we
 	// don't need to do anything here to clear implicit transaction state.
 	//

--- a/enginetest/transaction_queries.go
+++ b/enginetest/transaction_queries.go
@@ -35,6 +35,7 @@ type TransactionTest struct {
 
 var TransactionTests = []TransactionTest{
 	{
+		// Repro for https://github.com/dolthub/dolt/issues/3402
 		Name: "Changes from transactions are available before analyzing statements in other sessions (autocommit on)",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/enginetest/transaction_queries.go
+++ b/enginetest/transaction_queries.go
@@ -35,36 +35,6 @@ type TransactionTest struct {
 
 var TransactionTests = []TransactionTest{
 	{
-		// Repro for https://github.com/dolthub/dolt/issues/3402
-		Name: "Changes from transactions are available before analyzing statements in other sessions (autocommit on)",
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:    "/* client a */ select @@autocommit;",
-				Expected: []sql.Row{{1}},
-			},
-			{
-				Query:    "/* client b */ select @@autocommit;",
-				Expected: []sql.Row{{1}},
-			},
-			{
-				Query:       "/* client a */ select * from t;",
-				ExpectedErr: sql.ErrTableNotFound,
-			},
-			{
-				Query:       "/* client b */ select * from t;",
-				ExpectedErr: sql.ErrTableNotFound,
-			},
-			{
-				Query:    "/* client a */ create table t(pk int primary key);",
-				Expected: []sql.Row{{sql.OkResult{}}},
-			},
-			{
-				Query:    "/* client b */ select count(*) from t;",
-				Expected: []sql.Row{{0}},
-			},
-		},
-	},
-	{
 		Name: "Changes from transactions are available before analyzing statements in other sessions (autocommit off)",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/enginetest/transaction_queries.go
+++ b/enginetest/transaction_queries.go
@@ -35,6 +35,27 @@ type TransactionTest struct {
 
 var TransactionTests = []TransactionTest{
 	{
+		Name: "Changes from transactions are available before analyzing statements in other sessions",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "/* client a */ select * from t;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				Query:       "/* client b */ select * from t;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				Query:    "/* client a */ create table t(pk int primary key);",
+				Expected: []sql.Row{{sql.OkResult{}}},
+			},
+			{
+				Query:    "/* client b */ select count(*) from t;",
+				Expected: []sql.Row{{0}},
+			},
+		},
+	},
+	{
 		Name: "autocommit on",
 		SetUpScript: []string{
 			"create table t (x int primary key, y int)",

--- a/sql/plan/transaction_committing_iter.go
+++ b/sql/plan/transaction_committing_iter.go
@@ -122,7 +122,7 @@ func (t transactionCommittingIter) Close(ctx *sql.Context) error {
 	}
 
 	tx := ctx.GetTransaction()
-	// TODO: In the future we should ensure that analyzer supports impicit commits instead of directly
+	// TODO: In the future we should ensure that analyzer supports implicit commits instead of directly
 	// accessing autocommit here.
 	// cc. https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
 	autocommit, err := isSessionAutocommit(ctx)

--- a/sql/plan/transaction_committing_iter.go
+++ b/sql/plan/transaction_committing_iter.go
@@ -125,7 +125,7 @@ func (t transactionCommittingIter) Close(ctx *sql.Context) error {
 	// TODO: In the future we should ensure that analyzer supports implicit commits instead of directly
 	// accessing autocommit here.
 	// cc. https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
-	autocommit, err := isSessionAutocommit(ctx)
+	autocommit, err := IsSessionAutocommit(ctx)
 	if err != nil {
 		return err
 	}
@@ -144,7 +144,9 @@ func (t transactionCommittingIter) Close(ctx *sql.Context) error {
 	return nil
 }
 
-func isSessionAutocommit(ctx *sql.Context) (bool, error) {
+// IsSessionAutocommit returns true if the current session is using implicit transaction management
+// through autocommit.
+func IsSessionAutocommit(ctx *sql.Context) (bool, error) {
 	if ReadCommitted(ctx) {
 		return true, nil
 	}


### PR DESCRIPTION
Moves transaction creation ahead of query analysis, so that queries can be executed with the latest committed state from other transactions. 

Fixes: https://github.com/dolthub/dolt/issues/3402