### PR TITLE
Additional fixes to collation coercion

### DIFF
--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -137,15 +137,24 @@ func (c *comparison) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 		} else if leftCollation == rightCollation {
 			collationPreference = leftCollation
 		} else { // Collations are not equal
-			if leftCollation.CharacterSet() != rightCollation.CharacterSet() {
-				return 0, sql.ErrCollationIllegalMix.New(leftCollation.Name(), rightCollation.Name())
-			}
-			// If the right collation is not _bin, then we default to the left collation (regardless of whether it is
-			// or is not _bin).
-			if strings.HasSuffix(rightCollation.Name(), "_bin") {
-				collationPreference = rightCollation
-			} else {
-				collationPreference = leftCollation
+			leftCharset := leftCollation.CharacterSet()
+			rightCharset := rightCollation.CharacterSet()
+			if leftCharset != rightCharset {
+				if leftCharset.MaxLength() == 1 && rightCharset.MaxLength() > 1 { // Left non-Unicode, Right Unicode
+					collationPreference = rightCollation
+				} else if leftCharset.MaxLength() > 1 && rightCharset.MaxLength() == 1 { // Left Unicode, Right non-Unicode
+					collationPreference = leftCollation
+				} else {
+					return 0, sql.ErrCollationIllegalMix.New(leftCollation.Name(), rightCollation.Name())
+				}
+			} else { // Character sets are equal
+				// If the right collation is not _bin, then we default to the left collation (regardless of whether it is
+				// or is not _bin).
+				if strings.HasSuffix(rightCollation.Name(), "_bin") {
+					collationPreference = rightCollation
+				} else {
+					collationPreference = leftCollation
+				}
 			}
 		}
 


### PR DESCRIPTION
Coercion rules specify that Unicode and non-Unicode characters may the Unicode collation applied in the event that they're being compared, concatenated, etc. I'm not exactly sure how to determine what a "Unicode" collation is, so I'm assuming that all collations that use more than one byte are Unicode. I can almost guarantee that this is incorrect, however it's a better approximation of behavior than not considering it at all.