### PR TITLE
Fix prep AS OF

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -321,16 +321,16 @@ func (e *Engine) analyzeQuery(ctx *sql.Context, query string, parsed sql.Node, b
 		return nil, err
 	}
 
-	analyzed, err = e.Analyzer.Analyze(ctx, parsed, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	if len(bindings) > 0 {
-		analyzed, err = plan.ApplyBindings(analyzed, bindings)
+		parsed, err = plan.ApplyBindings(parsed, bindings)
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	analyzed, err = e.Analyzer.Analyze(ctx, parsed, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	return analyzed, nil

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -256,6 +256,10 @@ func TestQueryWithEngine(t *testing.T, harness Harness, e *sqle.Engine, tt queri
 func TestQueryWithContext(t *testing.T, ctx *sql.Context, e *sqle.Engine, q string, expected []sql.Row, expectedCols []*sql.Column, bindings map[string]sql.Expression) {
 	ctx = ctx.WithQuery(q)
 	require := require.New(t)
+	if len(bindings) > 0 {
+		_, err := e.PrepareQuery(ctx, q)
+		require.NoError(err)
+	}
 	sch, iter, err := e.QueryWithBindings(ctx, q, bindings)
 	require.NoError(err, "Unexpected error for query %s", q)
 

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -175,8 +175,8 @@ func TestWriteCreateTableQueries(t *testing.T) {
 	for _, tt := range queries.CreateTableQueries {
 		ctx := NewContext(harness)
 		engine := mustNewEngine(t, harness)
-		_ = MustQuery(ctx, engine, tt.WriteQuery)
-		res := MustQuery(ctx, engine, tt.SelectQuery)
+		_, _ = MustQuery(ctx, engine, tt.WriteQuery)
+		_, res := MustQuery(ctx, engine, tt.SelectQuery)
 
 		w.WriteString("  {\n")
 		w.WriteString(fmt.Sprintf("    WriteQuery:`%s`,\n", tt.WriteQuery))

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -268,7 +268,11 @@ func reresolveTables(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 			if n.Database != nil {
 				db = n.Database.Name()
 			}
-			to, err = resolveTable(ctx, plan.NewUnresolvedTable(n.Name(), db), a)
+			var asof sql.Expression
+			if n.AsOf != nil {
+				asof = expression.NewLiteral(n.AsOf, nil)
+			}
+			to, err = resolveTable(ctx, plan.NewUnresolvedTableAsOf(n.Name(), db, asof), a)
 			if err != nil {
 				return nil, transform.SameTree, err
 			}


### PR DESCRIPTION
Prepared AS OFs errored when the asof target was not a bindvar. All of our previous tests treated ASOF also as a bindvar.