### PR TITLE
Added limited support for collation coercibility

### DIFF
--- a/enginetest/queries/charset_collation_wire.go
+++ b/enginetest/queries/charset_collation_wire.go
@@ -229,6 +229,26 @@ var CharsetCollationWireTests = []CharsetCollationWireTest{
 		},
 	},
 	{
+		Name: "Coercibility test using HEX",
+		SetUpScript: []string{
+			"SET NAMES utf8mb4;",
+		},
+		Queries: []CharsetCollationWireTestQuery{
+			{
+				Query:    "SELECT HEX(UNHEX('c0a80000')) = 'c0a80000'",
+				Expected: []sql.Row{{"1"}},
+			},
+			{
+				Query:    "SET collation_connection = 'utf8mb4_0900_bin';",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
+			},
+			{
+				Query:    "SELECT HEX(UNHEX('c0a80000')) = 'c0a80000'",
+				Expected: []sql.Row{{"0"}},
+			},
+		},
+	},
+	{
 		Name: "ENUM collation handling",
 		SetUpScript: []string{
 			"SET character_set_results = 'binary';",

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -609,13 +609,16 @@ var (
 	// ErrCollationInvalidForCharSet is returned when the wrong collation is given for the character set when parsing.
 	ErrCollationInvalidForCharSet = errors.NewKind("COLLATION '%s' is not valid for CHARACTER SET '%s'")
 
-	// ErrCollationUnknown is returned when the collation is not a recognized MySQL collation
+	// ErrCollationUnknown is returned when the collation is not a recognized MySQL collation.
 	ErrCollationUnknown = errors.NewKind("Unknown collation: %v")
 
 	// ErrCollationNotYetImplementedTemp is returned when the collation is valid but has not yet been implemented.
 	// This error is temporary, and will be removed once all collations have been added.
 	ErrCollationNotYetImplementedTemp = errors.NewKind("The collation `%s` has not yet been implemented, " +
 		"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
+
+	// ErrCollationIllegalMix is returned when two different collations are used in a scenario where they are not compatible.
+	ErrCollationIllegalMix = errors.NewKind("Illegal mix of collations (%v) and (%v)")
 
 	// ErrCharSetIntroducer is returned when a character set introducer is not attached to a string
 	ErrCharSetIntroducer = errors.NewKind("CHARACTER SET introducer must be attached to a string")

--- a/sql/expression/collatedexpr.go
+++ b/sql/expression/collatedexpr.go
@@ -124,7 +124,7 @@ func (ce *CollatedExpression) Child() sql.Expression {
 // returned integer, the more explicit the defined collation. A value of 0 indicates that an explicit COLLATE was given.
 // Returns sql.Collation_Invalid if the expression in invalid in some way.
 //
-//TODO: This function's implementation is extremely basic, and is sure to return an incorrect result in some cases. A
+// TODO: This function's implementation is extremely basic, and is sure to return an incorrect result in some cases. A
 // more accurate implementation would have each expression return its own collation and coercion values.
 func GetCollationViaCoercion(expr sql.Expression) (sql.CollationID, int) {
 	if expr == nil {

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -16,6 +16,7 @@ package expression
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	errors "gopkg.in/src-d/go-errors.v1"
@@ -125,6 +126,29 @@ func (c *comparison) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 		}
 	}
 	if sql.IsTextOnly(compareType) {
+		// This does an approximation of MySQL's coercibility rules:
+		// https://dev.mysql.com/doc/refman/8.0/en/charset-collation-coercibility.html
+		leftCollation, leftCoercibility := GetCollationViaCoercion(c.Left())
+		rightCollation, rightCoercibility := GetCollationViaCoercion(c.Right())
+		if leftCoercibility < rightCoercibility {
+			collationPreference = leftCollation
+		} else if leftCoercibility > rightCoercibility {
+			collationPreference = rightCollation
+		} else if leftCollation == rightCollation {
+			collationPreference = leftCollation
+		} else { // Collations are not equal
+			if leftCollation.CharacterSet() != rightCollation.CharacterSet() {
+				return 0, sql.ErrCollationIllegalMix.New(leftCollation.Name(), rightCollation.Name())
+			}
+			// If the right collation is not _bin, then we default to the left collation (regardless of whether it is
+			// or is not _bin).
+			if strings.HasSuffix(rightCollation.Name(), "_bin") {
+				collationPreference = rightCollation
+			} else {
+				collationPreference = leftCollation
+			}
+		}
+
 		stringCompareType := compareType.(sql.StringType)
 		compareType = sql.MustCreateString(stringCompareType.Type(), stringCompareType.Length(), collationPreference)
 	}


### PR DESCRIPTION
This adds a sort of "fix" for the first issue identified in https://github.com/dolthub/go-mysql-server/issues/1232. This is basically a hack for collation coercibility, which is a significant undertaking. This should suffice in the meantime.