### PR TITLE
[no-release-notes] Removing unnecessary foreign key reference in test

### DIFF
--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -70,7 +70,7 @@ var OrderByGroupByScriptTests = []ScriptTest{
 			"INSERT INTO `users` (`id`,`username`) VALUES (1,'u2');",
 			"INSERT INTO `users` (`id`,`username`) VALUES (2,'u3');",
 			"INSERT INTO `users` (`id`,`username`) VALUES (3,'u4');",
-			"CREATE TABLE `tweet` (`id` int NOT NULL AUTO_INCREMENT,  `user_id` int NOT NULL,  `content` text NOT NULL,  `timestamp` bigint NOT NULL,  PRIMARY KEY (`id`),  KEY `tweet_user_id` (`user_id`),  CONSTRAINT `0qpfesgd` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`));",
+			"CREATE TABLE `tweet` (`id` int NOT NULL AUTO_INCREMENT,  `user_id` int NOT NULL,  `content` text NOT NULL,  `timestamp` bigint NOT NULL,  PRIMARY KEY (`id`),  KEY `tweet_user_id` (`user_id`));",
 			"INSERT INTO `tweet` (`id`,`user_id`,`content`,`timestamp`) VALUES (1,1,'meow',1647463727);",
 			"INSERT INTO `tweet` (`id`,`user_id`,`content`,`timestamp`) VALUES (2,1,'purr',1647463727);",
 			"INSERT INTO `tweet` (`id`,`user_id`,`content`,`timestamp`) VALUES (3,2,'hiss',1647463727);",


### PR DESCRIPTION
Dolt's test harness hit a problem with a foreign key constraint while trying to reset the db tables between test runs now that a new test was added in GMS's order by group by tests. The foreign key isn't actually needed for what the tests are testing, so removing it.  
https://github.com/dolthub/dolt/actions/runs/3430009076/jobs/5716406785