### PR TITLE
Handle IN expressions with NULL values for string typed columns

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1667,6 +1667,18 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{false}},
 	},
 	{
+		Query:    "SELECT * FROM stringandtable WHERE v IN (NULL)",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT * FROM stringandtable WHERE v IS NULL",
+		Expected: []sql.Row{{int64(5), int64(5), nil}},
+	},
+	{
+		Query:    "SELECT * FROM stringandtable WHERE v IN ('')",
+		Expected: []sql.Row{{int64(2), int64(2), ""}},
+	},
+	{
 		Query:    "SELECT 1 FROM DUAL WHERE 1 IN (SELECT '1' FROM DUAL)",
 		Expected: []sql.Row{{1}},
 	},

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -198,6 +198,10 @@ func newInMap(ctx *sql.Context, right Tuple, lType sql.Type) (map[uint64]sql.Exp
 }
 
 func hashOfSimple(i interface{}, t sql.Type) (uint64, error) {
+	if i == nil {
+		return 0, nil
+	}
+
 	// Collated strings that are equivalent may have different runes, so we must make them hash to the same value
 	if sql.IsTextOnly(t) {
 		if str, ok := i.(string); ok {


### PR DESCRIPTION
fixes string assertion panic [here](https://github.com/dolthub/go-mysql-server/blob/main/sql/expression/in.go#L210)