### PR TITLE
type convert simplifications

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -218,12 +218,11 @@ func bindingsToExprs(bindings map[string]*query.BindVariable) (map[string]sql.Ex
 			}
 			res[k] = expression.NewLiteral(c, t)
 		case v.Type() == sqltypes.Decimal:
-			t := sql.MustCreateDecimalType(sql.DecimalTypeMaxPrecision, sql.DecimalTypeMaxScale)
-			v, err := t.Convert(string(v.ToBytes()))
+			v, err := sql.InternalDecimalType.Convert(string(v.ToBytes()))
 			if err != nil {
 				return nil, err
 			}
-			res[k] = expression.NewLiteral(v, t)
+			res[k] = expression.NewLiteral(v, sql.InternalDecimalType)
 		case v.Type() == sqltypes.Bit:
 			t := sql.MustCreateBitType(sql.BitTypeMaxBits)
 			v, err := t.Convert(v.ToBytes())

--- a/sql/decimal.go
+++ b/sql/decimal.go
@@ -51,8 +51,10 @@ type DecimalType interface {
 	// noting that Convert() returns a nil value for nil inputs, and also returns decimal.Decimal rather than
 	// decimal.NullDecimal.
 	ConvertToNullDecimal(v interface{}) (decimal.NullDecimal, error)
-	//
+	//ConvertNoBoundsCheck normalizes an interface{} to a decimal type without performing expensive bound checks
 	ConvertNoBoundsCheck(v interface{}) (decimal.Decimal, error)
+	// BoundsCheck rounds and validates a decimal
+	BoundsCheck(v decimal.Decimal) (decimal.Decimal, error)
 	// ExclusiveUpperBound returns the exclusive upper bound for this Decimal.
 	// For example, DECIMAL(5,2) would return 1000, as 999.99 is the max represented.
 	ExclusiveUpperBound() decimal.Decimal

--- a/sql/decimal.go
+++ b/sql/decimal.go
@@ -51,6 +51,8 @@ type DecimalType interface {
 	// noting that Convert() returns a nil value for nil inputs, and also returns decimal.Decimal rather than
 	// decimal.NullDecimal.
 	ConvertToNullDecimal(v interface{}) (decimal.NullDecimal, error)
+	//
+	ConvertNoBoundsCheck(v interface{}) (decimal.Decimal, error)
 	// ExclusiveUpperBound returns the exclusive upper bound for this Decimal.
 	// For example, DECIMAL(5,2) would return 1000, as 999.99 is the max represented.
 	ExclusiveUpperBound() decimal.Decimal
@@ -123,12 +125,20 @@ func (t decimalType) Compare(a interface{}, b interface{}) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	ad, err := t.BoundsCheck(af.Decimal)
+	if err != nil {
+		return 0, err
+	}
 	bf, err := t.ConvertToNullDecimal(b)
 	if err != nil {
 		return 0, err
 	}
+	bd, err := t.BoundsCheck(bf.Decimal)
+	if err != nil {
+		return 0, err
+	}
 
-	return af.Decimal.Cmp(bf.Decimal), nil
+	return ad.Cmp(bd), nil
 }
 
 // Convert implements Type interface.
@@ -139,6 +149,17 @@ func (t decimalType) Convert(v interface{}) (interface{}, error) {
 	}
 	if !dec.Valid {
 		return nil, nil
+	}
+	return t.BoundsCheck(dec.Decimal)
+}
+
+func (t decimalType) ConvertNoBoundsCheck(v interface{}) (decimal.Decimal, error) {
+	dec, err := t.ConvertToNullDecimal(v)
+	if err != nil {
+		return decimal.Decimal{}, err
+	}
+	if !dec.Valid {
+		return decimal.Decimal{}, nil
 	}
 	return dec.Decimal, nil
 }
@@ -208,12 +229,19 @@ func (t decimalType) ConvertToNullDecimal(v interface{}) (decimal.NullDecimal, e
 		return decimal.NullDecimal{}, ErrConvertingToDecimal.New(v)
 	}
 
-	res = res.Round(int32(t.scale))
-	if !res.Abs().LessThan(t.exclusiveUpperBound) {
-		return decimal.NullDecimal{}, ErrConvertToDecimalLimit.New()
-	}
-
 	return decimal.NullDecimal{Decimal: res, Valid: true}, nil
