### PR TITLE
Moved privilege caching to session

### DIFF
--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/dolthub/vitess/go/mysql"
 	flatbuffers "github.com/google/flatbuffers/go"
@@ -70,7 +69,7 @@ type MySQLDb struct {
 	persister MySQLDbPersistence
 	plugins   map[string]PlaintextAuthPlugin
 
-	cache *privilegeCache
+	updateCounter uint64
 }
 
 var _ sql.Database = (*MySQLDb)(nil)
@@ -101,7 +100,9 @@ func CreateEmptyMySQLDb() *MySQLDb {
 	// mysqlTable shims
 	mysqlDb.db = newMySQLTableShim(dbTblName, dbTblSchema, mysqlDb.user, DbConverter{})
 	mysqlDb.tables_priv = newMySQLTableShim(tablesPrivTblName, tablesPrivTblSchema, mysqlDb.user, TablesPrivConverter{})
-	mysqlDb.cache = newPrivilegeCache()
+
+	// Start the counter at 1, all new sessions will start at zero so this forces an update for any new session
+	mysqlDb.updateCounter = 1
 
 	return mysqlDb
 }
@@ -127,7 +128,7 @@ func (db *MySQLDb) LoadPrivilegeData(ctx *sql.Context, users []*User, roleConnec
 		}
 	}
 
-	db.clearCache()
+	db.updateCounter++
 
 	return nil
 }
@@ -188,7 +189,7 @@ func (db *MySQLDb) LoadData(ctx *sql.Context, buf []byte) (err error) {
 		}
 	}
 
-	db.clearCache()
+	db.updateCounter++
 
 	// TODO: fill in other tables when they exist
 	return
@@ -215,7 +216,7 @@ func (db *MySQLDb) VerifyPlugin(plugin string) error {
 func (db *MySQLDb) AddRootAccount() {
 	db.Enabled = true
 	addSuperUser(db.user, "root", "localhost", "")
-	db.clearCache()
+	db.updateCounter++
 }
 
 // AddSuperUser adds the given username and password to the list of accounts. This is a temporary function, which is
@@ -233,7 +234,7 @@ func (db *MySQLDb) AddSuperUser(username string, host string, password string) {
 		password = "*" + strings.ToUpper(hex.EncodeToString(s2))
 	}
 	addSuperUser(db.user, username, host, password)
-	db.clearCache()
+	db.updateCounter++
 }
 
 // GetUser returns a user matching the given user and host if it exists. Due to the slight difference between users and
@@ -282,14 +283,15 @@ func (db *MySQLDb) GetUser(user string, host string, roleSearch bool) *User {
 // UserActivePrivilegeSet fetches the User, and returns their entire active privilege set. This takes into account the
 // active roles, which are set in the context, therefore the user is also pulled from the context.
 func (db *MySQLDb) UserActivePrivilegeSet(ctx *sql.Context) PrivilegeSet {
+	if privSet, counter := ctx.Session.GetPrivilegeSet(); db.updateCounter == counter {
+		// If the counters are equal, we can guarantee that the privilege set exists and is valid
+		return privSet.(PrivilegeSet)
+	}
+
 	client := ctx.Session.Client()
 	user := db.GetUser(client.User, client.Address, false)
 	if user == nil {
 		return NewPrivilegeSet()
-	}
-
-	if priv, ok := db.cache.userPrivileges(user); ok {
-		return priv
 	}
 
 	privSet := user.PrivilegeSet.Copy()
@@ -307,10 +309,7 @@ func (db *MySQLDb) UserActivePrivilegeSet(ctx *sql.Context) PrivilegeSet {
 		}
 	}
 
-	// This is technically a race -- two clients could cache at the same time. But this shouldn't matter, as they will
-	// eventually get the same data after the cache is cleared on a write, and MySQL doesn't even guarantee immediate
-	// effect for grant statements.
-	db.cache.cacheUserPrivileges(user, privSet)
+	ctx.Session.SetPrivilegeSet(privSet, db.updateCounter)
 	return privSet
 }
 
