### PR TITLE
Ensuring read-only check is executed for prepared and non-prepared statements

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -190,6 +190,11 @@ func (e *Engine) QueryNodeWithBindings(
 		return nil, nil, err
 	}
 
+	err = e.readOnlyCheck(parsed)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	err = e.beginTransaction(ctx, transactionDatabase)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Quick fix for: https://github.com/dolthub/dolt/issues/4434

Tested locally with a python script to verify that prepared statements to read-only dbs are now correctly blocked. After getting this fix out, we will follow up with more formal, automated test to cover this. 