### PR TITLE
fix example package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.a
 *.so
 
+# Compiled binaries
+_example/_example
+
 # Folders
 _obj
 _test

--- a/_example/main.go
+++ b/_example/main.go
@@ -43,6 +43,7 @@ func main() {
 			createTestDatabase(),
 			information_schema.NewInformationSchemaDatabase(),
 		))
+	engine.Analyzer.Catalog.MySQLDb.AddRootAccount()
 
 	config := server.Config{
 		Protocol: "tcp",
@@ -74,9 +75,9 @@ func createTestDatabase() *memory.Database {
 	creationTime := time.Unix(1524044473, 0).UTC()
 	db.AddTable(tableName, table)
 	ctx := sql.NewEmptyContext()
-	table.Insert(ctx, sql.NewRow("John Doe", "john@doe.com", []string{"555-555-555"}, creationTime))
-	table.Insert(ctx, sql.NewRow("John Doe", "johnalt@doe.com", []string{}, creationTime))
-	table.Insert(ctx, sql.NewRow("Jane Doe", "jane@doe.com", []string{}, creationTime))
-	table.Insert(ctx, sql.NewRow("Evil Bob", "evilbob@gmail.com", []string{"555-666-555", "666-666-666"}, creationTime))
+	table.Insert(ctx, sql.NewRow("John Doe", "john@doe.com", sql.JSONDocument{Val: []string{"555-555-555"}}, creationTime))
+	table.Insert(ctx, sql.NewRow("John Doe", "johnalt@doe.com", sql.JSONDocument{Val: []string{}}, creationTime))
+	table.Insert(ctx, sql.NewRow("Jane Doe", "jane@doe.com", sql.JSONDocument{Val: []string{}}, creationTime))
+	table.Insert(ctx, sql.NewRow("Evil Bob", "evilbob@gmail.com", sql.JSONDocument{Val: []string{"555-666-555", "666-666-666"}}, creationTime))
 	return db
 }


### PR DESCRIPTION
close #1357 

This fixes  runtime panic raised by example app in `/_example`. 

I checked SQL client can obtain response in my local machine.

```bash
~/go-mysql-server/_example$ go build
~/go-mysql-server/_example$ ./_example
```

```bash
$ mysql --host=127.0.0.1 --port=3306 --database=mydb -u root
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.7.9-Vitess

Copyright (c) 2000, 2022, Oracle and/or its affiliates.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> select * from mytable;
+----------+-------------------+-------------------------------+---------------------+
| name     | email             | phone_numbers                 | created_at          |
+----------+-------------------+-------------------------------+---------------------+
| Evil Bob | evilbob@gmail.com | ["555-666-555","666-666-666"] | 2018-04-18 09:41:13 |
| Jane Doe | jane@doe.com      | []                            | 2018-04-18 09:41:13 |
| John Doe | john@doe.com      | ["555-555-555"]               | 2018-04-18 09:41:13 |
| John Doe | johnalt@doe.com   | []                            | 2018-04-18 09:41:13 |
+----------+-------------------+-------------------------------+---------------------+
4 rows in set (0.00 sec)
```