### PR TITLE
feat:(sql function) support last_insert_id with expr

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -713,7 +713,7 @@ var ScriptTests = []ScriptTest{
 			},
 			{
 				Query:    "insert into a (x, y) values (1, 1) on duplicate key update y = 2, x=last_insert_id(x)",
-				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2, InsertID: 1}}},
 			},
 			{
 				Query:    "select last_insert_id()",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -698,6 +698,30 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "last_insert_id(expr) behavior",
+		SetUpScript: []string{
+			"create table a (x int primary key auto_increment, y int)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "insert into a (y) values (1)",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 1, InsertID: 1}}},
+			},
+			{
+				Query:    "select last_insert_id()",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "insert into a (x, y) values (1, 1) on duplicate key update y = 2, x=last_insert_id(x)",
+				Expected: []sql.Row{{sql.OkResult{RowsAffected: 2}}},
+			},
+			{
+				Query:    "select last_insert_id()",
+				Expected: []sql.Row{{1}},
+			},
+		},
+	},
+	{
 		Name: "row_count() behavior",
 		SetUpScript: []string{
 			"create table b (x int primary key)",

--- a/sql/expression/function/queryinfo.go
+++ b/sql/expression/function/queryinfo.go
@@ -1,6 +1,10 @@
 package function
 
-import "github.com/dolthub/go-mysql-server/sql"
+import (
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
 
 // RowCount implements the ROW_COUNT() function
 type RowCount struct{}
@@ -61,14 +65,23 @@ func (r RowCount) FunctionName() string {
 }
 
 // LastInsertId implements the LAST_INSERT_ID() function
-type LastInsertId struct{}
+type LastInsertId struct {
+	expression.UnaryExpression
+}
 
 func (r LastInsertId) IsNonDeterministic() bool {
 	return true
 }
 
-func NewLastInsertId() sql.Expression {
-	return LastInsertId{}
+func NewLastInsertId(children ...sql.Expression) (sql.Expression, error) {
+	switch len(children) {
+	case 0:
+		return LastInsertId{}, nil
+	case 1:
+		return LastInsertId{UnaryExpression: expression.UnaryExpression{Child: children[0]}}, nil
+	default:
+		return nil, sql.ErrInvalidArgumentNumber.New("LastInsertId", len(children), 1)
+	}
 }
 
 var _ sql.FunctionExpression = LastInsertId{}
@@ -85,7 +98,7 @@ func (r LastInsertId) Resolved() bool {
 
 // String implements sql.Expression
 func (r LastInsertId) String() string {
-	return "LAST_INSERT_ID()"
+	return fmt.Sprintf("LAST_INSERT_ID(%s)", r.Child)
 }
 
 // Type implements sql.Expression
@@ -100,17 +113,31 @@ func (r LastInsertId) IsNullable() bool {
 
 // Eval implements sql.Expression
 func (r LastInsertId) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	return ctx.GetLastQueryInfo(sql.LastInsertId), nil
+	// if no expr like LAST_INSERT_ID(), we should return lastInsertId from ctx
+	if len(r.Children()) == 0 {
+		return ctx.GetLastQueryInfo(sql.LastInsertId), nil
+	}
+	// if expr is provided like LAST_INSERT_ID(id + 1), then the return value is the
+	// value of expr and we also need to save the lastinsertid into ctx for next query
+	res, err := r.Child.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	ctx.SetLastQueryInfo(sql.LastInsertId, toInt64(res))
+	return res, nil
 }
 
 // Children implements sql.Expression
 func (r LastInsertId) Children() []sql.Expression {
-	return nil
+	if r.Child == nil {
+		return nil
+	}
+	return []sql.Expression{r.Child}
 }
 
 // WithChildren implements sql.Expression
 func (r LastInsertId) WithChildren(children ...sql.Expression) (sql.Expression, error) {
-	return sql.NillaryWithChildren(r, children...)
+	return NewLastInsertId(children...)
 }
 
 // FunctionName implements sql.FunctionExpression
@@ -174,4 +201,35 @@ func (r FoundRows) Children() []sql.Expression {
 // WithChildren implements sql.Expression
 func (r FoundRows) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return sql.NillaryWithChildren(r, children...)
+}
+
+func toInt64(x interface{}) int64 {
+	switch x := x.(type) {
+	case int:
+		return int64(x)
+	case uint:
+		return int64(x)
+	case int8:
+		return int64(x)
+	case uint8:
+		return int64(x)
+	case int16:
+		return int64(x)
+	case uint16:
+		return int64(x)
+	case int32:
+		return int64(x)
+	case uint32:
+		return int64(x)
+	case int64:
+		return x
+	case uint64:
+		return int64(x)
+	case float32:
+		return int64(x)
+	case float64:
+		return int64(x)
+	default:
+		panic(fmt.Sprintf("Expected a numeric auto increment value, but got %T", x))
+	}
 }

--- a/sql/expression/function/queryinfo.go
+++ b/sql/expression/function/queryinfo.go
@@ -123,7 +123,12 @@ func (r LastInsertId) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx.SetLastQueryInfo(sql.LastInsertId, toInt64(res))
+	id, err := sql.Int64.Convert(res)
+	if err != nil {
+		return nil, err
+	}
+	// if we goes here id is must int64, we don't need to checkout the err of convert interface type to int64
+	ctx.SetLastQueryInfo(sql.LastInsertId, id.(int64))
 	return res, nil
 }
 
@@ -201,35 +206,4 @@ func (r FoundRows) Children() []sql.Expression {
 // WithChildren implements sql.Expression
 func (r FoundRows) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return sql.NillaryWithChildren(r, children...)
-}
-
-func toInt64(x interface{}) int64 {
-	switch x := x.(type) {
-	case int:
-		return int64(x)
-	case uint:
-		return int64(x)
-	case int8:
-		return int64(x)
-	case uint8:
-		return int64(x)
-	case int16:
-		return int64(x)
-	case uint16:
-		return int64(x)
-	case int32:
-		return int64(x)
-	case uint32:
-		return int64(x)
-	case int64:
-		return x
-	case uint64:
-		return int64(x)
-	case float32:
-		return int64(x)
-	case float64:
-		return int64(x)
-	default:
-		panic(fmt.Sprintf("Expected a numeric auto increment value, but got %T", x))
-	}
 }

--- a/sql/expression/function/queryinfo.go
+++ b/sql/expression/function/queryinfo.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"fmt"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 )

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -133,7 +133,7 @@ var BuiltIns = []sql.Function{
 	sql.FunctionN{Name: "json_value", Fn: NewJSONValue},
 	sql.FunctionN{Name: "lag", Fn: func(e ...sql.Expression) (sql.Expression, error) { return window.NewLag(e...) }},
 	sql.Function1{Name: "last", Fn: func(e sql.Expression) sql.Expression { return aggregation.NewLast(e) }},
-	sql.Function0{Name: "last_insert_id", Fn: NewLastInsertId},
+	sql.FunctionN{Name: "last_insert_id", Fn: NewLastInsertId},
 	sql.Function1{Name: "lcase", Fn: NewLower},
 	sql.FunctionN{Name: "lead", Fn: func(e ...sql.Expression) (sql.Expression, error) { return window.NewLead(e...) }},
 	sql.FunctionN{Name: "least", Fn: NewLeast},


### PR DESCRIPTION
mysql support parameter for LAST_INSERT_ID(expr), it is useful in upsert query when we want to get the updated recored id
ref: https://dev.mysql.com/doc/refman/8.0/en/information-functions.html#function_last-insert-id