### PR TITLE
Fixes filtering for null values on json extract

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -330,4 +330,102 @@ var JsonScripts = []ScriptTest{
 			},
 		},
 	},
+	// from https://dev.mysql.com/doc/refman/8.0/en/json.html#json-converting-between-types:~:text=information%20and%20examples.-,Comparison%20and%20Ordering%20of%20JSON%20Values,-JSON%20values%20can
+	{
+		Name: "json is ordered correctly",
+		SetUpScript: []string{
+			"create table t (pk int primary key, col1 json);",
+			"insert into t values (1, '{\"items\": {\"1\": 1, \"2\": 2}}');",
+			"insert into t values (2, null);",
+			"insert into t values (3, '{}');",
+			"insert into t values (4, '{\"items\": null}');",
+			"insert into t values (5, (select json_extract('{\"a\": null}', '$.a')));",
+			"insert into t values (6, 0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from t order by col1 asc;",
+				Expected: []sql.Row{
+					{2, nil},
+					{5, sql.MustJSON("null")},
+					{6, sql.MustJSON("0")},
+					{3, sql.MustJSON("{}")},
+					{4, sql.MustJSON("{\"items\": null}")},
+					{1, sql.MustJSON("{\"items\": {\"1\": 1, \"2\": 2}}")},
+				},
+			},
+			{
+				Query: "select * from t order by col1 desc;",
+				Expected: []sql.Row{
+					{1, sql.MustJSON("{\"items\": {\"1\": 1, \"2\": 2}}")},
+					{4, sql.MustJSON("{\"items\": null}")},
+					{3, sql.MustJSON("{}")},
+					{6, sql.MustJSON("0")},
+					{5, sql.MustJSON("null")},
+					{2, nil},
+				},
+			},
+		},
+	},
+	{
+		Name: "json_extract returns missing keys as sql null and handles json null literals correctly",
+		SetUpScript: []string{
+			"create table t (pk int primary key, col1 json);",
+			"insert into t values (1, '{\"items\": {\"1\": 1, \"2\": 2}}');",
+			"insert into t values (2, null);",
+			"insert into t values (3, '{}');",
+			"insert into t values (4, '{\"items\": null}');",
+			"insert into t values (5, (select json_extract('{\"a\": null}', '$.a')));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select pk, json_extract(col1, '$.items') from t order by pk;",
+				Expected: []sql.Row{
+					{1, sql.MustJSON("{\"1\":1,\"2\":2}")},
+					{2, nil},
+					{3, nil},
+					{4, sql.MustJSON("null")},
+					{5, nil},
+				},
+			},
+			{
+				Query: "select pk, json_extract(col1, '$') from t order by pk;",
+				Expected: []sql.Row{
+					{1, sql.MustJSON("{\"items\": {\"1\": 1, \"2\": 2}}")},
+					{2, nil},
+					{3, sql.MustJSON("{}")},
+					{4, sql.MustJSON("{\"items\": null}")},
+					{5, sql.MustJSON("null")},
+				},
+			},
+			{
+				Query: "select pk, json_extract(col1, '$.items') is null from t order by pk;",
+				Expected: []sql.Row{
+					{1, false},
+					{2, true},
+					{3, true},
+					{4, false},
+					{5, true},
+				},
+			},
+			{
+				Query: "select pk, json_extract(col1, '$.items') <> null from t order by pk;",
+				Expected: []sql.Row{
+					{1, nil},
+					{2, nil},
+					{3, nil},
+					{4, nil},
+					{5, nil},
+				},
+			},
+			{
+				Query:    "select pk from t where json_extract(col1, '$.items') is null;",
+				Expected: []sql.Row{{2}, {3}, {5}},
+			},
+			{
+				Query:    "select pk from t where json_extract(col1, '$.items') <> null;",
+				Expected: []sql.Row{},
+			},
+		},
+	},
 }

