### PR TITLE
prevent foreign keys from referencing indexes with prefix lengths

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -61,6 +61,18 @@ var ForeignKeyTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "indexes with prefix lengths are ignored for foreign keys",
+		SetUpScript: []string{
+			"create table prefixParent(v varchar(100), index(v(1)))",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "create table prefixChild(v varchar(100), foreign key (v) references prefixParent(v))",
+				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
+			},
+		},
+	},
+	{
 		Name: "CREATE TABLE Name Collision",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/memory/table.go
+++ b/memory/table.go
@@ -1253,12 +1253,26 @@ func (t *Table) createIndex(name string, columns []sql.IndexColumn, constraint s
 
 	exprs := make([]sql.Expression, len(columns))
 	colNames := make([]string, len(columns))
-	prefixLengths := make([]uint16, len(columns))
 	for i, column := range columns {
 		idx, field := t.getField(column.Name)
 		exprs[i] = expression.NewGetFieldWithTable(idx, field.Type, t.name, field.Name, field.Nullable)
 		colNames[i] = column.Name
-		prefixLengths[i] = uint16(column.Length)
+	}
+
+	var hasNonZeroLengthColumn bool
+	for _, column := range columns {
+		if column.Length > 0 {
+			hasNonZeroLengthColumn = true
+			break
+		}
+	}
+	var prefixLengths []uint16
+	if hasNonZeroLengthColumn {
+		prefixLengths = make([]uint16, len(columns))
+		for i, column := range columns {
+			prefixLengths[i] = uint16(column.Length)
+		}
+
 	}
 
 	if constraint == sql.IndexConstraint_Unique {

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -537,6 +537,13 @@ func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexAddressableTable, prefix
 	if err != nil {
 		return nil, false, err
 	}
+	// ignore indexes with prefix lengths; they are unsupported in MySQL
+	// https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html#:~:text=Index%20prefixes%20on%20foreign%20key%20columns%20are%20not%20supported.
+	for _, idx := range indexes {
+		if len(idx.PrefixLengths()) > 0 {
+			ignoredIndexesMap[idx.ID()] = struct{}{}
+		}
+	}
 	tblName := strings.ToLower(tbl.Name())
 	exprCols := make([]string, len(prefixCols))
 	for i, prefixCol := range prefixCols {


### PR DESCRIPTION
MySQL does not support foreign keys that reference indexes with prefixes, but we could?
https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html#:~:text=Index%20prefixes%20on%20foreign%20key%20columns%20are%20not%20supported