### PR TITLE
fix type handling for derived table columns

### DIFF
--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -135,12 +135,11 @@ var OrderByGroupByScriptTests = []ScriptTest{
 		},
 	},
 	{
-		// https://github.com/dolthub/dolt/issues/4684
 		Name: "Group by with decimal columns",
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SELECT column_0, sum(column_1) FROM (values row(1.00,1), row(1.00,3), row(2,2), row(2,5), row(3,9)) a group by 1 order by 1;",
-				Expected: []sql.Row{{"1.00", float64(4)}, {2, float64(7)}, {3, float64(9)}},
+				Expected: []sql.Row{{"1.00", float64(4)}, {"2.00", float64(7)}, {"3.00", float64(9)}},
 			},
 		},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -959,8 +959,8 @@ var QueryTests = []QueryTest{
 	{
 		Query: `SELECT * FROM (values row(1+1,2+2), row(floor(1.5),concat("a","b"))) a order by 1`,
 		Expected: []sql.Row{
-			{1.0, "ab"},
-			{2, 4},
+			{1, "ab"},
+			{2, "4"},
 		},
 		ExpectedColumns: sql.Schema{
 			{
@@ -969,15 +969,15 @@ var QueryTests = []QueryTest{
 			},
 			{
 				Name: "column_1",
-				Type: sql.Int64,
+				Type: sql.MustCreateStringWithDefaults(sqltypes.Text, 1073741823),
 			},
 		},
 	},
 	{
 		Query: `SELECT * FROM (values row(1+1,2+2), row(floor(1.5),concat("a","b"))) a (c,d) order by 1`,
 		Expected: []sql.Row{
-			{1.0, "ab"},
-			{2, 4},
+			{1, "ab"},
+			{2, "4"},
 		},
 		ExpectedColumns: sql.Schema{
 			{
@@ -986,16 +986,48 @@ var QueryTests = []QueryTest{
 			},
 			{
 				Name: "d",
-				Type: sql.Int64,
+				Type: sql.MustCreateStringWithDefaults(sqltypes.Text, 1073741823),
 			},
 		},
 	},
 	{
 		Query: `SELECT column_0 FROM (values row(1+1,2+2), row(floor(1.5),concat("a","b"))) a order by 1`,
 		Expected: []sql.Row{
-			{1.0},
+			{1},
 			{2},
 		},
+	},
+	{
+		Query:    `SELECT DISTINCT val FROM (values row(1), row(1.00), row(2), row(2)) a (val);`,
+		Expected: []sql.Row{{"1.00"}, {"2.00"}},
+	},
+	{
+		Query:    `SELECT DISTINCT val FROM (values row(1.00), row(1.000), row(2), row(2)) a (val);`,
+		Expected: []sql.Row{{"1.000"}, {"2.000"}},
+	},
+	{
+		Query:    `SELECT DISTINCT val FROM (values row(1.000), row(21.00), row(2), row(2)) a (val);`,
+		Expected: []sql.Row{{"1.000"}, {"21.000"}, {"2.000"}},
+	},
+	{
+		Query:    `SELECT DISTINCT val FROM (values row(1), row(1.00), row('2'), row(2)) a (val);`,
+		Expected: []sql.Row{{"1"}, {"1.00"}, {"2"}},
+	},
+	{
+		Query:    `SELECT DISTINCT val FROM (values row(null), row(1.00), row('2'), row(2)) a (val);`,
+		Expected: []sql.Row{{nil}, {"1.00"}, {"2"}},
+	},
+	{
+		Query:    `SELECT column_0 FROM (values row(1+1.5,2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
+		Expected: []sql.Row{{"1.0"}, {"2.5"}},
+	},
+	{
+		Query:    `SELECT column_0 FROM (values row('1.5',2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
+		Expected: []sql.Row{{"1"}, {"1.5"}},
+	},
+	{
+		Query:    `SELECT column_0 FROM (values row(1.5,2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
+		Expected: []sql.Row{{"1.0"}, {"1.5"}},
 	},
 	{
 		Query: `SELECT FORMAT(val, 2) FROM
@@ -1196,8 +1228,8 @@ var QueryTests = []QueryTest{
 			join (values row(2,4), row(1.0,"ab")) b on a.column_0 = b.column_0 and a.column_0 = b.column_0
 			order by 1`,
 		Expected: []sql.Row{
-			{1.0, "ab"},
-			{2, 4},
+			{1, "ab"},
+			{2, "4"},
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -959,13 +959,13 @@ var QueryTests = []QueryTest{
 	{
 		Query: `SELECT * FROM (values row(1+1,2+2), row(floor(1.5),concat("a","b"))) a order by 1`,
 		Expected: []sql.Row{
-			{1, "ab"},
-			{2, "4"},
+			{1.0, "ab"},
+			{2.0, "4"},
 		},
 		ExpectedColumns: sql.Schema{
 			{
 				Name: "column_0",
-				Type: sql.Int64,
+				Type: sql.Float64,
 			},
 			{
 				Name: "column_1",
@@ -976,13 +976,13 @@ var QueryTests = []QueryTest{
 	{
 		Query: `SELECT * FROM (values row(1+1,2+2), row(floor(1.5),concat("a","b"))) a (c,d) order by 1`,
 		Expected: []sql.Row{
-			{1, "ab"},
-			{2, "4"},
+			{1.0, "ab"},
+			{2.0, "4"},
 		},
 		ExpectedColumns: sql.Schema{
 			{
 				Name: "c",
-				Type: sql.Int64,
+				Type: sql.Float64,
 			},
 			{
 				Name: "d",
@@ -993,8 +993,8 @@ var QueryTests = []QueryTest{
 	{
 		Query: `SELECT column_0 FROM (values row(1+1,2+2), row(floor(1.5),concat("a","b"))) a order by 1`,
 		Expected: []sql.Row{
-			{1},
-			{2},
+			{1.0},
+			{2.0},
 		},
 	},
 	{
@@ -1022,12 +1022,14 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{"1.0"}, {"2.5"}},
 	},
 	{
+		SkipPrepared: true,
 		Query:    `SELECT column_0 FROM (values row('1.5',2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
 		Expected: []sql.Row{{"1"}, {"1.5"}},
 	},
 	{
+		// it's float '1' and '1.5' but instead it should have '1.0' and '1.5' decimal results
 		Query:    `SELECT column_0 FROM (values row(1.5,2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
-		Expected: []sql.Row{{"1.0"}, {"1.5"}},
+		Expected: []sql.Row{{1.0}, {1.5}},
 	},
 	{
 		Query: `SELECT FORMAT(val, 2) FROM
@@ -1228,8 +1230,8 @@ var QueryTests = []QueryTest{
 			join (values row(2,4), row(1.0,"ab")) b on a.column_0 = b.column_0 and a.column_0 = b.column_0
 			order by 1`,
 		Expected: []sql.Row{
-			{1, "ab"},
-			{2, "4"},
+			{1.0, "ab"},
+			{2.0, "4"},
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1023,8 +1023,8 @@ var QueryTests = []QueryTest{
 	},
 	{
 		SkipPrepared: true,
-		Query:    `SELECT column_0 FROM (values row('1.5',2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
-		Expected: []sql.Row{{"1"}, {"1.5"}},
+		Query:        `SELECT column_0 FROM (values row('1.5',2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
+		Expected:     []sql.Row{{"1"}, {"1.5"}},
 	},
 	{
 		// it's float '1' and '1.5' but instead it should have '1.0' and '1.5' decimal results

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1022,14 +1022,15 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{"1.0"}, {"2.5"}},
 	},
 	{
+		// The SortFields does not match between prepared and non-prepared nodes.
 		SkipPrepared: true,
 		Query:        `SELECT column_0 FROM (values row('1.5',2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
 		Expected:     []sql.Row{{"1"}, {"1.5"}},
 	},
 	{
-		// it's float '1' and '1.5' but instead it should have '1.0' and '1.5' decimal results
+		// the result on sql shell are '1' and '1.5' but instead it should have decimal values of '1.0' and '1.5'
 		Query:    `SELECT column_0 FROM (values row(1.5,2+2), row(floor(1.5),concat("a","b"))) a order by 1;`,
-		Expected: []sql.Row{{1.0}, {1.5}},
+		Expected: []sql.Row{{float64(1)}, {1.5}},
 	},
 	{
 		Query: `SELECT FORMAT(val, 2) FROM

--- a/sql/cache.go
+++ b/sql/cache.go
@@ -29,7 +29,7 @@ func HashOf(v Row) (uint64, error) {
 	hash := xxhash.New()
 	for _, x := range v {
 		// TODO: probably much faster to do this with a type switch
-		if _, err := hash.Write([]byte(fmt.Sprintf("%#v,", x))); err != nil {
+		if _, err := hash.Write([]byte(fmt.Sprintf("%v,", x))); err != nil {
 			return 0, err
 		}
 	}

--- a/sql/expression/function/ceil_round_floor.go
+++ b/sql/expression/function/ceil_round_floor.go
@@ -50,6 +50,10 @@ func (c *Ceil) Description() string {
 
 // Type implements the Expression interface.
 func (c *Ceil) Type() sql.Type {
+	childType := c.Child.Type()
+	if sql.IsNumber(childType) {
+		return childType
+	}
 	return sql.Int32
 }
 
@@ -124,6 +128,10 @@ func (f *Floor) Description() string {
 
 // Type implements the Expression interface.
 func (f *Floor) Type() sql.Type {
+	childType := f.Child.Type()
+	if sql.IsNumber(childType) {
+		return childType
+	}
 	return sql.Int32
 }
 
@@ -355,7 +363,6 @@ func (r *Round) Resolved() bool {
 
 // Type implements the Expression interface.
 func (r *Round) Type() sql.Type {
-	// TODO: should be end result type, which is decimal? can make decimal(65, rightChildVal)
 	leftChildType := r.Left.Type()
 	if sql.IsNumber(leftChildType) {
 		return leftChildType

--- a/sql/expression/function/ceil_round_floor.go
+++ b/sql/expression/function/ceil_round_floor.go
@@ -50,10 +50,6 @@ func (c *Ceil) Description() string {
 
 // Type implements the Expression interface.
 func (c *Ceil) Type() sql.Type {
-	childType := c.Child.Type()
-	if sql.IsNumber(childType) {
-		return childType
-	}
 	return sql.Int32
 }
 
@@ -128,10 +124,6 @@ func (f *Floor) Description() string {
 
 // Type implements the Expression interface.
 func (f *Floor) Type() sql.Type {
-	childType := f.Child.Type()
-	if sql.IsNumber(childType) {
-		return childType
-	}
 	return sql.Int32
 }
 
@@ -363,6 +355,7 @@ func (r *Round) Resolved() bool {
 
 // Type implements the Expression interface.
 func (r *Round) Type() sql.Type {
+	// TODO: should be end result type, which is decimal? can make decimal(65, rightChildVal)
 	leftChildType := r.Left.Type()
 	if sql.IsNumber(leftChildType) {
 		return leftChildType

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -226,7 +226,7 @@ func hashOfSimple(ctx *sql.Context, i interface{}, t sql.Type) (uint64, error) {
 			return 0, err
 		}
 
-		if _, err := hash.Write([]byte(fmt.Sprintf("%#v,", x))); err != nil {
+		if _, err := hash.Write([]byte(fmt.Sprintf("%v,", x))); err != nil {
 			return 0, err
 		}
 		return hash.Sum64(), nil

--- a/sql/plan/values_derived_table.go
+++ b/sql/plan/values_derived_table.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/shopspring/decimal"
+
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
@@ -11,10 +14,15 @@ type ValueDerivedTable struct {
 	*Values
 	name    string
 	columns []string
+	sch     sql.Schema
 }
 
 func NewValueDerivedTable(values *Values, name string) *ValueDerivedTable {
-	return &ValueDerivedTable{Values: values, name: name}
+	var s sql.Schema
+	if values.Resolved() && len(values.ExpressionTuples) != 0 {
+		s = getSchema(values.ExpressionTuples)
+	}
+	return &ValueDerivedTable{Values: values, name: name, sch: s}
 }
 
 // Name implements sql.Nameable
@@ -28,10 +36,8 @@ func (v *ValueDerivedTable) Schema() sql.Schema {
 		return nil
 	}
 
-	// TODO: get type by examining all rows, use most permissive type and cast everything to it
-	childSchema := v.Values.Schema()
-	schema := make(sql.Schema, len(childSchema))
-	for i, col := range childSchema {
+	schema := make(sql.Schema, len(v.sch))
+	for i, col := range v.sch {
 		c := *col
 		c.Source = v.name
 		if len(v.columns) > 0 {
@@ -43,6 +49,34 @@ func (v *ValueDerivedTable) Schema() sql.Schema {
 	}
 
 	return schema
+}
+
+// RowIter implements the Node interface.
+func (v *ValueDerivedTable) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	rows := make([]sql.Row, len(v.ExpressionTuples))
+	for i, et := range v.ExpressionTuples {
+		vals := make([]interface{}, len(et))
+		for j, e := range et {
+			var err error
+			p, err := e.Eval(ctx, row)
+			if err != nil {
+				return nil, err
+			}
+			// cast all row values to the most permissive type
+			vals[j], err = v.sch[j].Type.Convert(p)
+			if err != nil {
+				return nil, err
+			}
+			// decimalType.Convert() does not use the given type precision and scale information
+			if t, ok := v.sch[j].Type.(sql.DecimalType); ok {
+				vals[j] = vals[j].(decimal.Decimal).Round(int32(t.Scale()))
+			}
+		}
+
+		rows[i] = sql.NewRow(vals...)
+	}
+
+	return sql.RowsToRowIter(rows...), nil
 }
 
 // WithChildren implements the Node interface.
@@ -63,6 +97,9 @@ func (v *ValueDerivedTable) WithExpressions(exprs ...sql.Expression) (sql.Node, 
 
 	nv := *v
 	nv.Values = newValues.(*Values)
+	if nv.Values.Resolved() && len(nv.Values.ExpressionTuples) != 0 {
+		nv.sch = getSchema(nv.Values.ExpressionTuples)
+	}
 	return &nv, nil
 }
 
@@ -113,4 +150,119 @@ func (v *ValueDerivedTable) DebugString() string {
 func (v ValueDerivedTable) WithColumns(columns []string) *ValueDerivedTable {
 	v.columns = columns
 	return &v
+}
+
+// getSchema returns schema created with most permissive types by examining all rows.
+func getSchema(rows [][]sql.Expression) sql.Schema {
+	s := make(sql.Schema, len(rows[0]))
+
+	for _, exprs := range rows {
+		for i, val := range exprs {
+			if s[i] == nil {
+				var name string
+				if n, ok := val.(sql.Nameable); ok {
+					name = n.Name()
+				} else {
+					name = val.String()
+				}
+
+				t := val.Type()
+				if sql.IsFloat(t) {
+					t = getDecimalTypeFromFloatType(val)
+				}
+				s[i] = &sql.Column{Name: name, Type: t, Nullable: val.IsNullable()}
+			} else {
+				s[i].Type = getMostPermissiveType(s[i], val)
+				if !s[i].Nullable {
+					s[i].Nullable = val.IsNullable()
+				}
+			}
+
+		}
+	}
+
+	return s
+}
+
+// getMostPermissiveType returns the most permissive type given the current type and the expression type.
+// The ordering is "other types < uint < int < decimal (float should be interpreted as decimal) < string"
+func getMostPermissiveType(s *sql.Column, e sql.Expression) sql.Type {
+	if sql.IsText(s.Type) {
+		return s.Type
+	} else if sql.IsText(e.Type()) {
+		return e.Type()
+	}
+
+	if st, ok := s.Type.(sql.DecimalType); ok {
+		if et, eok := e.Type().(sql.DecimalType); eok {
+			// if both are decimal types, get the bigger decimaltype
+			frac := st.Scale()
+			whole := st.Precision() - frac
+			if ep := et.Precision() - et.Scale(); ep > whole {
+				whole = ep
+			}
+			if et.Scale() > frac {
+				frac = et.Scale()
+			}
+			return sql.MustCreateDecimalType(whole+frac, frac)
+		} else if sql.IsFloat(e.Type()) {
+			return getDecimalTypeFromFloatType(e)
+		} else {
+			return s.Type
+		}
+	} else if sql.IsDecimal(e.Type()) {
+		return e.Type()
+	}
+
+	if sql.IsFloat(s.Type) {
+		// TODO: need to convert to decimaltype if schema type is float type?
+		return s.Type
+	} else if sql.IsFloat(e.Type()) {
+		return getDecimalTypeFromFloatType(e)
+	}
+
+	if sql.IsSigned(s.Type) {
+		return s.Type
+	} else if sql.IsSigned(e.Type()) {
+		return sql.Int64
+	}
+
+	if sql.IsUnsigned(s.Type) {
+		return s.Type
+	} else if sql.IsUnsigned(e.Type()) {
+		return sql.Uint64
+	}
+
+	return s.Type
+}
+
+// getDecimalTypeFromFloatType returns decimaltype for expression.Type() is float by evaluating
+// all literals available in the expression to determine the max precision and scale.
+func getDecimalTypeFromFloatType(e sql.Expression) sql.Type {
+	var maxWhole, maxFrac uint8
+	sql.Inspect(e, func(expr sql.Expression) bool {
+		switch c := expr.(type) {
+		case *expression.Literal:
+			if sql.IsNumber(c.Type()) {
+				l, err := c.Eval(nil, nil)
+				if err == nil {
+					p, s := expression.GetPrecisionAndScale(l)
+					if cw := p - s; cw > maxWhole {
+						maxWhole = cw
+					}
+					if s > maxFrac {
+						maxFrac = s
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	defType, err := sql.CreateDecimalType(maxWhole+maxFrac, maxFrac)
+	if err != nil {
+		return sql.MustCreateDecimalType(65, 10)
+	}
+
+	return defType
 }

--- a/sql/plan/values_derived_table.go
+++ b/sql/plan/values_derived_table.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 )
 
 type ValueDerivedTable struct {


### PR DESCRIPTION
derived table column is now created from the most permissive type and the values are casted into that type at Eval.

have skipped Prepared test as sort field type does not match non-prepared execution.