### PR TITLE
Fix nested subquery join index in subquery expression w/ outer scope visibility

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -20,6 +20,10 @@ import (
 
 var JoinQueryTests = []QueryTest{
 	{
+		Query:    `with cte1 as (select u, v from cte2 join ab on cte2.u = b), cte2 as (select u,v from uv join ab on u = b where u in (2,3)) select * from xy where (x) not in (select u from cte1) order by 1`,
+		Expected: []sql.Row{{0, 2}, {1, 0}, {3, 3}},
+	},
+	{
 		Query:    `SELECT (SELECT 1 FROM (SELECT x FROM xy INNER JOIN uv ON (x = u OR y = v) LIMIT 1) r) AS s FROM xy`,
 		Expected: []sql.Row{{1}, {1}, {1}, {1}},
 	},

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -334,6 +334,9 @@ func fixRemainingFieldsIndexes(ctx *sql.Context, a *Analyzer, node sql.Node, sco
 			// do nothing, column defaults have already been resolved
 			return node, transform.SameTree, nil
 		case *plan.SubqueryAlias:
+			if !n.OuterScopeVisibility {
+				return n, transform.SameTree, nil
+			}
 			child, same, err := fixRemainingFieldsIndexes(ctx, a, n.Child, scope)
 			if err != nil {
 				return nil, transform.SameTree, err


### PR DESCRIPTION
The plan representation and exec scope passing diverged for subqueries. We were indexing assuming no scope passing, but at runtime still prepending scope rows, which indirectly snuck around not explicitly passing scope through the subquery alias.