### PR TITLE
Fixed returning null type instead of null value

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3955,7 +3955,7 @@ var QueryTests = []QueryTest{
 	{
 		Query: `SELECT nullif(NULL, NULL)`,
 		Expected: []sql.Row{
-			{sql.Null},
+			{nil},
 		},
 	},
 	{
@@ -3967,7 +3967,7 @@ var QueryTests = []QueryTest{
 	{
 		Query: `SELECT nullif(123, 123)`,
 		Expected: []sql.Row{
-			{sql.Null},
+			{nil},
 		},
 	},
 	{
@@ -5948,35 +5948,35 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query:    "SELECT 1/0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 0/0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 1.0/0.0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 0.0/0.0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 1 div 0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 1.0 div 0.0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 0 div 0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT 0.0 div 0.0 FROM dual",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT NULL <=> NULL FROM dual",
@@ -7221,7 +7221,7 @@ var DateParseQueries = []QueryTest{
 	},
 	{
 		Query:    "SELECT STR_TO_DATE('invalid', 'notvalid')",
-		Expected: []sql.Row{{sql.Null}},
+		Expected: []sql.Row{{nil}},
 	},
 }
 

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -376,7 +376,7 @@ func div(lval, rval interface{}) (interface{}, error) {
 		switch r := rval.(type) {
 		case uint64:
 			if r == 0 {
-				return sql.Null, nil
+				return nil, nil
 			}
 			return l / r, nil
 		}
@@ -385,7 +385,7 @@ func div(lval, rval interface{}) (interface{}, error) {
 		switch r := rval.(type) {
 		case int64:
 			if r == 0 {
-				return sql.Null, nil
+				return nil, nil
 			}
 			return l / r, nil
 		}
@@ -394,7 +394,7 @@ func div(lval, rval interface{}) (interface{}, error) {
 		switch r := rval.(type) {
 		case float64:
 			if r == 0 {
-				return sql.Null, nil
+				return nil, nil
 			}
 			return l / r, nil
 		}
@@ -487,7 +487,7 @@ func intDiv(lval, rval interface{}) (interface{}, error) {
 		switch r := rval.(type) {
 		case uint64:
 			if r == 0 {
-				return sql.Null, nil
+				return nil, nil
 			}
 			return uint64(l / r), nil
 		}
@@ -496,7 +496,7 @@ func intDiv(lval, rval interface{}) (interface{}, error) {
 		switch r := rval.(type) {
 		case int64:
 			if r == 0 {
-				return sql.Null, nil
+				return nil, nil
 			}
 			return int64(l / r), nil
 		}

--- a/sql/expression/arithmetic_test.go
+++ b/sql/expression/arithmetic_test.go
@@ -178,7 +178,7 @@ func TestDiv(t *testing.T) {
 			).Eval(sql.NewEmptyContext(), sql.NewRow())
 			require.NoError(t, err)
 			if tt.null {
-				assert.Equal(t, sql.Null, result)
+				assert.Equal(t, nil, result)
 			} else {
 				assert.Equal(t, tt.expected, result)
 			}
@@ -205,7 +205,7 @@ func TestDiv(t *testing.T) {
 			).Eval(sql.NewEmptyContext(), sql.NewRow())
 			require.NoError(t, err)
 			if tt.null {
-				assert.Equal(t, sql.Null, result)
+				assert.Equal(t, nil, result)
 			} else {
 				assert.Equal(t, tt.expected, result)
 			}
@@ -231,7 +231,7 @@ func TestDiv(t *testing.T) {
 			).Eval(sql.NewEmptyContext(), sql.NewRow())
 			require.NoError(t, err)
 			if tt.null {
-				assert.Equal(t, sql.Null, result)
+				assert.Equal(t, nil, result)
 			} else {
 				assert.Equal(t, tt.expected, result)
 			}
@@ -392,7 +392,7 @@ func TestIntDiv(t *testing.T) {
 			).Eval(sql.NewEmptyContext(), sql.NewRow())
 			require.NoError(err)
 			if tt.null {
-				assert.Equal(t, sql.Null, result)
+				assert.Equal(t, nil, result)
 			} else {
 				assert.Equal(t, tt.expected, result)
 			}

--- a/sql/expression/function/nullif.go
+++ b/sql/expression/function/nullif.go
@@ -51,7 +51,7 @@ func (f *NullIf) Description() string {
 // Eval implements the Expression interface.
 func (f *NullIf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if sql.IsNull(f.Left) && sql.IsNull(f.Right) {
-		return sql.Null, nil
+		return nil, nil
 	}
 
 	val, err := expression.NewEquals(f.Left, f.Right).Eval(ctx, row)
@@ -59,7 +59,7 @@ func (f *NullIf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 	if b, ok := val.(bool); ok && b {
-		return sql.Null, nil
+		return nil, nil
 	}
 
 	return f.Left.Eval(ctx, row)

--- a/sql/expression/function/nullif_test.go
+++ b/sql/expression/function/nullif_test.go
@@ -31,7 +31,7 @@ func TestNullIf(t *testing.T) {
 		expected interface{}
 	}{
 		{"foo", "bar", "foo"},
-		{"foo", "foo", sql.Null},
+		{"foo", "foo", nil},
 		{nil, "foo", nil},
 		{"foo", nil, "foo"},
 		{nil, nil, nil},

--- a/sql/expression/function/str_to_date.go
+++ b/sql/expression/function/str_to_date.go
@@ -74,7 +74,7 @@ func (s StringToDatetime) Eval(ctx *sql.Context, row sql.Row) (interface{}, erro
 	}
 	goTime, err := dateparse.ParseDateWithFormat(dateStr, formatStr)
 	if err != nil {
-		return sql.Null, nil
+		return nil, nil
 	}
 	return goTime, nil
 }

--- a/sql/expression/function/str_to_date_test.go
+++ b/sql/expression/function/str_to_date_test.go
@@ -60,7 +60,7 @@ func TestStrToDateFailure(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			dtime := eval(t, f, sql.NewRow(tt.dateStr, tt.fmtStr))
-			require.Equal(t, sql.Null, dtime)
+			require.Equal(t, nil, dtime)
 		})
 		req := require.New(t)
 		req.True(f.IsNullable())


### PR DESCRIPTION
A few places, such as `NULLIF()`, were returning the null type (`sql.Null`) when they should have been returning a null value (`nil` in Go). This has been fixed.