### PR TITLE
Fix logic for replacing expressions with alias references in OrderBy clause

### DIFF
--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -49,6 +49,18 @@ var OrderByGroupByScriptTests = []ScriptTest{
 				Query:       "SELECT team, COUNT(*) FROM members GROUP BY team ORDER BY columndoesnotexist",
 				ExpectedErr: sql.ErrColumnNotFound,
 			},
+			{
+				Query:    "SELECT DISTINCT BINARY t1.id as id FROM members AS t1 JOIN members AS t2 ON t1.id = t2.id WHERE t1.id > 0 ORDER BY BINARY t1.id",
+				Expected: []sql.Row{{[]uint8{0x33}}, {[]uint8{0x34}}, {[]uint8{0x35}}, {[]uint8{0x36}}, {[]uint8{0x37}}, {[]uint8{0x38}}},
+			},
+			{
+				Query:    "SELECT DISTINCT BINARY t1.id as id FROM members AS t1 JOIN members AS t2 ON t1.id = t2.id WHERE t1.id > 0 ORDER BY t1.id",
+				Expected: []sql.Row{{[]uint8{0x33}}, {[]uint8{0x34}}, {[]uint8{0x35}}, {[]uint8{0x36}}, {[]uint8{0x37}}, {[]uint8{0x38}}},
+			},
+			{
+				Query:    "SELECT DISTINCT t1.id as id FROM members AS t1 JOIN members AS t2 ON t1.id = t2.id WHERE t2.id > 0 ORDER BY t1.id",
+				Expected: []sql.Row{{3}, {4}, {5}, {6}, {7}, {8}},
+			},
 		},
 	},
 	{
@@ -100,23 +112,6 @@ var OrderByGroupByScriptTests = []ScriptTest{
 			{
 				Query:    "SELECT COUNT(id) as ct, user_id as uid FROM tweet WHERE tweet.id is NOT NULL GROUP BY tweet.user_id HAVING COUNT(tweet.id) > 0 ORDER BY COUNT(tweet.id), user_id LIMIT 1;",
 				Expected: []sql.Row{{1, 2}},
-			},
-			// TODO: Split these test assertions out to a different test case?
-			{
-				// TODO: This failure mode depends on the alias having the same name as the column
-				// Previously failing with: table "t1" does not have column "user_id"
-				Query:    "SELECT DISTINCT BINARY t1.user_id as user_id FROM tweet AS t1 JOIN users AS u2 ON t1.user_id = u2.id WHERE t1.user_id > 0 ORDER BY BINARY t1.user_id",
-				Expected: []sql.Row{{[]uint8{0x31}}, {[]uint8{0x32}}, {[]uint8{0x33}}},
-			},
-			{
-				// Previously failing with: table "t1" does not have column "user_id"
-				Query:    "SELECT DISTINCT BINARY t1.user_id as user_id FROM tweet AS t1 JOIN users AS u2 ON t1.user_id = u2.id WHERE t1.user_id > 0 ORDER BY t1.user_id",
-				Expected: []sql.Row{{[]uint8{0x31}}, {[]uint8{0x32}}, {[]uint8{0x33}}},
-			},
-			{
-				// Previously failing with: table "t1" does not have column "user_id"
-				Query:    "SELECT DISTINCT t1.user_id as user_id FROM tweet AS t1 JOIN users AS u2 ON t1.user_id = u2.id WHERE t1.user_id > 0 ORDER BY t1.user_id",
-				Expected: []sql.Row{{1}, {2}, {3}},
 			},
 		},
 	},

--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -101,6 +101,23 @@ var OrderByGroupByScriptTests = []ScriptTest{
 				Query:    "SELECT COUNT(id) as ct, user_id as uid FROM tweet WHERE tweet.id is NOT NULL GROUP BY tweet.user_id HAVING COUNT(tweet.id) > 0 ORDER BY COUNT(tweet.id), user_id LIMIT 1;",
 				Expected: []sql.Row{{1, 2}},
 			},
+			// TODO: Split these test assertions out to a different test case?
+			{
+				// TODO: This failure mode depends on the alias having the same name as the column
+				// Previously failing with: table "t1" does not have column "user_id"
+				Query:    "SELECT DISTINCT BINARY t1.user_id as user_id FROM tweet AS t1 JOIN users AS u2 ON t1.user_id = u2.id WHERE t1.user_id > 0 ORDER BY BINARY t1.user_id",
+				Expected: []sql.Row{{[]uint8{0x31}}, {[]uint8{0x32}}, {[]uint8{0x33}}},
+			},
+			{
+				// Previously failing with: table "t1" does not have column "user_id"
+				Query:    "SELECT DISTINCT BINARY t1.user_id as user_id FROM tweet AS t1 JOIN users AS u2 ON t1.user_id = u2.id WHERE t1.user_id > 0 ORDER BY t1.user_id",
+				Expected: []sql.Row{{[]uint8{0x31}}, {[]uint8{0x32}}, {[]uint8{0x33}}},
+			},
+			{
+				// Previously failing with: table "t1" does not have column "user_id"
+				Query:    "SELECT DISTINCT t1.user_id as user_id FROM tweet AS t1 JOIN users AS u2 ON t1.user_id = u2.id WHERE t1.user_id > 0 ORDER BY t1.user_id",
+				Expected: []sql.Row{{1}, {2}, {3}},
+			},
 		},
 	},
 }

