### PR TITLE
adding tests for unique indexes

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -6466,6 +6466,15 @@ func TestBlobs(t *testing.T, h Harness) {
 	}
 }
 
+func TestIndexes(t *testing.T, h Harness) {
+	e := mustNewEngine(t, h)
+	defer e.Close()
+
+	for _, tt := range queries.IndexQueries {
+		TestScript(t, h, tt)
+	}
+}
+
 func TestIndexPrefix(t *testing.T, h Harness) {
 	e := mustNewEngine(t, h)
 	defer e.Close()

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -757,6 +757,10 @@ func TestBlobs(t *testing.T) {
 	enginetest.TestBlobs(t, enginetest.NewDefaultMemoryHarness())
 }
 
+func TestIndexes(t *testing.T) {
+	enginetest.TestIndexes(t, enginetest.NewDefaultMemoryHarness())
+}
+
 func TestIndexPrefix(t *testing.T) {
 	enginetest.TestIndexPrefix(t, enginetest.NewDefaultMemoryHarness())
 }


### PR DESCRIPTION
verifies this was fixed: https://github.com/dolthub/go-mysql-server/issues/571

pulls a `duplicate key update` test from dolt