### PR TITLE
prevent modifying columns to blob/text without prefix length in index

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2354,12 +2354,12 @@ func TestModifyColumn(t *testing.T, harness Harness) {
 	db, err := e.Analyzer.Catalog.Database(NewContext(harness), "mydb")
 	require.NoError(t, err)
 
-	TestQueryWithContext(t, ctx, e, harness, "ALTER TABLE mytable MODIFY COLUMN i TEXT NOT NULL COMMENT 'modified'", []sql.Row{{sql.NewOkResult(0)}}, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, "ALTER TABLE mytable MODIFY COLUMN i bigint NOT NULL COMMENT 'modified'", []sql.Row{{sql.NewOkResult(0)}}, nil, nil)
 	tbl, ok, err := db.GetTableInsensitive(NewContext(harness), "mytable")
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, sql.Schema{
-		{Name: "i", Type: sql.Text, Source: "mytable", Comment: "modified", PrimaryKey: true},
+		{Name: "i", Type: sql.Int64, Source: "mytable", Comment: "modified", PrimaryKey: true},
 		{Name: "s", Type: sql.MustCreateStringWithDefaults(sqltypes.VarChar, 20), Source: "mytable", Comment: "column s"},
 	}, tbl.Schema())
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -178,27 +178,16 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
-
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "create table as select distinct",
+			Name: "DELETE ME",
 			SetUpScript: []string{
-				"CREATE TABLE t1 (a int, b varchar(10));",
-				"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
+				"create table t (i int primary key, v varchar(10), unique index(v))",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "create table t2 as select distinct b, a from t1;",
-					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
-				},
-				{
-					Query: "select * from t2 order by a;",
-					Expected: []sql.Row{
-						{"a", 1},
-						{"b", 2},
-						{"c", 3},
-					},
+					Query:       "alter table t modify column v blob",
+					ExpectedErr: sql.ErrInvalidBlobTextKey,
 				},
 			},
 		},
@@ -215,6 +204,43 @@ func TestSingleScript(t *testing.T) {
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
+	//t.Skip()
+	//
+	//var scripts = []queries.ScriptTest{
+	//	{
+	//		Name: "create table as select distinct",
+	//		SetUpScript: []string{
+	//			"CREATE TABLE t1 (a int, b varchar(10));",
+	//			"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
+	//		},
+	//		Assertions: []queries.ScriptTestAssertion{
+	//			{
+	//				Query:    "create table t2 as select distinct b, a from t1;",
+	//				Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
+	//			},
+	//			{
+	//				Query: "select * from t2 order by a;",
+	//				Expected: []sql.Row{
+	//					{"a", 1},
+	//					{"b", 2},
+	//					{"c", 3},
+	//				},
+	//			},
+	//		},
+	//	},
+	//}
+	//
+	//for _, test := range scripts {
+	//	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
+	//	engine, err := harness.NewEngine(t)
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//	engine.Analyzer.Debug = true
+	//	engine.Analyzer.Verbose = true
+	//
+	//	enginetest.TestScriptWithEngine(t, engine, harness, test)
+	//}
 }
 
 func TestUnbuildableIndex(t *testing.T) {

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -178,27 +178,14 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
-
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "create table as select distinct",
-			SetUpScript: []string{
-				"CREATE TABLE t1 (a int, b varchar(10));",
-				"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
-			},
+			Name:        "DELETE ME",
+			SetUpScript: []string{},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "create table t2 as select distinct b, a from t1;",
-					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
-				},
-				{
-					Query: "select * from t2 order by a;",
-					Expected: []sql.Row{
-						{"a", 1},
-						{"b", 2},
-						{"c", 3},
-					},
+					Query:       "create table t (i blob, index (i(3073)));",
+					ExpectedErr: sql.ErrKeyTooLong,
 				},
 			},
 		},
