### PR TITLE
Bug fixes for AlterPK and column defaults

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4625,7 +4625,7 @@ func TestAlterTable(t *testing.T, harness Harness) {
 	}
 
 	t.Run("variety of alter column statements in a single statement", func(t *testing.T) {
-		RunQuery(t, e, harness, "CREATE TABLE t32(pk BIGINT PRIMARY KEY, v1 int, v2 int, v3 int, toRename int)")
+		RunQuery(t, e, harness, "CREATE TABLE t32(pk BIGINT PRIMARY KEY, v1 int, v2 int, v3 int default (v1), toRename int)")
 		RunQuery(t, e, harness, `alter table t32 add column v4 int after pk,
 			drop column v2, modify v1 varchar(100) not null,
 			alter column v3 set default 100, rename column toRename to newName`)

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -322,7 +322,7 @@ func shouldPruneExpr(e sql.Expression, cols usedColumns) bool {
 func fixRemainingFieldsIndexes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, transform.TreeIdentity, error) {
 	return transform.NodeWithCtx(n, canPruneChild, func(c transform.Context) (sql.Node, transform.TreeIdentity, error) {
 		switch n := c.Node.(type) {
-		case *plan.RenameColumn, *plan.AddColumn, *plan.ModifyColumn, *plan.AlterDefaultSet, *plan.DropColumn, *plan.ShowCreateTable, *plan.ShowColumns:
+		case *plan.RenameColumn, *plan.AddColumn, *plan.ModifyColumn, *plan.AlterDefaultSet, *plan.DropColumn, *plan.ShowCreateTable, *plan.ShowColumns, *plan.AlterPK:
 			// do nothing, column defaults already have been resolved
 			return n, transform.SameTree, nil
 		case *plan.SubqueryAlias:

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -319,12 +319,12 @@ func shouldPruneExpr(e sql.Expression, cols usedColumns) bool {
 	return !cols.has(gf.Table(), gf.Name())
 }
 
-func fixRemainingFieldsIndexes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (sql.Node, transform.TreeIdentity, error) {
-	return transform.NodeWithCtx(n, canPruneChild, func(c transform.Context) (sql.Node, transform.TreeIdentity, error) {
+func fixRemainingFieldsIndexes(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope) (sql.Node, transform.TreeIdentity, error) {
+	return transform.NodeWithCtx(node, canPruneChild, func(c transform.Context) (sql.Node, transform.TreeIdentity, error) {
 		switch n := c.Node.(type) {
-		case *plan.RenameColumn, *plan.AddColumn, *plan.ModifyColumn, *plan.AlterDefaultSet, *plan.DropColumn, *plan.ShowCreateTable, *plan.ShowColumns, *plan.AlterPK:
-			// do nothing, column defaults already have been resolved
-			return n, transform.SameTree, nil
+		case sql.SchemaTarget:
+			// do nothing, column defaults have already been resolved
+			return node, transform.SameTree, nil
 		case *plan.SubqueryAlias:
 			child, same, err := fixRemainingFieldsIndexes(ctx, a, n.Child, nil)
 			if err != nil {

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -600,7 +600,7 @@ func transformColumnDefaultsForNode(ctx *sql.Context, input sql.Node) (sql.Node,
 			return e, transform.SameTree, nil
 		}
 		switch node.(type) {
-		case *plan.Values, *plan.InsertDestination, *plan.AddColumn, *plan.ShowColumns, *plan.ShowCreateTable, *plan.RenameColumn, *plan.ModifyColumn, *plan.DropColumn, *plan.CreateTable, *plan.AlterPK:
+		case *plan.Values, *plan.InsertDestination, sql.SchemaTarget:
 			return parseColumnDefaultsForWrapper(ctx, eWrapper)
 		default:
 			return e, transform.SameTree, nil

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -543,7 +543,6 @@ func lookupColumnForTargetSchema(_ *sql.Context, node sql.SchemaTarget, colIndex
 		} else {
 			return nil, sql.ErrColumnNotFound.New(colIndex)
 		}
-		return schema[colIndex], nil
 	}
 }
 

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -205,7 +205,7 @@ func setTargetSchemas(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, s
 
 		// Skip filling in target schema info for CreateTable nodes, since the
 		// target schema must be provided by the user and we don't want to pick
-		//  up any resolved tables in a subquery node.
+		//  up any resolved tables from a subquery node.
 		if _, ok := n.(*plan.CreateTable); ok {
 			return n, transform.SameTree, nil
 		}

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -203,6 +203,13 @@ func setTargetSchemas(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, s
 			return n, transform.SameTree, nil
 		}
 
+		// Skip filling in target schema info for CreateTable nodes, since the
+		// target schema must be provided by the user and we don't want to pick
+		//  up any resolved tables in a subquery node.
+		if _, ok := n.(*plan.CreateTable); ok {
+			return n, transform.SameTree, nil
+		}
+
 		table := getResolvedTable(n)
 		if table == nil {
 			return n, transform.SameTree, nil

--- a/sql/plan/alter_pk.go
+++ b/sql/plan/alter_pk.go
@@ -64,6 +64,12 @@ func NewAlterDropPk(db sql.Database, table sql.Node) *AlterPK {
 }
 
 func (a *AlterPK) Resolved() bool {
+	for _, expr := range a.Expressions() {
+		if expr.Resolved() == false {
+			return false
+		}
+	}
+
 	return a.Table.Resolved() && a.ddlNode.Resolved()
 }
 

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -147,6 +147,10 @@ type AddColumn struct {
 	targetSch sql.Schema
 }
 
+var _ sql.Node = (*AddColumn)(nil)
+var _ sql.Expressioner = (*AddColumn)(nil)
+var _ sql.SchemaTarget = (*AddColumn)(nil)
+
 func (a *AddColumn) DebugString() string {
 	pr := sql.NewTreePrinter()
 	pr.WriteNode("add column %s to %s", a.column.Name, a.Table)
@@ -160,9 +164,6 @@ func (a *AddColumn) DebugString() string {
 	pr.WriteChildren(children...)
 	return pr.String()
 }
-
-var _ sql.Node = (*AddColumn)(nil)
-var _ sql.Expressioner = (*AddColumn)(nil)
 
 func NewAddColumn(database sql.Database, table *UnresolvedTable, column *sql.Column, order *sql.ColumnOrder) *AddColumn {
 	column.Source = table.name
@@ -630,6 +631,7 @@ type DropColumn struct {
 
 var _ sql.Node = (*DropColumn)(nil)
 var _ sql.Databaser = (*DropColumn)(nil)
+var _ sql.SchemaTarget = (*DropColumn)(nil)
 
 func NewDropColumn(database sql.Database, table *UnresolvedTable, column string) *DropColumn {
 	return &DropColumn{
@@ -913,6 +915,7 @@ type RenameColumn struct {
 
 var _ sql.Node = (*RenameColumn)(nil)
 var _ sql.Databaser = (*RenameColumn)(nil)
+var _ sql.SchemaTarget = (*RenameColumn)(nil)
 
 func NewRenameColumn(database sql.Database, table *UnresolvedTable, columnName string, newColumnName string) *RenameColumn {
 	return &RenameColumn{
@@ -1061,6 +1064,7 @@ type ModifyColumn struct {
 var _ sql.Node = (*ModifyColumn)(nil)
 var _ sql.Expressioner = (*ModifyColumn)(nil)
 var _ sql.Databaser = (*ModifyColumn)(nil)
+var _ sql.SchemaTarget = (*ModifyColumn)(nil)
 
 func NewModifyColumn(database sql.Database, table *UnresolvedTable, columnName string, column *sql.Column, order *sql.ColumnOrder) *ModifyColumn {
 	column.Source = table.name

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -133,6 +133,7 @@ type CreateTable struct {
 var _ sql.Databaser = (*CreateTable)(nil)
 var _ sql.Node = (*CreateTable)(nil)
 var _ sql.Expressioner = (*CreateTable)(nil)
+var _ sql.SchemaTarget = (*CreateTable)(nil)
 
 // NewCreateTable creates a new CreateTable node
 func NewCreateTable(db sql.Database, name string, ifn IfNotExistsOption, temp TempTableOption, tableSpec *TableSpec) *CreateTable {
@@ -180,6 +181,16 @@ func NewCreateTableSelect(db sql.Database, name string, selectNode sql.Node, tab
 		ifNotExists:  ifn,
 		temporary:    temp,
 	}
+}
+
+// WithTargetSchema  implements the sql.TargetSchema interface.
+func (c *CreateTable) WithTargetSchema(schema sql.Schema) (sql.Node, error) {
+	return nil, fmt.Errorf("unable to set target schema without primary key info")
+}
+
+// TargetSchema implements the sql.TargetSchema interface.
+func (c *CreateTable) TargetSchema() sql.Schema {
+	return c.CreateSchema.Schema
 }
 
 // WithDatabase implements the sql.Databaser interface.


### PR DESCRIPTION
Operations that modify a table's schema were not consistently resolving column default values:
* `AlterPK` was missed in resolve column default switch cases, and also wasn't considering its expressions when checking for resolution. 
* `AlterDefaultSet` was resolving the wrong schema (its output schema, `OkResultSchema`, instead of the target schema). 

While I was in there, I cleaned up the code to more consistently use the `sql.TargetSchema` interface and combined some copy/pasted switch cases. 

Updated existing tests to use column default values and verified they caught both of these failures. Have already run Dolt engine tests and verified they pass correctly. 

Fixes: https://github.com/dolthub/dolt/issues/3788