### PR TITLE
Improving error message when a stored procedure isn't found and no DB is selected

### DIFF
--- a/sql/analyzer/stored_procedures.go
+++ b/sql/analyzer/stored_procedures.go
@@ -378,7 +378,12 @@ func applyProceduresCall(ctx *sql.Context, a *Analyzer, call *plan.Call, scope *
 
 	procedure := scope.procedures.Get(ctx.GetCurrentDatabase(), call.Name, len(call.Params))
 	if procedure == nil {
-		return nil, transform.SameTree, sql.ErrStoredProcedureDoesNotExist.New(call.Name)
+		err := sql.ErrStoredProcedureDoesNotExist.New(call.Name)
+		if ctx.GetCurrentDatabase() == "" {
+			cause := errors.NewKind("this might be because no database is selected")
+			err = sql.ErrStoredProcedureDoesNotExist.Wrap(cause.New(), call.Name)
+		}
+		return nil, transform.SameTree, err
 	}
 	if procedure.HasVariadicParameter() {
 		procedure = procedure.ExtendVariadic(ctx, len(call.Params))

--- a/sql/analyzer/stored_procedures.go
+++ b/sql/analyzer/stored_procedures.go
@@ -380,8 +380,7 @@ func applyProceduresCall(ctx *sql.Context, a *Analyzer, call *plan.Call, scope *
 	if procedure == nil {
 		err := sql.ErrStoredProcedureDoesNotExist.New(call.Name)
 		if ctx.GetCurrentDatabase() == "" {
-			cause := errors.NewKind("this might be because no database is selected")
-			err = sql.ErrStoredProcedureDoesNotExist.Wrap(cause.New(), call.Name)
+			return nil, transform.SameTree, fmt.Errorf("%w; this might be because no database is selected", err)
 		}
 		return nil, transform.SameTree, err
 	}

--- a/sql/analyzer/stored_procedures_test.go
+++ b/sql/analyzer/stored_procedures_test.go
@@ -39,6 +39,6 @@ func TestStoredProcedureNotFoundWithNoDatabaseSelected(t *testing.T) {
 	node, identity, err := applyProceduresCall(ctx, analyzer, call, scope, DefaultRuleSelector)
 	assert.Nil(t, node)
 	assert.Equal(t, transform.SameTree, identity)
-	assert.True(t, sql.ErrStoredProcedureDoesNotExist.Is(err))
+	assert.Contains(t, err.Error(), "stored procedure \"non_existent_procedure\" does not exist")
 	assert.Contains(t, err.Error(), "this might be because no database is selected")
 }

--- a/sql/analyzer/stored_procedures_test.go
+++ b/sql/analyzer/stored_procedures_test.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package analyzer
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+)
+
+func TestStoredProcedureNotFoundWithNoDatabaseSelected(t *testing.T) {
+	db := memory.NewDatabase("mydb")
+	analyzer := NewBuilder(sql.NewDatabaseProvider(db)).Build()
+	ctx := sql.NewContext(context.Background(), sql.WithSession(sql.NewBaseSession()))
+
+	call := plan.NewCall("non_existent_procedure", []sql.Expression{})
+	scope, err := loadStoredProcedures(ctx, analyzer, call, newScope(call), DefaultRuleSelector)
+	require.NoError(t, err)
+
+	node, identity, err := applyProceduresCall(ctx, analyzer, call, scope, DefaultRuleSelector)
+	assert.Nil(t, node)
+	assert.Equal(t, transform.SameTree, identity)
+	assert.True(t, sql.ErrStoredProcedureDoesNotExist.Is(err))
+	assert.Contains(t, err.Error(), "this might be because no database is selected")
+}


### PR DESCRIPTION
Previously, if a user tried to call a stored procedure with no database selected, they would get this error message:
```
stored procedure "%s" does not exist
```

We've seen some users connect to a sql-server, but not use a database and be confused by this error message, so this change adds extra content to the error message when no current database is selected: 
```
stored procedure "%s" does not exist: this might be because no database is selected
```