### PR TITLE
internal/sockstate: Fix sockets ending up in blocking mode when we monitor them for disconnects.

### DIFF
--- a/internal/sockstate/netstat_unix.go
+++ b/internal/sockstate/netstat_unix.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build linux || darwin
 // +build linux darwin
 
 package sockstate
@@ -37,4 +38,3 @@ func getConnFd(c *net.TCPConn) (fd uintptr, err error) {
 
 	return fd, nil
 }
-


### PR DESCRIPTION
As documented in `os`, calling *os.File.Fd() will put the socket into blocking mode, makes SetDeadline methods stop working, etc. This syscall to SetNonblocking restores desired functionality.

This was discovered when testing clustering control plane operations in Dolt, which rely on the timely ability to terminate all client connections by calling Close() on them.

We were able to reproduce the issue on macOS by doing the same File() behavior there, despite not having an implementation to actually use the fd for external monitoring of the connection state. To keep as much behavioral parity going forward, I left the fd translation in, since we've observed that it can radically change behavior.