--- a/sql/expression/function/json_contains.go
+++ b/sql/expression/function/json_contains.go
@@ -145,6 +145,9 @@ func (j *JSONContains) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 		if err != nil {
 			return nil, err
 		}
+		if result == nil {
+			return nil, nil
+		}
 
 		target, err = result.Unmarshall(ctx)
 		if err != nil {

--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -78,6 +78,10 @@ func (j *JSONExtract) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	//  sql NULLs, should result in sql NULLs.
+	if js == nil {
+		return nil, err
+	}
 
 	js, err = j.Type().Convert(js)
 	if err != nil {

--- a/sql/expression/function/json_extract_test.go
+++ b/sql/expression/function/json_extract_test.go
@@ -72,8 +72,8 @@ func TestJSONExtract(t *testing.T) {
 		err      error
 	}{
 		//{f2, sql.Row{json, "FOO"}, nil, errors.New("should start with '$'")},
-		{f2, sql.Row{nil, "$.b.c"}, sql.JSONDocument{Val: nil}, nil},
-		{f2, sql.Row{json, "$.foo"}, sql.JSONDocument{Val: nil}, nil},
+		{f2, sql.Row{nil, "$.b.c"}, nil, nil},
+		{f2, sql.Row{json, "$.foo"}, nil, nil},
 		{f2, sql.Row{json, "$.b.c"}, sql.JSONDocument{Val: "foo"}, nil},
 		{f3, sql.Row{json, "$.b.c", "$.b.d"}, sql.JSONDocument{Val: []interface{}{"foo", true}}, nil},
 		{f4, sql.Row{json, "$.b.c", "$.b.d", "$.e[0][*]"}, sql.JSONDocument{Val: []interface{}{

--- a/sql/json_test.go
+++ b/sql/json_test.go
@@ -36,11 +36,11 @@ func TestJsonCompare(t *testing.T) {
 		{`[0]`, `{"a": 0}`, 1},
 		{`{"a": 0}`, `"a"`, 1},
 		{`"a"`, `0`, 1},
-		{`0`, `null`, -1},
+		{`0`, `null`, 1},
 
 		// null
-		{`null`, `0`, 1},
-		{`0`, `null`, -1},
+		{`null`, `0`, -1},
+		{`0`, `null`, 1},
 		{`null`, `null`, 0},
 
 		// boolean

--- a/sql/json_value.go
+++ b/sql/json_value.go
@@ -87,13 +87,32 @@ func (doc JSONDocument) Contains(ctx *Context, candidate JSONValue) (val interfa
 }
 
 func (doc JSONDocument) Extract(ctx *Context, path string) (JSONValue, error) {
+	if path == "$" {
+		// Special case the identity operation to handle a nil value for doc.Val
+		return doc, nil
+	}
+
 	c, err := jsonpath.Compile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO(andy) handle error
-	val, _ := c.Lookup(doc.Val) // err ignored
+	// Lookup(obj) throws an error if obj is nil. We want lookups on a json null
+	// to always result in sql NULL, except in the case of the identity lookup
+	// $.
+	r := doc.Val
+	if r == nil {
+		return nil, nil
+	}
+
+	val, err := c.Lookup(r)
+	if err != nil {
+		if strings.Contains(err.Error(), "key error") {
+			// A missing key results in a SQL null
+			return nil, nil
+		}
+		return nil, err
+	}
 
 	return JSONDocument{Val: val}, nil
 }
@@ -314,7 +333,7 @@ func containsJSONNumber(a float64, b interface{}) (bool, error) {
 //
 // https://dev.mysql.com/doc/refman/8.0/en/json.html#json-comparison
 func compareJSON(a, b interface{}) (int, error) {
-	if hasNulls, res := compareNulls(a, b); hasNulls {
+	if hasNulls, res := compareNulls(b, a); hasNulls {
 		return res, nil
 	}
 


### PR DESCRIPTION
This PR fixes two issues:
- JSON_EXTRACT returning json null values when it should be returning sql null values if a path is unresolvable.
- The relative ordering between json null values, sql null values, and json values.