@@ -210,11 +197,46 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		engine.Analyzer.Debug = true
-		engine.Analyzer.Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
+	//t.Skip()
+	//
+	//var scripts = []queries.ScriptTest{
+	//	{
+	//		Name: "create table as select distinct",
+	//		SetUpScript: []string{
+	//			"CREATE TABLE t1 (a int, b varchar(10));",
+	//			"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
+	//		},
+	//		Assertions: []queries.ScriptTestAssertion{
+	//			{
+	//				Query:    "create table t2 as select distinct b, a from t1;",
+	//				Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
+	//			},
+	//			{
+	//				Query: "select * from t2 order by a;",
+	//				Expected: []sql.Row{
+	//					{"a", 1},
+	//					{"b", 2},
+	//					{"c", 3},
+	//				},
+	//			},
+	//		},
+	//	},
+	//}
+	//
+	//for _, test := range scripts {
+	//	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
+	//	engine, err := harness.NewEngine(t)
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//	engine.Analyzer.Debug = true
+	//	engine.Analyzer.Verbose = true
+	//
+	//	enginetest.TestScriptWithEngine(t, engine, harness, test)
+	//}
 }
 
 func TestUnbuildableIndex(t *testing.T) {

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -178,16 +178,27 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
+	t.Skip()
+
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "DELETE ME",
+			Name: "create table as select distinct",
 			SetUpScript: []string{
-				"create table t (i int primary key, v varchar(10), unique index(v))",
+				"CREATE TABLE t1 (a int, b varchar(10));",
+				"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:       "alter table t modify column v blob",
-					ExpectedErr: sql.ErrInvalidBlobTextKey,
+					Query:    "create table t2 as select distinct b, a from t1;",
+					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
+				},
+				{
+					Query: "select * from t2 order by a;",
+					Expected: []sql.Row{
+						{"a", 1},
+						{"b", 2},
+						{"c", 3},
+					},
 				},
 			},
 		},
@@ -204,43 +215,6 @@ func TestSingleScript(t *testing.T) {
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
-	//t.Skip()
-	//
-	//var scripts = []queries.ScriptTest{
-	//	{
-	//		Name: "create table as select distinct",
-	//		SetUpScript: []string{
-	//			"CREATE TABLE t1 (a int, b varchar(10));",
-	//			"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
-	//		},
-	//		Assertions: []queries.ScriptTestAssertion{
-	//			{
-	//				Query:    "create table t2 as select distinct b, a from t1;",
-	//				Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
-	//			},
-	//			{
-	//				Query: "select * from t2 order by a;",
-	//				Expected: []sql.Row{
-	//					{"a", 1},
-	//					{"b", 2},
-	//					{"c", 3},
-	//				},
-	//			},
-	//		},
-	//	},
-	//}
-	//
-	//for _, test := range scripts {
-	//	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
-	//	engine, err := harness.NewEngine(t)
-	//	if err != nil {
-	//		panic(err)
-	//	}
-	//	engine.Analyzer.Debug = true
-	//	engine.Analyzer.Verbose = true
-	//
-	//	enginetest.TestScriptWithEngine(t, engine, harness, test)
-	//}
 }
 
 func TestUnbuildableIndex(t *testing.T) {

--- a/enginetest/queries/blob_queries.go
+++ b/enginetest/queries/blob_queries.go
@@ -100,16 +100,6 @@ var BlobWriteQueries = []WriteQueryTest{
 		},
 	},
 	{
-		WriteQuery:          "alter table mytable modify s blob",
-		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
-		SelectQuery:         "select * from blobt",
-		ExpectedSelect: []sql.Row{
-			{1, []byte("first row")},
-			{2, []byte("second row")},
-			{3, []byte("third row")},
-		},
-	},
-	{
 		WriteQuery:          "alter table blobt rename column b to v, add v1 int",
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
 		SelectQuery:         "select * from blobt",
@@ -151,16 +141,6 @@ var BlobWriteQueries = []WriteQueryTest{
 		},
 	},
 	{
-		WriteQuery:          "alter table mytable modify s text",
-		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
-		SelectQuery:         "select * from textt",
-		ExpectedSelect: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
 		WriteQuery:          "alter table textt rename column t to v, add v1 int",
 		ExpectedWriteResult: []sql.Row{{sql.NewOkResult(0)}},
 		SelectQuery:         "select * from textt",
@@ -183,6 +163,14 @@ var BlobWriteQueries = []WriteQueryTest{
 }
 
 var BlobErrors = []QueryErrorTest{
+	{
+		Query:       "alter table mytable modify s blob",
+		ExpectedErr: sql.ErrInvalidBlobTextKey,
+	},
+	{
+		Query:       "alter table mytable modify s text",
+		ExpectedErr: sql.ErrInvalidBlobTextKey,
+	},
 	{
 		Query:       "alter table blobt add index bidx (b)",
 		ExpectedErr: sql.ErrInvalidBlobTextKey,

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -11331,4 +11331,42 @@ var IndexPrefixQueries = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name:        "test prefix limits",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create table varchar_limit(c varchar(10000), index (c(768)))",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
+			},
+			{
+				Query:    "create table text_limit(c text, index (c(768)))",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
+			},
+			{
+				Query:    "create table varbinary_limit(c varbinary(10000), index (c(3072)))",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
+			},
+			{
+				Query:    "create table blob_limit(c blob, index (c(3072)))",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
+			},
+			{
+				Query:       "create table bad(c varchar(10000), index (c(769)))",
+				ExpectedErr: sql.ErrKeyTooLong,
+			},
+			{
+				Query:       "create table bad(c text, index (c(769)))",
+				ExpectedErr: sql.ErrKeyTooLong,
+			},
+			{
+				Query:       "create table bad(c varbinary(10000), index (c(3073)))",
+				ExpectedErr: sql.ErrKeyTooLong,
+			},
+			{
+				Query:       "create table bad(c blob, index (c(3073)))",
+				ExpectedErr: sql.ErrKeyTooLong,
+			},
+		},
+	},
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -11006,7 +11006,7 @@ var IndexPrefixQueries = []ScriptTest{
 			},
 		},
 	},
