### PR TITLE
Disambiguate aggregation expressions

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2756,6 +2756,34 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "identical expressions over different windows should produce different results",
+		SetUpScript: []string{
+			"CREATE TABLE t(a INT, b INT);",
+			"INSERT INTO t(a, b) VALUES (1, 1), (1, 2), (1, 3), (2, 4), (2, 5), (2, 6);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT SUM(b) OVER (PARTITION BY a ORDER BY b) FROM t ORDER BY 1;",
+				Expected: []sql.Row{{float64(1)}, {float64(3)}, {float64(4)}, {float64(6)}, {float64(9)}, {float64(15)}},
+			},
+			{
+				Query:    "SELECT SUM(b) OVER (ORDER BY b) FROM t ORDER BY 1;",
+				Expected: []sql.Row{{float64(1)}, {float64(3)}, {float64(6)}, {float64(10)}, {float64(15)}, {float64(21)}},
+			},
+			{
+				Query: "SELECT SUM(b) OVER (PARTITION BY a ORDER BY b), SUM(b) OVER (ORDER BY b) FROM t;",
+				Expected: []sql.Row{
+					{float64(1), float64(1)},
+					{float64(3), float64(3)},
+					{float64(6), float64(6)},
+					{float64(4), float64(10)},
+					{float64(9), float64(15)},
+					{float64(15), float64(21)},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/optgen/cmd/support/agg_gen.go
+++ b/optgen/cmd/support/agg_gen.go
@@ -92,7 +92,11 @@ func (g *AggGen) genAggStringer(define AggDef) {
 		sqlName = define.SqlName
 	}
 	fmt.Fprintf(g.w, "func (a *%s)  String() string {\n", define.Name)
-	fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s(%%s)\", a.Child)\n", strings.ToUpper(sqlName))
+	fmt.Fprintf(g.w, "    res := fmt.Sprintf(\"%s(%%s)\", a.Child)\n", strings.ToUpper(sqlName))
+	fmt.Fprintf(g.w, "    if a.window != nil {\n")
+	fmt.Fprintf(g.w, "    	res = res + \" - \" + a.window.String()\n")
+	fmt.Fprintf(g.w, "    }\n")
+	fmt.Fprintf(g.w, "    return res\n")
 	fmt.Fprintf(g.w, "}\n\n")
 }
 

