### PR TITLE
Use literal for Enum/set default

### DIFF
--- a/sql/information_schema/columns_table.go
+++ b/sql/information_schema/columns_table.go
@@ -321,6 +321,10 @@ func getColumnDefaultValue(ctx *sql.Context, cd *sql.ColumnDefaultValue) interfa
 		return fmt.Sprint(defStr)
 	}
 
+	if sql.IsEnum(cd.Type()) || sql.IsSet(cd.Type()) {
+		return strings.Trim(defStr, "'")
+	}
+
 	v, err := cd.Eval(ctx, nil)
 	if err != nil {
 		return nil

--- a/sql/type.go
+++ b/sql/type.go
@@ -659,6 +659,18 @@ func IsTime(t Type) bool {
 	return ok
 }
 
+// IsEnum checks if t is a enum
+func IsEnum(t Type) bool {
+	_, ok := t.(enumType)
+	return ok
+}
+
+// IsEnum checks if t is a set
+func IsSet(t Type) bool {
+	_, ok := t.(setType)
+	return ok
+}
+
 // IsTuple checks if t is a tuple type.
 // Note that TupleType instances with just 1 value are not considered
 // as a tuple, but a parenthesized value.


### PR DESCRIPTION
Currently enum / set default value will be evaluated(converted to int) and store in `information_schema`, think better to leave as their literals.

PS: I'm also investigating if this issue related to #1131 