### PR TITLE
Better join commutativity count

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8494,26 +8494,6 @@ var ErrorQueries = []QueryErrorTest{
 	{
 		Query: `SELECT t1.*
 					  FROM
-						mytable as t1,
-						mytable as t2,
-						mytable as t3,
-						mytable as t4,
-						mytable as t5,
-						mytable as t6,
-						mytable as t7,
-						mytable as t8,
-						mytable as t9,
-						mytable as t10,
-						mytable as t11,
-						mytable as t12,
-						mytable as t13,
-						mytable as t14,
-						mytable as t15`,
-		ExpectedErr: sql.ErrUnsupportedJoinFactorCount,
-	},
-	{
-		Query: `SELECT t1.*
-					  FROM
 						mytable as t1
 						LEFT JOIN mytable as t2 ON t1.i = t2.i
 						LEFT JOIN mytable as t3 ON t2.i = t3.i

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -403,7 +403,10 @@ func replanJoin(
 	joinHint := extractJoinHint(node)
 
 	// Collect all tables
-	tableJoinOrder := newJoinOrderNode(node)
+	tableJoinOrder, cnt := newJoinOrderNode(node)
+	if cnt > joinComplexityLimit {
+		return nil, transform.SameTree, sql.ErrUnsupportedJoinFactorCount.New(joinComplexityLimit, cnt)
+	}
 
 	// Find a hinted or cost optimized access order for them
 	ordered := false

--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -57,7 +57,6 @@ var OnceBeforeDefault = []Rule{
 	{validateDatabaseSetId, validateDatabaseSet},
 	{validatePriviledgesId, validatePrivileges}, // Ensure that checking privileges happens after db, table  & table function resolution
 	{stripDecorationsId, stripDecorations},
-	{validateJoinComplexityId, validateJoinComplexity},
 }
 
 // DefaultRules to apply when analyzing nodes.


### PR DESCRIPTION
We excluded joins on the basis of join factors in the logical join tree,
rather than distinct join subtrees subject to commutativity. The
difference is that we have to permute n! to optimize the search space
of all valid commutative trees, versus a k^n (k = table rows) execution
runtime. 12! blocks analysis, k^12 is steep but can be OK depending on
cardinality and indexes. We impose no limits on k^n joins.