-	// TODO (james): not sure if collations work for in-memory tables; this test is in dolt_queries.go
+	// TODO (james): collations do not work for in-memory tables; this test is in dolt_queries.go
 	{
 		Name: "inline secondary indexes with collation",
 		SetUpScript: []string{
@@ -11194,7 +11194,6 @@ var IndexPrefixQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "explain select * from t where v1 = 'a'",
 				Expected: []sql.Row{
 					{"Filter(t.v1 = 'a')"},
@@ -11211,7 +11210,6 @@ var IndexPrefixQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "explain select * from t where v1 = 'abc'",
 				Expected: []sql.Row{
 					{"Filter(t.v1 = 'abc')"},
@@ -11226,7 +11224,6 @@ var IndexPrefixQueries = []ScriptTest{
 				Expected: []sql.Row{},
 			},
 			{
-				Skip:  true,
 				Query: "explain select * from t where v1 = 'abcd'",
 				Expected: []sql.Row{
 					{"Filter(t.v1 = 'abcd')"},
@@ -11244,7 +11241,6 @@ var IndexPrefixQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "explain select * from t where v1 > 'a' and v1 < 'abcde'",
 				Expected: []sql.Row{
 					{"Filter((t.v1 > 'a') AND (t.v1 < 'abcde'))"},
@@ -11262,7 +11258,6 @@ var IndexPrefixQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "explain select * from t where v1 > 'a' and v2 < 'abcde'",
 				Expected: []sql.Row{
 					{"Filter((t.v1 > 'a') AND (t.v2 < 'abcde'))"},
@@ -11279,7 +11274,6 @@ var IndexPrefixQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "explain update t set v1 = concat(v1, 'z') where v1 >= 'a'",
 				Expected: []sql.Row{
 					{"Update"},
@@ -11306,7 +11300,6 @@ var IndexPrefixQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "explain delete from t where v1 >= 'a'",
 				Expected: []sql.Row{
 					{"Delete"},

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -297,6 +297,9 @@ func validateModifyColumn(ctx *sql.Context, initialSch sql.Schema, schema sql.Sc
 				if len(prefixLengths) == 0 || prefixLengths[i] == 0 {
 					return nil, sql.ErrInvalidBlobTextKey.New(col.Name)
 				}
+				if sql.IsTextOnly(newCol.Type) && prefixLengths[i]*4 > MaxBytePrefix {
+					return nil, sql.ErrKeyTooLong.New()
+				}
 			}
 		}
 	}

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -406,9 +406,9 @@ func validatePrefixLength(schCol *sql.Column, idxCol sql.IndexColumn) error {
 		return sql.ErrInvalidIndexPrefix.New(schCol.Name)
 	}
 
-	// Get prefix key length in bytes, so times 4 for text
+	// Get prefix key length in bytes, so times 4 for varchar, text, and varchar
 	prefixByteLength := idxCol.Length
-	if sql.IsText(schCol.Type) {
+	if sql.IsTextOnly(schCol.Type) {
 		prefixByteLength = 4 * idxCol.Length
 	}
 

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -414,7 +414,7 @@ func validatePrefixLength(schCol *sql.Column, idxCol sql.IndexColumn) error {
 
 	// Prefix length is longer than max
 	if prefixByteLength > MaxBytePrefix {
-		return sql.ErrKeyTooLong.New(schCol.Name)
+		return sql.ErrKeyTooLong.New()
 	}
 
 	// The specified prefix length is longer than the column


### PR DESCRIPTION
There's an edge case in where there's an index defined over a column without a prefix length, and if you modify that colunm to a text/blob it should throw an error. Additionally, it should preserve prefix lengths when it's still a string type. If the new type is too short, the prefix length should be dropped.