### PR TITLE
If a window does not have "ORDER BY" specified, use a default frame.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4161,8 +4161,8 @@ func TestNamedWindows(t *testing.T, harness Harness) {
 	RunQuery(t, e, harness, "CREATE TABLE a (x INTEGER PRIMARY KEY, y INTEGER, z INTEGER)")
 	RunQuery(t, e, harness, "INSERT INTO a VALUES (0,0,0), (1,1,0), (2,2,0), (3,0,0), (4,1,0), (5,3,0)")
 
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(4)}, {float64(7)}}, nil, nil)
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (partition by z) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(4)}, {float64(7)}}, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (partition by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over w FROM a WINDOW w as (partition by z order by x rows unbounded preceding) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(4)}, {float64(7)}}, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over w FROM a WINDOW w as (partition by z order by x rows current row) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(2)}, {float64(0)}, {float64(1)}, {float64(3)}}, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w) FROM a WINDOW w as (partition by z order by x rows 2 preceding) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(3)}, {float64(4)}}, nil, nil)

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -3051,8 +3051,8 @@ inner join pq on true
 	{
 		Query: `SELECT t, n, lag(t, 1, t+1) over (partition by n) FROM bigtable`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [bigtable.t, bigtable.n, lag(bigtable.t, 1, (bigtable.t + 1)) over ( partition by bigtable.n) as lag(t, 1, t+1) over (partition by n)]\n" +
-			" └─ Window(bigtable.t, bigtable.n, lag(bigtable.t, 1, (bigtable.t + 1)) over ( partition by bigtable.n))\n" +
+			" ├─ columns: [bigtable.t, bigtable.n, lag(bigtable.t, 1, (bigtable.t + 1)) over ( partition by bigtable.n ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as lag(t, 1, t+1) over (partition by n)]\n" +
+			" └─ Window(bigtable.t, bigtable.n, lag(bigtable.t, 1, (bigtable.t + 1)) over ( partition by bigtable.n ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))\n" +
 			"     └─ Table(bigtable)\n" +
 			"         └─ columns: [t n]\n" +
 			"",
@@ -3060,8 +3060,8 @@ inner join pq on true
 	{
 		Query: `select i, row_number() over (w3) from mytable window w1 as (w2), w2 as (), w3 as (w1)`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mytable.i, row_number() over () as row_number() over (w3)]\n" +
-			" └─ Window(mytable.i, row_number() over ())\n" +
+			" ├─ columns: [mytable.i, row_number() over ( ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as row_number() over (w3)]\n" +
+			" └─ Window(mytable.i, row_number() over ( ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))\n" +
 			"     └─ Table(mytable)\n" +
 			"         └─ columns: [i]\n" +
 			"",
@@ -3069,8 +3069,8 @@ inner join pq on true
 	{
 		Query: `select i, row_number() over (w1 partition by s) from mytable window w1 as (order by i asc)`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mytable.i, row_number() over ( partition by mytable.s order by mytable.i ASC) as row_number() over (w1 partition by s)]\n" +
-			" └─ Window(mytable.i, row_number() over ( partition by mytable.s order by mytable.i ASC))\n" +
+			" ├─ columns: [mytable.i, row_number() over ( partition by mytable.s order by mytable.i ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) as row_number() over (w1 partition by s)]\n" +
+			" └─ Window(mytable.i, row_number() over ( partition by mytable.s order by mytable.i ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING))\n" +
 			"     └─ Table(mytable)\n" +
 			"         └─ columns: [i s]\n" +
 			"",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2784,6 +2784,34 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "windows without ORDER BY should be treated as RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING",
+		SetUpScript: []string{
+			"CREATE TABLE t(a INT, b INT);",
+			"INSERT INTO t(a, b) VALUES (1, 1), (1, 2), (1, 3), (2, 4), (2, 5), (2, 6);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT SUM(b) OVER (PARTITION BY a) FROM t ORDER BY 1;",
+				Expected: []sql.Row{{float64(6)}, {float64(6)}, {float64(6)}, {float64(15)}, {float64(15)}, {float64(15)}},
+			},
+			{
+				Query:    "SELECT SUM(b) OVER () FROM t ORDER BY 1;",
+				Expected: []sql.Row{{float64(21)}, {float64(21)}, {float64(21)}, {float64(21)}, {float64(21)}, {float64(21)}},
+			},
+			{
+				Query: "SELECT SUM(b) OVER (PARTITION BY a), SUM(b) OVER () FROM t;",
+				Expected: []sql.Row{
+					{float64(6), float64(21)},
+					{float64(6), float64(21)},
+					{float64(6), float64(21)},
+					{float64(15), float64(21)},
+					{float64(15), float64(21)},
+					{float64(15), float64(21)},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/replace_window_names_test.go
+++ b/sql/analyzer/replace_window_names_test.go
@@ -288,7 +288,7 @@ func TestReplaceWindowNames(t *testing.T) {
 									[]sql.Expression{}, nil,
 									plan.NewRangeNPrecedingToCurrentRowFrame(
 										expression.NewInterval(
-											expression.NewLiteral("2:30", sql.LongText),
+											expression.NewLiteral("2:35", sql.LongText),
 											"MINUTE_SECOND",
 										),
 									), "w", "")),

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -3437,6 +3437,13 @@ func windowDefToWindow(ctx *sql.Context, def *sqlparser.WindowDef) (*sql.WindowD
 	if err != nil {
 		return nil, err
 	}
+
+	// According to MySQL documentation at https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html
+	// "If OVER() is empty, the window consists of all query rows and the window function computes a result using all rows."
+	if def.OrderBy == nil && frame == nil {
+		frame = plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame()
+	}
+
 	return sql.NewWindowDefinition(partitions, sortFields, frame, def.NameRef.Lowered(), def.Name.Lowered()), nil
 }
 

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -3864,7 +3864,9 @@ CREATE TABLE t2
 				[]sql.Expression{
 					expression.NewUnresolvedColumn("a"),
 					expression.NewAlias("count(i) over ()",
-						expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""), expression.NewUnresolvedColumn("i")),
+						expression.NewUnresolvedFunction("count", true,
+							sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", ""),
+							expression.NewUnresolvedColumn("i")),
 					),
 				},
 				plan.NewUnresolvedTable("foo", ""),
