### PR TITLE
Add end-to-end tests for timestamp insertion, and patch the conversion issue

### DIFF
--- a/e2etests/timestamp_test.go
+++ b/e2etests/timestamp_test.go
@@ -38,6 +38,8 @@ func Test_TimestampBindings_CanBeConverted(t *testing.T) {
 	_, err = db.Exec("CREATE TABLE mytable (t TIMESTAMP)")
 	require.NoError(t, err)
 
+	// All we are doing in this test is ensuring that writing a timestamp to the
+	// database does not throw an error.
 	_, err = db.Exec("INSERT INTO mytable (t) VALUES (?)", time.Now())
 	require.NoError(t, err)
 }

--- a/e2etests/timestamp_test.go
+++ b/e2etests/timestamp_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2etests
 
 import (

--- a/e2etests/timestamp_test.go
+++ b/e2etests/timestamp_test.go
@@ -15,19 +15,18 @@
 package e2etests
 
 import (
+	connector "database/sql"
 	"testing"
 	"time"
 
-	connector "database/sql"
-
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_TimestampBindings_CanBeConverted(t *testing.T) {

--- a/e2etests/timestamp_test.go
+++ b/e2etests/timestamp_test.go
@@ -1,0 +1,43 @@
+package e2etests
+
+import (
+	"testing"
+	"time"
+
+	connector "database/sql"
+
+	_ "github.com/go-sql-driver/mysql"
+
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TimestampBindings_CanBeConverted(t *testing.T) {
+	provider := sql.NewDatabaseProvider(
+		memory.NewDatabase("mydb"),
+	)
+	engine := sqle.New(analyzer.NewDefault(provider), &sqle.Config{
+		IncludeRootAccount: true,
+	})
+	cfg := server.Config{
+		Protocol: "tcp",
+		Address:  "localhost:3306",
+	}
+	srv, err := server.NewDefaultServer(cfg, engine)
+	require.NoError(t, err)
+	go srv.Start()
+	defer srv.Close()
+
+	db, err := connector.Open("mysql", "root:@tcp(localhost:3306)/mydb")
+	require.NoError(t, err)
+
+	_, err = db.Exec("CREATE TABLE mytable (t TIMESTAMP)")
+	require.NoError(t, err)
+
+	_, err = db.Exec("INSERT INTO mytable (t) VALUES (?)", time.Now())
+	require.NoError(t, err)
+}

--- a/sql/datetimetype.go
+++ b/sql/datetimetype.go
@@ -211,6 +211,9 @@ func ConvertToTime(v interface{}, t datetimeType) (time.Time, error) {
 func (t datetimeType) ConvertWithoutRangeCheck(v interface{}) (time.Time, error) {
 	var res time.Time
 
+	if bs, ok := v.([]byte); ok {
+		v = string(bs)
+	}
 	switch value := v.(type) {
 	case string:
 		if value == zeroDateStr || value == zeroTimestampDatetimeStr {


### PR DESCRIPTION
# Summary
This PR introduces an `e2etests/` directory with "end to end" tests:
- set up a memory engine
- start the server
- connect using the normal Go mysql driver
- execute queries

This can catch issues that a unit test against the engine itself cannot.

There is only a single test thus far, and it is fairly verbose. I know that there is at least one more issue with timestamps, and I will open a follow-up PR to address that issue as soon as I track down its source. For now I'm opting for clarity rather than code reusability.

Lastly, this PR introduces a little patch to the timestamp conversion logic, which was accidentally broken in https://github.com/dolthub/go-mysql-server/pull/1061 because it only handles `string` but the server layer now passes it `[]byte`. This patch is very dumb and simple: just convert `[]byte` to `string` before parsing.

# Motivation
https://github.com/dolthub/go-mysql-server/issues/1139