### PR TITLE
get better convertToType for mergeUnionSchema rule

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -200,43 +200,6 @@ func TestSingleScript(t *testing.T) {
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
-	//t.Skip()
-	//
-	//var scripts = []queries.ScriptTest{
-	//	{
-	//		Name: "create table as select distinct",
-	//		SetUpScript: []string{
-	//			"CREATE TABLE t1 (a int, b varchar(10));",
-	//			"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
-	//		},
-	//		Assertions: []queries.ScriptTestAssertion{
-	//			{
-	//				Query:    "create table t2 as select distinct b, a from t1;",
-	//				Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
-	//			},
-	//			{
-	//				Query: "select * from t2 order by a;",
-	//				Expected: []sql.Row{
-	//					{"a", 1},
-	//					{"b", 2},
-	//					{"c", 3},
-	//				},
-	//			},
-	//		},
-	//	},
-	//}
-	//
-	//for _, test := range scripts {
-	//	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
-	//	engine, err := harness.NewEngine(t)
-	//	if err != nil {
-	//		panic(err)
-	//	}
-	//	engine.Analyzer.Debug = true
-	//	engine.Analyzer.Verbose = true
-	//
-	//	enginetest.TestScriptWithEngine(t, engine, harness, test)
-	//}
 }
 
 func TestUnbuildableIndex(t *testing.T) {

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1710,15 +1710,33 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: "with recursive t (n) as (select sum('1') from dual union all select (2.00) from dual) select sum(n) from t;",
+		Expected: []sql.Row{
+			{float64(3)},
+		},
+	},
+	{
 		Query: "with recursive t (n) as (select sum(1) from dual union all select (2.00) from dual) select sum(n) from t;",
 		Expected: []sql.Row{
 			{"3.00"},
 		},
 	},
 	{
+		Query: "with recursive t (n) as (select sum(1) from dual union all select (2.00/3.0) from dual) select sum(n) from t;",
+		Expected: []sql.Row{
+			{"1.666667"},
+		},
+	},
+	{
 		Query: "with recursive t (n) as (select sum(1) from dual union all select n+1 from t where n < 10) select sum(n) from t;",
 		Expected: []sql.Row{
 			{float64(55)},
+		},
+	},
+	{
+		Query: "with recursive t (n) as (select sum(1.0) from dual union all select n+1 from t where n < 10) select sum(n) from t;",
+		Expected: []sql.Row{
+			{"55.0"},
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1710,6 +1710,12 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: "with recursive t (n) as (select sum(1) from dual union all select (2.00) from dual) select sum(n) from t;",
+		Expected: []sql.Row{
+			{"3.00"},
+		},
+	},
+	{
 		Query: "with recursive t (n) as (select sum(1) from dual union all select n+1 from t where n < 10) select sum(n) from t;",
 		Expected: []sql.Row{
 			{float64(55)},
@@ -8202,14 +8208,6 @@ var BrokenQueries = []QueryTest{
 	{
 		Query:    "STR_TO_DATE('2013 32 Tuesday', '%X %V %W')", // Tuesday of 32th week
 		Expected: []sql.Row{{"2013-08-13"}},
-	},
-	// mergeUnionSchemas adds convert the decimal value to cast to string, which loses decimal type info.
-	// 				https://github.com/dolthub/dolt/issues/4331
-	{
-		Query: "with recursive t (n) as (select sum(1) from dual union all select (2.00) from dual) select sum(n) from t;",
-		Expected: []sql.Row{
-			{"3.00"},
-		},
 	},
 }
 

--- a/sql/analyzer/resolve_unions.go
+++ b/sql/analyzer/resolve_unions.go
@@ -136,7 +136,7 @@ func mergeUnionSchemas(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, 
 				}
 				hasdiff = true
 
-				// try to get optimal type to convert both into?
+				// try to get optimal type to convert both into
 				convertTo := getConvertToType(ls[i].Type, rs[i].Type)
 
 				// TODO: Principled type coercion...
@@ -162,7 +162,7 @@ func mergeUnionSchemas(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, 
 	})
 }
 
-// getConvertToType returns which type the both left anf right values should be converted to.
+// getConvertToType returns which type the both left and right values should be converted to.
 // If neither sql.Type represent number, then converted to string. Otherwise, we try to get
 // the appropriate type to avoid any precision loss.
 func getConvertToType(l, r sql.Type) string {

--- a/sql/analyzer/resolve_unions_test.go
+++ b/sql/analyzer/resolve_unions_test.go
@@ -83,7 +83,7 @@ func TestMergeUnionSchemas(t *testing.T) {
 			plan.NewUnion(plan.NewProject(
 				[]sql.Expression{
 					expression.NewAlias("1", expression.NewConvert(
-						expression.NewGetField(0, sql.Int64, "1", false), "char")),
+						expression.NewGetField(0, sql.Int64, "1", false), "signed")),
 				},
 				plan.NewProject(
 					[]sql.Expression{expression.NewLiteral(int64(1), sql.Int64)},
@@ -92,7 +92,7 @@ func TestMergeUnionSchemas(t *testing.T) {
 			), plan.NewProject(
 				[]sql.Expression{
 					expression.NewAlias("3", expression.NewConvert(
-						expression.NewGetField(0, sql.Int32, "3", false), "char")),
+						expression.NewGetField(0, sql.Int32, "3", false), "signed")),
 				},
 				plan.NewProject(
 					[]sql.Expression{expression.NewLiteral(int32(3), sql.Int32)},


### PR DESCRIPTION
Instead of converting every values to string, the type can be determined as appropriate as possible to avoid precision loss in number types.