### PR TITLE
Subquery row iter fix field indexes

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -505,6 +505,15 @@ inner join pq on true order by 1,2,3,4,5,6,7,8 limit 5;`,
 			{3, 1, 3, 3, 3, 3},
 		},
 	},
+	{
+		Query: `select * from (select a,v from ab join uv on a=u) av join (select x,q from xy join pq on x = p) xq on av.v = xq.x`,
+		Expected: []sql.Row{
+			{0, 1, 1, 1},
+			{1, 1, 1, 1},
+			{2, 2, 2, 2},
+			{3, 2, 2, 2},
+		},
+	},
 }
 
 var SkippedJoinQueryTests = []QueryTest{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -24,6 +24,31 @@ type QueryPlanTest struct {
 // easier to construct this way.
 var PlanTests = []QueryPlanTest{
 	{
+		Query: "select * from (select a,v from ab join uv on a=u) av join (select x,q from xy join pq on x = p) xq on av.v = xq.x",
+		ExpectedPlan: "HashJoin(av.v = xq.x)\n" +
+			" ├─ SubqueryAlias(av)\n" +
+			" │   └─ Project\n" +
+			" │       ├─ columns: [ab.a, uv.v]\n" +
+			" │       └─ LookupJoin(ab.a = uv.u)\n" +
+			" │           ├─ Table(ab)\n" +
+			" │           │   └─ columns: [a]\n" +
+			" │           └─ IndexedTableAccess(uv)\n" +
+			" │               ├─ index: [uv.u]\n" +
+			" │               └─ columns: [u v]\n" +
+			" └─ HashLookup(child: (xq.x), lookup: (av.v))\n" +
+			"     └─ CachedResults\n" +
+			"         └─ SubqueryAlias(xq)\n" +
+			"             └─ Project\n" +
+			"                 ├─ columns: [xy.x, pq.q]\n" +
+			"                 └─ LookupJoin(xy.x = pq.p)\n" +
+			"                     ├─ Table(xy)\n" +
+			"                     │   └─ columns: [x]\n" +
+			"                     └─ IndexedTableAccess(pq)\n" +
+			"                         ├─ index: [pq.p]\n" +
+			"                         └─ columns: [p q]\n" +
+			"",
+	},
+	{
 		Query: `select * from mytable t1 natural join mytable t2 join othertable t3 on t2.i = t3.i2;`,
 		ExpectedPlan: "InnerJoin(t1.i = t3.i2)\n" +
 			" ├─ Project\n" +

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -67,7 +67,11 @@ func (sq *SubqueryAlias) Schema() sql.Schema {
 func (sq *SubqueryAlias) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	span, ctx := ctx.Span("plan.SubqueryAlias")
 
+	if !sq.OuterScopeVisibility {
+		row = nil
+	}
 	iter, err := sq.Child.RowIter(ctx, row)
+
 	if err != nil {
 		span.End()
 		return nil, err


### PR DESCRIPTION
Recent changes to subquery scope visibility use the scope to communicate column definition availability; i.e., we do not pass the scope into subqueries we have determined to not depend on the outer scope, marking the same scope as cacheable. This analysis change needs a corresponding runtime change to indicate whether the scope row is expected at execution time.