### PR TITLE
remove `ValidateCanPersist()`

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5576,10 +5576,6 @@ type memoryPersister struct {
 
 var _ mysql_db.MySQLDbPersistence = &memoryPersister{}
 
-func (p *memoryPersister) ValidateCanPersist() error {
-	return nil
-}
-
 func (p *memoryPersister) Persist(ctx *sql.Context, data []byte) error {
 	//erase everything from users and roles
 	p.users = make([]*mysql_db.User, 0)

--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -32,7 +32,6 @@ import (
 
 // MySQLDbPersistence is used to determine the behavior of how certain tables in MySQLDb will be persisted.
 type MySQLDbPersistence interface {
-	ValidateCanPersist() error
 	Persist(ctx *sql.Context, data []byte) error
 }
 
@@ -40,11 +39,6 @@ type MySQLDbPersistence interface {
 type NoopPersister struct{}
 
 var _ MySQLDbPersistence = &NoopPersister{}
-
-// CanPersist implements the MySQLDbPersistence interface
-func (p *NoopPersister) ValidateCanPersist() error {
-	return nil
-}
 
 // Persist implements the MySQLDbPersistence interface
 func (p *NoopPersister) Persist(ctx *sql.Context, data []byte) error {
@@ -364,11 +358,6 @@ func (t *MySQLDb) Negotiate(c *mysql.Conn, user string, addr net.Addr) (mysql.Ge
 		return MysqlConnectionUser{User: user, Host: host}, nil
 	}
 	return nil, fmt.Errorf(`the only user login interface currently supported is "mysql_native_password"`)
-}
-
-// CanPersist calls the persister's CanPersist method
-func (t *MySQLDb) ValidateCanPersist() error {
-	return t.persister.ValidateCanPersist()
 }
 
 // Persist passes along all changes to the integrator.

--- a/sql/plan/create_role.go
+++ b/sql/plan/create_role.go
@@ -107,11 +107,6 @@ func (n *CreateRole) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error)
 		return nil, sql.ErrDatabaseNotFound.New("mysql")
 	}
 
-	// Check if you can even persist in the first place
-	if err := mysqlDb.ValidateCanPersist(); err != nil {
-		return nil, err
-	}
-
 	userTableData := mysqlDb.UserTable().Data()
 	for _, role := range n.Roles {
 		userPk := mysql_db.UserPrimaryKey{

--- a/sql/plan/create_user.go
+++ b/sql/plan/create_user.go
@@ -100,10 +100,6 @@ func (n *CreateUser) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error)
 	if !ok {
 		return nil, sql.ErrDatabaseNotFound.New("mysql")
 	}
-	// Check if you can even persist in the first place
-	if err := mysqlDb.ValidateCanPersist(); err != nil {
-		return nil, err
-	}
 	userTableData := mysqlDb.UserTable().Data()
 	for _, user := range n.Users {
 		userPk := mysql_db.UserPrimaryKey{

--- a/sql/plan/grant.go
+++ b/sql/plan/grant.go
@@ -201,10 +201,6 @@ func (n *Grant) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	if !ok {
 		return nil, sql.ErrDatabaseNotFound.New("mysql")
 	}
-	// Check if you can even persist in the first place
-	if err := mysqlDb.ValidateCanPersist(); err != nil {
-		return nil, err
-	}
 	if n.PrivilegeLevel.Database == "*" && n.PrivilegeLevel.TableRoutine == "*" {
 		if n.ObjectType != ObjectType_Any {
 			return nil, sql.ErrGrantRevokeIllegalPrivilege.New()


### PR DESCRIPTION
removes the `ValidateCanPersist()` from `Persister` interface, as it is no longer used.

Companion PR: https://github.com/dolthub/dolt/pull/3732