### PR TITLE
prepend rows for only projector nodes

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2341,6 +2341,51 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "using having and group by clauses in subquery ",
+		SetUpScript: []string{
+			"CREATE TABLE t (i int, t varchar(2));",
+			"insert into t values (1, 'a'), (1, 'a2'), (2, 'b'), (3, 'c'), (3, 'c2'), (4, 'd'), (5, 'e'), (5, 'e2');", //, (6, 'f'), (7, 'g'), (7, 'g2')
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select i from t group by i having count(1) = 1 order by i asc",
+				Expected: []sql.Row{{2}, {4}},
+			},
+			{
+				Query:    "select i from t group by i having count(1) != 1 order by i asc",
+				Expected: []sql.Row{{1}, {3}, {5}},
+			},
+			{
+				Query:    "select * from t where i in (select i from t group by i having count(1) = 1) order by i, t asc;",
+				Expected: []sql.Row{{2, "b"}, {4, "d"}},
+			},
+			{
+				Query:    "select * from t where i in (select i from t group by i having count(1) != 1) order by i, t asc;",
+				Expected: []sql.Row{{1, "a"}, {1, "a2"}, {3, "c"}, {3, "c2"}, {5, "e"}, {5, "e2"}},
+			},
+			{
+				Query:    "select * from t where i in (select i from t where i = 2 group by i having count(1) = 1) order by i, t asc;",
+				Expected: []sql.Row{{2, "b"}},
+			},
+			{
+				Query:    "select * from t where i in (select i from t where i = 3 group by i having count(1) != 1) order by i, t asc;",
+				Expected: []sql.Row{{3, "c"}, {3, "c2"}},
+			},
+			{
+				Query:    "select * from t where i in (select i from t where i > 2 group by i having count(1) != 1) order by i, t asc;",
+				Expected: []sql.Row{{3, "c"}, {3, "c2"}, {5, "e"}, {5, "e2"}},
+			},
+			{
+				Query:    "select * from t where i in (select i from t where i > 2 group by i having count(1) != 1 order by i desc) order by i, t asc;",
+				Expected: []sql.Row{{3, "c"}, {3, "c2"}, {5, "e"}, {5, "e2"}},
+			},
+			{
+				Query:    "select * from t where i in (select i from t where i > 2 group by i having count(1) != 1) order by i desc, t asc;",
+				Expected: []sql.Row{{5, "e"}, {5, "e2"}, {3, "c"}, {3, "c2"}},
+			},
+		},
+	},
+	{
 		Name: "can't create view with same name as existing table",
 		SetUpScript: []string{
 			"create table t (i int);",

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -221,7 +221,7 @@ func (s *Subquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 func prependRowInPlan(row sql.Row) func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 	return func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		switch n := n.(type) {
-		case sql.Table, *Project, *GroupBy, *Window, *Having, *ValueDerivedTable:
+		case sql.Table, sql.Projector, *ValueDerivedTable:
 			return &prependNode{
 				UnaryNode: UnaryNode{Child: n},
 				row:       row,


### PR DESCRIPTION
This PR was reverted but now it has fixed tests that passes for dolt engine tests. The table is keyless table, which causes output result to be in randomized order in dolt compared to gms, so the tests now include order by clauses to persist the order of the output rows.