### PR TITLE
SET NAMES collation fix, results have proper charset

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3820,6 +3820,14 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: "SET collation_connection = '" +
+			sql.Collation_Default.String() +
+			"';",
+		Expected: []sql.Row{
+			{},
+		},
+	},
+	{
 		Query:    `SHOW DATABASES`,
 		Expected: []sql.Row{{"mydb"}, {"foo"}, {"information_schema"}, {"mysql"}},
 	},

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -162,11 +162,11 @@ var VariableQueries = []ScriptTest{
 	{
 		Name: "set names quoted",
 		SetUpScript: []string{
-			`set NAMES "charset"`,
+			`set NAMES "utf8mb3"`,
 		},
 		Query: "SELECT @@character_set_client, @@character_set_connection, @@character_set_results",
 		Expected: []sql.Row{
-			{"charset", "charset", "charset"},
+			{"utf8mb3", "utf8mb3", "utf8mb3"},
 		},
 	},
 	{

--- a/server/handler.go
+++ b/server/handler.go
@@ -500,7 +500,7 @@ func (h *Handler) doQuery(
 						continue
 					}
 
-					outputRow, err := rowToSQL(schema, row)
+					outputRow, err := rowToSQL(ctx, schema, row)
 					if err != nil {
 						return err
 					}
@@ -711,7 +711,7 @@ func (h *Handler) WarningCount(c *mysql.Conn) uint16 {
 	return 0
 }
 
-func rowToSQL(s sql.Schema, row sql.Row) ([]sqltypes.Value, error) {
+func rowToSQL(ctx *sql.Context, s sql.Schema, row sql.Row) ([]sqltypes.Value, error) {
 	o := make([]sqltypes.Value, len(row))
 	var err error
 	for i, v := range row {
@@ -720,7 +720,7 @@ func rowToSQL(s sql.Schema, row sql.Row) ([]sqltypes.Value, error) {
 			continue
 		}
 
-		o[i], err = s[i].Type.SQL(nil, v)
+		o[i], err = s[i].Type.SQL(ctx, nil, v)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/bit.go
+++ b/sql/bit.go
@@ -195,7 +195,7 @@ func (t bitType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t bitType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t bitType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/charactersets.go
+++ b/sql/charactersets.go
@@ -195,7 +195,7 @@ func ParseCharacterSet(str string) (CharacterSetID, error) {
 		return cs, nil
 	}
 	// It is valid to parse the invalid charset, as some analyzer steps may temporarily use the invalid charset
-	if str == CharacterSet_Invalid.Name() {
+	if str == CharacterSet_Invalid.Name() || str == "" {
 		return CharacterSet_Invalid, nil
 	}
 	return CharacterSet_Invalid, ErrCharSetUnknown.New(str)

--- a/sql/datetimetype.go
+++ b/sql/datetimetype.go
@@ -347,7 +347,7 @@ func (t datetimeType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t datetimeType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t datetimeType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/decimal.go
+++ b/sql/decimal.go
@@ -281,7 +281,7 @@ func (t decimalType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t decimalType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t decimalType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/deferredtype.go
+++ b/sql/deferredtype.go
@@ -79,7 +79,7 @@ func (t deferredType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t deferredType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t deferredType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	return sqltypes.NULL, nil
 }
 

--- a/sql/geometry.go
+++ b/sql/geometry.go
@@ -353,7 +353,7 @@ func (t GeometryType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t GeometryType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t GeometryType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/json.go
+++ b/sql/json.go
@@ -102,7 +102,7 @@ func (t jsonType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t jsonType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t jsonType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/json_test.go
+++ b/sql/json_test.go
@@ -154,7 +154,7 @@ func TestJsonSQL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.val), func(t *testing.T) {
-			val, err := JSON.SQL(nil, test.val)
+			val, err := JSON.SQL(NewEmptyContext(), nil, test.val)
 			if test.expectedErr {
 				require.Error(t, err)
 			} else {
@@ -166,7 +166,7 @@ func TestJsonSQL(t *testing.T) {
 
 	// test that nulls are null
 	t.Run(fmt.Sprintf("%v", nil), func(t *testing.T) {
-		val, err := JSON.SQL(nil, nil)
+		val, err := JSON.SQL(NewEmptyContext(), nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, querypb.Type_NULL_TYPE, val.Type())
 	})

--- a/sql/linestring.go
+++ b/sql/linestring.go
@@ -151,7 +151,7 @@ func (t LineStringType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t LineStringType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t LineStringType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/nulltype.go
+++ b/sql/nulltype.go
@@ -76,7 +76,7 @@ func (t nullType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t nullType) SQL([]byte, interface{}) (sqltypes.Value, error) {
+func (t nullType) SQL(*Context, []byte, interface{}) (sqltypes.Value, error) {
 	return sqltypes.NULL, nil
 }
 

--- a/sql/numbertype.go
+++ b/sql/numbertype.go
@@ -393,7 +393,7 @@ func (t numberTypeImpl) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t numberTypeImpl) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t numberTypeImpl) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/numbertype_test.go
+++ b/sql/numbertype_test.go
@@ -237,11 +237,11 @@ func TestNumberConvert(t *testing.T) {
 }
 
 func TestNumberSQL_BooleanFromBoolean(t *testing.T) {
-	val, err := Boolean.SQL(nil, true)
+	val, err := Boolean.SQL(NewEmptyContext(), nil, true)
 	require.NoError(t, err)
 	assert.Equal(t, "INT8(1)", val.String())
 
-	val, err = Boolean.SQL(nil, false)
+	val, err = Boolean.SQL(NewEmptyContext(), nil, false)
 	require.NoError(t, err)
 	assert.Equal(t, "INT8(0)", val.String())
 }

--- a/sql/point.go
+++ b/sql/point.go
@@ -138,7 +138,7 @@ func (t PointType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t PointType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t PointType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/polygon.go
+++ b/sql/polygon.go
@@ -151,7 +151,7 @@ func (t PolygonType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t PolygonType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t PolygonType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/settype.go
+++ b/sql/settype.go
@@ -235,7 +235,7 @@ func (t setType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t setType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t setType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
@@ -248,7 +248,11 @@ func (t setType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
 		return sqltypes.Value{}, err
 	}
 
-	encodedBytes, ok := t.collation.CharacterSet().Encoder().Encode(encodings.StringToBytes(value))
+	resultCharset := ctx.GetCharacterSetResults()
+	if resultCharset == CharacterSet_Invalid || resultCharset == CharacterSet_binary {
+		resultCharset = t.collation.CharacterSet()
+	}
+	encodedBytes, ok := resultCharset.Encoder().Encode(encodings.StringToBytes(value))
 	if !ok {
 		return sqltypes.Value{}, ErrCharSetFailedToEncode.New(t.collation.CharacterSet().Name())
 	}

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -485,7 +485,7 @@ func (t stringType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t stringType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t stringType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}
@@ -502,7 +502,11 @@ func (t stringType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
 		if err != nil {
 			return sqltypes.Value{}, err
 		}
-		encodedBytes, ok := t.collation.CharacterSet().Encoder().Encode(encodings.StringToBytes(v))
+		resultCharset := ctx.GetCharacterSetResults()
+		if resultCharset == CharacterSet_Invalid || resultCharset == CharacterSet_binary {
+			resultCharset = t.collation.CharacterSet()
+		}
+		encodedBytes, ok := resultCharset.Encoder().Encode(encodings.StringToBytes(v))
 		if !ok {
 			return sqltypes.Value{}, ErrCharSetFailedToEncode.New(t.collation.CharacterSet().Name())
 		}

--- a/sql/system_booltype.go
+++ b/sql/system_booltype.go
@@ -149,7 +149,7 @@ func (t systemBoolType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t systemBoolType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t systemBoolType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/system_doubletype.go
+++ b/sql/system_doubletype.go
@@ -134,7 +134,7 @@ func (t systemDoubleType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t systemDoubleType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t systemDoubleType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/system_enumtype.go
+++ b/sql/system_enumtype.go
@@ -154,7 +154,7 @@ func (t systemEnumType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t systemEnumType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t systemEnumType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/system_inttype.go
+++ b/sql/system_inttype.go
@@ -142,7 +142,7 @@ func (t systemIntType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t systemIntType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t systemIntType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/system_settype.go
+++ b/sql/system_settype.go
@@ -130,7 +130,7 @@ func (t systemSetType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t systemSetType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t systemSetType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/system_stringtype.go
+++ b/sql/system_stringtype.go
@@ -98,7 +98,7 @@ func (t systemStringType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t systemStringType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t systemStringType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/system_uinttype.go
+++ b/sql/system_uinttype.go
@@ -138,7 +138,7 @@ func (t systemUintType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t systemUintType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t systemUintType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/timetype.go
+++ b/sql/timetype.go
@@ -252,7 +252,7 @@ func (t timespanType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t timespanType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t timespanType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}

--- a/sql/tupletype.go
+++ b/sql/tupletype.go
@@ -119,7 +119,7 @@ func (t TupleType) Promote() Type {
 	return t
 }
 
-func (t TupleType) SQL([]byte, interface{}) (sqltypes.Value, error) {
+func (t TupleType) SQL(*Context, []byte, interface{}) (sqltypes.Value, error) {
 	return sqltypes.Value{}, fmt.Errorf("unable to convert tuple type to SQL")
 }
 

--- a/sql/tupletype_test.go
+++ b/sql/tupletype_test.go
@@ -40,7 +40,7 @@ func TestTuple(t *testing.T) {
 	require.NoError(err)
 	assert.Equal(t, []interface{}{int32(1), "2", int64(3)}, conVal)
 
-	_, err = typ.SQL(nil, nil)
+	_, err = typ.SQL(NewEmptyContext(), nil, nil)
 	require.Error(err)
 
 	require.Equal(sqltypes.Expression, typ.Type())

--- a/sql/type.go
+++ b/sql/type.go
@@ -65,7 +65,7 @@ type Type interface {
 	// SQL returns the sqltypes.Value for the given value.
 	// Implementations can optionally use |dest| to append
 	// serialized data, but should not mutate existing data.
-	SQL(dest []byte, v interface{}) (sqltypes.Value, error)
+	SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error)
 	// Type returns the query.Type for the given Type.
 	Type() query.Type
 	// ValueType returns the Go type of the value returned by Convert().

--- a/sql/yeartype.go
+++ b/sql/yeartype.go
@@ -166,7 +166,7 @@ func (t yearType) Promote() Type {
 }
 
 // SQL implements Type interface.
-func (t yearType) SQL(dest []byte, v interface{}) (sqltypes.Value, error) {
+func (t yearType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value, error) {
 	if v == nil {
 		return sqltypes.NULL, nil
 	}


### PR DESCRIPTION
Fixes two issues. `SET NAMES` would cause all statements that feature a `COLLATE` expression to error if the character set and collation did not match, however such a comparison only makes sense for string literals (at parse time). This has been fixed, as the parse-time check only occurs for literals, and checks that require analysis (such as table columns) now occur at the appropriate time. In addition, the system variable `character_set_results` was not used when returning string results, resulting in unexpected behavior, which has also been fixed.