### PR TITLE
Provide better errors when attempting to use stored procedures without a DB

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1594,6 +1594,18 @@ func TestStoredProcedures(t *testing.T, harness Harness) {
 		ctx := NewContext(harness)
 		ctx.SetCurrentDatabase("")
 
+		for _, script := range queries.NoDbProcedureTests {
+			if script.Expected != nil || script.SkipResultsCheck {
+				expectedResult := script.Expected
+				if script.SkipResultsCheck {
+					expectedResult = nil
+				}
+				TestQueryWithContext(t, ctx, e, harness, script.Query, expectedResult, nil, nil)
+			} else if script.ExpectedErr != nil {
+				AssertErrWithCtx(t, e, harness, ctx, script.Query, script.ExpectedErr)
+			}
+		}
+
 		TestQueryWithContext(t, ctx, e, harness, "CREATE PROCEDURE mydb.p1() SELECT 5", []sql.Row{{sql.OkResult{}}}, nil, nil)
 		TestQueryWithContext(t, ctx, e, harness, "CREATE PROCEDURE mydb.p2() SELECT 6", []sql.Row{{sql.OkResult{}}}, nil, nil)
 
@@ -1602,12 +1614,16 @@ func TestStoredProcedures(t *testing.T, harness Harness) {
 				"DEFINER", "", "utf8mb4", "utf8mb4_0900_bin", "utf8mb4_0900_bin"},
 			{"mydb", "p2", "PROCEDURE", "", time.Unix(0, 0).UTC(), time.Unix(0, 0).UTC(),
 				"DEFINER", "", "utf8mb4", "utf8mb4_0900_bin", "utf8mb4_0900_bin"},
+			{"mydb", "p5", "PROCEDURE", "", time.Unix(0, 0).UTC(), time.Unix(0, 0).UTC(),
+				"DEFINER", "", "utf8mb4", "utf8mb4_0900_bin", "utf8mb4_0900_bin"},
 		}, nil, nil)
 
 		TestQueryWithContext(t, ctx, e, harness, "DROP PROCEDURE mydb.p1", []sql.Row{}, nil, nil)
 
 		TestQueryWithContext(t, ctx, e, harness, "SHOW PROCEDURE STATUS", []sql.Row{
 			{"mydb", "p2", "PROCEDURE", "", time.Unix(0, 0).UTC(), time.Unix(0, 0).UTC(),
+				"DEFINER", "", "utf8mb4", "utf8mb4_0900_bin", "utf8mb4_0900_bin"},
+			{"mydb", "p5", "PROCEDURE", "", time.Unix(0, 0).UTC(), time.Unix(0, 0).UTC(),
 				"DEFINER", "", "utf8mb4", "utf8mb4_0900_bin", "utf8mb4_0900_bin"},
 		}, nil, nil)
 	})

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -270,7 +270,9 @@ func TestQueryWithContext(t *testing.T, ctx *sql.Context, e *sqle.Engine, harnes
 	rows, err := sql.RowIterToRows(ctx, sch, iter)
 	require.NoError(err, "Unexpected error for query %s: %s", q, err)
 
-	checkResults(t, require, expected, expectedCols, sch, rows, q)
+	if expected != nil {
+		checkResults(t, require, expected, expectedCols, sch, rows, q)
+	}
 
 	require.Equal(0, ctx.Memory.NumCaches())
 	validateEngine(t, ctx, harness, e)

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1429,3 +1429,26 @@ var ProcedureShowCreate = []ScriptTest{
 		},
 	},
 }
+
+var NoDbProcedureTests = []ScriptTestAssertion{
+	{
+		Query:    "SHOW databases;",
+		Expected: []sql.Row{{"information_schema"}, {"mydb"}, {"mysql"}},
+	},
+	{
+		Query:    "SELECT database();",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "CREATE PROCEDURE mydb.p5() SELECT 42;",
+		Expected: []sql.Row{{sql.NewOkResult(0)}},
+	},
+	{
+		Query:            "SHOW CREATE PROCEDURE mydb.p5;",
+		SkipResultsCheck: true,
+	},
+	{
+		Query:       "SHOW CREATE PROCEDURE p5;",
+		ExpectedErr: sql.ErrNoDatabaseSelected,
+	},
+}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -502,6 +502,13 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 
 		return node, nil
 	case "create procedure":
+		dbName := s.Table.Qualifier.String()
+		if dbName == "" {
+			dbName = ctx.GetCurrentDatabase()
+		}
+		if dbName == "" {
+			return nil, sql.ErrNoDatabaseSelected.New()
+		}
 		return plan.NewShowCreateProcedure(
 			sql.UnresolvedDatabase(s.Table.Qualifier.String()),
 			s.Table.Name.String(),

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -510,7 +510,7 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 			return nil, sql.ErrNoDatabaseSelected.New()
 		}
 		return plan.NewShowCreateProcedure(
-			sql.UnresolvedDatabase(s.Table.Qualifier.String()),
+			sql.UnresolvedDatabase(dbName),
 			s.Table.Name.String(),
 		), nil
 	case "procedure status":


### PR DESCRIPTION
Initial attempt at fixing https://github.com/dolthub/dolt/issues/3832 by throwing a better-worded error if no database is selected.
