### PR TITLE
Allow SHOW CREATE PROCEDURE for external procedures + display a fake CREATE PROCEDURE

### DIFF
--- a/sql/analyzer/resolve_external_stored_procedures.go
+++ b/sql/analyzer/resolve_external_stored_procedures.go
@@ -15,7 +15,6 @@
 package analyzer
 
 import (
-	"fmt"
 	"reflect"
 	"strconv"
 	"time"
@@ -145,15 +144,14 @@ func resolveExternalStoredProcedure(ctx *sql.Context, dbName string, externalPro
 		}
 	}
 
-	comment := fmt.Sprintf("External stored procedure defined by %s", dbName)
 	procedure := plan.NewProcedure(
 		externalProcedure.Name,
 		"root",
 		paramDefinitions,
 		plan.ProcedureSecurityContext_Definer,
-		comment,
+		externalProcedure.Comment(dbName),
 		nil,
-		comment,
+		externalProcedure.FakeCreateProcedureStmt(dbName),
 		&plan.ExternalProcedure{
 			ExternalStoredProcedureDetails: externalProcedure,
 			ParamDefinitions:               paramDefinitions,

--- a/sql/core.go
+++ b/sql/core.go
@@ -1054,6 +1054,17 @@ type ExternalStoredProcedureDetails struct {
 	Function interface{}
 }
 
+// Comment returns a comment stating that this is an external stored procedure, which is defined by the given database.
+func (espd ExternalStoredProcedureDetails) Comment(dbName string) string {
+	return fmt.Sprintf("External stored procedure defined by %s", dbName)
+}
+
+// FakeCreateProcedureStmt returns a parseable CREATE PROCEDURE statement for this external stored procedure, as some
+// tools (such as Java's JDBC connector) require a valid statement in some situations.
+func (espd ExternalStoredProcedureDetails) FakeCreateProcedureStmt(dbName string) string {
+	return fmt.Sprintf("CREATE PROCEDURE %s() SELECT '%s';", espd.Name, espd.Comment(dbName))
+}
+
 // StoredProcedureDatabase is a database that supports the creation and execution of stored procedures. The engine will
 // handle all parsing and execution logic for stored procedures. Integrators only need to store and retrieve
 // StoredProcedureDetails, while verifying that all stored procedures have a unique name without regard to


### PR DESCRIPTION
A note regarding the fake `CREATE PROCEDURE`. It seems that Java's JDBC checks that the procedure creation statement is a valid statement, regardless of whether the statement remotely matches that of a stored procedure. So rather than returning a random statement, we return a "valid" `CREATE PROCEDURE` statement.

Fixes https://github.com/dolthub/dolt/issues/3428 and https://github.com/dolthub/dolt/issues/3424