### PR TITLE
allow `having` node access to all tables in itself

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -154,6 +154,10 @@ func TestScriptWithEnginePrepared(t *testing.T, e *sqle.Engine, harness Harness,
 				t.Skip()
 			}
 		}
+		if assertion.Skip {
+			t.Skip()
+		}
+
 		if assertion.ExpectedErr != nil {
 			t.Run(assertion.Query, func(t *testing.T) {
 				AssertErr(t, e, harness, assertion.Query, assertion.ExpectedErr)

--- a/enginetest/queries/column_alias_queries.go
+++ b/enginetest/queries/column_alias_queries.go
@@ -157,6 +157,10 @@ var ColumnAliasQueries = []ScriptTest{
 					{"third row", float64(3)},
 				},
 			},
+			{
+				Query:    "select t1.i as a from mytable as t1 having a = t1.i;",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
 		},
 	},
 	{
@@ -250,13 +254,6 @@ var ColumnAliasQueries = []ScriptTest{
 				Skip:        true,
 				Query:       `select 1 as a, (select b), 0 as b;`,
 				ExpectedErr: sql.ErrColumnNotFound,
-			},
-			{
-				// GMS returns the error "found HAVING clause with no GROUP BY", but MySQL executes
-				// this query without any problems.
-				Skip:     true,
-				Query:    "select t1.i as a from mytable as t1 having a = t1.i;",
-				Expected: []sql.Row{{1}, {2}, {3}},
 			},
 			{
 				// GMS returns "expression 'dt.two' doesn't appear in the group by expressions", but MySQL will execute

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2312,8 +2312,8 @@ var ScriptTests = []ScriptTest{
 			{
 				// MySQL returns `Unknown column 'val' in 'having clause'` error for this query,
 				// but GMS builds GroupBy for any aggregate function.
-				SkipResultsCheck: true,
-				Query:            "select count(*) from numbers having count(*) > val;",
+				Skip:  true,
+				Query: "select count(*) from numbers having count(*) > val;",
 				//ExpectedErrStr:   "found HAVING clause with no GROUP BY", // not the exact error we want
 			},
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2273,6 +2273,55 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "having clause without groupby clause, all rows implicitly form a single aggregate group",
+		SetUpScript: []string{
+			"create table numbers (val int);",
+			"insert into numbers values (1), (2), (3);",
+			"insert into numbers values (2), (4);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select val from numbers;",
+				Expected: []sql.Row{{1}, {2}, {3}, {2}, {4}},
+			},
+			{
+				Query:    "select val as a from numbers having a = val;",
+				Expected: []sql.Row{{1}, {2}, {3}, {2}, {4}},
+			},
+			{
+				Query:    "select val as a from numbers group by val having a = val;",
+				Expected: []sql.Row{{1}, {2}, {3}, {4}},
+			},
+			{
+				Query:    "select val as a from numbers as t1 group by t1.val having a = t1.val;",
+				Expected: []sql.Row{{1}, {2}, {3}, {4}},
+			},
+			{
+				Query:    "select t1.val as a from numbers as t1 group by 1 having a = t1.val;",
+				Expected: []sql.Row{{1}, {2}, {3}, {4}},
+			},
+			{
+				Query:    "select t1.val as a from numbers as t1 having a = t1.val;",
+				Expected: []sql.Row{{1}, {2}, {3}, {2}, {4}},
+			},
+			{
+				Query:    "select count(*) from numbers having count(*) = 5;",
+				Expected: []sql.Row{{5}},
+			},
+			{
+				// MySQL returns `Unknown column 'val' in 'having clause'` error for this query,
+				// but GMS builds GroupBy for any aggregate function.
+				SkipResultsCheck: true,
+				Query:            "select count(*) from numbers having count(*) > val;",
+				//ExpectedErrStr:   "found HAVING clause with no GROUP BY", // not the exact error we want
+			},
+			{
+				Query:    "select count(*) from numbers group by val having count(*) < val;",
+				Expected: []sql.Row{{1}, {1}},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -776,6 +776,7 @@ func indexColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (map[
 	// so reset idx for any additional schema
 	switch n.(type) {
 	case *plan.Having:
+
 		transform.Inspect(n, func(node sql.Node) bool {
 			for _, child := range n.Children() {
 				indexChildNode(child)

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -762,27 +762,12 @@ func indexColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope) (map[
 		shouldIndexChildNode = false
 	case *plan.RecursiveCte, *plan.Union:
 		shouldIndexChildNode = false
-	case *plan.Having:
-		shouldIndexChildNode = false
 	}
 
 	if shouldIndexChildNode {
 		for _, child := range n.Children() {
 			indexChildNode(child)
 		}
-	}
-
-	// having node need access to all table references within its children node,
-	// so reset idx for any additional schema
-	switch n.(type) {
-	case *plan.Having:
-
-		transform.Inspect(n, func(node sql.Node) bool {
-			for _, child := range n.Children() {
-				indexChildNode(child)
-			}
-			return true
-		})
 	}
 
 	// For certain DDL nodes, we have to do more work

--- a/sql/analyzer/resolve_having.go
+++ b/sql/analyzer/resolve_having.go
@@ -126,9 +126,7 @@ func pullMissingColumnsUp(having *plan.Having, missingCols map[string]bool) (*pl
 		if n == nil {
 			return false
 		}
-		for _, child := range n.Children() {
-			loopSchema(child.Schema())
-		}
+		loopSchema(n.Schema())
 		return true
 	})
 

--- a/sql/analyzer/resolve_having.go
+++ b/sql/analyzer/resolve_having.go
@@ -73,17 +73,17 @@ func resolveHaving(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope, s
 	})
 }
 
-func findMissingColumns(node sql.Node, expr sql.Expression) []string {
+func findMissingColumns(node sql.Node, expr sql.Expression) map[string]bool {
 	var schemaCols []string
 	for _, col := range node.Schema() {
 		schemaCols = append(schemaCols, strings.ToLower(col.Name))
 	}
 
-	var missingCols []string
+	var missingCols = make(map[string]bool)
 	for _, n := range findExprNameables(expr) {
 		name := strings.ToLower(n.Name())
 		if !stringContains(schemaCols, name) {
-			missingCols = append(missingCols, n.Name())
+			missingCols[n.Name()] = true
 		}
 	}
 
@@ -104,37 +104,46 @@ func projectOriginalAggregation(having *plan.Having, schema sql.Schema) *plan.Pr
 
 var errHavingChildMissingRef = errors.NewKind("cannot find column %s referenced in HAVING clause in either GROUP BY or its child")
 
-func pullMissingColumnsUp(having *plan.Having, missingCols []string) (*plan.Having, error) {
-	groupBy, err := findGroupBy(having)
-	if err != nil {
-		return nil, err
-	}
-
-	schema := groupBy.Child.Schema()
+// pullMissingColumnsUp will attempt to find given missing columns. It will traverse on plan.Having node and scan
+// its children's schema to find the missing columns. The columns that are found will be added in Projections of
+// underlying plan.Project node and SelectExprs of underlying plan.GroupBy node.
+func pullMissingColumnsUp(having *plan.Having, missingCols map[string]bool) (*plan.Having, error) {
 	var newAggregate []sql.Expression
-	for _, c := range missingCols {
-		idx := -1
-		for i, col := range schema {
-			if strings.ToLower(c) == strings.ToLower(col.Name) {
-				idx = i
-				break
+	loopSchema := func(schema sql.Schema) {
+		for i, c := range schema {
+			if _, ok := missingCols[strings.ToLower(c.Name)]; ok {
+				col := schema[i]
+				delete(missingCols, c.Name)
+				newAggregate = append(
+					newAggregate,
+					expression.NewGetFieldWithTable(i, col.Type, col.Source, col.Name, col.Nullable),
+				)
 			}
 		}
-		if idx < 0 {
-			return nil, errHavingChildMissingRef.New(c)
-		}
-		col := schema[idx]
-		newAggregate = append(
-			newAggregate,
-			expression.NewGetFieldWithTable(idx, col.Type, col.Source, col.Name, col.Nullable),
-		)
 	}
 
-	node, err := addColumnsToGroupBy(having, newAggregate)
+	transform.Inspect(having.Child, func(n sql.Node) bool {
+		if n == nil {
+			return false
+		}
+		for _, child := range n.Children() {
+			loopSchema(child.Schema())
+		}
+		return true
+	})
+
+	if len(missingCols) > 0 {
+		var cs []string
+		for c, _ := range missingCols {
+			cs = append(cs, c)
+		}
+		return nil, errHavingChildMissingRef.New(strings.Join(cs, ", "))
+	}
+
+	node, err := addColumnsToGroupByAndProjectNodes(having, newAggregate)
 	if err != nil {
 		return nil, err
 	}
-
 	return node.(*plan.Having), nil
 }
 
@@ -151,10 +160,13 @@ func findGroupBy(n sql.Node) (*plan.GroupBy, error) {
 	return findGroupBy(children[0])
 }
 
-func addColumnsToGroupBy(node sql.Node, columns []sql.Expression) (sql.Node, error) {
+// addColumnsToGroupByAndProjectNodes will add the given columns to Projections of every plan.Project and
+// SelectExprs of plan.GroupBy nodes to expose these columns to schema of plan.Having node for its condition
+// expressions to refer to.
+func addColumnsToGroupByAndProjectNodes(node sql.Node, columns []sql.Expression) (sql.Node, error) {
 	switch node := node.(type) {
 	case *plan.Project:
-		child, err := addColumnsToGroupBy(node.Child, columns)
+		child, err := addColumnsToGroupByAndProjectNodes(node.Child, columns)
 		if err != nil {
 			return nil, err
 		}
@@ -187,7 +199,7 @@ func addColumnsToGroupBy(node sql.Node, columns []sql.Expression) (sql.Node, err
 		*plan.Offset,
 		*plan.Distinct,
 		*plan.Having:
-		child, err := addColumnsToGroupBy(node.Children()[0], columns)
+		child, err := addColumnsToGroupByAndProjectNodes(node.Children()[0], columns)
 		if err != nil {
 			return nil, err
 		}
@@ -195,7 +207,7 @@ func addColumnsToGroupBy(node sql.Node, columns []sql.Expression) (sql.Node, err
 	case *plan.GroupBy:
 		return plan.NewGroupBy(append(node.SelectedExprs, columns...), node.GroupByExprs, node.Child), nil
 	default:
-		return nil, errHavingNeedsGroupBy.New()
+		return node, nil
 	}
 }
 
@@ -351,7 +363,7 @@ func replaceAggregations(ctx *sql.Context, having *plan.Having) (*plan.Having, b
 	// The new aggregations will be added to the group by and pushed up until
 	// the topmost node.
 	having = plan.NewHaving(cond, having.Child)
-	node, err := addColumnsToGroupBy(having, newAggregate)
+	node, err := addColumnsToGroupByAndProjectNodes(having, newAggregate)
 	if err != nil {
 		return nil, false, err
 	}


### PR DESCRIPTION
`HAVING` clause can reference column that is not in its select result or group by result (there can be no group by clause). These column references are from tables in `HAVING` node that it is not in its immediate children nodes.