### PR TITLE
Stop requiring `order by` clause for range frames that only use unbounded preceding/following and current row

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3851,6 +3851,16 @@ func TestWindowRangeFrames(t *testing.T, harness Harness) {
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by x range between unbounded preceding and unbounded following) FROM a order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by z order by x range between 2 preceding and 1 preceding) FROM a order by x`, []sql.Row{{nil}, {float64(0)}, {float64(1)}, {float64(3)}, {float64(2)}, {float64(1)}}, nil, nil)
 
+	// range framing without an order by clause
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by y range between unbounded preceding and unbounded following) FROM a order by x`,
+		[]sql.Row{{float64(0)}, {float64(2)}, {float64(2)}, {float64(0)}, {float64(2)}, {float64(3)}}, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by y range between unbounded preceding and current row) FROM a order by x`,
+		[]sql.Row{{float64(0)}, {float64(2)}, {float64(2)}, {float64(0)}, {float64(2)}, {float64(3)}}, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by y range between current row and unbounded following) FROM a order by x`,
+		[]sql.Row{{float64(0)}, {float64(2)}, {float64(2)}, {float64(0)}, {float64(2)}, {float64(3)}}, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (partition by y range between current row and current row) FROM a order by x`,
+		[]sql.Row{{float64(0)}, {float64(2)}, {float64(2)}, {float64(0)}, {float64(2)}, {float64(3)}}, nil, nil)
+
 	// fixed frame size, 3 days
 	RunQuery(t, e, harness, "CREATE TABLE b (x INTEGER PRIMARY KEY, y INTEGER, z INTEGER, date DATE)")
 	RunQuery(t, e, harness, "INSERT INTO b VALUES (0,0,0,'2022-01-26'), (1,0,0,'2022-01-27'), (2,0,0, '2022-01-28'), (3,1,0,'2022-01-29'), (4,1,0,'2022-01-30'), (5,3,0,'2022-01-31')")

--- a/optgen/cmd/support/framer_gen.go
+++ b/optgen/cmd/support/framer_gen.go
@@ -77,14 +77,14 @@ func (g *FramerGen) genNewFramer(def frameDef) {
 			(def.end != unboundedFollowing && def.end != endCurrentRow))
 
 	if orderByRequired {
-		fmt.Fprintf(g.w, "  if len(window.OrderBy.ToExpressions()) != 1 {\n")
+		fmt.Fprintf(g.w, "  if len(window.OrderBy) != 1 {\n")
 		fmt.Fprintf(g.w, "    return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))\n")
 		fmt.Fprintf(g.w, "  }\n")
 	}
 
 	if def.unit == rang {
 		fmt.Fprintf(g.w, "  var orderBy sql.Expression\n")
-		fmt.Fprintf(g.w, "  if len(window.OrderBy.ToExpressions()) > 0 {\n")
+		fmt.Fprintf(g.w, "  if len(window.OrderBy) > 0 {\n")
 		fmt.Fprintf(g.w, "    orderBy = window.OrderBy.ToExpressions()[0]\n")
 		fmt.Fprintf(g.w, "  }\n")
 	}

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -402,7 +402,11 @@ func (f *rangeFramerBase) Next(ctx *sql.Context, buf sql.WindowBuffer) (sql.Wind
 	var err error
 	newStart := f.frameStart
 	switch {
-	case newStart < f.partitionStart, f.unboundedPreceding:
+	case newStart < f.partitionStart, f.unboundedPreceding, f.startCurrentRow && f.orderBy == nil:
+		// Start the frame at the partition start for unbounded preceding, or for current row when no order by clause
+		// has been specified. From the MySQL docs, when an order by clause is not specified with range framing, the
+		// default frame includes all rows, since all rows in the current partition are peers when no order has been
+		// specified.
 		newStart = f.partitionStart
 	default:
 		newStart, err = findInclusionBoundary(ctx, f.idx, newStart, f.partitionEnd, f.startInclusion, f.orderBy, buf, greaterThanOrEqual)
@@ -416,7 +420,7 @@ func (f *rangeFramerBase) Next(ctx *sql.Context, buf sql.WindowBuffer) (sql.Wind
 		newEnd = newStart
 	}
 	switch {
-	case newEnd > f.partitionEnd, f.unboundedFollowing:
+	case newEnd > f.partitionEnd, f.unboundedFollowing, f.endCurrentRow && f.orderBy == nil:
 		newEnd = f.partitionEnd
 	default:
 		newEnd, err = findInclusionBoundary(ctx, f.idx, newEnd, f.partitionEnd, f.endInclusion, f.orderBy, buf, greaterThan)

--- a/sql/expression/function/aggregation/window_framer.og.go
+++ b/sql/expression/function/aggregation/window_framer.og.go
@@ -336,13 +336,16 @@ var _ sql.WindowFramer = (*RangeUnboundedPrecedingToNPrecedingFramer)(nil)
 func NewRangeUnboundedPrecedingToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	unboundedPreceding := true
 	endNPreceding := frame.EndNPreceding()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToNPrecedingFramer{
 		rangeFramerBase{
-			orderBy:            exprs[0],
+			orderBy:            orderBy,
 			unboundedPreceding: unboundedPreceding,
 			endNPreceding:      endNPreceding,
 		},
@@ -358,13 +361,13 @@ var _ sql.WindowFramer = (*RangeUnboundedPrecedingToCurrentRowFramer)(nil)
 func NewRangeUnboundedPrecedingToCurrentRowFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	unboundedPreceding := true
 	endCurrentRow := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToCurrentRowFramer{
 		rangeFramerBase{
-			orderBy:            exprs[0],
+			orderBy:            orderBy,
 			unboundedPreceding: unboundedPreceding,
 			endCurrentRow:      endCurrentRow,
 		},
@@ -380,13 +383,16 @@ var _ sql.WindowFramer = (*RangeUnboundedPrecedingToNFollowingFramer)(nil)
 func NewRangeUnboundedPrecedingToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	unboundedPreceding := true
 	endNFollowing := frame.EndNFollowing()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToNFollowingFramer{
 		rangeFramerBase{
-			orderBy:            exprs[0],
+			orderBy:            orderBy,
 			unboundedPreceding: unboundedPreceding,
 			endNFollowing:      endNFollowing,
 		},
@@ -402,13 +408,13 @@ var _ sql.WindowFramer = (*RangeUnboundedPrecedingToUnboundedFollowingFramer)(ni
 func NewRangeUnboundedPrecedingToUnboundedFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	unboundedPreceding := true
 	unboundedFollowing := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToUnboundedFollowingFramer{
 		rangeFramerBase{
-			orderBy:            exprs[0],
+			orderBy:            orderBy,
 			unboundedPreceding: unboundedPreceding,
 			unboundedFollowing: unboundedFollowing,
 		},
@@ -424,13 +430,16 @@ var _ sql.WindowFramer = (*RangeNPrecedingToNPrecedingFramer)(nil)
 func NewRangeNPrecedingToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	endNPreceding := frame.EndNPreceding()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToNPrecedingFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startNPreceding: startNPreceding,
 			endNPreceding:   endNPreceding,
 		},
@@ -446,13 +455,16 @@ var _ sql.WindowFramer = (*RangeNPrecedingToCurrentRowFramer)(nil)
 func NewRangeNPrecedingToCurrentRowFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	endCurrentRow := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToCurrentRowFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startNPreceding: startNPreceding,
 			endCurrentRow:   endCurrentRow,
 		},
@@ -468,13 +480,16 @@ var _ sql.WindowFramer = (*RangeNPrecedingToNFollowingFramer)(nil)
 func NewRangeNPrecedingToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	endNFollowing := frame.EndNFollowing()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToNFollowingFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startNPreceding: startNPreceding,
 			endNFollowing:   endNFollowing,
 		},
@@ -490,13 +505,16 @@ var _ sql.WindowFramer = (*RangeNPrecedingToUnboundedFollowingFramer)(nil)
 func NewRangeNPrecedingToUnboundedFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	unboundedFollowing := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToUnboundedFollowingFramer{
 		rangeFramerBase{
-			orderBy:            exprs[0],
+			orderBy:            orderBy,
 			startNPreceding:    startNPreceding,
 			unboundedFollowing: unboundedFollowing,
 		},
@@ -512,13 +530,16 @@ var _ sql.WindowFramer = (*RangeCurrentRowToNPrecedingFramer)(nil)
 func NewRangeCurrentRowToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startCurrentRow := true
 	endNPreceding := frame.EndNPreceding()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToNPrecedingFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startCurrentRow: startCurrentRow,
 			endNPreceding:   endNPreceding,
 		},
@@ -534,13 +555,13 @@ var _ sql.WindowFramer = (*RangeCurrentRowToCurrentRowFramer)(nil)
 func NewRangeCurrentRowToCurrentRowFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startCurrentRow := true
 	endCurrentRow := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToCurrentRowFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startCurrentRow: startCurrentRow,
 			endCurrentRow:   endCurrentRow,
 		},
@@ -556,13 +577,16 @@ var _ sql.WindowFramer = (*RangeCurrentRowToNFollowingFramer)(nil)
 func NewRangeCurrentRowToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startCurrentRow := true
 	endNFollowing := frame.EndNFollowing()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToNFollowingFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startCurrentRow: startCurrentRow,
 			endNFollowing:   endNFollowing,
 		},
@@ -578,13 +602,13 @@ var _ sql.WindowFramer = (*RangeCurrentRowToUnboundedFollowingFramer)(nil)
 func NewRangeCurrentRowToUnboundedFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startCurrentRow := true
 	unboundedFollowing := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToUnboundedFollowingFramer{
 		rangeFramerBase{
-			orderBy:            exprs[0],
+			orderBy:            orderBy,
 			startCurrentRow:    startCurrentRow,
 			unboundedFollowing: unboundedFollowing,
 		},
@@ -600,13 +624,16 @@ var _ sql.WindowFramer = (*RangeNFollowingToNPrecedingFramer)(nil)
 func NewRangeNFollowingToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	endNPreceding := frame.EndNPreceding()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToNPrecedingFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startNFollowing: startNFollowing,
 			endNPreceding:   endNPreceding,
 		},
@@ -622,13 +649,16 @@ var _ sql.WindowFramer = (*RangeNFollowingToCurrentRowFramer)(nil)
 func NewRangeNFollowingToCurrentRowFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	endCurrentRow := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToCurrentRowFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startNFollowing: startNFollowing,
 			endCurrentRow:   endCurrentRow,
 		},
@@ -644,13 +674,16 @@ var _ sql.WindowFramer = (*RangeNFollowingToNFollowingFramer)(nil)
 func NewRangeNFollowingToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	endNFollowing := frame.EndNFollowing()
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToNFollowingFramer{
 		rangeFramerBase{
-			orderBy:         exprs[0],
+			orderBy:         orderBy,
 			startNFollowing: startNFollowing,
 			endNFollowing:   endNFollowing,
 		},
@@ -666,13 +699,16 @@ var _ sql.WindowFramer = (*RangeNFollowingToUnboundedFollowingFramer)(nil)
 func NewRangeNFollowingToUnboundedFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	unboundedFollowing := true
-	exprs := window.OrderBy.ToExpressions()
-	if len(exprs) != 1 {
-		return nil, ErrRangeInvalidOrderBy.New(len(exprs))
+	if len(window.OrderBy.ToExpressions()) != 1 {
+		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
+	}
+	var orderBy sql.Expression
+	if len(window.OrderBy.ToExpressions()) > 0 {
+		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToUnboundedFollowingFramer{
 		rangeFramerBase{
-			orderBy:            exprs[0],
+			orderBy:            orderBy,
 			startNFollowing:    startNFollowing,
 			unboundedFollowing: unboundedFollowing,
 		},

--- a/sql/expression/function/aggregation/window_framer.og.go
+++ b/sql/expression/function/aggregation/window_framer.og.go
@@ -336,11 +336,11 @@ var _ sql.WindowFramer = (*RangeUnboundedPrecedingToNPrecedingFramer)(nil)
 func NewRangeUnboundedPrecedingToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	unboundedPreceding := true
 	endNPreceding := frame.EndNPreceding()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToNPrecedingFramer{
@@ -362,7 +362,7 @@ func NewRangeUnboundedPrecedingToCurrentRowFramer(frame sql.WindowFrame, window 
 	unboundedPreceding := true
 	endCurrentRow := true
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToCurrentRowFramer{
@@ -383,11 +383,11 @@ var _ sql.WindowFramer = (*RangeUnboundedPrecedingToNFollowingFramer)(nil)
 func NewRangeUnboundedPrecedingToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	unboundedPreceding := true
 	endNFollowing := frame.EndNFollowing()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToNFollowingFramer{
@@ -409,7 +409,7 @@ func NewRangeUnboundedPrecedingToUnboundedFollowingFramer(frame sql.WindowFrame,
 	unboundedPreceding := true
 	unboundedFollowing := true
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeUnboundedPrecedingToUnboundedFollowingFramer{
@@ -430,11 +430,11 @@ var _ sql.WindowFramer = (*RangeNPrecedingToNPrecedingFramer)(nil)
 func NewRangeNPrecedingToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	endNPreceding := frame.EndNPreceding()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToNPrecedingFramer{
@@ -455,11 +455,11 @@ var _ sql.WindowFramer = (*RangeNPrecedingToCurrentRowFramer)(nil)
 func NewRangeNPrecedingToCurrentRowFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	endCurrentRow := true
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToCurrentRowFramer{
@@ -480,11 +480,11 @@ var _ sql.WindowFramer = (*RangeNPrecedingToNFollowingFramer)(nil)
 func NewRangeNPrecedingToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	endNFollowing := frame.EndNFollowing()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToNFollowingFramer{
@@ -505,11 +505,11 @@ var _ sql.WindowFramer = (*RangeNPrecedingToUnboundedFollowingFramer)(nil)
 func NewRangeNPrecedingToUnboundedFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNPreceding := frame.StartNPreceding()
 	unboundedFollowing := true
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNPrecedingToUnboundedFollowingFramer{
@@ -530,11 +530,11 @@ var _ sql.WindowFramer = (*RangeCurrentRowToNPrecedingFramer)(nil)
 func NewRangeCurrentRowToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startCurrentRow := true
 	endNPreceding := frame.EndNPreceding()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToNPrecedingFramer{
@@ -556,7 +556,7 @@ func NewRangeCurrentRowToCurrentRowFramer(frame sql.WindowFrame, window *sql.Win
 	startCurrentRow := true
 	endCurrentRow := true
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToCurrentRowFramer{
@@ -577,11 +577,11 @@ var _ sql.WindowFramer = (*RangeCurrentRowToNFollowingFramer)(nil)
 func NewRangeCurrentRowToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startCurrentRow := true
 	endNFollowing := frame.EndNFollowing()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToNFollowingFramer{
@@ -603,7 +603,7 @@ func NewRangeCurrentRowToUnboundedFollowingFramer(frame sql.WindowFrame, window 
 	startCurrentRow := true
 	unboundedFollowing := true
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeCurrentRowToUnboundedFollowingFramer{
@@ -624,11 +624,11 @@ var _ sql.WindowFramer = (*RangeNFollowingToNPrecedingFramer)(nil)
 func NewRangeNFollowingToNPrecedingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	endNPreceding := frame.EndNPreceding()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToNPrecedingFramer{
@@ -649,11 +649,11 @@ var _ sql.WindowFramer = (*RangeNFollowingToCurrentRowFramer)(nil)
 func NewRangeNFollowingToCurrentRowFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	endCurrentRow := true
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToCurrentRowFramer{
@@ -674,11 +674,11 @@ var _ sql.WindowFramer = (*RangeNFollowingToNFollowingFramer)(nil)
 func NewRangeNFollowingToNFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	endNFollowing := frame.EndNFollowing()
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToNFollowingFramer{
@@ -699,11 +699,11 @@ var _ sql.WindowFramer = (*RangeNFollowingToUnboundedFollowingFramer)(nil)
 func NewRangeNFollowingToUnboundedFollowingFramer(frame sql.WindowFrame, window *sql.WindowDefinition) (sql.WindowFramer, error) {
 	startNFollowing := frame.StartNFollowing()
 	unboundedFollowing := true
-	if len(window.OrderBy.ToExpressions()) != 1 {
+	if len(window.OrderBy) != 1 {
 		return nil, ErrRangeInvalidOrderBy.New(len(window.OrderBy.ToExpressions()))
 	}
 	var orderBy sql.Expression
-	if len(window.OrderBy.ToExpressions()) > 0 {
+	if len(window.OrderBy) > 0 {
 		orderBy = window.OrderBy.ToExpressions()[0]
 	}
 	return &RangeNFollowingToUnboundedFollowingFramer{


### PR DESCRIPTION
We were requiring the `order by` clause for all range frame queries, but it is optional when the frame only uses `unbounded preceding/following` and `current row`. 

Fixes: https://github.com/dolthub/dolt/issues/4141