### PR TITLE
pulling out large JSON test scripts

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -18,30 +18,6 @@ import "github.com/dolthub/go-mysql-server/sql"
 
 var JsonScripts = []ScriptTest{
 	{
-		Name: "JSON under max length limit",
-		SetUpScript: []string{
-			"create table t (j JSON)",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:    `insert into t set j= concat('[', repeat('"word",', 10000000), '"word"]')`,
-				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
-			},
-		},
-	},
-	{
-		Name: "JSON over max length limit",
-		SetUpScript: []string{
-			"create table t (j JSON)",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:       `insert into t set j= concat('[', repeat('"word",', 50000000), '"word"]')`,
-				ExpectedErr: sql.ErrLengthTooLarge,
-			},
-		},
-	},
-	{
 		Name: "JSON_ARRAYAGG on one column",
 		SetUpScript: []string{
 			"create table t (o_id int primary key)",


### PR DESCRIPTION
The large JSON test scripts have been causing `go test -race` to fail for Dolt (on ubuntu at least). This PR removes them from go-mysql-server and PR https://github.com/dolthub/dolt/pull/3824 moves them into Dolt. 

Confirmed that `go test -race` for Dolt's enginetests passes again on Ubuntu after this change.