### PR TITLE
Adding error code mapping and more tests for `ErrNonAggregatedColumnWithoutGroupBy`

### DIFF
--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -152,6 +152,21 @@ var OrderByGroupByScriptTests = []ScriptTest{
 				Query:       "select AVG(val), val from t;",
 				ExpectedErr: sql.ErrNonAggregatedColumnWithoutGroupBy,
 			},
+			{
+				// Test validation for a derived table opaque node
+				Query:       "select * from (SELECT AVG(val), LAST_VALUE(val) OVER w FROM t WINDOW w AS (ORDER BY num RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)) as dt;",
+				ExpectedErr: sql.ErrNonAggregatedColumnWithoutGroupBy,
+			},
+			{
+				// Test validation for a union opaque node
+				Query:       "select 1, 1 union SELECT AVG(val), LAST_VALUE(val) OVER w FROM t WINDOW w AS (ORDER BY num RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING);",
+				ExpectedErr: sql.ErrNonAggregatedColumnWithoutGroupBy,
+			},
+			{
+				// Test validation for a recursive CTE opaque node
+				Query:       "select * from (with recursive a as (select 1 as c1, 1 as c2 union SELECT AVG(t.val), LAST_VALUE(t.val) OVER w FROM t WINDOW w AS (ORDER BY num RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)) select * from a union select * from a limit 1) as dt;",
+				ExpectedErr: sql.ErrNonAggregatedColumnWithoutGroupBy,
+			},
 		},
 	},
 }

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -696,6 +696,8 @@ func CastSQLError(err error) *mysql.SQLError {
 		code = mysql.EROperandColumns
 	case ErrInsertIntoNonNullableProvidedNull.Is(err):
 		code = mysql.ERBadNullError
+	case ErrNonAggregatedColumnWithoutGroupBy.Is(err):
+		code = mysql.ERMixOfGroupFuncAndFields
 	case ErrPrimaryKeyViolation.Is(err):
 		code = mysql.ERDupEntry
 	case ErrUniqueKeyViolation.Is(err):


### PR DESCRIPTION
Adding a SQL error code mapping for `ErrNonAggregatedColumnWithoutGroupBy` and tests for validation with opaque nodes. 

From PR feedback in: https://github.com/dolthub/go-mysql-server/pull/1396