### PR TITLE
Adding skipped tests for broken alias queries 

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -179,6 +179,11 @@ func TestBrokenQueries(t *testing.T, harness Harness) {
 	RunQueryTests(t, harness, queries.BrokenQueries)
 }
 
+func TestBrokenAliasQueries(t *testing.T, harness Harness) {
+	harness.Setup(setup.MydbData, setup.MytableData, setup.Pk_tablesData, setup.Fk_tblData)
+	RunQueryTests(t, harness, queries.BrokenAliasQueries)
+}
+
 func TestPreparedStaticIndexQuery(t *testing.T, harness Harness) {
 	harness.Setup(setup.MydbData)
 	engine := mustNewEngine(t, harness)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -269,6 +269,10 @@ func TestBrokenQueries(t *testing.T) {
 	enginetest.TestBrokenQueries(t, enginetest.NewSkippingMemoryHarness())
 }
 
+func TestBrokenAliasQueries(t *testing.T) {
+	enginetest.TestBrokenAliasQueries(t, enginetest.NewSkippingMemoryHarness())
+}
+
 func TestTestQueryPlanTODOs(t *testing.T) {
 	harness := enginetest.NewSkippingMemoryHarness()
 	harness.Setup(setup.MydbData, setup.Pk_tablesData, setup.NiltableData)

--- a/enginetest/queries/column_alias_queries.go
+++ b/enginetest/queries/column_alias_queries.go
@@ -31,8 +31,8 @@ var BrokenAliasQueries = []QueryTest{
 		// This query crashes Dolt with "panic: unexpected type x"
 		// Seems likely to be coming from dual table's schema and dummy value.
 		// https://github.com/dolthub/dolt/issues/4256
-		Query:    `SELECT *, (select pk union select pk) as a from mydb;`,
-		Expected: []sql.Row{{1, 1}},
+		Query:    `SELECT *, (select i union select i) as a from mytable;`,
+		Expected: []sql.Row{{1, "first row", 1}, {2, "second row", 2}, {3, "third row", 3}},
 	},
 	{
 		// This query actually works correctly in GMS, but not in Dolt
@@ -58,14 +58,14 @@ var BrokenAliasQueries = []QueryTest{
 	{
 		// GMS returns the error "found HAVING clause with no GROUP BY", but MySQL executes
 		// this query without any problems.
-		Query:    "select t1.pk as a from mydb as t1 having a = t1.pk;",
-		Expected: []sql.Row{{1}},
+		Query:    "select t1.i as a from mytable as t1 having a = t1.i;",
+		Expected: []sql.Row{{1}, {2}, {3}},
 	},
 	{
 		// GMS returns "expression 'dt.two' doesn't appear in the group by expressions", but MySQL will execute
 		// this query. It does seem odd that we are not selecting dt.two though. Perhaps MySQL sees those values are
 		// always going to be literals and optimizes?
-		Query:    "select 1 as a, one + 1 as mod1, dt.* from mydb as t1, (select 1, 2 from t) as dt (one, two) where dt.one > 0 group by one;",
+		Query:    "select 1 as a, one + 1 as mod1, dt.* from mytable as t1, (select 1, 2 from mytable) as dt (one, two) where dt.one > 0 group by one;",
 		Expected: []sql.Row{{1}},
 	},
 }

--- a/sql/analyzer/reorder_projections.go
+++ b/sql/analyzer/reorder_projections.go
@@ -22,7 +22,7 @@ import (
 )
 
 // reorderProjection adds intermediate Project nodes to the descendants of existing Project nodes, adding fields to
-// the schemas of these intermediate nodes. This is important because the naive parse tree might a descendant of a
+// the schemas of these intermediate nodes. This is important because the naive parse tree might have a descendant of a
 // Project refer to a node introduced in that project (typically an alias). For the child to be able to resolve this
 // reference, it needs to be pushed lower down in the tree, underneath that child.
 // The canonical case here looks something like:

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -345,7 +345,7 @@ func qualifyExpression(e sql.Expression, symbols availableNames) (sql.Expression
 			return col, transform.SameTree, nil
 		}
 
-		// Look in all the scope, inner to outer, to identify the column. Stop as soon as we have a scope with exactly 1
+		// Look in all the scopes, inner to outer, to identify the column. Stop as soon as we have a scope with exactly 1
 		// match for the column name. If any scope has ambiguity in available column names, that's an error.
 		name := strings.ToLower(col.Name())
 		levels := symbols.levels()
@@ -356,7 +356,6 @@ func qualifyExpression(e sql.Expression, symbols availableNames) (sql.Expression
 			levels = levels[len(symbols)-1:]
 		}
 		for _, level := range levels {
-
 			tablesForColumn := symbols.tablesForColumnAtLevel(name, level)
 
 			// If the table exists but it's not available for this node it

--- a/sql/analyzer/resolve_columns_test.go
+++ b/sql/analyzer/resolve_columns_test.go
@@ -179,7 +179,7 @@ func TestQualifyColumns(t *testing.T) {
 			),
 		},
 		{
-			name: "already qualified with alias",
+			name: "already qualified with table alias",
 			node: plan.NewProject(
 				[]sql.Expression{
 					uqc("a", "i"),
@@ -317,7 +317,7 @@ func TestQualifyColumns(t *testing.T) {
 								plan.NewResolvedTable(table2, nil, nil),
 							),
 						),
-						"select y from mytable2 where x > i"),
+						"select max(y) from mytable2 where x > i"),
 				},
 				plan.NewResolvedTable(table, nil, nil),
 			)),


### PR DESCRIPTION
Capturing some of the edge cases I found while testing aliases as skipped enginetests. 

I've found where a few of these are coming from, but still need to figure out the best way to fix them. @max-hoffman – if you have any intuition/thoughts/hints on the specific failing tests, I'd love to hear it. 