### PR TITLE
[no-release-notes] alter schema needs primary key only in dolt

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1990,7 +1990,7 @@ var ScriptTests = []ScriptTest{
 	{
 		Name: "ALTER AUTO INCREMENT TABLE ADD column",
 		SetUpScript: []string{
-			"CREATE TABLE test (pk int UNIQUE KEY auto_increment);",
+			"CREATE TABLE test (pk int primary key, uk int UNIQUE KEY auto_increment);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{


### PR DESCRIPTION
Altering tables only works if that table has a primary key, specifically in dolt.
As a result , the test I wrote here works in GMS, but not dolt

https://github.com/dolthub/dolt/blob/main/go/libraries/doltcore/sqle/alterschema.go#L507