### PR TITLE
Filter for join orders that respect join condition associations

### DIFF
--- a/sql/analyzer/join_search.go
+++ b/sql/analyzer/join_search.go
@@ -312,7 +312,7 @@ func (jo *joinOrderNode) estimateCost(ctx *sql.Context, joinIndexes joinIndexesB
 			}
 		}
 		for accessOrder, err := perm.Next(); err == nil; accessOrder, err = perm.Next() {
-			if !isCongruentJoinOrder(accessOrder, jo.tableNames(), cond) {
+			if !isConnectedJoinOrder(accessOrder, jo.tableNames(), cond) {
 				continue
 			}
 			cost, err := jo.estimateAccessOrderCost(ctx, accessOrder, joinIndexes, lowestCost, availableSchemaForKeys)
@@ -331,10 +331,10 @@ func (jo *joinOrderNode) estimateCost(ctx *sql.Context, joinIndexes joinIndexesB
 	return nil
 }
 
-// isCongruentJoinOrder returns true if the table order is a valid path
+// isConnectedJoinOrder returns true if the table order is a valid path
 // through the condition adjacency matrix, or false if the table order
 // leaves disjoin condition(s) that convert to cross joins
-func isCongruentJoinOrder(order []int, tables []string, condAdj condAdjMap) bool {
+func isConnectedJoinOrder(order []int, tables []string, condAdj condAdjMap) bool {
 	for i := 1; i < len(order); i++ {
 		// valid if any preceding tab has a relation to this tab
 		rels := condAdj[tables[order[i]]]

--- a/sql/analyzer/join_search.go
+++ b/sql/analyzer/join_search.go
@@ -64,7 +64,6 @@ func assignConditions(root *joinSearchNode, conditions []*joinCond) {
 			// for each assignment of conditions to the right tree
 			return helper(n.right, func() bool {
 				columns := n.tableCols()
-				fmt.Printf("accumulated table columns: %s", columns)
 				// look at every remaining condition
 				for i := range conditions {
 					cond := conditions[i]

--- a/sql/analyzer/join_search_test.go
+++ b/sql/analyzer/join_search_test.go
@@ -1040,7 +1040,7 @@ func TestValidIndexedJoin(t *testing.T) {
 			}
 			adj := conditionAdjacencyMap(joinConds)
 			assert.Equal(t, tt.adj, adj)
-			assert.Equal(t, tt.valid, isCongruentJoinOrder(tt.order, tt.tables, tt.adj))
+			assert.Equal(t, tt.valid, isConnectedJoinOrder(tt.order, tt.tables, tt.adj))
 		})
 	}
 }


### PR DESCRIPTION
To convert joins into indexed access, we must consider only join orders where all relations are connected via join conditions.

TODO: conjunction conditions still broken
TODO: find simpler tests than knut's repro