### PR TITLE
sql/analyzer: Update Index Selection heuristics to prioritize Primary Key indexes

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2009,38 +2009,6 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
-	{
-		Name: "Index Selection Heuristics",
-		SetUpScript: []string{
-			"CREATE TABLE indexed (" +
-				"pk1 int," +
-				"pk2 int," +
-				"c0 int," +
-				"PRIMARY KEY(pk1, pk2)," +
-				"KEY(pk1, c0)" +
-				")",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query: "EXPLAIN SELECT * FROM indexed WHERE pk1 = 1 AND c0 = 1",
-				Expected: []sql.Row{
-					{"IndexedTableAccess(indexed)"},
-					{" ├─ index: [indexed.pk1,indexed.c0]"},
-					{" ├─ filters: [{[1, 1], [1, 1]}]"},
-					{" └─ columns: [pk1 pk2 c0]"},
-				},
-			},
-			{
-				Query: "EXPLAIN SELECT * FROM indexed WHERE pk1 = 1",
-				Expected: []sql.Row{
-					{"IndexedTableAccess(indexed)"},
-					{" ├─ index: [indexed.pk1,indexed.pk2]"},
-					{" ├─ filters: [{[1, 1], [NULL, ∞)}]"},
-					{" └─ columns: [pk1 pk2 c0]"},
-				},
-			},
-		},
-	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2009,6 +2009,38 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Index Selection Heuristics",
+		SetUpScript: []string{
+			"CREATE TABLE indexed (" +
+				"pk1 int," +
+				"pk2 int," +
+				"c0 int," +
+				"PRIMARY KEY(pk1, pk2)," +
+				"KEY(pk1, c0)" +
+				")",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "EXPLAIN SELECT * FROM indexed WHERE pk1 = 1 AND c0 = 1",
+				Expected: []sql.Row{
+					{"IndexedTableAccess(indexed)"},
+					{" ├─ index: [indexed.pk1,indexed.c0]"},
+					{" ├─ filters: [{[1, 1], [1, 1]}]"},
+					{" └─ columns: [pk1 pk2 c0]"},
+				},
+			},
+			{
+				Query: "EXPLAIN SELECT * FROM indexed WHERE pk1 = 1",
+				Expected: []sql.Row{
+					{"IndexedTableAccess(indexed)"},
+					{" ├─ index: [indexed.pk1,indexed.pk2]"},
+					{" ├─ filters: [{[1, 1], [NULL, ∞)}]"},
+					{" └─ columns: [pk1 pk2 c0]"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/index_analyzer.go
+++ b/sql/analyzer/index_analyzer.go
@@ -133,11 +133,13 @@ func (r *indexAnalyzer) MatchingIndex(ctx *sql.Context, db string, table string,
 // MatchingIndexes returns a list of all matching indexes for the given expressions. The returned order of the indexes
 // are deterministic and follow the given rules, from the highest priority in descending order:
 //
-// 1. Expressions exactly match the index
-// 2. Expressions match as much of the index prefix as possible
-// 3. Primary Key index ordered before secondary indexes
-// 4. Largest index by expression count
-// 5. Index ID in ascending order
+//  1. Expressions exactly match the index
+//  2. Expressions match as much of the index prefix as possible
+//  3. Primary Key index ordered before secondary indexes
+//     TODO: for rule 3, we want to prioritize "covering" indexes over non-covering indexes, but sql.Index doesn't
+//     provide the necessary information to evaluate this condition. Primary Key status approximates it.
+//  4. Largest index by expression count
+//  5. Index ID in ascending order
 //
 // It is worth noting that all returned indexes will have at least the first index expression satisfied (creating a
 // partial index), as otherwise the index would be no better than a table scan (for which integrators may have

--- a/sql/analyzer/index_analyzer.go
+++ b/sql/analyzer/index_analyzer.go
@@ -192,6 +192,7 @@ func (r *indexAnalyzer) MatchingIndexes(ctx *sql.Context, db string, table strin
 			return false
 		} else if idxI.prefixCount != idxJ.prefixCount {
 			return idxI.prefixCount > idxJ.prefixCount
+			// TODO: ID() == "PRIMARY" is purely convention
 		} else if idxI.ID() == "PRIMARY" || idxJ.ID() == "PRIMARY" {
 			return idxI.ID() == "PRIMARY"
 		} else if idxI.exprLen != idxJ.exprLen {

--- a/sql/analyzer/index_analyzer.go
+++ b/sql/analyzer/index_analyzer.go
@@ -135,8 +135,9 @@ func (r *indexAnalyzer) MatchingIndex(ctx *sql.Context, db string, table string,
 //
 // 1. Expressions exactly match the index
 // 2. Expressions match as much of the index prefix as possible
-// 3. Largest index by expression count
-// 4. Index ID in ascending order
+// 3. Primary Key index ordered before secondary indexes
+// 4. Largest index by expression count
+// 5. Index ID in ascending order
 //
 // It is worth noting that all returned indexes will have at least the first index expression satisfied (creating a
 // partial index), as otherwise the index would be no better than a table scan (for which integrators may have
@@ -189,6 +190,8 @@ func (r *indexAnalyzer) MatchingIndexes(ctx *sql.Context, db string, table strin
 			return false
 		} else if idxI.prefixCount != idxJ.prefixCount {
 			return idxI.prefixCount > idxJ.prefixCount
+		} else if idxI.ID() == "PRIMARY" || idxJ.ID() == "PRIMARY" {
+			return idxI.ID() == "PRIMARY"
 		} else if idxI.exprLen != idxJ.exprLen {
 			return idxI.exprLen > idxJ.exprLen
 		} else {


### PR DESCRIPTION
In Dolt, this increases out TPC-C throughput by 2x for the new NBF.