### PR TITLE
Improved error message for converting unsupported geospatial types

### DIFF
--- a/sql/errors.go
+++ b/sql/errors.go
@@ -473,6 +473,9 @@ var (
 	// ErrIllegalGISValue is thrown when a spatial type constructor receives a non-geometric when one should be provided
 	ErrIllegalGISValue = errors.NewKind("illegal non geometric '%v' value found during parsing")
 
+	// ErrUnsupportedGISType is thrown when attempting to convert an unsupported geospatial value to a geometry struct
+	ErrUnsupportedGISType = errors.NewKind("unsupported geospatial type: %s from value: 0x%s")
+
 	// ErrUnsupportedSyntax is returned when syntax that parses correctly is not supported
 	ErrUnsupportedSyntax = errors.NewKind("unsupported syntax: %s")
 

--- a/sql/geometry.go
+++ b/sql/geometry.go
@@ -16,6 +16,7 @@ package sql
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"math"
 	"reflect"
 
@@ -240,13 +241,13 @@ func (t GeometryType) Convert(v interface{}) (interface{}, error) {
 		case WKBPolyID:
 			geom, err = WKBToPoly(inner[EWKBHeaderSize:], isBig, srid)
 		case WKBMultiPointID:
-			return nil, ErrUnsupportedFeature.New("MultiPoint geospatial type")
+			return nil, ErrUnsupportedGISType.New("MultiPoint", hex.EncodeToString(inner))
 		case WKBMultiLineID:
-			return nil, ErrUnsupportedFeature.New("MultiLineString geospatial type")
+			return nil, ErrUnsupportedGISType.New("MultiLineString", hex.EncodeToString(inner))
 		case WKBMultiPolyID:
-			return nil, ErrUnsupportedFeature.New("MultiPolygon geospatial type")
+			return nil, ErrUnsupportedGISType.New("MultiPolygon", hex.EncodeToString(inner))
 		case WKBGeoCollectionID:
-			return nil, ErrUnsupportedFeature.New("GeometryCollection geospatial type")
+			return nil, ErrUnsupportedGISType.New("GeometryCollection", hex.EncodeToString(inner))
 		default:
 			return nil, ErrInvalidGISData.New("GeometryType.Convert")
 		}

--- a/sql/geometry.go
+++ b/sql/geometry.go
@@ -68,6 +68,10 @@ const (
 	WKBPointID
 	WKBLineID
 	WKBPolyID
+	WKBMultiPointID
+	WKBMultiLineID
+	WKBMultiPolyID
+	WKBGeoCollectionID
 )
 
 // isLinearRing checks if a LineString is a linear ring
@@ -235,6 +239,14 @@ func (t GeometryType) Convert(v interface{}) (interface{}, error) {
 			geom, err = WKBToLine(inner[EWKBHeaderSize:], isBig, srid)
 		case WKBPolyID:
 			geom, err = WKBToPoly(inner[EWKBHeaderSize:], isBig, srid)
+		case WKBMultiPointID:
+			return nil, ErrUnsupportedFeature.New("MultiPoint geospatial type")
+		case WKBMultiLineID:
+			return nil, ErrUnsupportedFeature.New("MultiLineString geospatial type")
+		case WKBMultiPolyID:
+			return nil, ErrUnsupportedFeature.New("MultiPolygon geospatial type")
+		case WKBGeoCollectionID:
+			return nil, ErrUnsupportedFeature.New("GeometryCollection geospatial type")
 		default:
 			return nil, ErrInvalidGISData.New("GeometryType.Convert")
 		}

--- a/sql/geometry_test.go
+++ b/sql/geometry_test.go
@@ -119,8 +119,8 @@ func TestUnsupportedSpatialTypeByteArrayConversion(t *testing.T) {
 			convert, err := GeometryType{}.Convert(data)
 			require.Nil(t, convert)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "unsupported feature: ")
-			require.Contains(t, err.Error(), test.typeName)
+			require.Contains(t, err.Error(), "unsupported geospatial type: "+test.typeName)
+			require.Contains(t, err.Error(), "from value: 0x0")
 		})
 	}
 }


### PR DESCRIPTION
Improved the error message to tell customers that a specific geospatial data type they tried to use is currently unsupported. 

Fixes: https://github.com/dolthub/dolt/issues/3512