### PR TITLE
Invalidate CachedResult on Dispose

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1781,6 +1781,22 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: `
+			WITH RECURSIVE bus_dst as (
+				SELECT origin as dst FROM bus_routes WHERE origin='New York'
+				UNION
+				SELECT bus_routes.dst FROM bus_routes JOIN bus_dst ON concat(bus_dst.dst, 'aa') = concat(bus_routes.origin, 'aa')
+			)
+			SELECT * FROM bus_dst
+			ORDER BY dst`,
+		Expected: []sql.Row{
+			{"Boston"},
+			{"New York"},
+			{"Raleigh"},
+			{"Washington"},
+		},
+	},
+	{
 		Query: "SELECT s, (select i from mytable mt where sub.i = mt.i) as subi FROM (select i,s,'hello' FROM mytable where s = 'first row') as sub;",
 		Expected: []sql.Row{
 			{"first row", int64(1)},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25,6 +25,36 @@ type QueryPlanTest struct {
 // in testgen_test.go.
 var PlanTests = []QueryPlanTest{
 	{
+		Query: `
+			WITH RECURSIVE bus_dst as (
+				SELECT origin as dst FROM bus_routes WHERE origin='New York'
+				UNION
+				SELECT bus_routes.dst FROM bus_routes JOIN bus_dst ON concat(bus_dst.dst, 'aa') = concat(bus_routes.origin, 'aa')
+			)
+			SELECT * FROM bus_dst
+			ORDER BY dst`,
+		ExpectedPlan: "Sort(bus_dst.dst ASC)\n" +
+			" └─ SubqueryAlias(bus_dst)\n" +
+			"     └─ RecursiveCTE\n" +
+			"         └─ Union distinct\n" +
+			"             ├─ Project\n" +
+			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
+			"             │   └─ Filter(bus_routes.origin = 'New York')\n" +
+			"             │       └─ IndexedTableAccess(bus_routes)\n" +
+			"             │           ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
+			"             │           ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │           └─ columns: [origin]\n" +
+			"             └─ Project\n" +
+			"                 ├─ columns: [bus_routes.dst]\n" +
+			"                 └─ HashJoin(concat(bus_dst.dst, 'aa') = concat(bus_routes.origin, 'aa'))\n" +
+			"                     ├─ RecursiveTable(bus_dst)\n" +
+			"                     └─ HashLookup(child: (concat(bus_routes.origin, 'aa')), lookup: (concat(bus_dst.dst, 'aa')))\n" +
+			"                         └─ CachedResults\n" +
+			"                             └─ Table(bus_routes)\n" +
+			"                                 └─ columns: [origin dst]\n" +
+			"",
+	},
+	{
 		Query: `with cte1 as (select u, v from cte2 join ab on cte2.u = b), cte2 as (select u,v from uv join ab on u = b where u in (2,3)) select * from xy where (x) not in (select u from cte1) order by 1`,
 		ExpectedPlan: "Sort(xy.x ASC)\n" +
 			" └─ Filter(NOT((xy.x IN (Project\n" +

--- a/sql/plan/cached_results.go
+++ b/sql/plan/cached_results.go
@@ -69,6 +69,7 @@ func (n *CachedResults) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error
 }
 
 func (n *CachedResults) Dispose() {
+	n.noCache = true
 	cachedResultsGlobalCache.disposeCachedResultsById(n.id)
 }
 


### PR DESCRIPTION
Calling Dispose on a CachedResult would delete the underlying cache without maintaining a flag to indicate that we had done so if we tried to use the CachedResult again. As a result, a re-use of a Disposed CachedResult would mistakenly think the cache was intentionally empty, not invalidated. This distinguishes the `noCache` and empty `cacheDone` states.