### PR TITLE
Allow any select statement for `CREATE TABLE AS SELECT ...`

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -182,19 +182,23 @@ func TestSingleScript(t *testing.T) {
 
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "enums with default, case-sensitive collation (utf8mb4_0900_bin)",
+			Name: "create table as select distinct",
 			SetUpScript: []string{
-				"CREATE TABLE enumtest1 (pk int primary key, e enum('abc', 'XYZ'));",
-				"CREATE TABLE enumtest2 (pk int PRIMARY KEY, e enum('x ', 'X ', 'y', 'Y'));",
+				"CREATE TABLE t1 (a int, b varchar(10));",
+				"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "select data_type, column_type from information_schema.columns where table_name='enumtest1' and column_name='e';",
-					Expected: []sql.Row{{"enum('abc','XYZ')", "enum('abc','XYZ')"}},
+					Query:    "create table t2 as select distinct b, a from t1;",
+					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
 				},
 				{
-					Query:    "select data_type, column_type from information_schema.columns where table_name='enumtest2' and column_name='e';",
-					Expected: []sql.Row{{"enum('x','X','y','Y')", "enum('x','X','y','Y')"}},
+					Query:    "select * from t2 order by a;",
+					Expected: []sql.Row{
+						{"a", 1},
+						{"b", 2},
+						{"c", 3},
+					},
 				},
 			},
 		},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -193,7 +193,7 @@ func TestSingleScript(t *testing.T) {
 					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
 				},
 				{
-					Query:    "select * from t2 order by a;",
+					Query: "select * from t2 order by a;",
 					Expected: []sql.Row{
 						{"a", 1},
 						{"b", 2},

--- a/enginetest/queries/charset_collation_engine.go
+++ b/enginetest/queries/charset_collation_engine.go
@@ -313,7 +313,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			{
 				Query: "SHOW CREATE TABLE test4;",
 				Expected: []sql.Row{
-					{"test4", "CREATE TABLE `test4` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255) COLLATE utf8mb4_unicode_ci,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+					{"test4", "CREATE TABLE `test4` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255) COLLATE utf8mb4_unicode_ci\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
 			{

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -85,7 +85,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 SELECT * from mytable`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` bigint NOT NULL,\n  `s` varchar(20) NOT NULL COMMENT 'column s',\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` bigint NOT NULL,\n  `s` varchar(20) NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE mydb.t1 (a INTEGER NOT NULL PRIMARY KEY, b VARCHAR(10) NOT NULL)`,
@@ -160,7 +160,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 as select * from mytable`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         `show create table t1`,
-		ExpectedSelect:      []sql.Row{{1, "first row"}, {2, "second row"},{3, "third row"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` bigint NOT NULL,\n  `s` varchar(20) NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 as select s, i from mytable`,

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -150,4 +150,59 @@ var CreateTableQueries = []WriteQueryTest{
 		SelectQuery:         `SHOW CREATE TABLE t1`,
 		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` varchar(16383),\n  PRIMARY KEY (`i`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select * from mytable`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         `select * from t1 order by i`,
+		ExpectedSelect:      []sql.Row{{1, "first row"}, {2, "second row"},{3, "third row"}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select * from mytable`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         `show create table t1`,
+		ExpectedSelect:      []sql.Row{{1, "first row"}, {2, "second row"},{3, "third row"}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select s, i from mytable`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         `select * from t1 order by i`,
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select distinct s, i from mytable`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         `select * from t1 order by i`,
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select s, i from mytable order by s`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         `select * from t1 order by i`,
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+	},
+	// TODO: the second column should be named `sum(i)` but is `SUM(mytable.i)`
+	{
+		WriteQuery:          `CREATE TABLE t1 as select s, sum(i) from mytable group by s`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         `select * from t1 order by s`, // other column is named `SUM(mytable.i)`
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select s, sum(i) from mytable group by s having sum(i) > 2`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(1)}},
+		SelectQuery:         "select * from t1",
+		ExpectedSelect:      []sql.Row{{"third row", 3}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select s, i from mytable order by s limit 1`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(1)}},
+		SelectQuery:         `select * from t1 order by i`,
+		ExpectedSelect:      []sql.Row{{"first row", 1}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 as select concat("new", s), i from mytable`,
+		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
+		SelectQuery:         `select * from t1 order by i`,
+		ExpectedSelect:      []sql.Row{{"newfirst row", 1}, {"newsecond row", 2},{"newthird row", 3}},
+	},
 }

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -154,7 +154,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 as select * from mytable`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         `select * from t1 order by i`,
-		ExpectedSelect:      []sql.Row{{1, "first row"}, {2, "second row"},{3, "third row"}},
+		ExpectedSelect:      []sql.Row{{1, "first row"}, {2, "second row"}, {3, "third row"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 as select * from mytable`,
@@ -166,26 +166,26 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 as select s, i from mytable`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         `select * from t1 order by i`,
-		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2}, {"third row", 3}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 as select distinct s, i from mytable`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         `select * from t1 order by i`,
-		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2}, {"third row", 3}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 as select s, i from mytable order by s`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         `select * from t1 order by i`,
-		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2}, {"third row", 3}},
 	},
 	// TODO: the second column should be named `sum(i)` but is `SUM(mytable.i)`
 	{
 		WriteQuery:          `CREATE TABLE t1 as select s, sum(i) from mytable group by s`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         `select * from t1 order by s`, // other column is named `SUM(mytable.i)`
-		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2},{"third row", 3}},
+		ExpectedSelect:      []sql.Row{{"first row", 1}, {"second row", 2}, {"third row", 3}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 as select s, sum(i) from mytable group by s having sum(i) > 2`,
@@ -203,6 +203,6 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 as select concat("new", s), i from mytable`,
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(3)}},
 		SelectQuery:         `select * from t1 order by i`,
-		ExpectedSelect:      []sql.Row{{"newfirst row", 1}, {"newsecond row", 2},{"newthird row", 3}},
+		ExpectedSelect:      []sql.Row{{"newfirst row", 1}, {"newsecond row", 2}, {"newthird row", 3}},
 	},
 }


### PR DESCRIPTION
Also fixes a semantics bug in the schema produced by some such statements.