--- a/sql/analyzer/resolve_orderby.go
+++ b/sql/analyzer/resolve_orderby.go
@@ -57,18 +57,22 @@ func pushdownSort(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel R
 
 		var colsFromChild []string
 		var missingCols []tableCol
+		missingSortFieldExpressions := make(map[string]sql.Expression)
 		for _, f := range sort.SortFields {
 			ns := findExprNameables(f.Column)
 
 			for _, n := range ns {
+				col := tableColFromNameable(n)
+
+				// TODO: This next line is a problem... the name is really "t1.user_id", which we do NOT have access to
+				//       above the projection, but we see that there is an alias named that, so we throw away the table
+				//       name. This should NOT be done!
 				name := strings.ToLower(n.Name())
-				if stringContains(childAliases, name) {
+				if col.Table() == "" && stringContains(childAliases, name) {
 					colsFromChild = append(colsFromChild, n.Name())
-				} else {
-					col := tableColFromNameable(n)
-					if !tableColsContains(schemaCols, col) {
-						missingCols = append(missingCols, col)
-					}
+				} else if !tableColsContains(schemaCols, col) {
+					missingCols = append(missingCols, col)
+					missingSortFieldExpressions[strings.ToLower(f.Column.String())] = f.Column
 				}
 			}
 		}
@@ -79,11 +83,24 @@ func pushdownSort(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel R
 			return n, transform.SameTree, nil
 		}
 
+		// TODO: This code below isn't correct... if we are sorting by an expression that contains a function
+		//       missingCols will only report the referenced tableCol used in that function – it won't contain
+		//       the full expression, and we can only use this logic if the FULL expression can be swapped for
+		//       a defined expression alias.
+		// TODO: If we can replace ALL of the missingSortFieldExpressions with an alias, then we're golden.
+		//       Otherwise, we need to move into some plan reordering logic and abandon the alias swaps for now.
 		// If all the missing expressions are aliased, swap in the alias name and don't move the sort node
 		expressionToAliasName := aliasedExpressionsInNode(sort.Child)
-		if allMissingColsAreAliasedExpressions(expressionToAliasName, missingCols) {
-			a.Log("swapping in alias names for missing columns: %s", tableColsToString(missingCols))
-			return replaceOrderByExpressionsWithAliasReferences(sort, expressionToAliasName, missingCols)
+
+		if allMissingSortFieldsAreAliasedExpressions(expressionToAliasName, missingSortFieldExpressions) {
+			// TODO: Clean this junk up...
+			foo := make([]string, 0, len(missingSortFieldExpressions))
+			for missingSortField, _ := range missingSortFieldExpressions {
+				foo = append(foo, missingSortField)
+			}
+
+			a.Log("swapping in alias names for missing sort : %s", strings.Join(foo, ", "))
+			return replaceOrderByExpressionsWithAliasReferences(sort, expressionToAliasName, missingSortFieldExpressions)
 		}
 
 		// If there are no columns required by the order by available, then move the order by below its child.
@@ -251,36 +268,33 @@ func pushSortDown(sort *plan.Sort) (sql.Node, transform.TreeIdentity, error) {
 	}
 }
 
-// allMissingColsAreAliasedExpressions returns true if all the missing tableCols in |missingCols| are defined
-// as aliases in the map of aliased expressions to their alias name in |expressionToAliasName|.
-func allMissingColsAreAliasedExpressions(expressionToAliasName map[string]string, missingCols []tableCol) bool {
-	for _, missingCol := range missingCols {
-		if _, ok := expressionToAliasName[missingCol.String()]; !ok {
+// TODO: godocs
+func allMissingSortFieldsAreAliasedExpressions(expressionToAliasName map[string]string, missingSortFields map[string]sql.Expression) bool {
+	for missingSortField, _ := range missingSortFields {
+		if _, ok := expressionToAliasName[missingSortField]; !ok {
 			return false
 		}
 	}
-
 	return true
 }
 
+// TODO: Update docs
 // replaceOrderByExpressionsWithAliasReferences transforms the specified |sort| node, by replacing the specified
 // tableCols from |missingCols| with their aliased names from |expressionToAliasName|.
-func replaceOrderByExpressionsWithAliasReferences(sort *plan.Sort, expressionToAliasName map[string]string, missingCols []tableCol) (sql.Node, transform.TreeIdentity, error) {
+func replaceOrderByExpressionsWithAliasReferences(sort *plan.Sort, expressionToAliasName map[string]string, missingSortFieldExpressions map[string]sql.Expression) (sql.Node, transform.TreeIdentity, error) {
 	var newSortFields []sql.Expression
-	var replacedCols []string
 	for i, sortField := range sort.SortFields {
 		exprString := strings.ToLower(sortField.Column.String())
 
 		// if exprString is one of our missing columns and there's an alias we can reference, swap it in
-		for _, missingCol := range missingCols {
-			if missingCol.String() == exprString {
+		for missingSortField, _ := range missingSortFieldExpressions {
+			if missingSortField == exprString {
 				if aliasName, ok := expressionToAliasName[exprString]; ok {
 					if newSortFields == nil {
 						newSortFields = make([]sql.Expression, len(sort.SortFields))
 						copy(newSortFields, sort.SortFields.ToExpressions())
 					}
 					newSortFields[i] = expression.NewAliasReference(aliasName)
-					replacedCols = append(replacedCols, exprString)
 				}
 				break
 			}


### PR DESCRIPTION
The previous code in `pushdownSort` was able to replace a missing column reference with an alias reference when that column was aliased, but it wasn't able to correctly replace compound expressions such as `ORDER BY BINARY(mytable.mycol)` due to how we tracked only the missing column references and didn't consider the sort field expression as a whole. 

This change expands that alias substitution support so that it looks at the entire sort field expression (i.e. not just the individual named references inside it) and replaces missing sort fields with alias references only when the entire sort field expression matches the aliased expression. 

This fixes an issue with Prisma compatibility with Dolt (https://github.com/dolthub/dolt/issues/4511).