### PR TITLE
any number of column is allowed for where exists subquery

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6477,6 +6477,14 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{4}},
 	},
 	{
+		Query:    `SELECT 2 + 2 WHERE NOT EXISTS (SELECT * FROM one_pk WHERE pk > 4)`,
+		Expected: []sql.Row{{4}},
+	},
+	{
+		Query:    `SELECT 2 + 2 WHERE EXISTS (SELECT * FROM one_pk WHERE pk < 4)`,
+		Expected: []sql.Row{{4}},
+	},
+	{
 		Query:    `SELECT distinct pk1 FROM two_pk WHERE EXISTS (SELECT pk from one_pk where pk <= two_pk.pk1)`,
 		Expected: []sql.Row{{0}, {1}},
 	},

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -482,6 +482,8 @@ func validateOperands(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, s
 						}
 					case expression.Tuple:
 						// Tuple expressions can contain tuples...
+					case *plan.ExistsSubquery:
+						// Any number of columns are allowed.
 					default:
 						for _, e := range e.Children() {
 							nc := sql.NumColumns(e.Type())


### PR DESCRIPTION
Any number of column from the subquery is allowed. The result of `WHERE EXISTS subquery` is dependent on the number of rows rather than the number of columns
Fix for https://github.com/dolthub/dolt/issues/3772