### PR TITLE
allow adding new primary key to table with > 1 row iff it has auto_increment

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4997,23 +4997,62 @@ func TestAddDropPks(t *testing.T, harness Harness) {
 		}, nil, nil)
 	})
 
-	if _, ok := harness.(*MemoryHarness); ok {
-		t.Skip("in memory tables don't implement sql.Rewritable yet")
-	}
+}
+
+func TestAddAutoIncrementColumn(t *testing.T, harness Harness) {
+	harness.Setup([]setup.SetupScript{{
+		"create database mydb",
+		"use mydb",
+	}})
+	e := mustNewEngine(t, harness)
+	defer e.Close()
+	ctx := NewContext(harness)
 
 	t.Run("Add primary key column with auto increment", func(t *testing.T) {
 		ctx.SetCurrentDatabase("mydb")
-		RunQuery(t, e, harness, "CREATE TABLE t2 (i int, j int);")
-		RunQuery(t, e, harness, "insert into t2 values (1,1), (2,2), (3,3)")
+		RunQuery(t, e, harness, "CREATE TABLE t1 (i int, j int);")
+		RunQuery(t, e, harness, "insert into t1 values (1,1), (2,2), (3,3)")
 		AssertErr(
 			t, e, harness,
-			"alter table t2 add column pk int primary key;",
+			"alter table t1 add column pk int primary key;",
 			sql.ErrPrimaryKeyViolation,
 		)
 
 		TestQueryWithContext(
 			t, ctx, e, harness,
-			"alter table t2 add column pk int primary key auto_increment;",
+			"alter table t1 add column pk int primary key auto_increment;",
+			[]sql.Row{{sql.NewOkResult(0)}},
+			nil, nil,
+		)
+
+		TestQueryWithContext(
+			t, ctx, e, harness,
+			"select pk from t1;",
+			[]sql.Row{
+				{1},
+				{2},
+				{3},
+			},
+			nil, nil,
+		)
+
+		TestQueryWithContext(
+			t, ctx, e, harness,
+			"show create table t1;",
+			[]sql.Row{
+				{"t1", "CREATE TABLE `t1` (\n  `i` int,\n  `j` int,\n  `pk` int NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+			},
+			nil, nil,
+		)
+	})
+
+	t.Run("Add primary key column with auto increment first", func(t *testing.T) {
+		ctx.SetCurrentDatabase("mydb")
+		RunQuery(t, e, harness, "CREATE TABLE t2 (i int, j int);")
+		RunQuery(t, e, harness, "insert into t2 values (1,1), (2,2), (3,3)")
+		TestQueryWithContext(
+			t, ctx, e, harness,
+			"alter table t2 add column pk int primary key auto_increment first;",
 			[]sql.Row{{sql.NewOkResult(0)}},
 			nil, nil,
 		)
@@ -5033,39 +5072,7 @@ func TestAddDropPks(t *testing.T, harness Harness) {
 			t, ctx, e, harness,
 			"show create table t2;",
 			[]sql.Row{
-				{"t2", "CREATE TABLE `t2` (\n  `i` int,\n  `j` int,\n  `pk` int NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
-			},
-			nil, nil,
-		)
-	})
-
-	t.Run("Add primary key column with auto increment first", func(t *testing.T) {
-		ctx.SetCurrentDatabase("mydb")
-		RunQuery(t, e, harness, "CREATE TABLE t3 (i int, j int);")
-		RunQuery(t, e, harness, "insert into t3 values (1,1), (2,2), (3,3)")
-		TestQueryWithContext(
-			t, ctx, e, harness,
-			"alter table t3 add column pk int primary key auto_increment first;",
-			[]sql.Row{{sql.NewOkResult(0)}},
-			nil, nil,
-		)
-
-		TestQueryWithContext(
-			t, ctx, e, harness,
-			"select pk from t3;",
-			[]sql.Row{
-				{1},
-				{2},
-				{3},
-			},
-			nil, nil,
-		)
-
-		TestQueryWithContext(
-			t, ctx, e, harness,
-			"show create table t3;",
-			[]sql.Row{
-				{"t3", "CREATE TABLE `t3` (\n  `pk` int NOT NULL AUTO_INCREMENT,\n  `i` int,\n  `j` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				{"t2", "CREATE TABLE `t2` (\n  `pk` int NOT NULL AUTO_INCREMENT,\n  `i` int,\n  `j` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 			},
 			nil, nil,
 		)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -185,38 +185,6 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	script := queries.ScriptTest{
-		SetUpScript: []string{
-			"CREATE TABLE test (i int, j int);",
-			"insert into test values (1,1), (2,2), (3,3)",
-		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query:    "alter table test add column pk int primary key auto_increment;",
-				Expected: []sql.Row{{sql.NewOkResult(0)}},
-			},
-			{
-				Query: "select pk from test;",
-				Expected: []sql.Row{
-					{1},
-					{2},
-					{3},
-				},
-			},
-			{
-				Query: "show create table test;",
-				Expected: []sql.Row{
-					{"test", "CREATE TABLE `test` (\n  `i` int,\n  `j` int,\n  `pk` int NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
-				},
-			},
-		},
-	}
-	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
-	engine, err := harness.NewEngine(t)
-	enginetest.TestScriptWithEngine(t, engine, harness, script)
-	if err != nil {
-		panic(err)
-	}
 	t.Skip()
 
 	var scripts = []queries.ScriptTest{

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -185,6 +185,38 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
+	script := queries.ScriptTest{
+		SetUpScript: []string{
+			"CREATE TABLE test (i int, j int);",
+			"insert into test values (1,1), (2,2), (3,3)",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "alter table test add column pk int primary key auto_increment;",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
+			},
+			{
+				Query: "select pk from test;",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query: "show create table test;",
+				Expected: []sql.Row{
+					{"test", "CREATE TABLE `test` (\n  `i` int,\n  `j` int,\n  `pk` int NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	}
+	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
+	engine, err := harness.NewEngine(t)
+	enginetest.TestScriptWithEngine(t, engine, harness, script)
+	if err != nil {
+		panic(err)
+	}
 	t.Skip()
 
 	var scripts = []queries.ScriptTest{

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -774,6 +774,11 @@ func TestAddDropPks(t *testing.T) {
 	enginetest.TestAddDropPks(t, enginetest.NewDefaultMemoryHarness())
 }
 
+func TestAddAutoIncrementColumn(t *testing.T) {
+	t.Skip("in memory tables don't implement sql.RewritableTable yet")
+	enginetest.TestAddAutoIncrementColumn(t, enginetest.NewDefaultMemoryHarness())
+}
+
 func TestNullRanges(t *testing.T) {
 	enginetest.TestNullRanges(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/memory/table.go
+++ b/memory/table.go
@@ -122,7 +122,6 @@ var _ sql.StatisticsTable = (*Table)(nil)
 var _ sql.ProjectedTable = (*Table)(nil)
 var _ sql.PrimaryKeyAlterableTable = (*Table)(nil)
 var _ sql.PrimaryKeyTable = (*Table)(nil)
-var _ sql.RewritableTable = (*Table)(nil)
 
 // NewTable creates a new Table with the given name and schema. Assigns the default collation, therefore if a different
 // collation is desired, please use NewTableWithCollation.
@@ -983,25 +982,6 @@ func (t *Table) HandledFilters(filters []sql.Expression) []sql.Expression {
 	}
 
 	return handled
-}
-
-// ShouldRewriteTable implements sql.RewritableTable interface.
-func (t *Table) ShouldRewriteTable(
-	ctx *sql.Context,
-	oldSchema sql.PrimaryKeySchema,
-	newSchema sql.PrimaryKeySchema,
-	oldColumn *sql.Column,
-	newColumn *sql.Column,
-) bool {
-	return false
-}
-
-func (t *Table) RewriteInserter(
-	ctx *sql.Context,
-	oldSchema, newSchema sql.PrimaryKeySchema,
-	oldColumn, newColumn *sql.Column,
-) (sql.RowInserter, error) {
-	return t.newTableEditor(), nil
 }
 
 // FilteredTable functionality in the Table type was disabled for a long period of time, and has developed major

--- a/memory/table.go
+++ b/memory/table.go
@@ -122,6 +122,7 @@ var _ sql.StatisticsTable = (*Table)(nil)
 var _ sql.ProjectedTable = (*Table)(nil)
 var _ sql.PrimaryKeyAlterableTable = (*Table)(nil)
 var _ sql.PrimaryKeyTable = (*Table)(nil)
+var _ sql.RewritableTable = (*Table)(nil)
 
 // NewTable creates a new Table with the given name and schema. Assigns the default collation, therefore if a different
 // collation is desired, please use NewTableWithCollation.
@@ -982,6 +983,25 @@ func (t *Table) HandledFilters(filters []sql.Expression) []sql.Expression {
 	}
 
 	return handled
+}
+
+// ShouldRewriteTable implements sql.RewritableTable interface.
+func (t *Table) ShouldRewriteTable(
+	ctx *sql.Context,
+	oldSchema sql.PrimaryKeySchema,
+	newSchema sql.PrimaryKeySchema,
+	oldColumn *sql.Column,
+	newColumn *sql.Column,
+) bool {
+	return false
+}
+
+func (t *Table) RewriteInserter(
+	ctx *sql.Context,
+	oldSchema, newSchema sql.PrimaryKeySchema,
+	oldColumn, newColumn *sql.Column,
+) (sql.RowInserter, error) {
+	return t.newTableEditor(), nil
 }
 
 // FilteredTable functionality in the Table type was disabled for a long period of time, and has developed major

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -493,7 +493,11 @@ func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) 
 
 	var autoTbl sql.AutoIncrementTable
 	if newSch.HasAutoIncrement() {
-		autoTbl = rwt.(sql.AutoIncrementTable)
+		t, ok := rwt.(sql.AutoIncrementTable)
+		if !ok {
+			return false, ErrAutoIncrementNotSupported.New()
+		}
+		autoTbl = t
 	}
 	idx := newSch.IndexOf(i.a.column.Name, i.a.column.Source)
 

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -495,6 +495,7 @@ func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) 
 	if newSch.HasAutoIncrement() {
 		autoTbl = rwt.(sql.AutoIncrementTable)
 	}
+	idx := newSch.IndexOf(i.a.column.Name, i.a.column.Source)
 
 	for {
 		r, err := rowIter.Next(ctx)
@@ -510,11 +511,11 @@ func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) 
 		}
 
 		if autoTbl != nil {
-			val, err := autoTbl.GetNextAutoIncrementValue(ctx, newRow[len(newRow)-1])
+			val, err := autoTbl.GetNextAutoIncrementValue(ctx, newRow[idx])
 			if err != nil {
 				return false, err
 			}
-			newRow[len(newRow)-1] = val
+			newRow[idx] = val
 		}
 
 		err = inserter.Insert(ctx, newRow)


### PR DESCRIPTION
fix for: https://github.com/dolthub/dolt/issues/4581

tests in dolt because `memory.Table` doesn't implement `RewriteableTable`
https://github.com/dolthub/dolt/pull/4593