### PR TITLE
Allow floats to specify precision and scale to match MySQL's behavior

### DIFF
--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -18,6 +18,12 @@ import "github.com/dolthub/go-mysql-server/sql"
 
 var CreateTableQueries = []WriteQueryTest{
 	{
+		WriteQuery:          `create table floattypedefs (a float(10), b float(10, 2), c double(10, 2))`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE floattypedefs",
+		ExpectedSelect:      []sql.Row{sql.Row{"floattypedefs", "CREATE TABLE `floattypedefs` (\n  `a` float,\n  `b` float,\n  `c` double\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+	},
+	{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, b1 BOOL, b2 BOOLEAN NOT NULL, g DATETIME, h CHAR(40))`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -386,27 +386,6 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
-		Query:    "create table floattypedefs (a float(10), b float(10, 2), c double(10, 2))",
-		Expected: []sql.Row{{sql.OkResult{}}},
-	},
-	{
-		Query: "select * from floattypedefs",
-		ExpectedColumns: sql.Schema{
-			{
-				Name: "a",
-				Type: sql.Float32,
-			},
-			{
-				Name: "b",
-				Type: sql.Float32,
-			},
-			{
-				Name: "c",
-				Type: sql.Float64,
-			},
-		},
-	},
-	{
 		Query: "SELECT * FROM mytable;",
 		Expected: []sql.Row{
 			{int64(1), "first row"},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -386,6 +386,27 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
+		Query:    "create table floattypedefs (a float(10), b float(10, 2), c double(10, 2))",
+		Expected: []sql.Row{{sql.OkResult{}}},
+	},
+	{
+		Query: "select * from floattypedefs",
+		ExpectedColumns: sql.Schema{
+			{
+				Name: "a",
+				Type: sql.Float32,
+			},
+			{
+				Name: "b",
+				Type: sql.Float32,
+			},
+			{
+				Name: "c",
+				Type: sql.Float64,
+			},
+		},
+	},
+	{
 		Query: "SELECT * FROM mytable;",
 		Expected: []sql.Row{
 			{int64(1), "first row"},

--- a/sql/type.go
+++ b/sql/type.go
@@ -275,9 +275,7 @@ func ColumnTypeToType(ct *sqlparser.ColumnType) (Type, error) {
 		}
 		return Int64, nil
 	case "float":
-		if ct.Scale != nil {
-			return nil, ErrInvalidColTypeDefinition.New(ct.String(), "Cannot set both precision and scale")
-		} else if ct.Length != nil {
+		if ct.Length != nil {
 			precision, err := strconv.ParseInt(string(ct.Length.Val), 10, 8)
 			if err != nil {
 				return nil, err

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -29,7 +29,7 @@ func TestFloatCovert(t *testing.T) {
 		expected Type
 		err      bool
 	}{
-		{"53", "0", nil, true},
+		{"20", "2", Float32, false},
 		{"-1", "", nil, true},
 		{"54", "", nil, true},
 		{"", "", Float32, false},


### PR DESCRIPTION
MySQL supports a non-standard SQL syntax for specifying precision and scale for floats and doubles:
https://dev.mysql.com/doc/refman/8.0/en/floating-point-types.html

MySQL has marked this as deprecated, but existing MySQL applications (e.g. NocoDB) use this, so we should support it for compatibility. Doubles already support this notation. 

Fixes: https://github.com/dolthub/dolt/issues/3778