### PR TITLE
Bug fix for `now/current_timestamp` column default values not in parens

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5123,12 +5123,17 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 		RunQuery(t, e, harness, "alter table t33 rename column v1 to v1_new")
 		RunQuery(t, e, harness, "alter table t33 rename column name to name2")
 		RunQuery(t, e, harness, "alter table t33 drop column name2")
+		RunQuery(t, e, harness, "alter table t33 add column v3 datetime default CURRENT_TIMESTAMP()")
 
 		TestQueryWithContext(t, ctx, e, harness, "desc t33", []sql.Row{
 			{"pk", "varchar(100)", "NO", "PRI", "(replace(UUID(), '-', ''))", ""},
 			{"v1_new", "timestamp", "YES", "", "(NOW())", ""},
 			{"v2", "varchar(100)", "YES", "", "NULL", ""},
+			{"v3", "datetime", "YES", "", "(CURRENT_TIMESTAMP())", ""},
 		}, nil, nil)
+
+		AssertErr(t, e, harness, "alter table t33 add column v4 date default CURRENT_TIMESTAMP()", nil,
+			"only datetime/timestamp may declare default values of now()/current_timestamp() without surrounding parentheses")
 	})
 
 	t.Run("Function expressions must be enclosed in parens", func(t *testing.T) {

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5131,6 +5131,14 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 		}, nil, nil)
 	})
 
+	t.Run("Function expressions must be enclosed in parens", func(t *testing.T) {
+		AssertErr(t, e, harness, "create table t0 (v0 varchar(100) default repeat(\"_\", 99));", sql.ErrSyntaxError)
+	})
+
+	t.Run("Column references must be enclosed in parens", func(t *testing.T) {
+		AssertErr(t, e, harness, "Create table t0 (c0 int, c1 int default c0);", sql.ErrInvalidColumnDefaultValue)
+	})
+
 	t.Run("Invalid literal for column type", func(t *testing.T) {
 		AssertErr(t, e, harness, "CREATE TABLE t999(pk BIGINT PRIMARY KEY, v1 INT UNSIGNED DEFAULT -1)", sql.ErrIncompatibleDefaultType)
 	})

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4648,7 +4648,7 @@ func TestAlterTable(t *testing.T, harness Harness) {
 			{Name: "pk", Type: sql.Int64, Nullable: false, Source: "t32", PrimaryKey: true},
 			{Name: "v4", Type: sql.Int32, Nullable: true, Source: "t32"},
 			{Name: "v1", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 100), Source: "t32"},
-			{Name: "v3", Type: sql.Int32, Nullable: true, Source: "t32", Default: NewColumnDefaultValue(expression.NewLiteral(int8(100), sql.Int8), sql.Int32, true, true)},
+			{Name: "v3", Type: sql.Int32, Nullable: true, Source: "t32", Default: NewColumnDefaultValue(expression.NewLiteral(int8(100), sql.Int8), sql.Int32, true, false, true)},
 			{Name: "newName", Type: sql.Int32, Nullable: true, Source: "t32"},
 		}, t32.Schema())
 
@@ -4821,8 +4821,8 @@ func TestAlterTable(t *testing.T, harness Harness) {
 	})
 }
 
-func NewColumnDefaultValue(expr sql.Expression, outType sql.Type, representsLiteral bool, mayReturnNil bool) *sql.ColumnDefaultValue {
-	cdv, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, mayReturnNil)
+func NewColumnDefaultValue(expr sql.Expression, outType sql.Type, representsLiteral, isParenthesized, mayReturnNil bool) *sql.ColumnDefaultValue {
+	cdv, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, isParenthesized, mayReturnNil)
 	if err != nil {
 		panic(err)
 	}
