### PR TITLE
exclude procedure aliases from showing information_schema.routines table

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -194,7 +194,6 @@ func TestInfoSchema(t *testing.T, h Harness) {
 		require.NoError(t, err)
 
 		TestQueryWithContext(t, ctx, e, "SELECT * FROM information_schema.processlist", []sql.Row{{1, "root", "localhost", "NULL", "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"}}, nil, nil)
-		require.NoError(t, err)
 	})
 }
 

--- a/sql/information_schema/routines_table.go
+++ b/sql/information_schema/routines_table.go
@@ -35,6 +35,22 @@ var (
 	_ Table = (*routineTable)(nil)
 )
 
+var doltProcedureAliasSet = map[string]interface{}{
+	"dadd":                    nil,
+	"dbranch":                 nil,
+	"dcheckout":               nil,
+	"dclean":                  nil,
+	"dcommit":                 nil,
+	"dfetch":                  nil,
+	"dmerge":                  nil,
+	"dpull":                   nil,
+	"dpush":                   nil,
+	"dreset":                  nil,
+	"drevert":                 nil,
+	"dverify_constraints":     nil,
+	"dverify_all_constraints": nil,
+}
+
 func (t *routineTable) AssignCatalog(cat Catalog) Table {
 	t.catalog = cat
 	return t
@@ -105,6 +121,10 @@ func routinesRowIter(ctx *Context, c Catalog, p map[string][]*plan.Procedure) (R
 	}
 	for db, procedures := range p {
 		for _, procedure := range procedures {
+			// Skip dolt procedure aliases to show in this table
+			if _, isAlias := doltProcedureAliasSet[procedure.Name]; isAlias {
+				continue
+			}
 			// We skip external procedures if the variable to show them is set to false
 			if showExternalProcedures.(int8) == 0 && procedure.IsExternal() {
 				continue


### PR DESCRIPTION
Not show procedure aliases in information_schema.routines table
[Dolt PR](https://github.com/dolthub/dolt/pull/3554) tests this change