@@ -488,8 +487,7 @@ func (db *MySQLDb) Negotiate(c *mysql.Conn, user string, addr net.Addr) (mysql.G
 
 // Persist passes along all changes to the integrator.
 func (db *MySQLDb) Persist(ctx *sql.Context) error {
-	defer db.clearCache()
-
+	db.updateCounter++
 	// Extract all user entries from table, and sort
 	userEntries := db.user.data.ToSlice(ctx)
 	users := make([]*User, 0)
@@ -554,13 +552,6 @@ func (db *MySQLDb) UserTable() *mysqlTable {
 // RoleEdgesTable returns the "role_edges" table.
 func (db *MySQLDb) RoleEdgesTable() *mysqlTable {
 	return db.role_edges
-}
-
-func (db *MySQLDb) clearCache() {
-	if db == nil { // nil in the case of some tests
-		return
-	}
-	db.cache.clear()
 }
 
 // columnTemplate takes in a column as a template, and returns a new column with a different name based on the given
@@ -628,42 +619,4 @@ var _ sql.Partition = dummyPartition{}
 // Key implements the interface sql.Partition.
 func (d dummyPartition) Key() []byte {
 	return nil
-}
-
-type privilegeCache struct {
-	mu       sync.Mutex
-	userPriv map[string]PrivilegeSet
-}
-
-func newPrivilegeCache() *privilegeCache {
-	return &privilegeCache{
-		userPriv: make(map[string]PrivilegeSet),
-	}
-}
-
-func userKey(user *User) string {
-	return fmt.Sprintf("%s@%s", user.User, user.Host)
-}
-
-func (pc *privilegeCache) userPrivileges(user *User) (PrivilegeSet, bool) {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-
-	privs, ok := pc.userPriv[userKey(user)]
-	return privs, ok
-}
-
-// cacheUserPrivileges Caches the user privileges given. Needs external locking.
-func (pc *privilegeCache) cacheUserPrivileges(user *User, privs PrivilegeSet) {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-
-	pc.userPriv[userKey(user)] = privs
-}
-
-func (pc *privilegeCache) clear() {
-	pc.mu.Lock()
-	defer pc.mu.Unlock()
-
-	pc.userPriv = make(map[string]PrivilegeSet)
 }

--- a/sql/mysql_db/mysql_db_serialize.go
+++ b/sql/mysql_db/mysql_db_serialize.go
@@ -79,7 +79,7 @@ func serializeTables(b *flatbuffers.Builder, tables []PrivilegeSetTable) flatbuf
 	for i, table := range tables {
 		name := b.CreateString(table.Name())
 		privs := serializePrivilegeTypes(b, serial.PrivilegeSetTableStartPrivsVector, table.ToSlice())
-		cols := serializeColumns(b, table.GetColumns())
+		cols := serializeColumns(b, table.getColumns())
 
 		serial.PrivilegeSetTableStart(b)
 		serial.PrivilegeSetTableAddName(b, name)
@@ -98,7 +98,7 @@ func serializeDatabases(b *flatbuffers.Builder, databases []PrivilegeSetDatabase
 	for i, database := range databases {
 		name := b.CreateString(database.Name())
 		privs := serializePrivilegeTypes(b, serial.PrivilegeSetDatabaseStartPrivsVector, database.ToSlice())
-		tables := serializeTables(b, database.GetTables())
+		tables := serializeTables(b, database.getTables())
 
 		serial.PrivilegeSetDatabaseStart(b)
 		serial.PrivilegeSetDatabaseAddName(b, name)
@@ -115,7 +115,7 @@ func serializePrivilegeSet(b *flatbuffers.Builder, ps *PrivilegeSet) flatbuffers
 	// Write privilege set variables, and save offsets
 	globalStatic := serializePrivilegeTypes(b, serial.PrivilegeSetStartGlobalStaticVector, ps.ToSlice())
 	globalDynamic := serializeGlobalDynamic(b, ps.globalDynamic)
-	databases := serializeDatabases(b, ps.GetDatabases())
+	databases := serializeDatabases(b, ps.getDatabases())
 
 	// Write PrivilegeSet
 	serial.PrivilegeSetStart(b)

--- a/sql/mysql_db/mysql_table.go
+++ b/sql/mysql_db/mysql_table.go
@@ -102,7 +102,9 @@ func (t *mysqlTable) Replacer(ctx *sql.Context) sql.RowReplacer {
 
 // Truncate implements the interface sql.TruncateableTable.
 func (t *mysqlTable) Truncate(ctx *sql.Context) (int, error) {
-	defer t.db.clearCache()
+	if t.db != nil {
+		t.db.updateCounter++
+	}
 	count := t.data.Count()
 	t.data.Clear()
 	return int(count), nil
@@ -120,17 +122,23 @@ type cacheClearingDataEditor struct {
 }
 
 func (c cacheClearingDataEditor) Insert(ctx *sql.Context, row sql.Row) error {
-	defer c.db.clearCache()
+	if c.db != nil {
+		c.db.updateCounter++
+	}
 	return c.editor.Insert(ctx, row)
 }
 
 func (c cacheClearingDataEditor) Update(ctx *sql.Context, old sql.Row, new sql.Row) error {
-	defer c.db.clearCache()
+	if c.db != nil {
+		c.db.updateCounter++
+	}
 	return c.editor.Update(ctx, old, new)
 }
 
 func (c cacheClearingDataEditor) Delete(ctx *sql.Context, row sql.Row) error {
-	defer c.db.clearCache()
+	if c.db != nil {
+		c.db.updateCounter++
+	}
 	return c.editor.Delete(ctx, row)
 }
 

--- a/sql/mysql_db/privilege_set_json.go
+++ b/sql/mysql_db/privilege_set_json.go
@@ -52,7 +52,7 @@ var _ json.Unmarshaler = (*PrivilegeSet)(nil)
 
 // MarshalJSON implements the interface json.Marshaler.
 func (ps PrivilegeSet) MarshalJSON() ([]byte, error) {
-	globalStaticPrivs := ps.ToSortedSlice()
+	globalStaticPrivs := ps.ToSlice()
 	psm := privilegeSetMarshaler{
 		GlobalStatic: make([]string, len(globalStaticPrivs)),
 		Databases:    make([]privilegeSetMarshalerDatabase, len(ps.databases)),
@@ -61,11 +61,11 @@ func (ps PrivilegeSet) MarshalJSON() ([]byte, error) {
 		psm.GlobalStatic[i] = globalStaticPriv.String()
 	}
 	for dbIndex, database := range ps.GetDatabases() {
-		dbPrivs := database.ToSortedSlice()
+		dbPrivs := database.ToSlice()
 		dbm := privilegeSetMarshalerDatabase{
-			Name:       database.name,
+			Name:       database.Name(),
 			Privileges: make([]string, len(dbPrivs)),
-			Tables:     make([]privilegeSetMarshalerTable, len(database.tables)),
+			Tables:     make([]privilegeSetMarshalerTable, len(database.(PrivilegeSetDatabase).tables)),
 		}
 		for i, dbPriv := range dbPrivs {
 			dbm.Privileges[i] = dbPriv.String()
@@ -73,11 +73,11 @@ func (ps PrivilegeSet) MarshalJSON() ([]byte, error) {
 		psm.Databases[dbIndex] = dbm
 
 		for tblIndex, table := range database.GetTables() {
-			tblPrivs := table.ToSortedSlice()
+			tblPrivs := table.ToSlice()
 			tbm := privilegeSetMarshalerTable{
-				Name:       table.name,
-				Privileges: make([]string, len(table.privs)),
-				Columns:    make([]privilegeSetMarshalerColumn, len(table.columns)),
+				Name:       table.Name(),
+				Privileges: make([]string, len(table.(PrivilegeSetTable).privs)),
+				Columns:    make([]privilegeSetMarshalerColumn, len(table.(PrivilegeSetTable).columns)),
 			}
 			for i, tblPriv := range tblPrivs {
 				tbm.Privileges[i] = tblPriv.String()
@@ -85,10 +85,10 @@ func (ps PrivilegeSet) MarshalJSON() ([]byte, error) {
 			dbm.Tables[tblIndex] = tbm
 
 			for colIndex, column := range table.GetColumns() {
-				colPrivs := column.ToSortedSlice()
+				colPrivs := column.ToSlice()
 				cbm := privilegeSetMarshalerColumn{
-					Name:       column.name,
-					Privileges: make([]string, len(column.privs)),
+					Name:       column.Name(),
+					Privileges: make([]string, len(column.(PrivilegeSetColumn).privs)),
 				}
 				for i, colPriv := range colPrivs {
 					cbm.Privileges[i] = colPriv.String()

--- a/sql/mysql_db/privileged_database_provider.go
+++ b/sql/mysql_db/privileged_database_provider.go
@@ -45,7 +45,7 @@ func NewPrivilegedDatabaseProvider(grantTables *MySQLDb, p sql.DatabaseProvider)
 func (pdp PrivilegedDatabaseProvider) Database(ctx *sql.Context, name string) (sql.Database, error) {
 	privSet := pdp.grantTables.UserActivePrivilegeSet(ctx)
 	// If the user has no global static privileges or database-relevant privileges then the database is not accessible.
-	if privSet.StaticCount() == 0 && !privSet.Database(name).HasPrivileges() {
+	if privSet.Count() == 0 && !privSet.Database(name).HasPrivileges() {
 		return nil, sql.ErrDatabaseAccessDeniedForUser.New(pdp.usernameFromCtx(ctx), name)
 	}
 	if strings.ToLower(name) == "mysql" {
@@ -62,7 +62,7 @@ func (pdp PrivilegedDatabaseProvider) Database(ctx *sql.Context, name string) (s
 func (pdp PrivilegedDatabaseProvider) HasDatabase(ctx *sql.Context, name string) bool {
 	privSet := pdp.grantTables.UserActivePrivilegeSet(ctx)
 	// If the user has no global static privileges or database-relevant privileges then the database is not accessible.
-	if privSet.StaticCount() == 0 && !privSet.Database(name).HasPrivileges() {
+	if privSet.Count() == 0 && !privSet.Database(name).HasPrivileges() {
 		return false
 	}
 	return pdp.provider.HasDatabase(ctx, name)
@@ -71,7 +71,7 @@ func (pdp PrivilegedDatabaseProvider) HasDatabase(ctx *sql.Context, name string)
 // AllDatabases implements the interface sql.DatabaseProvider.
 func (pdp PrivilegedDatabaseProvider) AllDatabases(ctx *sql.Context) []sql.Database {
 	privilegeSet := pdp.grantTables.UserActivePrivilegeSet(ctx)
-	privilegeSetCount := privilegeSet.StaticCount()
+	privilegeSetCount := privilegeSet.Count()
 
 	var databasesWithAccess []sql.Database
 	allDatabases := pdp.provider.AllDatabases(ctx)
@@ -128,14 +128,14 @@ func (pdb PrivilegedDatabase) GetTableInsensitive(ctx *sql.Context, tblName stri
 	privSet := pdb.grantTables.UserActivePrivilegeSet(ctx)
 	dbSet := privSet.Database(pdb.db.Name())
 	// If there are no usable privileges for this database then the table is inaccessible.
-	if privSet.StaticCount() == 0 && !dbSet.HasPrivileges() {
+	if privSet.Count() == 0 && !dbSet.HasPrivileges() {
 		return nil, false, sql.ErrDatabaseAccessDeniedForUser.New(pdb.usernameFromCtx(ctx), pdb.db.Name())
 	}
 
 	tblSet := dbSet.Table(tblName)
 	// If the user has no global static privileges, database-level privileges, or table-relevant privileges then the
 	// table is not accessible.
-	if privSet.StaticCount() == 0 && dbSet.Count() == 0 && !tblSet.HasPrivileges() {
+	if privSet.Count() == 0 && dbSet.Count() == 0 && !tblSet.HasPrivileges() {
 		return nil, false, sql.ErrTableAccessDeniedForUser.New(pdb.usernameFromCtx(ctx), tblName)
 	}
 	return pdb.db.GetTableInsensitive(ctx, tblName)
@@ -146,7 +146,7 @@ func (pdb PrivilegedDatabase) GetTableNames(ctx *sql.Context) ([]string, error) 
 	privSet := pdb.grantTables.UserActivePrivilegeSet(ctx)
 	dbSet := privSet.Database(pdb.db.Name())
 	// If there are no usable privileges for this database then no table is accessible.
-	if privSet.StaticCount() == 0 && !dbSet.HasPrivileges() {
+	if privSet.Count() == 0 && !dbSet.HasPrivileges() {
 		return nil, nil
 	}
 
@@ -154,7 +154,7 @@ func (pdb PrivilegedDatabase) GetTableNames(ctx *sql.Context) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
-	privSetCount := privSet.StaticCount()
+	privSetCount := privSet.Count()
 	dbSetCount := dbSet.Count()
 	var tablesWithAccess []string
 	for _, tblName := range tblNames {
@@ -177,14 +177,14 @@ func (pdb PrivilegedDatabase) GetTableInsensitiveAsOf(ctx *sql.Context, tblName 
 	privSet := pdb.grantTables.UserActivePrivilegeSet(ctx)
 	dbSet := privSet.Database(pdb.db.Name())
 	// If there are no usable privileges for this database then the table is inaccessible.
-	if privSet.StaticCount() == 0 && !dbSet.HasPrivileges() {
+	if privSet.Count() == 0 && !dbSet.HasPrivileges() {
 		return nil, false, sql.ErrDatabaseAccessDeniedForUser.New(pdb.usernameFromCtx(ctx), pdb.db.Name())
 	}
 
 	tblSet := dbSet.Table(tblName)
 	// If the user has no global static privileges, database-level privileges, or table-relevant privileges then the
 	// table is not accessible.
-	if privSet.StaticCount() == 0 && dbSet.Count() == 0 && !tblSet.HasPrivileges() {
+	if privSet.Count() == 0 && dbSet.Count() == 0 && !tblSet.HasPrivileges() {
 		return nil, false, sql.ErrTableAccessDeniedForUser.New(pdb.usernameFromCtx(ctx), tblName)
 	}
 	return db.GetTableInsensitiveAsOf(ctx, tblName, asOf)
@@ -200,7 +200,7 @@ func (pdb PrivilegedDatabase) GetTableNamesAsOf(ctx *sql.Context, asOf interface
 	privSet := pdb.grantTables.UserActivePrivilegeSet(ctx)
 	dbSet := privSet.Database(pdb.db.Name())
 	// If there are no usable privileges for this database then no table is accessible.
-	if privSet.StaticCount() == 0 && !dbSet.HasPrivileges() {
+	if privSet.Count() == 0 && !dbSet.HasPrivileges() {
 		return nil, nil
 	}
 
@@ -208,7 +208,7 @@ func (pdb PrivilegedDatabase) GetTableNamesAsOf(ctx *sql.Context, asOf interface
 	if err != nil {
 		return nil, err
 	}
-	privSetCount := privSet.StaticCount()
+	privSetCount := privSet.Count()
 	dbSetCount := dbSet.Count()
 	var tablesWithAccess []string
 	for _, tblName := range tblNames {

--- a/sql/plan/show_grants.go
+++ b/sql/plan/show_grants.go
@@ -162,18 +162,18 @@ func (n *ShowGrants) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error)
 	//TODO: implement USING, perhaps by creating a new context with the chosen roles set as the active roles
 	var rows []sql.Row
 	userStr := user.UserHostToString("`")
-	privStr := generatePrivStrings("*", "*", userStr, user.PrivilegeSet.ToSortedSlice())
+	privStr := generatePrivStrings("*", "*", userStr, user.PrivilegeSet.ToSlice())
 	rows = append(rows, sql.Row{privStr})
 
 	for _, db := range user.PrivilegeSet.GetDatabases() {
 		dbStr := fmt.Sprintf("`%s`", db.Name())
-		if privStr = generatePrivStrings(dbStr, "*", userStr, db.ToSortedSlice()); len(privStr) != 0 {
+		if privStr = generatePrivStrings(dbStr, "*", userStr, db.ToSlice()); len(privStr) != 0 {
 			rows = append(rows, sql.Row{privStr})
 		}
 
 		for _, tbl := range db.GetTables() {
 			tblStr := fmt.Sprintf("`%s`", tbl.Name())
-			privStr = generatePrivStrings(dbStr, tblStr, userStr, tbl.ToSortedSlice())
+			privStr = generatePrivStrings(dbStr, tblStr, userStr, tbl.ToSlice())
 			rows = append(rows, sql.Row{privStr})
 		}
 	}

--- a/sql/privileges.go
+++ b/sql/privileges.go
@@ -27,6 +27,80 @@ type PrivilegedOperationChecker interface {
 	UserHasPrivileges(ctx *Context, operations ...PrivilegedOperation) bool
 }
 
+// PrivilegeSet is a set containing privileges. Integrators should not implement this interface.
+type PrivilegeSet interface {
+	// Has returns whether the given global privilege(s) exists.
+	Has(privileges ...PrivilegeType) bool
+	// HasPrivileges returns whether this PrivilegeSet has any privileges at any level.
+	HasPrivileges() bool
+	// Count returns the number of global privileges.
+	Count() int
+	// Database returns the set of privileges for the given database. Returns an empty set if the database does not exist.
+	Database(dbName string) PrivilegeSetDatabase
+	// GetDatabases returns all databases.
+	GetDatabases() []PrivilegeSetDatabase
+	// Equals returns whether the given set of privileges is equivalent to the calling set.
+	Equals(otherPs PrivilegeSet) bool
+	// ToSlice returns all of the global privileges contained as a sorted slice.
+	ToSlice() []PrivilegeType
+}
+
+// PrivilegeSetDatabase is a set containing database-level privileges. Integrators should not implement this interface.
+type PrivilegeSetDatabase interface {
+	// Name returns the name of the database that this privilege set belongs to.
+	Name() string
+	// Has returns whether the given database privilege(s) exists.
+	Has(privileges ...PrivilegeType) bool
+	// HasPrivileges returns whether this database has either database-level privileges, or privileges on a table or
+	// column contained within this database.
+	HasPrivileges() bool
+	// Count returns the number of database privileges.
+	Count() int
+	// Table returns the set of privileges for the given table. Returns an empty set if the table does not exist.
+	Table(tblName string) PrivilegeSetTable
+	// GetTables returns all tables.
+	GetTables() []PrivilegeSetTable
+	// Equals returns whether the given set of privileges is equivalent to the calling set.
+	Equals(otherPs PrivilegeSetDatabase) bool
+	// ToSlice returns all of the database privileges contained as a sorted slice.
+	ToSlice() []PrivilegeType
+}
+
+// PrivilegeSetTable is a set containing table-level privileges. Integrators should not implement this interface.
+type PrivilegeSetTable interface {
+	// Name returns the name of the table that this privilege set belongs to.
+	Name() string
+	// Has returns whether the given table privilege(s) exists.
+	Has(privileges ...PrivilegeType) bool
+	// HasPrivileges returns whether this table has either table-level privileges, or privileges on a column contained
+	// within this table.
+	HasPrivileges() bool
+	// Count returns the number of table privileges.
+	Count() int
+	// Column returns the set of privileges for the given column. Returns an empty set if the column does not exist.
+	Column(colName string) PrivilegeSetColumn
+	// GetColumns returns all columns.
+	GetColumns() []PrivilegeSetColumn
+	// Equals returns whether the given set of privileges is equivalent to the calling set.
+	Equals(otherPs PrivilegeSetTable) bool
+	// ToSlice returns all of the table privileges contained as a sorted slice.
+	ToSlice() []PrivilegeType
+}
+
+// PrivilegeSetColumn is a set containing column privileges. Integrators should not implement this interface.
+type PrivilegeSetColumn interface {
+	// Name returns the name of the column that this privilege set belongs to.
+	Name() string
+	// Has returns whether the given column privilege(s) exists.
+	Has(privileges ...PrivilegeType) bool
+	// Count returns the number of column privileges.
+	Count() int
+	// Equals returns whether the given set of privileges is equivalent to the calling set.
+	Equals(otherPs PrivilegeSetColumn) bool
+	// ToSlice returns all of the column privileges contained as a sorted slice.
+	ToSlice() []PrivilegeType
+}
+
 // PrivilegeType represents a privilege.
 type PrivilegeType int
 

--- a/sql/session.go
+++ b/sql/session.go
@@ -139,6 +139,13 @@ type Session interface {
 	GetCharacterSetResults() CharacterSetID
 	// GetCollation returns the collation for this session (defined by the system variable `collation_connection`).
 	GetCollation() CollationID
+	// GetPrivilegeSet returns the cached privilege set associated with this session, along with its counter. The
+	// PrivilegeSet is only valid when the counter is greater than zero.
+	GetPrivilegeSet() (PrivilegeSet, uint64)
+	// SetPrivilegeSet updates this session's cache with the given counter and privilege set. Setting the counter to a
+	// value of zero will force the cache to reload. This is an internal function and is not intended to be used by
+	// integrators.
+	SetPrivilegeSet(newPs PrivilegeSet, counter uint64)
 	// ValidateSession provides integrators a chance to do any custom validation of this session before any query is executed in it. For example, Dolt uses this hook to validate that the session's working set is valid.
 	ValidateSession(ctx *Context, dbName string) error
 }
@@ -181,6 +188,11 @@ type BaseSession struct {
 	lastQueryInfo    map[string]int64
 	tx               Transaction
 	ignoreAutocommit bool
+
+	// When the MySQL database updates any tables related to privileges, it increments its counter. We then update our
+	// privilege set if our counter doesn't equal the database's counter.
+	privSetCounter uint64
+	privilegeSet   PrivilegeSet
 }
 
 func (s *BaseSession) GetLogger() *logrus.Entry {
@@ -596,20 +608,30 @@ func (s *BaseSession) SetTransaction(tx Transaction) {
 	s.tx = tx
 }
 
+func (s *BaseSession) GetPrivilegeSet() (PrivilegeSet, uint64) {
+	return s.privilegeSet, s.privSetCounter
+}
+
+func (s *BaseSession) SetPrivilegeSet(newPs PrivilegeSet, counter uint64) {
+	s.privSetCounter = counter
+	s.privilegeSet = newPs
+}
+
 // NewBaseSessionWithClientServer creates a new session with data.
 func NewBaseSessionWithClientServer(server string, client Client, id uint32) *BaseSession {
 	//TODO: if system variable "activate_all_roles_on_login" if set, activate all roles
 	return &BaseSession{
-		addr:          server,
-		client:        client,
-		id:            id,
-		systemVars:    SystemVariables.NewSessionMap(),
-		userVars:      make(map[string]interface{}),
-		idxReg:        NewIndexRegistry(),
-		viewReg:       NewViewRegistry(),
-		mu:            sync.RWMutex{},
-		locks:         make(map[string]bool),
-		lastQueryInfo: defaultLastQueryInfo(),
+		addr:           server,
+		client:         client,
+		id:             id,
+		systemVars:     SystemVariables.NewSessionMap(),
+		userVars:       make(map[string]interface{}),
+		idxReg:         NewIndexRegistry(),
+		viewReg:        NewViewRegistry(),
+		mu:             sync.RWMutex{},
+		locks:          make(map[string]bool),
+		lastQueryInfo:  defaultLastQueryInfo(),
+		privSetCounter: 0,
 	}
 }
 
@@ -620,14 +642,15 @@ var autoSessionIDs uint32 = 1
 func NewBaseSession() *BaseSession {
 	//TODO: if system variable "activate_all_roles_on_login" if set, activate all roles
 	return &BaseSession{
-		id:            atomic.AddUint32(&autoSessionIDs, 1),
-		systemVars:    SystemVariables.NewSessionMap(),
-		userVars:      make(map[string]interface{}),
-		idxReg:        NewIndexRegistry(),
-		viewReg:       NewViewRegistry(),
-		mu:            sync.RWMutex{},
-		locks:         make(map[string]bool),
-		lastQueryInfo: defaultLastQueryInfo(),
+		id:             atomic.AddUint32(&autoSessionIDs, 1),
+		systemVars:     SystemVariables.NewSessionMap(),
+		userVars:       make(map[string]interface{}),
+		idxReg:         NewIndexRegistry(),
+		viewReg:        NewViewRegistry(),
+		mu:             sync.RWMutex{},
+		locks:          make(map[string]bool),
+		lastQueryInfo:  defaultLastQueryInfo(),
+		privSetCounter: 0,
 	}
 }
 
@@ -862,6 +885,7 @@ func (c *Context) NewErrgroup() (*errgroup.Group, *Context) {
 func (c *Context) NewCtxWithClient(client Client) *Context {
 	nc := *c
 	nc.Session.SetClient(client)
+	nc.Session.SetPrivilegeSet(nil, 0)
 	return &nc
 }
 


### PR DESCRIPTION
This accomplishes two things:
1) This changes how we cache privilege sets. The previous behavior was fine for the _existing_ feature set, but it didn't support roles all too well. Right now all roles are applied to any user that they're assigned to, but in a future PR roles will be selectable (like they are in MySQL). Role selection is at the session level, so it makes sense that the cached privilege set is also at the session level. It's straightforward to update a sesson's roles and invalidate the cache in the same place.
2) If an integrator wanted to see what privileges a session had, then they'd need to query the engine, which meant keeping a reference to the engine in multiple places. Now, they just query the session on the context, which they're already passing around.