### PR TITLE
Fix timestamp comparisons and add regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ _example/*.exe
 test-server
 
 .idea/*
+/.vscode/
 
 # OSX Files
 .DS_Store

--- a/e2etests/timestamp_test.go
+++ b/e2etests/timestamp_test.go
@@ -43,7 +43,6 @@ func Test_TimestampBindings_CanBeConverted(t *testing.T) {
 }
 
 func Test_TimestampBindings_CanBeCompared(t *testing.T) {
-	t.Skip("https://github.com/dolthub/go-mysql-server/issues/1139")
 	db, close := newDatabase()
 	defer close()
 

--- a/e2etests/timestamp_test.go
+++ b/e2etests/timestamp_test.go
@@ -30,13 +30,14 @@ func Test_TimestampBindings_CanBeConverted(t *testing.T) {
 }
 
 func Test_TimestampBindings_CanBeCompared(t *testing.T) {
+	t.Skip("https://github.com/dolthub/go-mysql-server/issues/1139")
 	db, close := newDatabase()
 	defer close()
 
 	_, err := db.Exec("CREATE TABLE mytable (t TIMESTAMP)")
 	require.NoError(t, err)
 
-	// We'll insert both of these
+	// We'll insert both of these timestamps and then try and filter them.
 	t0 := time.Date(2022, 01, 01, 0, 0, 0, 0, time.UTC)
 	t1 := t0.Add(1 * time.Minute)
 

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -153,6 +153,15 @@ func (c *comparison) castLeftAndRight(left, right interface{}) (interface{}, int
 		return left, right, c.Left().Type(), nil
 	}
 
+	if sql.IsTime(leftType) || sql.IsTime(rightType) {
+		l, r, err := convertLeftAndRight(left, right, ConvertToDatetime)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		return l, r, sql.Datetime, nil
+	}
+
 	if sql.IsBinaryType(leftType) || sql.IsBinaryType(rightType) {
 		l, r, err := convertLeftAndRight(left, right, ConvertToBinary)
 		if err != nil {
@@ -200,15 +209,6 @@ func (c *comparison) castLeftAndRight(left, right interface{}) (interface{}, int
 		}
 
 		return l, r, sql.Uint64, nil
-	}
-
-	if sql.IsTime(leftType) || sql.IsTime(rightType) {
-		l, r, err := convertLeftAndRight(left, right, ConvertToDatetime)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		return l, r, sql.Datetime, nil
 	}
 
 	left, right, err := convertLeftAndRight(left, right, ConvertToChar)

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -174,7 +174,8 @@ func convertValue(val interface{}, castTo string, originType sql.Type) (interfac
 	case ConvertToDate:
 		_, isTime := val.(time.Time)
 		_, isString := val.(string)
-		if !(isTime || isString) {
+		_, isBinary := val.([]byte)
+		if !(isTime || isString || isBinary) {
 			return nil, nil
 		}
 		d, err := sql.Date.Convert(val)
@@ -185,7 +186,8 @@ func convertValue(val interface{}, castTo string, originType sql.Type) (interfac
 	case ConvertToDatetime:
 		_, isTime := val.(time.Time)
 		_, isString := val.(string)
-		if !(isTime || isString) {
+		_, isBinary := val.([]byte)
+		if !(isTime || isString || isBinary) {
 			return nil, nil
 		}
 		d, err := sql.Datetime.Convert(val)


### PR DESCRIPTION
# Summary
This PR fixes another regression introduced by #1061. That PR altered the way that timestamps are represented internally (they went from `string` to `[]byte`) without updating all of the locations where the previous representation was assumed.

The particular regression this PR fixes deals with timestamp comparisons. A test like
```
CREATE TABLE mytable (t TIMESTAMP);
INSERT INTO mytable (t) VALUES ('1990-01-01'), ('2020-01-01');
SELECT COUNT(1) FROM mytable WHERE t > '2000-01-01';
```
should return `1`, but today it returns `2`.

The core issue is that the filter (e.g., `WHERE t > '2000-01-01'`) needs to compare timestamps. That comparison logic has type coercion, but the type coercion only knows how to coerce a _string_ into a timestamp, and it is now being handed a `[]byte`.

The fix here is two-fold:
1. increase the priority of timestamp type coercion so that it takes precedence over binary coercion
2. ensure that the `convertValue` function correctly converts `[]byte` into timestamps (and dates)

# Motivation
https://github.com/dolthub/go-mysql-server/issues/1139

This is not strictly speaking the same issue, but something wonky is going on with timestamps and I'd like to get to the bottom of it, and then fix it "for good".