@@ -5126,7 +5126,7 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 
 		TestQueryWithContext(t, ctx, e, harness, "desc t33", []sql.Row{
 			{"pk", "varchar(100)", "NO", "PRI", "(replace(UUID(), '-', ''))", ""},
-			{"v1_new", "timestamp", "YES", "", "NOW()", ""},
+			{"v1_new", "timestamp", "YES", "", "(NOW())", ""},
 			{"v2", "varchar(100)", "YES", "", "NULL", ""},
 		}, nil, nil)
 	})

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -45,7 +45,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, create_time timestamp(6) NOT NULL DEFAULT NOW(6), primary key (a))`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `create_time` timestamp NOT NULL DEFAULT NOW(6),\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `create_time` timestamp NOT NULL DEFAULT (NOW(6)),\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 LIKE mytable`,
@@ -142,6 +142,6 @@ var CreateTableQueries = []WriteQueryTest{
 		)`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE td",
-		ExpectedSelect:      []sql.Row{sql.Row{"td", "CREATE TABLE `td` (\n  `pk` int NOT NULL,\n  `col2` int NOT NULL DEFAULT '2',\n  `col3` double NOT NULL DEFAULT (ROUND(-1.58, 0)),\n  `col4` varchar(10) DEFAULT 'new row',\n  `col5` float DEFAULT '33.33',\n  `col6` int DEFAULT NULL,\n  `col7` timestamp DEFAULT NOW(),\n  `col8` bigint DEFAULT (NOW()),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{sql.Row{"td", "CREATE TABLE `td` (\n  `pk` int NOT NULL,\n  `col2` int NOT NULL DEFAULT '2',\n  `col3` double NOT NULL DEFAULT (ROUND(-1.58, 0)),\n  `col4` varchar(10) DEFAULT 'new row',\n  `col5` float DEFAULT '33.33',\n  `col6` int DEFAULT NULL,\n  `col7` timestamp DEFAULT (NOW()),\n  `col8` bigint DEFAULT (NOW()),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 }

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1116,6 +1116,9 @@ var InsertScripts = []ScriptTest{
 			"CREATE TABLE t2(id varchar(100) DEFAULT (uuid()));",
 			"CREATE TABLE t3(a int DEFAULT '1', b int default (2 * a));",
 			"CREATE TABLE t4(c0 varchar(10) null default 'c0', c1 varchar(10) null default 'c1');",
+			// MySQL allows the current_timestamp() function to NOT be in parens when used as a default
+			// https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html
+			"CREATE TABLE t5(c0 varchar(100) DEFAULT (repeat('_', 100)), c1 datetime DEFAULT current_timestamp());",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1181,6 +1184,18 @@ var InsertScripts = []ScriptTest{
 			{
 				Query:    "select * from t4",
 				Expected: []sql.Row{{nil, "c1"}},
+			},
+			{
+				Query:    "INSERT INTO T5 values (DEFAULT, DEFAULT)",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
+			},
+			{
+				Query:    "INSERT INTO T5 (c0, c1) values (DEFAULT, DEFAULT)",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
+			},
+			{
+				Query:    "INSERT INTO T5 (c1) values (DEFAULT)",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
 			},
 		},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8586,12 +8586,12 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: sql.ErrFunctionNotFound,
 	},
 	{
-		Query:       "CREATE TABLE table_test (id int PRIMARY KEY, c float DEFAULT rand())",
-		ExpectedErr: sql.ErrInvalidColumnDefaultValue,
+		Query:          "CREATE TABLE table_test (id int PRIMARY KEY, c float DEFAULT rand())",
+		ExpectedErrStr: "column default function expressions must be enclosed in parentheses",
 	},
 	{
-		Query:       "CREATE TABLE table_test (id int PRIMARY KEY, c float DEFAULT rand)",
-		ExpectedErr: sql.ErrInvalidColumnDefaultValue,
+		Query:          "CREATE TABLE table_test (id int PRIMARY KEY, c float DEFAULT rand)",
+		ExpectedErrStr: "column default function expressions must be enclosed in parentheses",
 	},
 	{
 		Query:       "CREATE TABLE table_test (id int PRIMARY KEY, c float DEFAULT (select 1))",

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -723,8 +723,11 @@ func resolveColumnDefaultsOnWrapper(ctx *sql.Context, col *sql.Column, e *expres
 				err = sql.ErrInvalidColumnDefaultFunction.New(funcName, col.Name)
 				return false
 			}
-			if newDefault.IsLiteral() {
+			if newDefault.IsParenthesized() == false {
 				if funcName == "now" || funcName == "current_timestamp" {
+					// now and current_timestamps are the only functions that don't have to be enclosed in
+					// parens when used as a column default value, but ONLY when they are used with a
+					// datetime or timestamp column, otherwise it's invalid.
 					if col.Type.Type() == sqltypes.Datetime || col.Type.Type() == sqltypes.Timestamp {
 						return true
 					} else {
@@ -732,10 +735,7 @@ func resolveColumnDefaultsOnWrapper(ctx *sql.Context, col *sql.Column, e *expres
 						return false
 					}
 				}
-				err = sql.ErrInvalidColumnDefaultValue.New(col.Name)
-				return false
 			}
-
 			return true
 		case *plan.Subquery:
 			err = sql.ErrColumnDefaultSubquery.New(col.Name)
@@ -773,7 +773,7 @@ func resolveColumnDefaultsOnWrapper(ctx *sql.Context, col *sql.Column, e *expres
 		}
 	}
 
-	newDefault, err = sql.NewColumnDefaultValue(newDefault.Expression, col.Type, isLiteral, col.Nullable)
+	newDefault, err = sql.NewColumnDefaultValue(newDefault.Expression, col.Type, isLiteral, newDefault.IsParenthesized(), col.Nullable)
 	if err != nil {
 		return nil, transform.SameTree, err
 	}

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -744,7 +744,7 @@ func resolveColumnDefaultsOnWrapper(ctx *sql.Context, col *sql.Column, e *expres
 			err = sql.ErrInvalidColumnDefaultValue.New(col.Name)
 			return false
 		case *expression.GetField:
-			if newDefault.IsLiteral() {
+			if newDefault.IsParenthesized() == false {
 				err = sql.ErrInvalidColumnDefaultValue.New(col.Name)
 				return false
 			} else {

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -22,30 +22,24 @@ import (
 // and a default expression. A nil pointer of this type represents an implicit default value and is thus valid, so all
 // method calls will return without error.
 type ColumnDefaultValue struct {
-	Expression      // the expression representing this default value
-	outType    Type // if non-nil, converts the output of the expression into this type
-	literal    bool // whether the default value is a literal or expression
-	returnNil  bool // if the expression returns a nil value, then this determines whether the result is returned or an error is returned
+	Expression         // the expression representing this default value
+	outType       Type // if non-nil, converts the output of the expression into this type
+	literal       bool // whether the default value is a literal or expression
+	returnNil     bool // if the expression returns a nil value, then this determines whether the result is returned or an error is returned
+	parenthesized bool // whether the value was specified in parens or not; this is typically the opposite of the literal field, but they can both be false in the case of now/current_timestamp for datetime and timestamp columns and certain usage validation checks require we know if a value was parenthesized or not.
 }
 
 var _ Expression = (*ColumnDefaultValue)(nil)
 
 // NewColumnDefaultValue returns a new ColumnDefaultValue expression.
-func NewColumnDefaultValue(expr Expression, outType Type, representsLiteral bool, mayReturnNil bool) (*ColumnDefaultValue, error) {
+func NewColumnDefaultValue(expr Expression, outType Type, representsLiteral bool, parenthesized bool, mayReturnNil bool) (*ColumnDefaultValue, error) {
 	return &ColumnDefaultValue{
-		Expression: expr,
-		outType:    outType,
-		literal:    representsLiteral,
-		returnNil:  mayReturnNil,
+		Expression:    expr,
+		outType:       outType,
+		literal:       representsLiteral,
+		returnNil:     mayReturnNil,
+		parenthesized: parenthesized,
 	}, nil
-}
-
-func MustNewNullDefault(expr Expression, outType Type, representsLiteral bool, mayReturnNil bool) *ColumnDefaultValue {
-	d, err := NewColumnDefaultValue(expr, outType, representsLiteral, mayReturnNil)
-	if err != nil {
-		panic(err)
-	}
-	return d
 }
 
 // NewUnresolvedColumnDefaultValue returns a column default
@@ -93,6 +87,14 @@ func (e *ColumnDefaultValue) IsLiteral() bool {
 		return true // we return the literal nil, hence true
 	}
 	return e.literal
+}
+
+// IsParenthesized returns whether this column default was specified in parentheses, using the expression default value form. It is almost always the opposite of IsLiteral, but there is one edge case where matching MySQL's behavior require that we can distinguish between a non-literal value in parens and a non-literal value not in parens. The edge case is using now/current_timestamp as a column default; now/current_timestamp can be specified without parens for datetime/timestamp fields, but it must be enclosed in parens to be used as the default for other types.
+func (e *ColumnDefaultValue) IsParenthesized() bool {
+	if e == nil {
+		return false // we return the literal nil, hence false
+	}
+	return e.parenthesized
 }
 
 // IsNullable implements sql.Expression
@@ -166,9 +168,10 @@ func (e *ColumnDefaultValue) WithChildren(children ...Expression) (Expression, e
 		return nil, ErrInvalidChildrenNumber.New(e, len(children), 1)
 	}
 	if e == nil {
-		return NewColumnDefaultValue(children[0], e.outType, len(children[0].Children()) == 0, true) //impossible to know, best guess
+		isLiteral := len(children[0].Children()) == 0 //impossible to know, best guess
+		return NewColumnDefaultValue(children[0], e.outType, isLiteral, !isLiteral, true)
 	} else {
-		return NewColumnDefaultValue(children[0], e.outType, e.literal, e.returnNil)
+		return NewColumnDefaultValue(children[0], e.outType, e.literal, e.parenthesized, e.returnNil)
 	}
 }
 

--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -596,7 +596,7 @@ func validateMysqlNativePassword(authResponse, salt []byte, mysqlNativePassword 
 
 // mustDefault enforces that no error occurred when constructing the column default value.
 func mustDefault(expr sql.Expression, outType sql.Type, representsLiteral bool, mayReturnNil bool) *sql.ColumnDefaultValue {
-	colDef, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, mayReturnNil)
+	colDef, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, !representsLiteral, mayReturnNil)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2051,23 +2051,30 @@ func convertDefaultExpression(ctx *sql.Context, defaultExpr sqlparser.Expr) (*sq
 	if err != nil {
 		return nil, err
 	}
-	// The literal and function expression distinction seems to be decided by the presence of parentheses, even for defaults like NOW() vs (NOW())
-	_, isExpr := defaultExpr.(*sqlparser.ParenExpr)
+
+	// Function expressions must be enclosed in parentheses (except for current_timestamp() and now())
+	_, isParenthesized := defaultExpr.(*sqlparser.ParenExpr)
+	isLiteral := !isParenthesized
+
 	// A literal will never have children, thus we can also check for that.
 	if unaryExpr, is := defaultExpr.(*sqlparser.UnaryExpr); is {
 		if _, lit := unaryExpr.Expr.(*sqlparser.SQLVal); lit {
-			isExpr = false
+			isLiteral = true
 		}
-	} else if !isExpr && len(parsedExpr.Children()) != 0 {
+	} else if !isParenthesized {
 		if f, ok := parsedExpr.(*expression.UnresolvedFunction); ok {
-			// This will be resolved accordingly in analyzer for column type of Datetime or Timestamp
-			if f.Name() != "now" && f.Name() != "timestamp" {
+			// Datetime and Timestamp columns allow now and current_timestamp to not be enclosed in parens,
+			// but they still need to be treated as function expressions
+			if f.Name() == "now" || f.Name() == "current_timestamp" {
+				isLiteral = false
+			} else {
+				// All other functions must *always* be enclosed in parens
 				return nil, sql.ErrSyntaxError.New("column default function expressions must be enclosed in parentheses")
 			}
 		}
 	}
 
-	return ExpressionToColumnDefaultValue(ctx, parsedExpr, !isExpr)
+	return ExpressionToColumnDefaultValue(ctx, parsedExpr, isLiteral, isParenthesized)
 }
 
 func convertAccountName(names ...sqlparser.AccountName) []plan.UserName {
@@ -2874,28 +2881,28 @@ func StringToColumnDefaultValue(ctx *sql.Context, exprStr string) (*sql.ColumnDe
 	if err != nil {
 		return nil, err
 	}
-	// The literal and function expression distinction seems to be decided by the presence of parentheses, even for defaults like NOW() vs (NOW())
-	// 2+2 would evaluate to a literal under the parentheses check, but will have children due to being an Arithmetic expression, thus we check for children.
+	// The literal and function expression distinction is based primarily on the presence of parentheses,
+	// with the exception that now/current_timestamp are not literal expressions but can be used without
+	// parens
+	_, isParenthesized := aliasedExpr.Expr.(*sqlparser.ParenExpr)
 
 	var isLiteral bool
 	switch e := parsedExpr.(type) {
 	case *expression.UnaryMinus:
 		_, isLiteral = e.Child.(*expression.Literal)
 	case *expression.UnresolvedFunction:
-		if !strings.HasPrefix(exprStr, "(") && (e.Name() == "now" || e.Name() == "current_timestamp") {
-			isLiteral = true
-		}
+		isLiteral = false
 	default:
 		isLiteral = len(parsedExpr.Children()) == 0 && !strings.HasPrefix(exprStr, "(")
 	}
-	return ExpressionToColumnDefaultValue(ctx, parsedExpr, isLiteral)
+	return ExpressionToColumnDefaultValue(ctx, parsedExpr, isLiteral, isParenthesized)
 }
 
 // ExpressionToColumnDefaultValue takes in an Expression and returns the equivalent ColumnDefaultValue if the expression
 // is valid for a default value. If the expression represents a literal (and not an expression that returns a literal, so "5"
 // rather than "(5)"), then the parameter "isLiteral" should be true.
-func ExpressionToColumnDefaultValue(ctx *sql.Context, inputExpr sql.Expression, isLiteral bool) (*sql.ColumnDefaultValue, error) {
-	return sql.NewColumnDefaultValue(inputExpr, nil, isLiteral, true)
+func ExpressionToColumnDefaultValue(_ *sql.Context, inputExpr sql.Expression, isLiteral, isParenthesized bool) (*sql.ColumnDefaultValue, error) {
+	return sql.NewColumnDefaultValue(inputExpr, nil, isLiteral, isParenthesized, true)
 }
 
 // MustStringToColumnDefaultValue is used for creating default values on tables that do not go through the analyzer. Does not handle
@@ -2905,7 +2912,7 @@ func MustStringToColumnDefaultValue(ctx *sql.Context, exprStr string, outType sq
 	if err != nil {
 		panic(err)
 	}
-	expr, err = sql.NewColumnDefaultValue(expr.Expression, outType, expr.IsLiteral(), nullable)
+	expr, err = sql.NewColumnDefaultValue(expr.Expression, outType, expr.IsLiteral(), !expr.IsLiteral(), nullable)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/parse/parsecolumndefault_test.go
+++ b/sql/parse/parsecolumndefault_test.go
@@ -36,6 +36,7 @@ func TestStringToColumnDefaultValue(t *testing.T) {
 				expression.NewLiteral(int8(2), sql.Int8),
 				nil,
 				true,
+				false,
 				true,
 			),
 		},
@@ -45,6 +46,7 @@ func TestStringToColumnDefaultValue(t *testing.T) {
 				expression.NewLiteral(int8(2), sql.Int8),
 				nil,
 				false,
+				true,
 				true,
 			),
 		},
@@ -59,6 +61,7 @@ func TestStringToColumnDefaultValue(t *testing.T) {
 				nil,
 				false,
 				true,
+				true,
 			),
 		},
 		{
@@ -70,6 +73,7 @@ func TestStringToColumnDefaultValue(t *testing.T) {
 				),
 				nil,
 				false,
+				true,
 				true,
 			),
 		},
@@ -111,8 +115,8 @@ func must(f interface{}, args ...interface{}) sql.Expression {
 	return out[0].Interface().(sql.Expression)
 }
 
-func NewColumnDefaultValue(expr sql.Expression, outType sql.Type, representsLiteral bool, mayReturnNil bool) *sql.ColumnDefaultValue {
-	cdv, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, mayReturnNil)
+func NewColumnDefaultValue(expr sql.Expression, outType sql.Type, isLiteral, isParenthesized, mayReturnNil bool) *sql.ColumnDefaultValue {
+	cdv, err := sql.NewColumnDefaultValue(expr, outType, isLiteral, isParenthesized, mayReturnNil)
 	if err != nil {
 		panic(err)
 	}

--- a/sql/plan/alter_table_test.go
+++ b/sql/plan/alter_table_test.go
@@ -96,11 +96,11 @@ func TestAddColumnToSchema(t *testing.T) {
 				Name:    "i2",
 				Type:    sql.Int64,
 				Source:  "mytable",
-				Default: mustDefault(expression.NewGetField(1, sql.Int64, "i", false), sql.Int64, false, true),
+				Default: mustDefault(expression.NewGetField(1, sql.Int64, "i", false), sql.Int64, false, true, true),
 			},
 			order: &sql.ColumnOrder{First: true},
 			newSchema: sql.Schema{
-				{Name: "i2", Type: sql.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(0, sql.Int64, "i", false), sql.Int64, false, true)},
+				{Name: "i2", Type: sql.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(0, sql.Int64, "i", false), sql.Int64, false, true, true)},
 				{Name: "i", Type: sql.Int64, Source: "mytable", PrimaryKey: true},
 				{Name: "s", Type: varchar20, Source: "mytable", Comment: "column s"},
 			},
@@ -109,7 +109,7 @@ func TestAddColumnToSchema(t *testing.T) {
 					Name:    "i2",
 					Type:    sql.Int64,
 					Source:  "mytable",
-					Default: mustDefault(expression.NewGetField(0, sql.Int64, "i", false), sql.Int64, false, true),
+					Default: mustDefault(expression.NewGetField(0, sql.Int64, "i", false), sql.Int64, false, true, true),
 				}},
 				expression.NewGetField(0, sql.Int64, "i", false),
 				expression.NewGetField(1, varchar20, "s", false),
@@ -138,12 +138,12 @@ func TestAddColumnToSchema(t *testing.T) {
 				Name:    "i2",
 				Type:    sql.Int64,
 				Source:  "mytable",
-				Default: mustDefault(expression.NewGetField(2, sql.Int64, "s", false), sql.Int64, false, true),
+				Default: mustDefault(expression.NewGetField(2, sql.Int64, "s", false), sql.Int64, false, true, true),
 			},
 			order: &sql.ColumnOrder{AfterColumn: "i"},
 			newSchema: sql.Schema{
 				{Name: "i", Type: sql.Int64, Source: "mytable", PrimaryKey: true},
-				{Name: "i2", Type: sql.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(1, sql.Int64, "s", false), sql.Int64, false, true)},
+				{Name: "i2", Type: sql.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(1, sql.Int64, "s", false), sql.Int64, false, true, true)},
 				{Name: "s", Type: varchar20, Source: "mytable", Comment: "column s"},
 			},
 			projections: []sql.Expression{
@@ -152,7 +152,7 @@ func TestAddColumnToSchema(t *testing.T) {
 					Name:    "i2",
 					Type:    sql.Int64,
 					Source:  "mytable",
-					Default: mustDefault(expression.NewGetField(1, sql.Int64, "s", false), sql.Int64, false, true),
+					Default: mustDefault(expression.NewGetField(1, sql.Int64, "s", false), sql.Int64, false, true, true),
 				}},
 				expression.NewGetField(1, varchar20, "s", false),
 			},
@@ -333,24 +333,24 @@ func TestModifyColumnInSchema(t *testing.T) {
 				{Name: "two", Type: sql.Int64, Source: "mytable"},
 				{Name: "three", Type: sql.Int64, Source: "mytable", Default: mustDefault(
 					expression.NewGetFieldWithTable(1, sql.Int64, "mytable", "two", false),
-					sql.Int64, false, false),
+					sql.Int64, false, true, false),
 				},
 			},
 			colName: "two",
 			order:   &sql.ColumnOrder{First: true},
 			newColumn: &sql.Column{Name: "two", Type: sql.Int64, Source: "mytable", Default: mustDefault(
 				expression.NewGetFieldWithTable(0, sql.Int64, "mytable", "one", false),
-				sql.Int64, false, false),
+				sql.Int64, false, true, false),
 			},
 			newSchema: sql.Schema{
 				{Name: "two", Type: sql.Int64, Source: "mytable", Default: mustDefault(
 					expression.NewGetFieldWithTable(1, sql.Int64, "mytable", "one", false),
-					sql.Int64, false, false),
+					sql.Int64, false, true, false),
 				},
 				{Name: "one", Type: sql.Int64, Source: "mytable", PrimaryKey: true},
 				{Name: "three", Type: sql.Int64, Source: "mytable", Default: mustDefault(
 					expression.NewGetFieldWithTable(0, sql.Int64, "mytable", "two", false),
-					sql.Int64, false, false),
+					sql.Int64, false, true, false),
 				},
 			},
 			projections: []sql.Expression{
@@ -375,8 +375,8 @@ func TestModifyColumnInSchema(t *testing.T) {
 }
 
 // mustDefault enforces that no error occurred when constructing the column default value.
-func mustDefault(expr sql.Expression, outType sql.Type, representsLiteral bool, mayReturnNil bool) *sql.ColumnDefaultValue {
-	colDef, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, mayReturnNil)
+func mustDefault(expr sql.Expression, outType sql.Type, representsLiteral bool, parenthesized bool, mayReturnNil bool) *sql.ColumnDefaultValue {
+	colDef, err := sql.NewColumnDefaultValue(expr, outType, representsLiteral, parenthesized, mayReturnNil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Our column default logic was conflating whether a default value was a literal value or an expression when the `now` or `current_timestamp` functions were used as the column default. Those column defaults were marked as literals, even though they are expressions that need to be resolved and evaluated. These two functions are the only functions that may be used as a column default value without being enclosed in parens, and when used that way, they were not getting resolved and causing a panic (see linked issue for more details). 

This change makes `ColumnDefaultValue.IsLiteral` always return true if the default value is a literal value and always return false if the default value is some expression that needs to be resolved and evaluated. To keep consistency with MySQL's behavior, it requires that we track whether the column default was enclosed in parens when defined. This is necessary because MySQL allows the now/current_timestamp functions to be used without parens for datetime/timestamp column, but **must** be specified in parens when used as the default for any other column type. Since that validation is done in a separate spot from the parsing, we need to track that as part of ColumnDefaultValue. 

Testing: Dolt engine tests and Dolt unit tests all pass correctly with these changes. 

Fixes: https://github.com/dolthub/dolt/issues/2618