### PR TITLE
stripNodes in subquery block apply_hash_lookup optimization

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7021,6 +7021,28 @@ var QueryTests = []QueryTest{
 		Query:    "with a(j) as (select 1), b(i) as (select 1) (select j from a union all select i from b) union select j from a;",
 		Expected: []sql.Row{{1}},
 	},
+	{
+		Query: `
+With c as (
+  select * from (
+    select a.s
+    From mytable a
+    Join (
+      Select t2.*
+      From mytable t2
+      Where t2.i in (1,2)
+    ) b
+    On a.i = b.i
+    Join (
+      select t1.*
+      from mytable t1
+      Where t1.I in (2,3)
+    ) e
+    On b.I = e.i
+  ) d   
+) select * from c;`,
+		Expected: []sql.Row{{"second row"}},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/analyzer/aliases.go
+++ b/sql/analyzer/aliases.go
@@ -54,7 +54,7 @@ func getTableAliases(n sql.Node, scope *Scope) (TableAliases, error) {
 	var aliasFn func(node sql.Node) bool
 	var analysisErr error
 	var recScope *Scope
-	if scope != nil && len(scope.Schema()) > 0 {
+	if !scope.IsEmpty() {
 		recScope = recScope.withMemos(scope.memos)
 	}
 

--- a/sql/analyzer/aliases.go
+++ b/sql/analyzer/aliases.go
@@ -54,7 +54,7 @@ func getTableAliases(n sql.Node, scope *Scope) (TableAliases, error) {
 	var aliasFn func(node sql.Node) bool
 	var analysisErr error
 	var recScope *Scope
-	if scope != nil {
+	if scope != nil && len(scope.Schema()) > 0 {
 		recScope = recScope.withMemos(scope.memos)
 	}
 

--- a/sql/analyzer/apply_indexes_from_outer_scope.go
+++ b/sql/analyzer/apply_indexes_from_outer_scope.go
@@ -30,7 +30,7 @@ import (
 // apply, effectively, an indexed join between two tables, one of which is defined in the outer scope. This is similar
 // to the process in the join analyzer.
 func applyIndexesFromOuterScope(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel RuleSelector) (sql.Node, transform.TreeIdentity, error) {
-	if scope == nil || len(scope.Schema()) == 0 {
+	if scope.IsEmpty() {
 		return n, transform.SameTree, nil
 	}
 

--- a/sql/analyzer/apply_indexes_from_outer_scope.go
+++ b/sql/analyzer/apply_indexes_from_outer_scope.go
@@ -30,7 +30,7 @@ import (
 // apply, effectively, an indexed join between two tables, one of which is defined in the outer scope. This is similar
 // to the process in the join analyzer.
 func applyIndexesFromOuterScope(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel RuleSelector) (sql.Node, transform.TreeIdentity, error) {
-	if scope == nil {
+	if scope == nil || len(scope.Schema()) == 0 {
 		return n, transform.SameTree, nil
 	}
 

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -279,7 +279,7 @@ func replaceTableAccessWithIndexedAccess(
 			return nil, transform.SameTree, err
 		}
 
-		if scope != nil && len(scope.Schema()) > 0 {
+		if !scope.IsEmpty() {
 			left = plan.NewStripRowNode(left, len(scope.Schema()))
 		}
 
@@ -289,7 +289,7 @@ func replaceTableAccessWithIndexedAccess(
 			return nil, transform.SameTree, err
 		}
 
-		if scope != nil && len(scope.Schema()) > 0 {
+		if !scope.IsEmpty() {
 			right = plan.NewStripRowNode(right, len(scope.Schema()))
 		}
 

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -279,7 +279,7 @@ func replaceTableAccessWithIndexedAccess(
 			return nil, transform.SameTree, err
 		}
 
-		if scope != nil {
+		if scope != nil && len(scope.Schema()) > 0 {
 			left = plan.NewStripRowNode(left, len(scope.Schema()))
 		}
 
@@ -289,7 +289,7 @@ func replaceTableAccessWithIndexedAccess(
 			return nil, transform.SameTree, err
 		}
 
-		if scope != nil {
+		if scope != nil && len(scope.Schema()) > 0 {
 			right = plan.NewStripRowNode(right, len(scope.Schema()))
 		}
 

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -268,7 +268,7 @@ func cacheSubqueryAlisesInJoins(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 	// We only want to do this if we're at the top of the tree.
 	// TODO: Not a perfect indicator of whether we're at the top of the tree...
 	sameD := transform.SameTree
-	if scope == nil || len(scope.Schema()) == 0 {
+	if scope.IsEmpty() {
 		selector := func(c transform.Context) bool {
 			if _, isIndexedJoin := c.Parent.(*plan.IndexedJoin); isIndexedJoin {
 				return c.ChildNum == 0

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -268,7 +268,7 @@ func cacheSubqueryAlisesInJoins(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 	// We only want to do this if we're at the top of the tree.
 	// TODO: Not a perfect indicator of whether we're at the top of the tree...
 	sameD := transform.SameTree
-	if scope == nil {
+	if scope == nil || len(scope.Schema()) == 0 {
 		selector := func(c transform.Context) bool {
 			if _, isIndexedJoin := c.Parent.(*plan.IndexedJoin); isIndexedJoin {
 				return c.ChildNum == 0

--- a/sql/analyzer/scope.go
+++ b/sql/analyzer/scope.go
@@ -34,6 +34,11 @@ type Scope struct {
 	procedures *ProcedureCache
 }
 
+func (s *Scope) IsEmpty() bool {
+	return s == nil || len(s.nodes) == 0
+
+}
+
 // newScope creates a new Scope object with the additional innermost Node context. When constructing with a subquery,
 // the Node given should be the sibling Node of the subquery.
 func (s *Scope) newScope(node sql.Node) *Scope {


### PR DESCRIPTION
A HashLookup requires two rules, 1) converting a JOIN -> SUBQUERY_ALIAS => JOIN => CACHED_RESULT(SQ), 2) converting the CACHED_RESULT into a HASHED_LOOKUP.

Prevent StripRowNode from breaking the pattern matcher for the first step. Every other node can screw up the rule, but we have a test now at least.
