### PR TITLE
Adjust limits on varbinary/json data

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1434,6 +1434,14 @@ var InsertErrorScripts = []ScriptTest{
 		Query:       "insert into bad values ('1234567890')",
 		ExpectedErr: sql.ErrLengthBeyondLimit,
 	},
+	{
+		Name: "try inserting varbinary larger than max limit",
+		SetUpScript: []string{
+			"create table bad (vb varbinary(65535))",
+		},
+		Query:       "insert into bad values (repeat('0', 65536))",
+		ExpectedErr: sql.ErrLengthBeyondLimit,
+	},
 }
 
 var InsertIgnoreScripts = []ScriptTest{

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -18,6 +18,18 @@ import "github.com/dolthub/go-mysql-server/sql"
 
 var JsonScripts = []ScriptTest{
 	{
+		Name: "JSON max length limit",
+		SetUpScript: []string{
+			"create table t (j JSON)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       `insert into t set j= concat('[', repeat('"word",', 50000000), '"word"]')`,
+				ExpectedErr: sql.ErrLengthTooLarge,
+			},
+		},
+	},
+	{
 		Name: "JSON_ARRAYAGG on one column",
 		SetUpScript: []string{
 			"create table t (o_id int primary key)",

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -18,7 +18,19 @@ import "github.com/dolthub/go-mysql-server/sql"
 
 var JsonScripts = []ScriptTest{
 	{
-		Name: "JSON max length limit",
+		Name: "JSON under max length limit",
+		SetUpScript: []string{
+			"create table t (j JSON)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    `insert into t set j= concat('[', repeat('"word",', 10000000), '"word"]')`,
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
+			},
+		},
+	},
+	{
+		Name: "JSON over max length limit",
 		SetUpScript: []string{
 			"create table t (j JSON)",
 		},

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -127,7 +127,7 @@ func CreateString(baseType query.Type, length int64, collation CollationID) (Str
 		}
 	case sqltypes.VarBinary:
 		// VarBinary fields transmitted over the wire could be for a VarBinary field,
-		// or a JSON field, so we validate against JSON's larger upper limit (1GB)
+		// or a JSON field, so we validate against JSON's larger limit (1GB)
 		// instead of VarBinary's smaller limit (65k).
 		if byteLength > MaxJsonFieldByteLength {
 			return nil, ErrLengthTooLarge.New(length, MaxJsonFieldByteLength/charsetMaxLength)

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -121,10 +121,16 @@ func CreateString(baseType query.Type, length int64, collation CollationID) (Str
 		if length > charBinaryMax {
 			return nil, ErrLengthTooLarge.New(length, charBinaryMax)
 		}
-	case sqltypes.VarChar, sqltypes.VarBinary:
-		// We limit on byte length, so acceptable character lengths are variable
+	case sqltypes.VarChar:
 		if byteLength > varcharVarbinaryMax {
 			return nil, ErrLengthTooLarge.New(length, varcharVarbinaryMax/charsetMaxLength)
+		}
+	case sqltypes.VarBinary:
+		// VarBinary fields transmitted over the wire could be for a VarBinary field,
+		// or a JSON field, so we validate against JSON's larger upper limit (1GB)
+		// instead of VarBinary's smaller limit (65k).
+		if byteLength > MaxJsonFieldByteLength {
+			return nil, ErrLengthTooLarge.New(length, MaxJsonFieldByteLength/charsetMaxLength)
 		}
 	case sqltypes.Text, sqltypes.Blob:
 		// We overall limit on character length, but determine tiny, medium, etc. based on byte length.

--- a/sql/stringtype_test.go
+++ b/sql/stringtype_test.go
@@ -205,7 +205,9 @@ func TestStringCreateString(t *testing.T) {
 		{sqltypes.Blob, longTextBlobMax + 1, Collation_binary, stringType{}, true},
 		{sqltypes.Char, charBinaryMax + 1, Collation_Default, stringType{}, true},
 		{sqltypes.Text, longTextBlobMax + 1, Collation_Default, stringType{}, true},
-		{sqltypes.VarBinary, varcharVarbinaryMax + 1, Collation_binary, stringType{}, true},
+
+		// JSON strings can also come in over the wire as VARBINARY types, and JSON allows a much larger length limit (1GB).
+		{sqltypes.VarBinary, MaxJsonFieldByteLength + 1, Collation_binary, stringType{}, true},
 		{sqltypes.VarChar, varcharVarbinaryMax, Collation_Default, stringType{}, true},
 
 		// Default collation is not valid for these types


### PR DESCRIPTION
- Relaxed limit on incoming varbinary fields to allow for large JSON fields, which have a max size of 1GB and come across the wire as varbinary types. 
- Added a test to ensure limits on varbinary fields are still being honored. 
- Added a size limit on JSON fields at 1GB.

Fixes: https://github.com/dolthub/dolt/issues/3728