+}
+
+func (t decimalType) BoundsCheck(v decimal.Decimal) (decimal.Decimal, error) {
+	if -v.Exponent() > int32(t.scale) {
+		v = v.Round(int32(t.scale))
+	}
+	// TODO add shortcut for common case
+	// ex: certain num of bits fast tracks OK
+	if !v.Abs().LessThan(t.exclusiveUpperBound) {
+		return decimal.Decimal{}, ErrConvertToDecimalLimit.New()
+	}
+	return v, nil
 }
 
 // MustConvert implements the Type interface.
@@ -243,12 +271,12 @@ func (t decimalType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
-	value, err := t.Convert(v)
+	value, err := t.ConvertToNullDecimal(v)
 	if err != nil {
 		return sqltypes.Value{}, err
 	}
 
-	val := appendAndSliceString(dest, value.(decimal.Decimal).StringFixed(int32(t.scale)))
+	val := appendAndSliceString(dest, value.Decimal.StringFixed(int32(t.scale)))
 
 	return sqltypes.MakeTrusted(sqltypes.Decimal, val), nil
 }

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -245,6 +245,18 @@ func (t stringType) Convert(v interface{}) (interface{}, error) {
 		return nil, nil
 	}
 
+	val, err := ConvertToString(v, t)
+	if err != nil {
+		return nil, err
+	}
+
+	if IsBinaryType(t) {
+		return []byte(val), nil
+	}
+	return val, nil
+}
+
+func ConvertToString(v interface{}, t stringType) (string, error) {
 	var val string
 	switch s := v.(type) {
 	case bool:
@@ -283,49 +295,45 @@ func (t stringType) Convert(v interface{}) (interface{}, error) {
 		val = s.String()
 	case decimal.NullDecimal:
 		if !s.Valid {
-			return nil, nil
+			return "", nil
 		}
 		val = s.Decimal.String()
 	case JSONValue:
 		str, err := s.ToString(nil)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 
 		val, err = istrings.Unquote(str)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 	default:
-		return nil, ErrConvertToSQL.New(t)
+		return "", ErrConvertToSQL.New(t)
 	}
 
 	if t.baseType == sqltypes.Text {
 		// for TEXT types, we use the byte length instead of the character length
 		if int64(len(val)) > t.MaxByteLength() {
-			return nil, ErrLengthBeyondLimit.New(val, t.String())
+			return "", ErrLengthBeyondLimit.New(val, t.String())
 		}
 	} else {
 		if t.CharacterSet().MaxLength() == 1 {
 			// if the character set only has a max size of 1, we can just count the bytes
 			if int64(len(val)) > t.charLength {
-				return nil, ErrLengthBeyondLimit.New(val, t.String())
+				return "", ErrLengthBeyondLimit.New(val, t.String())
 			}
 		} else {
 			//TODO: this should count the string's length properly according to the character set
 			//convert 'val' string to rune to count the character length, not byte length
 			if int64(len([]rune(val))) > t.charLength {
-				return nil, ErrLengthBeyondLimit.New(val, t.String())
+				return "", ErrLengthBeyondLimit.New(val, t.String())
 			}
 		}
 	}
 
 	if t.baseType == sqltypes.Binary {
 		val += strings.Repeat(string([]byte{0}), int(t.charLength)-len(val))
-	}
-
-	if IsBinaryType(t) {
-		return []byte(val), nil
 	}
 
 	return val, nil
@@ -366,16 +374,19 @@ func (t stringType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
 		return sqltypes.NULL, nil
 	}
 
-	v, err := t.Convert(v)
-	if err != nil {
-		return sqltypes.Value{}, err
-	}
-
 	var val []byte
 	if IsBinaryType(t) {
+		v, err := t.Convert(v)
+		if err != nil {
+			return sqltypes.Value{}, err
+		}
 		val = appendAndSliceBytes(dest, v.([]byte))
 	} else {
-		val = appendAndSliceString(dest, v.(string))
+		v, err := ConvertToString(v, t)
+		if err != nil {
+			return sqltypes.Value{}, err
+		}
+		val = appendAndSliceString(dest, v)
 	}
 
 	return sqltypes.MakeTrusted(t.baseType, val), nil


### PR DESCRIPTION
dolt bump here: https://github.com/dolthub/dolt/pull/3757

This expands some `Convert` methods into smaller helper functions that can be used more precisely:
- avoid interface conversions
- sidestep bound checks that don't apply on the read path unless we are explicitly running a `Cast`

These are a bit rough and ready, the interfaces and semantic check organization could be formalized, but gives 15% boost on table scan.