### PR TITLE
limit arithmetic literals are all ints but different types

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5859,6 +5859,10 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query:    `SELECT sum(i) as isum, s FROM mytable GROUP BY i ORDER BY isum ASC LIMIT 0, 200`,
+		Expected: []sql.Row{{1.0, "first row"}, {2.0, "second row"}, {3.0, "third row"}},
+	},
+	{
 		Query:    `SELECT (SELECT i FROM mytable ORDER BY i ASC LIMIT 1) AS x`,
 		Expected: []sql.Row{{int64(1)}},
 	},

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -151,6 +151,11 @@ func (a *Arithmetic) Type() sql.Type {
 		return sql.Int64
 	}
 
+	// if one is uint and the other is int of any size, then use int64
+	if sql.IsInteger(lTyp) && sql.IsInteger(rTyp) {
+		return sql.Int64
+	}
+
 	return floatOrDecimalType(a)
 }
 


### PR DESCRIPTION
for query with `... limit 0, 200` in TopN plan, arithmetic was returning decimal type because `200` was handled as`uint8` and `0` was `int8` types, so if the both the values are any non-matching int type, the values are converted to `int64` for `+` and `-` operations.