### PR TITLE
Convert errors during `ComPrepare` to `SQLError`

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -623,6 +623,7 @@ func AssertErrWithCtx(t *testing.T, e *sqle.Engine, harness Harness, ctx *sql.Co
 	}
 	require.Error(t, err)
 	if expectedErrKind != nil {
+		err = sql.UnwrapError(err)
 		require.True(t, expectedErrKind.Is(err), "Expected error of type %s but got %s", expectedErrKind, err)
 	}
 	// If there are multiple error strings then we only match against the first

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -623,8 +623,7 @@ func AssertErrWithCtx(t *testing.T, e *sqle.Engine, harness Harness, ctx *sql.Co
 	}
 	require.Error(t, err)
 	if expectedErrKind != nil {
-		_, orig, _ := sql.CastSQLError(err)
-		require.True(t, expectedErrKind.Is(orig), "Expected error of type %s but got %s", expectedErrKind, err)
+		require.True(t, expectedErrKind.Is(err), "Expected error of type %s but got %s", expectedErrKind, err)
 	}
 	// If there are multiple error strings then we only match against the first
 	if len(errStrs) >= 1 {

--- a/server/handler.go
+++ b/server/handler.go
@@ -614,7 +614,9 @@ func (h *Handler) errorWrappedDoQuery(
 	}
 
 	remainder, err := h.doQuery(c, query, mode, bindings, callback)
-	err = sql.CastSQLError(err)
+	if err != nil {
+		err = sql.CastSQLError(err)
+	}
 
 	if h.sel != nil {
 		h.sel.QueryCompleted(err == nil, time.Since(start))

--- a/server/handler.go
+++ b/server/handler.go
@@ -112,6 +112,7 @@ func (h *Handler) ComPrepare(c *mysql.Conn, query string) ([]*query.Field, error
 		analyzed, err = h.e.PrepareQuery(ctx, query)
 	}
 	if err != nil {
+		err := sql.CastSQLError(err)
 		return nil, err
 	}
 
@@ -613,18 +614,13 @@ func (h *Handler) errorWrappedDoQuery(
 	}
 
 	remainder, err := h.doQuery(c, query, mode, bindings, callback)
-	err, _, ok := sql.CastSQLError(err)
-
-	var retErr error
-	if !ok {
-		retErr = err
-	}
+	err = sql.CastSQLError(err)
 
 	if h.sel != nil {
-		h.sel.QueryCompleted(retErr == nil, time.Since(start))
+		h.sel.QueryCompleted(err == nil, time.Since(start))
 	}
 
-	return remainder, retErr
+	return remainder, err
 }
 
 // Periodically polls the connection socket to determine if it is has been closed by the client, returning an error

--- a/sql/errors_test.go
+++ b/sql/errors_test.go
@@ -25,8 +25,8 @@ func TestSQLErrorCast(t *testing.T) {
 	for _, test := range tests {
 		var nilErr *mysql.SQLError = nil
 		t.Run(fmt.Sprintf("%v %v", test.err, test.code), func(t *testing.T) {
-			err, _, ok := CastSQLError(test.err)
-			if !ok {
+			err := CastSQLError(test.err)
+			if err != nil {
 				require.Error(t, err)
 				assert.Equal(t, err.Number(), test.code)
 			} else {

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -569,7 +569,7 @@ func convertDataAndWarn(ctx *sql.Context, tableSchema sql.Schema, row sql.Row, c
 		row[columnIdx] = tableSchema[columnIdx].Type.Zero()
 	}
 
-	sqlerr, _, _ := sql.CastSQLError(err)
+	sqlerr := sql.CastSQLError(err)
 
 	// Add a warning instead
 	ctx.Session.Warn(&sql.Warning{
@@ -585,7 +585,7 @@ func warnOnIgnorableError(ctx *sql.Context, row sql.Row, err error) error {
 	// Check that this error is a part of the list of Ignorable Errors and create the relevant warning
 	for _, ie := range IgnorableErrors {
 		if ie.Is(err) {
-			sqlerr, _, _ := sql.CastSQLError(err)
+			sqlerr := sql.CastSQLError(err)
 
 			// Add a warning instead
 			ctx.Session.Warn(&sql.Warning{


### PR DESCRIPTION
We were already converting errors in `ComStmtExecute`, `ComMultiQuery`, and `ComQuery` to `SQLError` so that the correct error codes would be sent to clients. This change adds that support to `ComPrepare`, too. 

Added a unit test for that case and took the opportunity to simplify the interface for `CastSQLError` a little bit. 

This change helps get Prisma support a little further along (https://github.com/dolthub/dolt/issues/4511), but it doesn't look like it fully resolves everything Prisma needs to work with Dolt. 