### PR TITLE
trim collation for `information_schema.columns.dataType` and `information_schema.columns.colType`

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -161,8 +161,8 @@ var ScriptTests = []ScriptTest{
 			{
 				Query: "select data_type, column_type from information_schema.columns where table_name='enumtest1' and column_name='e';",
 				Expected: []sql.Row{{
-					"enum('abc','XYZ') COLLATE utf8mb4_0900_ai_ci",
-					"enum('abc','XYZ') COLLATE utf8mb4_0900_ai_ci"}},
+					"enum('abc','XYZ')",
+					"enum('abc','XYZ')"}},
 			},
 			{
 				Query:    "CREATE TABLE enumtest2 (pk int PRIMARY KEY, e enum('x ', 'X ', 'y', 'Y'));",

--- a/sql/information_schema/columns_table.go
+++ b/sql/information_schema/columns_table.go
@@ -196,8 +196,8 @@ func (c *ColumnsTable) columnsRowIter(ctx *sql.Context) (sql.RowIter, error) {
 					columnKey  string
 					nullable   = "NO"
 					ordinalPos = uint32(i + 1)
-					colType    = col.Type.String()
-					dataType   = strings.Split(colType, " COLLATE")[0]
+					colType    = strings.Split(col.Type.String(), " COLLATE")[0]
+					dataType   = colType
 					srsId      interface{}
 				)
 

--- a/sql/information_schema/columns_table.go
+++ b/sql/information_schema/columns_table.go
@@ -197,7 +197,7 @@ func (c *ColumnsTable) columnsRowIter(ctx *sql.Context) (sql.RowIter, error) {
 					nullable   = "NO"
 					ordinalPos = uint32(i + 1)
 					colType    = col.Type.String()
-					dataType   = colType
+					dataType   = strings.Split(colType, " COLLATE")[0]
 					srsId      interface{}
 				)
 

--- a/sql/plan/showtablestatus.go
+++ b/sql/plan/showtablestatus.go
@@ -104,7 +104,7 @@ func (s *ShowTableStatus) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, e
 			}
 		}
 
-		rows[i] = tableToStatusRow(tName, numRows, dataLength)
+		rows[i] = tableToStatusRow(tName, numRows, dataLength, table.Collation())
 	}
 
 	return sql.RowsToRowIter(rows...), nil
@@ -130,7 +130,7 @@ func (s *ShowTableStatus) CheckPrivileges(ctx *sql.Context, opChecker sql.Privil
 }
 
 // cc here: https://dev.mysql.com/doc/refman/8.0/en/show-table-status.html
-func tableToStatusRow(table string, numRows uint64, dataLength uint64) sql.Row {
+func tableToStatusRow(table string, numRows uint64, dataLength uint64, collation sql.CollationID) sql.Row {
 	var avgLength uint64 = 0
 	if numRows > 0 {
 		avgLength = dataLength / numRows
@@ -141,21 +141,21 @@ func tableToStatusRow(table string, numRows uint64, dataLength uint64) sql.Row {
 		// This column is unused. With the removal of .frm files in MySQL 8.0, this
 		// column now reports a hardcoded value of 10, which is the last .frm file
 		// version used in MySQL 5.7.
-		"10",                           // Version
-		"Fixed",                        // Row_format
-		numRows,                        // Rows
-		avgLength,                      // Avg_row_length
-		dataLength,                     // Data_length
-		uint64(0),                      // Max_data_length (Unused for InnoDB)
-		int64(0),                       // Index_length
-		int64(0),                       // Data_free
-		nil,                            // Auto_increment (always null)
-		nil,                            // Create_time
-		nil,                            // Update_time
-		nil,                            // Check_time
-		sql.Collation_Default.String(), // Collation
-		nil,                            // Checksum
-		nil,                            // Create_options
-		nil,                            // Comments
+		"10",               // Version
+		"Fixed",            // Row_format
+		numRows,            // Rows
+		avgLength,          // Avg_row_length
+		dataLength,         // Data_length
+		uint64(0),          // Max_data_length (Unused for InnoDB)
+		int64(0),           // Index_length
+		int64(0),           // Data_free
+		nil,                // Auto_increment (always null)
+		nil,                // Create_time
+		nil,                // Update_time
+		nil,                // Check_time
+		collation.String(), // Collation
+		nil,                // Checksum
+		nil,                // Create_options
+		nil,                // Comments
 	)
 }

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -556,9 +556,9 @@ func (t stringType) String() string {
 		if t.CharacterSet() != Collation_Default.CharacterSet() {
 			s += " CHARACTER SET " + t.CharacterSet().String()
 		}
-		if t.collation != Collation_Default {
-			s += " COLLATE " + t.collation.Name()
-		}
+		//if t.collation != Collation_Default {
+		//	s += " COLLATE " + t.collation.Name()
+		//}
 	}
 
 	return s

--- a/sql/stringtype.go
+++ b/sql/stringtype.go
@@ -556,9 +556,9 @@ func (t stringType) String() string {
 		if t.CharacterSet() != Collation_Default.CharacterSet() {
 			s += " CHARACTER SET " + t.CharacterSet().String()
 		}
-		//if t.collation != Collation_Default {
-		//	s += " COLLATE " + t.collation.Name()
-		//}
+		if t.collation != Collation_Default {
+			s += " COLLATE " + t.collation.Name()
+		}
 	}
 
 	return s


### PR DESCRIPTION
Our `dataType` column in the `information_schema.columns` table didn't match MySQL when there were columns that had collations. dBeaver reads in metadata from `information_schema.columns`, and when there was an error, it threw an error saying that the table was read-only.

fix for: https://github.com/dolthub/dolt/issues/4891