### PR TITLE
fix intDiv `div` operation and more edge cases with precision for all arithmetic operations

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1382,8 +1382,8 @@ var QueryTests = []QueryTest{
 		Query: "select i+0.0/(lag(i) over (order by s)) from mytable order by 1;",
 		Expected: []sql.Row{
 			{nil},
-			{2.0},
-			{3.0},
+			{"2.00000"},
+			{"3.00000"},
 		},
 	},
 	{
@@ -2718,9 +2718,9 @@ var QueryTests = []QueryTest{
 	{
 		Query: "SELECT unix_timestamp(timestamp_col) div 60 * 60 as timestamp_col, avg(i) from datetime_table group by 1 order by unix_timestamp(timestamp_col) div 60 * 60",
 		Expected: []sql.Row{
-			{float64(1577966400), 1.0},
-			{float64(1578225600), 2.0},
-			{float64(1578398400), 3.0}},
+			{"1577966400", 1.0},
+			{"1578225600", 2.0},
+			{"1578398400", 3.0}},
 		SkipPrepared: true,
 	},
 	{
@@ -5307,15 +5307,15 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query:    "select ceil(i + 0.5) from mytable order by 1",
-		Expected: []sql.Row{{2.0}, {3.0}, {4.0}},
+		Expected: []sql.Row{{"2"}, {"3"}, {"4"}},
 	},
 	{
 		Query:    "select floor(i + 0.5) from mytable order by 1",
-		Expected: []sql.Row{{1.0}, {2.0}, {3.0}},
+		Expected: []sql.Row{{"1"}, {"2"}, {"3"}},
 	},
 	{
 		Query:    "select round(i + 0.55, 1) from mytable order by 1",
-		Expected: []sql.Row{{1.6}, {2.6}, {3.6}},
+		Expected: []sql.Row{{"1.6"}, {"2.6"}, {"3.6"}},
 	},
 	{
 		Query:    "select date_format(da, '%s') from typestable order by 1",
@@ -6960,9 +6960,9 @@ var QueryTests = []QueryTest{
 			row_number() over (order by length(s),i) + 0.0 / row_number() over (order by length(s) desc,i desc) + 0.0
 			from mytable order by 1;`,
 		Expected: []sql.Row{
-			{1, 6, 1.0},
-			{2, 5, 3.0},
-			{3, 4, 2.0},
+			{1, 6, "1.00000"},
+			{2, 5, "3.00000"},
+			{3, 4, "2.00000"},
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3056,19 +3056,27 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query:    `select 'a'+4;`,
-		Expected: []sql.Row{{float64(4)}},
+		Expected: []sql.Row{{4.0}},
 	},
 	{
 		Query:    `select '20a'+4;`,
-		Expected: []sql.Row{{float64(24)}},
+		Expected: []sql.Row{{24.0}},
+	},
+	{
+		Query:    `select '10.a'+4;`,
+		Expected: []sql.Row{{14.0}},
+	},
+	{
+		Query:    `select '.20a'+4;`,
+		Expected: []sql.Row{{4.2}},
 	},
 	{
 		Query:    `select 4+'a';`,
-		Expected: []sql.Row{{float64(4)}},
+		Expected: []sql.Row{{4.0}},
 	},
 	{
 		Query:    `select 'a'+'a';`,
-		Expected: []sql.Row{{float64(0)}},
+		Expected: []sql.Row{{0.0}},
 	},
 	{
 		Query:    "SELECT STR_TO_DATE('01,5,2013 09:30:17','%d,%m,%Y %h:%i:%s') + STR_TO_DATE('01,5,2013 09:30:17','%d,%m,%Y %h:%i:%s');",
@@ -3076,43 +3084,43 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query:    `select 'a'-4;`,
-		Expected: []sql.Row{{float64(-4)}},
+		Expected: []sql.Row{{-4.0}},
 	},
 	{
 		Query:    `select 4-'a';`,
-		Expected: []sql.Row{{float64(4)}},
+		Expected: []sql.Row{{4.0}},
 	},
 	{
 		Query:    `select 4-'2a';`,
-		Expected: []sql.Row{{float64(2)}},
+		Expected: []sql.Row{{2.0}},
 	},
 	{
 		Query:    `select 'a'-'a';`,
-		Expected: []sql.Row{{float64(0)}},
+		Expected: []sql.Row{{0.0}},
 	},
 	{
 		Query:    `select 'a'*4;`,
-		Expected: []sql.Row{{float64(0)}},
+		Expected: []sql.Row{{0.0}},
 	},
 	{
 		Query:    `select 4*'a';`,
-		Expected: []sql.Row{{float64(0)}},
+		Expected: []sql.Row{{0.0}},
 	},
 	{
 		Query:    `select 'a'*'a';`,
-		Expected: []sql.Row{{float64(0)}},
+		Expected: []sql.Row{{0.0}},
 	},
 	{
 		Query:    "select 1 * '2.50a';",
-		Expected: []sql.Row{{float64(2.5)}},
+		Expected: []sql.Row{{2.5}},
 	},
 	{
 		Query:    "select 1 * '2.a50a';",
-		Expected: []sql.Row{{float64(2)}},
+		Expected: []sql.Row{{2.0}},
 	},
 	{
 		Query:    `select 'a'/4;`,
-		Expected: []sql.Row{{float64(0)}},
+		Expected: []sql.Row{{0.0}},
 	},
 	{
 		Query:    `select 4/'a';`,
@@ -3124,11 +3132,11 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query:    "select 1 / '2.50a';",
-		Expected: []sql.Row{{float64(0.4)}},
+		Expected: []sql.Row{{0.4}},
 	},
 	{
 		Query:    "select 1 / '2.a50a';",
-		Expected: []sql.Row{{float64(0.5)}},
+		Expected: []sql.Row{{0.5}},
 	},
 	{
 		Query:    `select STR_TO_DATE('01,5,2013 09:30:17','%d,%m,%Y %h:%i:%s') / 1;`,

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1466,10 +1466,10 @@ var ScriptTests = []ScriptTest{
 				GROUP BY 1
 				ORDER BY UNIX_TIMESTAMP(time) DIV 60 * 60`,
 				Expected: []sql.Row{
-					{1625133600, 4.0},
-					{1625220000, 3.0},
-					{1625306400, 2.0},
-					{1625392800, 1.0},
+					{float64(1625133600), 4.0},
+					{float64(1625220000), 3.0},
+					{float64(1625306400), 2.0},
+					{float64(1625392800), 1.0},
 				},
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1459,17 +1459,13 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: `SELECT
-				UNIX_TIMESTAMP(time) DIV 60 * 60 AS "time",
-				avg(value) AS "value"
-				FROM test
-				GROUP BY 1
-				ORDER BY UNIX_TIMESTAMP(time) DIV 60 * 60`,
+				Query: `SELECT UNIX_TIMESTAMP(time) DIV 60 * 60 AS "time", avg(value) AS "value"
+				FROM test GROUP BY 1 ORDER BY UNIX_TIMESTAMP(time) DIV 60 * 60`,
 				Expected: []sql.Row{
-					{float64(1625133600), 4.0},
-					{float64(1625220000), 3.0},
-					{float64(1625306400), 2.0},
-					{float64(1625392800), 1.0},
+					{"1625133600", 4.0},
+					{"1625220000", 3.0},
+					{"1625306400", 2.0},
+					{"1625392800", 1.0},
 				},
 			},
 		},

--- a/sql/expression/arithmetic_test.go
+++ b/sql/expression/arithmetic_test.go
@@ -167,38 +167,6 @@ func TestMult(t *testing.T) {
 	require.Equal("100", r.StringFixed(r.Exponent()*-1))
 }
 
-func TestIntDiv(t *testing.T) {
-	var testCases = []struct {
-		name        string
-		left, right int64
-		expected    int64
-		null        bool
-	}{
-		{"1 div 1", 1, 1, 1, false},
-		{"8 div 3", 8, 3, 2, false},
-		{"1 div 3", 1, 3, 0, false},
-		{"0 div -1024", 0, -1024, 0, false},
-		{"1 div 0", 1, 0, 0, true},
-		{"0 div 0", 1, 0, 0, true},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-			result, err := NewIntDiv(
-				NewLiteral(tt.left, sql.Int64),
-				NewLiteral(tt.right, sql.Int64),
-			).Eval(sql.NewEmptyContext(), sql.NewRow())
-			require.NoError(err)
-			if tt.null {
-				assert.Equal(t, nil, result)
-			} else {
-				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
 func TestMod(t *testing.T) {
 	var testCases = []struct {
 		name        string

--- a/sql/expression/arithmetic_test.go
+++ b/sql/expression/arithmetic_test.go
@@ -55,9 +55,7 @@ func TestPlus(t *testing.T) {
 	result, err := NewPlus(NewLiteral("2", sql.LongText), NewLiteral(3, sql.Float64)).
 		Eval(sql.NewEmptyContext(), sql.NewRow())
 	require.NoError(err)
-	r, ok := result.(decimal.Decimal)
-	require.True(ok)
-	require.Equal("5", r.StringFixed(r.Exponent()*-1))
+	require.Equal(5.0, result)
 }
 
 func TestPlusInterval(t *testing.T) {
@@ -113,9 +111,7 @@ func TestMinus(t *testing.T) {
 	result, err := NewMinus(NewLiteral("10", sql.LongText), NewLiteral(10, sql.Int64)).
 		Eval(sql.NewEmptyContext(), sql.NewRow())
 	require.NoError(err)
-	r, ok := result.(decimal.Decimal)
-	require.True(ok)
-	require.Equal("0", r.StringFixed(r.Exponent()*-1))
+	require.Equal(0.0, result)
 }
 
 func TestMinusInterval(t *testing.T) {
@@ -162,9 +158,7 @@ func TestMult(t *testing.T) {
 	result, err := NewMult(NewLiteral("10", sql.LongText), NewLiteral("10", sql.LongText)).
 		Eval(sql.NewEmptyContext(), sql.NewRow())
 	require.NoError(err)
-	r, ok := result.(decimal.Decimal)
-	require.True(ok)
-	require.Equal("100", r.StringFixed(r.Exponent()*-1))
+	require.Equal(100.0, result)
 }
 
 func TestMod(t *testing.T) {

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -16,12 +16,13 @@ package expression
 
 import (
 	"fmt"
-	"github.com/dolthub/vitess/go/vt/sqlparser"
-	"github.com/shopspring/decimal"
-	"gopkg.in/src-d/go-errors.v1"
 	"math"
 	"strings"
 	"time"
+
+	"github.com/dolthub/vitess/go/vt/sqlparser"
+	"github.com/shopspring/decimal"
+	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -16,14 +16,17 @@ package expression
 
 import (
 	"fmt"
-	"math"
-	"strings"
-
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/shopspring/decimal"
+	"gopkg.in/src-d/go-errors.v1"
+	"math"
+	"strings"
+	"time"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )
+
+var ErrIntDivDataOutOfRange = errors.NewKind("BIGINT value is out of range (%s DIV %s)")
 
 // '4 scales' are added to scale of the number on the left side of division operator at every division operation.
 // The default value is 4, and it can be set using sysvar https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_div_precision_increment
@@ -77,10 +80,6 @@ func (d *Div) DebugString() string {
 
 // IsNullable implements the sql.Expression interface.
 func (d *Div) IsNullable() bool {
-	if d.Type() == sql.Timestamp || d.Type() == sql.Datetime {
-		return true
-	}
-
 	return d.BinaryExpression.IsNullable()
 }
 
@@ -96,12 +95,8 @@ func (d *Div) Type() sql.Type {
 		return lTyp
 	}
 
-	if isInterval(d.Left) || isInterval(d.Right) {
-		return sql.Datetime
-	}
-
-	if sql.IsTime(lTyp) && sql.IsTime(rTyp) {
-		return sql.Int64
+	if sql.IsText(lTyp) || sql.IsText(rTyp) {
+		return sql.Float64
 	}
 
 	// for division operation, it's either float or decimal.Decimal type
@@ -162,28 +157,15 @@ func (d *Div) evalLeftRight(ctx *sql.Context, row sql.Row) (interface{}, interfa
 	var lval, rval interface{}
 	var err error
 
-	if i, ok := d.Left.(*Interval); ok {
-		lval, err = i.EvalDelta(ctx, row)
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		lval, err = d.Left.Eval(ctx, row)
-		if err != nil {
-			return nil, nil, err
-		}
+	// division used with Interval error is caught at parsing the query
+	lval, err = d.Left.Eval(ctx, row)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	if i, ok := d.Right.(*Interval); ok {
-		rval, err = i.EvalDelta(ctx, row)
-		if err != nil {
-			return nil, nil, err
-		}
-	} else {
-		rval, err = d.Right.Eval(ctx, row)
-		if err != nil {
-			return nil, nil, err
-		}
+	rval, err = d.Right.Eval(ctx, row)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	return lval, rval, nil
@@ -197,31 +179,25 @@ func (d *Div) evalLeftRight(ctx *sql.Context, row sql.Row) (interface{}, interfa
 // should be preserved.
 func (d *Div) convertLeftRight(ctx *sql.Context, left interface{}, right interface{}) (interface{}, interface{}) {
 	typ := d.Type()
+	lIsTimeType := sql.IsTime(d.Left.Type())
+	rIsTimeType := sql.IsTime(d.Right.Type())
 
-	if i, ok := left.(*TimeDelta); ok {
-		left = i
+	if sql.IsFloat(typ) {
+		left = convertValueToType(ctx, typ, left, lIsTimeType)
 	} else {
-		left = floatOrDecimalValue(ctx, typ, left)
+		left = convertToDecimalValue(left, lIsTimeType)
 	}
 
-	if i, ok := right.(*TimeDelta); ok {
-		right = i
+	if sql.IsFloat(typ) {
+		right = convertValueToType(ctx, typ, right, rIsTimeType)
 	} else {
-		right = floatOrDecimalValue(ctx, typ, right)
+		right = convertToDecimalValue(right, rIsTimeType)
 	}
 
 	return left, right
 }
 
 func (d *Div) div(ctx *sql.Context, lval, rval interface{}) (interface{}, error) {
-	if rval == nil {
-		arithmeticWarning(ctx, ERDivisionByZero, fmt.Sprintf("Division by 0"))
-		return nil, nil
-	}
-	if lval == nil {
-		return 0, nil
-	}
-
 	switch l := lval.(type) {
 	case float32:
 		switch r := rval.(type) {
@@ -315,28 +291,27 @@ func floatOrDecimalType(e sql.Expression) sql.Type {
 	return defType
 }
 
-// floatOrDecimalValue returns value converted to either float or decimaltype.
-// If typ is defined as float64, the value is converted to float. For all
-// other types, the value is converted to decimaltype value. If the value
-// is invalid, it returns nil with warning, and it is interpreted as 0.
-// This function is used for 'div' or 'mod' arithmetic operation, which requires
+// convertToDecimalValue returns value converted to decimaltype.
+// If the value is invalid, it returns decimal 0. This function
+// is used for 'div' or 'mod' arithmetic operation, which requires
 // the result value to have precise precision and scale.
-func floatOrDecimalValue(ctx *sql.Context, typ sql.Type, val interface{}) interface{} {
-	if sql.IsFloat(typ) {
-		val = convertValueToType(ctx, typ, val)
-	} else {
-		if _, ok := val.(decimal.Decimal); !ok {
-			p, s := getPrecisionAndScale(val)
-			ltyp, err := sql.CreateDecimalType(p, s)
-			if err != nil {
-				val = nil
-			}
-			val, err = ltyp.Convert(val)
-			if err != nil {
-				val = nil
-			}
+func convertToDecimalValue(val interface{}, isTimeType bool) interface{} {
+	if isTimeType {
+		val = convertTimeTypeToString(val)
+	}
+
+	if _, ok := val.(decimal.Decimal); !ok {
+		p, s := getPrecisionAndScale(val)
+		dtyp, err := sql.CreateDecimalType(p, s)
+		if err != nil {
+			val = decimal.Zero
+		}
+		val, err = dtyp.Convert(val)
+		if err != nil {
+			val = decimal.Zero
 		}
 	}
+
 	return val
 }
 
@@ -457,6 +432,8 @@ func GetDecimalPrecisionAndScale(val string) (uint8, uint8) {
 func getPrecisionAndScale(val interface{}) (uint8, uint8) {
 	var str string
 	switch v := val.(type) {
+	case time.Time:
+		str = fmt.Sprintf("%v", v.In(time.UTC).Format("2006-01-02 15:04:05"))
 	case decimal.Decimal:
 		str = v.StringFixed(v.Exponent() * -1)
 	case float32:
@@ -466,7 +443,7 @@ func getPrecisionAndScale(val interface{}) (uint8, uint8) {
 		d := decimal.NewFromFloat(v)
 		str = d.StringFixed(d.Exponent() * -1)
 	default:
-		str = fmt.Sprintf("%v", val)
+		str = fmt.Sprintf("%v", v)
 	}
 	return GetDecimalPrecisionAndScale(str)
 }
@@ -522,4 +499,194 @@ func getPrecInc(e sql.Expression, cur int) int {
 	} else {
 		return cur
 	}
+}
+
+var _ ArithmeticOp = (*IntDiv)(nil)
+
+// IntDiv expression represents integer "div" arithmetic operation
+type IntDiv struct {
+	BinaryExpression
+}
+
+// NewIntDiv creates a new IntDiv 'div' sql.Expression.
+func NewIntDiv(left, right sql.Expression) *IntDiv {
+	a := &IntDiv{BinaryExpression{Left: left, Right: right}}
+	return a
+}
+
+func (i *IntDiv) LeftChild() sql.Expression {
+	return i.Left
+}
+
+func (i *IntDiv) RightChild() sql.Expression {
+	return i.Right
+}
+
+func (i *IntDiv) Operator() string {
+	return sqlparser.IntDivStr
+}
+
+func (i *IntDiv) String() string {
+	return fmt.Sprintf("(%s div %s)", i.Left, i.Right)
+}
+
+func (i *IntDiv) DebugString() string {
+	return fmt.Sprintf("(%s div %s)", sql.DebugString(i.Left), sql.DebugString(i.Right))
+}
+
+// IsNullable implements the sql.Expression interface.
+func (i *IntDiv) IsNullable() bool {
+	return i.BinaryExpression.IsNullable()
+}
+
+// Type returns the greatest type for given operation.
+func (i *IntDiv) Type() sql.Type {
+	//TODO: what if both BindVars? should be constant folded
+	rTyp := i.Right.Type()
+	if sql.IsDeferredType(rTyp) {
+		return rTyp
+	}
+	lTyp := i.Left.Type()
+	if sql.IsDeferredType(lTyp) {
+		return lTyp
+	}
+
+	if sql.IsTime(lTyp) && sql.IsTime(rTyp) {
+		return sql.Int64
+	}
+
+	if sql.IsText(lTyp) || sql.IsText(rTyp) {
+		return sql.Float64
+	}
+
+	if sql.IsUnsigned(lTyp) && sql.IsUnsigned(rTyp) {
+		return sql.Uint64
+	} else if sql.IsSigned(lTyp) && sql.IsSigned(rTyp) {
+		return sql.Int64
+	}
+
+	// using max precision which is 65.
+	defType := sql.MustCreateDecimalType(65, 0)
+	return defType
+}
+
+// WithChildren implements the Expression interface.
+func (i *IntDiv) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(i, len(children), 2)
+	}
+	return NewIntDiv(children[0], children[1]), nil
+}
+
+// Eval implements the Expression interface.
+func (i *IntDiv) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	lval, rval, err := i.evalLeftRight(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if lval == nil || rval == nil {
+		return nil, nil
+	}
+
+	lval, rval = i.convertLeftRight(ctx, lval, rval)
+
+	return intDiv(ctx, lval, rval)
+}
+
+func (i *IntDiv) evalLeftRight(ctx *sql.Context, row sql.Row) (interface{}, interface{}, error) {
+	var lval, rval interface{}
+	var err error
+
+	// int division used with Interval error is caught at parsing the query
+	lval, err = i.Left.Eval(ctx, row)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rval, err = i.Right.Eval(ctx, row)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return lval, rval, nil
+}
+
+// convertLeftRight return most appropriate value for left and right from evaluated value,
+// which can might or might not be converted from its original value.
+// It checks for float type column reference, then the both values converted to the same float types.
+// If there is no float type column reference, both values should be handled as decimal type
+// The decimal types of left and right value does NOT need to be the same. Both the types
+// should be preserved.
+func (i *IntDiv) convertLeftRight(ctx *sql.Context, left interface{}, right interface{}) (interface{}, interface{}) {
+	typ := i.Type()
+	lIsTimeType := sql.IsTime(i.Left.Type())
+	rIsTimeType := sql.IsTime(i.Right.Type())
+
+	if sql.IsInteger(typ) || sql.IsFloat(typ) {
+		left = convertValueToType(ctx, typ, left, lIsTimeType)
+	} else {
+		left = convertToDecimalValue(left, lIsTimeType)
+	}
+
+	if sql.IsInteger(typ) || sql.IsFloat(typ) {
+		right = convertValueToType(ctx, typ, right, rIsTimeType)
+	} else {
+		right = convertToDecimalValue(right, rIsTimeType)
+	}
+
+	return left, right
+}
+
+func intDiv(ctx *sql.Context, lval, rval interface{}) (interface{}, error) {
+	switch l := lval.(type) {
+	case uint64:
+		switch r := rval.(type) {
+		case uint64:
+			if r == 0 {
+				arithmeticWarning(ctx, ERDivisionByZero, fmt.Sprintf("Division by 0"))
+				return nil, nil
+			}
+			return l / r, nil
+		}
+	case int64:
+		switch r := rval.(type) {
+		case int64:
+			if r == 0 {
+				arithmeticWarning(ctx, ERDivisionByZero, fmt.Sprintf("Division by 0"))
+				return nil, nil
+			}
+			return l / r, nil
+		}
+	case float64:
+		switch r := rval.(type) {
+		case float64:
+			if r == 0 {
+				arithmeticWarning(ctx, ERDivisionByZero, fmt.Sprintf("Division by 0"))
+				return nil, nil
+			}
+			res := l / r
+			return int64(math.Floor(res)), nil
+		}
+	case decimal.Decimal:
+		switch r := rval.(type) {
+		case decimal.Decimal:
+			if r.Equal(decimal.NewFromInt(0)) {
+				arithmeticWarning(ctx, ERDivisionByZero, fmt.Sprintf("Division by 0"))
+				return nil, nil
+			}
+
+			// intDiv operation gets the integer part of the divided value
+			divRes := l.DivRound(r, 2)
+			intPart := divRes.IntPart()
+
+			if (divRes.IsNegative() && intPart >= 0) || (divRes.IsPositive() && intPart < 0) {
+				return nil, ErrIntDivDataOutOfRange.New(l.StringFixed(l.Exponent()), r.StringFixed(r.Exponent()))
+			}
+
+			return intPart, nil
+		}
+	}
+
+	return nil, errUnableToCast.New(lval, rval)
 }

--- a/sql/expression/div_test.go
+++ b/sql/expression/div_test.go
@@ -116,3 +116,39 @@ func TestDiv(t *testing.T) {
 		})
 	}
 }
+
+func TestIntDiv(t *testing.T) {
+	var testCases = []struct {
+		name                string
+		left, right         interface{}
+		leftType, rightType sql.Type
+		expected            int64
+		null                bool
+	}{
+		{"1 div 1", 1, 1, sql.Int64, sql.Int64, 1, false},
+		{"8 div 3", 8, 3, sql.Int64, sql.Int64, 2, false},
+		{"1 div 3", 1, 3, sql.Int64, sql.Int64, 0, false},
+		{"0 div -1024", 0, -1024, sql.Int64, sql.Int64, 0, false},
+		{"1 div 0", 1, 0, sql.Int64, sql.Int64, 0, true},
+		{"0 div 0", 1, 0, sql.Int64, sql.Int64, 0, true},
+		{"10.24 div 0.6", 10.24, 0.6, sql.Float64, sql.Float64, 17, false},
+		{"-10.24 div 0.6", -10.24, 0.6, sql.Float64, sql.Float64, -17, false},
+		{"-10.24 div -0.6", -10.24, -0.6, sql.Float64, sql.Float64, 17, false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			result, err := NewIntDiv(
+				NewLiteral(tt.left, tt.leftType),
+				NewLiteral(tt.right, tt.rightType),
+			).Eval(sql.NewEmptyContext(), sql.NewRow())
+			require.NoError(err)
+			if tt.null {
+				assert.Equal(t, nil, result)
+			} else {
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/sql/expression/function/ceil_round_floor.go
+++ b/sql/expression/function/ceil_round_floor.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"reflect"
 	"strconv"
 
 	"github.com/shopspring/decimal"
@@ -82,6 +81,7 @@ func (c *Ceil) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
+	// non number type will be caught here
 	if !sql.IsNumber(c.Child.Type()) {
 		child, err = sql.Float64.Convert(child)
 		if err != nil {
@@ -91,17 +91,16 @@ func (c *Ceil) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return int32(math.Ceil(child.(float64))), nil
 	}
 
-	if !sql.IsFloat(c.Child.Type()) {
-		return child, err
-	}
-
+	// if it's number type and not float value, it does not need ceil-ing
 	switch num := child.(type) {
 	case float64:
 		return math.Ceil(num), nil
 	case float32:
 		return float32(math.Ceil(float64(num))), nil
+	case decimal.Decimal:
+		return num.Ceil(), nil
 	default:
-		return nil, sql.ErrInvalidType.New(reflect.TypeOf(num))
+		return child, nil
 	}
 }
 

--- a/sql/numbertype.go
+++ b/sql/numbertype.go
@@ -88,7 +88,7 @@ var (
 	numberFloat32ValueType = reflect.TypeOf(float32(0))
 	numberFloat64ValueType = reflect.TypeOf(float64(0))
 
-	numre = regexp.MustCompile("[0-9]")
+	numre = regexp.MustCompile(`^[ ]*[0-9]*\.?[0-9]+`)
 )
 
 // NumberType represents all integer and floating point types.
@@ -1013,7 +1013,7 @@ func convertToFloat64(t numberTypeImpl, v interface{}) (float64, error) {
 		i, err := strconv.ParseFloat(v, 64)
 		if err != nil {
 			// parse the first longest valid numbers
-			s := getFirstLongestNumberValue(v)
+			s := numre.FindString(v)
 			i, _ = strconv.ParseFloat(s, 64)
 			return i, ErrInvalidValue.New(v, t.String())
 		}
@@ -1028,23 +1028,6 @@ func convertToFloat64(t numberTypeImpl, v interface{}) (float64, error) {
 	default:
 		return 0, ErrInvalidValueType.New(v, t.String())
 	}
-}
-
-func getFirstLongestNumberValue(v string) string {
-	j := 0
-	gotPoint := false
-	for _, s := range []byte(v) {
-		if numre.Match([]byte{s}) {
-			j++
-		} else if !gotPoint && '.' == s {
-			gotPoint = true
-			j++
-		} else {
-			break
-		}
-	}
-	res := string([]byte(v)[:j])
-	return res
 }
 
 func convertValueToFloat64(t numberTypeImpl, v Value) (float64, error) {

--- a/sql/numbertype.go
+++ b/sql/numbertype.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -86,6 +87,8 @@ var (
 	numberUint64ValueType  = reflect.TypeOf(uint64(0))
 	numberFloat32ValueType = reflect.TypeOf(float32(0))
 	numberFloat64ValueType = reflect.TypeOf(float64(0))
+
+	numre = regexp.MustCompile("[0-9]")
 )
 
 // NumberType represents all integer and floating point types.
@@ -1009,7 +1012,10 @@ func convertToFloat64(t numberTypeImpl, v interface{}) (float64, error) {
 	case string:
 		i, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			return 0, ErrInvalidValue.New(v, t.String())
+			// parse the first longest valid numbers
+			s := getFirstLongestNumberValue(v)
+			i, _ = strconv.ParseFloat(s, 64)
+			return i, ErrInvalidValue.New(v, t.String())
 		}
 		return i, nil
 	case bool:
@@ -1022,6 +1028,23 @@ func convertToFloat64(t numberTypeImpl, v interface{}) (float64, error) {
 	default:
 		return 0, ErrInvalidValueType.New(v, t.String())
 	}
+}
+
+func getFirstLongestNumberValue(v string) string {
+	j := 0
+	gotPoint := false
+	for _, s := range []byte(v) {
+		if numre.Match([]byte{s}) {
+			j++
+		} else if !gotPoint && '.' == s {
+			gotPoint = true
+			j++
+		} else {
+			break
+		}
+	}
+	res := string([]byte(v)[:j])
+	return res
 }
 
 func convertValueToFloat64(t numberTypeImpl, v Value) (float64, error) {

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -3773,6 +3773,8 @@ func binaryExprToExpression(ctx *sql.Context, be *sqlparser.BinaryExpr) (sql.Exp
 			return expression.NewMod(l, r), nil
 		case sqlparser.BitAndStr, sqlparser.BitOrStr, sqlparser.BitXorStr, sqlparser.ShiftRightStr, sqlparser.ShiftLeftStr:
 			return expression.NewBitOp(l, r, be.Operator), nil
+		case sqlparser.IntDivStr:
+			return expression.NewIntDiv(l, r), nil
 		default:
 			return expression.NewArithmetic(l, r, be.Operator), nil
 		}

--- a/sql/type.go
+++ b/sql/type.go
@@ -617,7 +617,7 @@ func IsNull(ex Expression) bool {
 // IsNumber checks if t is a number type
 func IsNumber(t Type) bool {
 	switch t.(type) {
-	case numberTypeImpl, decimalType, bitType, yearType:
+	case numberTypeImpl, decimalType, bitType, yearType, systemBoolType:
 		return true
 	default:
 		return false

--- a/sql/type.go
+++ b/sql/type.go
@@ -626,6 +626,10 @@ func IsNumber(t Type) bool {
 
 // IsSigned checks if t is a signed type.
 func IsSigned(t Type) bool {
+	// systemBoolType is Int8
+	if _, ok := t.(systemBoolType); ok {
+		return true
+	}
 	return t == Int8 || t == Int16 || t == Int24 || t == Int32 || t == Int64
 }
 


### PR DESCRIPTION
IntDiv does operations in decimal type values and returns the int part of the decimal value result. If the value goes out of bound of int64, it errors. 

Fixed few more edge cases for all arithmetic operations including:
- any time type value gets parsed as int value with pattern of `YYYYMMDDHHMMSS` or `YYYYMMDD` depending on what's defined. This applies to all arithmetic operations. 
- invalid string tries to parse available numbers from the beginning of the string value and used in the arithmetic operation. `12.4ag3.2jgw499` is parsed as number `12.4`, and `a942.6ng488` is parsed as `0`. 