### PR TITLE
[no-release-notes] Rewrote parse tests to be table driven

### DIFF
--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -53,493 +53,1267 @@ type parseTest struct {
 }
 
 func TestParse(t *testing.T) {
-var fixtures = []parseTest{
-	{
-		input: `CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME, h CHAR(40))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:     "a",
-					Type:     sql.Int32,
-					Nullable: true,
-				}, {
-					Name:     "b",
-					Type:     sql.Text,
-					Nullable: true,
-				}, {
-					Name:     "c",
-					Type:     sql.Date,
-					Nullable: true,
-				}, {
-					Name:     "d",
-					Type:     sql.Timestamp,
-					Nullable: true,
-				}, {
-					Name:     "e",
-					Type:     sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20),
-					Nullable: true,
-				}, {
-					Name:     "f",
-					Type:     sql.Blob,
-					Nullable: false,
-				}, {
-					Name:     "g",
-					Type:     sql.Datetime,
-					Nullable: true,
-				}, {
-					Name:     "h",
-					Type:     sql.MustCreateStringWithDefaults(sqltypes.Char, 40),
-					Nullable: true,
-				}}),
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY, b TEXT)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Text,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY COMMENT "hello", b TEXT COMMENT "goodbye")`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-					Comment:    "hello",
-				}, {
-					Name:       "b",
-					Type:       sql.Text,
-					Nullable:   true,
-					PrimaryKey: false,
-					Comment:    "goodbye",
-				}}),
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Text,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{
-					{
-						IndexName: "PRIMARY",
-						Columns: []sql.IndexColumn{
-							{Name: "a"},
+	var fixtures = []parseTest{
+		{
+			input: `CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME, h CHAR(40))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:     "a",
+						Type:     sql.Int32,
+						Nullable: true,
+					}, {
+						Name:     "b",
+						Type:     sql.Text,
+						Nullable: true,
+					}, {
+						Name:     "c",
+						Type:     sql.Date,
+						Nullable: true,
+					}, {
+						Name:     "d",
+						Type:     sql.Timestamp,
+						Nullable: true,
+					}, {
+						Name:     "e",
+						Type:     sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20),
+						Nullable: true,
+					}, {
+						Name:     "f",
+						Type:     sql.Blob,
+						Nullable: false,
+					}, {
+						Name:     "g",
+						Type:     sql.Datetime,
+						Nullable: true,
+					}, {
+						Name:     "h",
+						Type:     sql.MustCreateStringWithDefaults(sqltypes.Char, 40),
+						Nullable: true,
+					}}),
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY, b TEXT)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Text,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY COMMENT "hello", b TEXT COMMENT "goodbye")`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+						Comment:    "hello",
+					}, {
+						Name:       "b",
+						Type:       sql.Text,
+						Nullable:   true,
+						PrimaryKey: false,
+						Comment:    "goodbye",
+					}}),
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Text,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{
+						{
+							IndexName: "PRIMARY",
+							Columns: []sql.IndexColumn{
+								{Name: "a"},
+							},
+							Constraint: sql.IndexConstraint_Primary,
 						},
-						Constraint: sql.IndexConstraint_Primary,
 					},
 				},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Text,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{
-					{
-						IndexName: "PRIMARY",
-						Columns: []sql.IndexColumn{
-							{Name: "a"},
-							{Name: "b"},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Text,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{
+						{
+							IndexName: "PRIMARY",
+							Columns: []sql.IndexColumn{
+								{Name: "a"},
+								{Name: "b"},
+							},
+							Constraint: sql.IndexConstraint_Primary,
 						},
-						Constraint: sql.IndexConstraint_Primary,
 					},
 				},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (b, a))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Text,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}, 1, 0),
-				IdxDefs: []*plan.IndexDefinition{
-					{
-						IndexName: "PRIMARY",
-						Columns: []sql.IndexColumn{
-							{Name: "b"},
-							{Name: "a"},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (b, a))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Text,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}, 1, 0),
+					IdxDefs: []*plan.IndexDefinition{
+						{
+							IndexName: "PRIMARY",
+							Columns: []sql.IndexColumn{
+								{Name: "b"},
+								{Name: "a"},
+							},
+							Constraint: sql.IndexConstraint_Primary,
 						},
-						Constraint: sql.IndexConstraint_Primary,
 					},
 				},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER, b int, CONSTRAINT pk PRIMARY KEY (b, a), CONSTRAINT UNIQUE KEY (a))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}, 1, 0),
-				IdxDefs: []*plan.IndexDefinition{
-					{
-						IndexName: "pk",
-						Columns: []sql.IndexColumn{
-							{Name: "b"},
-							{Name: "a"},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER, b int, CONSTRAINT pk PRIMARY KEY (b, a), CONSTRAINT UNIQUE KEY (a))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}, 1, 0),
+					IdxDefs: []*plan.IndexDefinition{
+						{
+							IndexName: "pk",
+							Columns: []sql.IndexColumn{
+								{Name: "b"},
+								{Name: "a"},
+							},
+							Constraint: sql.IndexConstraint_Primary,
 						},
-						Constraint: sql.IndexConstraint_Primary,
+						{
+							Columns: []sql.IndexColumn{
+								{Name: "a"},
+							},
+							Constraint: sql.IndexConstraint_Unique,
+						},
 					},
-					{
-						Columns: []sql.IndexColumn{
-							{Name: "a"},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE IF NOT EXISTS t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExists,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Text,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{
+						{
+							IndexName:  "PRIMARY",
+							Constraint: sql.IndexConstraint_Primary,
+							Columns: []sql.IndexColumn{
+								{Name: "a"},
+								{Name: "b"},
+							},
 						},
+					},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{
+						{
+							IndexName:  "",
+							Using:      sql.IndexUsing_Default,
+							Constraint: sql.IndexConstraint_None,
+							Columns:    []sql.IndexColumn{{"b", 0}},
+							Comment:    "",
+						},
+					},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{{
+						IndexName:  "idx_name",
+						Using:      sql.IndexUsing_Default,
+						Constraint: sql.IndexConstraint_None,
+						Columns:    []sql.IndexColumn{{"b", 0}},
+						Comment:    "",
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b) COMMENT 'hi')`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{{
+						IndexName:  "idx_name",
+						Using:      sql.IndexUsing_Default,
+						Constraint: sql.IndexConstraint_None,
+						Columns:    []sql.IndexColumn{{"b", 0}},
+						Comment:    "hi",
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE INDEX (b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{{
+						IndexName:  "",
+						Using:      sql.IndexUsing_Default,
 						Constraint: sql.IndexConstraint_Unique,
-					},
+						Columns:    []sql.IndexColumn{{"b", 0}},
+						Comment:    "",
+					}},
 				},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE IF NOT EXISTS t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExists,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Text,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{
-					{
-						IndexName:  "PRIMARY",
-						Constraint: sql.IndexConstraint_Primary,
-						Columns: []sql.IndexColumn{
-							{Name: "a"},
-							{Name: "b"},
-						},
-					},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE (b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{{
+						IndexName:  "",
+						Using:      sql.IndexUsing_Default,
+						Constraint: sql.IndexConstraint_Unique,
+						Columns:    []sql.IndexColumn{{"b", 0}},
+						Comment:    "",
+					}},
 				},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{
-					{
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b, a))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{{
+						IndexName:  "",
+						Using:      sql.IndexUsing_Default,
+						Constraint: sql.IndexConstraint_None,
+						Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
+						Comment:    "",
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b), INDEX (b, a))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					IdxDefs: []*plan.IndexDefinition{{
 						IndexName:  "",
 						Using:      sql.IndexUsing_Default,
 						Constraint: sql.IndexConstraint_None,
 						Columns:    []sql.IndexColumn{{"b", 0}},
 						Comment:    "",
+					}, {
+						IndexName:  "",
+						Using:      sql.IndexUsing_Default,
+						Constraint: sql.IndexConstraint_None,
+						Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
+						Comment:    "",
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b_id",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					FkDefs: []*sql.ForeignKeyConstraint{{
+						Name:           "",
+						Database:       "",
+						Table:          "t1",
+						Columns:        []string{"b_id"},
+						ParentDatabase: "",
+						ParentTable:    "t0",
+						ParentColumns:  []string{"b"},
+						OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+						OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+						IsResolved:     false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b_id",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					FkDefs: []*sql.ForeignKeyConstraint{{
+						Name:           "fk_name",
+						Database:       "",
+						Table:          "t1",
+						Columns:        []string{"b_id"},
+						ParentDatabase: "",
+						ParentTable:    "t0",
+						ParentColumns:  []string{"b"},
+						OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+						OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+						IsResolved:     false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b_id",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					FkDefs: []*sql.ForeignKeyConstraint{{
+						Name:           "",
+						Database:       "",
+						Table:          "t1",
+						Columns:        []string{"b_id"},
+						ParentDatabase: "",
+						ParentTable:    "t0",
+						ParentColumns:  []string{"b"},
+						OnUpdate:       sql.ForeignKeyReferentialAction_Cascade,
+						OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+						IsResolved:     false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b_id",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					FkDefs: []*sql.ForeignKeyConstraint{{
+						Name:           "",
+						Database:       "",
+						Table:          "t1",
+						Columns:        []string{"b_id"},
+						ParentDatabase: "",
+						ParentTable:    "t0",
+						ParentColumns:  []string{"b"},
+						OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+						OnDelete:       sql.ForeignKeyReferentialAction_Restrict,
+						IsResolved:     false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b_id",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+
+					FkDefs: []*sql.ForeignKeyConstraint{{
+						Name:           "",
+						Database:       "",
+						Table:          "t1",
+						Columns:        []string{"b_id"},
+						ParentDatabase: "",
+						ParentTable:    "t0",
+						ParentColumns:  []string{"b"},
+						OnUpdate:       sql.ForeignKeyReferentialAction_SetNull,
+						OnDelete:       sql.ForeignKeyReferentialAction_NoAction,
+						IsResolved:     false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b_id",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}, {
+						Name:       "c_id",
+						Type:       sql.Int64,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					FkDefs: []*sql.ForeignKeyConstraint{{
+						Name:           "",
+						Database:       "",
+						Table:          "t1",
+						Columns:        []string{"b_id", "c_id"},
+						ParentDatabase: "",
+						ParentTable:    "t0",
+						ParentColumns:  []string{"b", "c"},
+						OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+						OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+						IsResolved:     false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}, {
+						Name:       "b_id",
+						Type:       sql.Int32,
+						Nullable:   true,
+						PrimaryKey: false,
+					}, {
+						Name:       "c_id",
+						Type:       sql.Int64,
+						Nullable:   true,
+						PrimaryKey: false,
+					}}),
+					FkDefs: []*sql.ForeignKeyConstraint{{
+						Name:           "fk_name",
+						Database:       "",
+						Table:          "t1",
+						Columns:        []string{"b_id", "c_id"},
+						ParentDatabase: "",
+						ParentTable:    "t0",
+						ParentColumns:  []string{"b", "c"},
+						OnUpdate:       sql.ForeignKeyReferentialAction_Restrict,
+						OnDelete:       sql.ForeignKeyReferentialAction_Cascade,
+						IsResolved:     false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, CHECK (a > 0))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}),
+					ChDefs: []*sql.CheckConstraint{{
+						Name: "",
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: true,
+					}},
+				},
+			),
+		},
+		{
+			input: `
+CREATE TABLE t4
+(
+  CHECK (c1 = c2),
+  c1 INT CHECK (c1 > 10),
+  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
+  CHECK (c1 > c3)
+);`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t4",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{
+						{
+							Name:     "c1",
+							Source:   "t4",
+							Type:     sql.Int32,
+							Nullable: true,
+						},
+						{
+							Name:     "c2",
+							Source:   "t4",
+							Type:     sql.Int32,
+							Nullable: true,
+						},
+					}),
+					ChDefs: []*sql.CheckConstraint{
+						{
+							Expr: expression.NewEquals(
+								expression.NewUnresolvedColumn("c1"),
+								expression.NewUnresolvedColumn("c2"),
+							),
+							Enforced: true,
+						},
+						{
+							Expr: expression.NewGreaterThan(
+								expression.NewUnresolvedColumn("c1"),
+								expression.NewLiteral(int8(10), sql.Int8),
+							),
+							Enforced: true,
+						},
+						{
+							Name: "c2_positive",
+							Expr: expression.NewGreaterThan(
+								expression.NewUnresolvedColumn("c2"),
+								expression.NewLiteral(int8(0), sql.Int8),
+							),
+							Enforced: true,
+						},
+						{
+							Expr: expression.NewGreaterThan(
+								expression.NewUnresolvedColumn("c1"),
+								expression.NewUnresolvedColumn("c3"),
+							),
+							Enforced: true,
+						},
 					},
 				},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{{
-					IndexName:  "idx_name",
-					Using:      sql.IndexUsing_Default,
-					Constraint: sql.IndexConstraint_None,
-					Columns:    []sql.IndexColumn{{"b", 0}},
-					Comment:    "",
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b) COMMENT 'hi')`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{{
-					IndexName:  "idx_name",
-					Using:      sql.IndexUsing_Default,
-					Constraint: sql.IndexConstraint_None,
-					Columns:    []sql.IndexColumn{{"b", 0}},
-					Comment:    "hi",
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE INDEX (b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{{
-					IndexName:  "",
-					Using:      sql.IndexUsing_Default,
-					Constraint: sql.IndexConstraint_Unique,
-					Columns:    []sql.IndexColumn{{"b", 0}},
-					Comment:    "",
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE (b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{{
-					IndexName:  "",
-					Using:      sql.IndexUsing_Default,
-					Constraint: sql.IndexConstraint_Unique,
-					Columns:    []sql.IndexColumn{{"b", 0}},
-					Comment:    "",
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b, a))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{{
-					IndexName:  "",
-					Using:      sql.IndexUsing_Default,
-					Constraint: sql.IndexConstraint_None,
-					Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
-					Comment:    "",
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b), INDEX (b, a))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				IdxDefs: []*plan.IndexDefinition{{
-					IndexName:  "",
-					Using:      sql.IndexUsing_Default,
-					Constraint: sql.IndexConstraint_None,
-					Columns:    []sql.IndexColumn{{"b", 0}},
-					Comment:    "",
-				}, {
-					IndexName:  "",
-					Using:      sql.IndexUsing_Default,
-					Constraint: sql.IndexConstraint_None,
-					Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
-					Comment:    "",
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b_id",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				FkDefs: []*sql.ForeignKeyConstraint{{
+			),
+		},
+		{
+			input: `
+CREATE TABLE t2
+(
+  CHECK (c1 = c2),
+  c1 INT CHECK (c1 > 10),
+  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
+  c3 INT CHECK (c3 < 100),
+  CONSTRAINT c1_nonzero CHECK (c1 = 0),
+  CHECK (c1 > c3)
+);`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t2",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{
+						{
+							Name:     "c1",
+							Source:   "t2",
+							Type:     sql.Int32,
+							Nullable: true,
+						},
+						{
+							Name:     "c2",
+							Source:   "t2",
+							Type:     sql.Int32,
+							Nullable: true,
+						},
+						{
+							Name:     "c3",
+							Source:   "t2",
+							Type:     sql.Int32,
+							Nullable: true,
+						},
+					}),
+					ChDefs: []*sql.CheckConstraint{
+						{
+							Expr: expression.NewEquals(
+								expression.NewUnresolvedColumn("c1"),
+								expression.NewUnresolvedColumn("c2"),
+							),
+							Enforced: true,
+						},
+						{
+							Expr: expression.NewGreaterThan(
+								expression.NewUnresolvedColumn("c1"),
+								expression.NewLiteral(int8(10), sql.Int8),
+							),
+							Enforced: true,
+						},
+						{
+							Name: "c2_positive",
+							Expr: expression.NewGreaterThan(
+								expression.NewUnresolvedColumn("c2"),
+								expression.NewLiteral(int8(0), sql.Int8),
+							),
+							Enforced: true,
+						},
+						{
+							Expr: expression.NewLessThan(
+								expression.NewUnresolvedColumn("c3"),
+								expression.NewLiteral(int8(100), sql.Int8),
+							),
+							Enforced: true,
+						},
+						{
+							Name: "c1_nonzero",
+							Expr: expression.NewEquals(
+								expression.NewUnresolvedColumn("c1"),
+								expression.NewLiteral(int8(0), sql.Int8),
+							),
+							Enforced: true,
+						},
+						{
+							Expr: expression.NewGreaterThan(
+								expression.NewUnresolvedColumn("c1"),
+								expression.NewUnresolvedColumn("c3"),
+							),
+							Enforced: true,
+						},
+					},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}),
+					ChDefs: []*sql.CheckConstraint{{
+						Name: "",
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: true,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, CONSTRAINT ch1 CHECK (a > 0))`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}),
+					ChDefs: []*sql.CheckConstraint{{
+						Name: "ch1",
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: true,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) ENFORCED)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}),
+					ChDefs: []*sql.CheckConstraint{{
+						Name: "",
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: true,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) NOT ENFORCED)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTableAbsent,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:       "a",
+						Type:       sql.Int32,
+						Nullable:   false,
+						PrimaryKey: true,
+					}}),
+					ChDefs: []*sql.CheckConstraint{{
+						Name: "",
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: false,
+					}},
+				},
+			),
+		},
+		{
+			input: `CREATE TEMPORARY TABLE t1(a INTEGER, b TEXT)`,
+			plan: plan.NewCreateTable(
+				sql.UnresolvedDatabase(""),
+				"t1",
+				plan.IfNotExistsAbsent,
+				plan.IsTempTable,
+				&plan.TableSpec{
+					Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+						Name:     "a",
+						Type:     sql.Int32,
+						Nullable: true,
+					}, {
+						Name:     "b",
+						Type:     sql.Text,
+						Nullable: true,
+					}}),
+				},
+			),
+		},
+		{
+			input: `CREATE TEMPORARY TABLE mytable AS SELECT * from othertable`,
+			plan: plan.NewCreateTableSelect(
+				sql.UnresolvedDatabase(""),
+				"mytable",
+				plan.NewProject([]sql.Expression{expression.NewStar()}, plan.NewUnresolvedTable("othertable", "")),
+				&plan.TableSpec{},
+				plan.IfNotExistsAbsent,
+				plan.IsTempTable),
+		},
+		{
+			input: `DROP TABLE curdb.foo;`,
+			plan: plan.NewDropTable(
+				[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, false,
+			),
+		},
+		{
+			input: `DROP TABLE t1, t2;`,
+			plan: plan.NewDropTable(
+				[]sql.Node{plan.NewUnresolvedTable("t1", ""), plan.NewUnresolvedTable("t2", "")}, false,
+			),
+		},
+		{
+			input: `DROP TABLE IF EXISTS curdb.foo;`,
+			plan: plan.NewDropTable(
+				[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, true,
+			),
+		},
+		{
+			input: `DROP TABLE IF EXISTS curdb.foo, curdb.bar, curdb.baz;`,
+			plan: plan.NewDropTable(
+				[]sql.Node{plan.NewUnresolvedTable("foo", "curdb"), plan.NewUnresolvedTable("bar", "curdb"), plan.NewUnresolvedTable("baz", "curdb")}, true,
+			),
+		},
+		{
+			input: `RENAME TABLE foo TO bar`,
+			plan: plan.NewRenameTable(
+				sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
+			),
+		},
+		{
+			input: `RENAME TABLE foo TO bar, baz TO qux`,
+			plan: plan.NewRenameTable(
+				sql.UnresolvedDatabase(""), []string{"foo", "baz"}, []string{"bar", "qux"},
+			),
+		},
+		{
+			input: `ALTER TABLE foo RENAME bar`,
+			plan: plan.NewRenameTable(
+				sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
+			),
+		},
+		{
+			input: `ALTER TABLE foo RENAME TO bar`,
+			plan: plan.NewRenameTable(
+				sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
+			),
+		},
+		{
+			input: `ALTER TABLE foo RENAME COLUMN bar TO baz`,
+			plan: plan.NewRenameColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("foo", ""), "bar", "baz",
+			),
+		},
+		{
+			input: `ALTER TABLE otherdb.mytable RENAME COLUMN i TO s`,
+			plan: plan.NewRenameColumn(
+				sql.UnresolvedDatabase("otherdb"),
+				plan.NewUnresolvedTable("mytable", "otherdb"), "i", "s",
+			),
+		},
+		{
+			input: `ALTER TABLE mytable RENAME COLUMN bar TO baz, RENAME COLUMN abc TO xyz`,
+			plan: plan.NewBlock(
+				[]sql.Node{
+					plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "bar", "baz"),
+					plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "abc", "xyz"),
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+					Name:     "bar",
+					Type:     sql.Int32,
+					Nullable: false,
+				}, nil,
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT 42 COMMENT 'hello' AFTER baz`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+					Name:     "bar",
+					Type:     sql.Int32,
+					Nullable: false,
+					Comment:  "hello",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "42", nil, true),
+				}, &sql.ColumnOrder{AfterColumn: "baz"},
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT -42.0 COMMENT 'hello' AFTER baz`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+					Name:     "bar",
+					Type:     sql.Int32,
+					Nullable: false,
+					Comment:  "hello",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "-42.0", nil, true),
+				}, &sql.ColumnOrder{AfterColumn: "baz"},
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT ((2+2)/2) COMMENT 'hello' AFTER baz`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+					Name:     "bar",
+					Type:     sql.Int32,
+					Nullable: false,
+					Comment:  "hello",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "((2+2)/2)", nil, true),
+				}, &sql.ColumnOrder{AfterColumn: "baz"},
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello'`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+					Name:     "bar",
+					Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
+					Nullable: true,
+					Comment:  "hello",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+				}, nil,
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD COLUMN bar FLOAT NULL DEFAULT 32.0 COMMENT 'hello'`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+					Name:     "bar",
+					Type:     sql.Float32,
+					Nullable: true,
+					Comment:  "hello",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "32.0", nil, true),
+				}, nil,
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD COLUMN bar INT DEFAULT 1 FIRST`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+					Name:     "bar",
+					Type:     sql.Int32,
+					Nullable: true,
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
+				}, &sql.ColumnOrder{First: true},
+			),
+		},
+		{
+			input: `ALTER TABLE mydb.mytable ADD COLUMN bar INT DEFAULT 1 COMMENT 'otherdb'`,
+			plan: plan.NewAddColumn(
+				sql.UnresolvedDatabase("mydb"),
+				plan.NewUnresolvedTable("mytable", "mydb"), &sql.Column{
+					Name:     "bar",
+					Type:     sql.Int32,
+					Nullable: true,
+					Comment:  "otherdb",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
+				}, nil,
+			),
+		},
+		{
+			input: `ALTER TABLE mytable ADD INDEX (v1)`,
+			plan: plan.NewAlterCreateIndex(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""),
+				"",
+				sql.IndexUsing_BTree,
+				sql.IndexConstraint_None,
+				[]sql.IndexColumn{{"v1", 0}},
+				"",
+			),
+		},
+		{
+			input: `ALTER TABLE mytable DROP COLUMN bar`,
+			plan: plan.NewDropColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("mytable", ""), "bar",
+			),
+		},
+		{
+			input: `ALTER TABLE otherdb.mytable DROP COLUMN bar`,
+			plan: plan.NewDropColumn(
+				sql.UnresolvedDatabase("otherdb"),
+				plan.NewUnresolvedTable("mytable", "otherdb"), "bar",
+			),
+		},
+		{
+			input: `ALTER TABLE tabletest MODIFY COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`,
+			plan: plan.NewModifyColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
+					Name:     "bar",
+					Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
+					Nullable: true,
+					Comment:  "hello",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+				}, &sql.ColumnOrder{First: true},
+			),
+		},
+		{
+			input: `ALTER TABLE tabletest CHANGE COLUMN bar baz VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`,
+			plan: plan.NewModifyColumn(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
+					Name:     "baz",
+					Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
+					Nullable: true,
+					Comment:  "hello",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+				}, &sql.ColumnOrder{First: true},
+			),
+		},
+		{
+			input: `ALTER TABLE mydb.mytable MODIFY COLUMN col1 VARCHAR(20) NULL DEFAULT 'string' COMMENT 'changed'`,
+			plan: plan.NewModifyColumn(
+				sql.UnresolvedDatabase("mydb"),
+				plan.NewUnresolvedTable("mytable", "mydb"), "col1", &sql.Column{
+					Name:     "col1",
+					Type:     sql.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Invalid),
+					Nullable: true,
+					Comment:  "changed",
+					Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+				}, nil,
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b)`,
+			plan: plan.NewAlterAddForeignKey(
+				&sql.ForeignKeyConstraint{
 					Name:           "",
 					Database:       "",
 					Table:          "t1",
@@ -550,30 +1324,13 @@ var fixtures = []parseTest{
 					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 					IsResolved:     false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b_id",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				FkDefs: []*sql.ForeignKeyConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b)`,
+			plan: plan.NewAlterAddForeignKey(
+				&sql.ForeignKeyConstraint{
 					Name:           "fk_name",
 					Database:       "",
 					Table:          "t1",
@@ -584,30 +1341,13 @@ var fixtures = []parseTest{
 					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 					IsResolved:     false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b_id",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				FkDefs: []*sql.ForeignKeyConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE`,
+			plan: plan.NewAlterAddForeignKey(
+				&sql.ForeignKeyConstraint{
 					Name:           "",
 					Database:       "",
 					Table:          "t1",
@@ -618,30 +1358,13 @@ var fixtures = []parseTest{
 					OnUpdate:       sql.ForeignKeyReferentialAction_Cascade,
 					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 					IsResolved:     false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b_id",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				FkDefs: []*sql.ForeignKeyConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT`,
+			plan: plan.NewAlterAddForeignKey(
+				&sql.ForeignKeyConstraint{
 					Name:           "",
 					Database:       "",
 					Table:          "t1",
@@ -652,31 +1375,13 @@ var fixtures = []parseTest{
 					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 					OnDelete:       sql.ForeignKeyReferentialAction_Restrict,
 					IsResolved:     false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b_id",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-
-				FkDefs: []*sql.ForeignKeyConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION`,
+			plan: plan.NewAlterAddForeignKey(
+				&sql.ForeignKeyConstraint{
 					Name:           "",
 					Database:       "",
 					Table:          "t1",
@@ -687,35 +1392,13 @@ var fixtures = []parseTest{
 					OnUpdate:       sql.ForeignKeyReferentialAction_SetNull,
 					OnDelete:       sql.ForeignKeyReferentialAction_NoAction,
 					IsResolved:     false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b_id",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}, {
-					Name:       "c_id",
-					Type:       sql.Int64,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				FkDefs: []*sql.ForeignKeyConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c)`,
+			plan: plan.NewAlterAddForeignKey(
+				&sql.ForeignKeyConstraint{
 					Name:           "",
 					Database:       "",
 					Table:          "t1",
@@ -726,35 +1409,13 @@ var fixtures = []parseTest{
 					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 					IsResolved:     false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}, {
-					Name:       "b_id",
-					Type:       sql.Int32,
-					Nullable:   true,
-					PrimaryKey: false,
-				}, {
-					Name:       "c_id",
-					Type:       sql.Int64,
-					Nullable:   true,
-					PrimaryKey: false,
-				}}),
-				FkDefs: []*sql.ForeignKeyConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE`,
+			plan: plan.NewAlterAddForeignKey(
+				&sql.ForeignKeyConstraint{
 					Name:           "fk_name",
 					Database:       "",
 					Table:          "t1",
@@ -765,972 +1426,262 @@ var fixtures = []parseTest{
 					OnUpdate:       sql.ForeignKeyReferentialAction_Restrict,
 					OnDelete:       sql.ForeignKeyReferentialAction_Cascade,
 					IsResolved:     false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, CHECK (a > 0))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}),
-				ChDefs: []*sql.CheckConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD CHECK (a > 0)`,
+			plan: plan.NewAlterAddCheck(
+				plan.NewUnresolvedTable("t1", ""),
+				&sql.CheckConstraint{
 					Name: "",
 					Expr: expression.NewGreaterThan(
 						expression.NewUnresolvedColumn("a"),
 						expression.NewLiteral(int8(0), sql.Int8),
 					),
 					Enforced: true,
-				}},
-			},
-		),
-	},
-	{
-		input: `
-CREATE TABLE t4
-(
-  CHECK (c1 = c2),
-  c1 INT CHECK (c1 > 10),
-  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
-  CHECK (c1 > c3)
-);`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t4",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{
-					{
-						Name:     "c1",
-						Source:   "t4",
-						Type:     sql.Int32,
-						Nullable: true,
-					},
-					{
-						Name:     "c2",
-						Source:   "t4",
-						Type:     sql.Int32,
-						Nullable: true,
-					},
-				}),
-				ChDefs: []*sql.CheckConstraint{
-					{
-						Expr: expression.NewEquals(
-							expression.NewUnresolvedColumn("c1"),
-							expression.NewUnresolvedColumn("c2"),
-						),
-						Enforced: true,
-					},
-					{
-						Expr: expression.NewGreaterThan(
-							expression.NewUnresolvedColumn("c1"),
-							expression.NewLiteral(int8(10), sql.Int8),
-						),
-						Enforced: true,
-					},
-					{
-						Name: "c2_positive",
-						Expr: expression.NewGreaterThan(
-							expression.NewUnresolvedColumn("c2"),
-							expression.NewLiteral(int8(0), sql.Int8),
-						),
-						Enforced: true,
-					},
-					{
-						Expr: expression.NewGreaterThan(
-							expression.NewUnresolvedColumn("c1"),
-							expression.NewUnresolvedColumn("c3"),
-						),
-						Enforced: true,
-					},
 				},
-			},
-		),
-	},
-	{
-		input: `
-CREATE TABLE t2
-(
-  CHECK (c1 = c2),
-  c1 INT CHECK (c1 > 10),
-  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
-  c3 INT CHECK (c3 < 100),
-  CONSTRAINT c1_nonzero CHECK (c1 = 0),
-  CHECK (c1 > c3)
-);`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t2",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{
-					{
-						Name:     "c1",
-						Source:   "t2",
-						Type:     sql.Int32,
-						Nullable: true,
-					},
-					{
-						Name:     "c2",
-						Source:   "t2",
-						Type:     sql.Int32,
-						Nullable: true,
-					},
-					{
-						Name:     "c3",
-						Source:   "t2",
-						Type:     sql.Int32,
-						Nullable: true,
-					},
-				}),
-				ChDefs: []*sql.CheckConstraint{
-					{
-						Expr: expression.NewEquals(
-							expression.NewUnresolvedColumn("c1"),
-							expression.NewUnresolvedColumn("c2"),
-						),
-						Enforced: true,
-					},
-					{
-						Expr: expression.NewGreaterThan(
-							expression.NewUnresolvedColumn("c1"),
-							expression.NewLiteral(int8(10), sql.Int8),
-						),
-						Enforced: true,
-					},
-					{
-						Name: "c2_positive",
-						Expr: expression.NewGreaterThan(
-							expression.NewUnresolvedColumn("c2"),
-							expression.NewLiteral(int8(0), sql.Int8),
-						),
-						Enforced: true,
-					},
-					{
-						Expr: expression.NewLessThan(
-							expression.NewUnresolvedColumn("c3"),
-							expression.NewLiteral(int8(100), sql.Int8),
-						),
-						Enforced: true,
-					},
-					{
-						Name: "c1_nonzero",
-						Expr: expression.NewEquals(
-							expression.NewUnresolvedColumn("c1"),
-							expression.NewLiteral(int8(0), sql.Int8),
-						),
-						Enforced: true,
-					},
-					{
-						Expr: expression.NewGreaterThan(
-							expression.NewUnresolvedColumn("c1"),
-							expression.NewUnresolvedColumn("c3"),
-						),
-						Enforced: true,
-					},
-				},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}),
-				ChDefs: []*sql.CheckConstraint{{
-					Name: "",
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("a"),
-						expression.NewLiteral(int8(0), sql.Int8),
-					),
-					Enforced: true,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, CONSTRAINT ch1 CHECK (a > 0))`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}),
-				ChDefs: []*sql.CheckConstraint{{
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD CONSTRAINT ch1 CHECK (a > 0)`,
+			plan: plan.NewAlterAddCheck(
+				plan.NewUnresolvedTable("t1", ""),
+				&sql.CheckConstraint{
 					Name: "ch1",
 					Expr: expression.NewGreaterThan(
 						expression.NewUnresolvedColumn("a"),
 						expression.NewLiteral(int8(0), sql.Int8),
 					),
 					Enforced: true,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) ENFORCED)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}),
-				ChDefs: []*sql.CheckConstraint{{
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 ADD CONSTRAINT CHECK (a > 0)`,
+			plan: plan.NewAlterAddCheck(
+				plan.NewUnresolvedTable("t1", ""),
+				&sql.CheckConstraint{
 					Name: "",
 					Expr: expression.NewGreaterThan(
 						expression.NewUnresolvedColumn("a"),
 						expression.NewLiteral(int8(0), sql.Int8),
 					),
 					Enforced: true,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) NOT ENFORCED)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTableAbsent,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:       "a",
-					Type:       sql.Int32,
-					Nullable:   false,
-					PrimaryKey: true,
-				}}),
-				ChDefs: []*sql.CheckConstraint{{
-					Name: "",
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("a"),
-						expression.NewLiteral(int8(0), sql.Int8),
-					),
-					Enforced: false,
-				}},
-			},
-		),
-	},
-	{
-		input: `CREATE TEMPORARY TABLE t1(a INTEGER, b TEXT)`,
-		plan: plan.NewCreateTable(
-			sql.UnresolvedDatabase(""),
-			"t1",
-			plan.IfNotExistsAbsent,
-			plan.IsTempTable,
-			&plan.TableSpec{
-				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-					Name:     "a",
-					Type:     sql.Int32,
-					Nullable: true,
-				}, {
-					Name:     "b",
-					Type:     sql.Text,
-					Nullable: true,
-				}}),
-			},
-		),
-	},
-	{
-		input: `CREATE TEMPORARY TABLE mytable AS SELECT * from othertable`,
-		plan: plan.NewCreateTableSelect(
-			sql.UnresolvedDatabase(""),
-			"mytable",
-			plan.NewProject([]sql.Expression{expression.NewStar()}, plan.NewUnresolvedTable("othertable", "")),
-			&plan.TableSpec{},
-			plan.IfNotExistsAbsent,
-			plan.IsTempTable),
-	},
-	{
-		input: `DROP TABLE curdb.foo;`,
-		plan: plan.NewDropTable(
-			[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, false,
-		),
-	},
-	{
-		input: `DROP TABLE t1, t2;`,
-		plan: plan.NewDropTable(
-			[]sql.Node{plan.NewUnresolvedTable("t1", ""), plan.NewUnresolvedTable("t2", "")}, false,
-		),
-	},
-	{
-		input: `DROP TABLE IF EXISTS curdb.foo;`,
-		plan: plan.NewDropTable(
-			[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, true,
-		),
-	},
-	{
-		input: `DROP TABLE IF EXISTS curdb.foo, curdb.bar, curdb.baz;`,
-		plan: plan.NewDropTable(
-			[]sql.Node{plan.NewUnresolvedTable("foo", "curdb"), plan.NewUnresolvedTable("bar", "curdb"), plan.NewUnresolvedTable("baz", "curdb")}, true,
-		),
-	},
-	{
-		input: `RENAME TABLE foo TO bar`,
-		plan: plan.NewRenameTable(
-			sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-		),
-	},
-	{
-		input: `RENAME TABLE foo TO bar, baz TO qux`,
-		plan: plan.NewRenameTable(
-			sql.UnresolvedDatabase(""), []string{"foo", "baz"}, []string{"bar", "qux"},
-		),
-	},
-	{
-		input: `ALTER TABLE foo RENAME bar`,
-		plan: plan.NewRenameTable(
-			sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-		),
-	},
-	{
-		input: `ALTER TABLE foo RENAME TO bar`,
-		plan: plan.NewRenameTable(
-			sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-		),
-	},
-	{
-		input: `ALTER TABLE foo RENAME COLUMN bar TO baz`,
-		plan: plan.NewRenameColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("foo", ""), "bar", "baz",
-		),
-	},
-	{
-		input: `ALTER TABLE otherdb.mytable RENAME COLUMN i TO s`,
-		plan: plan.NewRenameColumn(
-			sql.UnresolvedDatabase("otherdb"),
-			plan.NewUnresolvedTable("mytable", "otherdb"), "i", "s",
-		),
-	},
-	{
-		input: `ALTER TABLE mytable RENAME COLUMN bar TO baz, RENAME COLUMN abc TO xyz`,
-		plan: plan.NewBlock(
-			[]sql.Node{
-				plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "bar", "baz"),
-				plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "abc", "xyz"),
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-				Name:     "bar",
-				Type:     sql.Int32,
-				Nullable: false,
-			}, nil,
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT 42 COMMENT 'hello' AFTER baz`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-				Name:     "bar",
-				Type:     sql.Int32,
-				Nullable: false,
-				Comment:  "hello",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "42", nil, true),
-			}, &sql.ColumnOrder{AfterColumn: "baz"},
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT -42.0 COMMENT 'hello' AFTER baz`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-				Name:     "bar",
-				Type:     sql.Int32,
-				Nullable: false,
-				Comment:  "hello",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "-42.0", nil, true),
-			}, &sql.ColumnOrder{AfterColumn: "baz"},
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT ((2+2)/2) COMMENT 'hello' AFTER baz`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-				Name:     "bar",
-				Type:     sql.Int32,
-				Nullable: false,
-				Comment:  "hello",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "((2+2)/2)", nil, true),
-			}, &sql.ColumnOrder{AfterColumn: "baz"},
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello'`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-				Name:     "bar",
-				Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
-				Nullable: true,
-				Comment:  "hello",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-			}, nil,
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD COLUMN bar FLOAT NULL DEFAULT 32.0 COMMENT 'hello'`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-				Name:     "bar",
-				Type:     sql.Float32,
-				Nullable: true,
-				Comment:  "hello",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "32.0", nil, true),
-			}, nil,
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD COLUMN bar INT DEFAULT 1 FIRST`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-				Name:     "bar",
-				Type:     sql.Int32,
-				Nullable: true,
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
-			}, &sql.ColumnOrder{First: true},
-		),
-	},
-	{
-		input: `ALTER TABLE mydb.mytable ADD COLUMN bar INT DEFAULT 1 COMMENT 'otherdb'`,
-		plan: plan.NewAddColumn(
-			sql.UnresolvedDatabase("mydb"),
-			plan.NewUnresolvedTable("mytable", "mydb"), &sql.Column{
-				Name:     "bar",
-				Type:     sql.Int32,
-				Nullable: true,
-				Comment:  "otherdb",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
-			}, nil,
-		),
-	},
-	{
-		input: `ALTER TABLE mytable ADD INDEX (v1)`,
-		plan: plan.NewAlterCreateIndex(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""),
-			"",
-			sql.IndexUsing_BTree,
-			sql.IndexConstraint_None,
-			[]sql.IndexColumn{{"v1", 0}},
-			"",
-		),
-	},
-	{
-		input: `ALTER TABLE mytable DROP COLUMN bar`,
-		plan: plan.NewDropColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("mytable", ""), "bar",
-		),
-	},
-	{
-		input: `ALTER TABLE otherdb.mytable DROP COLUMN bar`,
-		plan: plan.NewDropColumn(
-			sql.UnresolvedDatabase("otherdb"),
-			plan.NewUnresolvedTable("mytable", "otherdb"), "bar",
-		),
-	},
-	{
-		input: `ALTER TABLE tabletest MODIFY COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`,
-		plan: plan.NewModifyColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
-				Name:     "bar",
-				Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
-				Nullable: true,
-				Comment:  "hello",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-			}, &sql.ColumnOrder{First: true},
-		),
-	},
-	{
-		input: `ALTER TABLE tabletest CHANGE COLUMN bar baz VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`,
-		plan: plan.NewModifyColumn(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
-				Name:     "baz",
-				Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
-				Nullable: true,
-				Comment:  "hello",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-			}, &sql.ColumnOrder{First: true},
-		),
-	},
-	{
-		input: `ALTER TABLE mydb.mytable MODIFY COLUMN col1 VARCHAR(20) NULL DEFAULT 'string' COMMENT 'changed'`,
-		plan: plan.NewModifyColumn(
-			sql.UnresolvedDatabase("mydb"),
-			plan.NewUnresolvedTable("mytable", "mydb"), "col1", &sql.Column{
-				Name:     "col1",
-				Type:     sql.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Invalid),
-				Nullable: true,
-				Comment:  "changed",
-				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-			}, nil,
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b)`,
-		plan: plan.NewAlterAddForeignKey(
-			&sql.ForeignKeyConstraint{
-				Name:           "",
-				Database:       "",
-				Table:          "t1",
-				Columns:        []string{"b_id"},
-				ParentDatabase: "",
-				ParentTable:    "t0",
-				ParentColumns:  []string{"b"},
-				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-				IsResolved:     false,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b)`,
-		plan: plan.NewAlterAddForeignKey(
-			&sql.ForeignKeyConstraint{
-				Name:           "fk_name",
-				Database:       "",
-				Table:          "t1",
-				Columns:        []string{"b_id"},
-				ParentDatabase: "",
-				ParentTable:    "t0",
-				ParentColumns:  []string{"b"},
-				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-				IsResolved:     false,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE`,
-		plan: plan.NewAlterAddForeignKey(
-			&sql.ForeignKeyConstraint{
-				Name:           "",
-				Database:       "",
-				Table:          "t1",
-				Columns:        []string{"b_id"},
-				ParentDatabase: "",
-				ParentTable:    "t0",
-				ParentColumns:  []string{"b"},
-				OnUpdate:       sql.ForeignKeyReferentialAction_Cascade,
-				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-				IsResolved:     false,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT`,
-		plan: plan.NewAlterAddForeignKey(
-			&sql.ForeignKeyConstraint{
-				Name:           "",
-				Database:       "",
-				Table:          "t1",
-				Columns:        []string{"b_id"},
-				ParentDatabase: "",
-				ParentTable:    "t0",
-				ParentColumns:  []string{"b"},
-				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-				OnDelete:       sql.ForeignKeyReferentialAction_Restrict,
-				IsResolved:     false,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION`,
-		plan: plan.NewAlterAddForeignKey(
-			&sql.ForeignKeyConstraint{
-				Name:           "",
-				Database:       "",
-				Table:          "t1",
-				Columns:        []string{"b_id"},
-				ParentDatabase: "",
-				ParentTable:    "t0",
-				ParentColumns:  []string{"b"},
-				OnUpdate:       sql.ForeignKeyReferentialAction_SetNull,
-				OnDelete:       sql.ForeignKeyReferentialAction_NoAction,
-				IsResolved:     false,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c)`,
-		plan: plan.NewAlterAddForeignKey(
-			&sql.ForeignKeyConstraint{
-				Name:           "",
-				Database:       "",
-				Table:          "t1",
-				Columns:        []string{"b_id", "c_id"},
-				ParentDatabase: "",
-				ParentTable:    "t0",
-				ParentColumns:  []string{"b", "c"},
-				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-				IsResolved:     false,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE`,
-		plan: plan.NewAlterAddForeignKey(
-			&sql.ForeignKeyConstraint{
-				Name:           "fk_name",
-				Database:       "",
-				Table:          "t1",
-				Columns:        []string{"b_id", "c_id"},
-				ParentDatabase: "",
-				ParentTable:    "t0",
-				ParentColumns:  []string{"b", "c"},
-				OnUpdate:       sql.ForeignKeyReferentialAction_Restrict,
-				OnDelete:       sql.ForeignKeyReferentialAction_Cascade,
-				IsResolved:     false,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD CHECK (a > 0)`,
-		plan: plan.NewAlterAddCheck(
-			plan.NewUnresolvedTable("t1", ""),
-			&sql.CheckConstraint{
-				Name: "",
-				Expr: expression.NewGreaterThan(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral(int8(0), sql.Int8),
-				),
-				Enforced: true,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD CONSTRAINT ch1 CHECK (a > 0)`,
-		plan: plan.NewAlterAddCheck(
-			plan.NewUnresolvedTable("t1", ""),
-			&sql.CheckConstraint{
-				Name: "ch1",
-				Expr: expression.NewGreaterThan(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral(int8(0), sql.Int8),
-				),
-				Enforced: true,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 ADD CONSTRAINT CHECK (a > 0)`,
-		plan: plan.NewAlterAddCheck(
-			plan.NewUnresolvedTable("t1", ""),
-			&sql.CheckConstraint{
-				Name: "",
-				Expr: expression.NewGreaterThan(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral(int8(0), sql.Int8),
-				),
-				Enforced: true,
-			},
-		),
-	},
-	{
-		input: `ALTER TABLE t1 DROP FOREIGN KEY fk_name`,
-		plan:  plan.NewAlterDropForeignKey("", "t1", "fk_name"),
-	},
-	{
-		input: `ALTER TABLE t1 DROP CONSTRAINT fk_name`,
-		plan: plan.NewDropConstraint(
-			plan.NewUnresolvedTable("t1", ""),
-			"fk_name",
-		),
-	},
-	{
-		input: `DESCRIBE foo;`,
-		plan: plan.NewShowColumns(false,
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `DESC foo;`,
-		plan: plan.NewShowColumns(false,
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: "DESCRIBE FORMAT=tree SELECT * FROM foo",
-		plan: plan.NewDescribeQuery(
-			"tree", plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
+				},
+			),
+		},
+		{
+			input: `ALTER TABLE t1 DROP FOREIGN KEY fk_name`,
+			plan:  plan.NewAlterDropForeignKey("", "t1", "fk_name"),
+		},
+		{
+			input: `ALTER TABLE t1 DROP CONSTRAINT fk_name`,
+			plan: plan.NewDropConstraint(
+				plan.NewUnresolvedTable("t1", ""),
+				"fk_name",
+			),
+		},
+		{
+			input: `DESCRIBE foo;`,
+			plan: plan.NewShowColumns(false,
 				plan.NewUnresolvedTable("foo", ""),
-			)),
-	},
-	{
-		input: "DESC FORMAT=tree SELECT * FROM foo",
-		plan: plan.NewDescribeQuery(
-			"tree", plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
+			),
+		},
+		{
+			input: `DESC foo;`,
+			plan: plan.NewShowColumns(false,
 				plan.NewUnresolvedTable("foo", ""),
-			)),
-	},
-	{
-		input: "EXPLAIN FORMAT=tree SELECT * FROM foo",
-		plan: plan.NewDescribeQuery(
-			"tree", plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
-				plan.NewUnresolvedTable("foo", "")),
-		),
-	},
-	{
-		input: "DESCRIBE SELECT * FROM foo",
-		plan: plan.NewDescribeQuery(
-			"tree", plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
-				plan.NewUnresolvedTable("foo", ""),
-			)),
-	},
-	{
-		input: "DESC SELECT * FROM foo",
-		plan: plan.NewDescribeQuery(
-			"tree", plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
-				plan.NewUnresolvedTable("foo", ""),
-			)),
-	},
-	{
-		input: "EXPLAIN SELECT * FROM foo",
-		plan: plan.NewDescribeQuery(
-			"tree", plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
-				plan.NewUnresolvedTable("foo", "")),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT foo IS NULL, bar IS NOT NULL FROM foo;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewIsNull(expression.NewUnresolvedColumn("foo")),
-				expression.NewAlias("bar IS NOT NULL",
-					expression.NewNot(expression.NewIsNull(expression.NewUnresolvedColumn("bar"))),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT foo IS TRUE, bar IS NOT FALSE FROM foo;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewIsTrue(expression.NewUnresolvedColumn("foo")),
-				expression.NewAlias("bar IS NOT FALSE",
-					expression.NewNot(expression.NewIsFalse(expression.NewUnresolvedColumn("bar"))),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT foo AS bar FROM foo;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT foo AS bAz FROM foo;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("bAz", expression.NewUnresolvedColumn("foo")),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT foo AS bar FROM foo AS OF '2019-01-01' AS baz;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
-			},
-			plan.NewTableAlias("baz",
-				plan.NewUnresolvedTableAsOf("foo", "",
-					expression.NewLiteral("2019-01-01", sql.LongText))),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo WHERE foo = bar;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewFilter(
-				expression.NewEquals(
+			),
+		},
+		{
+			input: "DESCRIBE FORMAT=tree SELECT * FROM foo",
+			plan: plan.NewDescribeQuery(
+				"tree", plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				)),
+		},
+		{
+			input: "DESC FORMAT=tree SELECT * FROM foo",
+			plan: plan.NewDescribeQuery(
+				"tree", plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				)),
+		},
+		{
+			input: "EXPLAIN FORMAT=tree SELECT * FROM foo",
+			plan: plan.NewDescribeQuery(
+				"tree", plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", "")),
+			),
+		},
+		{
+			input: "DESCRIBE SELECT * FROM foo",
+			plan: plan.NewDescribeQuery(
+				"tree", plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				)),
+		},
+		{
+			input: "DESC SELECT * FROM foo",
+			plan: plan.NewDescribeQuery(
+				"tree", plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				)),
+		},
+		{
+			input: "EXPLAIN SELECT * FROM foo",
+			plan: plan.NewDescribeQuery(
+				"tree", plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", "")),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM foo;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
 					expression.NewUnresolvedColumn("foo"),
 					expression.NewUnresolvedColumn("bar"),
-				),
+				},
 				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo WHERE foo = 'bar';`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewFilter(
-				expression.NewEquals(
+		},
+		{
+			input: `SELECT foo IS NULL, bar IS NOT NULL FROM foo;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewIsNull(expression.NewUnresolvedColumn("foo")),
+					expression.NewAlias("bar IS NOT NULL",
+						expression.NewNot(expression.NewIsNull(expression.NewUnresolvedColumn("bar"))),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT foo IS TRUE, bar IS NOT FALSE FROM foo;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewIsTrue(expression.NewUnresolvedColumn("foo")),
+					expression.NewAlias("bar IS NOT FALSE",
+						expression.NewNot(expression.NewIsFalse(expression.NewUnresolvedColumn("bar"))),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT foo AS bar FROM foo;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT foo AS bAz FROM foo;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("bAz", expression.NewUnresolvedColumn("foo")),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT foo AS bar FROM foo AS OF '2019-01-01' AS baz;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
+				},
+				plan.NewTableAlias("baz",
+					plan.NewUnresolvedTableAsOf("foo", "",
+						expression.NewLiteral("2019-01-01", sql.LongText))),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM foo WHERE foo = bar;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
 					expression.NewUnresolvedColumn("foo"),
-					expression.NewLiteral("bar", sql.LongText),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewFilter(
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					),
+					plan.NewUnresolvedTable("foo", ""),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo WHERE foo = ?;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewFilter(
-				expression.NewEquals(
+		},
+		{
+			input: `SELECT foo, bar FROM foo WHERE foo = 'bar';`,
+			plan: plan.NewProject(
+				[]sql.Expression{
 					expression.NewUnresolvedColumn("foo"),
-					expression.NewBindVar("v1"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewFilter(
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewLiteral("bar", sql.LongText),
+					),
+					plan.NewUnresolvedTable("foo", ""),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM (SELECT * FROM foo WHERE bar = ?) a;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewSubqueryAlias(
-				"a",
-				"select * from foo where bar = :v1",
-				plan.NewProject(
-					[]sql.Expression{
-						expression.NewStar(),
-					},
-					plan.NewFilter(
-						expression.NewEquals(
-							expression.NewUnresolvedColumn("bar"),
-							expression.NewBindVar("v1"),
+		},
+		{
+			input: `SELECT foo, bar FROM foo WHERE foo = ?;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewFilter(
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewBindVar("v1"),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM (SELECT * FROM foo WHERE bar = ?) a;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewSubqueryAlias(
+					"a",
+					"select * from foo where bar = :v1",
+					plan.NewProject(
+						[]sql.Expression{
+							expression.NewStar(),
+						},
+						plan.NewFilter(
+							expression.NewEquals(
+								expression.NewUnresolvedColumn("bar"),
+								expression.NewBindVar("v1"),
+							),
+							plan.NewUnresolvedTable("foo", ""),
 						),
-						plan.NewUnresolvedTable("foo", ""),
 					),
 				),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM (values row(1,2), row(3,4)) a;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewValueDerivedTable(
-				plan.NewValues([][]sql.Expression{
-					{
-						expression.NewLiteral(int8(1), sql.Int8),
-						expression.NewLiteral(int8(2), sql.Int8),
-					},
-					{
-						expression.NewLiteral(int8(3), sql.Int8),
-						expression.NewLiteral(int8(4), sql.Int8),
-					},
-				}),
-				"a"),
-		),
-	},
-	{
-		input: `SELECT * FROM (values row(1+1,2+2), row(rand(),concat("a","b"))) a;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewValueDerivedTable(
-				plan.NewValues([][]sql.Expression{
-					{
-						expression.NewArithmetic(
-							expression.NewLiteral(int8(1), sql.Int8),
-							expression.NewLiteral(int8(1), sql.Int8),
-							"+",
-						),
-						expression.NewArithmetic(
-							expression.NewLiteral(int8(2), sql.Int8),
-							expression.NewLiteral(int8(2), sql.Int8),
-							"+",
-						),
-					},
-					{
-						expression.NewUnresolvedFunction("rand", false, nil),
-						expression.NewUnresolvedFunction("concat", false, nil, expression.NewLiteral("a", sql.LongText), expression.NewLiteral("b", sql.LongText)),
-					},
-				}),
-				"a"),
-		),
-	},
-	{
-		input: `SELECT column_0 FROM (values row(1,2), row(3,4)) a limit 1`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
-			plan.NewProject(
+		},
+		{
+			input: `SELECT * FROM (values row(1,2), row(3,4)) a;`,
+			plan: plan.NewProject(
 				[]sql.Expression{
-					expression.NewUnresolvedColumn("column_0"),
+					expression.NewStar(),
 				},
 				plan.NewValueDerivedTable(
 					plan.NewValues([][]sql.Expression{
@@ -1745,91 +1696,76 @@ CREATE TABLE t2
 					}),
 					"a"),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo WHERE foo <=> bar;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewFilter(
-				expression.NewNullSafeEquals(
-					expression.NewUnresolvedColumn("foo"),
-					expression.NewUnresolvedColumn("bar"),
+		},
+		{
+			input: `SELECT * FROM (values row(1+1,2+2), row(rand(),concat("a","b"))) a;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewValueDerivedTable(
+					plan.NewValues([][]sql.Expression{
+						{
+							expression.NewArithmetic(
+								expression.NewLiteral(int8(1), sql.Int8),
+								expression.NewLiteral(int8(1), sql.Int8),
+								"+",
+							),
+							expression.NewArithmetic(
+								expression.NewLiteral(int8(2), sql.Int8),
+								expression.NewLiteral(int8(2), sql.Int8),
+								"+",
+							),
+						},
+						{
+							expression.NewUnresolvedFunction("rand", false, nil),
+							expression.NewUnresolvedFunction("concat", false, nil, expression.NewLiteral("a", sql.LongText), expression.NewLiteral("b", sql.LongText)),
+						},
+					}),
+					"a"),
+			),
+		},
+		{
+			input: `SELECT column_0 FROM (values row(1,2), row(3,4)) a limit 1`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("column_0"),
+					},
+					plan.NewValueDerivedTable(
+						plan.NewValues([][]sql.Expression{
+							{
+								expression.NewLiteral(int8(1), sql.Int8),
+								expression.NewLiteral(int8(2), sql.Int8),
+							},
+							{
+								expression.NewLiteral(int8(3), sql.Int8),
+								expression.NewLiteral(int8(4), sql.Int8),
+							},
+						}),
+						"a"),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo WHERE foo = :var;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewFilter(
-				expression.NewEquals(
-					expression.NewUnresolvedColumn("foo"),
-					expression.NewBindVar("var"),
-				),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE foo != 'bar';`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewFilter(
-				expression.NewNot(expression.NewEquals(
-					expression.NewUnresolvedColumn("foo"),
-					expression.NewLiteral("bar", sql.LongText),
-				)),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo LIMIT 10;`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
-			plan.NewProject(
+		},
+		{
+			input: `SELECT foo, bar FROM foo WHERE foo <=> bar;`,
+			plan: plan.NewProject(
 				[]sql.Expression{
 					expression.NewUnresolvedColumn("foo"),
 					expression.NewUnresolvedColumn("bar"),
 				},
-				plan.NewUnresolvedTable("foo", ""),
+				plan.NewFilter(
+					expression.NewNullSafeEquals(
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo ORDER BY baz DESC;`,
-		plan: plan.NewSort(
-			[]sql.SortField{
-				{
-					Column:       expression.NewUnresolvedColumn("baz"),
-					Column2:      expression.NewUnresolvedColumn("baz"),
-					Order:        sql.Descending,
-					NullOrdering: sql.NullsFirst,
-				},
-			},
-			plan.NewProject(
-				[]sql.Expression{
-					expression.NewUnresolvedColumn("foo"),
-					expression.NewUnresolvedColumn("bar"),
-				},
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo WHERE foo = bar LIMIT 10;`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
-			plan.NewProject(
+		},
+		{
+			input: `SELECT foo, bar FROM foo WHERE foo = :var;`,
+			plan: plan.NewProject(
 				[]sql.Expression{
 					expression.NewUnresolvedColumn("foo"),
 					expression.NewUnresolvedColumn("bar"),
@@ -1837,17 +1773,42 @@ CREATE TABLE t2
 				plan.NewFilter(
 					expression.NewEquals(
 						expression.NewUnresolvedColumn("foo"),
-						expression.NewUnresolvedColumn("bar"),
+						expression.NewBindVar("var"),
 					),
 					plan.NewUnresolvedTable("foo", ""),
 				),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo ORDER BY baz DESC LIMIT 1;`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
-			plan.NewSort(
+		},
+		{
+			input: `SELECT * FROM foo WHERE foo != 'bar';`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewFilter(
+					expression.NewNot(expression.NewEquals(
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewLiteral("bar", sql.LongText),
+					)),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM foo LIMIT 10;`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM foo ORDER BY baz DESC;`,
+			plan: plan.NewSort(
 				[]sql.SortField{
 					{
 						Column:       expression.NewUnresolvedColumn("baz"),
@@ -1864,20 +1825,10 @@ CREATE TABLE t2
 					plan.NewUnresolvedTable("foo", ""),
 				),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo WHERE qux = 1 ORDER BY baz DESC LIMIT 1;`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
-			plan.NewSort(
-				[]sql.SortField{
-					{
-						Column:       expression.NewUnresolvedColumn("baz"),
-						Column2:      expression.NewUnresolvedColumn("baz"),
-						Order:        sql.Descending,
-						NullOrdering: sql.NullsFirst,
-					},
-				},
+		},
+		{
+			input: `SELECT foo, bar FROM foo WHERE foo = bar LIMIT 10;`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
 				plan.NewProject(
 					[]sql.Expression{
 						expression.NewUnresolvedColumn("foo"),
@@ -1885,1725 +1836,1719 @@ CREATE TABLE t2
 					},
 					plan.NewFilter(
 						expression.NewEquals(
-							expression.NewUnresolvedColumn("qux"),
-							expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewUnresolvedColumn("foo"),
+							expression.NewUnresolvedColumn("bar"),
 						),
 						plan.NewUnresolvedTable("foo", ""),
 					),
 				),
 			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM t1, t2;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewCrossJoin(
-				plan.NewUnresolvedTable("t1", ""),
-				plan.NewUnresolvedTable("t2", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM t1 JOIN t2;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewCrossJoin(
-				plan.NewUnresolvedTable("t1", ""),
-				plan.NewUnresolvedTable("t2", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM t1 GROUP BY foo, bar;`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("t1", ""),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM t1 GROUP BY 1, 2;`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("t1", ""),
-		),
-	},
-	{
-		input: `SELECT COUNT(*) FROM t1;`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("COUNT(*)",
-					expression.NewUnresolvedFunction("count", true, nil,
-						expression.NewStar()),
+		},
+		{
+			input: `SELECT foo, bar FROM foo ORDER BY baz DESC LIMIT 1;`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
+				plan.NewSort(
+					[]sql.SortField{
+						{
+							Column:       expression.NewUnresolvedColumn("baz"),
+							Column2:      expression.NewUnresolvedColumn("baz"),
+							Order:        sql.Descending,
+							NullOrdering: sql.NullsFirst,
+						},
+					},
+					plan.NewProject(
+						[]sql.Expression{
+							expression.NewUnresolvedColumn("foo"),
+							expression.NewUnresolvedColumn("bar"),
+						},
+						plan.NewUnresolvedTable("foo", ""),
+					),
 				),
-			},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("t1", ""),
-		),
-	},
-	{
-		input: `SELECT a FROM t1 where a regexp '.*test.*';`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-			},
-			plan.NewFilter(
-				expression.NewRegexp(
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM foo WHERE qux = 1 ORDER BY baz DESC LIMIT 1;`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
+				plan.NewSort(
+					[]sql.SortField{
+						{
+							Column:       expression.NewUnresolvedColumn("baz"),
+							Column2:      expression.NewUnresolvedColumn("baz"),
+							Order:        sql.Descending,
+							NullOrdering: sql.NullsFirst,
+						},
+					},
+					plan.NewProject(
+						[]sql.Expression{
+							expression.NewUnresolvedColumn("foo"),
+							expression.NewUnresolvedColumn("bar"),
+						},
+						plan.NewFilter(
+							expression.NewEquals(
+								expression.NewUnresolvedColumn("qux"),
+								expression.NewLiteral(int8(1), sql.Int8),
+							),
+							plan.NewUnresolvedTable("foo", ""),
+						),
+					),
+				),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM t1, t2;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewCrossJoin(
+					plan.NewUnresolvedTable("t1", ""),
+					plan.NewUnresolvedTable("t2", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM t1 JOIN t2;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewCrossJoin(
+					plan.NewUnresolvedTable("t1", ""),
+					plan.NewUnresolvedTable("t2", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM t1 GROUP BY foo, bar;`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewUnresolvedTable("t1", ""),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM t1 GROUP BY 1, 2;`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewUnresolvedTable("t1", ""),
+			),
+		},
+		{
+			input: `SELECT COUNT(*) FROM t1;`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias("COUNT(*)",
+						expression.NewUnresolvedFunction("count", true, nil,
+							expression.NewStar()),
+					),
+				},
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("t1", ""),
+			),
+		},
+		{
+			input: `SELECT a FROM t1 where a regexp '.*test.*';`,
+			plan: plan.NewProject(
+				[]sql.Expression{
 					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral(".*test.*", sql.LongText),
-				),
-				plan.NewUnresolvedTable("t1", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT a FROM t1 where a regexp '*main.go';`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-			},
-			plan.NewFilter(
-				expression.NewRegexp(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral("*main.go", sql.LongText),
-				),
-				plan.NewUnresolvedTable("t1", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT a FROM t1 where a not regexp '.*test.*';`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-			},
-			plan.NewFilter(
-				expression.NewNot(
+				},
+				plan.NewFilter(
 					expression.NewRegexp(
 						expression.NewUnresolvedColumn("a"),
 						expression.NewLiteral(".*test.*", sql.LongText),
 					),
+					plan.NewUnresolvedTable("t1", ""),
 				),
-				plan.NewUnresolvedTable("t1", ""),
 			),
-		),
-	},
-	{
-		input: `INSERT INTO t1 (col1, col2) VALUES ('a', 1)`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-			expression.NewLiteral("a", sql.LongText),
-			expression.NewLiteral(int8(1), sql.Int8),
-		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	},
-	{
-		input: `INSERT INTO mydb.t1 (col1, col2) VALUES ('a', 1)`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase("mydb"), plan.NewUnresolvedTable("t1", "mydb"), plan.NewValues([][]sql.Expression{{
-			expression.NewLiteral("a", sql.LongText),
-			expression.NewLiteral(int8(1), sql.Int8),
-		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	},
-	{
-		input: `INSERT INTO t1 (col1, col2) VALUES (?, ?)`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-			expression.NewBindVar("v1"),
-			expression.NewBindVar("v2"),
-		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	},
-	{
-		input: `INSERT INTO t1 VALUES (b'0111')`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-			expression.NewLiteral(uint64(7), sql.Uint64),
-		}}), false, []string{}, []sql.Expression{}, false),
-	},
-	{
-		input: `INSERT INTO t1 (col1, col2) VALUES ('a', DEFAULT)`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-			expression.NewLiteral("a", sql.LongText),
-			&expression.DefaultColumn{},
-		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	},
-	{
-		input: `INSERT INTO test (decimal_col) VALUES (11981.5923291839784651)`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
-			expression.NewLiteral(decimal.RequireFromString("11981.5923291839784651"), sql.MustCreateDecimalType(21, 16)),
-		}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
-	},
-	{
-		input: `INSERT INTO test (decimal_col) VALUES (119815923291839784651.11981592329183978465111981592329183978465144)`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
-			expression.NewLiteral("119815923291839784651.11981592329183978465111981592329183978465144", sql.LongText),
-		}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
-	},
-	{
-		input: `UPDATE t1 SET col1 = ?, col2 = ? WHERE id = ?`,
-		plan: plan.NewUpdate(plan.NewFilter(
-			expression.NewEquals(expression.NewUnresolvedColumn("id"), expression.NewBindVar("v3")),
-			plan.NewUnresolvedTable("t1", ""),
-		), false, []sql.Expression{
-			expression.NewSetField(expression.NewUnresolvedColumn("col1"), expression.NewBindVar("v1")),
-			expression.NewSetField(expression.NewUnresolvedColumn("col2"), expression.NewBindVar("v2")),
-		}),
-	},
-	{
-		input: `REPLACE INTO t1 (col1, col2) VALUES ('a', 1)`,
-		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-			expression.NewLiteral("a", sql.LongText),
-			expression.NewLiteral(int8(1), sql.Int8),
-		}}), true, []string{"col1", "col2"}, []sql.Expression{}, false),
-	},
-	{
-		input: `SHOW TABLES`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), false, nil),
-	},
-	{
-		input: `SHOW FULL TABLES`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), true, nil),
-	},
-	{
-		input: `SHOW TABLES FROM foo`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
-	},
-	{
-		input: `SHOW TABLES IN foo`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
-	},
-	{
-		input: `SHOW FULL TABLES FROM foo`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
-	},
-	{
-		input: `SHOW FULL TABLES IN foo`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
-	},
-	{
-		input: `SHOW TABLES AS OF 'abc'`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), false, expression.NewLiteral("abc", sql.LongText)),
-	},
-	{
-		input: `SHOW FULL TABLES AS OF 'abc'`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), true, expression.NewLiteral("abc", sql.LongText)),
-	},
-	{
-		input: `SHOW TABLES FROM foo AS OF 'abc'`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, expression.NewLiteral("abc", sql.LongText)),
-	},
-	{
-		input: `SHOW FULL TABLES FROM foo AS OF 'abc'`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
-	},
-	{
-		input: `SHOW FULL TABLES IN foo AS OF 'abc'`,
-		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
-	},
-	{
-		input: `SHOW TABLES FROM mydb LIKE 'foo'`,
-		plan: plan.NewFilter(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("Tables_in_mydb"),
-				expression.NewLiteral("foo", sql.LongText),
-				nil,
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, nil),
-		),
-	},
-	{
-		input: `SHOW TABLES FROM mydb AS OF 'abc' LIKE 'foo'`,
-		plan: plan.NewFilter(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("Tables_in_mydb"),
-				expression.NewLiteral("foo", sql.LongText),
-				nil,
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, expression.NewLiteral("abc", sql.LongText)),
-		),
-	},
-	{
-		input: "SHOW TABLES FROM bar WHERE `Tables_in_bar` = 'foo'",
-		plan: plan.NewFilter(
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("Tables_in_bar"),
-				expression.NewLiteral("foo", sql.LongText),
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("bar"), false, nil),
-		),
-	},
-	{
-		input: `SHOW FULL TABLES FROM mydb LIKE 'foo'`,
-		plan: plan.NewFilter(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("Tables_in_mydb"),
-				expression.NewLiteral("foo", sql.LongText),
-				nil,
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("mydb"), true, nil),
-		),
-	},
-	{
-		input: "SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'foo'",
-		plan: plan.NewFilter(
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("Tables_in_bar"),
-				expression.NewLiteral("foo", sql.LongText),
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
-		),
-	},
-	{
-		input: `SHOW FULL TABLES FROM bar LIKE 'foo'`,
-		plan: plan.NewFilter(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("Tables_in_bar"),
-				expression.NewLiteral("foo", sql.LongText),
-				nil,
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
-		),
-	},
-	{
-		input: `SHOW FULL TABLES FROM bar AS OF 'abc' LIKE 'foo'`,
-		plan: plan.NewFilter(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("Tables_in_bar"),
-				expression.NewLiteral("foo", sql.LongText),
-				nil,
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, expression.NewLiteral("abc", sql.LongText)),
-		),
-	},
-	{
-		input: "SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'test'",
-		plan: plan.NewFilter(
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("Tables_in_bar"),
-				expression.NewLiteral("test", sql.LongText),
-			),
-			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
-		),
-	},
-	{
-		input: `SELECT DISTINCT foo, bar FROM foo;`,
-		plan: plan.NewDistinct(
-			plan.NewProject(
+		},
+		{
+			input: `SELECT a FROM t1 where a regexp '*main.go';`,
+			plan: plan.NewProject(
 				[]sql.Expression{
-					expression.NewUnresolvedColumn("foo"),
-					expression.NewUnresolvedColumn("bar"),
-				},
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo LIMIT 2 OFFSET 5;`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
-			plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
-				[]sql.Expression{
-					expression.NewUnresolvedColumn("foo"),
-					expression.NewUnresolvedColumn("bar"),
-				},
-				plan.NewUnresolvedTable("foo", ""),
-			)),
-		),
-	},
-	{
-		input: `SELECT foo, bar FROM foo LIMIT 5,2;`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
-			plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
-				[]sql.Expression{
-					expression.NewUnresolvedColumn("foo"),
-					expression.NewUnresolvedColumn("bar"),
-				},
-				plan.NewUnresolvedTable("foo", ""),
-			)),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE (a = 1)`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewFilter(
-				expression.NewEquals(
 					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral(int8(1), sql.Int8),
-				),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo, bar, baz, qux`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewCrossJoin(
-				plan.NewCrossJoin(
-					plan.NewCrossJoin(
-						plan.NewUnresolvedTable("foo", ""),
-						plan.NewUnresolvedTable("bar", ""),
-					),
-					plan.NewUnresolvedTable("baz", ""),
-				),
-				plan.NewUnresolvedTable("qux", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo join bar join baz join qux`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewCrossJoin(
-				plan.NewCrossJoin(
-					plan.NewCrossJoin(
-						plan.NewUnresolvedTable("foo", ""),
-						plan.NewUnresolvedTable("bar", ""),
-					),
-					plan.NewUnresolvedTable("baz", ""),
-				),
-				plan.NewUnresolvedTable("qux", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE a = b AND c = d`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewAnd(
-					expression.NewEquals(
+				},
+				plan.NewFilter(
+					expression.NewRegexp(
 						expression.NewUnresolvedColumn("a"),
-						expression.NewUnresolvedColumn("b"),
+						expression.NewLiteral("*main.go", sql.LongText),
 					),
-					expression.NewEquals(
-						expression.NewUnresolvedColumn("c"),
-						expression.NewUnresolvedColumn("d"),
-					),
+					plan.NewUnresolvedTable("t1", ""),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE a = b OR c = d`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewOr(
-					expression.NewEquals(
-						expression.NewUnresolvedColumn("a"),
-						expression.NewUnresolvedColumn("b"),
+		},
+		{
+			input: `SELECT a FROM t1 where a not regexp '.*test.*';`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+				},
+				plan.NewFilter(
+					expression.NewNot(
+						expression.NewRegexp(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewLiteral(".*test.*", sql.LongText),
+						),
 					),
-					expression.NewEquals(
-						expression.NewUnresolvedColumn("c"),
-						expression.NewUnresolvedColumn("d"),
-					),
+					plan.NewUnresolvedTable("t1", ""),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo as bar`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewTableAlias(
-				"bar",
-				plan.NewUnresolvedTable("foo", ""),
+		},
+		{
+			input: `INSERT INTO t1 (col1, col2) VALUES ('a', 1)`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+				expression.NewLiteral("a", sql.LongText),
+				expression.NewLiteral(int8(1), sql.Int8),
+			}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+		},
+		{
+			input: `INSERT INTO mydb.t1 (col1, col2) VALUES ('a', 1)`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase("mydb"), plan.NewUnresolvedTable("t1", "mydb"), plan.NewValues([][]sql.Expression{{
+				expression.NewLiteral("a", sql.LongText),
+				expression.NewLiteral(int8(1), sql.Int8),
+			}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+		},
+		{
+			input: `INSERT INTO t1 (col1, col2) VALUES (?, ?)`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+				expression.NewBindVar("v1"),
+				expression.NewBindVar("v2"),
+			}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+		},
+		{
+			input: `INSERT INTO t1 VALUES (b'0111')`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+				expression.NewLiteral(uint64(7), sql.Uint64),
+			}}), false, []string{}, []sql.Expression{}, false),
+		},
+		{
+			input: `INSERT INTO t1 (col1, col2) VALUES ('a', DEFAULT)`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+				expression.NewLiteral("a", sql.LongText),
+				&expression.DefaultColumn{},
+			}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+		},
+		{
+			input: `INSERT INTO test (decimal_col) VALUES (11981.5923291839784651)`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
+				expression.NewLiteral(decimal.RequireFromString("11981.5923291839784651"), sql.MustCreateDecimalType(21, 16)),
+			}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
+		},
+		{
+			input: `INSERT INTO test (decimal_col) VALUES (119815923291839784651.11981592329183978465111981592329183978465144)`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
+				expression.NewLiteral("119815923291839784651.11981592329183978465111981592329183978465144", sql.LongText),
+			}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
+		},
+		{
+			input: `UPDATE t1 SET col1 = ?, col2 = ? WHERE id = ?`,
+			plan: plan.NewUpdate(plan.NewFilter(
+				expression.NewEquals(expression.NewUnresolvedColumn("id"), expression.NewBindVar("v3")),
+				plan.NewUnresolvedTable("t1", ""),
+			), false, []sql.Expression{
+				expression.NewSetField(expression.NewUnresolvedColumn("col1"), expression.NewBindVar("v1")),
+				expression.NewSetField(expression.NewUnresolvedColumn("col2"), expression.NewBindVar("v2")),
+			}),
+		},
+		{
+			input: `REPLACE INTO t1 (col1, col2) VALUES ('a', 1)`,
+			plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+				expression.NewLiteral("a", sql.LongText),
+				expression.NewLiteral(int8(1), sql.Int8),
+			}}), true, []string{"col1", "col2"}, []sql.Expression{}, false),
+		},
+		{
+			input: `SHOW TABLES`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), false, nil),
+		},
+		{
+			input: `SHOW FULL TABLES`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), true, nil),
+		},
+		{
+			input: `SHOW TABLES FROM foo`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
+		},
+		{
+			input: `SHOW TABLES IN foo`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
+		},
+		{
+			input: `SHOW FULL TABLES FROM foo`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
+		},
+		{
+			input: `SHOW FULL TABLES IN foo`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
+		},
+		{
+			input: `SHOW TABLES AS OF 'abc'`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), false, expression.NewLiteral("abc", sql.LongText)),
+		},
+		{
+			input: `SHOW FULL TABLES AS OF 'abc'`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), true, expression.NewLiteral("abc", sql.LongText)),
+		},
+		{
+			input: `SHOW TABLES FROM foo AS OF 'abc'`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, expression.NewLiteral("abc", sql.LongText)),
+		},
+		{
+			input: `SHOW FULL TABLES FROM foo AS OF 'abc'`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
+		},
+		{
+			input: `SHOW FULL TABLES IN foo AS OF 'abc'`,
+			plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
+		},
+		{
+			input: `SHOW TABLES FROM mydb LIKE 'foo'`,
+			plan: plan.NewFilter(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("Tables_in_mydb"),
+					expression.NewLiteral("foo", sql.LongText),
+					nil,
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, nil),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM (SELECT * FROM foo) AS bar`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewSubqueryAlias(
-				"bar", "select * from foo",
+		},
+		{
+			input: `SHOW TABLES FROM mydb AS OF 'abc' LIKE 'foo'`,
+			plan: plan.NewFilter(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("Tables_in_mydb"),
+					expression.NewLiteral("foo", sql.LongText),
+					nil,
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, expression.NewLiteral("abc", sql.LongText)),
+			),
+		},
+		{
+			input: "SHOW TABLES FROM bar WHERE `Tables_in_bar` = 'foo'",
+			plan: plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("Tables_in_bar"),
+					expression.NewLiteral("foo", sql.LongText),
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("bar"), false, nil),
+			),
+		},
+		{
+			input: `SHOW FULL TABLES FROM mydb LIKE 'foo'`,
+			plan: plan.NewFilter(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("Tables_in_mydb"),
+					expression.NewLiteral("foo", sql.LongText),
+					nil,
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("mydb"), true, nil),
+			),
+		},
+		{
+			input: "SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'foo'",
+			plan: plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("Tables_in_bar"),
+					expression.NewLiteral("foo", sql.LongText),
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
+			),
+		},
+		{
+			input: `SHOW FULL TABLES FROM bar LIKE 'foo'`,
+			plan: plan.NewFilter(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("Tables_in_bar"),
+					expression.NewLiteral("foo", sql.LongText),
+					nil,
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
+			),
+		},
+		{
+			input: `SHOW FULL TABLES FROM bar AS OF 'abc' LIKE 'foo'`,
+			plan: plan.NewFilter(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("Tables_in_bar"),
+					expression.NewLiteral("foo", sql.LongText),
+					nil,
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, expression.NewLiteral("abc", sql.LongText)),
+			),
+		},
+		{
+			input: "SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'test'",
+			plan: plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("Tables_in_bar"),
+					expression.NewLiteral("test", sql.LongText),
+				),
+				plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
+			),
+		},
+		{
+			input: `SELECT DISTINCT foo, bar FROM foo;`,
+			plan: plan.NewDistinct(
 				plan.NewProject(
-					[]sql.Expression{expression.NewStar()},
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					},
 					plan.NewUnresolvedTable("foo", ""),
 				),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE 1 NOT BETWEEN 2 AND 5`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewNot(
+		},
+		{
+			input: `SELECT * FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM foo LIMIT 2 OFFSET 5;`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
+				plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				)),
+			),
+		},
+		{
+			input: `SELECT foo, bar FROM foo LIMIT 5,2;`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
+				plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				)),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE (a = 1)`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewFilter(
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewLiteral(int8(1), sql.Int8),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo, bar, baz, qux`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewCrossJoin(
+					plan.NewCrossJoin(
+						plan.NewCrossJoin(
+							plan.NewUnresolvedTable("foo", ""),
+							plan.NewUnresolvedTable("bar", ""),
+						),
+						plan.NewUnresolvedTable("baz", ""),
+					),
+					plan.NewUnresolvedTable("qux", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo join bar join baz join qux`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewCrossJoin(
+					plan.NewCrossJoin(
+						plan.NewCrossJoin(
+							plan.NewUnresolvedTable("foo", ""),
+							plan.NewUnresolvedTable("bar", ""),
+						),
+						plan.NewUnresolvedTable("baz", ""),
+					),
+					plan.NewUnresolvedTable("qux", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE a = b AND c = d`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewAnd(
+						expression.NewEquals(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewUnresolvedColumn("b"),
+						),
+						expression.NewEquals(
+							expression.NewUnresolvedColumn("c"),
+							expression.NewUnresolvedColumn("d"),
+						),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE a = b OR c = d`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewOr(
+						expression.NewEquals(
+							expression.NewUnresolvedColumn("a"),
+							expression.NewUnresolvedColumn("b"),
+						),
+						expression.NewEquals(
+							expression.NewUnresolvedColumn("c"),
+							expression.NewUnresolvedColumn("d"),
+						),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo as bar`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewTableAlias(
+					"bar",
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM (SELECT * FROM foo) AS bar`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewSubqueryAlias(
+					"bar", "select * from foo",
+					plan.NewProject(
+						[]sql.Expression{expression.NewStar()},
+						plan.NewUnresolvedTable("foo", ""),
+					),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE 1 NOT BETWEEN 2 AND 5`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewNot(
+						expression.NewBetween(
+							expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewLiteral(int8(2), sql.Int8),
+							expression.NewLiteral(int8(5), sql.Int8),
+						),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE 1 BETWEEN 2 AND 5`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
 					expression.NewBetween(
 						expression.NewLiteral(int8(1), sql.Int8),
 						expression.NewLiteral(int8(2), sql.Int8),
 						expression.NewLiteral(int8(5), sql.Int8),
 					),
+					plan.NewUnresolvedTable("foo", ""),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE 1 BETWEEN 2 AND 5`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewBetween(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(2), sql.Int8),
-					expression.NewLiteral(int8(5), sql.Int8),
-				),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT 0x01AF`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("0x01AF",
-					expression.NewLiteral([]byte{1, 175}, sql.LongBlob),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT X'41'`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("X'41'",
-					expression.NewLiteral([]byte{'A'}, sql.LongBlob),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT * FROM b WHERE SOMEFUNC((1, 2), (3, 4))`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewUnresolvedFunction(
-					"somefunc",
-					false,
-					nil,
-					expression.NewTuple(
-						expression.NewLiteral(int8(1), sql.Int8),
-						expression.NewLiteral(int8(2), sql.Int8),
+		},
+		{
+			input: `SELECT 0x01AF`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("0x01AF",
+						expression.NewLiteral([]byte{1, 175}, sql.LongBlob),
 					),
-					expression.NewTuple(
-						expression.NewLiteral(int8(3), sql.Int8),
-						expression.NewLiteral(int8(4), sql.Int8),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT X'41'`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("X'41'",
+						expression.NewLiteral([]byte{'A'}, sql.LongBlob),
 					),
-				),
-				plan.NewUnresolvedTable("b", ""),
+				},
+				plan.NewResolvedDualTable(),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE :foo_id = 2`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewEquals(
-					expression.NewBindVar("foo_id"),
-					expression.NewLiteral(int8(2), sql.Int8),
-				),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE ? = 2 and foo.s = ? and ? <> foo.i`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewAnd(
-					expression.NewAnd(
-						expression.NewEquals(
-							expression.NewBindVar("v1"),
+		},
+		{
+			input: `SELECT * FROM b WHERE SOMEFUNC((1, 2), (3, 4))`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewUnresolvedFunction(
+						"somefunc",
+						false,
+						nil,
+						expression.NewTuple(
+							expression.NewLiteral(int8(1), sql.Int8),
 							expression.NewLiteral(int8(2), sql.Int8),
 						),
-						expression.NewEquals(
-							expression.NewUnresolvedQualifiedColumn("foo", "s"),
-							expression.NewBindVar("v2"),
+						expression.NewTuple(
+							expression.NewLiteral(int8(3), sql.Int8),
+							expression.NewLiteral(int8(4), sql.Int8),
 						),
 					),
-					expression.NewNot(expression.NewEquals(
-						expression.NewBindVar("v3"),
-						expression.NewUnresolvedQualifiedColumn("foo", "i"),
-					)),
-				),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo INNER JOIN bar ON a = b`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewInnerJoin(
-				plan.NewUnresolvedTable("foo", ""),
-				plan.NewUnresolvedTable("bar", ""),
-				expression.NewEquals(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewUnresolvedColumn("b"),
+					plan.NewUnresolvedTable("b", ""),
 				),
 			),
-		),
-	},
-	{
-		input: `SELECT foo.a FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedQualifiedColumn("foo", "a"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT CAST(-3 AS UNSIGNED) FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("CAST(-3 AS UNSIGNED)",
-					expression.NewConvert(expression.NewLiteral(int8(-3), sql.Int8), expression.ConvertToUnsigned),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT 2 = 2 FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("2 = 2",
-					expression.NewEquals(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(2), sql.Int8))),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT *, bar FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT *, foo.* FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-				expression.NewQualifiedStar("foo"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT bar, foo.* FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("bar"),
-				expression.NewQualifiedStar("foo"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT bar, *, foo.* FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("bar"),
-				expression.NewStar(),
-				expression.NewQualifiedStar("foo"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT *, * FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE 1 IN ('1', 2)`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewInTuple(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewTuple(
-						expression.NewLiteral("1", sql.LongText),
+		},
+		{
+			input: `SELECT * FROM foo WHERE :foo_id = 2`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewEquals(
+						expression.NewBindVar("foo_id"),
 						expression.NewLiteral(int8(2), sql.Int8),
 					),
+					plan.NewUnresolvedTable("foo", ""),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE 1 NOT IN ('1', 2)`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewNotInTuple(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewTuple(
-						expression.NewLiteral("1", sql.LongText),
-						expression.NewLiteral(int8(2), sql.Int8),
+		},
+		{
+			input: `SELECT * FROM foo WHERE ? = 2 and foo.s = ? and ? <> foo.i`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewAnd(
+						expression.NewAnd(
+							expression.NewEquals(
+								expression.NewBindVar("v1"),
+								expression.NewLiteral(int8(2), sql.Int8),
+							),
+							expression.NewEquals(
+								expression.NewUnresolvedQualifiedColumn("foo", "s"),
+								expression.NewBindVar("v2"),
+							),
+						),
+						expression.NewNot(expression.NewEquals(
+							expression.NewBindVar("v3"),
+							expression.NewUnresolvedQualifiedColumn("foo", "i"),
+						)),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo INNER JOIN bar ON a = b`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewInnerJoin(
+					plan.NewUnresolvedTable("foo", ""),
+					plan.NewUnresolvedTable("bar", ""),
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewUnresolvedColumn("b"),
 					),
 				),
-				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE i IN (SELECT j FROM baz)`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				plan.NewInSubquery(
-					expression.NewUnresolvedColumn("i"),
-					plan.NewSubquery(plan.NewProject(
-						[]sql.Expression{expression.NewUnresolvedColumn("j")},
-						plan.NewUnresolvedTable("baz", ""),
-					), "select j from baz"),
-				),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE i NOT IN (SELECT j FROM baz)`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				plan.NewNotInSubquery(
-					expression.NewUnresolvedColumn("i"),
-					plan.NewSubquery(plan.NewProject(
-						[]sql.Expression{expression.NewUnresolvedColumn("j")},
-						plan.NewUnresolvedTable("baz", ""),
-					), "select j from baz"),
-				),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT a, b FROM t ORDER BY 2, 1`,
-		plan: plan.NewSort(
-			[]sql.SortField{
-				{
-					Column:       expression.NewLiteral(int8(2), sql.Int8),
-					Column2:      expression.NewLiteral(int8(2), sql.Int8),
-					Order:        sql.Ascending,
-					NullOrdering: sql.NullsFirst,
-				},
-				{
-					Column:       expression.NewLiteral(int8(1), sql.Int8),
-					Column2:      expression.NewLiteral(int8(1), sql.Int8),
-					Order:        sql.Ascending,
-					NullOrdering: sql.NullsFirst,
-				},
-			},
-			plan.NewProject(
+		},
+		{
+			input: `SELECT foo.a FROM foo`,
+			plan: plan.NewProject(
 				[]sql.Expression{
-					expression.NewUnresolvedColumn("a"),
-					expression.NewUnresolvedColumn("b"),
+					expression.NewUnresolvedQualifiedColumn("foo", "a"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT CAST(-3 AS UNSIGNED) FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("CAST(-3 AS UNSIGNED)",
+						expression.NewConvert(expression.NewLiteral(int8(-3), sql.Int8), expression.ConvertToUnsigned),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT 2 = 2 FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("2 = 2",
+						expression.NewEquals(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(2), sql.Int8))),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT *, bar FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT *, foo.* FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+					expression.NewQualifiedStar("foo"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT bar, foo.* FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("bar"),
+					expression.NewQualifiedStar("foo"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT bar, *, foo.* FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("bar"),
+					expression.NewStar(),
+					expression.NewQualifiedStar("foo"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT *, * FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE 1 IN ('1', 2)`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewInTuple(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewTuple(
+							expression.NewLiteral("1", sql.LongText),
+							expression.NewLiteral(int8(2), sql.Int8),
+						),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE 1 NOT IN ('1', 2)`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewNotInTuple(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewTuple(
+							expression.NewLiteral("1", sql.LongText),
+							expression.NewLiteral(int8(2), sql.Int8),
+						),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE i IN (SELECT j FROM baz)`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					plan.NewInSubquery(
+						expression.NewUnresolvedColumn("i"),
+						plan.NewSubquery(plan.NewProject(
+							[]sql.Expression{expression.NewUnresolvedColumn("j")},
+							plan.NewUnresolvedTable("baz", ""),
+						), "select j from baz"),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE i NOT IN (SELECT j FROM baz)`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					plan.NewNotInSubquery(
+						expression.NewUnresolvedColumn("i"),
+						plan.NewSubquery(plan.NewProject(
+							[]sql.Expression{expression.NewUnresolvedColumn("j")},
+							plan.NewUnresolvedTable("baz", ""),
+						), "select j from baz"),
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT a, b FROM t ORDER BY 2, 1`,
+			plan: plan.NewSort(
+				[]sql.SortField{
+					{
+						Column:       expression.NewLiteral(int8(2), sql.Int8),
+						Column2:      expression.NewLiteral(int8(2), sql.Int8),
+						Order:        sql.Ascending,
+						NullOrdering: sql.NullsFirst,
+					},
+					{
+						Column:       expression.NewLiteral(int8(1), sql.Int8),
+						Column2:      expression.NewLiteral(int8(1), sql.Int8),
+						Order:        sql.Ascending,
+						NullOrdering: sql.NullsFirst,
+					},
+				},
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("a"),
+						expression.NewUnresolvedColumn("b"),
+					},
+					plan.NewUnresolvedTable("t", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT -i FROM mytable`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnaryMinus(
+						expression.NewUnresolvedColumn("i"),
+					),
+				},
+				plan.NewUnresolvedTable("mytable", ""),
+			),
+		},
+		{
+			input: `SELECT +i FROM mytable`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("+i",
+						expression.NewUnresolvedColumn("i"),
+					),
+				},
+				plan.NewUnresolvedTable("mytable", ""),
+			),
+		},
+		{
+			input: `SELECT - 4 - - 80`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("- 4 - - 80",
+						expression.NewMinus(
+							expression.NewLiteral(int8(-4), sql.Int8),
+							expression.NewLiteral(int8(-80), sql.Int8),
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT + - - i FROM mytable`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("+ - - i",
+						expression.NewUnaryMinus(
+							expression.NewUnaryMinus(
+								expression.NewUnresolvedColumn("i"),
+							),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("mytable", ""),
+			),
+		},
+		{
+			input: `SELECT 1 + 1;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("1 + 1",
+						expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT 1 + 1 as foo;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("foo",
+						expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT 1 * (2 + 1);`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("1 * (2 + 1)",
+						expression.NewMult(expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewPlus(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT (0 - 1) * (1 | 1);`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("(0 - 1) * (1 | 1)",
+						expression.NewMult(
+							expression.NewMinus(expression.NewLiteral(int8(0), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
+							expression.NewBitOr(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT (1 << 3) % (2 div 1);`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("(1 << 3) % (2 div 1)",
+						expression.NewMod(
+							expression.NewShiftLeft(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(3), sql.Int8)),
+							expression.NewIntDiv(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT 1.0 * a + 2.0 * b FROM t;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("1.0 * a + 2.0 * b",
+						expression.NewPlus(
+							expression.NewMult(expression.NewLiteral(decimal.RequireFromString("1.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("a")),
+							expression.NewMult(expression.NewLiteral(decimal.RequireFromString("2.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("b")),
+						),
+					),
 				},
 				plan.NewUnresolvedTable("t", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT -i FROM mytable`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnaryMinus(
-					expression.NewUnresolvedColumn("i"),
-				),
-			},
-			plan.NewUnresolvedTable("mytable", ""),
-		),
-	},
-	{
-		input: `SELECT +i FROM mytable`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("+i",
-					expression.NewUnresolvedColumn("i"),
-				),
-			},
-			plan.NewUnresolvedTable("mytable", ""),
-		),
-	},
-	{
-		input: `SELECT - 4 - - 80`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("- 4 - - 80",
-					expression.NewMinus(
-						expression.NewLiteral(int8(-4), sql.Int8),
-						expression.NewLiteral(int8(-80), sql.Int8),
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT + - - i FROM mytable`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("+ - - i",
-					expression.NewUnaryMinus(
-						expression.NewUnaryMinus(
-							expression.NewUnresolvedColumn("i"),
+		},
+		{
+			input: `SELECT '1.0' + 2;`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("'1.0' + 2",
+						expression.NewPlus(
+							expression.NewLiteral("1.0", sql.LongText), expression.NewLiteral(int8(2), sql.Int8),
 						),
 					),
-				),
-			},
-			plan.NewUnresolvedTable("mytable", ""),
-		),
-	},
-	{
-		input: `SELECT 1 + 1;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("1 + 1",
-					expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT 1 + 1 as foo;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("foo",
-					expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT 1 * (2 + 1);`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("1 * (2 + 1)",
-					expression.NewMult(expression.NewLiteral(int8(1), sql.Int8),
-						expression.NewPlus(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT (0 - 1) * (1 | 1);`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("(0 - 1) * (1 | 1)",
-					expression.NewMult(
-						expression.NewMinus(expression.NewLiteral(int8(0), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
-						expression.NewBitOr(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT (1 << 3) % (2 div 1);`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("(1 << 3) % (2 div 1)",
-					expression.NewMod(
-						expression.NewShiftLeft(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(3), sql.Int8)),
-						expression.NewIntDiv(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT 1.0 * a + 2.0 * b FROM t;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("1.0 * a + 2.0 * b",
-					expression.NewPlus(
-						expression.NewMult(expression.NewLiteral(decimal.RequireFromString("1.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("a")),
-						expression.NewMult(expression.NewLiteral(decimal.RequireFromString("2.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("b")),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("t", ""),
-		),
-	},
-	{
-		input: `SELECT '1.0' + 2;`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("'1.0' + 2",
-					expression.NewPlus(
-						expression.NewLiteral("1.0", sql.LongText), expression.NewLiteral(int8(2), sql.Int8),
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT '1' + '2';`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("'1' + '2'",
-					expression.NewPlus(
-						expression.NewLiteral("1", sql.LongText), expression.NewLiteral("2", sql.LongText),
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `CREATE INDEX foo USING qux ON bar (baz)`,
-		plan: plan.NewCreateIndex(
-			"foo",
-			plan.NewUnresolvedTable("bar", ""),
-			[]sql.Expression{expression.NewUnresolvedColumn("baz")},
-			"qux",
-			make(map[string]string),
-		),
-	},
-	{
-		input: `CREATE INDEX idx USING BTREE ON foo (bar)`,
-		plan: plan.NewAlterCreateIndex(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("foo", ""),
-			"idx",
-			sql.IndexUsing_BTree,
-			sql.IndexConstraint_None,
-			[]sql.IndexColumn{
-				{"bar", 0},
-			},
-			"",
-		),
-	},
-	{
-		input: `      CREATE INDEX idx USING BTREE ON foo(bar)`,
-		plan: plan.NewAlterCreateIndex(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("foo", ""),
-			"idx",
-			sql.IndexUsing_BTree,
-			sql.IndexConstraint_None,
-			[]sql.IndexColumn{
-				{"bar", 0},
-			},
-			"",
-		),
-	},
-	{
-		input: `SELECT * FROM foo NATURAL JOIN bar`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewNaturalJoin(
-				plan.NewUnresolvedTable("foo", ""),
-				plan.NewUnresolvedTable("bar", ""),
+				},
+				plan.NewResolvedDualTable(),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo NATURAL JOIN bar NATURAL JOIN baz`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewNaturalJoin(
+		},
+		{
+			input: `SELECT '1' + '2';`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("'1' + '2'",
+						expression.NewPlus(
+							expression.NewLiteral("1", sql.LongText), expression.NewLiteral("2", sql.LongText),
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `CREATE INDEX foo USING qux ON bar (baz)`,
+			plan: plan.NewCreateIndex(
+				"foo",
+				plan.NewUnresolvedTable("bar", ""),
+				[]sql.Expression{expression.NewUnresolvedColumn("baz")},
+				"qux",
+				make(map[string]string),
+			),
+		},
+		{
+			input: `CREATE INDEX idx USING BTREE ON foo (bar)`,
+			plan: plan.NewAlterCreateIndex(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("foo", ""),
+				"idx",
+				sql.IndexUsing_BTree,
+				sql.IndexConstraint_None,
+				[]sql.IndexColumn{
+					{"bar", 0},
+				},
+				"",
+			),
+		},
+		{
+			input: `      CREATE INDEX idx USING BTREE ON foo(bar)`,
+			plan: plan.NewAlterCreateIndex(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("foo", ""),
+				"idx",
+				sql.IndexUsing_BTree,
+				sql.IndexConstraint_None,
+				[]sql.IndexColumn{
+					{"bar", 0},
+				},
+				"",
+			),
+		},
+		{
+			input: `SELECT * FROM foo NATURAL JOIN bar`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
 				plan.NewNaturalJoin(
 					plan.NewUnresolvedTable("foo", ""),
 					plan.NewUnresolvedTable("bar", ""),
 				),
-				plan.NewUnresolvedTable("baz", ""),
 			),
-		),
-	},
-	{
-		input: `DROP INDEX foo ON bar`,
-		plan: plan.NewAlterDropIndex(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("bar", ""),
-			"foo",
-		),
-	},
-	{
-		input: `DESCRIBE FORMAT=TREE SELECT * FROM foo`,
-		plan: plan.NewDescribeQuery(
-			"tree",
-			plan.NewProject(
+		},
+		{
+			input: `SELECT * FROM foo NATURAL JOIN bar NATURAL JOIN baz`,
+			plan: plan.NewProject(
 				[]sql.Expression{expression.NewStar()},
+				plan.NewNaturalJoin(
+					plan.NewNaturalJoin(
+						plan.NewUnresolvedTable("foo", ""),
+						plan.NewUnresolvedTable("bar", ""),
+					),
+					plan.NewUnresolvedTable("baz", ""),
+				),
+			),
+		},
+		{
+			input: `DROP INDEX foo ON bar`,
+			plan: plan.NewAlterDropIndex(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("bar", ""),
+				"foo",
+			),
+		},
+		{
+			input: `DESCRIBE FORMAT=TREE SELECT * FROM foo`,
+			plan: plan.NewDescribeQuery(
+				"tree",
+				plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT MAX(i)/2 FROM foo`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias("MAX(i)/2",
+						expression.NewArithmetic(
+							expression.NewUnresolvedFunction(
+								"max", true, nil, expression.NewUnresolvedColumn("i"),
+							),
+							expression.NewLiteral(int8(2), sql.Int8),
+							"/",
+						),
+					),
+				},
+				[]sql.Expression{},
 				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SELECT MAX(i)/2 FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("MAX(i)/2",
-					expression.NewArithmetic(
-						expression.NewUnresolvedFunction(
-							"max", true, nil, expression.NewUnresolvedColumn("i"),
-						),
-						expression.NewLiteral(int8(2), sql.Int8),
-						"/",
+		},
+		{
+			input: `SELECT current_user FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("current_user",
+						expression.NewUnresolvedFunction("current_user", false, nil),
 					),
-				),
-			},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT current_user FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("current_user",
-					expression.NewUnresolvedFunction("current_user", false, nil),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT current_USER(    ) FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("current_USER(    )",
-					expression.NewUnresolvedFunction("current_user", false, nil),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SHOW INDEXES FROM foo`,
-		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW INDEX FROM foo`,
-		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW KEYS FROM foo`,
-		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW INDEXES IN foo`,
-		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW INDEX IN foo`,
-		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW KEYS IN foo`,
-		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW FULL PROCESSLIST`,
-		plan:  plan.NewShowProcessList(),
-	},
-	{
-		input: `SHOW PROCESSLIST`,
-		plan:  plan.NewShowProcessList(),
-	},
-	{
-		input: `SELECT @@allowed_max_packet`,
-		plan: plan.NewProject([]sql.Expression{
-			expression.NewUnresolvedColumn("@@allowed_max_packet"),
-		}, plan.NewResolvedDualTable()),
-	},
-	{
-		input: `SET autocommit=1, foo="bar", baz=ON, qux=bareword`,
-		plan: plan.NewSet(
-			[]sql.Expression{
-				expression.NewSetField(expression.NewUnresolvedColumn("autocommit"), expression.NewLiteral(int8(1), sql.Int8)),
-				expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("bar", sql.LongText)),
-				expression.NewSetField(expression.NewUnresolvedColumn("baz"), expression.NewLiteral("ON", sql.LongText)),
-				expression.NewSetField(expression.NewUnresolvedColumn("qux"), expression.NewUnresolvedColumn("bareword")),
-			},
-		),
-	},
-	{
-		input: `SET @@session.autocommit=1, foo="true"`,
-		plan: plan.NewSet(
-			[]sql.Expression{
-				expression.NewSetField(expression.NewSystemVar("autocommit", sql.SystemVariableScope_Session), expression.NewLiteral(int8(1), sql.Int8)),
-				expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("true", sql.LongText)),
-			},
-		),
-	},
-	{
-		input: `SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
-		plan: plan.NewSet(
-			[]sql.Expression{
-				expression.NewSetField(expression.NewSystemVar("NET_READ_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
-				expression.NewSetField(expression.NewSystemVar("NET_WRITE_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
-			},
-		),
-	},
-	{
-		input: `SET gtid_mode=DEFAULT`,
-		plan: plan.NewSet(
-			[]sql.Expression{
-				expression.NewSetField(expression.NewUnresolvedColumn("gtid_mode"), expression.NewDefaultColumn("")),
-			},
-		),
-	},
-	{
-		input: `SET @@sql_select_limit=default`,
-		plan: plan.NewSet(
-			[]sql.Expression{
-				expression.NewSetField(expression.NewSystemVar("sql_select_limit", sql.SystemVariableScope_Session), expression.NewDefaultColumn("")),
-			},
-		),
-	},
-	{
-		input: "",
-		plan:  plan.Nothing,
-	},
-	{
-		input: "/* just a comment */",
-		plan:  plan.Nothing,
-	},
-	{
-		input: `/*!40101 SET NAMES utf8 */`,
-		plan: plan.NewSet(
-			[]sql.Expression{
-				expression.NewSetField(expression.NewUnresolvedColumn("character_set_client"), expression.NewLiteral("utf8", sql.LongText)),
-				expression.NewSetField(expression.NewUnresolvedColumn("character_set_connection"), expression.NewLiteral("utf8", sql.LongText)),
-				expression.NewSetField(expression.NewUnresolvedColumn("character_set_results"), expression.NewLiteral("utf8", sql.LongText)),
-			},
-		),
-	},
-	{
-		input: `SELECT /* a comment */ * FROM foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT /*!40101 * from */ foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-		// TODO: other optimizer hints than join_order are ignored for now
-	},
-	{
-		input: `SELECT /*+ JOIN_ORDER(a,b) */ * from foo`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT /*+ JOIN_ORDER(a,b) */ * FROM b join a on c = d limit 5`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(5), sql.Int8),
-			plan.NewProject(
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT current_USER(    ) FROM foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("current_USER(    )",
+						expression.NewUnresolvedFunction("current_user", false, nil),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SHOW INDEXES FROM foo`,
+			plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW INDEX FROM foo`,
+			plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW KEYS FROM foo`,
+			plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW INDEXES IN foo`,
+			plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW INDEX IN foo`,
+			plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW KEYS IN foo`,
+			plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW FULL PROCESSLIST`,
+			plan:  plan.NewShowProcessList(),
+		},
+		{
+			input: `SHOW PROCESSLIST`,
+			plan:  plan.NewShowProcessList(),
+		},
+		{
+			input: `SELECT @@allowed_max_packet`,
+			plan: plan.NewProject([]sql.Expression{
+				expression.NewUnresolvedColumn("@@allowed_max_packet"),
+			}, plan.NewResolvedDualTable()),
+		},
+		{
+			input: `SET autocommit=1, foo="bar", baz=ON, qux=bareword`,
+			plan: plan.NewSet(
+				[]sql.Expression{
+					expression.NewSetField(expression.NewUnresolvedColumn("autocommit"), expression.NewLiteral(int8(1), sql.Int8)),
+					expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("bar", sql.LongText)),
+					expression.NewSetField(expression.NewUnresolvedColumn("baz"), expression.NewLiteral("ON", sql.LongText)),
+					expression.NewSetField(expression.NewUnresolvedColumn("qux"), expression.NewUnresolvedColumn("bareword")),
+				},
+			),
+		},
+		{
+			input: `SET @@session.autocommit=1, foo="true"`,
+			plan: plan.NewSet(
+				[]sql.Expression{
+					expression.NewSetField(expression.NewSystemVar("autocommit", sql.SystemVariableScope_Session), expression.NewLiteral(int8(1), sql.Int8)),
+					expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("true", sql.LongText)),
+				},
+			),
+		},
+		{
+			input: `SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
+			plan: plan.NewSet(
+				[]sql.Expression{
+					expression.NewSetField(expression.NewSystemVar("NET_READ_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
+					expression.NewSetField(expression.NewSystemVar("NET_WRITE_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
+				},
+			),
+		},
+		{
+			input: `SET gtid_mode=DEFAULT`,
+			plan: plan.NewSet(
+				[]sql.Expression{
+					expression.NewSetField(expression.NewUnresolvedColumn("gtid_mode"), expression.NewDefaultColumn("")),
+				},
+			),
+		},
+		{
+			input: `SET @@sql_select_limit=default`,
+			plan: plan.NewSet(
+				[]sql.Expression{
+					expression.NewSetField(expression.NewSystemVar("sql_select_limit", sql.SystemVariableScope_Session), expression.NewDefaultColumn("")),
+				},
+			),
+		},
+		{
+			input: "",
+			plan:  plan.Nothing,
+		},
+		{
+			input: "/* just a comment */",
+			plan:  plan.Nothing,
+		},
+		{
+			input: `/*!40101 SET NAMES utf8 */`,
+			plan: plan.NewSet(
+				[]sql.Expression{
+					expression.NewSetField(expression.NewUnresolvedColumn("character_set_client"), expression.NewLiteral("utf8", sql.LongText)),
+					expression.NewSetField(expression.NewUnresolvedColumn("character_set_connection"), expression.NewLiteral("utf8", sql.LongText)),
+					expression.NewSetField(expression.NewUnresolvedColumn("character_set_results"), expression.NewLiteral("utf8", sql.LongText)),
+				},
+			),
+		},
+		{
+			input: `SELECT /* a comment */ * FROM foo`,
+			plan: plan.NewProject(
 				[]sql.Expression{
 					expression.NewStar(),
 				},
-				plan.NewInnerJoin(
-					plan.NewUnresolvedTable("b", ""),
-					plan.NewUnresolvedTable("a", ""),
-					expression.NewEquals(
-						expression.NewUnresolvedColumn("c"),
-						expression.NewUnresolvedColumn("d"),
-					),
-				).WithComment("/*+ JOIN_ORDER(a,b) */"),
+				plan.NewUnresolvedTable("foo", ""),
 			),
-		),
-	},
-	{
-		input: `SHOW DATABASES`,
-		plan:  plan.NewShowDatabases(),
-	},
-	{
-		input: `SELECT * FROM foo WHERE i LIKE 'foo'`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
+		},
+		{
+			input: `SELECT /*!40101 * from */ foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+			// TODO: other optimizer hints than join_order are ignored for now
+		},
+		{
+			input: `SELECT /*+ JOIN_ORDER(a,b) */ * from foo`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT /*+ JOIN_ORDER(a,b) */ * FROM b join a on c = d limit 5`,
+			plan: plan.NewLimit(expression.NewLiteral(int8(5), sql.Int8),
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewStar(),
+					},
+					plan.NewInnerJoin(
+						plan.NewUnresolvedTable("b", ""),
+						plan.NewUnresolvedTable("a", ""),
+						expression.NewEquals(
+							expression.NewUnresolvedColumn("c"),
+							expression.NewUnresolvedColumn("d"),
+						),
+					).WithComment("/*+ JOIN_ORDER(a,b) */"),
+				),
+			),
+		},
+		{
+			input: `SHOW DATABASES`,
+			plan:  plan.NewShowDatabases(),
+		},
+		{
+			input: `SELECT * FROM foo WHERE i LIKE 'foo'`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewLike(
+						expression.NewUnresolvedColumn("i"),
+						expression.NewLiteral("foo", sql.LongText),
+						nil,
+					),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo WHERE i NOT LIKE 'foo'`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewFilter(
+					expression.NewNot(expression.NewLike(
+						expression.NewUnresolvedColumn("i"),
+						expression.NewLiteral("foo", sql.LongText),
+						nil,
+					)),
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SHOW FIELDS FROM foo`,
+			plan:  plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW FULL COLUMNS FROM foo`,
+			plan:  plan.NewShowColumns(true, plan.NewUnresolvedTable("foo", "")),
+		},
+		{
+			input: `SHOW FIELDS FROM foo WHERE Field = 'bar'`,
+			plan: plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("Field"),
+					expression.NewLiteral("bar", sql.LongText),
+				),
+				plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
+			),
+		},
+		{
+			input: `SHOW FIELDS FROM foo LIKE 'bar'`,
+			plan: plan.NewFilter(
 				expression.NewLike(
-					expression.NewUnresolvedColumn("i"),
+					expression.NewUnresolvedColumn("Field"),
+					expression.NewLiteral("bar", sql.LongText),
+					nil,
+				),
+				plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
+			),
+		},
+		{
+			input: `SHOW TABLE STATUS LIKE 'foo'`,
+			plan: plan.NewFilter(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("Name"),
 					expression.NewLiteral("foo", sql.LongText),
 					nil,
 				),
-				plan.NewUnresolvedTable("foo", ""),
+				plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo WHERE i NOT LIKE 'foo'`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewFilter(
-				expression.NewNot(expression.NewLike(
-					expression.NewUnresolvedColumn("i"),
+		},
+		{
+			input: `SHOW TABLE STATUS FROM foo`,
+			plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
+		},
+		{
+			input: `SHOW TABLE STATUS IN foo`,
+			plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
+		},
+		{
+			input: `SHOW TABLE STATUS`,
+			plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
+		},
+		{
+			input: `SHOW TABLE STATUS WHERE Name = 'foo'`,
+			plan: plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("Name"),
+					expression.NewLiteral("foo", sql.LongText),
+				),
+				plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
+			),
+		},
+		{
+			input: `USE foo`,
+			plan:  plan.NewUse(sql.UnresolvedDatabase("foo")),
+		},
+		{
+			input: `DESCRIBE foo.bar`,
+			plan: plan.NewShowColumns(false,
+				plan.NewUnresolvedTable("bar", "foo"),
+			),
+		},
+		{
+			input: `DESC foo.bar`,
+			plan: plan.NewShowColumns(false,
+				plan.NewUnresolvedTable("bar", "foo"),
+			),
+		},
+		{
+			input: `SELECT * FROM foo.bar`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("bar", "foo"),
+			),
+		},
+		{
+			input: `SHOW VARIABLES`,
+			plan:  plan.NewShowVariables(nil),
+		},
+		{
+			input: `SHOW GLOBAL VARIABLES`,
+			plan:  plan.NewShowVariables(nil),
+		},
+		{
+			input: `SHOW SESSION VARIABLES`,
+			plan:  plan.NewShowVariables(nil),
+		},
+		{
+			input: `SHOW VARIABLES LIKE 'gtid_mode'`,
+			plan: plan.NewShowVariables(expression.NewLike(
+				expression.NewGetField(0, sql.LongText, "variable_name", false),
+				expression.NewLiteral("gtid_mode", sql.LongText),
+				nil,
+			)),
+		},
+		{
+			input: `SHOW SESSION VARIABLES LIKE 'autocommit'`,
+			plan: plan.NewShowVariables(expression.NewLike(
+				expression.NewGetField(0, sql.LongText, "variable_name", false),
+				expression.NewLiteral("autocommit", sql.LongText),
+				nil,
+			)),
+		},
+		{
+			input: `UNLOCK TABLES`,
+			plan:  plan.NewUnlockTables(),
+		},
+		{
+			input: `LOCK TABLES foo READ`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo", "")},
+			}),
+		},
+		{
+			input: `LOCK TABLES foo123 READ`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo123", "")},
+			}),
+		},
+		{
+			input: `LOCK TABLES foo AS f READ`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewTableAlias("f", plan.NewUnresolvedTable("foo", ""))},
+			}),
+		},
+		{
+			input: `LOCK TABLES foo READ LOCAL`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo", "")},
+			}),
+		},
+		{
+			input: `LOCK TABLES foo WRITE`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+			}),
+		},
+		{
+			input: `LOCK TABLES foo LOW_PRIORITY WRITE`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+			}),
+		},
+		{
+			input: `LOCK TABLES foo WRITE, bar READ`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+				{Table: plan.NewUnresolvedTable("bar", "")},
+			}),
+		},
+		{
+			input: "LOCK TABLES `foo` WRITE, `bar` READ",
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+				{Table: plan.NewUnresolvedTable("bar", "")},
+			}),
+		},
+		{
+			input: `LOCK TABLES foo READ, bar WRITE, baz READ`,
+			plan: plan.NewLockTables([]*plan.TableLock{
+				{Table: plan.NewUnresolvedTable("foo", "")},
+				{Table: plan.NewUnresolvedTable("bar", ""), Write: true},
+				{Table: plan.NewUnresolvedTable("baz", "")},
+			}),
+		},
+		{
+			input: `SHOW CREATE DATABASE foo`,
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		},
+		{
+			input: `SHOW CREATE SCHEMA foo`,
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		},
+		{
+			input: `SHOW CREATE DATABASE IF NOT EXISTS foo`,
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		},
+		{
+			input: `SHOW CREATE SCHEMA IF NOT EXISTS foo`,
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		},
+		{
+			input: `SHOW WARNINGS`,
+			plan:  plan.ShowWarnings(sql.NewEmptyContext().Warnings()),
+		},
+		{
+			input: `SHOW WARNINGS LIMIT 10`,
+			plan:  plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings())),
+		},
+		{
+			input: `SHOW WARNINGS LIMIT 5,10`,
+			plan:  plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings()))),
+		},
+		{
+			input: "SHOW CREATE DATABASE `foo`",
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		},
+		{
+			input: "SHOW CREATE SCHEMA `foo`",
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		},
+		{
+			input: "SHOW CREATE DATABASE IF NOT EXISTS `foo`",
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		},
+		{
+			input: "SHOW CREATE SCHEMA IF NOT EXISTS `foo`",
+			plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		},
+		{
+			input: "SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
+						expression.NewCase(
+							expression.NewUnresolvedColumn("foo"),
+							[]expression.CaseBranch{
+								{
+									Cond:  expression.NewLiteral(int8(1), sql.Int8),
+									Value: expression.NewLiteral("foo", sql.LongText),
+								},
+								{
+									Cond:  expression.NewLiteral(int8(2), sql.Int8),
+									Value: expression.NewLiteral("bar", sql.LongText),
+								},
+							},
+							expression.NewLiteral("baz", sql.LongText),
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: "SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END",
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END",
+						expression.NewCase(
+							expression.NewUnresolvedColumn("foo"),
+							[]expression.CaseBranch{
+								{
+									Cond:  expression.NewLiteral(int8(1), sql.Int8),
+									Value: expression.NewLiteral("foo", sql.LongText),
+								},
+								{
+									Cond:  expression.NewLiteral(int8(2), sql.Int8),
+									Value: expression.NewLiteral("bar", sql.LongText),
+								},
+							},
+							nil,
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: "SELECT CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END",
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END",
+						expression.NewCase(
+							nil,
+							[]expression.CaseBranch{
+								{
+									Cond: expression.NewEquals(
+										expression.NewUnresolvedColumn("foo"),
+										expression.NewLiteral(int8(1), sql.Int8),
+									),
+									Value: expression.NewLiteral("foo", sql.LongText),
+								},
+								{
+									Cond: expression.NewEquals(
+										expression.NewUnresolvedColumn("foo"),
+										expression.NewLiteral(int8(2), sql.Int8),
+									),
+									Value: expression.NewLiteral("bar", sql.LongText),
+								},
+							},
+							expression.NewLiteral("baz", sql.LongText),
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: "SHOW COLLATION",
+			plan:  showCollationProjection,
+		},
+		{
+			input: "SHOW COLLATION LIKE 'foo'",
+			plan: plan.NewHaving(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("collation"),
 					expression.NewLiteral("foo", sql.LongText),
 					nil,
-				)),
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SHOW FIELDS FROM foo`,
-		plan:  plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW FULL COLUMNS FROM foo`,
-		plan:  plan.NewShowColumns(true, plan.NewUnresolvedTable("foo", "")),
-	},
-	{
-		input: `SHOW FIELDS FROM foo WHERE Field = 'bar'`,
-		plan: plan.NewFilter(
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("Field"),
-				expression.NewLiteral("bar", sql.LongText),
-			),
-			plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
-		),
-	},
-	{
-		input: `SHOW FIELDS FROM foo LIKE 'bar'`,
-		plan: plan.NewFilter(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("Field"),
-				expression.NewLiteral("bar", sql.LongText),
-				nil,
-			),
-			plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
-		),
-	},
-	{
-		input: `SHOW TABLE STATUS LIKE 'foo'`,
-		plan: plan.NewFilter(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("Name"),
-				expression.NewLiteral("foo", sql.LongText),
-				nil,
-			),
-			plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
-		),
-	},
-	{
-		input: `SHOW TABLE STATUS FROM foo`,
-		plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
-	},
-	{
-		input: `SHOW TABLE STATUS IN foo`,
-		plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
-	},
-	{
-		input: `SHOW TABLE STATUS`,
-		plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
-	},
-	{
-		input: `SHOW TABLE STATUS WHERE Name = 'foo'`,
-		plan: plan.NewFilter(
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("Name"),
-				expression.NewLiteral("foo", sql.LongText),
-			),
-			plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
-		),
-	},
-	{
-		input: `USE foo`,
-		plan:  plan.NewUse(sql.UnresolvedDatabase("foo")),
-	},
-	{
-		input: `DESCRIBE foo.bar`,
-		plan: plan.NewShowColumns(false,
-			plan.NewUnresolvedTable("bar", "foo"),
-		),
-	},
-	{
-		input: `DESC foo.bar`,
-		plan: plan.NewShowColumns(false,
-			plan.NewUnresolvedTable("bar", "foo"),
-		),
-	},
-	{
-		input: `SELECT * FROM foo.bar`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("bar", "foo"),
-		),
-	},
-	{
-		input: `SHOW VARIABLES`,
-		plan:  plan.NewShowVariables(nil),
-	},
-	{
-		input: `SHOW GLOBAL VARIABLES`,
-		plan:  plan.NewShowVariables(nil),
-	},
-	{
-		input: `SHOW SESSION VARIABLES`,
-		plan:  plan.NewShowVariables(nil),
-	},
-	{
-		input: `SHOW VARIABLES LIKE 'gtid_mode'`,
-		plan: plan.NewShowVariables(expression.NewLike(
-			expression.NewGetField(0, sql.LongText, "variable_name", false),
-			expression.NewLiteral("gtid_mode", sql.LongText),
-			nil,
-		)),
-	},
-	{
-		input: `SHOW SESSION VARIABLES LIKE 'autocommit'`,
-		plan: plan.NewShowVariables(expression.NewLike(
-			expression.NewGetField(0, sql.LongText, "variable_name", false),
-			expression.NewLiteral("autocommit", sql.LongText),
-			nil,
-		)),
-	},
-	{
-		input: `UNLOCK TABLES`,
-		plan:  plan.NewUnlockTables(),
-	},
-	{
-		input: `LOCK TABLES foo READ`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo", "")},
-		}),
-	},
-	{
-		input: `LOCK TABLES foo123 READ`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo123", "")},
-		}),
-	},
-	{
-		input: `LOCK TABLES foo AS f READ`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewTableAlias("f", plan.NewUnresolvedTable("foo", ""))},
-		}),
-	},
-	{
-		input: `LOCK TABLES foo READ LOCAL`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo", "")},
-		}),
-	},
-	{
-		input: `LOCK TABLES foo WRITE`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-		}),
-	},
-	{
-		input: `LOCK TABLES foo LOW_PRIORITY WRITE`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-		}),
-	},
-	{
-		input: `LOCK TABLES foo WRITE, bar READ`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-			{Table: plan.NewUnresolvedTable("bar", "")},
-		}),
-	},
-	{
-		input: "LOCK TABLES `foo` WRITE, `bar` READ",
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-			{Table: plan.NewUnresolvedTable("bar", "")},
-		}),
-	},
-	{
-		input: `LOCK TABLES foo READ, bar WRITE, baz READ`,
-		plan: plan.NewLockTables([]*plan.TableLock{
-			{Table: plan.NewUnresolvedTable("foo", "")},
-			{Table: plan.NewUnresolvedTable("bar", ""), Write: true},
-			{Table: plan.NewUnresolvedTable("baz", "")},
-		}),
-	},
-	{
-		input: `SHOW CREATE DATABASE foo`,
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	},
-	{
-		input: `SHOW CREATE SCHEMA foo`,
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	},
-	{
-		input: `SHOW CREATE DATABASE IF NOT EXISTS foo`,
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	},
-	{
-		input: `SHOW CREATE SCHEMA IF NOT EXISTS foo`,
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	},
-	{
-		input: `SHOW WARNINGS`,
-		plan:  plan.ShowWarnings(sql.NewEmptyContext().Warnings()),
-	},
-	{
-		input: `SHOW WARNINGS LIMIT 10`,
-		plan:  plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings())),
-	},
-	{
-		input: `SHOW WARNINGS LIMIT 5,10`,
-		plan:  plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings()))),
-	},
-	{
-		input: "SHOW CREATE DATABASE `foo`",
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	},
-	{
-		input: "SHOW CREATE SCHEMA `foo`",
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	},
-	{
-		input: "SHOW CREATE DATABASE IF NOT EXISTS `foo`",
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	},
-	{
-		input: "SHOW CREATE SCHEMA IF NOT EXISTS `foo`",
-		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	},
-	{
-		input: "SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
-					expression.NewCase(
-						expression.NewUnresolvedColumn("foo"),
-						[]expression.CaseBranch{
-							{
-								Cond:  expression.NewLiteral(int8(1), sql.Int8),
-								Value: expression.NewLiteral("foo", sql.LongText),
-							},
-							{
-								Cond:  expression.NewLiteral(int8(2), sql.Int8),
-								Value: expression.NewLiteral("bar", sql.LongText),
-							},
-						},
-						expression.NewLiteral("baz", sql.LongText),
-					),
 				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: "SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END",
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END",
-					expression.NewCase(
-						expression.NewUnresolvedColumn("foo"),
-						[]expression.CaseBranch{
-							{
-								Cond:  expression.NewLiteral(int8(1), sql.Int8),
-								Value: expression.NewLiteral("foo", sql.LongText),
-							},
-							{
-								Cond:  expression.NewLiteral(int8(2), sql.Int8),
-								Value: expression.NewLiteral("bar", sql.LongText),
-							},
-						},
-						nil,
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: "SELECT CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END",
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END",
-					expression.NewCase(
-						nil,
-						[]expression.CaseBranch{
-							{
-								Cond: expression.NewEquals(
-									expression.NewUnresolvedColumn("foo"),
-									expression.NewLiteral(int8(1), sql.Int8),
-								),
-								Value: expression.NewLiteral("foo", sql.LongText),
-							},
-							{
-								Cond: expression.NewEquals(
-									expression.NewUnresolvedColumn("foo"),
-									expression.NewLiteral(int8(2), sql.Int8),
-								),
-								Value: expression.NewLiteral("bar", sql.LongText),
-							},
-						},
-						expression.NewLiteral("baz", sql.LongText),
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: "SHOW COLLATION",
-		plan:  showCollationProjection,
-	},
-	{
-		input: "SHOW COLLATION LIKE 'foo'",
-		plan: plan.NewHaving(
-			expression.NewLike(
-				expression.NewUnresolvedColumn("collation"),
-				expression.NewLiteral("foo", sql.LongText),
-				nil,
+				showCollationProjection,
 			),
-			showCollationProjection,
-		),
-	},
-	{
-		input: "SHOW COLLATION WHERE Charset = 'foo'",
-		plan: plan.NewHaving(
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("Charset"),
-				expression.NewLiteral("foo", sql.LongText),
+		},
+		{
+			input: "SHOW COLLATION WHERE Charset = 'foo'",
+			plan: plan.NewHaving(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("Charset"),
+					expression.NewLiteral("foo", sql.LongText),
+				),
+				showCollationProjection,
 			),
-			showCollationProjection,
-		),
-	},
-	{
-		input: "BEGIN",
-		plan:  plan.NewStartTransaction("", sql.ReadWrite),
-	},
-	{
-		input: "START TRANSACTION",
-		plan:  plan.NewStartTransaction("", sql.ReadWrite),
-	},
-	{
-		input: "COMMIT",
-		plan:  plan.NewCommit(""),
-	},
-	{
-		input: `ROLLBACK`,
-		plan:  plan.NewRollback(""),
-	},
-	{
-		input: "SAVEPOINT abc",
-		plan:  plan.NewCreateSavepoint("", "abc"),
-	},
-	{
-		input: "ROLLBACK TO SAVEPOINT abc",
-		plan:  plan.NewRollbackSavepoint("", "abc"),
-	},
-	{
-		input: "RELEASE SAVEPOINT abc",
-		plan:  plan.NewReleaseSavepoint("", "abc"),
-	},
-	{
-		input: "SHOW CREATE TABLE `mytable`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
-	},
-	{
-		input: "SHOW CREATE TABLE mytable",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
-	},
-	{
-		input: "SHOW CREATE TABLE mydb.`mytable`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
-	},
-	{
-		input: "SHOW CREATE TABLE `mydb`.mytable",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
-	},
-	{
-		input: "SHOW CREATE TABLE `mydb`.`mytable`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
-	},
-	{
-		input: "SHOW CREATE TABLE `my.table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), false),
-	},
-	{
-		input: "SHOW CREATE TABLE `my.db`.`my.table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), false),
-	},
-	{
-		input: "SHOW CREATE TABLE `my``table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), false),
-	},
-	{
-		input: "SHOW CREATE TABLE `my``db`.`my``table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), false),
-	},
-	{
-		input: "SHOW CREATE TABLE ````",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), false),
-	},
-	{
-		input: "SHOW CREATE TABLE `.`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), false),
-	},
-	{
-		input: "SHOW CREATE TABLE mytable as of 'version'",
-		plan: plan.NewShowCreateTableWithAsOf(
-			plan.NewUnresolvedTableAsOf("mytable", "", expression.NewLiteral("version", sql.LongText)),
-			false, expression.NewLiteral("version", sql.LongText)),
-	},
-	{
-		input: "SHOW CREATE VIEW `mytable`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
-	},
-	{
-		input: "SHOW CREATE VIEW mytable",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
-	},
-	{
-		input: "SHOW CREATE VIEW mydb.`mytable`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
-	},
-	{
-		input: "SHOW CREATE VIEW `mydb`.mytable",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
-	},
-	{
-		input: "SHOW CREATE VIEW `mydb`.`mytable`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
-	},
-	{
-		input: "SHOW CREATE VIEW `my.table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), true),
-	},
-	{
-		input: "SHOW CREATE VIEW `my.db`.`my.table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), true),
-	},
-	{
-		input: "SHOW CREATE VIEW `my``table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), true),
-	},
-	{
-		input: "SHOW CREATE VIEW `my``db`.`my``table`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), true),
-	},
-	{
-		input: "SHOW CREATE VIEW ````",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), true),
-	},
-	{
-		input: "SHOW CREATE VIEW `.`",
-		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), true),
-	},
-	{
-		input: `SELECT '2018-05-01' + INTERVAL 1 DAY`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY",
-					expression.NewArithmetic(
-						expression.NewLiteral("2018-05-01", sql.LongText),
-						expression.NewInterval(
-							expression.NewLiteral(int8(1), sql.Int8),
-							"DAY",
-						),
-						"+",
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT '2018-05-01' - INTERVAL 1 DAY`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("'2018-05-01' - INTERVAL 1 DAY",
-					expression.NewArithmetic(
-						expression.NewLiteral("2018-05-01", sql.LongText),
-						expression.NewInterval(
-							expression.NewLiteral(int8(1), sql.Int8),
-							"DAY",
-						),
-						"-",
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT INTERVAL 1 DAY + '2018-05-01'`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("INTERVAL 1 DAY + '2018-05-01'",
-					expression.NewArithmetic(
-						expression.NewInterval(
-							expression.NewLiteral(int8(1), sql.Int8),
-							"DAY",
-						),
-						expression.NewLiteral("2018-05-01", sql.LongText),
-						"+",
-					),
-				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT '2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY",
-					expression.NewArithmetic(
+		},
+		{
+			input: "BEGIN",
+			plan:  plan.NewStartTransaction("", sql.ReadWrite),
+		},
+		{
+			input: "START TRANSACTION",
+			plan:  plan.NewStartTransaction("", sql.ReadWrite),
+		},
+		{
+			input: "COMMIT",
+			plan:  plan.NewCommit(""),
+		},
+		{
+			input: `ROLLBACK`,
+			plan:  plan.NewRollback(""),
+		},
+		{
+			input: "SAVEPOINT abc",
+			plan:  plan.NewCreateSavepoint("", "abc"),
+		},
+		{
+			input: "ROLLBACK TO SAVEPOINT abc",
+			plan:  plan.NewRollbackSavepoint("", "abc"),
+		},
+		{
+			input: "RELEASE SAVEPOINT abc",
+			plan:  plan.NewReleaseSavepoint("", "abc"),
+		},
+		{
+			input: "SHOW CREATE TABLE `mytable`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
+		},
+		{
+			input: "SHOW CREATE TABLE mytable",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
+		},
+		{
+			input: "SHOW CREATE TABLE mydb.`mytable`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+		},
+		{
+			input: "SHOW CREATE TABLE `mydb`.mytable",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+		},
+		{
+			input: "SHOW CREATE TABLE `mydb`.`mytable`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+		},
+		{
+			input: "SHOW CREATE TABLE `my.table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), false),
+		},
+		{
+			input: "SHOW CREATE TABLE `my.db`.`my.table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), false),
+		},
+		{
+			input: "SHOW CREATE TABLE `my``table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), false),
+		},
+		{
+			input: "SHOW CREATE TABLE `my``db`.`my``table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), false),
+		},
+		{
+			input: "SHOW CREATE TABLE ````",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), false),
+		},
+		{
+			input: "SHOW CREATE TABLE `.`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), false),
+		},
+		{
+			input: "SHOW CREATE TABLE mytable as of 'version'",
+			plan: plan.NewShowCreateTableWithAsOf(
+				plan.NewUnresolvedTableAsOf("mytable", "", expression.NewLiteral("version", sql.LongText)),
+				false, expression.NewLiteral("version", sql.LongText)),
+		},
+		{
+			input: "SHOW CREATE VIEW `mytable`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
+		},
+		{
+			input: "SHOW CREATE VIEW mytable",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
+		},
+		{
+			input: "SHOW CREATE VIEW mydb.`mytable`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+		},
+		{
+			input: "SHOW CREATE VIEW `mydb`.mytable",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+		},
+		{
+			input: "SHOW CREATE VIEW `mydb`.`mytable`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+		},
+		{
+			input: "SHOW CREATE VIEW `my.table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), true),
+		},
+		{
+			input: "SHOW CREATE VIEW `my.db`.`my.table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), true),
+		},
+		{
+			input: "SHOW CREATE VIEW `my``table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), true),
+		},
+		{
+			input: "SHOW CREATE VIEW `my``db`.`my``table`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), true),
+		},
+		{
+			input: "SHOW CREATE VIEW ````",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), true),
+		},
+		{
+			input: "SHOW CREATE VIEW `.`",
+			plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), true),
+		},
+		{
+			input: `SELECT '2018-05-01' + INTERVAL 1 DAY`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY",
 						expression.NewArithmetic(
 							expression.NewLiteral("2018-05-01", sql.LongText),
 							expression.NewInterval(
@@ -3612,72 +3557,108 @@ CREATE TABLE t2
 							),
 							"+",
 						),
-						expression.NewInterval(
-							expression.NewLiteral(int8(1), sql.Int8),
-							"DAY",
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT '2018-05-01' - INTERVAL 1 DAY`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("'2018-05-01' - INTERVAL 1 DAY",
+						expression.NewArithmetic(
+							expression.NewLiteral("2018-05-01", sql.LongText),
+							expression.NewInterval(
+								expression.NewLiteral(int8(1), sql.Int8),
+								"DAY",
+							),
+							"-",
 						),
-						"+",
 					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT INTERVAL 1 DAY + '2018-05-01'`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("INTERVAL 1 DAY + '2018-05-01'",
+						expression.NewArithmetic(
+							expression.NewInterval(
+								expression.NewLiteral(int8(1), sql.Int8),
+								"DAY",
+							),
+							expression.NewLiteral("2018-05-01", sql.LongText),
+							"+",
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT '2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY",
+						expression.NewArithmetic(
+							expression.NewArithmetic(
+								expression.NewLiteral("2018-05-01", sql.LongText),
+								expression.NewInterval(
+									expression.NewLiteral(int8(1), sql.Int8),
+									"DAY",
+								),
+								"+",
+							),
+							expression.NewInterval(
+								expression.NewLiteral(int8(1), sql.Int8),
+								"DAY",
+							),
+							"+",
+						),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
+			input: `SELECT bar, AVG(baz) FROM foo GROUP BY bar HAVING COUNT(*) > 5`,
+			plan: plan.NewHaving(
+				expression.NewGreaterThan(
+					expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
+					expression.NewLiteral(int8(5), sql.Int8),
 				),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `SELECT bar, AVG(baz) FROM foo GROUP BY bar HAVING COUNT(*) > 5`,
-		plan: plan.NewHaving(
-			expression.NewGreaterThan(
-				expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
-				expression.NewLiteral(int8(5), sql.Int8),
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("bar"),
+						expression.NewAlias("AVG(baz)",
+							expression.NewUnresolvedFunction("avg", true, nil, expression.NewUnresolvedColumn("baz")),
+						),
+					},
+					[]sql.Expression{expression.NewUnresolvedColumn("bar")},
+					plan.NewUnresolvedTable("foo", ""),
+				),
 			),
-			plan.NewGroupBy(
-				[]sql.Expression{
-					expression.NewUnresolvedColumn("bar"),
-					expression.NewAlias("AVG(baz)",
-						expression.NewUnresolvedFunction("avg", true, nil, expression.NewUnresolvedColumn("baz")),
-					),
-				},
-				[]sql.Expression{expression.NewUnresolvedColumn("bar")},
-				plan.NewUnresolvedTable("foo", ""),
+		},
+		{
+			input: `SELECT foo FROM t GROUP BY foo HAVING i > 5`,
+			plan: plan.NewHaving(
+				expression.NewGreaterThan(
+					expression.NewUnresolvedColumn("i"),
+					expression.NewLiteral(int8(5), sql.Int8),
+				),
+				plan.NewGroupBy(
+					[]sql.Expression{expression.NewUnresolvedColumn("foo")},
+					[]sql.Expression{expression.NewUnresolvedColumn("foo")},
+					plan.NewUnresolvedTable("t", ""),
+				),
 			),
-		),
-	},
-	{
-		input: `SELECT foo FROM t GROUP BY foo HAVING i > 5`,
-		plan: plan.NewHaving(
-			expression.NewGreaterThan(
-				expression.NewUnresolvedColumn("i"),
-				expression.NewLiteral(int8(5), sql.Int8),
-			),
-			plan.NewGroupBy(
-				[]sql.Expression{expression.NewUnresolvedColumn("foo")},
-				[]sql.Expression{expression.NewUnresolvedColumn("foo")},
-				plan.NewUnresolvedTable("t", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`,
-		plan: plan.NewHaving(
-			expression.NewGreaterThan(
-				expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
-				expression.NewLiteral(int8(5), sql.Int8),
-			),
-			plan.NewGroupBy(
-				[]sql.Expression{
-					expression.NewAlias("COUNT(*)",
-						expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
-					),
-				},
-				[]sql.Expression{expression.NewUnresolvedColumn("a")},
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT DISTINCT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`,
-		plan: plan.NewDistinct(
-			plan.NewHaving(
+		},
+		{
+			input: `SELECT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`,
+			plan: plan.NewHaving(
 				expression.NewGreaterThan(
 					expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
 					expression.NewLiteral(int8(5), sql.Int8),
@@ -3692,1162 +3673,1181 @@ CREATE TABLE t2
 					plan.NewUnresolvedTable("foo", ""),
 				),
 			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo LEFT JOIN bar ON 1=1`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewLeftJoin(
-				plan.NewUnresolvedTable("foo", ""),
-				plan.NewUnresolvedTable("bar", ""),
-				expression.NewEquals(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(1), sql.Int8),
-				),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo LEFT OUTER JOIN bar ON 1=1`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewLeftJoin(
-				plan.NewUnresolvedTable("foo", ""),
-				plan.NewUnresolvedTable("bar", ""),
-				expression.NewEquals(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(1), sql.Int8),
-				),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo RIGHT JOIN bar ON 1=1`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewRightJoin(
-				plan.NewUnresolvedTable("foo", ""),
-				plan.NewUnresolvedTable("bar", ""),
-				expression.NewEquals(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(1), sql.Int8),
-				),
-			),
-		),
-	},
-	{
-		input: `SELECT * FROM foo RIGHT OUTER JOIN bar ON 1=1`,
-		plan: plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewRightJoin(
-				plan.NewUnresolvedTable("foo", ""),
-				plan.NewUnresolvedTable("bar", ""),
-				expression.NewEquals(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(1), sql.Int8),
-				),
-			),
-		),
-	},
-	{
-		input: `SELECT FIRST(i) FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("FIRST(i)",
-					expression.NewUnresolvedFunction("first", true, nil, expression.NewUnresolvedColumn("i")),
-				),
-			},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT LAST(i) FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("LAST(i)",
-					expression.NewUnresolvedFunction("last", true, nil, expression.NewUnresolvedColumn("i")),
-				),
-			},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT COUNT(DISTINCT i) FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("COUNT(DISTINCT i)",
-					aggregation.NewCountDistinct(expression.NewUnresolvedColumn("i"))),
-			},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT AVG(DISTINCT a) FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("AVG(DISTINCT a)",
-					expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("a")))),
-			},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT SUM(DISTINCT a*b) FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("SUM(DISTINCT a*b)",
-					expression.NewUnresolvedFunction("sum", true, nil,
-						expression.NewDistinctExpression(
-							expression.NewMult(expression.NewUnresolvedColumn("a"),
-								expression.NewUnresolvedColumn("b")))))},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT AVG(DISTINCT a / b) FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("AVG(DISTINCT a / b)",
-					expression.NewUnresolvedFunction("avg", true, nil,
-						expression.NewDistinctExpression(
-							expression.NewDiv(expression.NewUnresolvedColumn("a"),
-								expression.NewUnresolvedColumn("b")))))},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT SUM(DISTINCT POWER(a, 2)) FROM foo`,
-		plan: plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("SUM(DISTINCT POWER(a, 2))",
-					expression.NewUnresolvedFunction("sum", true, nil,
-						expression.NewDistinctExpression(
-							expression.NewUnresolvedFunction("power", false, nil,
-								expression.NewUnresolvedColumn("a"), expression.NewLiteral(int8(2), sql.Int8)))))},
-			[]sql.Expression{},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, row_number() over (partition by s order by x) FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("row_number() over (partition by s order by x)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("s"),
-					}, sql.SortFields{
-						{
-							Column:       expression.NewUnresolvedColumn("x"),
-							Column2:      expression.NewUnresolvedColumn("x"),
-							Order:        sql.Ascending,
-							NullOrdering: sql.NullsFirst,
-						},
-					}, nil, "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, count(i) over () FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("count(i) over ()",
-					expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""), expression.NewUnresolvedColumn("i")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, row_number() over (order by x), row_number() over (partition by y) FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("row_number() over (order by x)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-						{
-							Column:       expression.NewUnresolvedColumn("x"),
-							Column2:      expression.NewUnresolvedColumn("x"),
-							Order:        sql.Ascending,
-							NullOrdering: sql.NullsFirst,
-						},
-					}, nil, "", "")),
-				),
-				expression.NewAlias("row_number() over (partition by y)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("y"),
-					}, nil, nil, "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, row_number() over (order by x), max(b) over () FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("row_number() over (order by x)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-						{
-							Column:       expression.NewUnresolvedColumn("x"),
-							Column2:      expression.NewUnresolvedColumn("x"),
-							Order:        sql.Ascending,
-							NullOrdering: sql.NullsFirst,
-						},
-					}, nil, "", "")),
-				),
-				expression.NewAlias("max(b) over ()",
-					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""),
-						expression.NewUnresolvedColumn("b"),
+		},
+		{
+			input: `SELECT DISTINCT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`,
+			plan: plan.NewDistinct(
+				plan.NewHaving(
+					expression.NewGreaterThan(
+						expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
+						expression.NewLiteral(int8(5), sql.Int8),
 					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, row_number() over (partition by b), max(b) over (partition by b) FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("row_number() over (partition by b)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("b"),
-					}, nil, nil, "", "")),
-				),
-				expression.NewAlias("max(b) over (partition by b)",
-					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("b"),
-					}, nil, nil, "", ""),
-						expression.NewUnresolvedColumn("b"),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, row_number() over (partition by c), max(b) over (partition by b) FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("row_number() over (partition by c)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("c"),
-					}, nil, nil, "", "")),
-				),
-				expression.NewAlias("max(b) over (partition by b)",
-					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("b"),
-					}, nil, nil, "", ""),
-						expression.NewUnresolvedColumn("b"),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, count(i) over (order by x) FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("count(i) over (order by x)",
-					expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-						{
-							Column:       expression.NewUnresolvedColumn("x"),
-							Column2:      expression.NewUnresolvedColumn("x"),
-							Order:        sql.Ascending,
-							NullOrdering: sql.NullsFirst,
-						},
-					}, nil, "", ""),
-						expression.NewUnresolvedColumn("i"),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT a, count(i) over (partition by y) FROM foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("count(i) over (partition by y)",
-					expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("y"),
-					}, nil, nil, "", ""),
-						expression.NewUnresolvedColumn("i"),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT i, row_number() over (order by a), max(b) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("i"),
-				expression.NewAlias("row_number() over (order by a)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-						{
-							Column:       expression.NewUnresolvedColumn("a"),
-							Column2:      expression.NewUnresolvedColumn("a"),
-							Order:        sql.Ascending,
-							NullOrdering: sql.NullsFirst,
-						},
-					}, nil, "", "")),
-				),
-				expression.NewAlias("max(b)",
-					expression.NewUnresolvedFunction("max", true, nil,
-						expression.NewUnresolvedColumn("b"),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x ROWS UNBOUNDED PRECEDING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x ROWS UNBOUNDED PRECEDING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRowsUnboundedPrecedingToCurrentRowFrame(), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRowsNPrecedingToNFollowingFrame(
-						expression.NewLiteral(int8(1), sql.Int8),
-						expression.NewLiteral(int8(1), sql.Int8),
-					), "", ""),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRowsNFollowingToNFollowingFrame(
-						expression.NewLiteral(int8(1), sql.Int8),
-						expression.NewLiteral(int8(2), sql.Int8),
-					), "", ""),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRowsCurrentRowToCurrentRowFrame(), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRowsCurrentRowToNFollowingFrame(
-						expression.NewLiteral(int8(1), sql.Int8),
-					), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE CURRENT ROW) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE CURRENT ROW)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE 2 PRECEDING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE 2 PRECEDING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-						expression.NewLiteral(int8(2), sql.Int8),
-					), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE UNBOUNDED PRECEDING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE UNBOUNDED PRECEDING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeUnboundedPrecedingToCurrentRowFrame(), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE interval 5 DAY PRECEDING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE interval 5 DAY PRECEDING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-						expression.NewInterval(
-							expression.NewLiteral(int8(5), sql.Int8),
-							"DAY",
-						),
-					), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-						expression.NewInterval(
-							expression.NewLiteral("2:30", sql.LongText),
-							"MINUTE_SECOND",
-						),
-					), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeNPrecedingToNFollowingFrame(
-						expression.NewLiteral(int8(1), sql.Int8),
-						expression.NewLiteral(int8(1), sql.Int8),
-					), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeCurrentRowToNFollowingFrame(
-						expression.NewLiteral(int8(1), sql.Int8),
-					), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-						expression.NewInterval(
-							expression.NewLiteral(int8(5), sql.Int8),
-							"DAY",
-						),
-					), "", ""),
-					)),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW) from foo`,
-		plan: plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-						expression.NewUnresolvedColumn("x"),
-					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-						expression.NewInterval(
-							expression.NewLiteral("2:30", sql.LongText),
-							"MINUTE_SECOND",
-						),
-					), "", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	},
-	{
-		input: `SELECT row_number() over (w) from foo WINDOW w as (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)`,
-		plan: plan.NewNamedWindows(
-			map[string]*sql.WindowDefinition{
-				"w": sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-					expression.NewInterval(
-						expression.NewLiteral("2:30", sql.LongText),
-						"MINUTE_SECOND",
-					),
-				), "", "w"),
-			},
-			plan.NewWindow(
-				[]sql.Expression{
-					expression.NewAlias("row_number() over (w)",
-						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w", "")),
-					),
-				},
-				plan.NewUnresolvedTable("foo", ""),
-			)),
-	},
-	{
-		input: `SELECT a, row_number() over (w1), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`,
-		plan: plan.NewNamedWindows(
-			map[string]*sql.WindowDefinition{
-				"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-					{
-						Column:       expression.NewUnresolvedColumn("x"),
-						Column2:      expression.NewUnresolvedColumn("x"),
-						Order:        sql.Ascending,
-						NullOrdering: sql.NullsFirst,
-					},
-				}, nil, "w2", "w1"),
-				"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
-			},
-			plan.NewWindow(
-				[]sql.Expression{
-					expression.NewUnresolvedColumn("a"),
-					expression.NewAlias("row_number() over (w1)",
-						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w1", "")),
-					),
-					expression.NewAlias("max(b) over (w2)",
-						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
-							expression.NewUnresolvedColumn("b"),
-						),
-					),
-				},
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `SELECT a, row_number() over (w1 partition by y), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`,
-		plan: plan.NewNamedWindows(
-			map[string]*sql.WindowDefinition{
-				"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-					{
-						Column:       expression.NewUnresolvedColumn("x"),
-						Column2:      expression.NewUnresolvedColumn("x"),
-						Order:        sql.Ascending,
-						NullOrdering: sql.NullsFirst,
-					},
-				}, nil, "w2", "w1"),
-				"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
-			}, plan.NewWindow(
-				[]sql.Expression{
-					expression.NewUnresolvedColumn("a"),
-					expression.NewAlias("row_number() over (w1 partition by y)",
-						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("y"),
-							},
-							nil, nil, "w1", "")),
-					),
-					expression.NewAlias("max(b) over (w2)",
-						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
-							expression.NewUnresolvedColumn("b"),
-						),
-					),
-				},
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-	},
-	{
-		input: `with cte1 as (select a from b) select * from cte1`,
-		plan: plan.NewWith(
-			plan.NewProject(
-				[]sql.Expression{
-					expression.NewStar(),
-				},
-				plan.NewUnresolvedTable("cte1", "")),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select a from b",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("a"),
-							},
-							plan.NewUnresolvedTable("b", ""),
-						),
-					),
-					[]string{},
-				),
-			},
-			false,
-		),
-	},
-	{
-		input: `with cte1 as (select a from b) update c set d = e where f in (select * from cte1)`,
-		plan: plan.NewWith(
-			plan.NewUpdate(
-				plan.NewFilter(
-					plan.NewInSubquery(
-						expression.NewUnresolvedColumn("f"),
-						plan.NewSubquery(plan.NewProject(
-							[]sql.Expression{expression.NewStar()},
-							plan.NewUnresolvedTable("cte1", ""),
-						), "select * from cte1"),
-					),
-					plan.NewUnresolvedTable("c", ""),
-				),
-				false,
-				[]sql.Expression{
-					expression.NewSetField(expression.NewUnresolvedColumn("d"), expression.NewUnresolvedColumn("e")),
-				},
-			),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select a from b",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("a"),
-							},
-							plan.NewUnresolvedTable("b", ""),
-						),
-					),
-					[]string{},
-				),
-			},
-			false,
-		),
-	},
-	{
-		input: `with cte1 as (select a from b) delete from c where d in (select * from cte1)`,
-		plan: plan.NewWith(
-			plan.NewDeleteFrom(
-				plan.NewFilter(
-					plan.NewInSubquery(
-						expression.NewUnresolvedColumn("d"),
-						plan.NewSubquery(plan.NewProject(
-							[]sql.Expression{expression.NewStar()},
-							plan.NewUnresolvedTable("cte1", ""),
-						), "select * from cte1"),
-					),
-					plan.NewUnresolvedTable("c", ""),
-				),
-			),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select a from b",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("a"),
-							},
-							plan.NewUnresolvedTable("b", ""),
-						),
-					),
-					[]string{},
-				),
-			},
-			false,
-		),
-	},
-	{
-		input: `with cte1 as (select a from b) insert into c (select * from cte1)`,
-		plan: plan.NewWith(
-			plan.NewInsertInto(
-				sql.UnresolvedDatabase(""),
-				plan.NewUnresolvedTable("c", ""),
-				plan.NewProject(
-					[]sql.Expression{expression.NewStar()},
-					plan.NewUnresolvedTable("cte1", ""),
-				),
-				false, []string{}, []sql.Expression{}, false,
-			),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select a from b",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("a"),
-							},
-							plan.NewUnresolvedTable("b", ""),
-						),
-					),
-					[]string{},
-				),
-			},
-			false,
-		),
-	},
-	{
-		input: `with recursive cte1 as (select 1 union select n+1 from cte1 where n < 10) select * from cte1`,
-		plan: plan.NewWith(
-			plan.NewProject(
-				[]sql.Expression{
-					expression.NewStar(),
-				},
-				plan.NewUnresolvedTable("cte1", "")),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select 1 union select n + 1 from cte1 where n < 10",
-						plan.NewUnion(plan.NewProject(
-							[]sql.Expression{
-								expression.NewLiteral(int8(1), sql.Int8),
-							},
-							plan.NewResolvedDualTable(),
-						), plan.NewProject(
-							[]sql.Expression{
-								expression.NewArithmetic(
-									expression.NewUnresolvedColumn("n"),
-									expression.NewLiteral(int8(1), sql.Int8),
-									sqlparser.PlusStr,
-								),
-							},
-							plan.NewFilter(
-								expression.NewLessThan(
-									expression.NewUnresolvedColumn("n"),
-									expression.NewLiteral(int8(10), sql.Int8),
-								),
-								plan.NewUnresolvedTable("cte1", ""),
+					plan.NewGroupBy(
+						[]sql.Expression{
+							expression.NewAlias("COUNT(*)",
+								expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
 							),
-						), true, nil, nil),
+						},
+						[]sql.Expression{expression.NewUnresolvedColumn("a")},
+						plan.NewUnresolvedTable("foo", ""),
 					),
-					[]string{},
 				),
-			},
-			true,
-		),
-	},
-	{
-		input: `with cte1 as (select a from b), cte2 as (select c from d) select * from cte1`,
-		plan: plan.NewWith(
-			plan.NewProject(
+			),
+		},
+		{
+			input: `SELECT * FROM foo LEFT JOIN bar ON 1=1`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewLeftJoin(
+					plan.NewUnresolvedTable("foo", ""),
+					plan.NewUnresolvedTable("bar", ""),
+					expression.NewEquals(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(1), sql.Int8),
+					),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo LEFT OUTER JOIN bar ON 1=1`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewLeftJoin(
+					plan.NewUnresolvedTable("foo", ""),
+					plan.NewUnresolvedTable("bar", ""),
+					expression.NewEquals(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(1), sql.Int8),
+					),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo RIGHT JOIN bar ON 1=1`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewRightJoin(
+					plan.NewUnresolvedTable("foo", ""),
+					plan.NewUnresolvedTable("bar", ""),
+					expression.NewEquals(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(1), sql.Int8),
+					),
+				),
+			),
+		},
+		{
+			input: `SELECT * FROM foo RIGHT OUTER JOIN bar ON 1=1`,
+			plan: plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewRightJoin(
+					plan.NewUnresolvedTable("foo", ""),
+					plan.NewUnresolvedTable("bar", ""),
+					expression.NewEquals(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(1), sql.Int8),
+					),
+				),
+			),
+		},
+		{
+			input: `SELECT FIRST(i) FROM foo`,
+			plan: plan.NewGroupBy(
 				[]sql.Expression{
-					expression.NewStar(),
+					expression.NewAlias("FIRST(i)",
+						expression.NewUnresolvedFunction("first", true, nil, expression.NewUnresolvedColumn("i")),
+					),
 				},
-				plan.NewUnresolvedTable("cte1", "")),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select a from b",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("a"),
-							},
-							plan.NewUnresolvedTable("b", ""),
-						),
-					),
-					[]string{},
-				),
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte2", "select c from d",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("c"),
-							},
-							plan.NewUnresolvedTable("d", ""),
-						),
-					),
-					[]string{},
-				),
-			},
-			false,
-		),
-	},
-	{
-		input: `with cte1 (x) as (select a from b), cte2 (y,z) as (select c from d) select * from cte1`,
-		plan: plan.NewWith(
-			plan.NewProject(
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT LAST(i) FROM foo`,
+			plan: plan.NewGroupBy(
 				[]sql.Expression{
-					expression.NewStar(),
+					expression.NewAlias("LAST(i)",
+						expression.NewUnresolvedFunction("last", true, nil, expression.NewUnresolvedColumn("i")),
+					),
 				},
-				plan.NewUnresolvedTable("cte1", "")),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select a from b",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("a"),
-							},
-							plan.NewUnresolvedTable("b", ""),
-						),
-					),
-					[]string{"x"},
-				),
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte2", "select c from d",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("c"),
-							},
-							plan.NewUnresolvedTable("d", ""),
-						),
-					),
-					[]string{"y", "z"},
-				),
-			},
-			false,
-		),
-	},
-	{
-		input: `with cte1 as (select a from b) select c, (with cte2 as (select c from d) select e from cte2) from cte1`,
-		plan: plan.NewWith(
-			plan.NewProject(
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT COUNT(DISTINCT i) FROM foo`,
+			plan: plan.NewGroupBy(
 				[]sql.Expression{
-					expression.NewUnresolvedColumn("c"),
-					expression.NewAlias("(with cte2 as (select c from d) select e from cte2)",
-						plan.NewSubquery(
-							plan.NewWith(
-								plan.NewProject(
-									[]sql.Expression{
-										expression.NewUnresolvedColumn("e"),
-									},
-									plan.NewUnresolvedTable("cte2", "")),
-								[]*plan.CommonTableExpression{
-									plan.NewCommonTableExpression(
-										plan.NewSubqueryAlias("cte2", "select c from d",
-											plan.NewProject(
-												[]sql.Expression{
-													expression.NewUnresolvedColumn("c"),
-												},
-												plan.NewUnresolvedTable("d", ""),
-											),
-										),
-										[]string{},
+					expression.NewAlias("COUNT(DISTINCT i)",
+						aggregation.NewCountDistinct(expression.NewUnresolvedColumn("i"))),
+				},
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT AVG(DISTINCT a) FROM foo`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias("AVG(DISTINCT a)",
+						expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("a")))),
+				},
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT SUM(DISTINCT a*b) FROM foo`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias("SUM(DISTINCT a*b)",
+						expression.NewUnresolvedFunction("sum", true, nil,
+							expression.NewDistinctExpression(
+								expression.NewMult(expression.NewUnresolvedColumn("a"),
+									expression.NewUnresolvedColumn("b")))))},
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT AVG(DISTINCT a / b) FROM foo`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias("AVG(DISTINCT a / b)",
+						expression.NewUnresolvedFunction("avg", true, nil,
+							expression.NewDistinctExpression(
+								expression.NewDiv(expression.NewUnresolvedColumn("a"),
+									expression.NewUnresolvedColumn("b")))))},
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT SUM(DISTINCT POWER(a, 2)) FROM foo`,
+			plan: plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewAlias("SUM(DISTINCT POWER(a, 2))",
+						expression.NewUnresolvedFunction("sum", true, nil,
+							expression.NewDistinctExpression(
+								expression.NewUnresolvedFunction("power", false, nil,
+									expression.NewUnresolvedColumn("a"), expression.NewLiteral(int8(2), sql.Int8)))))},
+				[]sql.Expression{},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, row_number() over (partition by s order by x) FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("row_number() over (partition by s order by x)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("s"),
+						}, sql.SortFields{
+							{
+								Column:       expression.NewUnresolvedColumn("x"),
+								Column2:      expression.NewUnresolvedColumn("x"),
+								Order:        sql.Ascending,
+								NullOrdering: sql.NullsFirst,
+							},
+						}, nil, "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, count(i) over () FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("count(i) over ()",
+						expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""), expression.NewUnresolvedColumn("i")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, row_number() over (order by x), row_number() over (partition by y) FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("row_number() over (order by x)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+							{
+								Column:       expression.NewUnresolvedColumn("x"),
+								Column2:      expression.NewUnresolvedColumn("x"),
+								Order:        sql.Ascending,
+								NullOrdering: sql.NullsFirst,
+							},
+						}, nil, "", "")),
+					),
+					expression.NewAlias("row_number() over (partition by y)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("y"),
+						}, nil, nil, "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, row_number() over (order by x), max(b) over () FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("row_number() over (order by x)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+							{
+								Column:       expression.NewUnresolvedColumn("x"),
+								Column2:      expression.NewUnresolvedColumn("x"),
+								Order:        sql.Ascending,
+								NullOrdering: sql.NullsFirst,
+							},
+						}, nil, "", "")),
+					),
+					expression.NewAlias("max(b) over ()",
+						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""),
+							expression.NewUnresolvedColumn("b"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, row_number() over (partition by b), max(b) over (partition by b) FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("row_number() over (partition by b)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("b"),
+						}, nil, nil, "", "")),
+					),
+					expression.NewAlias("max(b) over (partition by b)",
+						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("b"),
+						}, nil, nil, "", ""),
+							expression.NewUnresolvedColumn("b"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, row_number() over (partition by c), max(b) over (partition by b) FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("row_number() over (partition by c)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("c"),
+						}, nil, nil, "", "")),
+					),
+					expression.NewAlias("max(b) over (partition by b)",
+						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("b"),
+						}, nil, nil, "", ""),
+							expression.NewUnresolvedColumn("b"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, count(i) over (order by x) FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("count(i) over (order by x)",
+						expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+							{
+								Column:       expression.NewUnresolvedColumn("x"),
+								Column2:      expression.NewUnresolvedColumn("x"),
+								Order:        sql.Ascending,
+								NullOrdering: sql.NullsFirst,
+							},
+						}, nil, "", ""),
+							expression.NewUnresolvedColumn("i"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT a, count(i) over (partition by y) FROM foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("count(i) over (partition by y)",
+						expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("y"),
+						}, nil, nil, "", ""),
+							expression.NewUnresolvedColumn("i"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT i, row_number() over (order by a), max(b) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("i"),
+					expression.NewAlias("row_number() over (order by a)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+							{
+								Column:       expression.NewUnresolvedColumn("a"),
+								Column2:      expression.NewUnresolvedColumn("a"),
+								Order:        sql.Ascending,
+								NullOrdering: sql.NullsFirst,
+							},
+						}, nil, "", "")),
+					),
+					expression.NewAlias("max(b)",
+						expression.NewUnresolvedFunction("max", true, nil,
+							expression.NewUnresolvedColumn("b"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x ROWS UNBOUNDED PRECEDING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x ROWS UNBOUNDED PRECEDING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRowsUnboundedPrecedingToCurrentRowFrame(), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRowsNPrecedingToNFollowingFrame(
+							expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewLiteral(int8(1), sql.Int8),
+						), "", ""),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRowsNFollowingToNFollowingFrame(
+							expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewLiteral(int8(2), sql.Int8),
+						), "", ""),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRowsCurrentRowToCurrentRowFrame(), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRowsCurrentRowToNFollowingFrame(
+							expression.NewLiteral(int8(1), sql.Int8),
+						), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE CURRENT ROW) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE CURRENT ROW)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE 2 PRECEDING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE 2 PRECEDING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+							expression.NewLiteral(int8(2), sql.Int8),
+						), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE UNBOUNDED PRECEDING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE UNBOUNDED PRECEDING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeUnboundedPrecedingToCurrentRowFrame(), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE interval 5 DAY PRECEDING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE interval 5 DAY PRECEDING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+							expression.NewInterval(
+								expression.NewLiteral(int8(5), sql.Int8),
+								"DAY",
+							),
+						), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+							expression.NewInterval(
+								expression.NewLiteral("2:30", sql.LongText),
+								"MINUTE_SECOND",
+							),
+						), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeNPrecedingToNFollowingFrame(
+							expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewLiteral(int8(1), sql.Int8),
+						), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeCurrentRowToNFollowingFrame(
+							expression.NewLiteral(int8(1), sql.Int8),
+						), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+							expression.NewInterval(
+								expression.NewLiteral(int8(5), sql.Int8),
+								"DAY",
+							),
+						), "", ""),
+						)),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW) from foo`,
+			plan: plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+							expression.NewUnresolvedColumn("x"),
+						}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+							expression.NewInterval(
+								expression.NewLiteral("2:30", sql.LongText),
+								"MINUTE_SECOND",
+							),
+						), "", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		},
+		{
+			input: `SELECT row_number() over (w) from foo WINDOW w as (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)`,
+			plan: plan.NewNamedWindows(
+				map[string]*sql.WindowDefinition{
+					"w": sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral("2:30", sql.LongText),
+							"MINUTE_SECOND",
+						),
+					), "", "w"),
+				},
+				plan.NewWindow(
+					[]sql.Expression{
+						expression.NewAlias("row_number() over (w)",
+							expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w", "")),
+						),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				)),
+		},
+		{
+			input: `SELECT a, row_number() over (w1), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`,
+			plan: plan.NewNamedWindows(
+				map[string]*sql.WindowDefinition{
+					"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+						{
+							Column:       expression.NewUnresolvedColumn("x"),
+							Column2:      expression.NewUnresolvedColumn("x"),
+							Order:        sql.Ascending,
+							NullOrdering: sql.NullsFirst,
+						},
+					}, nil, "w2", "w1"),
+					"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
+				},
+				plan.NewWindow(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("a"),
+						expression.NewAlias("row_number() over (w1)",
+							expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w1", "")),
+						),
+						expression.NewAlias("max(b) over (w2)",
+							expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
+								expression.NewUnresolvedColumn("b"),
+							),
+						),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `SELECT a, row_number() over (w1 partition by y), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`,
+			plan: plan.NewNamedWindows(
+				map[string]*sql.WindowDefinition{
+					"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+						{
+							Column:       expression.NewUnresolvedColumn("x"),
+							Column2:      expression.NewUnresolvedColumn("x"),
+							Order:        sql.Ascending,
+							NullOrdering: sql.NullsFirst,
+						},
+					}, nil, "w2", "w1"),
+					"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
+				}, plan.NewWindow(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("a"),
+						expression.NewAlias("row_number() over (w1 partition by y)",
+							expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("y"),
+								},
+								nil, nil, "w1", "")),
+						),
+						expression.NewAlias("max(b) over (w2)",
+							expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
+								expression.NewUnresolvedColumn("b"),
+							),
+						),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		},
+		{
+			input: `with cte1 as (select a from b) select * from cte1`,
+			plan: plan.NewWith(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewStar(),
+					},
+					plan.NewUnresolvedTable("cte1", "")),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select a from b",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("a"),
+								},
+								plan.NewUnresolvedTable("b", ""),
+							),
+						),
+						[]string{},
+					),
+				},
+				false,
+			),
+		},
+		{
+			input: `with cte1 as (select a from b) update c set d = e where f in (select * from cte1)`,
+			plan: plan.NewWith(
+				plan.NewUpdate(
+					plan.NewFilter(
+						plan.NewInSubquery(
+							expression.NewUnresolvedColumn("f"),
+							plan.NewSubquery(plan.NewProject(
+								[]sql.Expression{expression.NewStar()},
+								plan.NewUnresolvedTable("cte1", ""),
+							), "select * from cte1"),
+						),
+						plan.NewUnresolvedTable("c", ""),
+					),
+					false,
+					[]sql.Expression{
+						expression.NewSetField(expression.NewUnresolvedColumn("d"), expression.NewUnresolvedColumn("e")),
+					},
+				),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select a from b",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("a"),
+								},
+								plan.NewUnresolvedTable("b", ""),
+							),
+						),
+						[]string{},
+					),
+				},
+				false,
+			),
+		},
+		{
+			input: `with cte1 as (select a from b) delete from c where d in (select * from cte1)`,
+			plan: plan.NewWith(
+				plan.NewDeleteFrom(
+					plan.NewFilter(
+						plan.NewInSubquery(
+							expression.NewUnresolvedColumn("d"),
+							plan.NewSubquery(plan.NewProject(
+								[]sql.Expression{expression.NewStar()},
+								plan.NewUnresolvedTable("cte1", ""),
+							), "select * from cte1"),
+						),
+						plan.NewUnresolvedTable("c", ""),
+					),
+				),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select a from b",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("a"),
+								},
+								plan.NewUnresolvedTable("b", ""),
+							),
+						),
+						[]string{},
+					),
+				},
+				false,
+			),
+		},
+		{
+			input: `with cte1 as (select a from b) insert into c (select * from cte1)`,
+			plan: plan.NewWith(
+				plan.NewInsertInto(
+					sql.UnresolvedDatabase(""),
+					plan.NewUnresolvedTable("c", ""),
+					plan.NewProject(
+						[]sql.Expression{expression.NewStar()},
+						plan.NewUnresolvedTable("cte1", ""),
+					),
+					false, []string{}, []sql.Expression{}, false,
+				),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select a from b",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("a"),
+								},
+								plan.NewUnresolvedTable("b", ""),
+							),
+						),
+						[]string{},
+					),
+				},
+				false,
+			),
+		},
+		{
+			input: `with recursive cte1 as (select 1 union select n+1 from cte1 where n < 10) select * from cte1`,
+			plan: plan.NewWith(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewStar(),
+					},
+					plan.NewUnresolvedTable("cte1", "")),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select 1 union select n + 1 from cte1 where n < 10",
+							plan.NewUnion(plan.NewProject(
+								[]sql.Expression{
+									expression.NewLiteral(int8(1), sql.Int8),
+								},
+								plan.NewResolvedDualTable(),
+							), plan.NewProject(
+								[]sql.Expression{
+									expression.NewArithmetic(
+										expression.NewUnresolvedColumn("n"),
+										expression.NewLiteral(int8(1), sql.Int8),
+										sqlparser.PlusStr,
 									),
 								},
-								false,
-							),
-							"with cte2 as (select c from d) select e from cte2",
+								plan.NewFilter(
+									expression.NewLessThan(
+										expression.NewUnresolvedColumn("n"),
+										expression.NewLiteral(int8(10), sql.Int8),
+									),
+									plan.NewUnresolvedTable("cte1", ""),
+								),
+							), true, nil, nil),
 						),
+						[]string{},
 					),
 				},
-				plan.NewUnresolvedTable("cte1", ""),
+				true,
 			),
-			[]*plan.CommonTableExpression{
-				plan.NewCommonTableExpression(
-					plan.NewSubqueryAlias("cte1", "select a from b",
-						plan.NewProject(
-							[]sql.Expression{
-								expression.NewUnresolvedColumn("a"),
-							},
-							plan.NewUnresolvedTable("b", ""),
-						),
-					),
-					[]string{},
-				),
-			},
-			false,
-		),
-	},
-	{
-		input: `SELECT -128, 127, 255, -32768, 32767, 65535, -2147483648, 2147483647, 4294967295, -9223372036854775808, 9223372036854775807, 18446744073709551615`,
-		plan: plan.NewProject(
-			[]sql.Expression{
-				expression.NewLiteral(int8(math.MinInt8), sql.Int8),
-				expression.NewLiteral(int8(math.MaxInt8), sql.Int8),
-				expression.NewLiteral(uint8(math.MaxUint8), sql.Uint8),
-				expression.NewLiteral(int16(math.MinInt16), sql.Int16),
-				expression.NewLiteral(int16(math.MaxInt16), sql.Int16),
-				expression.NewLiteral(uint16(math.MaxUint16), sql.Uint16),
-				expression.NewLiteral(int32(math.MinInt32), sql.Int32),
-				expression.NewLiteral(int32(math.MaxInt32), sql.Int32),
-				expression.NewLiteral(uint32(math.MaxUint32), sql.Uint32),
-				expression.NewLiteral(int64(math.MinInt64), sql.Int64),
-				expression.NewLiteral(int64(math.MaxInt64), sql.Int64),
-				expression.NewLiteral(uint64(math.MaxUint64), sql.Uint64),
-			},
-			plan.NewResolvedDualTable(),
-		),
-	},
-	{
-		input: `CREATE VIEW v AS SELECT * FROM foo`,
-		plan: plan.NewCreateView(
-			sql.UnresolvedDatabase(""),
-			"v",
-			[]string{},
-			plan.NewSubqueryAlias(
-				"v", "SELECT * FROM foo",
+		},
+		{
+			input: `with cte1 as (select a from b), cte2 as (select c from d) select * from cte1`,
+			plan: plan.NewWith(
 				plan.NewProject(
-					[]sql.Expression{expression.NewStar()},
-					plan.NewUnresolvedTable("foo", ""),
-				),
-			),
-			false,
-		),
-	},
-	{
-		input: `CREATE VIEW myview AS SELECT AVG(DISTINCT foo) FROM b`,
-		plan: plan.NewCreateView(
-			sql.UnresolvedDatabase(""),
-			"myview",
-			[]string{},
-			plan.NewSubqueryAlias(
-				"myview", "SELECT AVG(DISTINCT foo) FROM b",
-				plan.NewGroupBy(
 					[]sql.Expression{
-						expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("foo"))),
+						expression.NewStar(),
 					},
-					[]sql.Expression{},
-					plan.NewUnresolvedTable("b", ""),
-				),
+					plan.NewUnresolvedTable("cte1", "")),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select a from b",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("a"),
+								},
+								plan.NewUnresolvedTable("b", ""),
+							),
+						),
+						[]string{},
+					),
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte2", "select c from d",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("c"),
+								},
+								plan.NewUnresolvedTable("d", ""),
+							),
+						),
+						[]string{},
+					),
+				},
+				false,
 			),
-			false,
-		),
-	},
-	{
-		input: `CREATE OR REPLACE VIEW v AS SELECT * FROM foo`,
-		plan: plan.NewCreateView(
-			sql.UnresolvedDatabase(""),
-			"v",
-			[]string{},
-			plan.NewSubqueryAlias(
-				"v", "SELECT * FROM foo",
+		},
+		{
+			input: `with cte1 (x) as (select a from b), cte2 (y,z) as (select c from d) select * from cte1`,
+			plan: plan.NewWith(
 				plan.NewProject(
-					[]sql.Expression{expression.NewStar()},
-					plan.NewUnresolvedTable("foo", ""),
-				),
+					[]sql.Expression{
+						expression.NewStar(),
+					},
+					plan.NewUnresolvedTable("cte1", "")),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select a from b",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("a"),
+								},
+								plan.NewUnresolvedTable("b", ""),
+							),
+						),
+						[]string{"x"},
+					),
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte2", "select c from d",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("c"),
+								},
+								plan.NewUnresolvedTable("d", ""),
+							),
+						),
+						[]string{"y", "z"},
+					),
+				},
+				false,
 			),
-			true,
-		),
-	},
-	{
-		input: `SELECT 2 UNION SELECT 3`,
-		plan: plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-	},
-	{
-		input: `(SELECT 2) UNION (SELECT 3)`,
-		plan: plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-	},
-	{
-		input: `SELECT 2 UNION ALL SELECT 3 UNION DISTINCT SELECT 4`,
-		plan: plan.NewUnion(plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), false, nil, nil),
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+		},
+		{
+			input: `with cte1 as (select a from b) select c, (with cte2 as (select c from d) select e from cte2) from cte1`,
+			plan: plan.NewWith(
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("c"),
+						expression.NewAlias("(with cte2 as (select c from d) select e from cte2)",
+							plan.NewSubquery(
+								plan.NewWith(
+									plan.NewProject(
+										[]sql.Expression{
+											expression.NewUnresolvedColumn("e"),
+										},
+										plan.NewUnresolvedTable("cte2", "")),
+									[]*plan.CommonTableExpression{
+										plan.NewCommonTableExpression(
+											plan.NewSubqueryAlias("cte2", "select c from d",
+												plan.NewProject(
+													[]sql.Expression{
+														expression.NewUnresolvedColumn("c"),
+													},
+													plan.NewUnresolvedTable("d", ""),
+												),
+											),
+											[]string{},
+										),
+									},
+									false,
+								),
+								"with cte2 as (select c from d) select e from cte2",
+							),
+						),
+					},
+					plan.NewUnresolvedTable("cte1", ""),
+				),
+				[]*plan.CommonTableExpression{
+					plan.NewCommonTableExpression(
+						plan.NewSubqueryAlias("cte1", "select a from b",
+							plan.NewProject(
+								[]sql.Expression{
+									expression.NewUnresolvedColumn("a"),
+								},
+								plan.NewUnresolvedTable("b", ""),
+							),
+						),
+						[]string{},
+					),
+				},
+				false,
+			),
+		},
+		{
+			input: `SELECT -128, 127, 255, -32768, 32767, 65535, -2147483648, 2147483647, 4294967295, -9223372036854775808, 9223372036854775807, 18446744073709551615`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewLiteral(int8(math.MinInt8), sql.Int8),
+					expression.NewLiteral(int8(math.MaxInt8), sql.Int8),
+					expression.NewLiteral(uint8(math.MaxUint8), sql.Uint8),
+					expression.NewLiteral(int16(math.MinInt16), sql.Int16),
+					expression.NewLiteral(int16(math.MaxInt16), sql.Int16),
+					expression.NewLiteral(uint16(math.MaxUint16), sql.Uint16),
+					expression.NewLiteral(int32(math.MinInt32), sql.Int32),
+					expression.NewLiteral(int32(math.MaxInt32), sql.Int32),
+					expression.NewLiteral(uint32(math.MaxUint32), sql.Uint32),
+					expression.NewLiteral(int64(math.MinInt64), sql.Int64),
+					expression.NewLiteral(int64(math.MaxInt64), sql.Int64),
+					expression.NewLiteral(uint64(math.MaxUint64), sql.Uint64),
+				},
 				plan.NewResolvedDualTable(),
-			), true, nil, nil),
-	},
-	{
-		input: `SELECT 2 UNION SELECT 3 UNION ALL SELECT 4`,
-		plan: plan.NewUnion(
-			plan.NewUnion(plan.NewProject(
+			),
+		},
+		{
+			input: `CREATE VIEW v AS SELECT * FROM foo`,
+			plan: plan.NewCreateView(
+				sql.UnresolvedDatabase(""),
+				"v",
+				[]string{},
+				plan.NewSubqueryAlias(
+					"v", "SELECT * FROM foo",
+					plan.NewProject(
+						[]sql.Expression{expression.NewStar()},
+						plan.NewUnresolvedTable("foo", ""),
+					),
+				),
+				false,
+			),
+		},
+		{
+			input: `CREATE VIEW myview AS SELECT AVG(DISTINCT foo) FROM b`,
+			plan: plan.NewCreateView(
+				sql.UnresolvedDatabase(""),
+				"myview",
+				[]string{},
+				plan.NewSubqueryAlias(
+					"myview", "SELECT AVG(DISTINCT foo) FROM b",
+					plan.NewGroupBy(
+						[]sql.Expression{
+							expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("foo"))),
+						},
+						[]sql.Expression{},
+						plan.NewUnresolvedTable("b", ""),
+					),
+				),
+				false,
+			),
+		},
+		{
+			input: `CREATE OR REPLACE VIEW v AS SELECT * FROM foo`,
+			plan: plan.NewCreateView(
+				sql.UnresolvedDatabase(""),
+				"v",
+				[]string{},
+				plan.NewSubqueryAlias(
+					"v", "SELECT * FROM foo",
+					plan.NewProject(
+						[]sql.Expression{expression.NewStar()},
+						plan.NewUnresolvedTable("foo", ""),
+					),
+				),
+				true,
+			),
+		},
+		{
+			input: `SELECT 2 UNION SELECT 3`,
+			plan: plan.NewUnion(plan.NewProject(
 				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
 				plan.NewResolvedDualTable(),
 			), plan.NewProject(
 				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 				plan.NewResolvedDualTable(),
 			), true, nil, nil),
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+		},
+		{
+			input: `(SELECT 2) UNION (SELECT 3)`,
+			plan: plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+		},
+		{
+			input: `SELECT 2 UNION ALL SELECT 3 UNION DISTINCT SELECT 4`,
+			plan: plan.NewUnion(plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 				plan.NewResolvedDualTable(),
 			), false, nil, nil),
-	},
-	{
-		input: `SELECT 2 UNION SELECT 3 UNION SELECT 4`,
-		plan: plan.NewUnion(
-			plan.NewUnion(plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-				plan.NewResolvedDualTable(),
-			), plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-				plan.NewResolvedDualTable(),
-			), true, nil, nil),
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
-				plan.NewResolvedDualTable(),
-			), true, nil, nil),
-	},
-	{
-		input: `SELECT 2 UNION (SELECT 3 UNION SELECT 4)`,
-		plan: plan.NewUnion(
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-				plan.NewResolvedDualTable(),
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, nil),
+		},
+		{
+			input: `SELECT 2 UNION SELECT 3 UNION ALL SELECT 4`,
+			plan: plan.NewUnion(
+				plan.NewUnion(plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, nil),
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), false, nil, nil),
+		},
+		{
+			input: `SELECT 2 UNION SELECT 3 UNION SELECT 4`,
+			plan: plan.NewUnion(
+				plan.NewUnion(plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, nil),
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, nil),
+		},
+		{
+			input: `SELECT 2 UNION (SELECT 3 UNION SELECT 4)`,
+			plan: plan.NewUnion(
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				),
+				plan.NewUnion(plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, nil),
+				true, nil, nil,
 			),
-			plan.NewUnion(plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+		},
+		{
+			input: `SELECT 2 UNION ALL SELECT 3`,
+			plan: plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
 				plan.NewResolvedDualTable(),
 			), plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 				plan.NewResolvedDualTable(),
-			), true, nil, nil),
-			true, nil, nil,
-		),
-	},
-	{
-		input: `SELECT 2 UNION ALL SELECT 3`,
-		plan: plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), false, nil, nil),
-	},
-	{
-		input: `SELECT 2 UNION DISTINCT SELECT 3`,
-		plan: plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-	},
-	{
-		input: `SELECT 2 UNION SELECT 3 UNION SELECT 4 LIMIT 10`,
-		plan: plan.NewUnion(
-			plan.NewUnion(plan.NewProject(
+			), false, nil, nil),
+		},
+		{
+			input: `SELECT 2 UNION DISTINCT SELECT 3`,
+			plan: plan.NewUnion(plan.NewProject(
 				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
 				plan.NewResolvedDualTable(),
 			), plan.NewProject(
 				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 				plan.NewResolvedDualTable(),
 			), true, nil, nil),
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
-				plan.NewResolvedDualTable(),
-			), true, expression.NewLiteral(int8(10), sql.Int8), nil),
-	},
-	{
-		input: `SELECT 2 UNION SELECT 3 UNION SELECT 4 ORDER BY 2`,
-		plan: plan.NewUnion(
-			plan.NewUnion(plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-				plan.NewResolvedDualTable(),
-			), plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-				plan.NewResolvedDualTable(),
-			), true, nil, nil),
-			plan.NewProject(
-				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
-				plan.NewResolvedDualTable(),
-			), true, nil, []sql.SortField{
-				{
-					Column:       expression.NewLiteral(int8(2), sql.Int8),
-					Column2:      expression.NewLiteral(int8(2), sql.Int8),
-					Order:        sql.Ascending,
-					NullOrdering: sql.NullsFirst,
-				},
-			}),
-	},
-	{
-		input: `CREATE DATABASE test`,
-		plan:  plan.NewCreateDatabase("test", false),
-	},
-	{
-		input: `CREATE DATABASE IF NOT EXISTS test`,
-		plan:  plan.NewCreateDatabase("test", true),
-	},
-	{
-		input: `DROP DATABASE test`,
-		plan:  plan.NewDropDatabase("test", false),
-	},
-	{
-		input: `DROP DATABASE IF EXISTS test`,
-		plan:  plan.NewDropDatabase("test", true),
-	},
-	{
-		input: `KILL QUERY 1`,
-		plan:  plan.NewKill(plan.KillType_Query, 1),
-	},
-	{
-		input: `KILL CONNECTION 1`,
-		plan:  plan.NewKill(plan.KillType_Connection, 1),
-	},
-}
+		},
+		{
+			input: `SELECT 2 UNION SELECT 3 UNION SELECT 4 LIMIT 10`,
+			plan: plan.NewUnion(
+				plan.NewUnion(plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, nil),
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, expression.NewLiteral(int8(10), sql.Int8), nil),
+		},
+		{
+			input: `SELECT 2 UNION SELECT 3 UNION SELECT 4 ORDER BY 2`,
+			plan: plan.NewUnion(
+				plan.NewUnion(plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, nil),
+				plan.NewProject(
+					[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+					plan.NewResolvedDualTable(),
+				), true, nil, []sql.SortField{
+					{
+						Column:       expression.NewLiteral(int8(2), sql.Int8),
+						Column2:      expression.NewLiteral(int8(2), sql.Int8),
+						Order:        sql.Ascending,
+						NullOrdering: sql.NullsFirst,
+					},
+				}),
+		},
+		{
+			input: `CREATE DATABASE test`,
+			plan:  plan.NewCreateDatabase("test", false),
+		},
+		{
+			input: `CREATE DATABASE IF NOT EXISTS test`,
+			plan:  plan.NewCreateDatabase("test", true),
+		},
+		{
+			input: `DROP DATABASE test`,
+			plan:  plan.NewDropDatabase("test", false),
+		},
+		{
+			input: `DROP DATABASE IF EXISTS test`,
+			plan:  plan.NewDropDatabase("test", true),
+		},
+		{
+			input: `KILL QUERY 1`,
+			plan:  plan.NewKill(plan.KillType_Query, 1),
+		},
+		{
+			input: `KILL CONNECTION 1`,
+			plan:  plan.NewKill(plan.KillType_Connection, 1),
+		},
+	}
 
 	for _, tt := range fixtures {
 		t.Run(tt.input, func(t *testing.T) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -49,7 +49,7 @@ var showCollationProjection = plan.NewProject([]sql.Expression{
 
 type parseTest struct {
 	input string
-	plan sql.Node
+	plan  sql.Node
 }
 
 var fixtures = []parseTest{
@@ -1473,7 +1473,7 @@ CREATE TABLE t2
 	},
 	{
 		input: `ALTER TABLE t1 DROP FOREIGN KEY fk_name`,
-		plan: plan.NewAlterDropForeignKey("", "t1", "fk_name"),
+		plan:  plan.NewAlterDropForeignKey("", "t1", "fk_name"),
 	},
 	{
 		input: `ALTER TABLE t1 DROP CONSTRAINT fk_name`,
@@ -2073,47 +2073,47 @@ CREATE TABLE t2
 	},
 	{
 		input: `SHOW TABLES`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), false, nil),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), false, nil),
 	},
 	{
 		input: `SHOW FULL TABLES`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), true, nil),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), true, nil),
 	},
 	{
 		input: `SHOW TABLES FROM foo`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
 	},
 	{
 		input: `SHOW TABLES IN foo`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
 	},
 	{
 		input: `SHOW FULL TABLES FROM foo`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
 	},
 	{
 		input: `SHOW FULL TABLES IN foo`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
 	},
 	{
 		input: `SHOW TABLES AS OF 'abc'`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), false, expression.NewLiteral("abc", sql.LongText)),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), false, expression.NewLiteral("abc", sql.LongText)),
 	},
 	{
 		input: `SHOW FULL TABLES AS OF 'abc'`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), true, expression.NewLiteral("abc", sql.LongText)),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase(""), true, expression.NewLiteral("abc", sql.LongText)),
 	},
 	{
 		input: `SHOW TABLES FROM foo AS OF 'abc'`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, expression.NewLiteral("abc", sql.LongText)),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, expression.NewLiteral("abc", sql.LongText)),
 	},
 	{
 		input: `SHOW FULL TABLES FROM foo AS OF 'abc'`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
 	},
 	{
 		input: `SHOW FULL TABLES IN foo AS OF 'abc'`,
-		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
+		plan:  plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
 	},
 	{
 		input: `SHOW TABLES FROM mydb LIKE 'foo'`,
@@ -2921,35 +2921,35 @@ CREATE TABLE t2
 	},
 	{
 		input: `SHOW INDEXES FROM foo`,
-		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW INDEX FROM foo`,
-		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW KEYS FROM foo`,
-		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW INDEXES IN foo`,
-		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW INDEX IN foo`,
-		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW KEYS IN foo`,
-		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW FULL PROCESSLIST`,
-		plan: plan.NewShowProcessList(),
+		plan:  plan.NewShowProcessList(),
 	},
 	{
 		input: `SHOW PROCESSLIST`,
-		plan: plan.NewShowProcessList(),
+		plan:  plan.NewShowProcessList(),
 	},
 	{
 		input: `SELECT @@allowed_max_packet`,
@@ -3004,11 +3004,11 @@ CREATE TABLE t2
 	},
 	{
 		input: "",
-		plan: plan.Nothing,
+		plan:  plan.Nothing,
 	},
 	{
 		input: "/* just a comment */",
-		plan: plan.Nothing,
+		plan:  plan.Nothing,
 	},
 	{
 		input: `/*!40101 SET NAMES utf8 */`,
@@ -3068,7 +3068,7 @@ CREATE TABLE t2
 	},
 	{
 		input: `SHOW DATABASES`,
-		plan: plan.NewShowDatabases(),
+		plan:  plan.NewShowDatabases(),
 	},
 	{
 		input: `SELECT * FROM foo WHERE i LIKE 'foo'`,
@@ -3100,11 +3100,11 @@ CREATE TABLE t2
 	},
 	{
 		input: `SHOW FIELDS FROM foo`,
-		plan: plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW FULL COLUMNS FROM foo`,
-		plan: plan.NewShowColumns(true, plan.NewUnresolvedTable("foo", "")),
+		plan:  plan.NewShowColumns(true, plan.NewUnresolvedTable("foo", "")),
 	},
 	{
 		input: `SHOW FIELDS FROM foo WHERE Field = 'bar'`,
@@ -3140,15 +3140,15 @@ CREATE TABLE t2
 	},
 	{
 		input: `SHOW TABLE STATUS FROM foo`,
-		plan: plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
+		plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
 	},
 	{
 		input: `SHOW TABLE STATUS IN foo`,
-		plan: plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
+		plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
 	},
 	{
 		input: `SHOW TABLE STATUS`,
-		plan: plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
+		plan:  plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
 	},
 	{
 		input: `SHOW TABLE STATUS WHERE Name = 'foo'`,
@@ -3162,7 +3162,7 @@ CREATE TABLE t2
 	},
 	{
 		input: `USE foo`,
-		plan: plan.NewUse(sql.UnresolvedDatabase("foo")),
+		plan:  plan.NewUse(sql.UnresolvedDatabase("foo")),
 	},
 	{
 		input: `DESCRIBE foo.bar`,
@@ -3187,15 +3187,15 @@ CREATE TABLE t2
 	},
 	{
 		input: `SHOW VARIABLES`,
-		plan: plan.NewShowVariables(nil),
+		plan:  plan.NewShowVariables(nil),
 	},
 	{
 		input: `SHOW GLOBAL VARIABLES`,
-		plan: plan.NewShowVariables(nil),
+		plan:  plan.NewShowVariables(nil),
 	},
 	{
 		input: `SHOW SESSION VARIABLES`,
-		plan: plan.NewShowVariables(nil),
+		plan:  plan.NewShowVariables(nil),
 	},
 	{
 		input: `SHOW VARIABLES LIKE 'gtid_mode'`,
@@ -3215,7 +3215,7 @@ CREATE TABLE t2
 	},
 	{
 		input: `UNLOCK TABLES`,
-		plan: plan.NewUnlockTables(),
+		plan:  plan.NewUnlockTables(),
 	},
 	{
 		input: `LOCK TABLES foo READ`,
@@ -3277,47 +3277,47 @@ CREATE TABLE t2
 	},
 	{
 		input: `SHOW CREATE DATABASE foo`,
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
 	},
 	{
 		input: `SHOW CREATE SCHEMA foo`,
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
 	},
 	{
 		input: `SHOW CREATE DATABASE IF NOT EXISTS foo`,
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
 	},
 	{
 		input: `SHOW CREATE SCHEMA IF NOT EXISTS foo`,
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
 	},
 	{
 		input: `SHOW WARNINGS`,
-		plan: plan.ShowWarnings(sql.NewEmptyContext().Warnings()),
+		plan:  plan.ShowWarnings(sql.NewEmptyContext().Warnings()),
 	},
 	{
 		input: `SHOW WARNINGS LIMIT 10`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings())),
+		plan:  plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings())),
 	},
 	{
 		input: `SHOW WARNINGS LIMIT 5,10`,
-		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings()))),
+		plan:  plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings()))),
 	},
 	{
 		input: "SHOW CREATE DATABASE `foo`",
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
 	},
 	{
 		input: "SHOW CREATE SCHEMA `foo`",
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
 	},
 	{
 		input: "SHOW CREATE DATABASE IF NOT EXISTS `foo`",
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
 	},
 	{
 		input: "SHOW CREATE SCHEMA IF NOT EXISTS `foo`",
-		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+		plan:  plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
 	},
 	{
 		input: "SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
@@ -3399,7 +3399,7 @@ CREATE TABLE t2
 	},
 	{
 		input: "SHOW COLLATION",
-		plan: showCollationProjection,
+		plan:  showCollationProjection,
 	},
 	{
 		input: "SHOW COLLATION LIKE 'foo'",
@@ -3424,75 +3424,75 @@ CREATE TABLE t2
 	},
 	{
 		input: "BEGIN",
-		plan: plan.NewStartTransaction("", sql.ReadWrite),
+		plan:  plan.NewStartTransaction("", sql.ReadWrite),
 	},
 	{
 		input: "START TRANSACTION",
-		plan: plan.NewStartTransaction("", sql.ReadWrite),
+		plan:  plan.NewStartTransaction("", sql.ReadWrite),
 	},
 	{
 		input: "COMMIT",
-		plan: plan.NewCommit(""),
+		plan:  plan.NewCommit(""),
 	},
 	{
 		input: `ROLLBACK`,
-		plan: plan.NewRollback(""),
+		plan:  plan.NewRollback(""),
 	},
 	{
 		input: "SAVEPOINT abc",
-		plan: plan.NewCreateSavepoint("", "abc"),
+		plan:  plan.NewCreateSavepoint("", "abc"),
 	},
 	{
 		input: "ROLLBACK TO SAVEPOINT abc",
-		plan: plan.NewRollbackSavepoint("", "abc"),
+		plan:  plan.NewRollbackSavepoint("", "abc"),
 	},
 	{
 		input: "RELEASE SAVEPOINT abc",
-		plan: plan.NewReleaseSavepoint("", "abc"),
+		plan:  plan.NewReleaseSavepoint("", "abc"),
 	},
 	{
 		input: "SHOW CREATE TABLE `mytable`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
 	},
 	{
 		input: "SHOW CREATE TABLE mytable",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
 	},
 	{
 		input: "SHOW CREATE TABLE mydb.`mytable`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
 	},
 	{
 		input: "SHOW CREATE TABLE `mydb`.mytable",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
 	},
 	{
 		input: "SHOW CREATE TABLE `mydb`.`mytable`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
 	},
 	{
 		input: "SHOW CREATE TABLE `my.table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), false),
 	},
 	{
 		input: "SHOW CREATE TABLE `my.db`.`my.table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), false),
 	},
 	{
 		input: "SHOW CREATE TABLE `my``table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), false),
 	},
 	{
 		input: "SHOW CREATE TABLE `my``db`.`my``table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), false),
 	},
 	{
 		input: "SHOW CREATE TABLE ````",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), false),
 	},
 	{
 		input: "SHOW CREATE TABLE `.`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), false),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), false),
 	},
 	{
 		input: "SHOW CREATE TABLE mytable as of 'version'",
@@ -3502,47 +3502,47 @@ CREATE TABLE t2
 	},
 	{
 		input: "SHOW CREATE VIEW `mytable`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
 	},
 	{
 		input: "SHOW CREATE VIEW mytable",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
 	},
 	{
 		input: "SHOW CREATE VIEW mydb.`mytable`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
 	},
 	{
 		input: "SHOW CREATE VIEW `mydb`.mytable",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
 	},
 	{
 		input: "SHOW CREATE VIEW `mydb`.`mytable`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
 	},
 	{
 		input: "SHOW CREATE VIEW `my.table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), true),
 	},
 	{
 		input: "SHOW CREATE VIEW `my.db`.`my.table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), true),
 	},
 	{
 		input: "SHOW CREATE VIEW `my``table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), true),
 	},
 	{
 		input: "SHOW CREATE VIEW `my``db`.`my``table`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), true),
 	},
 	{
 		input: "SHOW CREATE VIEW ````",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), true),
 	},
 	{
 		input: "SHOW CREATE VIEW `.`",
-		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), true),
+		plan:  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), true),
 	},
 	{
 		input: `SELECT '2018-05-01' + INTERVAL 1 DAY`,
@@ -4825,27 +4825,27 @@ CREATE TABLE t2
 	},
 	{
 		input: `CREATE DATABASE test`,
-		plan: plan.NewCreateDatabase("test", false),
+		plan:  plan.NewCreateDatabase("test", false),
 	},
 	{
 		input: `CREATE DATABASE IF NOT EXISTS test`,
-		plan: plan.NewCreateDatabase("test", true),
+		plan:  plan.NewCreateDatabase("test", true),
 	},
 	{
 		input: `DROP DATABASE test`,
-		plan: plan.NewDropDatabase("test", false),
+		plan:  plan.NewDropDatabase("test", false),
 	},
 	{
 		input: `DROP DATABASE IF EXISTS test`,
-		plan: plan.NewDropDatabase("test", true),
+		plan:  plan.NewDropDatabase("test", true),
 	},
 	{
 		input: `KILL QUERY 1`,
-		plan: plan.NewKill(plan.KillType_Query, 1),
+		plan:  plan.NewKill(plan.KillType_Query, 1),
 	},
 	{
 		input: `KILL CONNECTION 1`,
-		plan: plan.NewKill(plan.KillType_Connection, 1),
+		plan:  plan.NewKill(plan.KillType_Connection, 1),
 		/* fixtures end */
 	},
 }

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -47,447 +47,1273 @@ var showCollationProjection = plan.NewProject([]sql.Expression{
 	plan.NewUnresolvedTable("collations", "information_schema"),
 )
 
-var fixtures = map[string]sql.Node{
+type parseTest struct {
+	input string
+	plan sql.Node
+}
+
+var fixtures = []parseTest{
 	/* fixtures start */
-	`CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME, h CHAR(40))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:     "a",
-				Type:     sql.Int32,
-				Nullable: true,
-			}, {
-				Name:     "b",
-				Type:     sql.Text,
-				Nullable: true,
-			}, {
-				Name:     "c",
-				Type:     sql.Date,
-				Nullable: true,
-			}, {
-				Name:     "d",
-				Type:     sql.Timestamp,
-				Nullable: true,
-			}, {
-				Name:     "e",
-				Type:     sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20),
-				Nullable: true,
-			}, {
-				Name:     "f",
-				Type:     sql.Blob,
-				Nullable: false,
-			}, {
-				Name:     "g",
-				Type:     sql.Datetime,
-				Nullable: true,
-			}, {
-				Name:     "h",
-				Type:     sql.MustCreateStringWithDefaults(sqltypes.Char, 40),
-				Nullable: true,
-			}}),
-		},
-	),
-	`CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY, b TEXT)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Text,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-		},
-	),
-	`CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY COMMENT "hello", b TEXT COMMENT "goodbye")`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-				Comment:    "hello",
-			}, {
-				Name:       "b",
-				Type:       sql.Text,
-				Nullable:   true,
-				PrimaryKey: false,
-				Comment:    "goodbye",
-			}}),
-		},
-	),
-	`CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Text,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{
-				{
-					IndexName: "PRIMARY",
-					Columns: []sql.IndexColumn{
-						{Name: "a"},
+	{
+		input: `CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME, h CHAR(40))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:     "a",
+					Type:     sql.Int32,
+					Nullable: true,
+				}, {
+					Name:     "b",
+					Type:     sql.Text,
+					Nullable: true,
+				}, {
+					Name:     "c",
+					Type:     sql.Date,
+					Nullable: true,
+				}, {
+					Name:     "d",
+					Type:     sql.Timestamp,
+					Nullable: true,
+				}, {
+					Name:     "e",
+					Type:     sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20),
+					Nullable: true,
+				}, {
+					Name:     "f",
+					Type:     sql.Blob,
+					Nullable: false,
+				}, {
+					Name:     "g",
+					Type:     sql.Datetime,
+					Nullable: true,
+				}, {
+					Name:     "h",
+					Type:     sql.MustCreateStringWithDefaults(sqltypes.Char, 40),
+					Nullable: true,
+				}}),
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY, b TEXT)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Text,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER NOT NULL PRIMARY KEY COMMENT "hello", b TEXT COMMENT "goodbye")`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+					Comment:    "hello",
+				}, {
+					Name:       "b",
+					Type:       sql.Text,
+					Nullable:   true,
+					PrimaryKey: false,
+					Comment:    "goodbye",
+				}}),
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Text,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{
+					{
+						IndexName: "PRIMARY",
+						Columns: []sql.IndexColumn{
+							{Name: "a"},
+						},
+						Constraint: sql.IndexConstraint_Primary,
 					},
-					Constraint: sql.IndexConstraint_Primary,
 				},
 			},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Text,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{
-				{
-					IndexName: "PRIMARY",
-					Columns: []sql.IndexColumn{
-						{Name: "a"},
-						{Name: "b"},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Text,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{
+					{
+						IndexName: "PRIMARY",
+						Columns: []sql.IndexColumn{
+							{Name: "a"},
+							{Name: "b"},
+						},
+						Constraint: sql.IndexConstraint_Primary,
 					},
-					Constraint: sql.IndexConstraint_Primary,
 				},
 			},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (b, a))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Text,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}, 1, 0),
-			IdxDefs: []*plan.IndexDefinition{
-				{
-					IndexName: "PRIMARY",
-					Columns: []sql.IndexColumn{
-						{Name: "b"},
-						{Name: "a"},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER, b TEXT, PRIMARY KEY (b, a))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Text,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}, 1, 0),
+				IdxDefs: []*plan.IndexDefinition{
+					{
+						IndexName: "PRIMARY",
+						Columns: []sql.IndexColumn{
+							{Name: "b"},
+							{Name: "a"},
+						},
+						Constraint: sql.IndexConstraint_Primary,
 					},
-					Constraint: sql.IndexConstraint_Primary,
 				},
 			},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER, b int, CONSTRAINT pk PRIMARY KEY (b, a), CONSTRAINT UNIQUE KEY (a))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}, 1, 0),
-			IdxDefs: []*plan.IndexDefinition{
-				{
-					IndexName: "pk",
-					Columns: []sql.IndexColumn{
-						{Name: "b"},
-						{Name: "a"},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER, b int, CONSTRAINT pk PRIMARY KEY (b, a), CONSTRAINT UNIQUE KEY (a))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}, 1, 0),
+				IdxDefs: []*plan.IndexDefinition{
+					{
+						IndexName: "pk",
+						Columns: []sql.IndexColumn{
+							{Name: "b"},
+							{Name: "a"},
+						},
+						Constraint: sql.IndexConstraint_Primary,
 					},
-					Constraint: sql.IndexConstraint_Primary,
+					{
+						Columns: []sql.IndexColumn{
+							{Name: "a"},
+						},
+						Constraint: sql.IndexConstraint_Unique,
+					},
 				},
-				{
-					Columns: []sql.IndexColumn{
-						{Name: "a"},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE IF NOT EXISTS t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExists,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Text,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{
+					{
+						IndexName:  "PRIMARY",
+						Constraint: sql.IndexConstraint_Primary,
+						Columns: []sql.IndexColumn{
+							{Name: "a"},
+							{Name: "b"},
+						},
 					},
+				},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{
+					{
+						IndexName:  "",
+						Using:      sql.IndexUsing_Default,
+						Constraint: sql.IndexConstraint_None,
+						Columns:    []sql.IndexColumn{{"b", 0}},
+						Comment:    "",
+					},
+				},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{{
+					IndexName:  "idx_name",
+					Using:      sql.IndexUsing_Default,
+					Constraint: sql.IndexConstraint_None,
+					Columns:    []sql.IndexColumn{{"b", 0}},
+					Comment:    "",
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b) COMMENT 'hi')`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{{
+					IndexName:  "idx_name",
+					Using:      sql.IndexUsing_Default,
+					Constraint: sql.IndexConstraint_None,
+					Columns:    []sql.IndexColumn{{"b", 0}},
+					Comment:    "hi",
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE INDEX (b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{{
+					IndexName:  "",
+					Using:      sql.IndexUsing_Default,
 					Constraint: sql.IndexConstraint_Unique,
-				},
+					Columns:    []sql.IndexColumn{{"b", 0}},
+					Comment:    "",
+				}},
 			},
-		},
-	),
-	`CREATE TABLE IF NOT EXISTS t1(a INTEGER, b TEXT, PRIMARY KEY (a, b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExists,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Text,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{
-				{
-					IndexName:  "PRIMARY",
-					Constraint: sql.IndexConstraint_Primary,
-					Columns: []sql.IndexColumn{
-						{Name: "a"},
-						{Name: "b"},
-					},
-				},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE (b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{{
+					IndexName:  "",
+					Using:      sql.IndexUsing_Default,
+					Constraint: sql.IndexConstraint_Unique,
+					Columns:    []sql.IndexColumn{{"b", 0}},
+					Comment:    "",
+				}},
 			},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{
-				{
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b, a))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{{
+					IndexName:  "",
+					Using:      sql.IndexUsing_Default,
+					Constraint: sql.IndexConstraint_None,
+					Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
+					Comment:    "",
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b), INDEX (b, a))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				IdxDefs: []*plan.IndexDefinition{{
 					IndexName:  "",
 					Using:      sql.IndexUsing_Default,
 					Constraint: sql.IndexConstraint_None,
 					Columns:    []sql.IndexColumn{{"b", 0}},
 					Comment:    "",
+				}, {
+					IndexName:  "",
+					Using:      sql.IndexUsing_Default,
+					Constraint: sql.IndexConstraint_None,
+					Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
+					Comment:    "",
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b_id",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				FkDefs: []*sql.ForeignKeyConstraint{{
+					Name:           "",
+					Database:       "",
+					Table:          "t1",
+					Columns:        []string{"b_id"},
+					ParentDatabase: "",
+					ParentTable:    "t0",
+					ParentColumns:  []string{"b"},
+					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+					IsResolved:     false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b_id",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				FkDefs: []*sql.ForeignKeyConstraint{{
+					Name:           "fk_name",
+					Database:       "",
+					Table:          "t1",
+					Columns:        []string{"b_id"},
+					ParentDatabase: "",
+					ParentTable:    "t0",
+					ParentColumns:  []string{"b"},
+					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+					IsResolved:     false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b_id",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				FkDefs: []*sql.ForeignKeyConstraint{{
+					Name:           "",
+					Database:       "",
+					Table:          "t1",
+					Columns:        []string{"b_id"},
+					ParentDatabase: "",
+					ParentTable:    "t0",
+					ParentColumns:  []string{"b"},
+					OnUpdate:       sql.ForeignKeyReferentialAction_Cascade,
+					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+					IsResolved:     false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b_id",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				FkDefs: []*sql.ForeignKeyConstraint{{
+					Name:           "",
+					Database:       "",
+					Table:          "t1",
+					Columns:        []string{"b_id"},
+					ParentDatabase: "",
+					ParentTable:    "t0",
+					ParentColumns:  []string{"b"},
+					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+					OnDelete:       sql.ForeignKeyReferentialAction_Restrict,
+					IsResolved:     false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b_id",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+
+				FkDefs: []*sql.ForeignKeyConstraint{{
+					Name:           "",
+					Database:       "",
+					Table:          "t1",
+					Columns:        []string{"b_id"},
+					ParentDatabase: "",
+					ParentTable:    "t0",
+					ParentColumns:  []string{"b"},
+					OnUpdate:       sql.ForeignKeyReferentialAction_SetNull,
+					OnDelete:       sql.ForeignKeyReferentialAction_NoAction,
+					IsResolved:     false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b_id",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}, {
+					Name:       "c_id",
+					Type:       sql.Int64,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				FkDefs: []*sql.ForeignKeyConstraint{{
+					Name:           "",
+					Database:       "",
+					Table:          "t1",
+					Columns:        []string{"b_id", "c_id"},
+					ParentDatabase: "",
+					ParentTable:    "t0",
+					ParentColumns:  []string{"b", "c"},
+					OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
+					OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
+					IsResolved:     false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}, {
+					Name:       "b_id",
+					Type:       sql.Int32,
+					Nullable:   true,
+					PrimaryKey: false,
+				}, {
+					Name:       "c_id",
+					Type:       sql.Int64,
+					Nullable:   true,
+					PrimaryKey: false,
+				}}),
+				FkDefs: []*sql.ForeignKeyConstraint{{
+					Name:           "fk_name",
+					Database:       "",
+					Table:          "t1",
+					Columns:        []string{"b_id", "c_id"},
+					ParentDatabase: "",
+					ParentTable:    "t0",
+					ParentColumns:  []string{"b", "c"},
+					OnUpdate:       sql.ForeignKeyReferentialAction_Restrict,
+					OnDelete:       sql.ForeignKeyReferentialAction_Cascade,
+					IsResolved:     false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, CHECK (a > 0))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}),
+				ChDefs: []*sql.CheckConstraint{{
+					Name: "",
+					Expr: expression.NewGreaterThan(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewLiteral(int8(0), sql.Int8),
+					),
+					Enforced: true,
+				}},
+			},
+		),
+	},
+	{
+		input: `
+CREATE TABLE t4
+(
+  CHECK (c1 = c2),
+  c1 INT CHECK (c1 > 10),
+  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
+  CHECK (c1 > c3)
+);`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t4",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{
+					{
+						Name:     "c1",
+						Source:   "t4",
+						Type:     sql.Int32,
+						Nullable: true,
+					},
+					{
+						Name:     "c2",
+						Source:   "t4",
+						Type:     sql.Int32,
+						Nullable: true,
+					},
+				}),
+				ChDefs: []*sql.CheckConstraint{
+					{
+						Expr: expression.NewEquals(
+							expression.NewUnresolvedColumn("c1"),
+							expression.NewUnresolvedColumn("c2"),
+						),
+						Enforced: true,
+					},
+					{
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("c1"),
+							expression.NewLiteral(int8(10), sql.Int8),
+						),
+						Enforced: true,
+					},
+					{
+						Name: "c2_positive",
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("c2"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: true,
+					},
+					{
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("c1"),
+							expression.NewUnresolvedColumn("c3"),
+						),
+						Enforced: true,
+					},
 				},
 			},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{{
-				IndexName:  "idx_name",
-				Using:      sql.IndexUsing_Default,
-				Constraint: sql.IndexConstraint_None,
-				Columns:    []sql.IndexColumn{{"b", 0}},
-				Comment:    "",
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX idx_name (b) COMMENT 'hi')`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{{
-				IndexName:  "idx_name",
-				Using:      sql.IndexUsing_Default,
-				Constraint: sql.IndexConstraint_None,
-				Columns:    []sql.IndexColumn{{"b", 0}},
-				Comment:    "hi",
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE INDEX (b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{{
-				IndexName:  "",
-				Using:      sql.IndexUsing_Default,
-				Constraint: sql.IndexConstraint_Unique,
-				Columns:    []sql.IndexColumn{{"b", 0}},
-				Comment:    "",
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, UNIQUE (b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{{
-				IndexName:  "",
-				Using:      sql.IndexUsing_Default,
-				Constraint: sql.IndexConstraint_Unique,
-				Columns:    []sql.IndexColumn{{"b", 0}},
-				Comment:    "",
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b, a))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{{
-				IndexName:  "",
-				Using:      sql.IndexUsing_Default,
-				Constraint: sql.IndexConstraint_None,
-				Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
-				Comment:    "",
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b INTEGER, INDEX (b), INDEX (b, a))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			IdxDefs: []*plan.IndexDefinition{{
-				IndexName:  "",
-				Using:      sql.IndexUsing_Default,
-				Constraint: sql.IndexConstraint_None,
-				Columns:    []sql.IndexColumn{{"b", 0}},
-				Comment:    "",
-			}, {
-				IndexName:  "",
-				Using:      sql.IndexUsing_Default,
-				Constraint: sql.IndexConstraint_None,
-				Columns:    []sql.IndexColumn{{"b", 0}, {"a", 0}},
-				Comment:    "",
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b_id",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			FkDefs: []*sql.ForeignKeyConstraint{{
+		),
+	},
+	{
+		input: `
+CREATE TABLE t2
+(
+  CHECK (c1 = c2),
+  c1 INT CHECK (c1 > 10),
+  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
+  c3 INT CHECK (c3 < 100),
+  CONSTRAINT c1_nonzero CHECK (c1 = 0),
+  CHECK (c1 > c3)
+);`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t2",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{
+					{
+						Name:     "c1",
+						Source:   "t2",
+						Type:     sql.Int32,
+						Nullable: true,
+					},
+					{
+						Name:     "c2",
+						Source:   "t2",
+						Type:     sql.Int32,
+						Nullable: true,
+					},
+					{
+						Name:     "c3",
+						Source:   "t2",
+						Type:     sql.Int32,
+						Nullable: true,
+					},
+				}),
+				ChDefs: []*sql.CheckConstraint{
+					{
+						Expr: expression.NewEquals(
+							expression.NewUnresolvedColumn("c1"),
+							expression.NewUnresolvedColumn("c2"),
+						),
+						Enforced: true,
+					},
+					{
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("c1"),
+							expression.NewLiteral(int8(10), sql.Int8),
+						),
+						Enforced: true,
+					},
+					{
+						Name: "c2_positive",
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("c2"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: true,
+					},
+					{
+						Expr: expression.NewLessThan(
+							expression.NewUnresolvedColumn("c3"),
+							expression.NewLiteral(int8(100), sql.Int8),
+						),
+						Enforced: true,
+					},
+					{
+						Name: "c1_nonzero",
+						Expr: expression.NewEquals(
+							expression.NewUnresolvedColumn("c1"),
+							expression.NewLiteral(int8(0), sql.Int8),
+						),
+						Enforced: true,
+					},
+					{
+						Expr: expression.NewGreaterThan(
+							expression.NewUnresolvedColumn("c1"),
+							expression.NewUnresolvedColumn("c3"),
+						),
+						Enforced: true,
+					},
+				},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}),
+				ChDefs: []*sql.CheckConstraint{{
+					Name: "",
+					Expr: expression.NewGreaterThan(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewLiteral(int8(0), sql.Int8),
+					),
+					Enforced: true,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY, CONSTRAINT ch1 CHECK (a > 0))`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}),
+				ChDefs: []*sql.CheckConstraint{{
+					Name: "ch1",
+					Expr: expression.NewGreaterThan(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewLiteral(int8(0), sql.Int8),
+					),
+					Enforced: true,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) ENFORCED)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}),
+				ChDefs: []*sql.CheckConstraint{{
+					Name: "",
+					Expr: expression.NewGreaterThan(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewLiteral(int8(0), sql.Int8),
+					),
+					Enforced: true,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) NOT ENFORCED)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTableAbsent,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:       "a",
+					Type:       sql.Int32,
+					Nullable:   false,
+					PrimaryKey: true,
+				}}),
+				ChDefs: []*sql.CheckConstraint{{
+					Name: "",
+					Expr: expression.NewGreaterThan(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewLiteral(int8(0), sql.Int8),
+					),
+					Enforced: false,
+				}},
+			},
+		),
+	},
+	{
+		input: `CREATE TEMPORARY TABLE t1(a INTEGER, b TEXT)`,
+		plan: plan.NewCreateTable(
+			sql.UnresolvedDatabase(""),
+			"t1",
+			plan.IfNotExistsAbsent,
+			plan.IsTempTable,
+			&plan.TableSpec{
+				Schema: sql.NewPrimaryKeySchema(sql.Schema{{
+					Name:     "a",
+					Type:     sql.Int32,
+					Nullable: true,
+				}, {
+					Name:     "b",
+					Type:     sql.Text,
+					Nullable: true,
+				}}),
+			},
+		),
+	},
+	{
+		input: `CREATE TEMPORARY TABLE mytable AS SELECT * from othertable`,
+		plan: plan.NewCreateTableSelect(
+			sql.UnresolvedDatabase(""),
+			"mytable",
+			plan.NewProject([]sql.Expression{expression.NewStar()}, plan.NewUnresolvedTable("othertable", "")),
+			&plan.TableSpec{},
+			plan.IfNotExistsAbsent,
+			plan.IsTempTable),
+	},
+	{
+		input: `DROP TABLE curdb.foo;`,
+		plan: plan.NewDropTable(
+			[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, false,
+		),
+	},
+	{
+		input: `DROP TABLE t1, t2;`,
+		plan: plan.NewDropTable(
+			[]sql.Node{plan.NewUnresolvedTable("t1", ""), plan.NewUnresolvedTable("t2", "")}, false,
+		),
+	},
+	{
+		input: `DROP TABLE IF EXISTS curdb.foo;`,
+		plan: plan.NewDropTable(
+			[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, true,
+		),
+	},
+	{
+		input: `DROP TABLE IF EXISTS curdb.foo, curdb.bar, curdb.baz;`,
+		plan: plan.NewDropTable(
+			[]sql.Node{plan.NewUnresolvedTable("foo", "curdb"), plan.NewUnresolvedTable("bar", "curdb"), plan.NewUnresolvedTable("baz", "curdb")}, true,
+		),
+	},
+	{
+		input: `RENAME TABLE foo TO bar`,
+		plan: plan.NewRenameTable(
+			sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
+		),
+	},
+	{
+		input: `RENAME TABLE foo TO bar, baz TO qux`,
+		plan: plan.NewRenameTable(
+			sql.UnresolvedDatabase(""), []string{"foo", "baz"}, []string{"bar", "qux"},
+		),
+	},
+	{
+		input: `ALTER TABLE foo RENAME bar`,
+		plan: plan.NewRenameTable(
+			sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
+		),
+	},
+	{
+		input: `ALTER TABLE foo RENAME TO bar`,
+		plan: plan.NewRenameTable(
+			sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
+		),
+	},
+	{
+		input: `ALTER TABLE foo RENAME COLUMN bar TO baz`,
+		plan: plan.NewRenameColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("foo", ""), "bar", "baz",
+		),
+	},
+	{
+		input: `ALTER TABLE otherdb.mytable RENAME COLUMN i TO s`,
+		plan: plan.NewRenameColumn(
+			sql.UnresolvedDatabase("otherdb"),
+			plan.NewUnresolvedTable("mytable", "otherdb"), "i", "s",
+		),
+	},
+	{
+		input: `ALTER TABLE mytable RENAME COLUMN bar TO baz, RENAME COLUMN abc TO xyz`,
+		plan: plan.NewBlock(
+			[]sql.Node{
+				plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "bar", "baz"),
+				plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "abc", "xyz"),
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+				Name:     "bar",
+				Type:     sql.Int32,
+				Nullable: false,
+			}, nil,
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT 42 COMMENT 'hello' AFTER baz`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+				Name:     "bar",
+				Type:     sql.Int32,
+				Nullable: false,
+				Comment:  "hello",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "42", nil, true),
+			}, &sql.ColumnOrder{AfterColumn: "baz"},
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT -42.0 COMMENT 'hello' AFTER baz`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+				Name:     "bar",
+				Type:     sql.Int32,
+				Nullable: false,
+				Comment:  "hello",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "-42.0", nil, true),
+			}, &sql.ColumnOrder{AfterColumn: "baz"},
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT ((2+2)/2) COMMENT 'hello' AFTER baz`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+				Name:     "bar",
+				Type:     sql.Int32,
+				Nullable: false,
+				Comment:  "hello",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "((2+2)/2)", nil, true),
+			}, &sql.ColumnOrder{AfterColumn: "baz"},
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello'`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+				Name:     "bar",
+				Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
+				Nullable: true,
+				Comment:  "hello",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+			}, nil,
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD COLUMN bar FLOAT NULL DEFAULT 32.0 COMMENT 'hello'`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+				Name:     "bar",
+				Type:     sql.Float32,
+				Nullable: true,
+				Comment:  "hello",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "32.0", nil, true),
+			}, nil,
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD COLUMN bar INT DEFAULT 1 FIRST`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), &sql.Column{
+				Name:     "bar",
+				Type:     sql.Int32,
+				Nullable: true,
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
+			}, &sql.ColumnOrder{First: true},
+		),
+	},
+	{
+		input: `ALTER TABLE mydb.mytable ADD COLUMN bar INT DEFAULT 1 COMMENT 'otherdb'`,
+		plan: plan.NewAddColumn(
+			sql.UnresolvedDatabase("mydb"),
+			plan.NewUnresolvedTable("mytable", "mydb"), &sql.Column{
+				Name:     "bar",
+				Type:     sql.Int32,
+				Nullable: true,
+				Comment:  "otherdb",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
+			}, nil,
+		),
+	},
+	{
+		input: `ALTER TABLE mytable ADD INDEX (v1)`,
+		plan: plan.NewAlterCreateIndex(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""),
+			"",
+			sql.IndexUsing_BTree,
+			sql.IndexConstraint_None,
+			[]sql.IndexColumn{{"v1", 0}},
+			"",
+		),
+	},
+	{
+		input: `ALTER TABLE mytable DROP COLUMN bar`,
+		plan: plan.NewDropColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("mytable", ""), "bar",
+		),
+	},
+	{
+		input: `ALTER TABLE otherdb.mytable DROP COLUMN bar`,
+		plan: plan.NewDropColumn(
+			sql.UnresolvedDatabase("otherdb"),
+			plan.NewUnresolvedTable("mytable", "otherdb"), "bar",
+		),
+	},
+	{
+		input: `ALTER TABLE tabletest MODIFY COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`,
+		plan: plan.NewModifyColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
+				Name:     "bar",
+				Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
+				Nullable: true,
+				Comment:  "hello",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+			}, &sql.ColumnOrder{First: true},
+		),
+	},
+	{
+		input: `ALTER TABLE tabletest CHANGE COLUMN bar baz VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`,
+		plan: plan.NewModifyColumn(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
+				Name:     "baz",
+				Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
+				Nullable: true,
+				Comment:  "hello",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+			}, &sql.ColumnOrder{First: true},
+		),
+	},
+	{
+		input: `ALTER TABLE mydb.mytable MODIFY COLUMN col1 VARCHAR(20) NULL DEFAULT 'string' COMMENT 'changed'`,
+		plan: plan.NewModifyColumn(
+			sql.UnresolvedDatabase("mydb"),
+			plan.NewUnresolvedTable("mytable", "mydb"), "col1", &sql.Column{
+				Name:     "col1",
+				Type:     sql.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Invalid),
+				Nullable: true,
+				Comment:  "changed",
+				Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
+			}, nil,
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b)`,
+		plan: plan.NewAlterAddForeignKey(
+			&sql.ForeignKeyConstraint{
 				Name:           "",
 				Database:       "",
 				Table:          "t1",
@@ -498,27 +1324,13 @@ var fixtures = map[string]sql.Node{
 				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 				IsResolved:     false,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b_id",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			FkDefs: []*sql.ForeignKeyConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b)`,
+		plan: plan.NewAlterAddForeignKey(
+			&sql.ForeignKeyConstraint{
 				Name:           "fk_name",
 				Database:       "",
 				Table:          "t1",
@@ -529,27 +1341,13 @@ var fixtures = map[string]sql.Node{
 				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 				IsResolved:     false,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b_id",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			FkDefs: []*sql.ForeignKeyConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE`,
+		plan: plan.NewAlterAddForeignKey(
+			&sql.ForeignKeyConstraint{
 				Name:           "",
 				Database:       "",
 				Table:          "t1",
@@ -560,27 +1358,13 @@ var fixtures = map[string]sql.Node{
 				OnUpdate:       sql.ForeignKeyReferentialAction_Cascade,
 				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 				IsResolved:     false,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b_id",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			FkDefs: []*sql.ForeignKeyConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT`,
+		plan: plan.NewAlterAddForeignKey(
+			&sql.ForeignKeyConstraint{
 				Name:           "",
 				Database:       "",
 				Table:          "t1",
@@ -591,28 +1375,13 @@ var fixtures = map[string]sql.Node{
 				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 				OnDelete:       sql.ForeignKeyReferentialAction_Restrict,
 				IsResolved:     false,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b_id",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-
-			FkDefs: []*sql.ForeignKeyConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION`,
+		plan: plan.NewAlterAddForeignKey(
+			&sql.ForeignKeyConstraint{
 				Name:           "",
 				Database:       "",
 				Table:          "t1",
@@ -623,32 +1392,13 @@ var fixtures = map[string]sql.Node{
 				OnUpdate:       sql.ForeignKeyReferentialAction_SetNull,
 				OnDelete:       sql.ForeignKeyReferentialAction_NoAction,
 				IsResolved:     false,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b_id",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}, {
-				Name:       "c_id",
-				Type:       sql.Int64,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			FkDefs: []*sql.ForeignKeyConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c)`,
+		plan: plan.NewAlterAddForeignKey(
+			&sql.ForeignKeyConstraint{
 				Name:           "",
 				Database:       "",
 				Table:          "t1",
@@ -659,32 +1409,13 @@ var fixtures = map[string]sql.Node{
 				OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
 				OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
 				IsResolved:     false,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, b_id INTEGER, c_id BIGINT, CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}, {
-				Name:       "b_id",
-				Type:       sql.Int32,
-				Nullable:   true,
-				PrimaryKey: false,
-			}, {
-				Name:       "c_id",
-				Type:       sql.Int64,
-				Nullable:   true,
-				PrimaryKey: false,
-			}}),
-			FkDefs: []*sql.ForeignKeyConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE`,
+		plan: plan.NewAlterAddForeignKey(
+			&sql.ForeignKeyConstraint{
 				Name:           "fk_name",
 				Database:       "",
 				Table:          "t1",
@@ -695,771 +1426,262 @@ var fixtures = map[string]sql.Node{
 				OnUpdate:       sql.ForeignKeyReferentialAction_Restrict,
 				OnDelete:       sql.ForeignKeyReferentialAction_Cascade,
 				IsResolved:     false,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, CHECK (a > 0))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}),
-			ChDefs: []*sql.CheckConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD CHECK (a > 0)`,
+		plan: plan.NewAlterAddCheck(
+			plan.NewUnresolvedTable("t1", ""),
+			&sql.CheckConstraint{
 				Name: "",
 				Expr: expression.NewGreaterThan(
 					expression.NewUnresolvedColumn("a"),
 					expression.NewLiteral(int8(0), sql.Int8),
 				),
 				Enforced: true,
-			}},
-		},
-	),
-	`
-CREATE TABLE t4
-(
-  CHECK (c1 = c2),
-  c1 INT CHECK (c1 > 10),
-  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
-  CHECK (c1 > c3)
-);`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t4",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{
-				{
-					Name:     "c1",
-					Source:   "t4",
-					Type:     sql.Int32,
-					Nullable: true,
-				},
-				{
-					Name:     "c2",
-					Source:   "t4",
-					Type:     sql.Int32,
-					Nullable: true,
-				},
-			}),
-			ChDefs: []*sql.CheckConstraint{
-				{
-					Expr: expression.NewEquals(
-						expression.NewUnresolvedColumn("c1"),
-						expression.NewUnresolvedColumn("c2"),
-					),
-					Enforced: true,
-				},
-				{
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("c1"),
-						expression.NewLiteral(int8(10), sql.Int8),
-					),
-					Enforced: true,
-				},
-				{
-					Name: "c2_positive",
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("c2"),
-						expression.NewLiteral(int8(0), sql.Int8),
-					),
-					Enforced: true,
-				},
-				{
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("c1"),
-						expression.NewUnresolvedColumn("c3"),
-					),
-					Enforced: true,
-				},
 			},
-		},
-	),
-	`
-CREATE TABLE t2
-(
-  CHECK (c1 = c2),
-  c1 INT CHECK (c1 > 10),
-  c2 INT CONSTRAINT c2_positive CHECK (c2 > 0),
-  c3 INT CHECK (c3 < 100),
-  CONSTRAINT c1_nonzero CHECK (c1 = 0),
-  CHECK (c1 > c3)
-);`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t2",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{
-				{
-					Name:     "c1",
-					Source:   "t2",
-					Type:     sql.Int32,
-					Nullable: true,
-				},
-				{
-					Name:     "c2",
-					Source:   "t2",
-					Type:     sql.Int32,
-					Nullable: true,
-				},
-				{
-					Name:     "c3",
-					Source:   "t2",
-					Type:     sql.Int32,
-					Nullable: true,
-				},
-			}),
-			ChDefs: []*sql.CheckConstraint{
-				{
-					Expr: expression.NewEquals(
-						expression.NewUnresolvedColumn("c1"),
-						expression.NewUnresolvedColumn("c2"),
-					),
-					Enforced: true,
-				},
-				{
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("c1"),
-						expression.NewLiteral(int8(10), sql.Int8),
-					),
-					Enforced: true,
-				},
-				{
-					Name: "c2_positive",
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("c2"),
-						expression.NewLiteral(int8(0), sql.Int8),
-					),
-					Enforced: true,
-				},
-				{
-					Expr: expression.NewLessThan(
-						expression.NewUnresolvedColumn("c3"),
-						expression.NewLiteral(int8(100), sql.Int8),
-					),
-					Enforced: true,
-				},
-				{
-					Name: "c1_nonzero",
-					Expr: expression.NewEquals(
-						expression.NewUnresolvedColumn("c1"),
-						expression.NewLiteral(int8(0), sql.Int8),
-					),
-					Enforced: true,
-				},
-				{
-					Expr: expression.NewGreaterThan(
-						expression.NewUnresolvedColumn("c1"),
-						expression.NewUnresolvedColumn("c3"),
-					),
-					Enforced: true,
-				},
-			},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}),
-			ChDefs: []*sql.CheckConstraint{{
-				Name: "",
-				Expr: expression.NewGreaterThan(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral(int8(0), sql.Int8),
-				),
-				Enforced: true,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY, CONSTRAINT ch1 CHECK (a > 0))`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}),
-			ChDefs: []*sql.CheckConstraint{{
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD CONSTRAINT ch1 CHECK (a > 0)`,
+		plan: plan.NewAlterAddCheck(
+			plan.NewUnresolvedTable("t1", ""),
+			&sql.CheckConstraint{
 				Name: "ch1",
 				Expr: expression.NewGreaterThan(
 					expression.NewUnresolvedColumn("a"),
 					expression.NewLiteral(int8(0), sql.Int8),
 				),
 				Enforced: true,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) ENFORCED)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}),
-			ChDefs: []*sql.CheckConstraint{{
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 ADD CONSTRAINT CHECK (a > 0)`,
+		plan: plan.NewAlterAddCheck(
+			plan.NewUnresolvedTable("t1", ""),
+			&sql.CheckConstraint{
 				Name: "",
 				Expr: expression.NewGreaterThan(
 					expression.NewUnresolvedColumn("a"),
 					expression.NewLiteral(int8(0), sql.Int8),
 				),
 				Enforced: true,
-			}},
-		},
-	),
-	`CREATE TABLE t1(a INTEGER PRIMARY KEY CHECK (a > 0) NOT ENFORCED)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTableAbsent,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:       "a",
-				Type:       sql.Int32,
-				Nullable:   false,
-				PrimaryKey: true,
-			}}),
-			ChDefs: []*sql.CheckConstraint{{
-				Name: "",
-				Expr: expression.NewGreaterThan(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewLiteral(int8(0), sql.Int8),
-				),
-				Enforced: false,
-			}},
-		},
-	),
-	`CREATE TEMPORARY TABLE t1(a INTEGER, b TEXT)`: plan.NewCreateTable(
-		sql.UnresolvedDatabase(""),
-		"t1",
-		plan.IfNotExistsAbsent,
-		plan.IsTempTable,
-		&plan.TableSpec{
-			Schema: sql.NewPrimaryKeySchema(sql.Schema{{
-				Name:     "a",
-				Type:     sql.Int32,
-				Nullable: true,
-			}, {
-				Name:     "b",
-				Type:     sql.Text,
-				Nullable: true,
-			}}),
-		},
-	),
-	`CREATE TEMPORARY TABLE mytable AS SELECT * from othertable`: plan.NewCreateTableSelect(
-		sql.UnresolvedDatabase(""),
-		"mytable",
-		plan.NewProject([]sql.Expression{expression.NewStar()}, plan.NewUnresolvedTable("othertable", "")),
-		&plan.TableSpec{},
-		plan.IfNotExistsAbsent,
-		plan.IsTempTable),
-	`DROP TABLE curdb.foo;`: plan.NewDropTable(
-		[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, false,
-	),
-	`DROP TABLE t1, t2;`: plan.NewDropTable(
-		[]sql.Node{plan.NewUnresolvedTable("t1", ""), plan.NewUnresolvedTable("t2", "")}, false,
-	),
-	`DROP TABLE IF EXISTS curdb.foo;`: plan.NewDropTable(
-		[]sql.Node{plan.NewUnresolvedTable("foo", "curdb")}, true,
-	),
-	`DROP TABLE IF EXISTS curdb.foo, curdb.bar, curdb.baz;`: plan.NewDropTable(
-		[]sql.Node{plan.NewUnresolvedTable("foo", "curdb"), plan.NewUnresolvedTable("bar", "curdb"), plan.NewUnresolvedTable("baz", "curdb")}, true,
-	),
-	`RENAME TABLE foo TO bar`: plan.NewRenameTable(
-		sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-	),
-	`RENAME TABLE foo TO bar, baz TO qux`: plan.NewRenameTable(
-		sql.UnresolvedDatabase(""), []string{"foo", "baz"}, []string{"bar", "qux"},
-	),
-	`ALTER TABLE foo RENAME bar`: plan.NewRenameTable(
-		sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-	),
-	`ALTER TABLE foo RENAME TO bar`: plan.NewRenameTable(
-		sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-	),
-	`ALTER TABLE foo RENAME COLUMN bar TO baz`: plan.NewRenameColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("foo", ""), "bar", "baz",
-	),
-	`ALTER TABLE otherdb.mytable RENAME COLUMN i TO s`: plan.NewRenameColumn(
-		sql.UnresolvedDatabase("otherdb"),
-		plan.NewUnresolvedTable("mytable", "otherdb"), "i", "s",
-	),
-	`ALTER TABLE mytable RENAME COLUMN bar TO baz, RENAME COLUMN abc TO xyz`: plan.NewBlock(
-		[]sql.Node{
-			plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "bar", "baz"),
-			plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("mytable", ""), "abc", "xyz"),
-		},
-	),
-	`ALTER TABLE mytable ADD COLUMN bar INT NOT NULL`: plan.NewAddColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-			Name:     "bar",
-			Type:     sql.Int32,
-			Nullable: false,
-		}, nil,
-	),
-	`ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT 42 COMMENT 'hello' AFTER baz`: plan.NewAddColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-			Name:     "bar",
-			Type:     sql.Int32,
-			Nullable: false,
-			Comment:  "hello",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "42", nil, true),
-		}, &sql.ColumnOrder{AfterColumn: "baz"},
-	),
-	`ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT -42.0 COMMENT 'hello' AFTER baz`: plan.NewAddColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-			Name:     "bar",
-			Type:     sql.Int32,
-			Nullable: false,
-			Comment:  "hello",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "-42.0", nil, true),
-		}, &sql.ColumnOrder{AfterColumn: "baz"},
-	),
-	`ALTER TABLE mytable ADD COLUMN bar INT NOT NULL DEFAULT ((2+2)/2) COMMENT 'hello' AFTER baz`: plan.NewAddColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-			Name:     "bar",
-			Type:     sql.Int32,
-			Nullable: false,
-			Comment:  "hello",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "((2+2)/2)", nil, true),
-		}, &sql.ColumnOrder{AfterColumn: "baz"},
-	),
-	`ALTER TABLE mytable ADD COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello'`: plan.NewAddColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-			Name:     "bar",
-			Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
-			Nullable: true,
-			Comment:  "hello",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-		}, nil,
-	),
-	`ALTER TABLE mytable ADD COLUMN bar FLOAT NULL DEFAULT 32.0 COMMENT 'hello'`: plan.NewAddColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-			Name:     "bar",
-			Type:     sql.Float32,
-			Nullable: true,
-			Comment:  "hello",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "32.0", nil, true),
-		}, nil,
-	),
-	`ALTER TABLE mytable ADD COLUMN bar INT DEFAULT 1 FIRST`: plan.NewAddColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), &sql.Column{
-			Name:     "bar",
-			Type:     sql.Int32,
-			Nullable: true,
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
-		}, &sql.ColumnOrder{First: true},
-	),
-	`ALTER TABLE mydb.mytable ADD COLUMN bar INT DEFAULT 1 COMMENT 'otherdb'`: plan.NewAddColumn(
-		sql.UnresolvedDatabase("mydb"),
-		plan.NewUnresolvedTable("mytable", "mydb"), &sql.Column{
-			Name:     "bar",
-			Type:     sql.Int32,
-			Nullable: true,
-			Comment:  "otherdb",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), "1", nil, true),
-		}, nil,
-	),
-	`ALTER TABLE mytable ADD INDEX (v1)`: plan.NewAlterCreateIndex(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""),
-		"",
-		sql.IndexUsing_BTree,
-		sql.IndexConstraint_None,
-		[]sql.IndexColumn{{"v1", 0}},
-		"",
-	),
-	`ALTER TABLE mytable DROP COLUMN bar`: plan.NewDropColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("mytable", ""), "bar",
-	),
-	`ALTER TABLE otherdb.mytable DROP COLUMN bar`: plan.NewDropColumn(
-		sql.UnresolvedDatabase("otherdb"),
-		plan.NewUnresolvedTable("mytable", "otherdb"), "bar",
-	),
-	`ALTER TABLE tabletest MODIFY COLUMN bar VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`: plan.NewModifyColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
-			Name:     "bar",
-			Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
-			Nullable: true,
-			Comment:  "hello",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-		}, &sql.ColumnOrder{First: true},
-	),
-	`ALTER TABLE tabletest CHANGE COLUMN bar baz VARCHAR(10) NULL DEFAULT 'string' COMMENT 'hello' FIRST`: plan.NewModifyColumn(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("tabletest", ""), "bar", &sql.Column{
-			Name:     "baz",
-			Type:     sql.MustCreateString(sqltypes.VarChar, 10, sql.Collation_Invalid),
-			Nullable: true,
-			Comment:  "hello",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-		}, &sql.ColumnOrder{First: true},
-	),
-	`ALTER TABLE mydb.mytable MODIFY COLUMN col1 VARCHAR(20) NULL DEFAULT 'string' COMMENT 'changed'`: plan.NewModifyColumn(
-		sql.UnresolvedDatabase("mydb"),
-		plan.NewUnresolvedTable("mytable", "mydb"), "col1", &sql.Column{
-			Name:     "col1",
-			Type:     sql.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Invalid),
-			Nullable: true,
-			Comment:  "changed",
-			Default:  MustStringToColumnDefaultValue(sql.NewEmptyContext(), `"string"`, nil, true),
-		}, nil,
-	),
-	`ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b)`: plan.NewAlterAddForeignKey(
-		&sql.ForeignKeyConstraint{
-			Name:           "",
-			Database:       "",
-			Table:          "t1",
-			Columns:        []string{"b_id"},
-			ParentDatabase: "",
-			ParentTable:    "t0",
-			ParentColumns:  []string{"b"},
-			OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-			OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-			IsResolved:     false,
-		},
-	),
-	`ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id) REFERENCES t0(b)`: plan.NewAlterAddForeignKey(
-		&sql.ForeignKeyConstraint{
-			Name:           "fk_name",
-			Database:       "",
-			Table:          "t1",
-			Columns:        []string{"b_id"},
-			ParentDatabase: "",
-			ParentTable:    "t0",
-			ParentColumns:  []string{"b"},
-			OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-			OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-			IsResolved:     false,
-		},
-	),
-	`ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE CASCADE`: plan.NewAlterAddForeignKey(
-		&sql.ForeignKeyConstraint{
-			Name:           "",
-			Database:       "",
-			Table:          "t1",
-			Columns:        []string{"b_id"},
-			ParentDatabase: "",
-			ParentTable:    "t0",
-			ParentColumns:  []string{"b"},
-			OnUpdate:       sql.ForeignKeyReferentialAction_Cascade,
-			OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-			IsResolved:     false,
-		},
-	),
-	`ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON DELETE RESTRICT`: plan.NewAlterAddForeignKey(
-		&sql.ForeignKeyConstraint{
-			Name:           "",
-			Database:       "",
-			Table:          "t1",
-			Columns:        []string{"b_id"},
-			ParentDatabase: "",
-			ParentTable:    "t0",
-			ParentColumns:  []string{"b"},
-			OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-			OnDelete:       sql.ForeignKeyReferentialAction_Restrict,
-			IsResolved:     false,
-		},
-	),
-	`ALTER TABLE t1 ADD FOREIGN KEY (b_id) REFERENCES t0(b) ON UPDATE SET NULL ON DELETE NO ACTION`: plan.NewAlterAddForeignKey(
-		&sql.ForeignKeyConstraint{
-			Name:           "",
-			Database:       "",
-			Table:          "t1",
-			Columns:        []string{"b_id"},
-			ParentDatabase: "",
-			ParentTable:    "t0",
-			ParentColumns:  []string{"b"},
-			OnUpdate:       sql.ForeignKeyReferentialAction_SetNull,
-			OnDelete:       sql.ForeignKeyReferentialAction_NoAction,
-			IsResolved:     false,
-		},
-	),
-	`ALTER TABLE t1 ADD FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c)`: plan.NewAlterAddForeignKey(
-		&sql.ForeignKeyConstraint{
-			Name:           "",
-			Database:       "",
-			Table:          "t1",
-			Columns:        []string{"b_id", "c_id"},
-			ParentDatabase: "",
-			ParentTable:    "t0",
-			ParentColumns:  []string{"b", "c"},
-			OnUpdate:       sql.ForeignKeyReferentialAction_DefaultAction,
-			OnDelete:       sql.ForeignKeyReferentialAction_DefaultAction,
-			IsResolved:     false,
-		},
-	),
-	`ALTER TABLE t1 ADD CONSTRAINT fk_name FOREIGN KEY (b_id, c_id) REFERENCES t0(b, c) ON UPDATE RESTRICT ON DELETE CASCADE`: plan.NewAlterAddForeignKey(
-		&sql.ForeignKeyConstraint{
-			Name:           "fk_name",
-			Database:       "",
-			Table:          "t1",
-			Columns:        []string{"b_id", "c_id"},
-			ParentDatabase: "",
-			ParentTable:    "t0",
-			ParentColumns:  []string{"b", "c"},
-			OnUpdate:       sql.ForeignKeyReferentialAction_Restrict,
-			OnDelete:       sql.ForeignKeyReferentialAction_Cascade,
-			IsResolved:     false,
-		},
-	),
-	`ALTER TABLE t1 ADD CHECK (a > 0)`: plan.NewAlterAddCheck(
-		plan.NewUnresolvedTable("t1", ""),
-		&sql.CheckConstraint{
-			Name: "",
-			Expr: expression.NewGreaterThan(
-				expression.NewUnresolvedColumn("a"),
-				expression.NewLiteral(int8(0), sql.Int8),
-			),
-			Enforced: true,
-		},
-	),
-	`ALTER TABLE t1 ADD CONSTRAINT ch1 CHECK (a > 0)`: plan.NewAlterAddCheck(
-		plan.NewUnresolvedTable("t1", ""),
-		&sql.CheckConstraint{
-			Name: "ch1",
-			Expr: expression.NewGreaterThan(
-				expression.NewUnresolvedColumn("a"),
-				expression.NewLiteral(int8(0), sql.Int8),
-			),
-			Enforced: true,
-		},
-	),
-	`ALTER TABLE t1 ADD CONSTRAINT CHECK (a > 0)`: plan.NewAlterAddCheck(
-		plan.NewUnresolvedTable("t1", ""),
-		&sql.CheckConstraint{
-			Name: "",
-			Expr: expression.NewGreaterThan(
-				expression.NewUnresolvedColumn("a"),
-				expression.NewLiteral(int8(0), sql.Int8),
-			),
-			Enforced: true,
-		},
-	),
-	`ALTER TABLE t1 DROP FOREIGN KEY fk_name`: plan.NewAlterDropForeignKey("", "t1", "fk_name"),
-	`ALTER TABLE t1 DROP CONSTRAINT fk_name`: plan.NewDropConstraint(
-		plan.NewUnresolvedTable("t1", ""),
-		"fk_name",
-	),
-	`DESCRIBE foo;`: plan.NewShowColumns(false,
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`DESC foo;`: plan.NewShowColumns(false,
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	"DESCRIBE FORMAT=tree SELECT * FROM foo": plan.NewDescribeQuery(
-		"tree", plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
+			},
+		),
+	},
+	{
+		input: `ALTER TABLE t1 DROP FOREIGN KEY fk_name`,
+		plan: plan.NewAlterDropForeignKey("", "t1", "fk_name"),
+	},
+	{
+		input: `ALTER TABLE t1 DROP CONSTRAINT fk_name`,
+		plan: plan.NewDropConstraint(
+			plan.NewUnresolvedTable("t1", ""),
+			"fk_name",
+		),
+	},
+	{
+		input: `DESCRIBE foo;`,
+		plan: plan.NewShowColumns(false,
 			plan.NewUnresolvedTable("foo", ""),
-		)),
-	"DESC FORMAT=tree SELECT * FROM foo": plan.NewDescribeQuery(
-		"tree", plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
+		),
+	},
+	{
+		input: `DESC foo;`,
+		plan: plan.NewShowColumns(false,
 			plan.NewUnresolvedTable("foo", ""),
-		)),
-	"EXPLAIN FORMAT=tree SELECT * FROM foo": plan.NewDescribeQuery(
-		"tree", plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewUnresolvedTable("foo", "")),
-	),
-	"DESCRIBE SELECT * FROM foo": plan.NewDescribeQuery(
-		"tree", plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewUnresolvedTable("foo", ""),
-		)),
-	"DESC SELECT * FROM foo": plan.NewDescribeQuery(
-		"tree", plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewUnresolvedTable("foo", ""),
-		)),
-	"EXPLAIN SELECT * FROM foo": plan.NewDescribeQuery(
-		"tree", plan.NewProject(
-			[]sql.Expression{expression.NewStar()},
-			plan.NewUnresolvedTable("foo", "")),
-	),
-	`SELECT foo, bar FROM foo;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT foo IS NULL, bar IS NOT NULL FROM foo;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewIsNull(expression.NewUnresolvedColumn("foo")),
-			expression.NewAlias("bar IS NOT NULL",
-				expression.NewNot(expression.NewIsNull(expression.NewUnresolvedColumn("bar"))),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT foo IS TRUE, bar IS NOT FALSE FROM foo;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewIsTrue(expression.NewUnresolvedColumn("foo")),
-			expression.NewAlias("bar IS NOT FALSE",
-				expression.NewNot(expression.NewIsFalse(expression.NewUnresolvedColumn("bar"))),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT foo AS bar FROM foo;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT foo AS bAz FROM foo;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("bAz", expression.NewUnresolvedColumn("foo")),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT foo AS bar FROM foo AS OF '2019-01-01' AS baz;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
-		},
-		plan.NewTableAlias("baz",
-			plan.NewUnresolvedTableAsOf("foo", "",
-				expression.NewLiteral("2019-01-01", sql.LongText))),
-	),
-	`SELECT foo, bar FROM foo WHERE foo = bar;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewFilter(
-			expression.NewEquals(
+		),
+	},
+	{
+		input: "DESCRIBE FORMAT=tree SELECT * FROM foo",
+		plan: plan.NewDescribeQuery(
+			"tree", plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewUnresolvedTable("foo", ""),
+			)),
+	},
+	{
+		input: "DESC FORMAT=tree SELECT * FROM foo",
+		plan: plan.NewDescribeQuery(
+			"tree", plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewUnresolvedTable("foo", ""),
+			)),
+	},
+	{
+		input: "EXPLAIN FORMAT=tree SELECT * FROM foo",
+		plan: plan.NewDescribeQuery(
+			"tree", plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewUnresolvedTable("foo", "")),
+		),
+	},
+	{
+		input: "DESCRIBE SELECT * FROM foo",
+		plan: plan.NewDescribeQuery(
+			"tree", plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewUnresolvedTable("foo", ""),
+			)),
+	},
+	{
+		input: "DESC SELECT * FROM foo",
+		plan: plan.NewDescribeQuery(
+			"tree", plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewUnresolvedTable("foo", ""),
+			)),
+	},
+	{
+		input: "EXPLAIN SELECT * FROM foo",
+		plan: plan.NewDescribeQuery(
+			"tree", plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewUnresolvedTable("foo", "")),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM foo;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
 				expression.NewUnresolvedColumn("foo"),
 				expression.NewUnresolvedColumn("bar"),
-			),
+			},
 			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT foo, bar FROM foo WHERE foo = 'bar';`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewFilter(
-			expression.NewEquals(
+	},
+	{
+		input: `SELECT foo IS NULL, bar IS NOT NULL FROM foo;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewIsNull(expression.NewUnresolvedColumn("foo")),
+				expression.NewAlias("bar IS NOT NULL",
+					expression.NewNot(expression.NewIsNull(expression.NewUnresolvedColumn("bar"))),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT foo IS TRUE, bar IS NOT FALSE FROM foo;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewIsTrue(expression.NewUnresolvedColumn("foo")),
+				expression.NewAlias("bar IS NOT FALSE",
+					expression.NewNot(expression.NewIsFalse(expression.NewUnresolvedColumn("bar"))),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT foo AS bar FROM foo;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT foo AS bAz FROM foo;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("bAz", expression.NewUnresolvedColumn("foo")),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT foo AS bar FROM foo AS OF '2019-01-01' AS baz;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("bar", expression.NewUnresolvedColumn("foo")),
+			},
+			plan.NewTableAlias("baz",
+				plan.NewUnresolvedTableAsOf("foo", "",
+					expression.NewLiteral("2019-01-01", sql.LongText))),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM foo WHERE foo = bar;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
 				expression.NewUnresolvedColumn("foo"),
-				expression.NewLiteral("bar", sql.LongText),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				),
+				plan.NewUnresolvedTable("foo", ""),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT foo, bar FROM foo WHERE foo = ?;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewFilter(
-			expression.NewEquals(
+	},
+	{
+		input: `SELECT foo, bar FROM foo WHERE foo = 'bar';`,
+		plan: plan.NewProject(
+			[]sql.Expression{
 				expression.NewUnresolvedColumn("foo"),
-				expression.NewBindVar("v1"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewLiteral("bar", sql.LongText),
+				),
+				plan.NewUnresolvedTable("foo", ""),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT * FROM (SELECT * FROM foo WHERE bar = ?) a;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewSubqueryAlias(
-			"a",
-			"select * from foo where bar = :v1",
-			plan.NewProject(
-				[]sql.Expression{
-					expression.NewStar(),
-				},
-				plan.NewFilter(
-					expression.NewEquals(
-						expression.NewUnresolvedColumn("bar"),
-						expression.NewBindVar("v1"),
+	},
+	{
+		input: `SELECT foo, bar FROM foo WHERE foo = ?;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewBindVar("v1"),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM (SELECT * FROM foo WHERE bar = ?) a;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewSubqueryAlias(
+				"a",
+				"select * from foo where bar = :v1",
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewStar(),
+					},
+					plan.NewFilter(
+						expression.NewEquals(
+							expression.NewUnresolvedColumn("bar"),
+							expression.NewBindVar("v1"),
+						),
+						plan.NewUnresolvedTable("foo", ""),
 					),
-					plan.NewUnresolvedTable("foo", ""),
 				),
 			),
 		),
-	),
-	`SELECT * FROM (values row(1,2), row(3,4)) a;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewValueDerivedTable(
-			plan.NewValues([][]sql.Expression{
-				{
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(2), sql.Int8),
-				},
-				{
-					expression.NewLiteral(int8(3), sql.Int8),
-					expression.NewLiteral(int8(4), sql.Int8),
-				},
-			}),
-			"a"),
-	),
-	`SELECT * FROM (values row(1+1,2+2), row(rand(),concat("a","b"))) a;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewValueDerivedTable(
-			plan.NewValues([][]sql.Expression{
-				{
-					expression.NewArithmetic(
-						expression.NewLiteral(int8(1), sql.Int8),
-						expression.NewLiteral(int8(1), sql.Int8),
-						"+",
-					),
-					expression.NewArithmetic(
-						expression.NewLiteral(int8(2), sql.Int8),
-						expression.NewLiteral(int8(2), sql.Int8),
-						"+",
-					),
-				},
-				{
-					expression.NewUnresolvedFunction("rand", false, nil),
-					expression.NewUnresolvedFunction("concat", false, nil, expression.NewLiteral("a", sql.LongText), expression.NewLiteral("b", sql.LongText)),
-				},
-			}),
-			"a"),
-	),
-	`SELECT column_0 FROM (values row(1,2), row(3,4)) a limit 1`: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
-		plan.NewProject(
+	},
+	{
+		input: `SELECT * FROM (values row(1,2), row(3,4)) a;`,
+		plan: plan.NewProject(
 			[]sql.Expression{
-				expression.NewUnresolvedColumn("column_0"),
+				expression.NewStar(),
 			},
 			plan.NewValueDerivedTable(
 				plan.NewValues([][]sql.Expression{
@@ -1474,73 +1696,76 @@ CREATE TABLE t2
 				}),
 				"a"),
 		),
-	),
-	`SELECT foo, bar FROM foo WHERE foo <=> bar;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewFilter(
-			expression.NewNullSafeEquals(
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
+	},
+	{
+		input: `SELECT * FROM (values row(1+1,2+2), row(rand(),concat("a","b"))) a;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewValueDerivedTable(
+				plan.NewValues([][]sql.Expression{
+					{
+						expression.NewArithmetic(
+							expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewLiteral(int8(1), sql.Int8),
+							"+",
+						),
+						expression.NewArithmetic(
+							expression.NewLiteral(int8(2), sql.Int8),
+							expression.NewLiteral(int8(2), sql.Int8),
+							"+",
+						),
+					},
+					{
+						expression.NewUnresolvedFunction("rand", false, nil),
+						expression.NewUnresolvedFunction("concat", false, nil, expression.NewLiteral("a", sql.LongText), expression.NewLiteral("b", sql.LongText)),
+					},
+				}),
+				"a"),
+		),
+	},
+	{
+		input: `SELECT column_0 FROM (values row(1,2), row(3,4)) a limit 1`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("column_0"),
+				},
+				plan.NewValueDerivedTable(
+					plan.NewValues([][]sql.Expression{
+						{
+							expression.NewLiteral(int8(1), sql.Int8),
+							expression.NewLiteral(int8(2), sql.Int8),
+						},
+						{
+							expression.NewLiteral(int8(3), sql.Int8),
+							expression.NewLiteral(int8(4), sql.Int8),
+						},
+					}),
+					"a"),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT foo, bar FROM foo WHERE foo = :var;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewFilter(
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewBindVar("var"),
-			),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT * FROM foo WHERE foo != 'bar';`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewFilter(
-			expression.NewNot(expression.NewEquals(
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewLiteral("bar", sql.LongText),
-			)),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT foo, bar FROM foo LIMIT 10;`: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
-		plan.NewProject(
+	},
+	{
+		input: `SELECT foo, bar FROM foo WHERE foo <=> bar;`,
+		plan: plan.NewProject(
 			[]sql.Expression{
 				expression.NewUnresolvedColumn("foo"),
 				expression.NewUnresolvedColumn("bar"),
 			},
-			plan.NewUnresolvedTable("foo", ""),
+			plan.NewFilter(
+				expression.NewNullSafeEquals(
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
 		),
-	),
-	`SELECT foo, bar FROM foo ORDER BY baz DESC;`: plan.NewSort(
-		[]sql.SortField{
-			{
-				Column:       expression.NewUnresolvedColumn("baz"),
-				Column2:      expression.NewUnresolvedColumn("baz"),
-				Order:        sql.Descending,
-				NullOrdering: sql.NullsFirst,
-			},
-		},
-		plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT foo, bar FROM foo WHERE foo = bar LIMIT 10;`: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
-		plan.NewProject(
+	},
+	{
+		input: `SELECT foo, bar FROM foo WHERE foo = :var;`,
+		plan: plan.NewProject(
 			[]sql.Expression{
 				expression.NewUnresolvedColumn("foo"),
 				expression.NewUnresolvedColumn("bar"),
@@ -1548,14 +1773,42 @@ CREATE TABLE t2
 			plan.NewFilter(
 				expression.NewEquals(
 					expression.NewUnresolvedColumn("foo"),
-					expression.NewUnresolvedColumn("bar"),
+					expression.NewBindVar("var"),
 				),
 				plan.NewUnresolvedTable("foo", ""),
 			),
 		),
-	),
-	`SELECT foo, bar FROM foo ORDER BY baz DESC LIMIT 1;`: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
-		plan.NewSort(
+	},
+	{
+		input: `SELECT * FROM foo WHERE foo != 'bar';`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewFilter(
+				expression.NewNot(expression.NewEquals(
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewLiteral("bar", sql.LongText),
+				)),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM foo LIMIT 10;`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM foo ORDER BY baz DESC;`,
+		plan: plan.NewSort(
 			[]sql.SortField{
 				{
 					Column:       expression.NewUnresolvedColumn("baz"),
@@ -1572,17 +1825,10 @@ CREATE TABLE t2
 				plan.NewUnresolvedTable("foo", ""),
 			),
 		),
-	),
-	`SELECT foo, bar FROM foo WHERE qux = 1 ORDER BY baz DESC LIMIT 1;`: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
-		plan.NewSort(
-			[]sql.SortField{
-				{
-					Column:       expression.NewUnresolvedColumn("baz"),
-					Column2:      expression.NewUnresolvedColumn("baz"),
-					Order:        sql.Descending,
-					NullOrdering: sql.NullsFirst,
-				},
-			},
+	},
+	{
+		input: `SELECT foo, bar FROM foo WHERE foo = bar LIMIT 10;`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8),
 			plan.NewProject(
 				[]sql.Expression{
 					expression.NewUnresolvedColumn("foo"),
@@ -1590,1146 +1836,1719 @@ CREATE TABLE t2
 				},
 				plan.NewFilter(
 					expression.NewEquals(
-						expression.NewUnresolvedColumn("qux"),
-						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
 					),
 					plan.NewUnresolvedTable("foo", ""),
 				),
 			),
 		),
-	),
-	`SELECT foo, bar FROM t1, t2;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewCrossJoin(
-			plan.NewUnresolvedTable("t1", ""),
-			plan.NewUnresolvedTable("t2", ""),
-		),
-	),
-	`SELECT foo, bar FROM t1 JOIN t2;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewCrossJoin(
-			plan.NewUnresolvedTable("t1", ""),
-			plan.NewUnresolvedTable("t2", ""),
-		),
-	),
-	`SELECT foo, bar FROM t1 GROUP BY foo, bar;`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewUnresolvedTable("t1", ""),
-	),
-	`SELECT foo, bar FROM t1 GROUP BY 1, 2;`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("foo"),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewUnresolvedTable("t1", ""),
-	),
-	`SELECT COUNT(*) FROM t1;`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("COUNT(*)",
-				expression.NewUnresolvedFunction("count", true, nil,
-					expression.NewStar()),
+	},
+	{
+		input: `SELECT foo, bar FROM foo ORDER BY baz DESC LIMIT 1;`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
+			plan.NewSort(
+				[]sql.SortField{
+					{
+						Column:       expression.NewUnresolvedColumn("baz"),
+						Column2:      expression.NewUnresolvedColumn("baz"),
+						Order:        sql.Descending,
+						NullOrdering: sql.NullsFirst,
+					},
+				},
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					},
+					plan.NewUnresolvedTable("foo", ""),
+				),
 			),
-		},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("t1", ""),
-	),
-	`SELECT a FROM t1 where a regexp '.*test.*';`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-		},
-		plan.NewFilter(
-			expression.NewRegexp(
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM foo WHERE qux = 1 ORDER BY baz DESC LIMIT 1;`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(1), sql.Int8),
+			plan.NewSort(
+				[]sql.SortField{
+					{
+						Column:       expression.NewUnresolvedColumn("baz"),
+						Column2:      expression.NewUnresolvedColumn("baz"),
+						Order:        sql.Descending,
+						NullOrdering: sql.NullsFirst,
+					},
+				},
+				plan.NewProject(
+					[]sql.Expression{
+						expression.NewUnresolvedColumn("foo"),
+						expression.NewUnresolvedColumn("bar"),
+					},
+					plan.NewFilter(
+						expression.NewEquals(
+							expression.NewUnresolvedColumn("qux"),
+							expression.NewLiteral(int8(1), sql.Int8),
+						),
+						plan.NewUnresolvedTable("foo", ""),
+					),
+				),
+			),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM t1, t2;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewCrossJoin(
+				plan.NewUnresolvedTable("t1", ""),
+				plan.NewUnresolvedTable("t2", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM t1 JOIN t2;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewCrossJoin(
+				plan.NewUnresolvedTable("t1", ""),
+				plan.NewUnresolvedTable("t2", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM t1 GROUP BY foo, bar;`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewUnresolvedTable("t1", ""),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM t1 GROUP BY 1, 2;`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("foo"),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewUnresolvedTable("t1", ""),
+		),
+	},
+	{
+		input: `SELECT COUNT(*) FROM t1;`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias("COUNT(*)",
+					expression.NewUnresolvedFunction("count", true, nil,
+						expression.NewStar()),
+				),
+			},
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("t1", ""),
+		),
+	},
+	{
+		input: `SELECT a FROM t1 where a regexp '.*test.*';`,
+		plan: plan.NewProject(
+			[]sql.Expression{
 				expression.NewUnresolvedColumn("a"),
-				expression.NewLiteral(".*test.*", sql.LongText),
-			),
-			plan.NewUnresolvedTable("t1", ""),
-		),
-	),
-	`SELECT a FROM t1 where a regexp '*main.go';`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-		},
-		plan.NewFilter(
-			expression.NewRegexp(
-				expression.NewUnresolvedColumn("a"),
-				expression.NewLiteral("*main.go", sql.LongText),
-			),
-			plan.NewUnresolvedTable("t1", ""),
-		),
-	),
-	`SELECT a FROM t1 where a not regexp '.*test.*';`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-		},
-		plan.NewFilter(
-			expression.NewNot(
+			},
+			plan.NewFilter(
 				expression.NewRegexp(
 					expression.NewUnresolvedColumn("a"),
 					expression.NewLiteral(".*test.*", sql.LongText),
 				),
+				plan.NewUnresolvedTable("t1", ""),
 			),
-			plan.NewUnresolvedTable("t1", ""),
 		),
-	),
-	`INSERT INTO t1 (col1, col2) VALUES ('a', 1)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-		expression.NewLiteral("a", sql.LongText),
-		expression.NewLiteral(int8(1), sql.Int8),
-	}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	`INSERT INTO mydb.t1 (col1, col2) VALUES ('a', 1)`: plan.NewInsertInto(sql.UnresolvedDatabase("mydb"), plan.NewUnresolvedTable("t1", "mydb"), plan.NewValues([][]sql.Expression{{
-		expression.NewLiteral("a", sql.LongText),
-		expression.NewLiteral(int8(1), sql.Int8),
-	}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	`INSERT INTO t1 (col1, col2) VALUES (?, ?)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-		expression.NewBindVar("v1"),
-		expression.NewBindVar("v2"),
-	}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	`INSERT INTO t1 VALUES (b'0111')`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-		expression.NewLiteral(uint64(7), sql.Uint64),
-	}}), false, []string{}, []sql.Expression{}, false),
-	`INSERT INTO t1 (col1, col2) VALUES ('a', DEFAULT)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-		expression.NewLiteral("a", sql.LongText),
-		&expression.DefaultColumn{},
-	}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
-	`INSERT INTO test (decimal_col) VALUES (11981.5923291839784651)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
-		expression.NewLiteral(decimal.RequireFromString("11981.5923291839784651"), sql.MustCreateDecimalType(21, 16)),
-	}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
-	`INSERT INTO test (decimal_col) VALUES (119815923291839784651.11981592329183978465111981592329183978465144)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
-		expression.NewLiteral("119815923291839784651.11981592329183978465111981592329183978465144", sql.LongText),
-	}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
-	`UPDATE t1 SET col1 = ?, col2 = ? WHERE id = ?`: plan.NewUpdate(plan.NewFilter(
-		expression.NewEquals(expression.NewUnresolvedColumn("id"), expression.NewBindVar("v3")),
-		plan.NewUnresolvedTable("t1", ""),
-	), false, []sql.Expression{
-		expression.NewSetField(expression.NewUnresolvedColumn("col1"), expression.NewBindVar("v1")),
-		expression.NewSetField(expression.NewUnresolvedColumn("col2"), expression.NewBindVar("v2")),
-	}),
-	`REPLACE INTO t1 (col1, col2) VALUES ('a', 1)`: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
-		expression.NewLiteral("a", sql.LongText),
-		expression.NewLiteral(int8(1), sql.Int8),
-	}}), true, []string{"col1", "col2"}, []sql.Expression{}, false),
-	`SHOW TABLES`:                           plan.NewShowTables(sql.UnresolvedDatabase(""), false, nil),
-	`SHOW FULL TABLES`:                      plan.NewShowTables(sql.UnresolvedDatabase(""), true, nil),
-	`SHOW TABLES FROM foo`:                  plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
-	`SHOW TABLES IN foo`:                    plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
-	`SHOW FULL TABLES FROM foo`:             plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
-	`SHOW FULL TABLES IN foo`:               plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
-	`SHOW TABLES AS OF 'abc'`:               plan.NewShowTables(sql.UnresolvedDatabase(""), false, expression.NewLiteral("abc", sql.LongText)),
-	`SHOW FULL TABLES AS OF 'abc'`:          plan.NewShowTables(sql.UnresolvedDatabase(""), true, expression.NewLiteral("abc", sql.LongText)),
-	`SHOW TABLES FROM foo AS OF 'abc'`:      plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, expression.NewLiteral("abc", sql.LongText)),
-	`SHOW FULL TABLES FROM foo AS OF 'abc'`: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
-	`SHOW FULL TABLES IN foo AS OF 'abc'`:   plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
-	`SHOW TABLES FROM mydb LIKE 'foo'`: plan.NewFilter(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("Tables_in_mydb"),
-			expression.NewLiteral("foo", sql.LongText),
-			nil,
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, nil),
-	),
-	`SHOW TABLES FROM mydb AS OF 'abc' LIKE 'foo'`: plan.NewFilter(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("Tables_in_mydb"),
-			expression.NewLiteral("foo", sql.LongText),
-			nil,
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, expression.NewLiteral("abc", sql.LongText)),
-	),
-	"SHOW TABLES FROM bar WHERE `Tables_in_bar` = 'foo'": plan.NewFilter(
-		expression.NewEquals(
-			expression.NewUnresolvedColumn("Tables_in_bar"),
-			expression.NewLiteral("foo", sql.LongText),
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("bar"), false, nil),
-	),
-	`SHOW FULL TABLES FROM mydb LIKE 'foo'`: plan.NewFilter(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("Tables_in_mydb"),
-			expression.NewLiteral("foo", sql.LongText),
-			nil,
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("mydb"), true, nil),
-	),
-	"SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'foo'": plan.NewFilter(
-		expression.NewEquals(
-			expression.NewUnresolvedColumn("Tables_in_bar"),
-			expression.NewLiteral("foo", sql.LongText),
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
-	),
-	`SHOW FULL TABLES FROM bar LIKE 'foo'`: plan.NewFilter(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("Tables_in_bar"),
-			expression.NewLiteral("foo", sql.LongText),
-			nil,
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
-	),
-	`SHOW FULL TABLES FROM bar AS OF 'abc' LIKE 'foo'`: plan.NewFilter(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("Tables_in_bar"),
-			expression.NewLiteral("foo", sql.LongText),
-			nil,
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, expression.NewLiteral("abc", sql.LongText)),
-	),
-	"SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'test'": plan.NewFilter(
-		expression.NewEquals(
-			expression.NewUnresolvedColumn("Tables_in_bar"),
-			expression.NewLiteral("test", sql.LongText),
-		),
-		plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
-	),
-	`SELECT DISTINCT foo, bar FROM foo;`: plan.NewDistinct(
-		plan.NewProject(
+	},
+	{
+		input: `SELECT a FROM t1 where a regexp '*main.go';`,
+		plan: plan.NewProject(
 			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT * FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT foo, bar FROM foo LIMIT 2 OFFSET 5;`: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
-		plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		)),
-	),
-	`SELECT foo, bar FROM foo LIMIT 5,2;`: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
-		plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("foo"),
-				expression.NewUnresolvedColumn("bar"),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		)),
-	),
-	`SELECT * FROM foo WHERE (a = 1)`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewFilter(
-			expression.NewEquals(
 				expression.NewUnresolvedColumn("a"),
-				expression.NewLiteral(int8(1), sql.Int8),
-			),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT * FROM foo, bar, baz, qux`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewCrossJoin(
-			plan.NewCrossJoin(
-				plan.NewCrossJoin(
-					plan.NewUnresolvedTable("foo", ""),
-					plan.NewUnresolvedTable("bar", ""),
-				),
-				plan.NewUnresolvedTable("baz", ""),
-			),
-			plan.NewUnresolvedTable("qux", ""),
-		),
-	),
-	`SELECT * FROM foo join bar join baz join qux`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewCrossJoin(
-			plan.NewCrossJoin(
-				plan.NewCrossJoin(
-					plan.NewUnresolvedTable("foo", ""),
-					plan.NewUnresolvedTable("bar", ""),
-				),
-				plan.NewUnresolvedTable("baz", ""),
-			),
-			plan.NewUnresolvedTable("qux", ""),
-		),
-	),
-	`SELECT * FROM foo WHERE a = b AND c = d`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewAnd(
-				expression.NewEquals(
+			},
+			plan.NewFilter(
+				expression.NewRegexp(
 					expression.NewUnresolvedColumn("a"),
-					expression.NewUnresolvedColumn("b"),
+					expression.NewLiteral("*main.go", sql.LongText),
 				),
-				expression.NewEquals(
-					expression.NewUnresolvedColumn("c"),
-					expression.NewUnresolvedColumn("d"),
-				),
+				plan.NewUnresolvedTable("t1", ""),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT * FROM foo WHERE a = b OR c = d`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewOr(
-				expression.NewEquals(
-					expression.NewUnresolvedColumn("a"),
-					expression.NewUnresolvedColumn("b"),
+	},
+	{
+		input: `SELECT a FROM t1 where a not regexp '.*test.*';`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+			},
+			plan.NewFilter(
+				expression.NewNot(
+					expression.NewRegexp(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewLiteral(".*test.*", sql.LongText),
+					),
 				),
-				expression.NewEquals(
-					expression.NewUnresolvedColumn("c"),
-					expression.NewUnresolvedColumn("d"),
-				),
+				plan.NewUnresolvedTable("t1", ""),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT * FROM foo as bar`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewTableAlias(
-			"bar",
-			plan.NewUnresolvedTable("foo", ""),
+	},
+	{
+		input: `INSERT INTO t1 (col1, col2) VALUES ('a', 1)`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral("a", sql.LongText),
+			expression.NewLiteral(int8(1), sql.Int8),
+		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+	},
+	{
+		input: `INSERT INTO mydb.t1 (col1, col2) VALUES ('a', 1)`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase("mydb"), plan.NewUnresolvedTable("t1", "mydb"), plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral("a", sql.LongText),
+			expression.NewLiteral(int8(1), sql.Int8),
+		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+	},
+	{
+		input: `INSERT INTO t1 (col1, col2) VALUES (?, ?)`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+			expression.NewBindVar("v1"),
+			expression.NewBindVar("v2"),
+		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+	},
+	{
+		input: `INSERT INTO t1 VALUES (b'0111')`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral(uint64(7), sql.Uint64),
+		}}), false, []string{}, []sql.Expression{}, false),
+	},
+	{
+		input: `INSERT INTO t1 (col1, col2) VALUES ('a', DEFAULT)`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral("a", sql.LongText),
+			&expression.DefaultColumn{},
+		}}), false, []string{"col1", "col2"}, []sql.Expression{}, false),
+	},
+	{
+		input: `INSERT INTO test (decimal_col) VALUES (11981.5923291839784651)`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral(decimal.RequireFromString("11981.5923291839784651"), sql.MustCreateDecimalType(21, 16)),
+		}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
+	},
+	{
+		input: `INSERT INTO test (decimal_col) VALUES (119815923291839784651.11981592329183978465111981592329183978465144)`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("test", ""), plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral("119815923291839784651.11981592329183978465111981592329183978465144", sql.LongText),
+		}}), false, []string{"decimal_col"}, []sql.Expression{}, false),
+	},
+	{
+		input: `UPDATE t1 SET col1 = ?, col2 = ? WHERE id = ?`,
+		plan: plan.NewUpdate(plan.NewFilter(
+			expression.NewEquals(expression.NewUnresolvedColumn("id"), expression.NewBindVar("v3")),
+			plan.NewUnresolvedTable("t1", ""),
+		), false, []sql.Expression{
+			expression.NewSetField(expression.NewUnresolvedColumn("col1"), expression.NewBindVar("v1")),
+			expression.NewSetField(expression.NewUnresolvedColumn("col2"), expression.NewBindVar("v2")),
+		}),
+	},
+	{
+		input: `REPLACE INTO t1 (col1, col2) VALUES ('a', 1)`,
+		plan: plan.NewInsertInto(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t1", ""), plan.NewValues([][]sql.Expression{{
+			expression.NewLiteral("a", sql.LongText),
+			expression.NewLiteral(int8(1), sql.Int8),
+		}}), true, []string{"col1", "col2"}, []sql.Expression{}, false),
+	},
+	{
+		input: `SHOW TABLES`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), false, nil),
+	},
+	{
+		input: `SHOW FULL TABLES`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), true, nil),
+	},
+	{
+		input: `SHOW TABLES FROM foo`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
+	},
+	{
+		input: `SHOW TABLES IN foo`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, nil),
+	},
+	{
+		input: `SHOW FULL TABLES FROM foo`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
+	},
+	{
+		input: `SHOW FULL TABLES IN foo`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, nil),
+	},
+	{
+		input: `SHOW TABLES AS OF 'abc'`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), false, expression.NewLiteral("abc", sql.LongText)),
+	},
+	{
+		input: `SHOW FULL TABLES AS OF 'abc'`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase(""), true, expression.NewLiteral("abc", sql.LongText)),
+	},
+	{
+		input: `SHOW TABLES FROM foo AS OF 'abc'`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), false, expression.NewLiteral("abc", sql.LongText)),
+	},
+	{
+		input: `SHOW FULL TABLES FROM foo AS OF 'abc'`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
+	},
+	{
+		input: `SHOW FULL TABLES IN foo AS OF 'abc'`,
+		plan: plan.NewShowTables(sql.UnresolvedDatabase("foo"), true, expression.NewLiteral("abc", sql.LongText)),
+	},
+	{
+		input: `SHOW TABLES FROM mydb LIKE 'foo'`,
+		plan: plan.NewFilter(
+			expression.NewLike(
+				expression.NewUnresolvedColumn("Tables_in_mydb"),
+				expression.NewLiteral("foo", sql.LongText),
+				nil,
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, nil),
 		),
-	),
-	`SELECT * FROM (SELECT * FROM foo) AS bar`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewSubqueryAlias(
-			"bar", "select * from foo",
+	},
+	{
+		input: `SHOW TABLES FROM mydb AS OF 'abc' LIKE 'foo'`,
+		plan: plan.NewFilter(
+			expression.NewLike(
+				expression.NewUnresolvedColumn("Tables_in_mydb"),
+				expression.NewLiteral("foo", sql.LongText),
+				nil,
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("mydb"), false, expression.NewLiteral("abc", sql.LongText)),
+		),
+	},
+	{
+		input: "SHOW TABLES FROM bar WHERE `Tables_in_bar` = 'foo'",
+		plan: plan.NewFilter(
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("Tables_in_bar"),
+				expression.NewLiteral("foo", sql.LongText),
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("bar"), false, nil),
+		),
+	},
+	{
+		input: `SHOW FULL TABLES FROM mydb LIKE 'foo'`,
+		plan: plan.NewFilter(
+			expression.NewLike(
+				expression.NewUnresolvedColumn("Tables_in_mydb"),
+				expression.NewLiteral("foo", sql.LongText),
+				nil,
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("mydb"), true, nil),
+		),
+	},
+	{
+		input: "SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'foo'",
+		plan: plan.NewFilter(
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("Tables_in_bar"),
+				expression.NewLiteral("foo", sql.LongText),
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
+		),
+	},
+	{
+		input: `SHOW FULL TABLES FROM bar LIKE 'foo'`,
+		plan: plan.NewFilter(
+			expression.NewLike(
+				expression.NewUnresolvedColumn("Tables_in_bar"),
+				expression.NewLiteral("foo", sql.LongText),
+				nil,
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
+		),
+	},
+	{
+		input: `SHOW FULL TABLES FROM bar AS OF 'abc' LIKE 'foo'`,
+		plan: plan.NewFilter(
+			expression.NewLike(
+				expression.NewUnresolvedColumn("Tables_in_bar"),
+				expression.NewLiteral("foo", sql.LongText),
+				nil,
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, expression.NewLiteral("abc", sql.LongText)),
+		),
+	},
+	{
+		input: "SHOW FULL TABLES FROM bar WHERE `Tables_in_bar` = 'test'",
+		plan: plan.NewFilter(
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("Tables_in_bar"),
+				expression.NewLiteral("test", sql.LongText),
+			),
+			plan.NewShowTables(sql.UnresolvedDatabase("bar"), true, nil),
+		),
+	},
+	{
+		input: `SELECT DISTINCT foo, bar FROM foo;`,
+		plan: plan.NewDistinct(
 			plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
 				plan.NewUnresolvedTable("foo", ""),
 			),
 		),
-	),
-	`SELECT * FROM foo WHERE 1 NOT BETWEEN 2 AND 5`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewNot(
+	},
+	{
+		input: `SELECT * FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM foo LIMIT 2 OFFSET 5;`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
+			plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			)),
+		),
+	},
+	{
+		input: `SELECT foo, bar FROM foo LIMIT 5,2;`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(2), sql.Int8),
+			plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("foo"),
+					expression.NewUnresolvedColumn("bar"),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			)),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE (a = 1)`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewFilter(
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("a"),
+					expression.NewLiteral(int8(1), sql.Int8),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo, bar, baz, qux`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewCrossJoin(
+				plan.NewCrossJoin(
+					plan.NewCrossJoin(
+						plan.NewUnresolvedTable("foo", ""),
+						plan.NewUnresolvedTable("bar", ""),
+					),
+					plan.NewUnresolvedTable("baz", ""),
+				),
+				plan.NewUnresolvedTable("qux", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo join bar join baz join qux`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewCrossJoin(
+				plan.NewCrossJoin(
+					plan.NewCrossJoin(
+						plan.NewUnresolvedTable("foo", ""),
+						plan.NewUnresolvedTable("bar", ""),
+					),
+					plan.NewUnresolvedTable("baz", ""),
+				),
+				plan.NewUnresolvedTable("qux", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE a = b AND c = d`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewAnd(
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewUnresolvedColumn("b"),
+					),
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("c"),
+						expression.NewUnresolvedColumn("d"),
+					),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE a = b OR c = d`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewOr(
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("a"),
+						expression.NewUnresolvedColumn("b"),
+					),
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("c"),
+						expression.NewUnresolvedColumn("d"),
+					),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo as bar`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewTableAlias(
+				"bar",
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM (SELECT * FROM foo) AS bar`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewSubqueryAlias(
+				"bar", "select * from foo",
+				plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE 1 NOT BETWEEN 2 AND 5`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewNot(
+					expression.NewBetween(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(2), sql.Int8),
+						expression.NewLiteral(int8(5), sql.Int8),
+					),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE 1 BETWEEN 2 AND 5`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
 				expression.NewBetween(
 					expression.NewLiteral(int8(1), sql.Int8),
 					expression.NewLiteral(int8(2), sql.Int8),
 					expression.NewLiteral(int8(5), sql.Int8),
 				),
+				plan.NewUnresolvedTable("foo", ""),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT * FROM foo WHERE 1 BETWEEN 2 AND 5`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewBetween(
-				expression.NewLiteral(int8(1), sql.Int8),
-				expression.NewLiteral(int8(2), sql.Int8),
-				expression.NewLiteral(int8(5), sql.Int8),
-			),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT 0x01AF`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("0x01AF",
-				expression.NewLiteral([]byte{1, 175}, sql.LongBlob),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT X'41'`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("X'41'",
-				expression.NewLiteral([]byte{'A'}, sql.LongBlob),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT * FROM b WHERE SOMEFUNC((1, 2), (3, 4))`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewUnresolvedFunction(
-				"somefunc",
-				false,
-				nil,
-				expression.NewTuple(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(2), sql.Int8),
+	},
+	{
+		input: `SELECT 0x01AF`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("0x01AF",
+					expression.NewLiteral([]byte{1, 175}, sql.LongBlob),
 				),
-				expression.NewTuple(
-					expression.NewLiteral(int8(3), sql.Int8),
-					expression.NewLiteral(int8(4), sql.Int8),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT X'41'`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("X'41'",
+					expression.NewLiteral([]byte{'A'}, sql.LongBlob),
 				),
-			),
-			plan.NewUnresolvedTable("b", ""),
+			},
+			plan.NewResolvedDualTable(),
 		),
-	),
-	`SELECT * FROM foo WHERE :foo_id = 2`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewEquals(
-				expression.NewBindVar("foo_id"),
-				expression.NewLiteral(int8(2), sql.Int8),
-			),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT * FROM foo WHERE ? = 2 and foo.s = ? and ? <> foo.i`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewAnd(
-				expression.NewAnd(
-					expression.NewEquals(
-						expression.NewBindVar("v1"),
+	},
+	{
+		input: `SELECT * FROM b WHERE SOMEFUNC((1, 2), (3, 4))`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewUnresolvedFunction(
+					"somefunc",
+					false,
+					nil,
+					expression.NewTuple(
+						expression.NewLiteral(int8(1), sql.Int8),
 						expression.NewLiteral(int8(2), sql.Int8),
 					),
-					expression.NewEquals(
-						expression.NewUnresolvedQualifiedColumn("foo", "s"),
-						expression.NewBindVar("v2"),
+					expression.NewTuple(
+						expression.NewLiteral(int8(3), sql.Int8),
+						expression.NewLiteral(int8(4), sql.Int8),
 					),
 				),
-				expression.NewNot(expression.NewEquals(
-					expression.NewBindVar("v3"),
-					expression.NewUnresolvedQualifiedColumn("foo", "i"),
-				)),
-			),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT * FROM foo INNER JOIN bar ON a = b`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewInnerJoin(
-			plan.NewUnresolvedTable("foo", ""),
-			plan.NewUnresolvedTable("bar", ""),
-			expression.NewEquals(
-				expression.NewUnresolvedColumn("a"),
-				expression.NewUnresolvedColumn("b"),
+				plan.NewUnresolvedTable("b", ""),
 			),
 		),
-	),
-	`SELECT foo.a FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedQualifiedColumn("foo", "a"),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT CAST(-3 AS UNSIGNED) FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("CAST(-3 AS UNSIGNED)",
-				expression.NewConvert(expression.NewLiteral(int8(-3), sql.Int8), expression.ConvertToUnsigned),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT 2 = 2 FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("2 = 2",
-				expression.NewEquals(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(2), sql.Int8))),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT *, bar FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-			expression.NewUnresolvedColumn("bar"),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT *, foo.* FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-			expression.NewQualifiedStar("foo"),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT bar, foo.* FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("bar"),
-			expression.NewQualifiedStar("foo"),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT bar, *, foo.* FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("bar"),
-			expression.NewStar(),
-			expression.NewQualifiedStar("foo"),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT *, * FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-			expression.NewStar(),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT * FROM foo WHERE 1 IN ('1', 2)`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewInTuple(
-				expression.NewLiteral(int8(1), sql.Int8),
-				expression.NewTuple(
-					expression.NewLiteral("1", sql.LongText),
+	},
+	{
+		input: `SELECT * FROM foo WHERE :foo_id = 2`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewEquals(
+					expression.NewBindVar("foo_id"),
 					expression.NewLiteral(int8(2), sql.Int8),
 				),
+				plan.NewUnresolvedTable("foo", ""),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT * FROM foo WHERE 1 NOT IN ('1', 2)`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewNotInTuple(
-				expression.NewLiteral(int8(1), sql.Int8),
-				expression.NewTuple(
-					expression.NewLiteral("1", sql.LongText),
-					expression.NewLiteral(int8(2), sql.Int8),
+	},
+	{
+		input: `SELECT * FROM foo WHERE ? = 2 and foo.s = ? and ? <> foo.i`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewAnd(
+					expression.NewAnd(
+						expression.NewEquals(
+							expression.NewBindVar("v1"),
+							expression.NewLiteral(int8(2), sql.Int8),
+						),
+						expression.NewEquals(
+							expression.NewUnresolvedQualifiedColumn("foo", "s"),
+							expression.NewBindVar("v2"),
+						),
+					),
+					expression.NewNot(expression.NewEquals(
+						expression.NewBindVar("v3"),
+						expression.NewUnresolvedQualifiedColumn("foo", "i"),
+					)),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo INNER JOIN bar ON a = b`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewInnerJoin(
+				plan.NewUnresolvedTable("foo", ""),
+				plan.NewUnresolvedTable("bar", ""),
+				expression.NewEquals(
+					expression.NewUnresolvedColumn("a"),
+					expression.NewUnresolvedColumn("b"),
 				),
 			),
-			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT * FROM foo WHERE i IN (SELECT j FROM baz)`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			plan.NewInSubquery(
-				expression.NewUnresolvedColumn("i"),
-				plan.NewSubquery(plan.NewProject(
-					[]sql.Expression{expression.NewUnresolvedColumn("j")},
-					plan.NewUnresolvedTable("baz", ""),
-				), "select j from baz"),
-			),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT * FROM foo WHERE i NOT IN (SELECT j FROM baz)`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			plan.NewNotInSubquery(
-				expression.NewUnresolvedColumn("i"),
-				plan.NewSubquery(plan.NewProject(
-					[]sql.Expression{expression.NewUnresolvedColumn("j")},
-					plan.NewUnresolvedTable("baz", ""),
-				), "select j from baz"),
-			),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT a, b FROM t ORDER BY 2, 1`: plan.NewSort(
-		[]sql.SortField{
-			{
-				Column:       expression.NewLiteral(int8(2), sql.Int8),
-				Column2:      expression.NewLiteral(int8(2), sql.Int8),
-				Order:        sql.Ascending,
-				NullOrdering: sql.NullsFirst,
-			},
-			{
-				Column:       expression.NewLiteral(int8(1), sql.Int8),
-				Column2:      expression.NewLiteral(int8(1), sql.Int8),
-				Order:        sql.Ascending,
-				NullOrdering: sql.NullsFirst,
-			},
-		},
-		plan.NewProject(
+	},
+	{
+		input: `SELECT foo.a FROM foo`,
+		plan: plan.NewProject(
 			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewUnresolvedColumn("b"),
+				expression.NewUnresolvedQualifiedColumn("foo", "a"),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT CAST(-3 AS UNSIGNED) FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("CAST(-3 AS UNSIGNED)",
+					expression.NewConvert(expression.NewLiteral(int8(-3), sql.Int8), expression.ConvertToUnsigned),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT 2 = 2 FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("2 = 2",
+					expression.NewEquals(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(2), sql.Int8))),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT *, bar FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+				expression.NewUnresolvedColumn("bar"),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT *, foo.* FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+				expression.NewQualifiedStar("foo"),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT bar, foo.* FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("bar"),
+				expression.NewQualifiedStar("foo"),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT bar, *, foo.* FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("bar"),
+				expression.NewStar(),
+				expression.NewQualifiedStar("foo"),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT *, * FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+				expression.NewStar(),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE 1 IN ('1', 2)`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewInTuple(
+					expression.NewLiteral(int8(1), sql.Int8),
+					expression.NewTuple(
+						expression.NewLiteral("1", sql.LongText),
+						expression.NewLiteral(int8(2), sql.Int8),
+					),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE 1 NOT IN ('1', 2)`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewNotInTuple(
+					expression.NewLiteral(int8(1), sql.Int8),
+					expression.NewTuple(
+						expression.NewLiteral("1", sql.LongText),
+						expression.NewLiteral(int8(2), sql.Int8),
+					),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE i IN (SELECT j FROM baz)`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				plan.NewInSubquery(
+					expression.NewUnresolvedColumn("i"),
+					plan.NewSubquery(plan.NewProject(
+						[]sql.Expression{expression.NewUnresolvedColumn("j")},
+						plan.NewUnresolvedTable("baz", ""),
+					), "select j from baz"),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE i NOT IN (SELECT j FROM baz)`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				plan.NewNotInSubquery(
+					expression.NewUnresolvedColumn("i"),
+					plan.NewSubquery(plan.NewProject(
+						[]sql.Expression{expression.NewUnresolvedColumn("j")},
+						plan.NewUnresolvedTable("baz", ""),
+					), "select j from baz"),
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT a, b FROM t ORDER BY 2, 1`,
+		plan: plan.NewSort(
+			[]sql.SortField{
+				{
+					Column:       expression.NewLiteral(int8(2), sql.Int8),
+					Column2:      expression.NewLiteral(int8(2), sql.Int8),
+					Order:        sql.Ascending,
+					NullOrdering: sql.NullsFirst,
+				},
+				{
+					Column:       expression.NewLiteral(int8(1), sql.Int8),
+					Column2:      expression.NewLiteral(int8(1), sql.Int8),
+					Order:        sql.Ascending,
+					NullOrdering: sql.NullsFirst,
+				},
+			},
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewUnresolvedColumn("b"),
+				},
+				plan.NewUnresolvedTable("t", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT -i FROM mytable`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewUnaryMinus(
+					expression.NewUnresolvedColumn("i"),
+				),
+			},
+			plan.NewUnresolvedTable("mytable", ""),
+		),
+	},
+	{
+		input: `SELECT +i FROM mytable`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("+i",
+					expression.NewUnresolvedColumn("i"),
+				),
+			},
+			plan.NewUnresolvedTable("mytable", ""),
+		),
+	},
+	{
+		input: `SELECT - 4 - - 80`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("- 4 - - 80",
+					expression.NewMinus(
+						expression.NewLiteral(int8(-4), sql.Int8),
+						expression.NewLiteral(int8(-80), sql.Int8),
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT + - - i FROM mytable`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("+ - - i",
+					expression.NewUnaryMinus(
+						expression.NewUnaryMinus(
+							expression.NewUnresolvedColumn("i"),
+						),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("mytable", ""),
+		),
+	},
+	{
+		input: `SELECT 1 + 1;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("1 + 1",
+					expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT 1 + 1 as foo;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("foo",
+					expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT 1 * (2 + 1);`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("1 * (2 + 1)",
+					expression.NewMult(expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewPlus(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT (0 - 1) * (1 | 1);`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("(0 - 1) * (1 | 1)",
+					expression.NewMult(
+						expression.NewMinus(expression.NewLiteral(int8(0), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
+						expression.NewBitOr(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT (1 << 3) % (2 div 1);`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("(1 << 3) % (2 div 1)",
+					expression.NewMod(
+						expression.NewShiftLeft(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(3), sql.Int8)),
+						expression.NewIntDiv(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT 1.0 * a + 2.0 * b FROM t;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("1.0 * a + 2.0 * b",
+					expression.NewPlus(
+						expression.NewMult(expression.NewLiteral(decimal.RequireFromString("1.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("a")),
+						expression.NewMult(expression.NewLiteral(decimal.RequireFromString("2.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("b")),
+					),
+				),
 			},
 			plan.NewUnresolvedTable("t", ""),
 		),
-	),
-	`SELECT -i FROM mytable`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewUnaryMinus(
-				expression.NewUnresolvedColumn("i"),
-			),
-		},
-		plan.NewUnresolvedTable("mytable", ""),
-	),
-	`SELECT +i FROM mytable`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("+i",
-				expression.NewUnresolvedColumn("i"),
-			),
-		},
-		plan.NewUnresolvedTable("mytable", ""),
-	),
-	`SELECT - 4 - - 80`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("- 4 - - 80",
-				expression.NewMinus(
-					expression.NewLiteral(int8(-4), sql.Int8),
-					expression.NewLiteral(int8(-80), sql.Int8),
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT + - - i FROM mytable`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("+ - - i",
-				expression.NewUnaryMinus(
-					expression.NewUnaryMinus(
-						expression.NewUnresolvedColumn("i"),
+	},
+	{
+		input: `SELECT '1.0' + 2;`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("'1.0' + 2",
+					expression.NewPlus(
+						expression.NewLiteral("1.0", sql.LongText), expression.NewLiteral(int8(2), sql.Int8),
 					),
 				),
-			),
-		},
-		plan.NewUnresolvedTable("mytable", ""),
-	),
-	`SELECT 1 + 1;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("1 + 1",
-				expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT 1 + 1 as foo;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("foo",
-				expression.NewPlus(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT 1 * (2 + 1);`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("1 * (2 + 1)",
-				expression.NewMult(expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewPlus(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT (0 - 1) * (1 | 1);`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("(0 - 1) * (1 | 1)",
-				expression.NewMult(
-					expression.NewMinus(expression.NewLiteral(int8(0), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
-					expression.NewBitOr(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(1), sql.Int8)),
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT (1 << 3) % (2 div 1);`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("(1 << 3) % (2 div 1)",
-				expression.NewMod(
-					expression.NewShiftLeft(expression.NewLiteral(int8(1), sql.Int8), expression.NewLiteral(int8(3), sql.Int8)),
-					expression.NewIntDiv(expression.NewLiteral(int8(2), sql.Int8), expression.NewLiteral(int8(1), sql.Int8))),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT 1.0 * a + 2.0 * b FROM t;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("1.0 * a + 2.0 * b",
-				expression.NewPlus(
-					expression.NewMult(expression.NewLiteral(decimal.RequireFromString("1.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("a")),
-					expression.NewMult(expression.NewLiteral(decimal.RequireFromString("2.0"), sql.MustCreateDecimalType(2, 1)), expression.NewUnresolvedColumn("b")),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("t", ""),
-	),
-	`SELECT '1.0' + 2;`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("'1.0' + 2",
-				expression.NewPlus(
-					expression.NewLiteral("1.0", sql.LongText), expression.NewLiteral(int8(2), sql.Int8),
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT '1' + '2';`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("'1' + '2'",
-				expression.NewPlus(
-					expression.NewLiteral("1", sql.LongText), expression.NewLiteral("2", sql.LongText),
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`CREATE INDEX foo USING qux ON bar (baz)`: plan.NewCreateIndex(
-		"foo",
-		plan.NewUnresolvedTable("bar", ""),
-		[]sql.Expression{expression.NewUnresolvedColumn("baz")},
-		"qux",
-		make(map[string]string),
-	),
-	`CREATE INDEX idx USING BTREE ON foo (bar)`: plan.NewAlterCreateIndex(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("foo", ""),
-		"idx",
-		sql.IndexUsing_BTree,
-		sql.IndexConstraint_None,
-		[]sql.IndexColumn{
-			{"bar", 0},
-		},
-		"",
-	),
-	`      CREATE INDEX idx USING BTREE ON foo(bar)`: plan.NewAlterCreateIndex(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("foo", ""),
-		"idx",
-		sql.IndexUsing_BTree,
-		sql.IndexConstraint_None,
-		[]sql.IndexColumn{
-			{"bar", 0},
-		},
-		"",
-	),
-	`SELECT * FROM foo NATURAL JOIN bar`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewNaturalJoin(
-			plan.NewUnresolvedTable("foo", ""),
-			plan.NewUnresolvedTable("bar", ""),
+			},
+			plan.NewResolvedDualTable(),
 		),
-	),
-	`SELECT * FROM foo NATURAL JOIN bar NATURAL JOIN baz`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewNaturalJoin(
+	},
+	{
+		input: `SELECT '1' + '2';`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("'1' + '2'",
+					expression.NewPlus(
+						expression.NewLiteral("1", sql.LongText), expression.NewLiteral("2", sql.LongText),
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `CREATE INDEX foo USING qux ON bar (baz)`,
+		plan: plan.NewCreateIndex(
+			"foo",
+			plan.NewUnresolvedTable("bar", ""),
+			[]sql.Expression{expression.NewUnresolvedColumn("baz")},
+			"qux",
+			make(map[string]string),
+		),
+	},
+	{
+		input: `CREATE INDEX idx USING BTREE ON foo (bar)`,
+		plan: plan.NewAlterCreateIndex(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("foo", ""),
+			"idx",
+			sql.IndexUsing_BTree,
+			sql.IndexConstraint_None,
+			[]sql.IndexColumn{
+				{"bar", 0},
+			},
+			"",
+		),
+	},
+	{
+		input: `      CREATE INDEX idx USING BTREE ON foo(bar)`,
+		plan: plan.NewAlterCreateIndex(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("foo", ""),
+			"idx",
+			sql.IndexUsing_BTree,
+			sql.IndexConstraint_None,
+			[]sql.IndexColumn{
+				{"bar", 0},
+			},
+			"",
+		),
+	},
+	{
+		input: `SELECT * FROM foo NATURAL JOIN bar`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
 			plan.NewNaturalJoin(
 				plan.NewUnresolvedTable("foo", ""),
 				plan.NewUnresolvedTable("bar", ""),
 			),
-			plan.NewUnresolvedTable("baz", ""),
 		),
-	),
-	`DROP INDEX foo ON bar`: plan.NewAlterDropIndex(
-		sql.UnresolvedDatabase(""),
-		plan.NewUnresolvedTable("bar", ""),
-		"foo",
-	),
-	`DESCRIBE FORMAT=TREE SELECT * FROM foo`: plan.NewDescribeQuery(
-		"tree",
-		plan.NewProject(
+	},
+	{
+		input: `SELECT * FROM foo NATURAL JOIN bar NATURAL JOIN baz`,
+		plan: plan.NewProject(
 			[]sql.Expression{expression.NewStar()},
+			plan.NewNaturalJoin(
+				plan.NewNaturalJoin(
+					plan.NewUnresolvedTable("foo", ""),
+					plan.NewUnresolvedTable("bar", ""),
+				),
+				plan.NewUnresolvedTable("baz", ""),
+			),
+		),
+	},
+	{
+		input: `DROP INDEX foo ON bar`,
+		plan: plan.NewAlterDropIndex(
+			sql.UnresolvedDatabase(""),
+			plan.NewUnresolvedTable("bar", ""),
+			"foo",
+		),
+	},
+	{
+		input: `DESCRIBE FORMAT=TREE SELECT * FROM foo`,
+		plan: plan.NewDescribeQuery(
+			"tree",
+			plan.NewProject(
+				[]sql.Expression{expression.NewStar()},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT MAX(i)/2 FROM foo`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias("MAX(i)/2",
+					expression.NewArithmetic(
+						expression.NewUnresolvedFunction(
+							"max", true, nil, expression.NewUnresolvedColumn("i"),
+						),
+						expression.NewLiteral(int8(2), sql.Int8),
+						"/",
+					),
+				),
+			},
+			[]sql.Expression{},
 			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SELECT MAX(i)/2 FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("MAX(i)/2",
-				expression.NewArithmetic(
-					expression.NewUnresolvedFunction(
-						"max", true, nil, expression.NewUnresolvedColumn("i"),
-					),
-					expression.NewLiteral(int8(2), sql.Int8),
-					"/",
+	},
+	{
+		input: `SELECT current_user FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("current_user",
+					expression.NewUnresolvedFunction("current_user", false, nil),
 				),
-			),
-		},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT current_user FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("current_user",
-				expression.NewUnresolvedFunction("current_user", false, nil),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT current_USER(    ) FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("current_USER(    )",
-				expression.NewUnresolvedFunction("current_user", false, nil),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SHOW INDEXES FROM foo`: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	`SHOW INDEX FROM foo`:   plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	`SHOW KEYS FROM foo`:    plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	`SHOW INDEXES IN foo`:   plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	`SHOW INDEX IN foo`:     plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	`SHOW KEYS IN foo`:      plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
-	`SHOW FULL PROCESSLIST`: plan.NewShowProcessList(),
-	`SHOW PROCESSLIST`:      plan.NewShowProcessList(),
-	`SELECT @@allowed_max_packet`: plan.NewProject([]sql.Expression{
-		expression.NewUnresolvedColumn("@@allowed_max_packet"),
-	}, plan.NewResolvedDualTable()),
-	`SET autocommit=1, foo="bar", baz=ON, qux=bareword`: plan.NewSet(
-		[]sql.Expression{
-			expression.NewSetField(expression.NewUnresolvedColumn("autocommit"), expression.NewLiteral(int8(1), sql.Int8)),
-			expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("bar", sql.LongText)),
-			expression.NewSetField(expression.NewUnresolvedColumn("baz"), expression.NewLiteral("ON", sql.LongText)),
-			expression.NewSetField(expression.NewUnresolvedColumn("qux"), expression.NewUnresolvedColumn("bareword")),
-		},
-	),
-	`SET @@session.autocommit=1, foo="true"`: plan.NewSet(
-		[]sql.Expression{
-			expression.NewSetField(expression.NewSystemVar("autocommit", sql.SystemVariableScope_Session), expression.NewLiteral(int8(1), sql.Int8)),
-			expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("true", sql.LongText)),
-		},
-	),
-	`SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`: plan.NewSet(
-		[]sql.Expression{
-			expression.NewSetField(expression.NewSystemVar("NET_READ_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
-			expression.NewSetField(expression.NewSystemVar("NET_WRITE_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
-		},
-	),
-	`SET gtid_mode=DEFAULT`: plan.NewSet(
-		[]sql.Expression{
-			expression.NewSetField(expression.NewUnresolvedColumn("gtid_mode"), expression.NewDefaultColumn("")),
-		},
-	),
-	`SET @@sql_select_limit=default`: plan.NewSet(
-		[]sql.Expression{
-			expression.NewSetField(expression.NewSystemVar("sql_select_limit", sql.SystemVariableScope_Session), expression.NewDefaultColumn("")),
-		},
-	),
-	"":                     plan.Nothing,
-	"/* just a comment */": plan.Nothing,
-	`/*!40101 SET NAMES utf8 */`: plan.NewSet(
-		[]sql.Expression{
-			expression.NewSetField(expression.NewUnresolvedColumn("character_set_client"), expression.NewLiteral("utf8", sql.LongText)),
-			expression.NewSetField(expression.NewUnresolvedColumn("character_set_connection"), expression.NewLiteral("utf8", sql.LongText)),
-			expression.NewSetField(expression.NewUnresolvedColumn("character_set_results"), expression.NewLiteral("utf8", sql.LongText)),
-		},
-	),
-	`SELECT /* a comment */ * FROM foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT /*!40101 * from */ foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	// TODO: other optimizer hints than join_order are ignored for now
-	`SELECT /*+ JOIN_ORDER(a,b) */ * from foo`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT /*+ JOIN_ORDER(a,b) */ * FROM b join a on c = d limit 5`: plan.NewLimit(expression.NewLiteral(int8(5), sql.Int8),
-		plan.NewProject(
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT current_USER(    ) FROM foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("current_USER(    )",
+					expression.NewUnresolvedFunction("current_user", false, nil),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SHOW INDEXES FROM foo`,
+		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW INDEX FROM foo`,
+		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW KEYS FROM foo`,
+		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW INDEXES IN foo`,
+		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW INDEX IN foo`,
+		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW KEYS IN foo`,
+		plan: plan.NewShowIndexes(plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW FULL PROCESSLIST`,
+		plan: plan.NewShowProcessList(),
+	},
+	{
+		input: `SHOW PROCESSLIST`,
+		plan: plan.NewShowProcessList(),
+	},
+	{
+		input: `SELECT @@allowed_max_packet`,
+		plan: plan.NewProject([]sql.Expression{
+			expression.NewUnresolvedColumn("@@allowed_max_packet"),
+		}, plan.NewResolvedDualTable()),
+	},
+	{
+		input: `SET autocommit=1, foo="bar", baz=ON, qux=bareword`,
+		plan: plan.NewSet(
+			[]sql.Expression{
+				expression.NewSetField(expression.NewUnresolvedColumn("autocommit"), expression.NewLiteral(int8(1), sql.Int8)),
+				expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("bar", sql.LongText)),
+				expression.NewSetField(expression.NewUnresolvedColumn("baz"), expression.NewLiteral("ON", sql.LongText)),
+				expression.NewSetField(expression.NewUnresolvedColumn("qux"), expression.NewUnresolvedColumn("bareword")),
+			},
+		),
+	},
+	{
+		input: `SET @@session.autocommit=1, foo="true"`,
+		plan: plan.NewSet(
+			[]sql.Expression{
+				expression.NewSetField(expression.NewSystemVar("autocommit", sql.SystemVariableScope_Session), expression.NewLiteral(int8(1), sql.Int8)),
+				expression.NewSetField(expression.NewUnresolvedColumn("foo"), expression.NewLiteral("true", sql.LongText)),
+			},
+		),
+	},
+	{
+		input: `SET SESSION NET_READ_TIMEOUT= 700, SESSION NET_WRITE_TIMEOUT= 700`,
+		plan: plan.NewSet(
+			[]sql.Expression{
+				expression.NewSetField(expression.NewSystemVar("NET_READ_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
+				expression.NewSetField(expression.NewSystemVar("NET_WRITE_TIMEOUT", sql.SystemVariableScope_Session), expression.NewLiteral(int16(700), sql.Int16)),
+			},
+		),
+	},
+	{
+		input: `SET gtid_mode=DEFAULT`,
+		plan: plan.NewSet(
+			[]sql.Expression{
+				expression.NewSetField(expression.NewUnresolvedColumn("gtid_mode"), expression.NewDefaultColumn("")),
+			},
+		),
+	},
+	{
+		input: `SET @@sql_select_limit=default`,
+		plan: plan.NewSet(
+			[]sql.Expression{
+				expression.NewSetField(expression.NewSystemVar("sql_select_limit", sql.SystemVariableScope_Session), expression.NewDefaultColumn("")),
+			},
+		),
+	},
+	{
+		input: "",
+		plan: plan.Nothing,
+	},
+	{
+		input: "/* just a comment */",
+		plan: plan.Nothing,
+	},
+	{
+		input: `/*!40101 SET NAMES utf8 */`,
+		plan: plan.NewSet(
+			[]sql.Expression{
+				expression.NewSetField(expression.NewUnresolvedColumn("character_set_client"), expression.NewLiteral("utf8", sql.LongText)),
+				expression.NewSetField(expression.NewUnresolvedColumn("character_set_connection"), expression.NewLiteral("utf8", sql.LongText)),
+				expression.NewSetField(expression.NewUnresolvedColumn("character_set_results"), expression.NewLiteral("utf8", sql.LongText)),
+			},
+		),
+	},
+	{
+		input: `SELECT /* a comment */ * FROM foo`,
+		plan: plan.NewProject(
 			[]sql.Expression{
 				expression.NewStar(),
 			},
-			plan.NewInnerJoin(
-				plan.NewUnresolvedTable("b", ""),
-				plan.NewUnresolvedTable("a", ""),
-				expression.NewEquals(
-					expression.NewUnresolvedColumn("c"),
-					expression.NewUnresolvedColumn("d"),
-				),
-			).WithComment("/*+ JOIN_ORDER(a,b) */"),
+			plan.NewUnresolvedTable("foo", ""),
 		),
-	),
-	`SHOW DATABASES`: plan.NewShowDatabases(),
-	`SELECT * FROM foo WHERE i LIKE 'foo'`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
+	},
+	{
+		input: `SELECT /*!40101 * from */ foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+		// TODO: other optimizer hints than join_order are ignored for now
+	},
+	{
+		input: `SELECT /*+ JOIN_ORDER(a,b) */ * from foo`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT /*+ JOIN_ORDER(a,b) */ * FROM b join a on c = d limit 5`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(5), sql.Int8),
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewInnerJoin(
+					plan.NewUnresolvedTable("b", ""),
+					plan.NewUnresolvedTable("a", ""),
+					expression.NewEquals(
+						expression.NewUnresolvedColumn("c"),
+						expression.NewUnresolvedColumn("d"),
+					),
+				).WithComment("/*+ JOIN_ORDER(a,b) */"),
+			),
+		),
+	},
+	{
+		input: `SHOW DATABASES`,
+		plan: plan.NewShowDatabases(),
+	},
+	{
+		input: `SELECT * FROM foo WHERE i LIKE 'foo'`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewLike(
+					expression.NewUnresolvedColumn("i"),
+					expression.NewLiteral("foo", sql.LongText),
+					nil,
+				),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo WHERE i NOT LIKE 'foo'`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewFilter(
+				expression.NewNot(expression.NewLike(
+					expression.NewUnresolvedColumn("i"),
+					expression.NewLiteral("foo", sql.LongText),
+					nil,
+				)),
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SHOW FIELDS FROM foo`,
+		plan: plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW FULL COLUMNS FROM foo`,
+		plan: plan.NewShowColumns(true, plan.NewUnresolvedTable("foo", "")),
+	},
+	{
+		input: `SHOW FIELDS FROM foo WHERE Field = 'bar'`,
+		plan: plan.NewFilter(
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("Field"),
+				expression.NewLiteral("bar", sql.LongText),
+			),
+			plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
+		),
+	},
+	{
+		input: `SHOW FIELDS FROM foo LIKE 'bar'`,
+		plan: plan.NewFilter(
 			expression.NewLike(
-				expression.NewUnresolvedColumn("i"),
+				expression.NewUnresolvedColumn("Field"),
+				expression.NewLiteral("bar", sql.LongText),
+				nil,
+			),
+			plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
+		),
+	},
+	{
+		input: `SHOW TABLE STATUS LIKE 'foo'`,
+		plan: plan.NewFilter(
+			expression.NewLike(
+				expression.NewUnresolvedColumn("Name"),
 				expression.NewLiteral("foo", sql.LongText),
 				nil,
 			),
-			plan.NewUnresolvedTable("foo", ""),
+			plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
 		),
-	),
-	`SELECT * FROM foo WHERE i NOT LIKE 'foo'`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewFilter(
-			expression.NewNot(expression.NewLike(
-				expression.NewUnresolvedColumn("i"),
+	},
+	{
+		input: `SHOW TABLE STATUS FROM foo`,
+		plan: plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
+	},
+	{
+		input: `SHOW TABLE STATUS IN foo`,
+		plan: plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
+	},
+	{
+		input: `SHOW TABLE STATUS`,
+		plan: plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
+	},
+	{
+		input: `SHOW TABLE STATUS WHERE Name = 'foo'`,
+		plan: plan.NewFilter(
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("Name"),
+				expression.NewLiteral("foo", sql.LongText),
+			),
+			plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
+		),
+	},
+	{
+		input: `USE foo`,
+		plan: plan.NewUse(sql.UnresolvedDatabase("foo")),
+	},
+	{
+		input: `DESCRIBE foo.bar`,
+		plan: plan.NewShowColumns(false,
+			plan.NewUnresolvedTable("bar", "foo"),
+		),
+	},
+	{
+		input: `DESC foo.bar`,
+		plan: plan.NewShowColumns(false,
+			plan.NewUnresolvedTable("bar", "foo"),
+		),
+	},
+	{
+		input: `SELECT * FROM foo.bar`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewStar(),
+			},
+			plan.NewUnresolvedTable("bar", "foo"),
+		),
+	},
+	{
+		input: `SHOW VARIABLES`,
+		plan: plan.NewShowVariables(nil),
+	},
+	{
+		input: `SHOW GLOBAL VARIABLES`,
+		plan: plan.NewShowVariables(nil),
+	},
+	{
+		input: `SHOW SESSION VARIABLES`,
+		plan: plan.NewShowVariables(nil),
+	},
+	{
+		input: `SHOW VARIABLES LIKE 'gtid_mode'`,
+		plan: plan.NewShowVariables(expression.NewLike(
+			expression.NewGetField(0, sql.LongText, "variable_name", false),
+			expression.NewLiteral("gtid_mode", sql.LongText),
+			nil,
+		)),
+	},
+	{
+		input: `SHOW SESSION VARIABLES LIKE 'autocommit'`,
+		plan: plan.NewShowVariables(expression.NewLike(
+			expression.NewGetField(0, sql.LongText, "variable_name", false),
+			expression.NewLiteral("autocommit", sql.LongText),
+			nil,
+		)),
+	},
+	{
+		input: `UNLOCK TABLES`,
+		plan: plan.NewUnlockTables(),
+	},
+	{
+		input: `LOCK TABLES foo READ`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo", "")},
+		}),
+	},
+	{
+		input: `LOCK TABLES foo123 READ`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo123", "")},
+		}),
+	},
+	{
+		input: `LOCK TABLES foo AS f READ`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewTableAlias("f", plan.NewUnresolvedTable("foo", ""))},
+		}),
+	},
+	{
+		input: `LOCK TABLES foo READ LOCAL`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo", "")},
+		}),
+	},
+	{
+		input: `LOCK TABLES foo WRITE`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+		}),
+	},
+	{
+		input: `LOCK TABLES foo LOW_PRIORITY WRITE`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+		}),
+	},
+	{
+		input: `LOCK TABLES foo WRITE, bar READ`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+			{Table: plan.NewUnresolvedTable("bar", "")},
+		}),
+	},
+	{
+		input: "LOCK TABLES `foo` WRITE, `bar` READ",
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
+			{Table: plan.NewUnresolvedTable("bar", "")},
+		}),
+	},
+	{
+		input: `LOCK TABLES foo READ, bar WRITE, baz READ`,
+		plan: plan.NewLockTables([]*plan.TableLock{
+			{Table: plan.NewUnresolvedTable("foo", "")},
+			{Table: plan.NewUnresolvedTable("bar", ""), Write: true},
+			{Table: plan.NewUnresolvedTable("baz", "")},
+		}),
+	},
+	{
+		input: `SHOW CREATE DATABASE foo`,
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+	},
+	{
+		input: `SHOW CREATE SCHEMA foo`,
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+	},
+	{
+		input: `SHOW CREATE DATABASE IF NOT EXISTS foo`,
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+	},
+	{
+		input: `SHOW CREATE SCHEMA IF NOT EXISTS foo`,
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+	},
+	{
+		input: `SHOW WARNINGS`,
+		plan: plan.ShowWarnings(sql.NewEmptyContext().Warnings()),
+	},
+	{
+		input: `SHOW WARNINGS LIMIT 10`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings())),
+	},
+	{
+		input: `SHOW WARNINGS LIMIT 5,10`,
+		plan: plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings()))),
+	},
+	{
+		input: "SHOW CREATE DATABASE `foo`",
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+	},
+	{
+		input: "SHOW CREATE SCHEMA `foo`",
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
+	},
+	{
+		input: "SHOW CREATE DATABASE IF NOT EXISTS `foo`",
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+	},
+	{
+		input: "SHOW CREATE SCHEMA IF NOT EXISTS `foo`",
+		plan: plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
+	},
+	{
+		input: "SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
+					expression.NewCase(
+						expression.NewUnresolvedColumn("foo"),
+						[]expression.CaseBranch{
+							{
+								Cond:  expression.NewLiteral(int8(1), sql.Int8),
+								Value: expression.NewLiteral("foo", sql.LongText),
+							},
+							{
+								Cond:  expression.NewLiteral(int8(2), sql.Int8),
+								Value: expression.NewLiteral("bar", sql.LongText),
+							},
+						},
+						expression.NewLiteral("baz", sql.LongText),
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: "SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END",
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END",
+					expression.NewCase(
+						expression.NewUnresolvedColumn("foo"),
+						[]expression.CaseBranch{
+							{
+								Cond:  expression.NewLiteral(int8(1), sql.Int8),
+								Value: expression.NewLiteral("foo", sql.LongText),
+							},
+							{
+								Cond:  expression.NewLiteral(int8(2), sql.Int8),
+								Value: expression.NewLiteral("bar", sql.LongText),
+							},
+						},
+						nil,
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: "SELECT CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END",
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END",
+					expression.NewCase(
+						nil,
+						[]expression.CaseBranch{
+							{
+								Cond: expression.NewEquals(
+									expression.NewUnresolvedColumn("foo"),
+									expression.NewLiteral(int8(1), sql.Int8),
+								),
+								Value: expression.NewLiteral("foo", sql.LongText),
+							},
+							{
+								Cond: expression.NewEquals(
+									expression.NewUnresolvedColumn("foo"),
+									expression.NewLiteral(int8(2), sql.Int8),
+								),
+								Value: expression.NewLiteral("bar", sql.LongText),
+							},
+						},
+						expression.NewLiteral("baz", sql.LongText),
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: "SHOW COLLATION",
+		plan: showCollationProjection,
+	},
+	{
+		input: "SHOW COLLATION LIKE 'foo'",
+		plan: plan.NewHaving(
+			expression.NewLike(
+				expression.NewUnresolvedColumn("collation"),
 				expression.NewLiteral("foo", sql.LongText),
 				nil,
-			)),
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SHOW FIELDS FROM foo`:       plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
-	`SHOW FULL COLUMNS FROM foo`: plan.NewShowColumns(true, plan.NewUnresolvedTable("foo", "")),
-	`SHOW FIELDS FROM foo WHERE Field = 'bar'`: plan.NewFilter(
-		expression.NewEquals(
-			expression.NewUnresolvedColumn("Field"),
-			expression.NewLiteral("bar", sql.LongText),
-		),
-		plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
-	),
-	`SHOW FIELDS FROM foo LIKE 'bar'`: plan.NewFilter(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("Field"),
-			expression.NewLiteral("bar", sql.LongText),
-			nil,
-		),
-		plan.NewShowColumns(false, plan.NewUnresolvedTable("foo", "")),
-	),
-	`SHOW TABLE STATUS LIKE 'foo'`: plan.NewFilter(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("Name"),
-			expression.NewLiteral("foo", sql.LongText),
-			nil,
-		),
-		plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
-	),
-	`SHOW TABLE STATUS FROM foo`: plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
-	`SHOW TABLE STATUS IN foo`:   plan.NewShowTableStatus(sql.UnresolvedDatabase("foo")),
-	`SHOW TABLE STATUS`:          plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
-	`SHOW TABLE STATUS WHERE Name = 'foo'`: plan.NewFilter(
-		expression.NewEquals(
-			expression.NewUnresolvedColumn("Name"),
-			expression.NewLiteral("foo", sql.LongText),
-		),
-		plan.NewShowTableStatus(sql.UnresolvedDatabase("")),
-	),
-	`USE foo`: plan.NewUse(sql.UnresolvedDatabase("foo")),
-	`DESCRIBE foo.bar`: plan.NewShowColumns(false,
-		plan.NewUnresolvedTable("bar", "foo"),
-	),
-	`DESC foo.bar`: plan.NewShowColumns(false,
-		plan.NewUnresolvedTable("bar", "foo"),
-	),
-	`SELECT * FROM foo.bar`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewStar(),
-		},
-		plan.NewUnresolvedTable("bar", "foo"),
-	),
-	`SHOW VARIABLES`:         plan.NewShowVariables(nil),
-	`SHOW GLOBAL VARIABLES`:  plan.NewShowVariables(nil),
-	`SHOW SESSION VARIABLES`: plan.NewShowVariables(nil),
-	`SHOW VARIABLES LIKE 'gtid_mode'`: plan.NewShowVariables(expression.NewLike(
-		expression.NewGetField(0, sql.LongText, "variable_name", false),
-		expression.NewLiteral("gtid_mode", sql.LongText),
-		nil,
-	)),
-	`SHOW SESSION VARIABLES LIKE 'autocommit'`: plan.NewShowVariables(expression.NewLike(
-		expression.NewGetField(0, sql.LongText, "variable_name", false),
-		expression.NewLiteral("autocommit", sql.LongText),
-		nil,
-	)),
-	`UNLOCK TABLES`: plan.NewUnlockTables(),
-	`LOCK TABLES foo READ`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo", "")},
-	}),
-	`LOCK TABLES foo123 READ`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo123", "")},
-	}),
-	`LOCK TABLES foo AS f READ`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewTableAlias("f", plan.NewUnresolvedTable("foo", ""))},
-	}),
-	`LOCK TABLES foo READ LOCAL`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo", "")},
-	}),
-	`LOCK TABLES foo WRITE`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-	}),
-	`LOCK TABLES foo LOW_PRIORITY WRITE`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-	}),
-	`LOCK TABLES foo WRITE, bar READ`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-		{Table: plan.NewUnresolvedTable("bar", "")},
-	}),
-	"LOCK TABLES `foo` WRITE, `bar` READ": plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo", ""), Write: true},
-		{Table: plan.NewUnresolvedTable("bar", "")},
-	}),
-	`LOCK TABLES foo READ, bar WRITE, baz READ`: plan.NewLockTables([]*plan.TableLock{
-		{Table: plan.NewUnresolvedTable("foo", "")},
-		{Table: plan.NewUnresolvedTable("bar", ""), Write: true},
-		{Table: plan.NewUnresolvedTable("baz", "")},
-	}),
-	`SHOW CREATE DATABASE foo`:                 plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	`SHOW CREATE SCHEMA foo`:                   plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	`SHOW CREATE DATABASE IF NOT EXISTS foo`:   plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	`SHOW CREATE SCHEMA IF NOT EXISTS foo`:     plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	`SHOW WARNINGS`:                            plan.ShowWarnings(sql.NewEmptyContext().Warnings()),
-	`SHOW WARNINGS LIMIT 10`:                   plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings())),
-	`SHOW WARNINGS LIMIT 5,10`:                 plan.NewLimit(expression.NewLiteral(int8(10), sql.Int8), plan.NewOffset(expression.NewLiteral(int8(5), sql.Int8), plan.ShowWarnings(sql.NewEmptyContext().Warnings()))),
-	"SHOW CREATE DATABASE `foo`":               plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	"SHOW CREATE SCHEMA `foo`":                 plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), false),
-	"SHOW CREATE DATABASE IF NOT EXISTS `foo`": plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	"SHOW CREATE SCHEMA IF NOT EXISTS `foo`":   plan.NewShowCreateDatabase(sql.UnresolvedDatabase("foo"), true),
-	"SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END": plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' ELSE 'baz' END",
-				expression.NewCase(
-					expression.NewUnresolvedColumn("foo"),
-					[]expression.CaseBranch{
-						{
-							Cond:  expression.NewLiteral(int8(1), sql.Int8),
-							Value: expression.NewLiteral("foo", sql.LongText),
-						},
-						{
-							Cond:  expression.NewLiteral(int8(2), sql.Int8),
-							Value: expression.NewLiteral("bar", sql.LongText),
-						},
-					},
-					expression.NewLiteral("baz", sql.LongText),
-				),
 			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	"SELECT CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END": plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("CASE foo WHEN 1 THEN 'foo' WHEN 2 THEN 'bar' END",
-				expression.NewCase(
-					expression.NewUnresolvedColumn("foo"),
-					[]expression.CaseBranch{
-						{
-							Cond:  expression.NewLiteral(int8(1), sql.Int8),
-							Value: expression.NewLiteral("foo", sql.LongText),
-						},
-						{
-							Cond:  expression.NewLiteral(int8(2), sql.Int8),
-							Value: expression.NewLiteral("bar", sql.LongText),
-						},
-					},
-					nil,
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	"SELECT CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END": plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("CASE WHEN foo = 1 THEN 'foo' WHEN foo = 2 THEN 'bar' ELSE 'baz' END",
-				expression.NewCase(
-					nil,
-					[]expression.CaseBranch{
-						{
-							Cond: expression.NewEquals(
-								expression.NewUnresolvedColumn("foo"),
-								expression.NewLiteral(int8(1), sql.Int8),
-							),
-							Value: expression.NewLiteral("foo", sql.LongText),
-						},
-						{
-							Cond: expression.NewEquals(
-								expression.NewUnresolvedColumn("foo"),
-								expression.NewLiteral(int8(2), sql.Int8),
-							),
-							Value: expression.NewLiteral("bar", sql.LongText),
-						},
-					},
-					expression.NewLiteral("baz", sql.LongText),
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	"SHOW COLLATION": showCollationProjection,
-	"SHOW COLLATION LIKE 'foo'": plan.NewHaving(
-		expression.NewLike(
-			expression.NewUnresolvedColumn("collation"),
-			expression.NewLiteral("foo", sql.LongText),
-			nil,
+			showCollationProjection,
 		),
-		showCollationProjection,
-	),
-	"SHOW COLLATION WHERE Charset = 'foo'": plan.NewHaving(
-		expression.NewEquals(
-			expression.NewUnresolvedColumn("Charset"),
-			expression.NewLiteral("foo", sql.LongText),
+	},
+	{
+		input: "SHOW COLLATION WHERE Charset = 'foo'",
+		plan: plan.NewHaving(
+			expression.NewEquals(
+				expression.NewUnresolvedColumn("Charset"),
+				expression.NewLiteral("foo", sql.LongText),
+			),
+			showCollationProjection,
 		),
-		showCollationProjection,
-	),
-	"BEGIN":                                  plan.NewStartTransaction("", sql.ReadWrite),
-	"START TRANSACTION":                      plan.NewStartTransaction("", sql.ReadWrite),
-	"COMMIT":                                 plan.NewCommit(""),
-	`ROLLBACK`:                               plan.NewRollback(""),
-	"SAVEPOINT abc":                          plan.NewCreateSavepoint("", "abc"),
-	"ROLLBACK TO SAVEPOINT abc":              plan.NewRollbackSavepoint("", "abc"),
-	"RELEASE SAVEPOINT abc":                  plan.NewReleaseSavepoint("", "abc"),
-	"SHOW CREATE TABLE `mytable`":            plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
-	"SHOW CREATE TABLE mytable":              plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
-	"SHOW CREATE TABLE mydb.`mytable`":       plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
-	"SHOW CREATE TABLE `mydb`.mytable":       plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
-	"SHOW CREATE TABLE `mydb`.`mytable`":     plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
-	"SHOW CREATE TABLE `my.table`":           plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), false),
-	"SHOW CREATE TABLE `my.db`.`my.table`":   plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), false),
-	"SHOW CREATE TABLE `my``table`":          plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), false),
-	"SHOW CREATE TABLE `my``db`.`my``table`": plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), false),
-	"SHOW CREATE TABLE ````":                 plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), false),
-	"SHOW CREATE TABLE `.`":                  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), false),
-	"SHOW CREATE TABLE mytable as of 'version'": plan.NewShowCreateTableWithAsOf(
-		plan.NewUnresolvedTableAsOf("mytable", "", expression.NewLiteral("version", sql.LongText)),
-		false, expression.NewLiteral("version", sql.LongText)),
-	"SHOW CREATE VIEW `mytable`":            plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
-	"SHOW CREATE VIEW mytable":              plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
-	"SHOW CREATE VIEW mydb.`mytable`":       plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
-	"SHOW CREATE VIEW `mydb`.mytable":       plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
-	"SHOW CREATE VIEW `mydb`.`mytable`":     plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
-	"SHOW CREATE VIEW `my.table`":           plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), true),
-	"SHOW CREATE VIEW `my.db`.`my.table`":   plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), true),
-	"SHOW CREATE VIEW `my``table`":          plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), true),
-	"SHOW CREATE VIEW `my``db`.`my``table`": plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), true),
-	"SHOW CREATE VIEW ````":                 plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), true),
-	"SHOW CREATE VIEW `.`":                  plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), true),
-	`SELECT '2018-05-01' + INTERVAL 1 DAY`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY",
-				expression.NewArithmetic(
-					expression.NewLiteral("2018-05-01", sql.LongText),
-					expression.NewInterval(
-						expression.NewLiteral(int8(1), sql.Int8),
-						"DAY",
-					),
-					"+",
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT '2018-05-01' - INTERVAL 1 DAY`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("'2018-05-01' - INTERVAL 1 DAY",
-				expression.NewArithmetic(
-					expression.NewLiteral("2018-05-01", sql.LongText),
-					expression.NewInterval(
-						expression.NewLiteral(int8(1), sql.Int8),
-						"DAY",
-					),
-					"-",
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT INTERVAL 1 DAY + '2018-05-01'`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("INTERVAL 1 DAY + '2018-05-01'",
-				expression.NewArithmetic(
-					expression.NewInterval(
-						expression.NewLiteral(int8(1), sql.Int8),
-						"DAY",
-					),
-					expression.NewLiteral("2018-05-01", sql.LongText),
-					"+",
-				),
-			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT '2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY",
-				expression.NewArithmetic(
+	},
+	{
+		input: "BEGIN",
+		plan: plan.NewStartTransaction("", sql.ReadWrite),
+	},
+	{
+		input: "START TRANSACTION",
+		plan: plan.NewStartTransaction("", sql.ReadWrite),
+	},
+	{
+		input: "COMMIT",
+		plan: plan.NewCommit(""),
+	},
+	{
+		input: `ROLLBACK`,
+		plan: plan.NewRollback(""),
+	},
+	{
+		input: "SAVEPOINT abc",
+		plan: plan.NewCreateSavepoint("", "abc"),
+	},
+	{
+		input: "ROLLBACK TO SAVEPOINT abc",
+		plan: plan.NewRollbackSavepoint("", "abc"),
+	},
+	{
+		input: "RELEASE SAVEPOINT abc",
+		plan: plan.NewReleaseSavepoint("", "abc"),
+	},
+	{
+		input: "SHOW CREATE TABLE `mytable`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
+	},
+	{
+		input: "SHOW CREATE TABLE mytable",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), false),
+	},
+	{
+		input: "SHOW CREATE TABLE mydb.`mytable`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+	},
+	{
+		input: "SHOW CREATE TABLE `mydb`.mytable",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+	},
+	{
+		input: "SHOW CREATE TABLE `mydb`.`mytable`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), false),
+	},
+	{
+		input: "SHOW CREATE TABLE `my.table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), false),
+	},
+	{
+		input: "SHOW CREATE TABLE `my.db`.`my.table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), false),
+	},
+	{
+		input: "SHOW CREATE TABLE `my``table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), false),
+	},
+	{
+		input: "SHOW CREATE TABLE `my``db`.`my``table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), false),
+	},
+	{
+		input: "SHOW CREATE TABLE ````",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), false),
+	},
+	{
+		input: "SHOW CREATE TABLE `.`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), false),
+	},
+	{
+		input: "SHOW CREATE TABLE mytable as of 'version'",
+		plan: plan.NewShowCreateTableWithAsOf(
+			plan.NewUnresolvedTableAsOf("mytable", "", expression.NewLiteral("version", sql.LongText)),
+			false, expression.NewLiteral("version", sql.LongText)),
+	},
+	{
+		input: "SHOW CREATE VIEW `mytable`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
+	},
+	{
+		input: "SHOW CREATE VIEW mytable",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", ""), true),
+	},
+	{
+		input: "SHOW CREATE VIEW mydb.`mytable`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+	},
+	{
+		input: "SHOW CREATE VIEW `mydb`.mytable",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+	},
+	{
+		input: "SHOW CREATE VIEW `mydb`.`mytable`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("mytable", "mydb"), true),
+	},
+	{
+		input: "SHOW CREATE VIEW `my.table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", ""), true),
+	},
+	{
+		input: "SHOW CREATE VIEW `my.db`.`my.table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my.table", "my.db"), true),
+	},
+	{
+		input: "SHOW CREATE VIEW `my``table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", ""), true),
+	},
+	{
+		input: "SHOW CREATE VIEW `my``db`.`my``table`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("my`table", "my`db"), true),
+	},
+	{
+		input: "SHOW CREATE VIEW ````",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable("`", ""), true),
+	},
+	{
+		input: "SHOW CREATE VIEW `.`",
+		plan: plan.NewShowCreateTable(plan.NewUnresolvedTable(".", ""), true),
+	},
+	{
+		input: `SELECT '2018-05-01' + INTERVAL 1 DAY`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY",
 					expression.NewArithmetic(
 						expression.NewLiteral("2018-05-01", sql.LongText),
 						expression.NewInterval(
@@ -2738,60 +3557,108 @@ CREATE TABLE t2
 						),
 						"+",
 					),
-					expression.NewInterval(
-						expression.NewLiteral(int8(1), sql.Int8),
-						"DAY",
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT '2018-05-01' - INTERVAL 1 DAY`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("'2018-05-01' - INTERVAL 1 DAY",
+					expression.NewArithmetic(
+						expression.NewLiteral("2018-05-01", sql.LongText),
+						expression.NewInterval(
+							expression.NewLiteral(int8(1), sql.Int8),
+							"DAY",
+						),
+						"-",
 					),
-					"+",
 				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT INTERVAL 1 DAY + '2018-05-01'`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("INTERVAL 1 DAY + '2018-05-01'",
+					expression.NewArithmetic(
+						expression.NewInterval(
+							expression.NewLiteral(int8(1), sql.Int8),
+							"DAY",
+						),
+						expression.NewLiteral("2018-05-01", sql.LongText),
+						"+",
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT '2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewAlias("'2018-05-01' + INTERVAL 1 DAY + INTERVAL 1 DAY",
+					expression.NewArithmetic(
+						expression.NewArithmetic(
+							expression.NewLiteral("2018-05-01", sql.LongText),
+							expression.NewInterval(
+								expression.NewLiteral(int8(1), sql.Int8),
+								"DAY",
+							),
+							"+",
+						),
+						expression.NewInterval(
+							expression.NewLiteral(int8(1), sql.Int8),
+							"DAY",
+						),
+						"+",
+					),
+				),
+			},
+			plan.NewResolvedDualTable(),
+		),
+	},
+	{
+		input: `SELECT bar, AVG(baz) FROM foo GROUP BY bar HAVING COUNT(*) > 5`,
+		plan: plan.NewHaving(
+			expression.NewGreaterThan(
+				expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
+				expression.NewLiteral(int8(5), sql.Int8),
 			),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`SELECT bar, AVG(baz) FROM foo GROUP BY bar HAVING COUNT(*) > 5`: plan.NewHaving(
-		expression.NewGreaterThan(
-			expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
-			expression.NewLiteral(int8(5), sql.Int8),
+			plan.NewGroupBy(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("bar"),
+					expression.NewAlias("AVG(baz)",
+						expression.NewUnresolvedFunction("avg", true, nil, expression.NewUnresolvedColumn("baz")),
+					),
+				},
+				[]sql.Expression{expression.NewUnresolvedColumn("bar")},
+				plan.NewUnresolvedTable("foo", ""),
+			),
 		),
-		plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("bar"),
-				expression.NewAlias("AVG(baz)",
-					expression.NewUnresolvedFunction("avg", true, nil, expression.NewUnresolvedColumn("baz")),
-				),
-			},
-			[]sql.Expression{expression.NewUnresolvedColumn("bar")},
-			plan.NewUnresolvedTable("foo", ""),
+	},
+	{
+		input: `SELECT foo FROM t GROUP BY foo HAVING i > 5`,
+		plan: plan.NewHaving(
+			expression.NewGreaterThan(
+				expression.NewUnresolvedColumn("i"),
+				expression.NewLiteral(int8(5), sql.Int8),
+			),
+			plan.NewGroupBy(
+				[]sql.Expression{expression.NewUnresolvedColumn("foo")},
+				[]sql.Expression{expression.NewUnresolvedColumn("foo")},
+				plan.NewUnresolvedTable("t", ""),
+			),
 		),
-	),
-	`SELECT foo FROM t GROUP BY foo HAVING i > 5`: plan.NewHaving(
-		expression.NewGreaterThan(
-			expression.NewUnresolvedColumn("i"),
-			expression.NewLiteral(int8(5), sql.Int8),
-		),
-		plan.NewGroupBy(
-			[]sql.Expression{expression.NewUnresolvedColumn("foo")},
-			[]sql.Expression{expression.NewUnresolvedColumn("foo")},
-			plan.NewUnresolvedTable("t", ""),
-		),
-	),
-	`SELECT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`: plan.NewHaving(
-		expression.NewGreaterThan(
-			expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
-			expression.NewLiteral(int8(5), sql.Int8),
-		),
-		plan.NewGroupBy(
-			[]sql.Expression{
-				expression.NewAlias("COUNT(*)",
-					expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
-				),
-			},
-			[]sql.Expression{expression.NewUnresolvedColumn("a")},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT DISTINCT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`: plan.NewDistinct(
-		plan.NewHaving(
+	},
+	{
+		input: `SELECT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`,
+		plan: plan.NewHaving(
 			expression.NewGreaterThan(
 				expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
 				expression.NewLiteral(int8(5), sql.Int8),
@@ -2806,963 +3673,1181 @@ CREATE TABLE t2
 				plan.NewUnresolvedTable("foo", ""),
 			),
 		),
-	),
-	`SELECT * FROM foo LEFT JOIN bar ON 1=1`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewLeftJoin(
-			plan.NewUnresolvedTable("foo", ""),
-			plan.NewUnresolvedTable("bar", ""),
-			expression.NewEquals(
-				expression.NewLiteral(int8(1), sql.Int8),
-				expression.NewLiteral(int8(1), sql.Int8),
-			),
-		),
-	),
-	`SELECT * FROM foo LEFT OUTER JOIN bar ON 1=1`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewLeftJoin(
-			plan.NewUnresolvedTable("foo", ""),
-			plan.NewUnresolvedTable("bar", ""),
-			expression.NewEquals(
-				expression.NewLiteral(int8(1), sql.Int8),
-				expression.NewLiteral(int8(1), sql.Int8),
-			),
-		),
-	),
-	`SELECT * FROM foo RIGHT JOIN bar ON 1=1`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewRightJoin(
-			plan.NewUnresolvedTable("foo", ""),
-			plan.NewUnresolvedTable("bar", ""),
-			expression.NewEquals(
-				expression.NewLiteral(int8(1), sql.Int8),
-				expression.NewLiteral(int8(1), sql.Int8),
-			),
-		),
-	),
-	`SELECT * FROM foo RIGHT OUTER JOIN bar ON 1=1`: plan.NewProject(
-		[]sql.Expression{expression.NewStar()},
-		plan.NewRightJoin(
-			plan.NewUnresolvedTable("foo", ""),
-			plan.NewUnresolvedTable("bar", ""),
-			expression.NewEquals(
-				expression.NewLiteral(int8(1), sql.Int8),
-				expression.NewLiteral(int8(1), sql.Int8),
-			),
-		),
-	),
-	`SELECT FIRST(i) FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("FIRST(i)",
-				expression.NewUnresolvedFunction("first", true, nil, expression.NewUnresolvedColumn("i")),
-			),
-		},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT LAST(i) FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("LAST(i)",
-				expression.NewUnresolvedFunction("last", true, nil, expression.NewUnresolvedColumn("i")),
-			),
-		},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT COUNT(DISTINCT i) FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("COUNT(DISTINCT i)",
-				aggregation.NewCountDistinct(expression.NewUnresolvedColumn("i"))),
-		},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT AVG(DISTINCT a) FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("AVG(DISTINCT a)",
-				expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("a")))),
-		},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT SUM(DISTINCT a*b) FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("SUM(DISTINCT a*b)",
-				expression.NewUnresolvedFunction("sum", true, nil,
-					expression.NewDistinctExpression(
-						expression.NewMult(expression.NewUnresolvedColumn("a"),
-							expression.NewUnresolvedColumn("b")))))},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT AVG(DISTINCT a / b) FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("AVG(DISTINCT a / b)",
-				expression.NewUnresolvedFunction("avg", true, nil,
-					expression.NewDistinctExpression(
-						expression.NewDiv(expression.NewUnresolvedColumn("a"),
-							expression.NewUnresolvedColumn("b")))))},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT SUM(DISTINCT POWER(a, 2)) FROM foo`: plan.NewGroupBy(
-		[]sql.Expression{
-			expression.NewAlias("SUM(DISTINCT POWER(a, 2))",
-				expression.NewUnresolvedFunction("sum", true, nil,
-					expression.NewDistinctExpression(
-						expression.NewUnresolvedFunction("power", false, nil,
-							expression.NewUnresolvedColumn("a"), expression.NewLiteral(int8(2), sql.Int8)))))},
-		[]sql.Expression{},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, row_number() over (partition by s order by x) FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("row_number() over (partition by s order by x)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("s"),
-				}, sql.SortFields{
-					{
-						Column:       expression.NewUnresolvedColumn("x"),
-						Column2:      expression.NewUnresolvedColumn("x"),
-						Order:        sql.Ascending,
-						NullOrdering: sql.NullsFirst,
-					},
-				}, nil, "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, count(i) over () FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("count(i) over ()",
-				expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""), expression.NewUnresolvedColumn("i")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, row_number() over (order by x), row_number() over (partition by y) FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("row_number() over (order by x)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-					{
-						Column:       expression.NewUnresolvedColumn("x"),
-						Column2:      expression.NewUnresolvedColumn("x"),
-						Order:        sql.Ascending,
-						NullOrdering: sql.NullsFirst,
-					},
-				}, nil, "", "")),
-			),
-			expression.NewAlias("row_number() over (partition by y)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("y"),
-				}, nil, nil, "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, row_number() over (order by x), max(b) over () FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("row_number() over (order by x)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-					{
-						Column:       expression.NewUnresolvedColumn("x"),
-						Column2:      expression.NewUnresolvedColumn("x"),
-						Order:        sql.Ascending,
-						NullOrdering: sql.NullsFirst,
-					},
-				}, nil, "", "")),
-			),
-			expression.NewAlias("max(b) over ()",
-				expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""),
-					expression.NewUnresolvedColumn("b"),
+	},
+	{
+		input: `SELECT DISTINCT COUNT(*) FROM foo GROUP BY a HAVING COUNT(*) > 5`,
+		plan: plan.NewDistinct(
+			plan.NewHaving(
+				expression.NewGreaterThan(
+					expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
+					expression.NewLiteral(int8(5), sql.Int8),
 				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, row_number() over (partition by b), max(b) over (partition by b) FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("row_number() over (partition by b)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("b"),
-				}, nil, nil, "", "")),
-			),
-			expression.NewAlias("max(b) over (partition by b)",
-				expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("b"),
-				}, nil, nil, "", ""),
-					expression.NewUnresolvedColumn("b"),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, row_number() over (partition by c), max(b) over (partition by b) FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("row_number() over (partition by c)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("c"),
-				}, nil, nil, "", "")),
-			),
-			expression.NewAlias("max(b) over (partition by b)",
-				expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("b"),
-				}, nil, nil, "", ""),
-					expression.NewUnresolvedColumn("b"),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, count(i) over (order by x) FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("count(i) over (order by x)",
-				expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-					{
-						Column:       expression.NewUnresolvedColumn("x"),
-						Column2:      expression.NewUnresolvedColumn("x"),
-						Order:        sql.Ascending,
-						NullOrdering: sql.NullsFirst,
-					},
-				}, nil, "", ""),
-					expression.NewUnresolvedColumn("i"),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT a, count(i) over (partition by y) FROM foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("a"),
-			expression.NewAlias("count(i) over (partition by y)",
-				expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("y"),
-				}, nil, nil, "", ""),
-					expression.NewUnresolvedColumn("i"),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT i, row_number() over (order by a), max(b) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewUnresolvedColumn("i"),
-			expression.NewAlias("row_number() over (order by a)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-					{
-						Column:       expression.NewUnresolvedColumn("a"),
-						Column2:      expression.NewUnresolvedColumn("a"),
-						Order:        sql.Ascending,
-						NullOrdering: sql.NullsFirst,
-					},
-				}, nil, "", "")),
-			),
-			expression.NewAlias("max(b)",
-				expression.NewUnresolvedFunction("max", true, nil,
-					expression.NewUnresolvedColumn("b"),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x ROWS UNBOUNDED PRECEDING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x ROWS UNBOUNDED PRECEDING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRowsUnboundedPrecedingToCurrentRowFrame(), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRowsNPrecedingToNFollowingFrame(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(1), sql.Int8),
-				), "", ""),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRowsNFollowingToNFollowingFrame(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(2), sql.Int8),
-				), "", ""),
-				),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRowsCurrentRowToCurrentRowFrame(), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRowsCurrentRowToNFollowingFrame(
-					expression.NewLiteral(int8(1), sql.Int8),
-				), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE CURRENT ROW) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE CURRENT ROW)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE 2 PRECEDING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE 2 PRECEDING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-					expression.NewLiteral(int8(2), sql.Int8),
-				), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE UNBOUNDED PRECEDING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE UNBOUNDED PRECEDING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeUnboundedPrecedingToCurrentRowFrame(), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE interval 5 DAY PRECEDING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE interval 5 DAY PRECEDING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-					expression.NewInterval(
-						expression.NewLiteral(int8(5), sql.Int8),
-						"DAY",
-					),
-				), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-					expression.NewInterval(
-						expression.NewLiteral("2:30", sql.LongText),
-						"MINUTE_SECOND",
-					),
-				), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeNPrecedingToNFollowingFrame(
-					expression.NewLiteral(int8(1), sql.Int8),
-					expression.NewLiteral(int8(1), sql.Int8),
-				), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeCurrentRowToNFollowingFrame(
-					expression.NewLiteral(int8(1), sql.Int8),
-				), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-					expression.NewInterval(
-						expression.NewLiteral(int8(5), sql.Int8),
-						"DAY",
-					),
-				), "", ""),
-				)),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW) from foo`: plan.NewWindow(
-		[]sql.Expression{
-			expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)",
-				expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
-					expression.NewUnresolvedColumn("x"),
-				}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-					expression.NewInterval(
-						expression.NewLiteral("2:30", sql.LongText),
-						"MINUTE_SECOND",
-					),
-				), "", "")),
-			),
-		},
-		plan.NewUnresolvedTable("foo", ""),
-	),
-	`SELECT row_number() over (w) from foo WINDOW w as (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)`: plan.NewNamedWindows(
-		map[string]*sql.WindowDefinition{
-			"w": sql.NewWindowDefinition([]sql.Expression{
-				expression.NewUnresolvedColumn("x"),
-			}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
-				expression.NewInterval(
-					expression.NewLiteral("2:30", sql.LongText),
-					"MINUTE_SECOND",
-				),
-			), "", "w"),
-		},
-		plan.NewWindow(
-			[]sql.Expression{
-				expression.NewAlias("row_number() over (w)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w", "")),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		)),
-	`SELECT a, row_number() over (w1), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`: plan.NewNamedWindows(
-		map[string]*sql.WindowDefinition{
-			"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-				{
-					Column:       expression.NewUnresolvedColumn("x"),
-					Column2:      expression.NewUnresolvedColumn("x"),
-					Order:        sql.Ascending,
-					NullOrdering: sql.NullsFirst,
-				},
-			}, nil, "w2", "w1"),
-			"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
-		},
-		plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("row_number() over (w1)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w1", "")),
-				),
-				expression.NewAlias("max(b) over (w2)",
-					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
-						expression.NewUnresolvedColumn("b"),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`SELECT a, row_number() over (w1 partition by y), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`: plan.NewNamedWindows(
-		map[string]*sql.WindowDefinition{
-			"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
-				{
-					Column:       expression.NewUnresolvedColumn("x"),
-					Column2:      expression.NewUnresolvedColumn("x"),
-					Order:        sql.Ascending,
-					NullOrdering: sql.NullsFirst,
-				},
-			}, nil, "w2", "w1"),
-			"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
-		}, plan.NewWindow(
-			[]sql.Expression{
-				expression.NewUnresolvedColumn("a"),
-				expression.NewAlias("row_number() over (w1 partition by y)",
-					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("y"),
-						},
-						nil, nil, "w1", "")),
-				),
-				expression.NewAlias("max(b) over (w2)",
-					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
-						expression.NewUnresolvedColumn("b"),
-					),
-				),
-			},
-			plan.NewUnresolvedTable("foo", ""),
-		),
-	),
-	`with cte1 as (select a from b) select * from cte1`: plan.NewWith(
-		plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("cte1", "")),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select a from b",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("a"),
-						},
-						plan.NewUnresolvedTable("b", ""),
-					),
-				),
-				[]string{},
-			),
-		},
-		false,
-	),
-	`with cte1 as (select a from b) update c set d = e where f in (select * from cte1)`: plan.NewWith(
-		plan.NewUpdate(
-			plan.NewFilter(
-				plan.NewInSubquery(
-					expression.NewUnresolvedColumn("f"),
-					plan.NewSubquery(plan.NewProject(
-						[]sql.Expression{expression.NewStar()},
-						plan.NewUnresolvedTable("cte1", ""),
-					), "select * from cte1"),
-				),
-				plan.NewUnresolvedTable("c", ""),
-			),
-			false,
-			[]sql.Expression{
-				expression.NewSetField(expression.NewUnresolvedColumn("d"), expression.NewUnresolvedColumn("e")),
-			},
-		),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select a from b",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("a"),
-						},
-						plan.NewUnresolvedTable("b", ""),
-					),
-				),
-				[]string{},
-			),
-		},
-		false,
-	),
-	`with cte1 as (select a from b) delete from c where d in (select * from cte1)`: plan.NewWith(
-		plan.NewDeleteFrom(
-			plan.NewFilter(
-				plan.NewInSubquery(
-					expression.NewUnresolvedColumn("d"),
-					plan.NewSubquery(plan.NewProject(
-						[]sql.Expression{expression.NewStar()},
-						plan.NewUnresolvedTable("cte1", ""),
-					), "select * from cte1"),
-				),
-				plan.NewUnresolvedTable("c", ""),
-			),
-		),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select a from b",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("a"),
-						},
-						plan.NewUnresolvedTable("b", ""),
-					),
-				),
-				[]string{},
-			),
-		},
-		false,
-	),
-	`with cte1 as (select a from b) insert into c (select * from cte1)`: plan.NewWith(
-		plan.NewInsertInto(
-			sql.UnresolvedDatabase(""),
-			plan.NewUnresolvedTable("c", ""),
-			plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
-				plan.NewUnresolvedTable("cte1", ""),
-			),
-			false, []string{}, []sql.Expression{}, false,
-		),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select a from b",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("a"),
-						},
-						plan.NewUnresolvedTable("b", ""),
-					),
-				),
-				[]string{},
-			),
-		},
-		false,
-	),
-	`with recursive cte1 as (select 1 union select n+1 from cte1 where n < 10) select * from cte1`: plan.NewWith(
-		plan.NewProject(
-			[]sql.Expression{
-				expression.NewStar(),
-			},
-			plan.NewUnresolvedTable("cte1", "")),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select 1 union select n + 1 from cte1 where n < 10",
-					plan.NewUnion(plan.NewProject(
-						[]sql.Expression{
-							expression.NewLiteral(int8(1), sql.Int8),
-						},
-						plan.NewResolvedDualTable(),
-					), plan.NewProject(
-						[]sql.Expression{
-							expression.NewArithmetic(
-								expression.NewUnresolvedColumn("n"),
-								expression.NewLiteral(int8(1), sql.Int8),
-								sqlparser.PlusStr,
-							),
-						},
-						plan.NewFilter(
-							expression.NewLessThan(
-								expression.NewUnresolvedColumn("n"),
-								expression.NewLiteral(int8(10), sql.Int8),
-							),
-							plan.NewUnresolvedTable("cte1", ""),
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewAlias("COUNT(*)",
+							expression.NewUnresolvedFunction("count", true, nil, expression.NewStar()),
 						),
-					), true, nil, nil),
+					},
+					[]sql.Expression{expression.NewUnresolvedColumn("a")},
+					plan.NewUnresolvedTable("foo", ""),
 				),
-				[]string{},
 			),
-		},
-		true,
-	),
-	`with cte1 as (select a from b), cte2 as (select c from d) select * from cte1`: plan.NewWith(
-		plan.NewProject(
+		),
+	},
+	{
+		input: `SELECT * FROM foo LEFT JOIN bar ON 1=1`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewLeftJoin(
+				plan.NewUnresolvedTable("foo", ""),
+				plan.NewUnresolvedTable("bar", ""),
+				expression.NewEquals(
+					expression.NewLiteral(int8(1), sql.Int8),
+					expression.NewLiteral(int8(1), sql.Int8),
+				),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo LEFT OUTER JOIN bar ON 1=1`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewLeftJoin(
+				plan.NewUnresolvedTable("foo", ""),
+				plan.NewUnresolvedTable("bar", ""),
+				expression.NewEquals(
+					expression.NewLiteral(int8(1), sql.Int8),
+					expression.NewLiteral(int8(1), sql.Int8),
+				),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo RIGHT JOIN bar ON 1=1`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewRightJoin(
+				plan.NewUnresolvedTable("foo", ""),
+				plan.NewUnresolvedTable("bar", ""),
+				expression.NewEquals(
+					expression.NewLiteral(int8(1), sql.Int8),
+					expression.NewLiteral(int8(1), sql.Int8),
+				),
+			),
+		),
+	},
+	{
+		input: `SELECT * FROM foo RIGHT OUTER JOIN bar ON 1=1`,
+		plan: plan.NewProject(
+			[]sql.Expression{expression.NewStar()},
+			plan.NewRightJoin(
+				plan.NewUnresolvedTable("foo", ""),
+				plan.NewUnresolvedTable("bar", ""),
+				expression.NewEquals(
+					expression.NewLiteral(int8(1), sql.Int8),
+					expression.NewLiteral(int8(1), sql.Int8),
+				),
+			),
+		),
+	},
+	{
+		input: `SELECT FIRST(i) FROM foo`,
+		plan: plan.NewGroupBy(
 			[]sql.Expression{
-				expression.NewStar(),
+				expression.NewAlias("FIRST(i)",
+					expression.NewUnresolvedFunction("first", true, nil, expression.NewUnresolvedColumn("i")),
+				),
 			},
-			plan.NewUnresolvedTable("cte1", "")),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select a from b",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("a"),
-						},
-						plan.NewUnresolvedTable("b", ""),
-					),
-				),
-				[]string{},
-			),
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte2", "select c from d",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("c"),
-						},
-						plan.NewUnresolvedTable("d", ""),
-					),
-				),
-				[]string{},
-			),
-		},
-		false,
-	),
-	`with cte1 (x) as (select a from b), cte2 (y,z) as (select c from d) select * from cte1`: plan.NewWith(
-		plan.NewProject(
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT LAST(i) FROM foo`,
+		plan: plan.NewGroupBy(
 			[]sql.Expression{
-				expression.NewStar(),
+				expression.NewAlias("LAST(i)",
+					expression.NewUnresolvedFunction("last", true, nil, expression.NewUnresolvedColumn("i")),
+				),
 			},
-			plan.NewUnresolvedTable("cte1", "")),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select a from b",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("a"),
-						},
-						plan.NewUnresolvedTable("b", ""),
-					),
-				),
-				[]string{"x"},
-			),
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte2", "select c from d",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("c"),
-						},
-						plan.NewUnresolvedTable("d", ""),
-					),
-				),
-				[]string{"y", "z"},
-			),
-		},
-		false,
-	),
-	`with cte1 as (select a from b) select c, (with cte2 as (select c from d) select e from cte2) from cte1`: plan.NewWith(
-		plan.NewProject(
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT COUNT(DISTINCT i) FROM foo`,
+		plan: plan.NewGroupBy(
 			[]sql.Expression{
-				expression.NewUnresolvedColumn("c"),
-				expression.NewAlias("(with cte2 as (select c from d) select e from cte2)",
-					plan.NewSubquery(
-						plan.NewWith(
-							plan.NewProject(
-								[]sql.Expression{
-									expression.NewUnresolvedColumn("e"),
-								},
-								plan.NewUnresolvedTable("cte2", "")),
-							[]*plan.CommonTableExpression{
-								plan.NewCommonTableExpression(
-									plan.NewSubqueryAlias("cte2", "select c from d",
-										plan.NewProject(
-											[]sql.Expression{
-												expression.NewUnresolvedColumn("c"),
-											},
-											plan.NewUnresolvedTable("d", ""),
-										),
-									),
-									[]string{},
+				expression.NewAlias("COUNT(DISTINCT i)",
+					aggregation.NewCountDistinct(expression.NewUnresolvedColumn("i"))),
+			},
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT AVG(DISTINCT a) FROM foo`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias("AVG(DISTINCT a)",
+					expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("a")))),
+			},
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT SUM(DISTINCT a*b) FROM foo`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias("SUM(DISTINCT a*b)",
+					expression.NewUnresolvedFunction("sum", true, nil,
+						expression.NewDistinctExpression(
+							expression.NewMult(expression.NewUnresolvedColumn("a"),
+								expression.NewUnresolvedColumn("b")))))},
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT AVG(DISTINCT a / b) FROM foo`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias("AVG(DISTINCT a / b)",
+					expression.NewUnresolvedFunction("avg", true, nil,
+						expression.NewDistinctExpression(
+							expression.NewDiv(expression.NewUnresolvedColumn("a"),
+								expression.NewUnresolvedColumn("b")))))},
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT SUM(DISTINCT POWER(a, 2)) FROM foo`,
+		plan: plan.NewGroupBy(
+			[]sql.Expression{
+				expression.NewAlias("SUM(DISTINCT POWER(a, 2))",
+					expression.NewUnresolvedFunction("sum", true, nil,
+						expression.NewDistinctExpression(
+							expression.NewUnresolvedFunction("power", false, nil,
+								expression.NewUnresolvedColumn("a"), expression.NewLiteral(int8(2), sql.Int8)))))},
+			[]sql.Expression{},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, row_number() over (partition by s order by x) FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("row_number() over (partition by s order by x)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("s"),
+					}, sql.SortFields{
+						{
+							Column:       expression.NewUnresolvedColumn("x"),
+							Column2:      expression.NewUnresolvedColumn("x"),
+							Order:        sql.Ascending,
+							NullOrdering: sql.NullsFirst,
+						},
+					}, nil, "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, count(i) over () FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("count(i) over ()",
+					expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""), expression.NewUnresolvedColumn("i")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, row_number() over (order by x), row_number() over (partition by y) FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("row_number() over (order by x)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+						{
+							Column:       expression.NewUnresolvedColumn("x"),
+							Column2:      expression.NewUnresolvedColumn("x"),
+							Order:        sql.Ascending,
+							NullOrdering: sql.NullsFirst,
+						},
+					}, nil, "", "")),
+				),
+				expression.NewAlias("row_number() over (partition by y)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("y"),
+					}, nil, nil, "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, row_number() over (order by x), max(b) over () FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("row_number() over (order by x)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+						{
+							Column:       expression.NewUnresolvedColumn("x"),
+							Column2:      expression.NewUnresolvedColumn("x"),
+							Order:        sql.Ascending,
+							NullOrdering: sql.NullsFirst,
+						},
+					}, nil, "", "")),
+				),
+				expression.NewAlias("max(b) over ()",
+					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""),
+						expression.NewUnresolvedColumn("b"),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, row_number() over (partition by b), max(b) over (partition by b) FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("row_number() over (partition by b)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("b"),
+					}, nil, nil, "", "")),
+				),
+				expression.NewAlias("max(b) over (partition by b)",
+					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("b"),
+					}, nil, nil, "", ""),
+						expression.NewUnresolvedColumn("b"),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, row_number() over (partition by c), max(b) over (partition by b) FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("row_number() over (partition by c)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("c"),
+					}, nil, nil, "", "")),
+				),
+				expression.NewAlias("max(b) over (partition by b)",
+					expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("b"),
+					}, nil, nil, "", ""),
+						expression.NewUnresolvedColumn("b"),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, count(i) over (order by x) FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("count(i) over (order by x)",
+					expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+						{
+							Column:       expression.NewUnresolvedColumn("x"),
+							Column2:      expression.NewUnresolvedColumn("x"),
+							Order:        sql.Ascending,
+							NullOrdering: sql.NullsFirst,
+						},
+					}, nil, "", ""),
+						expression.NewUnresolvedColumn("i"),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT a, count(i) over (partition by y) FROM foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("a"),
+				expression.NewAlias("count(i) over (partition by y)",
+					expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("y"),
+					}, nil, nil, "", ""),
+						expression.NewUnresolvedColumn("i"),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT i, row_number() over (order by a), max(b) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewUnresolvedColumn("i"),
+				expression.NewAlias("row_number() over (order by a)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+						{
+							Column:       expression.NewUnresolvedColumn("a"),
+							Column2:      expression.NewUnresolvedColumn("a"),
+							Order:        sql.Ascending,
+							NullOrdering: sql.NullsFirst,
+						},
+					}, nil, "", "")),
+				),
+				expression.NewAlias("max(b)",
+					expression.NewUnresolvedFunction("max", true, nil,
+						expression.NewUnresolvedColumn("b"),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x ROWS UNBOUNDED PRECEDING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x ROWS UNBOUNDED PRECEDING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRowsUnboundedPrecedingToCurrentRowFrame(), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRowsNPrecedingToNFollowingFrame(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(1), sql.Int8),
+					), "", ""),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRowsNFollowingToNFollowingFrame(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(2), sql.Int8),
+					), "", ""),
+					),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND CURRENT ROW)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRowsCurrentRowToCurrentRowFrame(), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRowsCurrentRowToNFollowingFrame(
+						expression.NewLiteral(int8(1), sql.Int8),
+					), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE CURRENT ROW) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE CURRENT ROW)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE 2 PRECEDING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE 2 PRECEDING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewLiteral(int8(2), sql.Int8),
+					), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE UNBOUNDED PRECEDING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE UNBOUNDED PRECEDING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeUnboundedPrecedingToCurrentRowFrame(), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE interval 5 DAY PRECEDING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE interval 5 DAY PRECEDING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral(int8(5), sql.Int8),
+							"DAY",
+						),
+					), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE interval '2:30' MINUTE_SECOND PRECEDING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral("2:30", sql.LongText),
+							"MINUTE_SECOND",
+						),
+					), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeNPrecedingToNFollowingFrame(
+						expression.NewLiteral(int8(1), sql.Int8),
+						expression.NewLiteral(int8(1), sql.Int8),
+					), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND CURRENT ROW)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeCurrentRowToCurrentRowFrame(), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeCurrentRowToNFollowingFrame(
+						expression.NewLiteral(int8(1), sql.Int8),
+					), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval 5 DAY PRECEDING AND CURRENT ROW)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral(int8(5), sql.Int8),
+							"DAY",
+						),
+					), "", ""),
+					)),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW) from foo`,
+		plan: plan.NewWindow(
+			[]sql.Expression{
+				expression.NewAlias("row_number() over (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)",
+					expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
+						expression.NewUnresolvedColumn("x"),
+					}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+						expression.NewInterval(
+							expression.NewLiteral("2:30", sql.LongText),
+							"MINUTE_SECOND",
+						),
+					), "", "")),
+				),
+			},
+			plan.NewUnresolvedTable("foo", ""),
+		),
+	},
+	{
+		input: `SELECT row_number() over (w) from foo WINDOW w as (partition by x RANGE BETWEEN interval '2:30' MINUTE_SECOND PRECEDING AND CURRENT ROW)`,
+		plan: plan.NewNamedWindows(
+			map[string]*sql.WindowDefinition{
+				"w": sql.NewWindowDefinition([]sql.Expression{
+					expression.NewUnresolvedColumn("x"),
+				}, nil, plan.NewRangeNPrecedingToCurrentRowFrame(
+					expression.NewInterval(
+						expression.NewLiteral("2:30", sql.LongText),
+						"MINUTE_SECOND",
+					),
+				), "", "w"),
+			},
+			plan.NewWindow(
+				[]sql.Expression{
+					expression.NewAlias("row_number() over (w)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w", "")),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			)),
+	},
+	{
+		input: `SELECT a, row_number() over (w1), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`,
+		plan: plan.NewNamedWindows(
+			map[string]*sql.WindowDefinition{
+				"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+					{
+						Column:       expression.NewUnresolvedColumn("x"),
+						Column2:      expression.NewUnresolvedColumn("x"),
+						Order:        sql.Ascending,
+						NullOrdering: sql.NullsFirst,
+					},
+				}, nil, "w2", "w1"),
+				"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
+			},
+			plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("row_number() over (w1)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w1", "")),
+					),
+					expression.NewAlias("max(b) over (w2)",
+						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
+							expression.NewUnresolvedColumn("b"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `SELECT a, row_number() over (w1 partition by y), max(b) over (w2) FROM foo WINDOW w1 as (w2 order by x), w2 as ()`,
+		plan: plan.NewNamedWindows(
+			map[string]*sql.WindowDefinition{
+				"w1": sql.NewWindowDefinition([]sql.Expression{}, sql.SortFields{
+					{
+						Column:       expression.NewUnresolvedColumn("x"),
+						Column2:      expression.NewUnresolvedColumn("x"),
+						Order:        sql.Ascending,
+						NullOrdering: sql.NullsFirst,
+					},
+				}, nil, "w2", "w1"),
+				"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
+			}, plan.NewWindow(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("a"),
+					expression.NewAlias("row_number() over (w1 partition by y)",
+						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("y"),
+							},
+							nil, nil, "w1", "")),
+					),
+					expression.NewAlias("max(b) over (w2)",
+						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
+							expression.NewUnresolvedColumn("b"),
+						),
+					),
+				},
+				plan.NewUnresolvedTable("foo", ""),
+			),
+		),
+	},
+	{
+		input: `with cte1 as (select a from b) select * from cte1`,
+		plan: plan.NewWith(
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("cte1", "")),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select a from b",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("a"),
+							},
+							plan.NewUnresolvedTable("b", ""),
+						),
+					),
+					[]string{},
+				),
+			},
+			false,
+		),
+	},
+	{
+		input: `with cte1 as (select a from b) update c set d = e where f in (select * from cte1)`,
+		plan: plan.NewWith(
+			plan.NewUpdate(
+				plan.NewFilter(
+					plan.NewInSubquery(
+						expression.NewUnresolvedColumn("f"),
+						plan.NewSubquery(plan.NewProject(
+							[]sql.Expression{expression.NewStar()},
+							plan.NewUnresolvedTable("cte1", ""),
+						), "select * from cte1"),
+					),
+					plan.NewUnresolvedTable("c", ""),
+				),
+				false,
+				[]sql.Expression{
+					expression.NewSetField(expression.NewUnresolvedColumn("d"), expression.NewUnresolvedColumn("e")),
+				},
+			),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select a from b",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("a"),
+							},
+							plan.NewUnresolvedTable("b", ""),
+						),
+					),
+					[]string{},
+				),
+			},
+			false,
+		),
+	},
+	{
+		input: `with cte1 as (select a from b) delete from c where d in (select * from cte1)`,
+		plan: plan.NewWith(
+			plan.NewDeleteFrom(
+				plan.NewFilter(
+					plan.NewInSubquery(
+						expression.NewUnresolvedColumn("d"),
+						plan.NewSubquery(plan.NewProject(
+							[]sql.Expression{expression.NewStar()},
+							plan.NewUnresolvedTable("cte1", ""),
+						), "select * from cte1"),
+					),
+					plan.NewUnresolvedTable("c", ""),
+				),
+			),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select a from b",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("a"),
+							},
+							plan.NewUnresolvedTable("b", ""),
+						),
+					),
+					[]string{},
+				),
+			},
+			false,
+		),
+	},
+	{
+		input: `with cte1 as (select a from b) insert into c (select * from cte1)`,
+		plan: plan.NewWith(
+			plan.NewInsertInto(
+				sql.UnresolvedDatabase(""),
+				plan.NewUnresolvedTable("c", ""),
+				plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("cte1", ""),
+				),
+				false, []string{}, []sql.Expression{}, false,
+			),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select a from b",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("a"),
+							},
+							plan.NewUnresolvedTable("b", ""),
+						),
+					),
+					[]string{},
+				),
+			},
+			false,
+		),
+	},
+	{
+		input: `with recursive cte1 as (select 1 union select n+1 from cte1 where n < 10) select * from cte1`,
+		plan: plan.NewWith(
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("cte1", "")),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select 1 union select n + 1 from cte1 where n < 10",
+						plan.NewUnion(plan.NewProject(
+							[]sql.Expression{
+								expression.NewLiteral(int8(1), sql.Int8),
+							},
+							plan.NewResolvedDualTable(),
+						), plan.NewProject(
+							[]sql.Expression{
+								expression.NewArithmetic(
+									expression.NewUnresolvedColumn("n"),
+									expression.NewLiteral(int8(1), sql.Int8),
+									sqlparser.PlusStr,
 								),
 							},
-							false,
-						),
-						"with cte2 as (select c from d) select e from cte2",
+							plan.NewFilter(
+								expression.NewLessThan(
+									expression.NewUnresolvedColumn("n"),
+									expression.NewLiteral(int8(10), sql.Int8),
+								),
+								plan.NewUnresolvedTable("cte1", ""),
+							),
+						), true, nil, nil),
 					),
+					[]string{},
 				),
 			},
-			plan.NewUnresolvedTable("cte1", ""),
+			true,
 		),
-		[]*plan.CommonTableExpression{
-			plan.NewCommonTableExpression(
-				plan.NewSubqueryAlias("cte1", "select a from b",
-					plan.NewProject(
-						[]sql.Expression{
-							expression.NewUnresolvedColumn("a"),
-						},
-						plan.NewUnresolvedTable("b", ""),
-					),
-				),
-				[]string{},
-			),
-		},
-		false,
-	),
-	`SELECT -128, 127, 255, -32768, 32767, 65535, -2147483648, 2147483647, 4294967295, -9223372036854775808, 9223372036854775807, 18446744073709551615`: plan.NewProject(
-		[]sql.Expression{
-			expression.NewLiteral(int8(math.MinInt8), sql.Int8),
-			expression.NewLiteral(int8(math.MaxInt8), sql.Int8),
-			expression.NewLiteral(uint8(math.MaxUint8), sql.Uint8),
-			expression.NewLiteral(int16(math.MinInt16), sql.Int16),
-			expression.NewLiteral(int16(math.MaxInt16), sql.Int16),
-			expression.NewLiteral(uint16(math.MaxUint16), sql.Uint16),
-			expression.NewLiteral(int32(math.MinInt32), sql.Int32),
-			expression.NewLiteral(int32(math.MaxInt32), sql.Int32),
-			expression.NewLiteral(uint32(math.MaxUint32), sql.Uint32),
-			expression.NewLiteral(int64(math.MinInt64), sql.Int64),
-			expression.NewLiteral(int64(math.MaxInt64), sql.Int64),
-			expression.NewLiteral(uint64(math.MaxUint64), sql.Uint64),
-		},
-		plan.NewResolvedDualTable(),
-	),
-	`CREATE VIEW v AS SELECT * FROM foo`: plan.NewCreateView(
-		sql.UnresolvedDatabase(""),
-		"v",
-		[]string{},
-		plan.NewSubqueryAlias(
-			"v", "SELECT * FROM foo",
+	},
+	{
+		input: `with cte1 as (select a from b), cte2 as (select c from d) select * from cte1`,
+		plan: plan.NewWith(
 			plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
-				plan.NewUnresolvedTable("foo", ""),
-			),
-		),
-		false,
-	),
-	`CREATE VIEW myview AS SELECT AVG(DISTINCT foo) FROM b`: plan.NewCreateView(
-		sql.UnresolvedDatabase(""),
-		"myview",
-		[]string{},
-		plan.NewSubqueryAlias(
-			"myview", "SELECT AVG(DISTINCT foo) FROM b",
-			plan.NewGroupBy(
 				[]sql.Expression{
-					expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("foo"))),
+					expression.NewStar(),
 				},
-				[]sql.Expression{},
-				plan.NewUnresolvedTable("b", ""),
-			),
+				plan.NewUnresolvedTable("cte1", "")),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select a from b",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("a"),
+							},
+							plan.NewUnresolvedTable("b", ""),
+						),
+					),
+					[]string{},
+				),
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte2", "select c from d",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("c"),
+							},
+							plan.NewUnresolvedTable("d", ""),
+						),
+					),
+					[]string{},
+				),
+			},
+			false,
 		),
-		false,
-	),
-	`CREATE OR REPLACE VIEW v AS SELECT * FROM foo`: plan.NewCreateView(
-		sql.UnresolvedDatabase(""),
-		"v",
-		[]string{},
-		plan.NewSubqueryAlias(
-			"v", "SELECT * FROM foo",
+	},
+	{
+		input: `with cte1 (x) as (select a from b), cte2 (y,z) as (select c from d) select * from cte1`,
+		plan: plan.NewWith(
 			plan.NewProject(
-				[]sql.Expression{expression.NewStar()},
-				plan.NewUnresolvedTable("foo", ""),
-			),
+				[]sql.Expression{
+					expression.NewStar(),
+				},
+				plan.NewUnresolvedTable("cte1", "")),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select a from b",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("a"),
+							},
+							plan.NewUnresolvedTable("b", ""),
+						),
+					),
+					[]string{"x"},
+				),
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte2", "select c from d",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("c"),
+							},
+							plan.NewUnresolvedTable("d", ""),
+						),
+					),
+					[]string{"y", "z"},
+				),
+			},
+			false,
 		),
-		true,
-	),
-	`SELECT 2 UNION SELECT 3`: plan.NewUnion(plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), true, nil, nil),
-	`(SELECT 2) UNION (SELECT 3)`: plan.NewUnion(plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), true, nil, nil),
-	`SELECT 2 UNION ALL SELECT 3 UNION DISTINCT SELECT 4`: plan.NewUnion(plan.NewUnion(plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), false, nil, nil),
-		plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+	},
+	{
+		input: `with cte1 as (select a from b) select c, (with cte2 as (select c from d) select e from cte2) from cte1`,
+		plan: plan.NewWith(
+			plan.NewProject(
+				[]sql.Expression{
+					expression.NewUnresolvedColumn("c"),
+					expression.NewAlias("(with cte2 as (select c from d) select e from cte2)",
+						plan.NewSubquery(
+							plan.NewWith(
+								plan.NewProject(
+									[]sql.Expression{
+										expression.NewUnresolvedColumn("e"),
+									},
+									plan.NewUnresolvedTable("cte2", "")),
+								[]*plan.CommonTableExpression{
+									plan.NewCommonTableExpression(
+										plan.NewSubqueryAlias("cte2", "select c from d",
+											plan.NewProject(
+												[]sql.Expression{
+													expression.NewUnresolvedColumn("c"),
+												},
+												plan.NewUnresolvedTable("d", ""),
+											),
+										),
+										[]string{},
+									),
+								},
+								false,
+							),
+							"with cte2 as (select c from d) select e from cte2",
+						),
+					),
+				},
+				plan.NewUnresolvedTable("cte1", ""),
+			),
+			[]*plan.CommonTableExpression{
+				plan.NewCommonTableExpression(
+					plan.NewSubqueryAlias("cte1", "select a from b",
+						plan.NewProject(
+							[]sql.Expression{
+								expression.NewUnresolvedColumn("a"),
+							},
+							plan.NewUnresolvedTable("b", ""),
+						),
+					),
+					[]string{},
+				),
+			},
+			false,
+		),
+	},
+	{
+		input: `SELECT -128, 127, 255, -32768, 32767, 65535, -2147483648, 2147483647, 4294967295, -9223372036854775808, 9223372036854775807, 18446744073709551615`,
+		plan: plan.NewProject(
+			[]sql.Expression{
+				expression.NewLiteral(int8(math.MinInt8), sql.Int8),
+				expression.NewLiteral(int8(math.MaxInt8), sql.Int8),
+				expression.NewLiteral(uint8(math.MaxUint8), sql.Uint8),
+				expression.NewLiteral(int16(math.MinInt16), sql.Int16),
+				expression.NewLiteral(int16(math.MaxInt16), sql.Int16),
+				expression.NewLiteral(uint16(math.MaxUint16), sql.Uint16),
+				expression.NewLiteral(int32(math.MinInt32), sql.Int32),
+				expression.NewLiteral(int32(math.MaxInt32), sql.Int32),
+				expression.NewLiteral(uint32(math.MaxUint32), sql.Uint32),
+				expression.NewLiteral(int64(math.MinInt64), sql.Int64),
+				expression.NewLiteral(int64(math.MaxInt64), sql.Int64),
+				expression.NewLiteral(uint64(math.MaxUint64), sql.Uint64),
+			},
 			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-	`SELECT 2 UNION SELECT 3 UNION ALL SELECT 4`: plan.NewUnion(
-		plan.NewUnion(plan.NewProject(
+		),
+	},
+	{
+		input: `CREATE VIEW v AS SELECT * FROM foo`,
+		plan: plan.NewCreateView(
+			sql.UnresolvedDatabase(""),
+			"v",
+			[]string{},
+			plan.NewSubqueryAlias(
+				"v", "SELECT * FROM foo",
+				plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+			false,
+		),
+	},
+	{
+		input: `CREATE VIEW myview AS SELECT AVG(DISTINCT foo) FROM b`,
+		plan: plan.NewCreateView(
+			sql.UnresolvedDatabase(""),
+			"myview",
+			[]string{},
+			plan.NewSubqueryAlias(
+				"myview", "SELECT AVG(DISTINCT foo) FROM b",
+				plan.NewGroupBy(
+					[]sql.Expression{
+						expression.NewUnresolvedFunction("avg", true, nil, expression.NewDistinctExpression(expression.NewUnresolvedColumn("foo"))),
+					},
+					[]sql.Expression{},
+					plan.NewUnresolvedTable("b", ""),
+				),
+			),
+			false,
+		),
+	},
+	{
+		input: `CREATE OR REPLACE VIEW v AS SELECT * FROM foo`,
+		plan: plan.NewCreateView(
+			sql.UnresolvedDatabase(""),
+			"v",
+			[]string{},
+			plan.NewSubqueryAlias(
+				"v", "SELECT * FROM foo",
+				plan.NewProject(
+					[]sql.Expression{expression.NewStar()},
+					plan.NewUnresolvedTable("foo", ""),
+				),
+			),
+			true,
+		),
+	},
+	{
+		input: `SELECT 2 UNION SELECT 3`,
+		plan: plan.NewUnion(plan.NewProject(
 			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
 			plan.NewResolvedDualTable(),
 		), plan.NewProject(
 			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 			plan.NewResolvedDualTable(),
 		), true, nil, nil),
-		plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+	},
+	{
+		input: `(SELECT 2) UNION (SELECT 3)`,
+		plan: plan.NewUnion(plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+			plan.NewResolvedDualTable(),
+		), plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+			plan.NewResolvedDualTable(),
+		), true, nil, nil),
+	},
+	{
+		input: `SELECT 2 UNION ALL SELECT 3 UNION DISTINCT SELECT 4`,
+		plan: plan.NewUnion(plan.NewUnion(plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+			plan.NewResolvedDualTable(),
+		), plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 			plan.NewResolvedDualTable(),
 		), false, nil, nil),
-	`SELECT 2 UNION SELECT 3 UNION SELECT 4`: plan.NewUnion(
-		plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-		plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-	`SELECT 2 UNION (SELECT 3 UNION SELECT 4)`: plan.NewUnion(
-		plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+	},
+	{
+		input: `SELECT 2 UNION SELECT 3 UNION ALL SELECT 4`,
+		plan: plan.NewUnion(
+			plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), false, nil, nil),
+	},
+	{
+		input: `SELECT 2 UNION SELECT 3 UNION SELECT 4`,
+		plan: plan.NewUnion(
+			plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+	},
+	{
+		input: `SELECT 2 UNION (SELECT 3 UNION SELECT 4)`,
+		plan: plan.NewUnion(
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			),
+			plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+			true, nil, nil,
 		),
-		plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+	},
+	{
+		input: `SELECT 2 UNION ALL SELECT 3`,
+		plan: plan.NewUnion(plan.NewProject(
+			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
 			plan.NewResolvedDualTable(),
 		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-		true, nil, nil,
-	),
-	`SELECT 2 UNION ALL SELECT 3`: plan.NewUnion(plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), false, nil, nil),
-	`SELECT 2 UNION DISTINCT SELECT 3`: plan.NewUnion(plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), plan.NewProject(
-		[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-		plan.NewResolvedDualTable(),
-	), true, nil, nil),
-	`SELECT 2 UNION SELECT 3 UNION SELECT 4 LIMIT 10`: plan.NewUnion(
-		plan.NewUnion(plan.NewProject(
+		), false, nil, nil),
+	},
+	{
+		input: `SELECT 2 UNION DISTINCT SELECT 3`,
+		plan: plan.NewUnion(plan.NewProject(
 			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
 			plan.NewResolvedDualTable(),
 		), plan.NewProject(
 			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
 			plan.NewResolvedDualTable(),
 		), true, nil, nil),
-		plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, expression.NewLiteral(int8(10), sql.Int8), nil),
-	`SELECT 2 UNION SELECT 3 UNION SELECT 4 ORDER BY 2`: plan.NewUnion(
-		plan.NewUnion(plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, nil, nil),
-		plan.NewProject(
-			[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
-			plan.NewResolvedDualTable(),
-		), true, nil, []sql.SortField{
-			{
-				Column:       expression.NewLiteral(int8(2), sql.Int8),
-				Column2:      expression.NewLiteral(int8(2), sql.Int8),
-				Order:        sql.Ascending,
-				NullOrdering: sql.NullsFirst,
-			},
-		}),
-	`CREATE DATABASE test`:               plan.NewCreateDatabase("test", false),
-	`CREATE DATABASE IF NOT EXISTS test`: plan.NewCreateDatabase("test", true),
-	`DROP DATABASE test`:                 plan.NewDropDatabase("test", false),
-	`DROP DATABASE IF EXISTS test`:       plan.NewDropDatabase("test", true),
-	`KILL QUERY 1`:                       plan.NewKill(plan.KillType_Query, 1),
-	`KILL CONNECTION 1`:                  plan.NewKill(plan.KillType_Connection, 1),
-	/* fixtures end */
+	},
+	{
+		input: `SELECT 2 UNION SELECT 3 UNION SELECT 4 LIMIT 10`,
+		plan: plan.NewUnion(
+			plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, expression.NewLiteral(int8(10), sql.Int8), nil),
+	},
+	{
+		input: `SELECT 2 UNION SELECT 3 UNION SELECT 4 ORDER BY 2`,
+		plan: plan.NewUnion(
+			plan.NewUnion(plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(2), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(3), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, nil),
+			plan.NewProject(
+				[]sql.Expression{expression.NewLiteral(int8(4), sql.Int8)},
+				plan.NewResolvedDualTable(),
+			), true, nil, []sql.SortField{
+				{
+					Column:       expression.NewLiteral(int8(2), sql.Int8),
+					Column2:      expression.NewLiteral(int8(2), sql.Int8),
+					Order:        sql.Ascending,
+					NullOrdering: sql.NullsFirst,
+				},
+			}),
+	},
+	{
+		input: `CREATE DATABASE test`,
+		plan: plan.NewCreateDatabase("test", false),
+	},
+	{
+		input: `CREATE DATABASE IF NOT EXISTS test`,
+		plan: plan.NewCreateDatabase("test", true),
+	},
+	{
+		input: `DROP DATABASE test`,
+		plan: plan.NewDropDatabase("test", false),
+	},
+	{
+		input: `DROP DATABASE IF EXISTS test`,
+		plan: plan.NewDropDatabase("test", true),
+	},
+	{
+		input: `KILL QUERY 1`,
+		plan: plan.NewKill(plan.KillType_Query, 1),
+	},
+	{
+		input: `KILL CONNECTION 1`,
+		plan: plan.NewKill(plan.KillType_Connection, 1),
+		/* fixtures end */
+	},
 }
 
 var triggerFixtures = map[string]sql.Node{
@@ -3837,54 +4922,15 @@ var triggerFixtures = map[string]sql.Node{
 	),
 }
 
-type parseTest struct {
-	input string
-	plan sql.Node
-}
-
-// func TestOutput(t *testing.T) {
-// 	var queriesInOrder []string
-// 	for q := range fixtures {
-// 		queriesInOrder = append(queriesInOrder, q)
-// 	}
-// 	sort.Strings(queriesInOrder)
-//
-// 	file, err := ioutil.TempFile("", "fixtures")
-// 	require.NoError(t, err)
-//
-// 	prefix := `fixtures = []parseTest{\n`
-// 	tmpl := `{input: %s, plan: }`
-//
-// 	for _, query := range queriesInOrder {
-// 		expectedPlan := fixtures[query]
-// 		t.Run(query, func(t *testing.T) {
-// 			require := require.New(t)
-// 			ctx := sql.NewEmptyContext()
-// 			p, err := Parse(ctx, query)
-// 			require.NoError(err)
-// 			if !assertNodesEqualWithDiff(t, expectedPlan, p) {
-// 				t.Logf("Unexpected result for query %s", query)
-// 			}
-// 		})
-// 	}
-// }
-
 func TestParse(t *testing.T) {
-	var queriesInOrder []string
-	for q := range fixtures {
-		queriesInOrder = append(queriesInOrder, q)
-	}
-	sort.Strings(queriesInOrder)
-
-	for _, query := range queriesInOrder {
-		expectedPlan := fixtures[query]
-		t.Run(query, func(t *testing.T) {
+	for _, tt := range fixtures {
+		t.Run(tt.input, func(t *testing.T) {
 			require := require.New(t)
 			ctx := sql.NewEmptyContext()
-			p, err := Parse(ctx, query)
+			p, err := Parse(ctx, tt.input)
 			require.NoError(err)
-			if !assertNodesEqualWithDiff(t, expectedPlan, p) {
-				t.Logf("Unexpected result for query %s", query)
+			if !assertNodesEqualWithDiff(t, tt.plan, p) {
+				t.Logf("Unexpected result for query %s", tt.input)
 			}
 		})
 	}

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -48,6 +48,7 @@ var showCollationProjection = plan.NewProject([]sql.Expression{
 )
 
 var fixtures = map[string]sql.Node{
+	/* fixtures start */
 	`CREATE TABLE t1(a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, g DATETIME, h CHAR(40))`: plan.NewCreateTable(
 		sql.UnresolvedDatabase(""),
 		"t1",
@@ -3761,6 +3762,7 @@ CREATE TABLE t2
 	`DROP DATABASE IF EXISTS test`:       plan.NewDropDatabase("test", true),
 	`KILL QUERY 1`:                       plan.NewKill(plan.KillType_Query, 1),
 	`KILL CONNECTION 1`:                  plan.NewKill(plan.KillType_Connection, 1),
+	/* fixtures end */
 }
 
 var triggerFixtures = map[string]sql.Node{
@@ -3834,6 +3836,38 @@ var triggerFixtures = map[string]sql.Node{
 		"",
 	),
 }
+
+type parseTest struct {
+	input string
+	plan sql.Node
+}
+
+// func TestOutput(t *testing.T) {
+// 	var queriesInOrder []string
+// 	for q := range fixtures {
+// 		queriesInOrder = append(queriesInOrder, q)
+// 	}
+// 	sort.Strings(queriesInOrder)
+//
+// 	file, err := ioutil.TempFile("", "fixtures")
+// 	require.NoError(t, err)
+//
+// 	prefix := `fixtures = []parseTest{\n`
+// 	tmpl := `{input: %s, plan: }`
+//
+// 	for _, query := range queriesInOrder {
+// 		expectedPlan := fixtures[query]
+// 		t.Run(query, func(t *testing.T) {
+// 			require := require.New(t)
+// 			ctx := sql.NewEmptyContext()
+// 			p, err := Parse(ctx, query)
+// 			require.NoError(err)
+// 			if !assertNodesEqualWithDiff(t, expectedPlan, p) {
+// 				t.Logf("Unexpected result for query %s", query)
+// 			}
+// 		})
+// 	}
+// }
 
 func TestParse(t *testing.T) {
 	var queriesInOrder []string


### PR DESCRIPTION
This rewrites parse_test.go to use a slice of test structs rather than the map scheme. This makes it possible to run individual test cases from inside GoLand or other IDEs.

Validation performed: same number of tests run and passing as before