### PR TITLE
Prevent JSON and GEOMETRY columns from having literal default values

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8633,6 +8633,23 @@ var ErrorQueries = []QueryErrorTest{
 		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, v1 JSON DEFAULT JSON_ARRAY(1,2));",
 		ExpectedErr: sql.ErrSyntaxError,
 	},
+
+	{
+		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, j JSON DEFAULT '{}');",
+		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
+	},
+	{
+		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, g GEOMETRY DEFAULT '');",
+		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
+	},
+	{
+		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, t TEXT DEFAULT '');",
+		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
+	},
+	{
+		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, b BLOB DEFAULT '');",
+		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
+	},
 }
 
 // WriteQueryTest is a query test for INSERT, UPDATE, etc. statements. It has a query to run and a select query to

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8633,7 +8633,6 @@ var ErrorQueries = []QueryErrorTest{
 		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, v1 JSON DEFAULT JSON_ARRAY(1,2));",
 		ExpectedErr: sql.ErrSyntaxError,
 	},
-
 	{
 		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, j JSON DEFAULT '{}');",
 		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -697,7 +697,7 @@ func resolveColumnDefaultsOnWrapper(ctx *sql.Context, col *sql.Column, e *expres
 		return e, transform.SameTree, nil
 	}
 
-	if sql.IsTextBlob(col.Type) && newDefault.IsLiteral() && newDefault.Type() != sql.Null {
+	if (sql.IsTextBlob(col.Type) || sql.IsJSON(col.Type) || sql.IsGeometry(col.Type)) && newDefault.IsLiteral() && newDefault.Type() != sql.Null {
 		return nil, transform.SameTree, sql.ErrInvalidTextBlobColumnDefault.New()
 	}
 

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -121,7 +121,7 @@ var (
 	ErrIncompatibleDefaultType = errors.NewKind("incompatible type for default value")
 
 	// ErrInvalidTextBlobColumnDefault is returned when a column of type text/blob (or related) has a literal default set.
-	ErrInvalidTextBlobColumnDefault = errors.NewKind("text/blob types may only have expression default values")
+	ErrInvalidTextBlobColumnDefault = errors.NewKind("TEXT, BLOB, GEOMETRY, and JSON types may only have expression default values")
 
 	// ErrInvalidColumnDefaultFunction is returned when an invalid function is used in a default value.
 	ErrInvalidColumnDefaultFunction = errors.NewKind("function `%s` on column `%s` is not valid for usage in a default value")

--- a/sql/type.go
+++ b/sql/type.go
@@ -588,9 +588,20 @@ func IsInteger(t Type) bool {
 	return IsSigned(t) || IsUnsigned(t)
 }
 
+// IsJSON returns true if the specified type is a JSON type.
 func IsJSON(t Type) bool {
 	_, ok := t.(jsonType)
 	return ok
+}
+
+// IsGeometry returns true if the specified type is a Geometry type.
+func IsGeometry(t Type) bool {
+	switch t.(type) {
+	case GeometryType, PointType, LineStringType, PolygonType:
+		return true
+	default:
+		return false
+	}
 }
 
 // IsNull returns true if expression is nil or is Null Type, otherwise false.

--- a/sql/type_test.go
+++ b/sql/type_test.go
@@ -22,6 +22,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsGeometry(t *testing.T) {
+	assert.True(t, IsGeometry(GeometryType{}))
+	assert.True(t, IsGeometry(PointType{}))
+	assert.True(t, IsGeometry(LineStringType{}))
+	assert.True(t, IsGeometry(PolygonType{}))
+	assert.False(t, IsGeometry(stringType{}))
+	assert.False(t, IsGeometry(JSON))
+	assert.False(t, IsGeometry(Blob))
+}
+
+func TestIsJSON(t *testing.T) {
+	assert.True(t, IsJSON(JSON))
+	assert.False(t, IsJSON(Blob))
+	assert.False(t, IsJSON(numberTypeImpl{}))
+	assert.False(t, IsJSON(stringType{}))
+}
+
 func TestFloatCovert(t *testing.T) {
 	tests := []struct {
 		length   string


### PR DESCRIPTION
MySQL disallows BLOB, TEXT, JSON, and GEOMETRY columns from having a literal column default value: 
https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html#data-type-defaults.html#data-type-defaults-explicit

go-mysql-server already prevents BLOB and TEXT column types; this PR extends that check to cover JSON and GEOMETRY columns as well. 

Fixes: https://github.com/dolthub/dolt/issues/4003