### PR TITLE
Indexed joins range scans ignore non-equalities

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -118,7 +118,7 @@ func TestSpatialQueriesPrepared(t *testing.T, harness Harness) {
 
 // TestJoinQueries tests join queries against a provided harness.
 func TestJoinQueries(t *testing.T, harness Harness) {
-	harness.Setup(setup.MydbData, setup.MytableData, setup.Pk_tablesData, setup.OthertableData)
+	harness.Setup(setup.MydbData, setup.MytableData, setup.Pk_tablesData, setup.OthertableData, setup.NiltableData)
 	for _, tt := range queries.JoinQueryTests {
 		TestQuery(t, harness, tt.Query, tt.Expected, tt.ExpectedColumns, nil)
 	}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -122,7 +122,7 @@ func TestSingleQuery(t *testing.T) {
 
 	var test queries.QueryTest
 	test = queries.QueryTest{
-		Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.i = c.i`,
+		Query: `SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i2 and pk > 0 ORDER BY 2,3`,
 		Expected: []sql.Row{
 			{1, 2},
 		},
@@ -130,7 +130,7 @@ func TestSingleQuery(t *testing.T) {
 
 	fmt.Sprintf("%v", test)
 	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
-	harness.Setup(setup.Mytable...)
+	harness.Setup(setup.MydbData, setup.SpecialtableData, setup.Pk_tablesData, setup.NiltableData)
 	engine, err := harness.NewEngine(t)
 	if err != nil {
 		panic(err)

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -321,6 +321,33 @@ var JoinQueryTests = []QueryTest{
 			{2, "second row"},
 			{3, "third row"}},
 	},
+	{
+		Query: "select * from mytable a join niltable  b on a.i = b.i and b <=> NULL",
+		Expected: []sql.Row{
+			{1, "first row", 1, nil, nil, nil},
+		},
+	},
+	{
+		Query: "select * from mytable a join niltable  b on a.i = b.i and s IS NOT NULL",
+		Expected: []sql.Row{
+			{1, "first row", 1, nil, nil, nil},
+			{2, "second row", 2, 2, 1, nil},
+			{3, "third row", 3, nil, 0, nil},
+		},
+	},
+	{
+		Query: "select * from mytable a join niltable  b on a.i = b.i and b IS NOT NULL",
+		Expected: []sql.Row{
+			{2, "second row", 2, 2, 1, nil},
+			{3, "third row", 3, nil, 0, nil},
+		},
+	},
+	{
+		Query: "select * from mytable a join niltable  b on a.i = b.i and b != 0",
+		Expected: []sql.Row{
+			{2, "second row", 2, 2, 1, nil},
+		},
+	},
 }
 
 var SkippedJoinQueryTests = []QueryTest{

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -308,6 +308,19 @@ var JoinQueryTests = []QueryTest{
 			{4, 4, 4},
 		},
 	},
+	{
+		Query: "select a.* from mytable a join mytable b on a.i = b.i and a.i > 2",
+		Expected: []sql.Row{
+			{3, "third row"},
+		},
+	},
+	{
+		Query: "select a.* from mytable a join mytable b on a.i = b.i and now() >= coalesce(NULL, NULL, now())",
+		Expected: []sql.Row{
+			{1, "first row"},
+			{2, "second row"},
+			{3, "third row"}},
+	},
 }
 
 var SkippedJoinQueryTests = []QueryTest{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -2977,6 +2977,24 @@ var PlanTests = []QueryPlanTest{
 			"             └─ columns: [i]\n" +
 			"",
 	},
+	{
+		Query: `SELECT * from one_pk_three_idx where pk < 1 and v1 = 1 and v2 = 1`,
+		ExpectedPlan: "Filter(one_pk_three_idx.pk < 1)\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * from one_pk_three_idx where pk = 1 and v1 = 1 and v2 = 1`,
+		ExpectedPlan: "Filter(one_pk_three_idx.pk = 1)\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
+			"",
+	},
 }
 
 // Queries where the query planner produces a correct (results) but suboptimal plan.

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -2995,6 +2995,60 @@ var PlanTests = []QueryPlanTest{
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
+	{
+		Query: `select * from mytable a join niltable  b on a.i = b.i and b <=> NULL`,
+		ExpectedPlan: "IndexedJoin(a.i = b.i)\n" +
+			" ├─ TableAlias(a)\n" +
+			" │   └─ Table(mytable)\n" +
+			" │       └─ columns: [i s]\n" +
+			" └─ Filter(b.b <=> NULL)\n" +
+			"     └─ TableAlias(b)\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
+			"             ├─ index: [niltable.i]\n" +
+			"             └─ columns: [i i2 b f]\n" +
+			"",
+	},
+	{
+		Query: `select * from mytable a join niltable  b on a.i = b.i and b IS NOT NULL`,
+		ExpectedPlan: "IndexedJoin(a.i = b.i)\n" +
+			" ├─ TableAlias(a)\n" +
+			" │   └─ Table(mytable)\n" +
+			" │       └─ columns: [i s]\n" +
+			" └─ Filter(NOT(b.b IS NULL))\n" +
+			"     └─ TableAlias(b)\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
+			"             ├─ index: [niltable.i]\n" +
+			"             └─ columns: [i i2 b f]\n" +
+			"",
+	},
+	{
+		Query: `select * from mytable a join niltable  b on a.i = b.i and b != 0`,
+		ExpectedPlan: "IndexedJoin(a.i = b.i)\n" +
+			" ├─ TableAlias(a)\n" +
+			" │   └─ Table(mytable)\n" +
+			" │       └─ columns: [i s]\n" +
+			" └─ Filter(NOT((b.b = 0)))\n" +
+			"     └─ TableAlias(b)\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
+			"             ├─ index: [niltable.i]\n" +
+			"             └─ columns: [i i2 b f]\n" +
+			"",
+	},
+	{
+		Query: `select * from mytable a join niltable  b on a.i = b.i and s IS NOT NULL`,
+		ExpectedPlan: "IndexedJoin(a.i = b.i)\n" +
+			" ├─ Filter(NOT(a.s IS NULL))\n" +
+			" │   └─ TableAlias(a)\n" +
+			" │       └─ IndexedTableAccess(mytable)\n" +
+			" │           ├─ index: [mytable.s]\n" +
+			" │           ├─ filters: [{(NULL, ∞)}]\n" +
+			" │           └─ columns: [i s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
+			"         ├─ index: [niltable.i]\n" +
+			"         └─ columns: [i i2 b f]\n" +
+			"",
+	},
 }
 
 // Queries where the query planner produces a correct (results) but suboptimal plan.

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -553,19 +553,21 @@ var PlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND s > s2`,
-		ExpectedPlan: "InnerJoin((mytable.i = othertable.i2) AND (mytable.s > othertable.s2))\n" +
+		ExpectedPlan: "IndexedJoin((mytable.i = othertable.i2) AND (mytable.s > othertable.s2))\n" +
 			" ├─ Table(mytable)\n" +
 			" │   └─ columns: [i s]\n" +
-			" └─ Table(othertable)\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
+			"     ├─ index: [othertable.i2]\n" +
 			"     └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT(s > s2)`,
-		ExpectedPlan: "InnerJoin((mytable.i = othertable.i2) AND (NOT((mytable.s > othertable.s2))))\n" +
+		ExpectedPlan: "IndexedJoin((mytable.i = othertable.i2) AND (NOT((mytable.s > othertable.s2))))\n" +
 			" ├─ Table(mytable)\n" +
 			" │   └─ columns: [i s]\n" +
-			" └─ Table(othertable)\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
+			"     ├─ index: [othertable.i2]\n" +
 			"     └─ columns: [s2 i2]\n" +
 			"",
 	},
@@ -1786,11 +1788,13 @@ var PlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i and pk > 0`,
-		ExpectedPlan: "RightJoin((one_pk.pk = niltable.i) AND (one_pk.pk > 0))\n" +
-			" ├─ Table(one_pk)\n" +
-			" │   └─ columns: [pk]\n" +
-			" └─ Table(niltable)\n" +
-			"     └─ columns: [i f]\n" +
+		ExpectedPlan: "Project(one_pk.pk, niltable.i, niltable.f)\n" +
+			" └─ RightIndexedJoin((one_pk.pk = niltable.i) AND (one_pk.pk > 0))\n" +
+			"     ├─ Table(niltable)\n" +
+			"     │   └─ columns: [i f]\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
+			"         ├─ index: [one_pk.pk]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -2173,11 +2177,13 @@ var PlanTests = []QueryPlanTest{
 	{
 		Query: `SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i and pk > 0 ORDER BY 2,3`,
 		ExpectedPlan: "Sort(niltable.i ASC, niltable.f ASC)\n" +
-			" └─ RightJoin((one_pk.pk = niltable.i) AND (one_pk.pk > 0))\n" +
-			"     ├─ Table(one_pk)\n" +
-			"     │   └─ columns: [pk]\n" +
-			"     └─ Table(niltable)\n" +
-			"         └─ columns: [i f]\n" +
+			" └─ Project(one_pk.pk, niltable.i, niltable.f)\n" +
+			"     └─ RightIndexedJoin((one_pk.pk = niltable.i) AND (one_pk.pk > 0))\n" +
+			"         ├─ Table(niltable)\n" +
+			"         │   └─ columns: [i f]\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
+			"             ├─ index: [one_pk.pk]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -2940,6 +2946,35 @@ var PlanTests = []QueryPlanTest{
 			"                 └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"                     ├─ index: [one_pk_two_idx.pk]\n" +
 			"                     └─ columns: [pk]\n" +
+			"",
+	},
+	{
+		Query: `select a.* from mytable a join mytable b on a.i = b.i and a.i > 2`,
+		ExpectedPlan: "Project(a.i, a.s)\n" +
+			" └─ IndexedJoin(a.i = b.i)\n" +
+			"     ├─ Filter(a.i > 2)\n" +
+			"     │   └─ TableAlias(a)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           ├─ filters: [{(2, ∞)}]\n" +
+			"     │           └─ columns: [i s]\n" +
+			"     └─ TableAlias(b)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.i]\n" +
+			"             └─ columns: [i]\n" +
+			"",
+	},
+	{
+		Query: `select a.* from mytable a join mytable b on a.i = b.i and now() >= coalesce(NULL, NULL, now())`,
+		ExpectedPlan: "Project(a.i, a.s)\n" +
+			" └─ IndexedJoin(a.i = b.i)\n" +
+			"     ├─ TableAlias(a)\n" +
+			"     │   └─ Table(mytable)\n" +
+			"     │       └─ columns: [i s]\n" +
+			"     └─ TableAlias(b)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.i]\n" +
+			"             └─ columns: [i]\n" +
 			"",
 	},
 }

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -20,7 +20,7 @@ import (
 // query plan results. Handy when you've made a large change to the analyzer or node formatting, and you want to examine
 // how query plans have changed without a lot of manual copying and pasting.
 func TestWriteQueryPlans(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 
 	harness := NewDefaultMemoryHarness()
 	harness.Setup(setup.SimpleSetup...)

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -20,7 +20,7 @@ import (
 // query plan results. Handy when you've made a large change to the analyzer or node formatting, and you want to examine
 // how query plans have changed without a lot of manual copying and pasting.
 func TestWriteQueryPlans(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 
 	harness := NewDefaultMemoryHarness()
 	harness.Setup(setup.SimpleSetup...)

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -88,21 +88,12 @@ func replaceJoinPlans(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, s
 				return nil, transform.SameTree, err
 			}
 
-			//var unhandled sql.Expression
 			joinIndexes, err = findJoinIndexesByTable(ctx, n, tableAliases, a)
 			if err != nil {
 				return nil, transform.SameTree, err
 			}
 
 			return replanJoin(ctx, n, a, joinIndexes, scope)
-			//j, same, err := replanJoin(ctx, n, a, joinIndexes, scope)
-			//if err != nil {
-			//	return n, transform.SameTree, err
-			//}
-			//if !same && unhandled != nil {
-			//	return plan.NewFilter(unhandled, j), transform.NewTree, nil
-			//}
-			//return j, same, nil
 
 		default:
 			return n, transform.SameTree, nil
@@ -134,26 +125,6 @@ func replaceJoinPlans(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, s
 
 	return withIndexedTableAccess, transform.NewTree, nil
 }
-
-//func addUnhandled(n sql.Node, unhandled sql.Expression) {
-// in order traversal to push filters below sided-joins
-
-//var recurse func(sql.Node) sql.Node
-//recurse = func(n sql.Node) sql.Node {
-//	// check node for handed join
-//	jn, ok := n.(plan.JoinNode)
-//	if !ok {
-//		return n
-//	}
-//	switch jn.JoinType() {
-//	case plan.JoinTypeLeft:
-//	case plan.JoinTypeRight:
-//	default:
-//	}
-//	return plan.NewFilter(unhandled, n)
-//	// recurse into children
-//}
-//}
 
 // countTableFactors uses a naive algorithm to count
 // the number of join leaves in a query.
@@ -709,10 +680,6 @@ func findJoinIndexesByTable(
 	return joinIndexesByTable, err
 }
 
-//func filterSidedJoinUnhandled(n sql.Node, e sql.Expression) sql.Expression {
-//	// if sided join, kill filters that don't apply
-//}
-
 // getJoinIndexesByTable returns a map of table name to a slice of joinIndex on that table
 func getJoinIndexesByTable(
 	ctx *sql.Context,
@@ -733,16 +700,6 @@ func getJoinIndexesByTable(
 	}
 
 	return result
-}
-
-func conjUnhandled(e1 sql.Expression, e2 sql.Expression) sql.Expression {
-	if e2 == nil {
-		return e1
-	}
-	if e1 == nil {
-		return e2
-	}
-	return expression.NewAnd(e1, e2)
 }
 
 // merge merges the indexes with the ones given

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -249,7 +249,7 @@ func getIndexes(
 			// either return a merged index lookup for both values, or for neither. Returning either one leads to incorrect
 			// results.
 			if !canMergeIndexLookups(result, indexes) {
-				return nil, nil
+				continue
 			}
 			result, err = indexesIntersection(ctx, result, indexes)
 			if err != nil {


### PR DESCRIPTION
When building index lookups, do not about when we see non-equality expressions. Instead, continue with the equality subset.

Ex:
```diff
 SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i and pk > 0
-	RightJoin((one_pk.pk = niltable.i) AND (one_pk.pk > 0))
-	 	├─ Table(one_pk)
-		 │   └─ columns: [pk]
-		 └─ Table(niltable)
-		     └─ columns: [i f]
+	Project(one_pk.pk, niltable.i, niltable.f)
+	     └─ RightIndexedJoin((one_pk.pk = niltable.i) AND (one_pk.pk > 0))
+		     ├─ Table(niltable)
+		     │   └─ columns: [i f]
+		     └─ IndexedTableAccess(one_pk)
+		         ├─ index: [one_pk.pk]
+		        └─ columns: [pk]
```