### PR TITLE
fix str_to_date to returns time or date or datetime type results

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7375,24 +7375,75 @@ var VersionedScripts = []ScriptTest{
 var DateParseQueries = []QueryTest{
 	{
 		Query:    "SELECT STR_TO_DATE('Jan 3, 2000', '%b %e, %Y')",
-		Expected: []sql.Row{{time.Date(2000, time.January, 3, 0, 0, 0, 0, time.Local)}},
+		Expected: []sql.Row{{"2000-01-03"}},
 	},
 	{
-		Query:    "SELECT STR_TO_DATE('May 3, 10:23:00 PM 2000', '%b %e, %H:%i:%s %p %Y')",
-		Expected: []sql.Row{{time.Date(2000, time.May, 3, 22, 23, 0, 0, time.Local)}},
+		Query:    "SELECT STR_TO_DATE('01,5,2013', '%d,%m,%Y')",
+		Expected: []sql.Row{{"2013-05-01"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('May 1, 2013','%M %d,%Y')",
+		Expected: []sql.Row{{"2013-05-01"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('a09:30:17','a%h:%i:%s')",
+		Expected: []sql.Row{{"09:30:17"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('a09:30:17','%h:%i:%s')",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('09:30:17a','%h:%i:%s')",
+		Expected: []sql.Row{{"09:30:17"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('09:30:17 pm','%h:%i:%s %p')",
+		Expected: []sql.Row{{"21:30:17"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('9','%m')",
+		Expected: []sql.Row{{"0000-09-00"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('9','%s')",
+		Expected: []sql.Row{{"00:00:09"}},
 	},
 	{
 		Query:    "SELECT STR_TO_DATE('01/02/99 314', '%m/%e/%y %f')",
-		Expected: []sql.Row{{time.Date(1999, time.January, 2, 0, 0, 0, 314000, time.Local)}},
+		Expected: []sql.Row{{"1999-01-02 00:00:00.314000"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('01/02/99 0', '%m/%e/%y %f')",
+		Expected: []sql.Row{{"1999-01-02 00:00:00.000000"}},
 	},
 	{
 		Query:    "SELECT STR_TO_DATE('01/02/99 05:14:12 PM', '%m/%e/%y %r')",
-		Expected: []sql.Row{{time.Date(1999, time.January, 2, 17, 14, 12, 0, time.Local)}},
+		Expected: []sql.Row{{"1999-01-02 17:14:12"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('May 3, 10:23:00 2000', '%b %e, %H:%i:%s %Y')",
+		Expected: []sql.Row{{"2000-05-03 10:23:00"}},
+	},
+	{
+		// returns null for mysql
+		Query: "SELECT STR_TO_DATE('May 3, 10:23:00 PM 2000', '%b %e, %H:%i:%s %p %Y')",
+		//Expected: []sql.Row{{nil}},
+		Expected: []sql.Row{{"2000-05-03 22:23:00"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('abc','abc')",
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT STR_TO_DATE('invalid', 'notvalid')",
 		Expected: []sql.Row{{nil}},
 	},
+	// Parsers for u, U, v, V, w, W, x and X are not supported yet.
+	//{
+	//	Query:    "STR_TO_DATE('2013 32 Tuesday', '%X %V %W')", // Tuesday of 32th week
+	//	Expected: []sql.Row{{"2013-08-13"}},
+	//},
 }
 
 var InfoSchemaQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7426,10 +7426,12 @@ var DateParseQueries = []QueryTest{
 		Expected: []sql.Row{{"2000-05-03 10:23:00"}},
 	},
 	{
-		// returns null for mysql
-		Query: "SELECT STR_TO_DATE('May 3, 10:23:00 PM 2000', '%b %e, %H:%i:%s %p %Y')",
-		//Expected: []sql.Row{{nil}},
+		Query:    "SELECT STR_TO_DATE('May 3, 10:23:00 PM 2000', '%b %e, %h:%i:%s %p %Y')",
 		Expected: []sql.Row{{"2000-05-03 22:23:00"}},
+	},
+	{
+		Query:    "SELECT STR_TO_DATE('May 3, 10:23:00 PM 2000', '%b %e, %H:%i:%s %p %Y')", // cannot use 24 hour time (%H) with AM/PM (%p)
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "SELECT STR_TO_DATE('abc','abc')",

--- a/sql/expression/function/str_to_date.go
+++ b/sql/expression/function/str_to_date.go
@@ -12,48 +12,48 @@ func NewStrToDate(args ...sql.Expression) (sql.Expression, error) {
 	if len(args) != 2 {
 		return nil, sql.ErrInvalidArgumentNumber.New("STR_TO_DATE", 2, len(args))
 	}
-	return &StringToDatetime{
+	return &StrToDate{
 		Date:   args[0],
 		Format: args[1],
 	}, nil
 }
 
-// StringToDatetime defines the built-in function STR_TO_DATE(str, format)
-type StringToDatetime struct {
+// StrToDate defines the built-in function STR_TO_DATE(str, format)
+type StrToDate struct {
 	Date   sql.Expression
 	Format sql.Expression
 }
 
-var _ sql.FunctionExpression = (*StringToDatetime)(nil)
+var _ sql.FunctionExpression = (*StrToDate)(nil)
 
 // Description implements sql.FunctionExpression
-func (s StringToDatetime) Description() string {
+func (s StrToDate) Description() string {
 	return "parses the date/datetime/timestamp expression according to the format specifier."
 }
 
 // Resolved returns whether the node is resolved.
-func (s StringToDatetime) Resolved() bool {
+func (s StrToDate) Resolved() bool {
 	dateResolved := s.Date == nil || s.Date.Resolved()
 	formatResolved := s.Format == nil || s.Format.Resolved()
 	return dateResolved && formatResolved
 }
 
-func (s StringToDatetime) String() string {
+func (s StrToDate) String() string {
 	return fmt.Sprintf("STR_TO_DATE(%s, %s)", s.Date, s.Format)
 }
 
 // Type returns the expression type.
-func (s StringToDatetime) Type() sql.Type {
+func (s StrToDate) Type() sql.Type {
 	return sql.Datetime
 }
 
 // IsNullable returns whether the expression can be null.
-func (s StringToDatetime) IsNullable() bool {
+func (s StrToDate) IsNullable() bool {
 	return true
 }
 
 // Eval evaluates the given row and returns a result.
-func (s StringToDatetime) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+func (s StrToDate) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	date, err := s.Date.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -62,6 +62,7 @@ func (s StringToDatetime) Eval(ctx *sql.Context, row sql.Row) (interface{}, erro
 	if err != nil {
 		return nil, err
 	}
+
 	dateStr, ok := date.(string)
 	if !ok {
 		// TODO: improve this error
@@ -72,15 +73,19 @@ func (s StringToDatetime) Eval(ctx *sql.Context, row sql.Row) (interface{}, erro
 		// TODO: improve this error
 		return nil, sql.ErrInvalidType.New(fmt.Sprintf("%T", formatStr))
 	}
+
 	goTime, err := dateparse.ParseDateWithFormat(dateStr, formatStr)
 	if err != nil {
 		return nil, nil
 	}
+
+	// zero dates '0000-00-00' and '2010-00-13' are allowed,
+	// but depends on strict sql_mode with NO_ZERO_DATE or NO_ZERO_IN_DATE modes enabled.
 	return goTime, nil
 }
 
 // Children returns the children expressions of this expression.
-func (s StringToDatetime) Children() []sql.Expression {
+func (s StrToDate) Children() []sql.Expression {
 	children := make([]sql.Expression, 0, 2)
 	if s.Date != nil {
 		children = append(children, s.Date)
@@ -91,10 +96,10 @@ func (s StringToDatetime) Children() []sql.Expression {
 	return children
 }
 
-func (s StringToDatetime) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+func (s StrToDate) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return NewStrToDate(children...)
 }
 
-func (s StringToDatetime) FunctionName() string {
+func (s StrToDate) FunctionName() string {
 	return "str_to_date"
 }

--- a/sql/expression/function/str_to_date.go
+++ b/sql/expression/function/str_to_date.go
@@ -76,6 +76,7 @@ func (s StrToDate) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	goTime, err := dateparse.ParseDateWithFormat(dateStr, formatStr)
 	if err != nil {
+		ctx.Warn(1411, fmt.Sprintf("Incorrect value: '%s' for function %s", dateStr, s.FunctionName()))
 		return nil, nil
 	}
 

--- a/sql/expression/function/str_to_date_test.go
+++ b/sql/expression/function/str_to_date_test.go
@@ -19,7 +19,7 @@ func TestStrToDate(t *testing.T) {
 		fmtStr   string
 		expected string
 	}{
-		{"standard", "Dec 26, 2000 2:13:15", "%b %e, %Y %T", "2000-12-26 02:13:15 -0600 CST"},
+		{"standard", "Dec 26, 2000 2:13:15", "%b %e, %Y %T", "2000-12-26 02:13:15"},
 	}
 
 	for _, tt := range testCases {
@@ -32,7 +32,7 @@ func TestStrToDate(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			dtime := eval(t, f, sql.NewRow(tt.dateStr, tt.fmtStr))
-			require.Equal(t, tt.expected, dtime.(time.Time).String())
+			require.Equal(t, tt.expected, dtime)
 		})
 		req := require.New(t)
 		req.True(f.IsNullable())

--- a/sql/parse/dateparse/date.go
+++ b/sql/parse/dateparse/date.go
@@ -41,10 +41,10 @@ func ParseDateWithFormat(date, format string) (interface{}, error) {
 	for _, parser := range parsers {
 		target = takeAllSpaces(target)
 		rest, isTime, err := parser(&result, target)
-		types[isTime] = true
 		if err != nil {
-			return time.Time{}, err
+			return nil, err
 		}
+		types[isTime] = true
 		target = rest
 	}
 
@@ -56,7 +56,7 @@ func ParseDateWithFormat(date, format string) (interface{}, error) {
 	} else if types[Date] {
 		outType = DateOnly
 	} else {
-		return nil, err
+		return nil, fmt.Errorf("no value to evaluate")
 	}
 
 	return evaluate(result, outType)

--- a/sql/parse/dateparse/date_test.go
+++ b/sql/parse/dateparse/date_test.go
@@ -32,7 +32,14 @@ func TestParseDate(t *testing.T) {
 
 		{"time_only", "22:23:00", "%H:%i:%s", "22:23:00"},
 		{"with_time", "Sep 3, 22:23:00 2000", "%b %e, %H:%i:%s %Y", "2000-09-03 22:23:00"},
+		{"with_pm", "May 3, 10:23:00 PM 2000", "%b %e, %h:%i:%s %p %Y", "2000-05-03 22:23:00"},
+		{"lowercase_pm", "Jul 3, 10:23:00 pm 2000", "%b %e, %h:%i:%s %p %Y", "2000-07-03 22:23:00"},
+		{"with_am", "Mar 3, 10:23:00 am 2000", "%b %e, %h:%i:%s %p %Y", "2000-03-03 10:23:00"},
 
+		{"month_number", "1 3, 10:23:00 pm 2000", "%c %e, %h:%i:%s %p %Y", "2000-01-03 22:23:00"},
+
+		{"day_with_suffix", "Jun 3rd, 10:23:00 pm 2000", "%b %D, %h:%i:%s %p %Y", "2000-06-03 22:23:00"},
+		{"day_with_suffix_2", "Oct 21st, 10:23:00 pm 2000", "%b %D, %h:%i:%s %p %Y", "2000-10-21 22:23:00"},
 		{"with_timestamp", "01/02/2003, 12:13:14", "%c/%d/%Y, %T", "2003-01-02 12:13:14"},
 
 		{"month_number", "03: 3, 20", "%m: %e, %y", "2020-03-03"},
@@ -50,16 +57,6 @@ func TestParseDate(t *testing.T) {
 
 		{"date_by_year_offset", "100 20", "%j %y", "2020-04-09"},
 		{"date_by_year_offset_singledigit_year", "100 5", "%j %y", "2005-04-10"},
-
-		// should be null
-		{"with_pm", "May 3, 10:23:00 PM 2000", "%b %e, %H:%i:%s %p %Y", "2000-05-03 22:23:00"},
-		{"lowercase_pm", "Jul 3, 10:23:00 pm 2000", "%b %e, %H:%i:%s %p %Y", "2000-07-03 22:23:00"},
-		{"with_am", "Mar 3, 10:23:00 am 2000", "%b %e, %H:%i:%s %p %Y", "2000-03-03 10:23:00"},
-
-		{"month_number", "1 3, 10:23:00 pm 2000", "%c %e, %H:%i:%s %p %Y", "2000-01-03 22:23:00"},
-
-		{"day_with_suffix", "Jun 3rd, 10:23:00 pm 2000", "%b %D, %H:%i:%s %p %Y", "2000-06-03 22:23:00"},
-		{"day_with_suffix_2", "Oct 21st, 10:23:00 pm 2000", "%b %D, %H:%i:%s %p %Y", "2000-10-21 22:23:00"},
 	}
 
 	for _, tt := range tests {
@@ -94,6 +91,7 @@ func TestConversionFailure(t *testing.T) {
 		{"no_day", "Jan 2000", "%b %y", "2020-01-00", ""},
 		{"day_of_month_and_day_of_year", "Jan 3, 100 2000", "%b %e, %j %y", "2020-04-09", ""},
 
+		{"24hour_time_with_pm", "May 3, 10:23:00 PM 2000", "%b %e, %H:%i:%s %p %Y", nil, "cannot use 24 hour time (H) with AM/PM (p)"},
 		{"specifier_end_of_line", "Jan 3", "%b %e %", nil, `"%" found at end of format string`},
 		{"unknown_format_specifier", "Jan 3", "%b %e %L", nil, `unknown format specifier "L"`},
 		{"invalid_number_hour", "0021:12:14", "%T", nil, `specifier %T failed to parse "0021:12:14": expected literal ":", got "2"`},

--- a/sql/parse/dateparse/date_test.go
+++ b/sql/parse/dateparse/date_test.go
@@ -17,53 +17,56 @@ func TestParseDate(t *testing.T) {
 		format   string
 		expected string
 	}{
-		{"simple", "Jan 3, 2000", "%b %e, %Y", "2000-01-03 00:00:00 -0600 CST"},
-		{"simple_with_spaces", "Nov  03 ,   2000", "%b %e, %Y", "2000-11-03 00:00:00 -0600 CST"},
-		{"simple_with_spaces_2", "Dec  15 ,   2000", "%b %e, %Y", "2000-12-15 00:00:00 -0600 CST"},
-		{"reverse", "2023/Feb/ 1", "%Y/%b/%e", "2023-02-01 00:00:00 -0600 CST"},
-		{"reverse_with_spaces", " 2023 /Apr/ 01  ", "%Y/%b/%e", "2023-04-01 00:00:00 -0500 CDT"},
-		{"weekday", "Thu, Aug 5, 2021", "%a, %b %e, %Y", "2021-08-05 00:00:00 -0500 CDT"},
-		{"weekday", "Fri, Aug 6, 2021", "%a, %b %e, %Y", "2021-08-06 00:00:00 -0500 CDT"},
-		{"weekday", "Sat, Aug 7, 2021", "%a, %b %e, %Y", "2021-08-07 00:00:00 -0500 CDT"},
-		{"weekday", "Sun, Aug 8, 2021", "%a, %b %e, %Y", "2021-08-08 00:00:00 -0500 CDT"},
-		{"weekday", "Mon, Aug 9, 2021", "%a, %b %e, %Y", "2021-08-09 00:00:00 -0500 CDT"},
-		{"weekday", "Tue, Aug 10, 2021", "%a, %b %e, %Y", "2021-08-10 00:00:00 -0500 CDT"},
-		{"weekday", "Wed, Aug 11, 2021", "%a, %b %e, %Y", "2021-08-11 00:00:00 -0500 CDT"},
+		{"simple", "Jan 3, 2000", "%b %e, %Y", "2000-01-03"},
+		{"simple_with_spaces", "Nov  03 ,   2000", "%b %e, %Y", "2000-11-03"},
+		{"simple_with_spaces_2", "Dec  15 ,   2000", "%b %e, %Y", "2000-12-15"},
+		{"reverse", "2023/Feb/ 1", "%Y/%b/%e", "2023-02-01"},
+		{"reverse_with_spaces", " 2023 /Apr/ 01  ", "%Y/%b/%e", "2023-04-01"},
+		{"weekday", "Thu, Aug 5, 2021", "%a, %b %e, %Y", "2021-08-05"},
+		{"weekday", "Fri, Aug 6, 2021", "%a, %b %e, %Y", "2021-08-06"},
+		{"weekday", "Sat, Aug 7, 2021", "%a, %b %e, %Y", "2021-08-07"},
+		{"weekday", "Sun, Aug 8, 2021", "%a, %b %e, %Y", "2021-08-08"},
+		{"weekday", "Mon, Aug 9, 2021", "%a, %b %e, %Y", "2021-08-09"},
+		{"weekday", "Tue, Aug 10, 2021", "%a, %b %e, %Y", "2021-08-10"},
+		{"weekday", "Wed, Aug 11, 2021", "%a, %b %e, %Y", "2021-08-11"},
 
-		{"time_only", "22:23:00", "%H:%i:%s", "0001-01-01 22:23:00 +0000 UTC"},
-		{"with_time", "Sep 3, 22:23:00 2000", "%b %e, %H:%i:%s %Y", "2000-09-03 22:23:00 -0500 CDT"},
-		{"with_pm", "May 3, 10:23:00 PM 2000", "%b %e, %H:%i:%s %p %Y", "2000-05-03 22:23:00 -0500 CDT"},
-		{"lowercase_pm", "Jul 3, 10:23:00 pm 2000", "%b %e, %H:%i:%s %p %Y", "2000-07-03 22:23:00 -0500 CDT"},
-		{"with_am", "Mar 3, 10:23:00 am 2000", "%b %e, %H:%i:%s %p %Y", "2000-03-03 10:23:00 -0600 CST"},
+		{"time_only", "22:23:00", "%H:%i:%s", "22:23:00"},
+		{"with_time", "Sep 3, 22:23:00 2000", "%b %e, %H:%i:%s %Y", "2000-09-03 22:23:00"},
 
-		{"month_number", "1 3, 10:23:00 pm 2000", "%c %e, %H:%i:%s %p %Y", "2000-01-03 22:23:00 -0600 CST"},
+		{"with_timestamp", "01/02/2003, 12:13:14", "%c/%d/%Y, %T", "2003-01-02 12:13:14"},
 
-		{"day_with_suffix", "Jun 3rd, 10:23:00 pm 2000", "%b %D, %H:%i:%s %p %Y", "2000-06-03 22:23:00 -0500 CDT"},
-		{"day_with_suffix_2", "Oct 21st, 10:23:00 pm 2000", "%b %D, %H:%i:%s %p %Y", "2000-10-21 22:23:00 -0500 CDT"},
-		{"with_timestamp", "01/02/2003, 12:13:14", "%c/%d/%Y, %T", "2003-01-02 12:13:14 -0600 CST"},
+		{"month_number", "03: 3, 20", "%m: %e, %y", "2020-03-03"},
+		{"month_name", "march: 3, 20", "%M: %e, %y", "2020-03-03"},
+		{"two_digit_date", "january: 3, 20", "%M: %e, %y", "2020-01-03"},
+		{"two_digit_date_2000", "september: 3, 70", "%M: %e, %y", "1970-09-03"},
+		{"two_digit_date_1900", "may: 3, 69", "%M: %e, %y", "2069-05-03"},
 
-		{"month_number", "03: 3, 20", "%m: %e, %y", "2020-03-03 00:00:00 -0600 CST"},
-		{"month_name", "march: 3, 20", "%M: %e, %y", "2020-03-03 00:00:00 -0600 CST"},
-		{"two_digit_date", "january: 3, 20", "%M: %e, %y", "2020-01-03 00:00:00 -0600 CST"},
-		{"two_digit_date_2000", "september: 3, 70", "%M: %e, %y", "1970-09-03 00:00:00 -0500 CDT"},
-		{"two_digit_date_1900", "may: 3, 69", "%M: %e, %y", "2069-05-03 00:00:00 -0500 CDT"},
+		{"microseconds", "01/02/99 314", "%m/%e/%y %f", "1999-01-02 00:00:00.314000"},
+		{"hour_number", "01/02/99 5:14", "%m/%e/%y %h:%i", "1999-01-02 05:14:00"},
+		{"hour_number_2", "01/02/99 5:14", "%m/%e/%y %I:%i", "1999-01-02 05:14:00"},
 
-		{"microseconds", "01/02/99 314", "%m/%e/%y %f", "1999-01-02 00:00:00.000314 -0600 CST"},
-		{"hour_number", "01/02/99 5:14", "%m/%e/%y %h:%i", "1999-01-02 05:14:00 -0600 CST"},
-		{"hour_number_2", "01/02/99 5:14", "%m/%e/%y %I:%i", "1999-01-02 05:14:00 -0600 CST"},
+		{"timestamp", "01/02/99 05:14:12 PM", "%m/%e/%y %r", "1999-01-02 17:14:12"},
+		{"date_with_seconds", "01/02/99 57", "%m/%e/%y %S", "1999-01-02 00:00:57"},
 
-		{"timestamp", "01/02/99 05:14:12 PM", "%m/%e/%y %r", "1999-01-02 17:14:12 -0600 CST"},
-		{"date_with_seconds", "01/02/99 57", "%m/%e/%y %S", "1999-01-02 00:00:57 -0600 CST"},
+		{"date_by_year_offset", "100 20", "%j %y", "2020-04-09"},
+		{"date_by_year_offset_singledigit_year", "100 5", "%j %y", "2005-04-10"},
 
-		{"date_by_year_offset", "100 20", "%j %y", "2020-04-09 00:00:00 -0500 CDT"},
-		{"date_by_year_offset_singledigit_year", "100 5", "%j %y", "2005-04-10 00:00:00 -0500 CDT"},
+		// should be null
+		{"with_pm", "May 3, 10:23:00 PM 2000", "%b %e, %H:%i:%s %p %Y", "2000-05-03 22:23:00"},
+		{"lowercase_pm", "Jul 3, 10:23:00 pm 2000", "%b %e, %H:%i:%s %p %Y", "2000-07-03 22:23:00"},
+		{"with_am", "Mar 3, 10:23:00 am 2000", "%b %e, %H:%i:%s %p %Y", "2000-03-03 10:23:00"},
+
+		{"month_number", "1 3, 10:23:00 pm 2000", "%c %e, %H:%i:%s %p %Y", "2000-01-03 22:23:00"},
+
+		{"day_with_suffix", "Jun 3rd, 10:23:00 pm 2000", "%b %D, %H:%i:%s %p %Y", "2000-06-03 22:23:00"},
+		{"day_with_suffix_2", "Oct 21st, 10:23:00 pm 2000", "%b %D, %H:%i:%s %p %Y", "2000-10-21 22:23:00"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, err := ParseDateWithFormat(tt.date, tt.format)
 			require.NoError(t, err)
-			require.Equal(t, tt.expected, actual.String())
+			require.Equal(t, tt.expected, actual)
 		})
 	}
 }
@@ -83,22 +86,29 @@ func TestConversionFailure(t *testing.T) {
 		name          string
 		date          string
 		format        string
+		result        interface{}
 		expectedError string
 	}{
-		{"no_year", "Jan 3", "%b %e", "year is ambiguous"},
-		{"no_day", "Jan 2000", "%b %y", "day is ambiguous"},
-		{"day_of_month_and_day_of_year", "Jan 3, 100 2000", "%b %e, %j %y", "day is ambiguous"},
-		{"specifier_end_of_line", "Jan 3", "%b %e %", `"%" found at end of format string`},
-		{"unknown_format_specifier", "Jan 3", "%b %e %L", `unknown format specifier "L"`},
-		{"invalid_number_hour", "0021:12:14", "%T", `specifier %T failed to parse "0021:12:14": expected literal ":", got "2"`},
-		{"invalid_number_hour_2", "0012:12:14", "%r", `specifier %r failed to parse "0012:12:14": expected literal ":", got "1"`},
+		// with strict mode with NO_ZERO_IN_DATE,NO_ZERO_DATE enabled, these tests result NULL
+		{"no_year", "Jan 3", "%b %e", "0000-01-03", ""},
+		{"no_day", "Jan 2000", "%b %y", "2020-01-00", ""},
+		{"day_of_month_and_day_of_year", "Jan 3, 100 2000", "%b %e, %j %y", "2020-04-09", ""},
+
+		{"specifier_end_of_line", "Jan 3", "%b %e %", nil, `"%" found at end of format string`},
+		{"unknown_format_specifier", "Jan 3", "%b %e %L", nil, `unknown format specifier "L"`},
+		{"invalid_number_hour", "0021:12:14", "%T", nil, `specifier %T failed to parse "0021:12:14": expected literal ":", got "2"`},
+		{"invalid_number_hour_2", "0012:12:14", "%r", nil, `specifier %r failed to parse "0012:12:14": expected literal ":", got "1"`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParseDateWithFormat(tt.date, tt.format)
-			require.Error(t, err)
-			require.Equal(t, tt.expectedError, err.Error())
+			r, err := ParseDateWithFormat(tt.date, tt.format)
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err.Error())
+			} else {
+				require.Equal(t, tt.result, r)
+			}
 		})
 	}
 }

--- a/sql/parse/dateparse/eval.go
+++ b/sql/parse/dateparse/eval.go
@@ -33,7 +33,7 @@ func evaluate(dt datetime, outType OutType) (interface{}, error) {
 		return nil, nil
 	}
 
-	var result = getDate(dt)
+	var result string
 	if outType == DateTime {
 		d := getDate(dt)
 		t := getTime(dt)
@@ -56,19 +56,19 @@ func getDate(dt datetime) string {
 		year = int(*dt.year)
 	}
 
-	if dt.dayOfYear != nil {
-		// offset from Jan 1st by the specified number of days
-		dayOffsetted := time.Date(year, time.January, 0, 0, 0, 0, 0, time.Local).AddDate(0, 0, int(*dt.dayOfYear))
-		month = int(dayOffsetted.Month())
-		day = dayOffsetted.Day()
-	}
-
 	if dt.month != nil {
 		month = int(*dt.month)
 	}
 
 	if dt.day != nil {
 		day = int(*dt.day)
+	}
+
+	if dt.dayOfYear != nil {
+		// offset from Jan 1st by the specified number of days
+		dayOffsetted := time.Date(year, time.January, 0, 0, 0, 0, 0, time.Local).AddDate(0, 0, int(*dt.dayOfYear))
+		month = int(dayOffsetted.Month())
+		day = dayOffsetted.Day()
 	}
 
 	return fillWithZero(year, 4) + "-" + fillWithZero(month, 2) + "-" + fillWithZero(day, 2)

--- a/sql/parse/dateparse/eval.go
+++ b/sql/parse/dateparse/eval.go
@@ -5,51 +5,7 @@ import (
 	"time"
 )
 
-// Validate that the combination of fields in datetime
-// can be evaluated unambiguously to a time.Time.
-func validate(dt datetime) error {
-	if dt.year == nil && dt.day == nil && dt.month == nil && dt.dayOfYear == nil {
-		return nil
-	}
-	if dt.day == nil {
-		if dt.month != nil {
-			// TODO: ensure this behaves as expected
-			return fmt.Errorf("day is ambiguous")
-		}
-		return nil
-	}
-	if dt.dayOfYear != nil && dt.day != nil {
-		return fmt.Errorf("day is ambiguous")
-	}
-	if (dt.dayOfYear != nil || dt.day != nil) && dt.year == nil {
-		return fmt.Errorf("year is ambiguous")
-	}
-
-	return nil
-}
-
-func evaluate(dt datetime, outType OutType) (interface{}, error) {
-	if dt.isEmpty() {
-		return nil, nil
-	}
-
-	var result string
-	if outType == DateTime {
-		d := getDate(dt)
-		t := getTime(dt)
-		result = d + " " + t
-	} else if outType == TimeOnly {
-		result = getTime(dt)
-	} else if outType == DateOnly {
-		result = getDate(dt)
-	} else {
-		return nil, nil
-	}
-
-	return result, nil
-}
-
-func getDate(dt datetime) string {
+func evaluateDate(dt datetime) string {
 	var year, month, day int
 
 	if dt.year != nil {
@@ -74,7 +30,7 @@ func getDate(dt datetime) string {
 	return fillWithZero(year, 4) + "-" + fillWithZero(month, 2) + "-" + fillWithZero(day, 2)
 }
 
-func getTime(dt datetime) string {
+func evaluateTime(dt datetime) string {
 	var hours, minutes, seconds, milliseconds, microseconds, nanoseconds int
 
 	if dt.hours != nil {

--- a/sql/parse/dateparse/parsers.go
+++ b/sql/parse/dateparse/parsers.go
@@ -5,12 +5,20 @@ import (
 	"time"
 )
 
+type ParseType int
+
+const (
+	Time ParseType = iota
+	Date
+	None
+)
+
 // parser defines a function that processes a string and returns the
 // remaining characters unconsumed by the given parser.
 //
 // The data parsed from the consumed characters should be
 // written to the `datetime` struct.
-type parser func(result *datetime, chars string) (rest string, err error)
+type parser func(result *datetime, chars string) (rest string, parseType ParseType, err error)
 
 func trimPrefix(count int, str string) string {
 	if len(str) > count {
@@ -20,24 +28,24 @@ func trimPrefix(count int, str string) string {
 }
 
 func literalParser(literal byte) parser {
-	return func(dt *datetime, chars string) (rest string, _ error) {
+	return func(dt *datetime, chars string) (rest string, parseType ParseType, _ error) {
 		if len(chars) < 1 && literal != ' ' {
-			return "", fmt.Errorf("expected literal \"%c\", found empty string", literal)
+			return "", None, fmt.Errorf("expected literal \"%c\", found empty string", literal)
 		}
 		chars = takeAllSpaces(chars)
 		if literal == ' ' {
-			return chars, nil
+			return chars, None, nil
 		}
 		if chars[0] != literal {
-			return "", fmt.Errorf("expected literal \"%c\", got \"%c\"", literal, chars[0])
+			return "", None, fmt.Errorf("expected literal \"%c\", got \"%c\"", literal, chars[0])
 		}
-		return trimPrefix(1, chars), nil
+		return trimPrefix(1, chars), None, nil
 	}
 }
 
-func parseAmPm(result *datetime, chars string) (rest string, _ error) {
+func parseAmPm(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	if len(chars) < 2 {
-		return "", fmt.Errorf("expected > 2 chars, found %d", len(chars))
+		return "", None, fmt.Errorf("expected > 2 chars, found %d", len(chars))
 	}
 	switch chars[:2] {
 	case "am":
@@ -45,171 +53,171 @@ func parseAmPm(result *datetime, chars string) (rest string, _ error) {
 	case "pm":
 		result.am = boolPtr(false)
 	default:
-		return "", fmt.Errorf("expected AM or PM, got \"%s\"", chars[:2])
+		return "", None, fmt.Errorf("expected AM or PM, got \"%s\"", chars[:2])
 	}
-	return trimPrefix(2, chars), nil
+	return trimPrefix(2, chars), Time, nil
 }
 
-func parseWeedayAbbreviation(result *datetime, chars string) (rest string, _ error) {
+func parseWeekdayAbbreviation(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	if len(chars) < 3 {
-		return "", fmt.Errorf("expected at least 3 chars, got %d", len(chars))
+		return "", None, fmt.Errorf("expected at least 3 chars, got %d", len(chars))
 	}
 	weekday, ok := weekdayAbbrev(chars[:3])
 	if !ok {
-		return "", fmt.Errorf("invalid week abbreviation \"%s\"", chars[:3])
+		return "", None, fmt.Errorf("invalid week abbreviation \"%s\"", chars[:3])
 	}
 	result.weekday = &weekday
-	return trimPrefix(3, chars), nil
+	return trimPrefix(3, chars), Date, nil
 }
 
-func parseMonthAbbreviation(result *datetime, chars string) (rest string, _ error) {
+func parseMonthAbbreviation(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	if len(chars) < 3 {
-		return "", fmt.Errorf("expected at least 3 chars, got %d", len(chars))
+		return "", None, fmt.Errorf("expected at least 3 chars, got %d", len(chars))
 	}
 	month, ok := monthAbbrev(chars[:3])
 	if !ok {
-		return "", fmt.Errorf("invalid month abbreviation \"%s\"", chars[:3])
+		return "", None, fmt.Errorf("invalid month abbreviation \"%s\"", chars[:3])
 	}
 	result.month = &month
-	return trimPrefix(3, chars), nil
+	return trimPrefix(3, chars), Date, nil
 }
 
-func parseMonthNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseMonthNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	num, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	month := time.Month(num)
 	result.month = &month
-	return rest, nil
+	return rest, Date, nil
 }
 
-func parseDayOfMonthNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseDayOfMonthNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	num, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.day = &num
-	return rest, nil
+	return rest, Date, nil
 }
 
-func parseMicrosecondsNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseMicrosecondsNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	num, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.microseconds = &num
-	return rest, nil
+	return rest, Time, nil
 }
 
-func parse24HourNumeric(result *datetime, chars string) (rest string, _ error) {
+func parse24HourNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	hour, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.hours = &hour
-	return rest, nil
+	return rest, Time, nil
 }
 
-func parse12HourNumeric(result *datetime, chars string) (rest string, _ error) {
+func parse12HourNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	num, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.hours = &num
-	return rest, nil
+	return rest, Time, nil
 }
 
-func parseMinuteNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseMinuteNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	min, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.minutes = &min
-	return rest, nil
+	return rest, Time, nil
 }
 
-func parseMonthName(result *datetime, chars string) (rest string, _ error) {
+func parseMonthName(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	month, charCount, ok := monthName(chars)
 	if !ok {
-		return "", fmt.Errorf("unknown month name, got \"%s\"", chars)
+		return "", None, fmt.Errorf("unknown month name, got \"%s\"", chars)
 	}
 	result.month = &month
-	return trimPrefix(charCount, chars), nil
+	return trimPrefix(charCount, chars), Date, nil
 }
 
-func parse12HourTimestamp(result *datetime, chars string) (rest string, _ error) {
+func parse12HourTimestamp(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	hour, rest, err := takeNumberAtMostNChars(2, chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
-	rest, err = literalParser(':')(result, rest)
+	rest, parseType, err = literalParser(':')(result, rest)
 	if err != nil {
-		return "", err
+		return "", parseType, err
 	}
 	min, rest, err := takeNumberAtMostNChars(2, rest)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
-	rest, err = literalParser(':')(result, rest)
+	rest, parseType, err = literalParser(':')(result, rest)
 	if err != nil {
-		return "", err
+		return "", parseType, err
 	}
 	sec, rest, err := takeNumberAtMostNChars(2, rest)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	rest = takeAllSpaces(rest)
-	rest, err = parseAmPm(result, rest)
+	rest, parseType, err = parseAmPm(result, rest)
 	if err != nil {
-		return "", err
+		return "", parseType, err
 	}
 	result.seconds = &sec
 	result.minutes = &min
 	result.hours = &hour
-	return rest, nil
+	return rest, Time, nil
 }
 
-func parseSecondsNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseSecondsNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	sec, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.seconds = &sec
-	return rest, nil
+	return rest, Time, nil
 }
 
-func parse24HourTimestamp(result *datetime, chars string) (rest string, _ error) {
+func parse24HourTimestamp(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	hour, rest, err := takeNumberAtMostNChars(2, chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
-	rest, err = literalParser(':')(result, rest)
+	rest, parseType, err = literalParser(':')(result, rest)
 	if err != nil {
-		return "", err
+		return "", parseType, err
 	}
 	minute, rest, err := takeNumberAtMostNChars(2, rest)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
-	rest, err = literalParser(':')(result, rest)
+	rest, parseType, err = literalParser(':')(result, rest)
 	if err != nil {
-		return "", err
+		return "", parseType, err
 	}
 	seconds, rest, err := takeNumberAtMostNChars(2, rest)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.hours = &hour
 	result.minutes = &minute
 	result.seconds = &seconds
-	return rest, err
+	return rest, Time, nil
 }
 
-func parseYear2DigitNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseYear2DigitNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	year, rest, err := takeNumberAtMostNChars(2, chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	if year >= 70 {
 		year += 1900
@@ -217,35 +225,35 @@ func parseYear2DigitNumeric(result *datetime, chars string) (rest string, _ erro
 		year += 2000
 	}
 	result.year = &year
-	return rest, nil
+	return rest, Date, nil
 }
 
-func parseYear4DigitNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseYear4DigitNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	if len(chars) < 4 {
-		return "", fmt.Errorf("expected at least 4 chars, got %d", len(chars))
+		return "", None, fmt.Errorf("expected at least 4 chars, got %d", len(chars))
 	}
 	year, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.year = &year
-	return rest, nil
+	return rest, Date, nil
 }
 
-func parseDayNumericWithEnglishSuffix(result *datetime, chars string) (rest string, _ error) {
+func parseDayNumericWithEnglishSuffix(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	num, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.day = &num
-	return trimPrefix(2, rest), nil
+	return trimPrefix(2, rest), Date, nil
 }
 
-func parseDayOfYearNumeric(result *datetime, chars string) (rest string, _ error) {
+func parseDayOfYearNumeric(result *datetime, chars string) (rest string, parseType ParseType, _ error) {
 	num, rest, err := takeNumber(chars)
 	if err != nil {
-		return "", err
+		return "", None, err
 	}
 	result.dayOfYear = &num
-	return rest, nil
+	return rest, Date, nil
 }

--- a/sql/parse/dateparse/parsers_test.go
+++ b/sql/parse/dateparse/parsers_test.go
@@ -11,21 +11,19 @@ func TestParsers(t *testing.T) {
 		name             string
 		chars            string
 		parser           parser
-		parserType       ParseType
 		expectedRest     string
 		expectedDatetime datetime
 	}{
-		{"24_timestamp", "13:12:15", parse24HourTimestamp, Time, "",
+		{"24_timestamp", "13:12:15", parse24HourTimestamp, "",
 			datetime{hours: uintPtr(13), minutes: uintPtr(12), seconds: uintPtr(15)},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var dt datetime
-			rest, pt, err := tt.parser(&dt, tt.chars)
+			rest, err := tt.parser(&dt, tt.chars)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedRest, rest)
-			require.Equal(t, tt.parserType, pt)
 			require.Equal(t, tt.expectedDatetime, dt)
 		})
 	}
@@ -43,7 +41,7 @@ func TestParserErr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var dt datetime
-			_, _, err := tt.parser(&dt, tt.chars)
+			_, err := tt.parser(&dt, tt.chars)
 			require.Error(t, err)
 			require.Equal(t, tt.expectedErr, err.Error())
 		})

--- a/sql/parse/dateparse/parsers_test.go
+++ b/sql/parse/dateparse/parsers_test.go
@@ -11,19 +11,21 @@ func TestParsers(t *testing.T) {
 		name             string
 		chars            string
 		parser           parser
+		parserType       ParseType
 		expectedRest     string
 		expectedDatetime datetime
 	}{
-		{"24_timestamp", "13:12:15", parse24HourTimestamp, "",
+		{"24_timestamp", "13:12:15", parse24HourTimestamp, Time, "",
 			datetime{hours: uintPtr(13), minutes: uintPtr(12), seconds: uintPtr(15)},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var dt datetime
-			rest, err := tt.parser(&dt, tt.chars)
+			rest, pt, err := tt.parser(&dt, tt.chars)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedRest, rest)
+			require.Equal(t, tt.parserType, pt)
 			require.Equal(t, tt.expectedDatetime, dt)
 		})
 	}
@@ -41,7 +43,7 @@ func TestParserErr(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var dt datetime
-			_, err := tt.parser(&dt, tt.chars)
+			_, _, err := tt.parser(&dt, tt.chars)
 			require.Error(t, err)
 			require.Equal(t, tt.expectedErr, err.Error())
 		})


### PR DESCRIPTION
`STR_TO_DATE()` returns result type depending on Date given in the query. If only date parts like year, month and/or day was defined in Date argument, then the result is only Date type without time parts. If Date defined is date with time, then Datetime type is returned. 
Currently, STR_TO_DATE allows zero-date.