### PR TITLE
[no-release-notes] Setting the correct transaction database for testdata

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -65,8 +65,8 @@ func createTestDatabase() *memory.Database {
 
 	db := memory.NewDatabase(dbName)
 	table := memory.NewTable(tableName, sql.NewPrimaryKeySchema(sql.Schema{
-		{Name: "name", Type: sql.Text, Nullable: false, Source: tableName,PrimaryKey:true},
-		{Name: "email", Type: sql.Text, Nullable: false, Source: tableName,PrimaryKey:true},
+		{Name: "name", Type: sql.Text, Nullable: false, Source: tableName, PrimaryKey: true},
+		{Name: "email", Type: sql.Text, Nullable: false, Source: tableName, PrimaryKey: true},
 		{Name: "phone_numbers", Type: sql.JSON, Nullable: false, Source: tableName},
 		{Name: "created_at", Type: sql.Timestamp, Nullable: false, Source: tableName},
 	}), db.GetForeignKeyCollection())

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -406,7 +406,7 @@ func createSubsetTestData(t *testing.T, harness Harness, includedTables []string
 	}
 
 	if includeTable(includedTables, "other_table") {
-		wrapInTransaction(t, myDb, harness, func() {
+		wrapInTransaction(t, foo, harness, func() {
 			table, err = harness.NewTable(foo, "other_table", sql.NewPrimaryKeySchema(sql.Schema{
 				{Name: "text", Type: sql.Text, Source: "other_table", PrimaryKey: true},
 				{Name: "number", Type: sql.Int32, Source: "other_table"},


### PR DESCRIPTION
When creating the `other_table` in the `foo` database, testdata was running the transaction on the wrong db (mydb instead of foo). Fixing that caused Dolt tests to start failing because of a latent bug in DoltHarness that was causing all DBs to share the same underlying DoltDB, working set, etc.

Depends on: https://github.com/dolthub/dolt/pull/3444
