### PR TITLE
Insert dependency passthrough cols inbetween aggregation and projection

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1387,14 +1387,14 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query: "select f32/(lag(i) over (order by f64)) from floattable;",
+		Query: "select f64/f32, f32/(lag(i) over (order by f64)) from floattable;",
 		Expected: []sql.Row{
-			{nil},
-			{.6},
-			{-1.0},
-			{1.5},
-			{1.0},
-			{2.5 / float64(3)},
+			{1.0, nil},
+			{1.0, .5},
+			{1.0, -1.0},
+			{1.0, 1.5},
+			{1.0, 1.0},
+			{1.0, 2.5 / float64(3)},
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1379,6 +1379,25 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: "select i+0.0/(lag(i) over (order by s)) from mytable;",
+		Expected: []sql.Row{
+			{nil},
+			{2.0},
+			{3.0},
+		},
+	},
+	{
+		Query: "select f32/(lag(i) over (order by f64)) from floattable;",
+		Expected: []sql.Row{
+			{nil},
+			{.6},
+			{-1.0},
+			{1.5},
+			{1.0},
+			{2.5 / float64(3)},
+		},
+	},
+	{
 		Query: `WITH mt1 as (select i,s FROM mytable)
 			SELECT mtouter.i, (select s from mt1 where s = mtouter.s) FROM mt1 as mtouter where mtouter.i > 1 order by 1`,
 		Expected: []sql.Row{

--- a/sql/analyzer/aggregations.go
+++ b/sql/analyzer/aggregations.go
@@ -134,23 +134,6 @@ func replaceAggregatesWithGetFieldProjections(_ *sql.Context, projection []sql.E
 		}
 	}
 
-	// clean up projection dependency columns not synthesized by
-	// aggregation
-	//for _, e := range newProjection {
-	//	transform.InspectExpr(e, func(e sql.Expression) bool {
-	//		switch e := e.(type) {
-	//		case *expression.GetField:
-	//			if _, ok := aggPassthrough[e.Name()]; !ok {
-	//				// this is a column input to the projection that
-	//				// the aggregation parent has not passed-through.
-	//				newAggregates = append(newAggregates, e)
-	//			}
-	//		default:
-	//		}
-	//		return false
-	//	})
-	//}
-
 	return newProjection, newAggregates, transform.NewTree, nil
 }
 