--- a/optgen/cmd/support/agg_gen.go
+++ b/optgen/cmd/support/agg_gen.go
@@ -94,7 +94,7 @@ func (g *AggGen) genAggStringer(define AggDef) {
 	fmt.Fprintf(g.w, "func (a *%s)  String() string {\n", define.Name)
 	fmt.Fprintf(g.w, "    res := fmt.Sprintf(\"%s(%%s)\", a.Child)\n", strings.ToUpper(sqlName))
 	fmt.Fprintf(g.w, "    if a.window != nil {\n")
-	fmt.Fprintf(g.w, "    	res = res + \" - \" + a.window.String()\n")
+	fmt.Fprintf(g.w, "    	res = res + \" \" + a.window.String()\n")
 	fmt.Fprintf(g.w, "    }\n")
 	fmt.Fprintf(g.w, "    return res\n")
 	fmt.Fprintf(g.w, "}\n\n")

--- a/optgen/cmd/support/agg_gen_test.go
+++ b/optgen/cmd/support/agg_gen_test.go
@@ -54,7 +54,11 @@ func TestAggGen(t *testing.T) {
         }
 
         func (a *Test)  String() string {
-            return fmt.Sprintf("TEST(%s)", a.Child)
+            res := fmt.Sprintf("TEST(%s)", a.Child)
+            if a.window != nil {
+                res = res + " - " + a.window.String()
+            }
+            return res
         }
 
         func (a *Test) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {

--- a/optgen/cmd/support/agg_gen_test.go
+++ b/optgen/cmd/support/agg_gen_test.go
@@ -56,7 +56,7 @@ func TestAggGen(t *testing.T) {
         func (a *Test)  String() string {
             res := fmt.Sprintf("TEST(%s)", a.Child)
             if a.window != nil {
-                res = res + " - " + a.window.String()
+                res = res + " " + a.window.String()
             }
             return res
         }

--- a/sql/expression/function/aggregation/unary_aggs.og.go
+++ b/sql/expression/function/aggregation/unary_aggs.og.go
@@ -39,7 +39,7 @@ func (a *Avg) IsNullable() bool {
 func (a *Avg) String() string {
 	res := fmt.Sprintf("AVG(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -99,7 +99,7 @@ func (a *BitAnd) IsNullable() bool {
 func (a *BitAnd) String() string {
 	res := fmt.Sprintf("BITAND(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -159,7 +159,7 @@ func (a *BitOr) IsNullable() bool {
 func (a *BitOr) String() string {
 	res := fmt.Sprintf("BITOR(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -219,7 +219,7 @@ func (a *BitXor) IsNullable() bool {
 func (a *BitXor) String() string {
 	res := fmt.Sprintf("BITXOR(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -279,7 +279,7 @@ func (a *Count) IsNullable() bool {
 func (a *Count) String() string {
 	res := fmt.Sprintf("COUNT(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -339,7 +339,7 @@ func (a *First) IsNullable() bool {
 func (a *First) String() string {
 	res := fmt.Sprintf("FIRST(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -399,7 +399,7 @@ func (a *JsonArray) IsNullable() bool {
 func (a *JsonArray) String() string {
 	res := fmt.Sprintf("JSON_ARRAYAGG(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -459,7 +459,7 @@ func (a *Last) IsNullable() bool {
 func (a *Last) String() string {
 	res := fmt.Sprintf("LAST(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -519,7 +519,7 @@ func (a *Max) IsNullable() bool {
 func (a *Max) String() string {
 	res := fmt.Sprintf("MAX(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -579,7 +579,7 @@ func (a *Min) IsNullable() bool {
 func (a *Min) String() string {
 	res := fmt.Sprintf("MIN(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }
@@ -639,7 +639,7 @@ func (a *Sum) IsNullable() bool {
 func (a *Sum) String() string {
 	res := fmt.Sprintf("SUM(%s)", a.Child)
 	if a.window != nil {
-		res = res + " - " + a.window.String()
+		res = res + " " + a.window.String()
 	}
 	return res
 }

--- a/sql/expression/function/aggregation/unary_aggs.og.go
+++ b/sql/expression/function/aggregation/unary_aggs.og.go
@@ -37,7 +37,11 @@ func (a *Avg) IsNullable() bool {
 }
 
 func (a *Avg) String() string {
-	return fmt.Sprintf("AVG(%s)", a.Child)
+	res := fmt.Sprintf("AVG(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *Avg) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -93,7 +97,11 @@ func (a *BitAnd) IsNullable() bool {
 }
 
 func (a *BitAnd) String() string {
-	return fmt.Sprintf("BITAND(%s)", a.Child)
+	res := fmt.Sprintf("BITAND(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *BitAnd) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -149,7 +157,11 @@ func (a *BitOr) IsNullable() bool {
 }
 
 func (a *BitOr) String() string {
-	return fmt.Sprintf("BITOR(%s)", a.Child)
+	res := fmt.Sprintf("BITOR(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *BitOr) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -205,7 +217,11 @@ func (a *BitXor) IsNullable() bool {
 }
 
 func (a *BitXor) String() string {
-	return fmt.Sprintf("BITXOR(%s)", a.Child)
+	res := fmt.Sprintf("BITXOR(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *BitXor) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -261,7 +277,11 @@ func (a *Count) IsNullable() bool {
 }
 
 func (a *Count) String() string {
-	return fmt.Sprintf("COUNT(%s)", a.Child)
+	res := fmt.Sprintf("COUNT(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *Count) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -317,7 +337,11 @@ func (a *First) IsNullable() bool {
 }
 
 func (a *First) String() string {
-	return fmt.Sprintf("FIRST(%s)", a.Child)
+	res := fmt.Sprintf("FIRST(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *First) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -373,7 +397,11 @@ func (a *JsonArray) IsNullable() bool {
 }
 
 func (a *JsonArray) String() string {
-	return fmt.Sprintf("JSON_ARRAYAGG(%s)", a.Child)
+	res := fmt.Sprintf("JSON_ARRAYAGG(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *JsonArray) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -429,7 +457,11 @@ func (a *Last) IsNullable() bool {
 }
 
 func (a *Last) String() string {
-	return fmt.Sprintf("LAST(%s)", a.Child)
+	res := fmt.Sprintf("LAST(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *Last) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -485,7 +517,11 @@ func (a *Max) IsNullable() bool {
 }
 
 func (a *Max) String() string {
-	return fmt.Sprintf("MAX(%s)", a.Child)
+	res := fmt.Sprintf("MAX(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *Max) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -541,7 +577,11 @@ func (a *Min) IsNullable() bool {
 }
 
 func (a *Min) String() string {
-	return fmt.Sprintf("MIN(%s)", a.Child)
+	res := fmt.Sprintf("MIN(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *Min) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
@@ -597,7 +637,11 @@ func (a *Sum) IsNullable() bool {
 }
 
 func (a *Sum) String() string {
-	return fmt.Sprintf("SUM(%s)", a.Child)
+	res := fmt.Sprintf("SUM(%s)", a.Child)
+	if a.window != nil {
+		res = res + " - " + a.window.String()
+	}
+	return res
 }
 
 func (a *Sum) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {


### PR DESCRIPTION
Disambiguate aggregation expressions so different columns with same sources don't end up clobbering each other.

Fixes https://github.com/dolthub/dolt/issues/4140