### PR TITLE
fix sq finalize ordering bug

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -20,6 +20,17 @@ import (
 
 var JoinQueryTests = []QueryTest{
 	{
+		// sqe index lookup must reference schema of outer scope after
+		// join planning reorders (lookup uv xy)
+		Query: `select y, (select 1 from uv where y = 1 and u = x) is_one from xy join uv on x = v order by y;`,
+		Expected: []sql.Row{
+			{0, nil},
+			{0, nil},
+			{1, 1},
+			{1, 1},
+		},
+	},
+	{
 		Query: `select y, (select 1 where y = 1) is_one from xy join uv on x = v order by y`,
 		Expected: []sql.Row{
 			{0, nil},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -39,9 +39,9 @@ var PlanTests = []QueryPlanTest{
 			"         ├─ Table(uv)\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             └─ index: [xy.x]\n" +
-            "",
-    },
-    {
+			"",
+	},
+	{
 		Query: `select * from (select y, (select 1 where y = 1) is_one from xy join uv on x = v) sq order by y`,
 		ExpectedPlan: "Sort(sq.y ASC)\n" +
 			" └─ SubqueryAlias(sq)\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25,6 +25,23 @@ type QueryPlanTest struct {
 // in testgen_test.go.
 var PlanTests = []QueryPlanTest{
 	{
+		Query: `select y, (select 1 from uv where y = 1 and u = x) is_one from xy join uv on x = v order by y;`,
+		ExpectedPlan: "Sort(xy.y ASC)\n" +
+			" └─ Project\n" +
+			"     ├─ columns: [xy.y, (Project\n" +
+			"     │   ├─ columns: [1]\n" +
+			"     │   └─ Filter((xy.y = 1) AND (uv.u = xy.x))\n" +
+			"     │       └─ IndexedTableAccess(uv)\n" +
+			"     │           ├─ index: [uv.u]\n" +
+			"     │           └─ columns: [u]\n" +
+			"     │  ) as is_one]\n" +
+			"     └─ LookupJoin(xy.x = uv.v)\n" +
+			"         ├─ Table(uv)\n" +
+			"         └─ IndexedTableAccess(xy)\n" +
+			"             └─ index: [xy.x]\n" +
+			"",
+	},
+	{
 		Query: `select y,(select 1 where y = 1) is_one from xy join uv on x = v;`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [xy.y, (Project\n" +
@@ -45,7 +62,8 @@ var PlanTests = []QueryPlanTest{
 			"     └─ Project\n" +
 			"         ├─ columns: [mytable.i]\n" +
 			"         └─ Table(mytable)\n" +
-			"             └─ columns: [i s]\n",
+			"             └─ columns: [i s]\n" +
+			"",
 	},
 	{
 		Query: `
@@ -443,8 +461,7 @@ inner join pq on true
 			"     ├─ TableAlias(a)\n" +
 			"     │   └─ Table(mytable)\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.i]\n" +
+			"         └─ Table(mytable)\n" +
 			"             └─ columns: [i]\n" +
 			"",
 	},
@@ -456,8 +473,7 @@ inner join pq on true
 			"     ├─ TableAlias(a)\n" +
 			"     │   └─ Table(mytable)\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.i]\n" +
+			"         └─ Table(mytable)\n" +
 			"             └─ columns: [i]\n" +
 			"",
 	},
@@ -2968,9 +2984,10 @@ inner join pq on true
 		AND (SELECT i2 FROM othertable where i2 = i) IS NOT NULL`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [mt.i]\n" +
-			" └─ Filter((NOT((Filter((mytable.i = mt.i) AND (mytable.i > 2))\n" +
+			" └─ Filter((NOT((Filter(mytable.i = mt.i)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
+			"         ├─ filters: [{(2, ∞)}]\n" +
 			"         └─ columns: [i]\n" +
 			"    ) IS NULL)) AND (NOT((Filter(othertable.i2 = mt.i)\n" +
 			"     └─ IndexedTableAccess(othertable)\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -39,6 +39,9 @@ var PlanTests = []QueryPlanTest{
 			"         ├─ Table(uv)\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             └─ index: [xy.x]\n" +
+            "",
+    },
+    {
 		Query: `select * from (select y, (select 1 where y = 1) is_one from xy join uv on x = v) sq order by y`,
 		ExpectedPlan: "Sort(sq.y ASC)\n" +
 			" └─ SubqueryAlias(sq)\n" +

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -382,7 +382,8 @@ func NewResolveSubqueryExprSelector(sel RuleSelector) RuleSelector {
 			applyHashLookupsId,
 			finalizeSubqueriesId,
 			parallelizeId,
-			pushdownFiltersId:
+			pushdownFiltersId,
+			subqueryIndexesId:
 			return false
 		}
 		return sel(id)
@@ -392,7 +393,7 @@ func NewResolveSubqueryExprSelector(sel RuleSelector) RuleSelector {
 func NewFinalizeNestedSubquerySel(sel RuleSelector) RuleSelector {
 	return func(id RuleId) bool {
 		switch id {
-		case pruneColumnsId, optimizeJoinsId, setJoinScopeLenId, applyHashLookupsId, pushdownFiltersId:
+		case pruneColumnsId, optimizeJoinsId, setJoinScopeLenId, applyHashLookupsId, pushdownFiltersId, subqueryIndexesId:
 			return true
 		case finalizeSubqueriesId:
 			// Don't run finalizeSubqueries on subqueries, since calling it on the root of the statement will


### PR DESCRIPTION
Transform table + filter into table lookup in a subquery expression should happen in `finalizeSubquery`, not in `resolveSubquery`. Otherwise we will push a filter with a GetField index that could be rearranged when the parent scope is finalized.