### PR TITLE
Big fix for resolving column default values in correct order 

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1112,13 +1112,15 @@ var InsertScripts = []ScriptTest{
 	{
 		Name: "explicit DEFAULT",
 		SetUpScript: []string{
-			"CREATE TABLE t1(id int DEFAULT '2', vc varchar(255) DEFAULT '2');",
+			"CREATE TABLE t1(id int DEFAULT '2', dt datetime DEFAULT now());",
 			"CREATE TABLE t2(id varchar(100) DEFAULT (uuid()));",
 			"CREATE TABLE t3(a int DEFAULT '1', b int default (2 * a));",
 			"CREATE TABLE t4(c0 varchar(10) null default 'c0', c1 varchar(10) null default 'c1');",
 			// MySQL allows the current_timestamp() function to NOT be in parens when used as a default
 			// https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html
 			"CREATE TABLE t5(c0 varchar(100) DEFAULT (repeat('_', 100)), c1 datetime DEFAULT current_timestamp());",
+			// Regression test case for custom column ordering: https://github.com/dolthub/dolt/issues/4004
+			"create table t6 (color enum('red', 'blue', 'green') default 'blue', createdAt timestamp default (current_timestamp()));",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1126,11 +1128,11 @@ var InsertScripts = []ScriptTest{
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
 			},
 			{
-				Query:    "INSERT INTO t1 (id, VC) values (DEFAULT, DEFAULT)",
+				Query:    "INSERT INTO t1 (id, dt) values (DEFAULT, DEFAULT)",
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
 			},
 			{
-				Query:    "INSERT INTO t1 (vc, ID) values (DEFAULT, DEFAULT)",
+				Query:    "INSERT INTO t1 (dt, ID) values (DEFAULT, DEFAULT)",
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
 			},
 			{
@@ -1138,15 +1140,15 @@ var InsertScripts = []ScriptTest{
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
 			},
 			{
-				Query:    "INSERT INTO t1 (vc) values (DEFAULT), ('3')",
+				Query:    "INSERT INTO t1 (dt) values (DEFAULT), ('1981-02-16 00:00:00')",
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
 			},
 			{
-				Query:    "INSERT INTO t1 values (100, '100'), (DEFAULT, DEFAULT)",
+				Query:    "INSERT INTO t1 values (100, '2000-01-01 12:34:56'), (DEFAULT, DEFAULT)",
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
 			},
 			{
-				Query:    "INSERT INTO t1 (id, vc) values (100, '100'), (DEFAULT, DEFAULT)",
+				Query:    "INSERT INTO t1 (id, dt) values (100, '2022-01-01 01:01:01'), (DEFAULT, DEFAULT)",
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
 			},
 			{
@@ -1154,7 +1156,7 @@ var InsertScripts = []ScriptTest{
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
 			},
 			{
-				Query:    "INSERT INTO t1 (VC) values ('10'), (DEFAULT)",
+				Query:    "INSERT INTO t1 (DT) values ('2022-02-02 02:02:02'), (DEFAULT)",
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
 			},
 			{
@@ -1195,6 +1197,11 @@ var InsertScripts = []ScriptTest{
 			},
 			{
 				Query:    "INSERT INTO T5 (c1) values (DEFAULT)",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
+			},
+			{
+				// Custom column order should use the correct column defaults
+				Query:    "insert into T6(createdAt, color) values (DEFAULT, DEFAULT);",
 				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1}}},
 			},
 		},

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -480,9 +480,15 @@ func resolveColumnDefaults(ctx *sql.Context, _ *Analyzer, n sql.Node, _ *Scope, 
 				// Instead of grabbing the schema from TargetSchema(), use the Destination node
 				sch := node.Destination.Schema()
 
-				// InsertInto.Source can contain multiple rows, so loop over the columns in the schema
-				colIndex = colIndex % len(sch)
-				col := sch[colIndex]
+				// InsertInto.Source can contain multiple rows, so loop over the included columns
+				colIndex = colIndex % len(node.ColumnNames)
+
+				// Columns can be specified in any order, so use the order from the InsertInto statement
+				schemaIndex := sch.IndexOfColName(node.ColumnNames[colIndex])
+				if schemaIndex == -1 {
+					return nil, transform.SameTree, sql.ErrColumnNotFound.New(node.ColumnNames[colIndex])
+				}
+				col := sch[schemaIndex]
 				colIndex++
 				return resolveColumnDefaultsOnWrapper(ctx, col, eWrapper)
 			})

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -197,7 +197,7 @@ func (e *ColumnDefaultValue) CheckType(ctx *Context) error {
 		}
 		_, err = e.outType.Convert(val)
 		if err != nil {
-			return ErrIncompatibleDefaultType.New()
+			return ErrIncompatibleDefaultType.Wrap(err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes an issue where we weren't pulling the column definitions in the same order as the InsertInto specified the column values when resolving and validating column default values. 

We did have a test for this case, but because the types in the test were int and varchar, the default values were being coerced silently and the tests were passing when they should have failed. I've updated that test and also added a new test case using an enum that closely matches the case the customer reported. 

Fixes: https://github.com/dolthub/dolt/issues/4004