### PR TITLE
fix incorrect result from arithmetic ops

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3436,6 +3436,10 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{"50.00000"}},
 	},
 	{
+		Query:    "select 2000.0 * (24.0 * 6.0 * 6.25 * 10.0) / 250000000.0;",
+		Expected: []sql.Row{{"0.0720000000"}},
+	},
+	{
 		Query:    "select 1/2/3/4/5/6;",
 		Expected: []sql.Row{{"0.00138888888888888888"}},
 	},
@@ -8316,7 +8320,6 @@ var BrokenQueries = []QueryTest{
 		Query:    "select i, date_col from datetime_table",
 		Expected: []sql.Row{{1, "2019-12-31"}},
 	},
-	// Currently, not matching MySQL's information schema for this table
 	// Currently, not matching MySQL's result format. This []uint8 gets converted to '\n' instead.
 	{
 		Query:    "SELECT X'0a'",
@@ -8326,6 +8329,12 @@ var BrokenQueries = []QueryTest{
 	{
 		Query:    "STR_TO_DATE('2013 32 Tuesday', '%X %V %W')", // Tuesday of 32th week
 		Expected: []sql.Row{{"2013-08-13"}},
+	},
+	{
+		// https://github.com/dolthub/dolt/issues/4931
+		// The current output is "0.07200000000000"
+		Query:    "select 2000.0 / 250000000.0 * (24.0 * 6.0 * 6.25 * 10.0);",
+		Expected: []sql.Row{{"0.0720000000"}},
 	},
 }
 

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -64,7 +64,7 @@ var _ ArithmeticOp = (*Arithmetic)(nil)
 // Arithmetic expressions include plus, minus and multiplication (+, -, *) operations.
 type Arithmetic struct {
 	BinaryExpression
-	Op string
+	Op  string
 	ops int32
 }
 

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -273,8 +273,8 @@ func isInterval(expr sql.Expression) bool {
 	return ok
 }
 
-// countDivs returns the number of division operators in order on the left child node of the current node.
-// This lets us count how many division operator used one after the other. E.g. 24/3/2/1 will have this structure:
+// countArithmeticOps returns the number of arithmetic operators in order on the left child node of the current node.
+// This lets us count how many arithmetic operators used one after the other
 func countArithmeticOps(e sql.Expression) int32 {
 	if e == nil {
 		return 0
@@ -287,9 +287,8 @@ func countArithmeticOps(e sql.Expression) int32 {
 	return 0
 }
 
-// setDivs will set the innermost node's DivScale to the number counted by countDivs, and the rest of it
-// to 0. This allows us to calculate the first division with the exact precision of the end result. Otherwise,
-// we lose precision at each division since we only add 4 scales at every division operation.
+// setArithmeticOps will set ops number with number counted by countArithmeticOps. This allows
+// us to keep track of whether the expression is the last arithmetic operation.
 func setArithmeticOps(e sql.Expression, opScale int32) {
 	if e == nil {
 		return
@@ -304,9 +303,8 @@ func setArithmeticOps(e sql.Expression, opScale int32) {
 	return
 }
 
-// isOutermostDiv return whether the expression we're currently on is
-// the last division operation of all continuous divisions.
-// E.g. the top 'div' (divided by 1) is the outermost/last division that is calculated:
+// isOutermostArithmeticOp return whether the expression we're currently on is
+// the last arithmetic operation of all continuous arithmetic operations.
 func isOutermostArithmeticOp(e sql.Expression, d, dScale int32) bool {
 	if e == nil {
 		return false

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -55,6 +55,7 @@ type ArithmeticOp interface {
 	sql.Expression
 	LeftChild() sql.Expression
 	RightChild() sql.Expression
+	SetOpCount(int32)
 	Operator() string
 }
 
@@ -64,21 +65,20 @@ var _ ArithmeticOp = (*Arithmetic)(nil)
 type Arithmetic struct {
 	BinaryExpression
 	Op string
+	ops int32
 }
 
 // NewArithmetic creates a new Arithmetic sql.Expression.
 func NewArithmetic(left, right sql.Expression, op string) *Arithmetic {
-	return &Arithmetic{BinaryExpression{Left: left, Right: right}, op}
+	a := &Arithmetic{BinaryExpression{Left: left, Right: right}, op, 0}
+	ops := countArithmeticOps(a)
+	setArithmeticOps(a, ops)
+	return a
 }
 
 // NewPlus creates a new Arithmetic + sql.Expression.
 func NewPlus(left, right sql.Expression) *Arithmetic {
 	return NewArithmetic(left, right, sqlparser.PlusStr)
-}
-
-func NewIncrement(left sql.Expression) *Arithmetic {
-	one := NewLiteral(sql.NumericUnaryValue(left.Type()), left.Type())
-	return NewArithmetic(left, one, sqlparser.PlusStr)
 }
 
 // NewMinus creates a new Arithmetic - sql.Expression.
@@ -101,6 +101,10 @@ func (a *Arithmetic) RightChild() sql.Expression {
 
 func (a *Arithmetic) Operator() string {
 	return a.Op
+}
+
+func (a *Arithmetic) SetOpCount(i int32) {
+	a.ops = i
 }
 
 func (a *Arithmetic) String() string {
@@ -267,6 +271,57 @@ func (a *Arithmetic) convertLeftRight(ctx *sql.Context, left interface{}, right 
 func isInterval(expr sql.Expression) bool {
 	_, ok := expr.(*Interval)
 	return ok
+}
+
+// countDivs returns the number of division operators in order on the left child node of the current node.
+// This lets us count how many division operator used one after the other. E.g. 24/3/2/1 will have this structure:
+func countArithmeticOps(e sql.Expression) int32 {
+	if e == nil {
+		return 0
+	}
+
+	if a, ok := e.(ArithmeticOp); ok {
+		return countDivs(a.LeftChild()) + 1
+	}
+
+	return 0
+}
+
+// setDivs will set the innermost node's DivScale to the number counted by countDivs, and the rest of it
+// to 0. This allows us to calculate the first division with the exact precision of the end result. Otherwise,
+// we lose precision at each division since we only add 4 scales at every division operation.
+func setArithmeticOps(e sql.Expression, opScale int32) {
+	if e == nil {
+		return
+	}
+
+	if a, ok := e.(ArithmeticOp); ok {
+		a.SetOpCount(opScale)
+		setDivs(a.LeftChild(), opScale)
+		setDivs(a.RightChild(), opScale)
+	}
+
+	return
+}
+
+// isOutermostDiv return whether the expression we're currently on is
+// the last division operation of all continuous divisions.
+// E.g. the top 'div' (divided by 1) is the outermost/last division that is calculated:
+func isOutermostArithmeticOp(e sql.Expression, d, dScale int32) bool {
+	if e == nil {
+		return false
+	}
+
+	if a, ok := e.(ArithmeticOp); ok {
+		d = d + 1
+		if d == dScale {
+			return true
+		} else {
+			return isOutermostDiv(a.LeftChild(), d, dScale)
+		}
+	}
+
+	return false
 }
 
 // convertValueToType returns given value converted into the given type. If the value is

--- a/sql/expression/bit_ops.go
+++ b/sql/expression/bit_ops.go
@@ -26,9 +26,8 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
-var _ ArithmeticOp = (*BitOp)(nil)
-
 // BitOp expressions include BIT -AND, -OR and -XOR (&, | and ^) operations
+// https://dev.mysql.com/doc/refman/8.0/en/bit-functions.html
 type BitOp struct {
 	BinaryExpression
 	Op string
@@ -62,18 +61,6 @@ func NewShiftLeft(left, right sql.Expression) *BitOp {
 // NewShiftRight creates a new BitOp >> sql.Expression.
 func NewShiftRight(left, right sql.Expression) *BitOp {
 	return NewBitOp(left, right, sqlparser.ShiftRightStr)
-}
-
-func (b *BitOp) LeftChild() sql.Expression {
-	return b.Left
-}
-
-func (b *BitOp) RightChild() sql.Expression {
-	return b.Right
-}
-
-func (b *BitOp) Operator() string {
-	return b.Op
 }
 
 func (b *BitOp) String() string {

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -372,9 +372,9 @@ func countDivs(e sql.Expression) int32 {
 	return 0
 }
 
-// setDivs will set the innermost node's DivScale to the number counted by countDivs, and the rest of it
-// to 0. This allows us to calculate the first division with the exact precision of the end result. Otherwise,
-// we lose precision at each division since we only add 4 scales at every division operation.
+// setDivs will set each node's DivScale to the number counted by countDivs. This allows us to
+// keep track of whether the current Div expression is the last Div operation, so the result is
+// rounded appropriately.
 func setDivs(e sql.Expression, dScale int32) {
 	if e == nil {
 		return

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -43,7 +43,7 @@ var _ ArithmeticOp = (*Div)(nil)
 // Div expression represents "/" arithmetic operation
 type Div struct {
 	BinaryExpression
-
+	ops int32
 	// divScale is number of continuous division operations; this value will be available of all layers
 	divScale int32
 	// leftmostScale is a length of scale of the leftmost value in continuous division operation
@@ -53,9 +53,11 @@ type Div struct {
 
 // NewDiv creates a new Div / sql.Expression.
 func NewDiv(left, right sql.Expression) *Div {
-	a := &Div{BinaryExpression{Left: left, Right: right}, 0, 0, 0}
+	a := &Div{BinaryExpression{Left: left, Right: right}, 0, 0, 0, 0}
 	divs := countDivs(a)
 	setDivs(a, divs)
+	ops := countArithmeticOps(a)
+	setArithmeticOps(a, ops)
 	return a
 }
 
@@ -69,6 +71,10 @@ func (d *Div) RightChild() sql.Expression {
 
 func (d *Div) Operator() string {
 	return sqlparser.DivStr
+}
+
+func (d *Div) SetOpCount(i int32) {
+	d.ops = i
 }
 
 func (d *Div) String() string {
@@ -146,7 +152,10 @@ func (d *Div) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			if finalScale > sql.DecimalTypeMaxScale {
 				finalScale = sql.DecimalTypeMaxScale
 			}
-			return res.Round(finalScale), nil
+			if isOutermostArithmeticOp(d, 0, d.ops) {
+				return res.Round(finalScale), nil
+			}
+			// TODO : need to pass finalScale if this div is the last div but not the last arithmetic op
 		}
 	}
 
@@ -528,11 +537,14 @@ var _ ArithmeticOp = (*IntDiv)(nil)
 // IntDiv expression represents integer "div" arithmetic operation
 type IntDiv struct {
 	BinaryExpression
+	ops int32
 }
 
 // NewIntDiv creates a new IntDiv 'div' sql.Expression.
 func NewIntDiv(left, right sql.Expression) *IntDiv {
-	a := &IntDiv{BinaryExpression{Left: left, Right: right}}
+	a := &IntDiv{BinaryExpression{Left: left, Right: right}, 0}
+	ops := countArithmeticOps(a)
+	setArithmeticOps(a, ops)
 	return a
 }
 
@@ -546,6 +558,10 @@ func (i *IntDiv) RightChild() sql.Expression {
 
 func (i *IntDiv) Operator() string {
 	return sqlparser.IntDivStr
+}
+
+func (i *IntDiv) SetOpCount(i2 int32) {
+	i.ops = i2
 }
 
 func (i *IntDiv) String() string {

--- a/sql/expression/mod.go
+++ b/sql/expression/mod.go
@@ -29,11 +29,15 @@ var _ ArithmeticOp = (*Mod)(nil)
 // Mod expression represents "%" arithmetic operation
 type Mod struct {
 	BinaryExpression
+	ops int32
 }
 
 // NewMod creates a new Mod sql.Expression.
 func NewMod(left, right sql.Expression) *Mod {
-	return &Mod{BinaryExpression{Left: left, Right: right}}
+	a := &Mod{BinaryExpression{Left: left, Right: right}, 0}
+	ops := countArithmeticOps(a)
+	setArithmeticOps(a, ops)
+	return a
 }
 
 func (m *Mod) LeftChild() sql.Expression {
@@ -46,6 +50,10 @@ func (m *Mod) RightChild() sql.Expression {
 
 func (m *Mod) Operator() string {
 	return sqlparser.ModStr
+}
+
+func (m *Mod) SetOpCount(i int32) {
+	m.ops = i
 }
 
 func (m *Mod) String() string {


### PR DESCRIPTION
The result of the query `select 2000.0 / 250000000.0 * (24.0 * 6.0 * 6.25 * 10.0);` is fixed, but the decimal scale is incorrect (made [issue](https://github.com/dolthub/dolt/issues/4931) for it)