### PR TITLE
use float input as str for decimal type

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8818,6 +8818,18 @@ var ErrorQueries = []QueryErrorTest{
 		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, b BLOB DEFAULT '');",
 		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
 	},
+	{
+		Query:          "CREATE TABLE invalid_decimal (number DECIMAL(65,31));",
+		ExpectedErrStr: "Too big scale 31 specified. Maximum is 30.",
+	},
+	{
+		Query:          "CREATE TABLE invalid_decimal (number DECIMAL(66,30));",
+		ExpectedErrStr: "Too big precision 66 specified. Maximum is 65.",
+	},
+	{
+		Query:          "CREATE TABLE invalid_decimal (number DECIMAL(66,31));",
+		ExpectedErrStr: "Too big scale 31 specified. Maximum is 30.",
+	},
 }
 
 // WriteQueryTest is a query test for INSERT, UPDATE, etc. statements. It has a query to run and a select query to

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1615,6 +1615,7 @@ var ScriptTests = []ScriptTest{
 		SetUpScript: []string{
 			"create table test (number decimal(40,16));",
 			"insert into test values ('11981.5923291839784651');",
+			"create table small_test (n decimal(3,2));",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1638,16 +1639,24 @@ var ScriptTests = []ScriptTest{
 				Expected: []sql.Row{{1}},
 			},
 			{
-				Query:          "create table invalid_decimal (number decimal(65,31));",
-				ExpectedErrStr: "Too big scale 31 specified. Maximum is 30.",
+				Query:    "INSERT INTO test VALUES (1.1981592329183978465111981592329183978465111981592329183978465144);",
+				Expected: []sql.Row{{sql.NewOkResult(1)}},
 			},
 			{
-				Query:          "create table invalid_decimal (number decimal(66,30));",
-				ExpectedErrStr: "Too big precision 66 specified. Maximum is 65.",
+				Query:    "SELECT COUNT(*) FROM test WHERE number = CONVERT('1.1981592329183978', DECIMAL)",
+				Expected: []sql.Row{{1}},
 			},
 			{
-				Query:          "create table invalid_decimal (number decimal(66,31));",
-				ExpectedErrStr: "Too big scale 31 specified. Maximum is 30.",
+				Query:    "INSERT INTO test VALUES (1.1981592329183978545111981592329183978465111981592329183978465144);",
+				Expected: []sql.Row{{sql.NewOkResult(1)}},
+			},
+			{
+				Query:    "SELECT COUNT(*) FROM test WHERE number = CONVERT('1.1981592329183979', DECIMAL)",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:       "INSERT INTO small_test VALUES (12.1);",
+				ExpectedErr: sql.ErrConvertToDecimalLimit,
 			},
 		},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1611,6 +1611,27 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Ensure scale is not rounded when inserting to DECIMAL type through float64",
+		SetUpScript: []string{
+			"create table test (number decimal(40,16));",
+			"insert into test values ('11981.5923291839784651');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT COUNT(*) FROM test WHERE number = CONVERT('11981.5923291839784651', DECIMAL)",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "INSERT INTO test VALUES (11981.5923291839784651);",
+				Expected: []sql.Row{{sql.NewOkResult(1)}},
+			},
+			{
+				Query:    "SELECT COUNT(*) FROM test WHERE number = CONVERT('11981.5923291839784651', DECIMAL)",
+				Expected: []sql.Row{{2}},
+			},
+		},
+	},
+	{
 		Name: "JOIN on non-index-prefix columns do not panic (Dolt Issue #2366)",
 		SetUpScript: []string{
 			"CREATE TABLE `player_season_stat_totals` (`player_id` int NOT NULL, `team_id` int NOT NULL, `season_id` int NOT NULL, `minutes` int, `games_started` int, `games_played` int, `2pm` int, `2pa` int, `3pm` int, `3pa` int, `ftm` int, `fta` int, `ast` int, `stl` int, `blk` int, `tov` int, `pts` int, `orb` int, `drb` int, `trb` int, `pf` int, `season_type_id` int NOT NULL, `league_id` int NOT NULL DEFAULT 0, PRIMARY KEY (`player_id`,`team_id`,`season_id`,`season_type_id`,`league_id`));",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1629,6 +1629,26 @@ var ScriptTests = []ScriptTest{
 				Query:    "SELECT COUNT(*) FROM test WHERE number = CONVERT('11981.5923291839784651', DECIMAL)",
 				Expected: []sql.Row{{2}},
 			},
+			{
+				Query:    "INSERT INTO test VALUES (119815923291839784651.11981592329183978465111981592329183978465144);",
+				Expected: []sql.Row{{sql.NewOkResult(1)}},
+			},
+			{
+				Query:    "SELECT COUNT(*) FROM test WHERE number = CONVERT('119815923291839784651.1198159232918398', DECIMAL)",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:          "create table invalid_decimal (number decimal(65,31));",
+				ExpectedErrStr: "Too big scale 31 specified. Maximum is 30.",
+			},
+			{
+				Query:          "create table invalid_decimal (number decimal(66,30));",
+				ExpectedErrStr: "Too big precision 66 specified. Maximum is 65.",
+			},
+			{
+				Query:          "create table invalid_decimal (number decimal(66,31));",
+				ExpectedErrStr: "Too big scale 31 specified. Maximum is 30.",
+			},
 		},
 	},
 	{

--- a/sql/decimal.go
+++ b/sql/decimal.go
@@ -84,15 +84,16 @@ var InternalDecimalType DecimalType = decimalType{
 
 // CreateDecimalType creates a DecimalType.
 func CreateDecimalType(precision uint8, scale uint8) (DecimalType, error) {
+	if scale > DecimalTypeMaxScale {
+		return nil, fmt.Errorf("Too big scale %v specified. Maximum is %v.", scale, DecimalTypeMaxScale)
+	}
 	if precision > DecimalTypeMaxPrecision {
-		return nil, fmt.Errorf("%v is beyond the max precision", precision)
+		return nil, fmt.Errorf("Too big precision %v specified. Maximum is %v.", precision, DecimalTypeMaxPrecision)
 	}
 	if scale > precision {
-		return nil, fmt.Errorf("%v cannot be larger than the precision %v", scale, precision)
+		return nil, fmt.Errorf("Scale %v cannot be larger than the precision %v", scale, precision)
 	}
-	if scale > DecimalTypeMaxScale {
-		return nil, fmt.Errorf("%v is beyond the max scale", scale)
-	}
+
 	if precision == 0 {
 		precision = 10
 	}
@@ -236,6 +237,7 @@ func (t decimalType) ConvertToNullDecimal(v interface{}) (decimal.NullDecimal, e
 
 func (t decimalType) BoundsCheck(v decimal.Decimal) (decimal.Decimal, error) {
 	if -v.Exponent() > int32(t.scale) {
+		// TODO : add 'Data truncated' warning
 		v = v.Round(int32(t.scale))
 	}
 	// TODO add shortcut for common case

--- a/sql/decimal.go
+++ b/sql/decimal.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	ErrConvertingToDecimal   = errors.NewKind("value %v is not a valid Decimal")
-	ErrConvertToDecimalLimit = errors.NewKind("value of Decimal is too large for type")
+	ErrConvertToDecimalLimit = errors.NewKind("Out of range value for column of Decimal type ")
 	ErrMarshalNullDecimal    = errors.NewKind("Decimal cannot marshal a null value")
 
 	decimalValueType = reflect.TypeOf(decimal.Decimal{})

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -3381,6 +3381,11 @@ func convertVal(ctx *sql.Context, v *sqlparser.SQLVal) (sql.Expression, error) {
 		if err != nil {
 			return nil, err
 		}
+		// value that does not fit in float64 gets rounded up
+		// use the value as string format to keep precision and scale as defined for DECIMAL data type
+		if len(string(v.Val)) > len(fmt.Sprintf("%v", val)) {
+			return expression.NewLiteral(string(v.Val), sql.CreateLongText(ctx.GetCollation())), nil
+		}
 		return expression.NewLiteral(val, sql.Float64), nil
 	case sqlparser.HexNum:
 		//TODO: binary collation?

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -18,12 +18,17 @@ import (
 	"encoding/hex"
 	goerrors "errors"
 	"fmt"
-	"gopkg.in/src-d/go-errors.v1"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/encodings"
@@ -32,10 +37,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
-	"github.com/dolthub/vitess/go/mysql"
-	"github.com/dolthub/vitess/go/vt/sqlparser"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var (

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -3384,8 +3384,8 @@ func convertVal(ctx *sql.Context, v *sqlparser.SQLVal) (sql.Expression, error) {
 
 		// use the value as string format to keep precision and scale as defined for DECIMAL data type to avoid rounded up float64 value
 		if ps := strings.Split(string(v.Val), "."); len(ps) == 2 {
-			if scale, err := strconv.ParseUint(ps[1], 10, 64); err == nil && scale > 0 {
-				if len(string(v.Val)) > len(fmt.Sprintf("%v", val)) {
+			if scale, err := strconv.ParseUint(ps[1], 10, 64); err != nil || scale > 0 {
+				if len(string(v.Val)) >= len(fmt.Sprintf("%v", val)) {
 					return expression.NewLiteral(string(v.Val), sql.CreateLongText(ctx.GetCollation())), nil
 				}
 			}

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1705,6 +1705,12 @@ CREATE TABLE t2
 		expression.NewLiteral("a", sql.LongText),
 		&expression.DefaultColumn{},
 	}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+	`INSERT INTO test (decimal_col) VALUES (11981.5923291839784651)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
+		expression.NewLiteral("11981.5923291839784651", sql.LongText),
+	}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
+	`INSERT INTO test (decimal_col) VALUES (119815923291839784651.11981592329183978465111981592329183978465144)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
+		expression.NewLiteral("119815923291839784651.11981592329183978465111981592329183978465144", sql.LongText),
+	}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
 	`UPDATE t1 SET col1 = ?, col2 = ? WHERE id = ?`: plan.NewUpdate(plan.NewFilter(
 		expression.NewEquals(expression.NewUnresolvedColumn("id"), expression.NewBindVar("v3")),
 		plan.NewUnresolvedTable("t1", ""),


### PR DESCRIPTION
The scale of float input in INSERT statement gets rounded when converting to float64 value.
The scale of input for DECIMAL data type should not be rounded.