### PR TITLE
sqa finalize self before child recursion bug

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -29,6 +29,15 @@ var JoinQueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: `select * from (select y, (select 1 where y = 1) is_one from xy join uv on x = v) sq order by y`,
+		Expected: []sql.Row{
+			{0, nil},
+			{0, nil},
+			{1, 1},
+			{1, 1},
+		},
+	},
+	{
 		Query:    `with cte1 as (select u, v from cte2 join ab on cte2.u = b), cte2 as (select u,v from uv join ab on u = b where u in (2,3)) select * from xy where (x) not in (select u from cte1) order by 1`,
 		Expected: []sql.Row{{0, 2}, {1, 0}, {3, 3}},
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25,6 +25,22 @@ type QueryPlanTest struct {
 // in testgen_test.go.
 var PlanTests = []QueryPlanTest{
 	{
+		Query: `select * from (select y, (select 1 where y = 1) is_one from xy join uv on x = v) sq order by y`,
+		ExpectedPlan: "Sort(sq.y ASC)\n" +
+			" └─ SubqueryAlias(sq)\n" +
+			"     └─ Project\n" +
+			"         ├─ columns: [xy.y, (Project\n" +
+			"         │   ├─ columns: [1]\n" +
+			"         │   └─ Filter(xy.y = 1)\n" +
+			"         │       └─ Table()\n" +
+			"         │  ) as is_one]\n" +
+			"         └─ LookupJoin(xy.x = uv.v)\n" +
+			"             ├─ Table(uv)\n" +
+			"             └─ IndexedTableAccess(xy)\n" +
+			"                 └─ index: [xy.x]\n" +
+			"",
+	},
+	{
 		Query: `select y,(select 1 where y = 1) is_one from xy join uv on x = v;`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [xy.y, (Project\n" +


### PR DESCRIPTION
We must finalize a subquery [/ expression]'s scope before finalizing any child subquery [/expression]. Otherwise, the child may reference invalid parent scope indexes that are not fixed until the parent is finalized.