### PR TITLE
Throw error in alter table set default if default fails rule(s)

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5572,9 +5572,12 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 		AssertErr(t, e, harness, "CREATE TABLE t999(pk BIGINT PRIMARY KEY, v1 BIGINT DEFAULT (v2), v2 BIGINT DEFAULT (9))", sql.ErrInvalidDefaultValueOrder)
 	})
 
-	t.Run("TEXT literals", func(t *testing.T) {
+	t.Run("Blob types can't define defaults with literals", func(t *testing.T) {
 		AssertErr(t, e, harness, "CREATE TABLE t999(pk BIGINT PRIMARY KEY, v1 TEXT DEFAULT 'hi')", sql.ErrInvalidTextBlobColumnDefault)
 		AssertErr(t, e, harness, "CREATE TABLE t999(pk BIGINT PRIMARY KEY, v1 LONGTEXT DEFAULT 'hi')", sql.ErrInvalidTextBlobColumnDefault)
+		RunQuery(t, e, harness, "CREATE TABLE t34(pk INT PRIMARY KEY, v1 JSON)")
+		AssertErr(t, e, harness, "ALTER TABLE t34 alter column v1 set default '{}'", sql.ErrInvalidTextBlobColumnDefault)
+		RunQuery(t, e, harness, "ALTER TABLE t34 alter column v1 set default ('{}')")
 	})
 
 	t.Run("Other types using NOW/CURRENT_TIMESTAMP literal", func(t *testing.T) {

--- a/sql/plan/alter_default.go
+++ b/sql/plan/alter_default.go
@@ -114,7 +114,7 @@ func (d *AlterDefaultSet) CheckPrivileges(ctx *sql.Context, opChecker sql.Privil
 
 // Resolved implements the sql.Node interface.
 func (d *AlterDefaultSet) Resolved() bool {
-	return d.Table.Resolved() && d.ddlNode.Resolved()
+	return d.Table.Resolved() && d.ddlNode.Resolved() && d.Default.Resolved()
 }
 
 func (d *AlterDefaultSet) Expressions() []sql.Expression {


### PR DESCRIPTION
This PR makes `alter column set default` error when its default expression fails the default expression rules. Previously the DDL succeeded and when an insert or any other query was performed the default would cause a continuous error.

```sql
alter table t alter column col1 set default '{\"bye\":1}'
-- errors with: TEXT, BLOB, GEOMETRY, and JSON types may only have expression default values
```