@@ -3888,7 +3890,7 @@ CREATE TABLE t2
 					expression.NewAlias("row_number() over (partition by y)",
 						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
 							expression.NewUnresolvedColumn("y"),
-						}, nil, nil, "", "")),
+						}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", "")),
 					),
 				},
 				plan.NewUnresolvedTable("foo", ""),
@@ -3910,7 +3912,7 @@ CREATE TABLE t2
 						}, nil, "", "")),
 					),
 					expression.NewAlias("max(b) over ()",
-						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", ""),
+						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", ""),
 							expression.NewUnresolvedColumn("b"),
 						),
 					),
@@ -3926,12 +3928,12 @@ CREATE TABLE t2
 					expression.NewAlias("row_number() over (partition by b)",
 						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
 							expression.NewUnresolvedColumn("b"),
-						}, nil, nil, "", "")),
+						}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", "")),
 					),
 					expression.NewAlias("max(b) over (partition by b)",
 						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
 							expression.NewUnresolvedColumn("b"),
-						}, nil, nil, "", ""),
+						}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", ""),
 							expression.NewUnresolvedColumn("b"),
 						),
 					),
@@ -3947,12 +3949,12 @@ CREATE TABLE t2
 					expression.NewAlias("row_number() over (partition by c)",
 						expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{
 							expression.NewUnresolvedColumn("c"),
-						}, nil, nil, "", "")),
+						}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", "")),
 					),
 					expression.NewAlias("max(b) over (partition by b)",
 						expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{
 							expression.NewUnresolvedColumn("b"),
-						}, nil, nil, "", ""),
+						}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", ""),
 							expression.NewUnresolvedColumn("b"),
 						),
 					),
@@ -3989,7 +3991,7 @@ CREATE TABLE t2
 					expression.NewAlias("count(i) over (partition by y)",
 						expression.NewUnresolvedFunction("count", true, sql.NewWindowDefinition([]sql.Expression{
 							expression.NewUnresolvedColumn("y"),
-						}, nil, nil, "", ""),
+						}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", ""),
 							expression.NewUnresolvedColumn("i"),
 						),
 					),
@@ -4269,7 +4271,7 @@ CREATE TABLE t2
 				plan.NewWindow(
 					[]sql.Expression{
 						expression.NewAlias("row_number() over (w)",
-							expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w", "")),
+							expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "w", "")),
 						),
 					},
 					plan.NewUnresolvedTable("foo", ""),
@@ -4287,16 +4289,16 @@ CREATE TABLE t2
 							NullOrdering: sql.NullsFirst,
 						},
 					}, nil, "w2", "w1"),
-					"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
+					"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", "w2"),
 				},
 				plan.NewWindow(
 					[]sql.Expression{
 						expression.NewUnresolvedColumn("a"),
 						expression.NewAlias("row_number() over (w1)",
-							expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w1", "")),
+							expression.NewUnresolvedFunction("row_number", true, sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "w1", "")),
 						),
 						expression.NewAlias("max(b) over (w2)",
-							expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
+							expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "w2", ""),
 								expression.NewUnresolvedColumn("b"),
 							),
 						),
@@ -4317,7 +4319,7 @@ CREATE TABLE t2
 							NullOrdering: sql.NullsFirst,
 						},
 					}, nil, "w2", "w1"),
-					"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "", "w2"),
+					"w2": sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "", "w2"),
 				}, plan.NewWindow(
 					[]sql.Expression{
 						expression.NewUnresolvedColumn("a"),
@@ -4326,10 +4328,10 @@ CREATE TABLE t2
 								[]sql.Expression{
 									expression.NewUnresolvedColumn("y"),
 								},
-								nil, nil, "w1", "")),
+								nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "w1", "")),
 						),
 						expression.NewAlias("max(b) over (w2)",
-							expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, nil, "w2", ""),
+							expression.NewUnresolvedFunction("max", true, sql.NewWindowDefinition([]sql.Expression{}, nil, plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame(), "w2", ""),
 								expression.NewUnresolvedColumn("b"),
 							),
 						),


### PR DESCRIPTION
If a window does not have "ORDER BY" specified, use a default frame.

This fixes https://github.com/dolthub/go-mysql-server/issues/1449