### PR TITLE
`UpdateJoin` bug fixes 

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3366,31 +3366,11 @@ func TestChecksOnInsert(t *testing.T, harness Harness) {
 	TestQueryWithContext(t, ctx, e, harness, `SELECT count(*) FROM t1 where a = 4`, []sql.Row{{1}}, nil, nil)
 }
 
-// todo(max): rewrite into []ScriptTest
 func TestChecksOnUpdate(t *testing.T, harness Harness) {
 	harness.Setup(setup.MydbData)
-	e := mustNewEngine(t, harness)
-	defer e.Close()
-	ctx := NewContext(harness)
-
-	RunQuery(t, e, harness, "CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER)")
-	RunQuery(t, e, harness, "ALTER TABLE t1 ADD CONSTRAINT chk1 CHECK (b > 10) NOT ENFORCED")
-	RunQuery(t, e, harness, "ALTER TABLE t1 ADD CONSTRAINT chk2 CHECK (b > 0)")
-	RunQuery(t, e, harness, "ALTER TABLE t1 ADD CONSTRAINT chk3 CHECK ((a + b) / 2 >= 1) ENFORCED")
-	RunQuery(t, e, harness, "INSERT INTO t1 VALUES (1,1)")
-
-	TestQueryWithContext(t, ctx, e, harness, `SELECT * FROM t1`, []sql.Row{
-		{1, 1},
-	}, nil, nil)
-
-	AssertErr(t, e, harness, "UPDATE t1 set b = 0", sql.ErrCheckConstraintViolated)
-	AssertErr(t, e, harness, "UPDATE t1 set a = 0, b = 1", sql.ErrCheckConstraintViolated)
-	AssertErr(t, e, harness, "UPDATE t1 set b = 0 WHERE b = 1", sql.ErrCheckConstraintViolated)
-	AssertErr(t, e, harness, "UPDATE t1 set a = 0, b = 1 WHERE b = 1", sql.ErrCheckConstraintViolated)
-
-	TestQueryWithContext(t, ctx, e, harness, `SELECT * FROM t1`, []sql.Row{
-		{1, 1},
-	}, nil, nil)
+	for _, script := range queries.ChecksOnUpdateScriptTests {
+		TestScript(t, harness, script)
+	}
 }
 
 func TestDisallowedCheckConstraints(t *testing.T, harness Harness) {

--- a/enginetest/queries/check_scripts.go
+++ b/enginetest/queries/check_scripts.go
@@ -1,0 +1,96 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queries
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+)
+
+var ChecksOnUpdateScriptTests = []ScriptTest{
+	{
+		Name: "Single table updates",
+		SetUpScript: []string{
+			"CREATE TABLE t1 (a INTEGER PRIMARY KEY, b INTEGER)",
+			"ALTER TABLE t1 ADD CONSTRAINT chk1 CHECK (b > 10) NOT ENFORCED",
+			"ALTER TABLE t1 ADD CONSTRAINT chk2 CHECK (b > 0)",
+			"ALTER TABLE t1 ADD CONSTRAINT chk3 CHECK ((a + b) / 2 >= 1) ENFORCED",
+			"INSERT INTO t1 VALUES (1,1)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT * FROM t1;",
+				Expected: []sql.Row{{1, 1}},
+			},
+			{
+				Query:       "UPDATE t1 set b = 0;",
+				ExpectedErr: sql.ErrCheckConstraintViolated,
+			},
+			{
+				Query:       "UPDATE t1 set a = 0, b = 1;",
+				ExpectedErr: sql.ErrCheckConstraintViolated,
+			},
+			{
+				Query:       "UPDATE t1 set b = 0 WHERE b = 1;",
+				ExpectedErr: sql.ErrCheckConstraintViolated,
+			},
+			{
+				Query:       "UPDATE t1 set a = 0, b = 1 WHERE b = 1;",
+				ExpectedErr: sql.ErrCheckConstraintViolated,
+			},
+		},
+	},
+	{
+		Name: "Update join updates",
+		SetUpScript: []string{
+			"CREATE TABLE sales (year_built int primary key, CONSTRAINT `valid_year_built` CHECK (year_built <= 2022));",
+			"INSERT INTO sales VALUES (1981);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "UPDATE sales JOIN (SELECT year_built FROM sales) AS t ON sales.year_built = t.year_built SET sales.year_built = 1901;",
+				Expected: []sql.Row{{sql.OkResult{1, 0, plan.UpdateInfo{1, 1, 0}}}},
+			},
+			{
+				Query:    "select * from sales;",
+				Expected: []sql.Row{{1901}},
+			},
+			{
+				Query:    "UPDATE sales as s1 JOIN (SELECT year_built FROM sales) AS t SET S1.year_built = 1902;",
+				Expected: []sql.Row{{sql.OkResult{1, 0, plan.UpdateInfo{1, 1, 0}}}},
+			},
+			{
+				Query:    "select * from sales;",
+				Expected: []sql.Row{{1902}},
+			},
+			{
+				Query:       "UPDATE sales as s1 JOIN (SELECT year_built FROM sales) AS t SET t.year_built = 1903;",
+				ExpectedErr: plan.ErrUpdateForTableNotSupported,
+			},
+			{
+				Query:       "UPDATE sales JOIN (SELECT year_built FROM sales) AS t SET sales.year_built = 2030;",
+				ExpectedErr: sql.ErrCheckConstraintViolated,
+			},
+			{
+				Query:       "UPDATE sales as s1 JOIN (SELECT year_built FROM sales) AS t SET s1.year_built = 2030;",
+				ExpectedErr: sql.ErrCheckConstraintViolated,
+			},
+			{
+				Query:       "UPDATE sales as s1 JOIN (SELECT year_built FROM sales) AS t SET t.year_built = 2030;",
+				ExpectedErr: plan.ErrUpdateForTableNotSupported,
+			},
+		},
+	},
+}

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -61,21 +61,14 @@ func rowUpdatersByTable(ctx *sql.Context, node sql.Node, ij sql.Node) (map[strin
 			return nil, plan.ErrUpdateForTableNotSupported.New(tableToBeUpdated)
 		}
 
-		var updatable sql.UpdatableTable
-		switch tt := resolvedTable.Table.(type) {
-		case sql.UpdatableTable:
-			updatable = tt
-		case *plan.ProcessTable:
-			if ut, ok := tt.Table.(sql.UpdatableTable); ok {
-				updatable = ut
-			}
-		case *plan.ProcessIndexableTable:
-			if ut, ok := tt.DriverIndexableTable.(sql.UpdatableTable); ok {
-				updatable = ut
-			}
+		var table = resolvedTable.Table
+		if t, ok := table.(sql.TableWrapper); ok {
+			table = t.Underlying()
 		}
+
 		// If there is no UpdatableTable for a table being updated, error out
-		if updatable == nil {
+		updatable, ok := table.(sql.UpdatableTable)
+		if !ok && updatable == nil {
 			return nil, plan.ErrUpdateForTableNotSupported.New(tableToBeUpdated)
 		}
 

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -66,6 +66,10 @@ func rowUpdatersByTable(ctx *sql.Context, node sql.Node, ij sql.Node) (map[strin
 		switch tt := v.Table.(type) {
 		case sql.UpdatableTable:
 			updatable = tt
+		case *plan.ProcessTable:
+			if ut, ok := tt.Table.(sql.UpdatableTable); ok {
+				updatable = ut
+			}
 		case *plan.ProcessIndexableTable:
 			if ut, ok := tt.DriverIndexableTable.(sql.UpdatableTable); ok {
 				updatable = ut

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -280,15 +280,17 @@ func qualifyCheckConstraints(update *plan.Update) (sql.CheckConstraints, error) 
 	newExprs := make([]sql.Expression, len(checks))
 	for i, checkExpr := range checks.ToExpressions() {
 		newExpr, _, err := transform.Expr(checkExpr, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-			switch ee := e.(type) {
-			case column:
-				if ee.Table() == "" {
+			switch e := e.(type) {
+			case *expression.UnresolvedColumn:
+				if e.Table() == "" {
 					tableName := table.Name()
 					if alias != "" {
 						tableName = alias
 					}
-					return expression.NewUnresolvedQualifiedColumn(tableName, ee.Name()), transform.NewTree, nil
+					return expression.NewUnresolvedQualifiedColumn(tableName, e.Name()), transform.NewTree, nil
 				}
+			default:
+				// nothing else needed for other types
 			}
 			return e, transform.SameTree, nil
 		})

--- a/sql/analyzer/tables.go
+++ b/sql/analyzer/tables.go
@@ -132,6 +132,36 @@ func hasTable(name string, node sql.Node) bool {
 	return found
 }
 
+// getResolvedTableAndAlias returns the first resolved table in the specified node tree, along with its aliased name,
+// or the empty string if no table alias has been specified.
+func getResolvedTableAndAlias(node sql.Node) (*plan.ResolvedTable, string) {
+	var table *plan.ResolvedTable
+	var alias string
+
+	transform.Inspect(node, func(node sql.Node) bool {
+		// plan.Inspect will get called on all children of a node even if one of the children's calls returns false. We
+		// only want the first ResolvedTable match.
+		if table != nil {
+			return false
+		}
+
+		switch n := node.(type) {
+		case *plan.TableAlias:
+			table = getResolvedTable(n)
+			alias = n.Name()
+			return false
+		case *plan.ResolvedTable:
+			table = n
+			return false
+		case *plan.IndexedTableAccess:
+			table = n.ResolvedTable
+			return false
+		}
+		return true
+	})
+	return table, alias
+}
+
 // Finds first ResolvedTable node that is a descendant of the node given
 func getResolvedTable(node sql.Node) *plan.ResolvedTable {
 	var table *plan.ResolvedTable

--- a/sql/constraints.go
+++ b/sql/constraints.go
@@ -79,7 +79,7 @@ type CheckConstraint struct {
 
 type CheckConstraints []*CheckConstraint
 
-// ToExpressions returns the check expressions in these constrains as a slice of sql.Expression
+// ToExpressions returns the check expressions in these constraints as a slice of sql.Expression
 func (checks CheckConstraints) ToExpressions() []Expression {
 	exprs := make([]Expression, len(checks))
 	for i := range checks {

--- a/sql/plan/update.go
+++ b/sql/plan/update.go
@@ -24,6 +24,7 @@ import (
 )
 
 var ErrUpdateNotSupported = errors.NewKind("table doesn't support UPDATE")
+var ErrUpdateForTableNotSupported = errors.NewKind("The target table %s of the UPDATE is not updatable")
 var ErrUpdateUnexpectedSetResult = errors.NewKind("attempted to set field but expression returned %T")
 
 // Update is a node for updating rows on tables.

--- a/sql/plan/update_join.go
+++ b/sql/plan/update_join.go
@@ -126,7 +126,7 @@ func (u *updateJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 				}
 			}
 
-			// Determine whether this row in the table has already been update
+			// Determine whether this row in the table has already been updated
 			cache := u.getOrCreateCache(ctx, tableName)
 			hash, err := sql.HashOf(oldTableRow)
 			if err != nil {


### PR DESCRIPTION
Bug fixes for https://github.com/dolthub/dolt/issues/4288
- qualifying check constraint expressions when multiple tables are being updated
- support finding UpdatableTables through ProcessIndexableTable and ProcessTable nodes
- erroring out when a table updater isn't available for a SetField expression, instead of silently dropping it

This does **not** address another UpdateJoin bug I just found while testing: https://github.com/dolthub/dolt/issues/4304. Mentioning that one here so we have this context connected when we go to fix it. 

I verified that Dolt's enginetest suite runs correctly with these changes. 