### PR TITLE
add tests for sql type Zero() functions

### DIFF
--- a/sql/bit_test.go
+++ b/sql/bit_test.go
@@ -155,3 +155,8 @@ func TestBitString(t *testing.T) {
 		})
 	}
 }
+
+func TestBitZero(t *testing.T) {
+	_, ok := MustCreateBitType(1).Zero().(uint64)
+	require.True(t, ok)
+}

--- a/sql/datetimetype_test.go
+++ b/sql/datetimetype_test.go
@@ -330,3 +330,12 @@ func TestDatetimeString(t *testing.T) {
 		})
 	}
 }
+
+func TestDatetimeZero(t *testing.T) {
+	_, ok := MustCreateDatetimeType(sqltypes.Date).Zero().(time.Time)
+	require.True(t, ok)
+	_, ok = MustCreateDatetimeType(sqltypes.Datetime).Zero().(time.Time)
+	require.True(t, ok)
+	_, ok = MustCreateDatetimeType(sqltypes.Timestamp).Zero().(time.Time)
+	require.True(t, ok)
+}

--- a/sql/decimal.go
+++ b/sql/decimal.go
@@ -301,7 +301,7 @@ func (t decimalType) ValueType() reflect.Type {
 
 // Zero implements Type interface.
 func (t decimalType) Zero() interface{} {
-	return decimal.NewFromInt(0).StringFixed(int32(t.scale))
+	return decimal.NewFromInt(0)
 }
 
 // ExclusiveUpperBound implements DecimalType interface.

--- a/sql/decimal_test.go
+++ b/sql/decimal_test.go
@@ -317,3 +317,34 @@ func TestDecimalString(t *testing.T) {
 		})
 	}
 }
+
+func TestDecimalZero(t *testing.T) {
+	tests := []struct {
+		precision uint8
+		scale     uint8
+	}{
+		{0, 0},
+		{1, 0},
+		{5, 0},
+		{10, 0},
+		{65, 0},
+		{1, 1},
+		{5, 1},
+		{10, 1},
+		{65, 1},
+		{5, 5},
+		{10, 5},
+		{65, 5},
+		{10, 10},
+		{65, 10},
+		{65, 30},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v %v zero", test.precision, test.scale), func(t *testing.T) {
+			dt := MustCreateDecimalType(test.precision, test.scale)
+			_, ok := dt.Zero().(decimal.Decimal)
+			assert.True(t, ok)
+		})
+	}
+}

--- a/sql/enumtype.go
+++ b/sql/enumtype.go
@@ -283,7 +283,7 @@ func (t enumType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t enumType) Zero() interface{} {
 	/// If an ENUM column is declared NOT NULL, its default value is the first element of the list of permitted values.
-	return t.indexToVal[0]
+	return uint16(0)
 }
 
 // At implements EnumType interface.

--- a/sql/enumtype_test.go
+++ b/sql/enumtype_test.go
@@ -180,3 +180,21 @@ func TestEnumString(t *testing.T) {
 		})
 	}
 }
+
+func TestEnumZero(t *testing.T) {
+	tests := []struct {
+		vals []string
+	}{
+		{[]string{"a"}},
+		{[]string{"a", "b"}},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v ok", test.vals), func(t *testing.T) {
+			typ := MustCreateEnumType(test.vals, Collation_Default)
+			v, ok := typ.Zero().(uint16)
+			assert.True(t, ok)
+			assert.Equal(t, uint16(0), v)
+		})
+	}
+}

--- a/sql/geometry.go
+++ b/sql/geometry.go
@@ -496,7 +496,9 @@ func (t GeometryType) ValueType() reflect.Type {
 
 // Zero implements Type interface.
 func (t GeometryType) Zero() interface{} {
-	// TODO: it doesn't make sense for geometry to have a zero type
+	// MySQL throws an error for INSERT IGNORE, UPDATE IGNORE, etc. if the geometry type cannot be parsed:
+	// ERROR 1416 (22003): Cannot get geometry object from data you send to the GEOMETRY field
+	// So, we don't implement a zero type for this function.
 	return nil
 }
 

--- a/sql/json.go
+++ b/sql/json.go
@@ -141,7 +141,8 @@ func (t jsonType) ValueType() reflect.Type {
 
 // Zero implements Type interface.
 func (t jsonType) Zero() interface{} {
-	// JSON Null
+	// MySQL throws an error for INSERT IGNORE, UPDATE IGNORE, etc. when bad json is encountered:
+	// ERROR 3140 (22032): Invalid JSON text: "Invalid value." at position 0 in value for column 'table.column'.
 	return nil
 }
 

--- a/sql/timetype_test.go
+++ b/sql/timetype_test.go
@@ -217,3 +217,8 @@ func TestTimeConvertToTimeDuration(t *testing.T) {
 func TestTimeString(t *testing.T) {
 	require.Equal(t, "time(6)", Time.String())
 }
+
+func TestTimeZero(t *testing.T) {
+	_, ok := Time.Zero().(Timespan)
+	require.True(t, ok)
+}

--- a/sql/yeartype_test.go
+++ b/sql/yeartype_test.go
@@ -107,3 +107,8 @@ func TestYearConvert(t *testing.T) {
 func TestYearString(t *testing.T) {
 	require.Equal(t, "year", Year.String())
 }
+
+func TestYearZero(t *testing.T) {
+	_, ok := Year.Zero().(int16)
+	require.True(t, ok)
+}


### PR DESCRIPTION
Implementers of GMS might expect similar values to be returned by Convert() and Zero(). For decimal and enum implementations this was not the case and has been fixed.