### PR TITLE
[no-release-notes] Make sessions accessible from Server

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -140,6 +140,9 @@ func (s *SessionManager) SetDB(conn *mysql.Conn, db string) error {
 
 // Iter iterates over the active sessions and executes the specified callback function on each one.
 func (s *SessionManager) Iter(f func(session sql.Session) (stop bool, err error)) error {
+	// Lock the mutex guarding the sessions map while we make a copy of it to prevent errors from
+	// mutating a map while iterating over it. Making a copy of the map also allows us to guard
+	// against long running callback functions being passed in that could cause long mutex blocking.
 	s.mu.Lock()
 	sessionsCopy := make(map[uint32]*managedSession)
 	for key, value := range s.sessions {

--- a/server/server.go
+++ b/server/server.go
@@ -108,3 +108,8 @@ func (s *Server) Close() error {
 	s.Listener.Close()
 	return nil
 }
+
+// SessionManager returns the session manager for this server.
+func (s *Server) SessionManager() *SessionManager {
+	return s.h.sm
+}


### PR DESCRIPTION
This change enables callers to iterate over the active sessions in a running server. 

Needed by https://github.com/dolthub/dolt/pull/3487 for safe deletion of branches within SQL. 