### PR TITLE
Add support for database collations

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -791,6 +791,10 @@ func TestCharsetCollationWire(t *testing.T) {
 	enginetest.TestCharsetCollationWire(t, enginetest.NewDefaultMemoryHarness(), server.DefaultSessionBuilder)
 }
 
+func TestDatabaseCollationWire(t *testing.T) {
+	enginetest.TestDatabaseCollationWire(t, enginetest.NewDefaultMemoryHarness(), server.DefaultSessionBuilder)
+}
+
 func TestTypesOverWire(t *testing.T) {
 	enginetest.TestTypesOverWire(t, enginetest.NewDefaultMemoryHarness(), server.DefaultSessionBuilder)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20221004165409-08281765376f
+	github.com/dolthub/vitess v0.0.0-20221031111135-9aad77e7b39f
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474/go.mod h1:kMz7uXOXq4qRriCEyZ/LUeTqraLJCjf0WVZcUi6TxUY=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20221004165409-08281765376f h1:yE3Cbhk4ylOK1jYqFHnman6fpKN2Cap080GG/UpAVBs=
-github.com/dolthub/vitess v0.0.0-20221004165409-08281765376f/go.mod h1:oVFIBdqMFEkt4Xz2fzFJBNtzKhDEjwdCF0dzde39iKs=
+github.com/dolthub/vitess v0.0.0-20221031111135-9aad77e7b39f h1:2sNrQiE4pcdgCNp09RTOsmNeepgN5rL+ep8NF8Faw9U=
+github.com/dolthub/vitess v0.0.0-20221031111135-9aad77e7b39f/go.mod h1:oVFIBdqMFEkt4Xz2fzFJBNtzKhDEjwdCF0dzde39iKs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/memory/database.go
+++ b/memory/database.go
@@ -40,6 +40,7 @@ var _ sql.TableRenamer = (*Database)(nil)
 var _ sql.TriggerDatabase = (*Database)(nil)
 var _ sql.StoredProcedureDatabase = (*Database)(nil)
 var _ sql.ViewDatabase = (*Database)(nil)
+var _ sql.CollatedDatabase = (*Database)(nil)
 
 // BaseDatabase is an in-memory database that can't store views, only for testing the engine
 type BaseDatabase struct {
@@ -49,6 +50,7 @@ type BaseDatabase struct {
 	triggers          []sql.TriggerDefinition
 	storedProcedures  []sql.StoredProcedureDetails
 	primaryKeyIndexes bool
+	collation         sql.CollationID
 }
 
 var _ MemoryDatabase = (*Database)(nil)
@@ -279,6 +281,17 @@ func (d *BaseDatabase) DropStoredProcedure(ctx *sql.Context, name string) error 
 	if !found {
 		return sql.ErrStoredProcedureDoesNotExist.New(name)
 	}
+	return nil
+}
+
+// GetCollation implements sql.CollatedDatabase.
+func (d *BaseDatabase) GetCollation(ctx *sql.Context) sql.CollationID {
+	return d.collation
+}
+
+// SetCollation implements sql.CollatedDatabase.
+func (d *BaseDatabase) SetCollation(ctx *sql.Context, collation sql.CollationID) error {
+	d.collation = collation
 	return nil
 }
 

--- a/sql/analyzer/assign_catalog.go
+++ b/sql/analyzer/assign_catalog.go
@@ -70,6 +70,10 @@ func assignCatalog(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel 
 			nc := *node
 			nc.Catalog = a.Catalog
 			return &nc, transform.NewTree, nil
+		case *plan.AlterDB:
+			nc := *node
+			nc.Catalog = a.Catalog
+			return &nc, transform.NewTree, nil
 		case *plan.DropDB:
 			nc := *node
 			nc.Catalog = a.Catalog

--- a/sql/analyzer/autocommit.go
+++ b/sql/analyzer/autocommit.go
@@ -72,6 +72,8 @@ func GetTransactionDatabase(ctx *sql.Context, parsed sql.Node) string {
 		dbName = getDbHelper(n.Tables...)
 	case *plan.Truncate:
 		dbName = getDbHelper(n.Child)
+	case *plan.AlterDB:
+		dbName = n.Database(ctx)
 	default:
 	}
 	if dbName != "" {

--- a/sql/analyzer/resolve_create_select.go
+++ b/sql/analyzer/resolve_create_select.go
@@ -37,7 +37,8 @@ func resolveCreateSelect(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope
 	}
 
 	newSpec := inputSpec.WithSchema(sql.NewPrimaryKeySchema(newSch, pkOrdinals...))
-	newSpec.Collation = sql.Collation_Default // CREATE ... SELECT will always inherit the default collation for the table
+	// CREATE ... SELECT will always inherit the database collation for the table
+	newSpec.Collation = plan.GetDatabaseCollation(ctx, ct.Database())
 
 	newCreateTable := plan.NewCreateTable(ct.Database(), ct.Name(), ct.IfNotExists(), ct.Temporary(), newSpec)
 	analyzedCreate, err := a.Analyze(ctx, newCreateTable, scope)

--- a/sql/catalog.go
+++ b/sql/catalog.go
@@ -25,7 +25,7 @@ type Catalog interface {
 	Database(ctx *Context, db string) (Database, error)
 
 	// CreateDatabase creates a new database, or returns an error if the operation isn't supported or fails.
-	CreateDatabase(ctx *Context, dbName string) error
+	CreateDatabase(ctx *Context, dbName string, collation CollationID) error
 
 	// RemoveDatabase removes the  database named, or returns an error if the operation isn't supported or fails.
 	RemoveDatabase(ctx *Context, dbName string) error

--- a/sql/collations_test.go
+++ b/sql/collations_test.go
@@ -30,8 +30,8 @@ func TestParseCollation(t *testing.T) {
 		expectedCollation CollationID
 		expectedErr       bool
 	}{
-		{"", "", false, Collation_Default, false},
-		{"", "", true, Collation_Default.CharacterSet().BinaryCollation(), false},
+		{"", "", false, Collation_Unspecified, false},
+		{"", "", true, Collation_Unspecified, false},
 		{CharacterSet_big5.String(), "", false, CharacterSet_big5.DefaultCollation(), false},
 		{CharacterSet_eucjpms.String(), "", true, CharacterSet_eucjpms.BinaryCollation(), false},
 		{"", Collation_big5_chinese_ci.String(), false, Collation_big5_chinese_ci, false},

--- a/sql/core.go
+++ b/sql/core.go
@@ -714,6 +714,13 @@ type MutableDatabaseProvider interface {
 	DropDatabase(ctx *Context, name string) error
 }
 
+type CollatedDatabaseProvider interface {
+	MutableDatabaseProvider
+
+	// CreateCollatedDatabase creates a collated database and adds it to the provider's collection.
+	CreateCollatedDatabase(ctx *Context, name string, collation CollationID) error
+}
+
 // ExternalStoredProcedureProvider provides access to built-in stored procedures. These procedures are implemented
 // as functions, instead of as SQL statements. The returned stored procedures cannot be modified or deleted.
 type ExternalStoredProcedureProvider interface {
@@ -776,6 +783,17 @@ type VersionedDatabase interface {
 	// GetTableNamesAsOf returns the table names of every table in the database as of the revision given. Implementors
 	// must choose which types of expressions to accept as revision names.
 	GetTableNamesAsOf(ctx *Context, asOf interface{}) ([]string, error)
+}
+
+// CollatedDatabase is a Database that may store and update its collation.
+type CollatedDatabase interface {
+	Database
+
+	// GetCollation returns this database's collation.
+	GetCollation(ctx *Context) CollationID
+
+	// SetCollation updates this database's collation.
+	SetCollation(ctx *Context, collation CollationID) error
 }
 
 // UnresolvedTable is a Table that is either unresolved or deferred for until an asOf resolution

--- a/sql/enumtype.go
+++ b/sql/enumtype.go
@@ -40,6 +40,7 @@ const (
 var (
 	ErrConvertingToEnum  = errors.NewKind("value %v is not valid for this Enum")
 	ErrUnmarshallingEnum = errors.NewKind("value %v is not a marshalled value for this Enum")
+	ErrTemporaryEnum     = errors.NewKind("attempted to use temporary enum")
 
 	enumValueType = reflect.TypeOf(uint16(0))
 )
@@ -246,7 +247,7 @@ func (t enumType) SQL(ctx *Context, dest []byte, v interface{}) (sqltypes.Value,
 	value, _ := t.At(int(convertedValue.(uint16)))
 
 	resultCharset := ctx.GetCharacterSetResults()
-	if resultCharset == CharacterSet_Invalid || resultCharset == CharacterSet_binary {
+	if resultCharset == CharacterSet_Unspecified || resultCharset == CharacterSet_binary {
 		resultCharset = t.collation.CharacterSet()
 	}
 	encodedBytes, ok := resultCharset.Encoder().Encode(encodings.StringToBytes(value))
@@ -337,6 +338,6 @@ func (t enumType) Values() []string {
 }
 
 // WithNewCollation implements TypeWithCollation interface.
-func (t enumType) WithNewCollation(collation CollationID) Type {
-	return MustCreateEnumType(t.Values(), collation)
+func (t enumType) WithNewCollation(collation CollationID) (Type, error) {
+	return CreateEnumType(t.indexToVal, collation)
 }

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -79,6 +79,9 @@ var (
 	// ErrRenameTableNotSupported is thrown when the database doesn't support renaming tables
 	ErrRenameTableNotSupported = errors.NewKind("tables cannot be renamed on database %s")
 
+	// ErrDatabaseCollationsNotSupported is thrown when a database does not allow updating its collation
+	ErrDatabaseCollationsNotSupported = errors.NewKind("database %s does not support collation operations")
+
 	// ErrTableCreatedNotFound is thrown when a table is created from CREATE TABLE but cannot be found immediately afterward
 	ErrTableCreatedNotFound = errors.NewKind("table was created but could not be found")
 

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -125,7 +125,7 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if lm.collation == sql.Collation_Invalid {
+	if lm.collation == sql.Collation_Unspecified {
 		return false, nil
 	}
 

--- a/sql/expression/namedliteral.go
+++ b/sql/expression/namedliteral.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// NamedLiteral represents a literal value, but returns the name field rather than the value for String.
+type NamedLiteral struct {
+	*Literal
+	Name string
+}
+
+var _ sql.Expression = NamedLiteral{}
+var _ sql.Expression2 = NamedLiteral{}
+
+// NewNamedLiteral returns a new NamedLiteral.
+func NewNamedLiteral(name string, value interface{}, fieldType sql.Type) NamedLiteral {
+	return NamedLiteral{
+		Literal: NewLiteral(value, fieldType),
+		Name:    name,
+	}
+}
+
+// String implements the interface sql.Expression.
+func (lit NamedLiteral) String() string {
+	return lit.Name
+}

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -874,11 +874,12 @@ func schemataRowIter(ctx *Context, c Catalog) (RowIter, error) {
 
 	var rows []Row
 	for _, db := range dbs {
+		collation := plan.GetDatabaseCollation(ctx, db)
 		rows = append(rows, Row{
 			"def",
 			db.Name(),
-			Collation_Default.CharacterSet().String(),
-			Collation_Default.String(),
+			collation.CharacterSet().String(),
+			collation.String(),
 			nil,
 		})
 	}

--- a/sql/mysql_db/privileged_database_provider.go
+++ b/sql/mysql_db/privileged_database_provider.go
@@ -108,6 +108,7 @@ var _ sql.StoredProcedureDatabase = PrivilegedDatabase{}
 var _ sql.TableCopierDatabase = PrivilegedDatabase{}
 var _ sql.ReadOnlyDatabase = PrivilegedDatabase{}
 var _ sql.TemporaryTableDatabase = PrivilegedDatabase{}
+var _ sql.CollatedDatabase = PrivilegedDatabase{}
 
 // NewPrivilegedDatabase returns a new PrivilegedDatabase.
 func NewPrivilegedDatabase(grantTables *MySQLDb, db sql.Database) sql.Database {
@@ -322,6 +323,22 @@ func (pdb PrivilegedDatabase) GetAllTemporaryTables(ctx *sql.Context) ([]sql.Tab
 	}
 	// All current temp table checks skip if not implemented, same is iterating over an empty slice
 	return nil, nil
+}
+
+// GetCollation implements the interface sql.CollatedDatabase.
+func (pdb PrivilegedDatabase) GetCollation(ctx *sql.Context) sql.CollationID {
+	if db, ok := pdb.db.(sql.CollatedDatabase); ok {
+		return db.GetCollation(ctx)
+	}
+	return sql.Collation_Default
+}
+
+// SetCollation implements the interface sql.CollatedDatabase.
+func (pdb PrivilegedDatabase) SetCollation(ctx *sql.Context, collation sql.CollationID) error {
+	if db, ok := pdb.db.(sql.CollatedDatabase); ok {
+		return db.SetCollation(ctx, collation)
+	}
+	return sql.ErrDatabaseCollationsNotSupported.New(pdb.db.Name())
 }
 
 // Unwrap returns the wrapped sql.Database.

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -225,12 +225,18 @@ func (a *AddColumn) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) 
 	// an invalid collation, then one has not been assigned at this point, so we assign it the table's collation. This
 	// does not create a reference to the table's collation, which may change at any point, and therefore will have no
 	// relation to this column after assignment.
-	if collatedType, ok := a.column.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Invalid {
-		a.column.Type = collatedType.WithNewCollation(alterable.Collation())
+	if collatedType, ok := a.column.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Unspecified {
+		a.column.Type, err = collatedType.WithNewCollation(alterable.Collation())
+		if err != nil {
+			return nil, err
+		}
 	}
 	for _, col := range a.targetSch {
-		if collatedType, ok := col.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Invalid {
-			col.Type = collatedType.WithNewCollation(alterable.Collation())
+		if collatedType, ok := col.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Unspecified {
+			col.Type, err = collatedType.WithNewCollation(alterable.Collation())
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -1173,12 +1179,18 @@ func (m *ModifyColumn) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, erro
 	// an invalid collation, then one has not been assigned at this point, so we assign it the table's collation. This
 	// does not create a reference to the table's collation, which may change at any point, and therefore will have no
 	// relation to this column after assignment.
-	if collatedType, ok := m.column.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Invalid {
-		m.column.Type = collatedType.WithNewCollation(alterable.Collation())
+	if collatedType, ok := m.column.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Unspecified {
+		m.column.Type, err = collatedType.WithNewCollation(alterable.Collation())
+		if err != nil {
+			return nil, err
+		}
 	}
 	for _, col := range m.targetSchema {
-		if collatedType, ok := col.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Invalid {
-			col.Type = collatedType.WithNewCollation(alterable.Collation())
+		if collatedType, ok := col.Type.(sql.TypeWithCollation); ok && collatedType.Collation() == sql.Collation_Unspecified {
+			col.Type, err = collatedType.WithNewCollation(alterable.Collation())
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -521,7 +521,7 @@ func IsDDLNode(node sql.Node) bool {
 	switch node.(type) {
 	case *CreateTable, *DropTable, *Truncate,
 		*AddColumn, *ModifyColumn, *DropColumn,
-		*CreateDB, *DropDB,
+		*CreateDB, *DropDB, *AlterDB,
 		*RenameTable, *RenameColumn,
 		*CreateView, *DropView,
 		*CreateIndex, *AlterIndex, *DropIndex,

--- a/sql/session.go
+++ b/sql/session.go
@@ -326,7 +326,7 @@ func (s *BaseSession) GetCharacterSet() CharacterSetID {
 	defer s.mu.RUnlock()
 	val, _ := s.systemVars[characterSetConnectionSysVarName]
 	if val == nil {
-		return CharacterSet_Invalid
+		return CharacterSet_Unspecified
 	}
 	charSet, err := ParseCharacterSet(val.(string))
 	if err != nil {
@@ -341,7 +341,7 @@ func (s *BaseSession) GetCharacterSetResults() CharacterSetID {
 	defer s.mu.RUnlock()
 	val, _ := s.systemVars[characterSetResultsSysVarName]
 	if val == nil {
-		return CharacterSet_Invalid
+		return CharacterSet_Unspecified
 	}
 	charSet, err := ParseCharacterSet(val.(string))
 	if err != nil {
@@ -356,7 +356,7 @@ func (s *BaseSession) GetCollation() CollationID {
 	defer s.mu.Unlock()
 	val, _ := s.systemVars[collationConnectionSysVarName]
 	if val == nil {
-		return Collation_Invalid
+		return Collation_Unspecified
 	}
 	valStr := val.(string)
 	collation, err := ParseCollation(nil, &valStr, false)


### PR DESCRIPTION
This allows setting the database collation, such that all newly created tables within a database (that do not explicitly set their collation) will inherit the database collation.

Builds on https://github.com/dolthub/vitess/pull/199