### PR TITLE
[no-release-notes] deleting plan test for hashlook up

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2691,20 +2691,6 @@ var ScriptTests = []ScriptTest{
 					{2},
 				},
 			},
-			{
-				Query: "explain select uv.u from uv join xy on binary xy.x = binary uv.u;",
-				Expected: []sql.Row{
-					{"Project"},
-					{" ├─ columns: [uv.u]"},
-					{" └─ HashJoin(BINARY(xy.x) = BINARY(uv.u))"},
-					{"     ├─ Table(uv)"},
-					{"     │   └─ columns: [u]"},
-					{"     └─ HashLookup(child: (BINARY(xy.x)), lookup: (BINARY(uv.u)))"},
-					{"         └─ CachedResults"},
-					{"             └─ Table(xy)"},
-					{"                 └─ columns: [x]"},
-				},
-			},
 		},
 	},
 }


### PR DESCRIPTION
There are `Exchange` nodes present when the plan is tested in dolt.