### PR TITLE
Bug Fix: change `unix_timestamp(<expr>)` to return 0 when it can't convert `expr` to a date

### DIFF
--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -377,7 +377,6 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 	}
 
 	date, err := ut.Date.Eval(ctx, row)
-
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +386,8 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 
 	date, err = sql.Datetime.Convert(date)
 	if err != nil {
-		return nil, err
+		// If we aren't able to convert the value to a date, return 0 to match MySQL's behavior
+		return 0, nil
 	}
 
 	return toUnixTimestamp(date.(time.Time))

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -386,7 +386,9 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 
 	date, err = sql.Datetime.Convert(date)
 	if err != nil {
-		// If we aren't able to convert the value to a date, return 0 to match MySQL's behavior
+		// If we aren't able to convert the value to a date, return 0 and set
+		// a warning to match MySQL's behavior
+		ctx.Warn(1292, "Incorrect datetime value: %s", ut.Date.String())
 		return 0, nil
 	}
 

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -147,6 +147,20 @@ func TestUnixTimestamp(t *testing.T) {
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(expected, result)
+
+	// When MySQL can't convert the expression to a date, it always returns 0
+	ut, err = NewUnixTimestamp(expression.NewLiteral(1577995200, sql.Int64))
+	require.NoError(err)
+	result, err = ut.Eval(ctx, nil)
+	require.NoError(err)
+	require.Equal(0, result)
+
+	// When MySQL can't convert the expression to a date, it always returns 0
+	ut, err = NewUnixTimestamp(expression.NewLiteral("d0lthub", sql.Text))
+	require.NoError(err)
+	result, err = ut.Eval(ctx, nil)
+	require.NoError(err)
+	require.Equal(0, result)
 }
 
 func TestFromUnixtime(t *testing.T) {

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -133,6 +133,7 @@ func TestUnixTimestamp(t *testing.T) {
 	result, err := ut.Eval(ctx2, nil)
 	require.NoError(err)
 	require.Equal(expected, result)
+	require.Equal(uint16(0), ctx.WarningCount())
 
 	ut, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", sql.LongText))
 	require.NoError(err)
@@ -140,6 +141,7 @@ func TestUnixTimestamp(t *testing.T) {
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(expected, result)
+	require.Equal(uint16(0), ctx.WarningCount())
 
 	ut, err = NewUnixTimestamp(expression.NewLiteral(nil, sql.Null))
 	require.NoError(err)
@@ -147,20 +149,28 @@ func TestUnixTimestamp(t *testing.T) {
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(expected, result)
+	require.Equal(uint16(0), ctx.WarningCount())
 
-	// When MySQL can't convert the expression to a date, it always returns 0
+	// When MySQL can't convert the expression to a date, it always returns 0 and sets a warning
 	ut, err = NewUnixTimestamp(expression.NewLiteral(1577995200, sql.Int64))
 	require.NoError(err)
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(0, result)
+	require.Equal(uint16(1), ctx.WarningCount())
+	require.Equal("Incorrect datetime value: 1577995200", ctx.Warnings()[0].Message)
+	require.Equal(1292, ctx.Warnings()[0].Code)
 
-	// When MySQL can't convert the expression to a date, it always returns 0
+	// When MySQL can't convert the expression to a date, it always returns 0 and sets a warning
+	ctx.ClearWarnings()
 	ut, err = NewUnixTimestamp(expression.NewLiteral("d0lthub", sql.Text))
 	require.NoError(err)
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(0, result)
+	require.Equal(uint16(1), ctx.WarningCount())
+	require.Equal("Incorrect datetime value: 'd0lthub'", ctx.Warnings()[0].Message)
+	require.Equal(1292, ctx.Warnings()[0].Code)
 }
 
 func TestFromUnixtime(t *testing.T) {

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -163,6 +163,9 @@ func TestUnixTimestamp(t *testing.T) {
 
 	// When MySQL can't convert the expression to a date, it always returns 0 and sets a warning
 	ctx.ClearWarnings()
+	// TODO: ClearWarnings has to be called twice to actually clear the warnings because of the way it sets its
+	//       warncnt member var. This should be fixed, but existing behavior depends on this behavior currently.
+	ctx.ClearWarnings()
 	ut, err = NewUnixTimestamp(expression.NewLiteral("d0lthub", sql.Text))
 	require.NoError(err)
 	result, err = ut.Eval(ctx, nil)

--- a/sql/session.go
+++ b/sql/session.go
@@ -173,6 +173,7 @@ type BaseSession struct {
 	idxReg           *IndexRegistry
 	viewReg          *ViewRegistry
 	warnings         []*Warning
+	warncnt          uint16
 	locks            map[string]bool
 	queriedDb        string
 	lastQueryInfo    map[string]int64
@@ -413,8 +414,14 @@ func (s *BaseSession) ClearWarnings() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.warnings != nil {
-		s.warnings = s.warnings[:0]
+	cnt := uint16(len(s.warnings))
+	if s.warncnt == cnt {
+		if s.warnings != nil {
+			s.warnings = s.warnings[:0]
+		}
+		s.warncnt = 0
+	} else {
+		s.warncnt = cnt
 	}
 }
 

--- a/sql/session.go
+++ b/sql/session.go
@@ -173,7 +173,6 @@ type BaseSession struct {
 	idxReg           *IndexRegistry
 	viewReg          *ViewRegistry
 	warnings         []*Warning
-	warncnt          uint16
 	locks            map[string]bool
 	queriedDb        string
 	lastQueryInfo    map[string]int64
@@ -414,14 +413,8 @@ func (s *BaseSession) ClearWarnings() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	cnt := uint16(len(s.warnings))
-	if s.warncnt == cnt {
-		if s.warnings != nil {
-			s.warnings = s.warnings[:0]
-		}
-		s.warncnt = 0
-	} else {
-		s.warncnt = cnt
+	if s.warnings != nil {
+		s.warnings = s.warnings[:0]
 	}
 }
 


### PR DESCRIPTION
MySQL's implementation of `unix_timestamp(<expr>)` returns `0` when the expression can't be converted to a date and logs a warning. This PR changes Dolt to have the same behavior. It also includes a bug fix for `ctx.ClearWarnings` to correctly clear warnings. 

```sql
mysql> select unix_timestamp(1577995200);
+----------------------------+
| unix_timestamp(1577995200) |
+----------------------------+
|                          0 |
+----------------------------+
1 row in set, 1 warning (0.00 sec)

mysql> select unix_timestamp("jason");
+-------------------------+
| unix_timestamp("jason") |
+-------------------------+
|                0.000000 |
+-------------------------+
1 row in set, 1 warning (0.00 sec)

mysql> show warnings;
+---------+------+-----------------------------------+
| Level   | Code | Message                           |
+---------+------+-----------------------------------+
| Warning | 1292 | Incorrect datetime value: 'jason' |
+---------+------+-----------------------------------+
1 row in set (0.00 sec)
```

