### PR TITLE
Improve NULL handling in JOINs and index lookups on NULL comparisons.

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -2164,6 +2164,26 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{int64(2)}, {int64(4)}, {int64(6)}},
 	},
 	{
+		Query:    "SELECT * FROM niltable WHERE i2 = NULL",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT i2 FROM niltable WHERE i2 <=> NULL",
+		Expected: []sql.Row{{nil}, {nil}, {nil}},
+	},
+	{
+		Query:    "SELECT l.i, r.i2 FROM niltable l INNER JOIN niltable r ON l.i2 = r.i2 WHERE r.i2 IS NULL",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT l.i, r.i2 FROM niltable l INNER JOIN niltable r ON l.i2 != r.i2 WHERE r.i2 IS NULL",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT l.i, r.i2 FROM niltable l INNER JOIN niltable r ON l.i2 <=> r.i2 WHERE r.i2 IS NULL ORDER BY 1 ASC",
+		Expected: []sql.Row{{1, nil}, {1, nil}, {1, nil}, {3, nil}, {3, nil}, {3, nil}, {5, nil}, {5, nil}, {5, nil}},
+	},
+	{
 		Query:    "select i from datetime_table where date_col = date('2019-12-31T12:00:00')",
 		Expected: []sql.Row{{1}},
 	},
@@ -5976,7 +5996,7 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query:    "SELECT NULL <=> NULL FROM dual",
-		Expected: []sql.Row{{1}},
+		Expected: []sql.Row{{true}},
 	},
 	{
 		Query:    "SELECT POW(2,3) FROM dual",

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -994,6 +994,7 @@ func createNativeIndexes(t *testing.T, harness Harness, e *sqle.Engine) error {
 		"create index one_pk_two_idx_1 on one_pk_two_idx (v1)",
 		"create index one_pk_two_idx_2 on one_pk_two_idx (v1, v2)",
 		"create index one_pk_three_idx_idx on one_pk_three_idx (v1, v2, v3)",
+		"create index niltable_i2 on niltable (i2)",
 	}
 
 	for _, q := range createIndexes {

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -310,19 +310,41 @@ func getComparisonIndexLookup(
 
 	var lookup sql.IndexLookup
 	switch e.(type) {
-	case *expression.Equals, *expression.NullSafeEquals:
+	case *expression.NullSafeEquals:
 		if e.Right().Type() == sql.Null {
 			lookup, err = sql.NewIndexBuilder(ctx, idx).IsNull(ctx, normalizedExpressions[0].String()).Build(ctx)
 		} else {
 			lookup, err = sql.NewIndexBuilder(ctx, idx).Equals(ctx, normalizedExpressions[0].String(), value).Build(ctx)
 		}
+	case *expression.Equals:
+		if e.Right().Type() == sql.Null {
+			// Never true...
+			return nil, nil
+		}
+		lookup, err = sql.NewIndexBuilder(ctx, idx).Equals(ctx, normalizedExpressions[0].String(), value).Build(ctx)
 	case *expression.GreaterThan:
+		if e.Right().Type() == sql.Null {
+			// Never true...
+			return nil, nil
+		}
 		lookup, err = sql.NewIndexBuilder(ctx, idx).GreaterThan(ctx, normalizedExpressions[0].String(), value).Build(ctx)
 	case *expression.GreaterThanOrEqual:
+		if e.Right().Type() == sql.Null {
+			// Never true...
+			return nil, nil
+		}
 		lookup, err = sql.NewIndexBuilder(ctx, idx).GreaterOrEqual(ctx, normalizedExpressions[0].String(), value).Build(ctx)
 	case *expression.LessThan:
+		if e.Right().Type() == sql.Null {
+			// Never true...
+			return nil, nil
+		}
 		lookup, err = sql.NewIndexBuilder(ctx, idx).LessThan(ctx, normalizedExpressions[0].String(), value).Build(ctx)
 	case *expression.LessThanOrEqual:
+		if e.Right().Type() == sql.Null {
+			// Never true...
+			return nil, nil
+		}
 		lookup, err = sql.NewIndexBuilder(ctx, idx).LessOrEqual(ctx, normalizedExpressions[0].String(), value).Build(ctx)
 	default:
 		return nil, nil

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -252,6 +252,12 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 		return expression.NewLiteral(val, e.Type()), transform.NewTree, nil
 	}
 
+	// Non-null-safe compares evaluate to |NULL| when one of their operands
+	// is |NULL|. |evalCompare| is used in the |transform| below for
+	// |Equals|, |{Greater,Less}Than{,OrEqual}| expressions. If |left| or
+	// |right| statically evaluates to |NULL|, then we replace the
+	// comparison itself with |NULL|. Otherwise, we do what the default
+	// branch of the transform does, |eval(orig)|.
 	evalCompare := func(orig sql.Expression, left sql.Expression, right sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 		v, t, err := eval(left)
 		if err != nil {

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -239,7 +239,7 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 		return node, transform.SameTree, nil
 	}
 
-	eval := func (e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+	eval := func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 		if !isEvaluable(e) {
 			return e, transform.SameTree, nil
 		}

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -305,7 +305,7 @@ func NewNullSafeEquals(left sql.Expression, right sql.Expression) *NullSafeEqual
 
 // Type implements the Expression interface.
 func (e *NullSafeEquals) Type() sql.Type {
-	return sql.Int8
+	return sql.Boolean
 }
 
 func (e *NullSafeEquals) Compare(ctx *sql.Context, row sql.Row) (int, error) {
@@ -342,10 +342,7 @@ func (e *NullSafeEquals) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 		return nil, err
 	}
 
-	if result == 0 {
-		return 1, nil
-	}
-	return 0, nil
+	return result == 0, nil
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/comparison_test.go
+++ b/sql/expression/comparison_test.go
@@ -142,22 +142,22 @@ func TestNullSafeEquals(t *testing.T) {
 		require.NotNil(get1)
 		seq := expression.NewNullSafeEquals(get0, get1)
 		require.NotNil(seq)
-		require.Equal(sql.Int8, seq.Type())
+		require.Equal(sql.Boolean, seq.Type())
 		for cmpResult, cases := range cmpCase {
 			for _, pair := range cases {
 				row := sql.NewRow(pair[0], pair[1])
 				require.NotNil(row)
 				cmp := eval(t, seq, row)
 				if cmpResult == testEqual {
-					require.Equal(1, cmp)
+					require.Equal(true, cmp)
 				} else if cmpResult == testNil {
 					if pair[0] == nil && pair[1] == nil {
-						require.Equal(1, cmp)
+						require.Equal(true, cmp)
 					} else {
-						require.Equal(0, cmp)
+						require.Equal(false, cmp)
 					}
 				} else {
-					require.Equal(0, cmp)
+					require.Equal(false, cmp)
 				}
 			}
 		}


### PR DESCRIPTION
INNER JOIN ON a <=> b was broken because of the implementation of
NullSafeEquals. The implementation returned an Int8, but the join
implementation was expecting a Boolean.

SELECT WHERE indexed_column = NULL was broken because index selection
would select the index, and also drop the filter.