--- a/sql/analyzer/aggregations.go
+++ b/sql/analyzer/aggregations.go
@@ -116,13 +116,10 @@ func replaceAggregatesWithGetFieldProjections(_ *sql.Context, projection []sql.E
 	// find subset of allGetFields not covered by newAggregates
 	newAggDeps := make(map[int]struct{}, 0)
 	for _, agg := range newAggregates {
-		_ = transform.InspectExpr(agg, func(e sql.Expression) bool {
-			switch e := e.(type) {
-			case *expression.GetField:
-				newAggDeps[e.Index()] = struct{}{}
-			}
-			return false
-		})
+		switch e := agg.(type) {
+		case *expression.GetField:
+			newAggDeps[e.Index()] = struct{}{}
+		}
 	}
 	for i, _ := range projDeps {
 		if _, ok := newAggDeps[i]; !ok {

--- a/sql/analyzer/aggregations.go
+++ b/sql/analyzer/aggregations.go
@@ -70,33 +70,37 @@ func flattenedGroupBy(ctx *sql.Context, projection, grouping []sql.Expression, c
 	), transform.NewTree, nil
 }
 
-// replaceAggregatesWithGetFieldProjections takes a slice of projection expressions and flattens out any aggregate
-// expressions within, wrapping all such flattened aggregations into a GetField projection. Returns two new slices: the
-// new set of project expressions, and the new set of aggregations. The former always matches the size of the projection
-// expressions passed in. The latter will have the size of the number of aggregate expressions contained in the input
-// slice.
+// replaceAggregatesWithGetFieldProjections inserts an indirection Projection
+// between an aggregation and its scope output, resulting in two buckets of
+// expressions:
+// 1) Parent projection expressions.
+// 2) Child aggregation expressions.
+//
+// A scope always returns a fixed number of columns, so the number of projection
+// inputs and outputs must match.
+//
+// The aggregation must provide input dependencies for parent projections.
+// Each parent expression can depend on zero or many aggregation expressions.
+// There are two basic kinds of aggregation expressions:
+// 1) Passthrough columns from scope input relation.
+// 2) Synthesized columns from in-scope aggregation relation.
 func replaceAggregatesWithGetFieldProjections(_ *sql.Context, projection []sql.Expression) (projections, aggregations []sql.Expression, identity transform.TreeIdentity, err error) {
 	var newProjection = make([]sql.Expression, len(projection))
 	var newAggregates []sql.Expression
-	allGetFields := make(map[int]sql.Expression)
-	projDeps := make(map[int]struct{})
+	aggPassthrough := make(map[string]struct{})
+	/* every aggregation creates one pass-through reference into parent */
 	for i, p := range projection {
 		e, same, err := transform.Expr(p, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			switch e := e.(type) {
 			case sql.Aggregation, sql.WindowAggregation:
-			// continue on
-			case *expression.GetField:
-				allGetFields[e.Index()] = e
-				projDeps[e.Index()] = struct{}{}
-				return e, transform.SameTree, nil
+				newAggregates = append(newAggregates, e)
+				aggPassthrough[e.String()] = struct{}{}
+				return expression.NewGetField(
+					len(newAggregates)-1, e.Type(), e.String(), e.IsNullable(),
+				), transform.NewTree, nil
 			default:
 				return e, transform.SameTree, nil
 			}
-
-			newAggregates = append(newAggregates, e)
-			return expression.NewGetField(
-				len(newAggregates)-1, e.Type(), e.String(), e.IsNullable(),
-			), transform.NewTree, nil
 		})
 		if err != nil {
 			return nil, nil, transform.SameTree, err
@@ -110,23 +114,42 @@ func replaceAggregatesWithGetFieldProjections(_ *sql.Context, projection []sql.E
 			)
 		} else {
 			newProjection[i] = e
+			transform.InspectExpr(e, func(e sql.Expression) bool {
+				// clean up projection dependency columns not synthesized by
+				// aggregation.
+				switch e := e.(type) {
+				case *expression.GetField:
+					if _, ok := aggPassthrough[e.Name()]; !ok {
+						// this is a column input to the projection that
+						// the aggregation parent has not passed-through.
+						// TODO: for functions without aggregate dependency,
+						// we just execute the function in the aggregation.
+						// why don't we do that for both?
+						newAggregates = append(newAggregates, e)
+					}
+				default:
+				}
+				return false
+			})
 		}
 	}
 
-	// find subset of allGetFields not covered by newAggregates
-	newAggDeps := make(map[int]struct{}, 0)
-	for _, agg := range newAggregates {
-		switch e := agg.(type) {
-		case *expression.GetField:
-			newAggDeps[e.Index()] = struct{}{}
-		}
-	}
-	for i, _ := range projDeps {
-		if _, ok := newAggDeps[i]; !ok {
-			// add pass-through dependency
-			newAggregates = append(newAggregates, allGetFields[i])
-		}
-	}
+	// clean up projection dependency columns not synthesized by
+	// aggregation
+	//for _, e := range newProjection {
+	//	transform.InspectExpr(e, func(e sql.Expression) bool {
+	//		switch e := e.(type) {
+	//		case *expression.GetField:
+	//			if _, ok := aggPassthrough[e.Name()]; !ok {
+	//				// this is a column input to the projection that
+	//				// the aggregation parent has not passed-through.
+	//				newAggregates = append(newAggregates, e)
+	//			}
+	//		default:
+	//		}
+	//		return false
+	//	})
+	//}
 
 	return newProjection, newAggregates, transform.NewTree, nil
 }


### PR DESCRIPTION
Re: https://github.com/dolthub/dolt/issues/4735

Aggregation flattening dropped passthrough column dependencies, causing the parent Projection to throw GetField resolve errors.

From the new docstring:
```
// The aggregation node must provide input dependencies for parent projections.
// Each parent expression can depend on zero or many aggregation expressions.
// There are two basic kinds of aggregation expressions:
// 1) Passthrough columns from scope input relation.
// 2) Synthesized columns from in-scope aggregation relation.
```

This is only relevant for expression that reference aggregations, which is somewhat curious. So for example, in `select x/y, x/count(y) from x`, the `x/y` expression is executed entirely in the child aggregation node. `x/count(y)` is separated into two steps, 1) evaluate `count(y)` and passthrough `x`, and then evaluate arithmetic `x/count(y)` in the parent projection. The error here is we were failing to expose the `x` passthrough to the parent operator that evaluated the division.
