### PR TITLE
fix test ordering

### DIFF
--- a/enginetest/queries/json_table_queries.go
+++ b/enginetest/queries/json_table_queries.go
@@ -61,7 +61,7 @@ var JSONTableQueryTests = []QueryTest{
 		},
 	},
 	{
-		Query: "select * from JSON_TABLE('[{\"a\":1},{\"a\":2}]', '$[*]' COLUMNS(x int path '$.a')) as t1 join one_pk order by x;",
+		Query: "select * from JSON_TABLE('[{\"a\":1},{\"a\":2}]', '$[*]' COLUMNS(x int path '$.a')) as t1 join one_pk order by x, pk;",
 		Expected: []sql.Row{
 			{1, 0, 0, 1, 2, 3, 4},
 			{1, 1, 10, 11, 12, 13, 14},
@@ -74,7 +74,7 @@ var JSONTableQueryTests = []QueryTest{
 		},
 	},
 	{
-		Query: "select * from one_pk join JSON_TABLE('[{\"a\":1},{\"a\":2}]', '$[*]' COLUMNS(x int path '$.a')) as t1 order by x;",
+		Query: "select * from one_pk join JSON_TABLE('[{\"a\":1},{\"a\":2}]', '$[*]' COLUMNS(x int path '$.a')) as t1 order by x, pk;",
 		Expected: []sql.Row{
 			{0, 0, 1, 2, 3, 4, 1},
 			{1, 10, 11, 12, 13, 14, 1},


### PR DESCRIPTION
some tests on dolt were failing for `JSON_TABLES`, due to abiguous `ORDER BY`
Companion PR: https://github.com/dolthub/dolt/pull/4355