### PR TITLE
fixes bug where TIMEDIFF wasn't returning null when given null

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1105,6 +1105,18 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query:    "SELECT TIMEDIFF(null, '2017-11-30 22:59:59');",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT DATEDIFF('2019/12/28', null);",
+		Expected: []sql.Row{{nil}},
+	},
+	{
+		Query:    "SELECT TIMESTAMPDIFF(SECOND, null, '2007-12-31 00:00:00');",
+		Expected: []sql.Row{{nil}},
+	},
+	{
 		Query: `SELECT JSON_MERGE_PRESERVE('{ "a": 1, "b": 2 }','{ "a": 3, "c": 4 }','{ "a": 5, "d": 6 }')`,
 		Expected: []sql.Row{
 			{sql.MustJSON(`{"a": [1, 3, 5], "b": 2, "c": 4, "d": 6}`)},

--- a/sql/expression/function/timediff.go
+++ b/sql/expression/function/timediff.go
@@ -56,9 +56,6 @@ func (td *TimeDiff) Description() string {
 // Type implements the Expression interface.
 func (td *TimeDiff) Type() sql.Type { return sql.Time }
 
-// IsNullable implements the Expression interface.
-func (td *TimeDiff) IsNullable() bool { return false }
-
 func (td *TimeDiff) String() string {
 	return fmt.Sprintf("TIMEDIFF(%s, %s)", td.Left, td.Right)
 }
@@ -85,6 +82,10 @@ func convToDateOrTime(val interface{}) (interface{}, error) {
 
 // Eval implements the Expression interface.
 func (td *TimeDiff) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	if td.Left == nil || td.Right == nil {
+		return nil, nil
+	}
+
 	left, err := td.Left.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -165,21 +166,6 @@ func (d *DateDiff) Description() string {
 	return "gets difference between two dates in result of days."
 }
 
-// Children implements the sql.Expression interface.
-func (d *DateDiff) Children() []sql.Expression {
-	return []sql.Expression{d.Left, d.Right}
-}
-
-// Resolved implements the sql.Expression interface.
-func (d *DateDiff) Resolved() bool {
-	return d.Left.Resolved() && d.Right.Resolved()
-}
-
-// IsNullable implements the sql.Expression interface.
-func (d *DateDiff) IsNullable() bool {
-	return d.Left.IsNullable() && d.Right.IsNullable()
-}
-
 // Type implements the sql.Expression interface.
 func (d *DateDiff) Type() sql.Type { return sql.Int64 }
 
@@ -193,6 +179,10 @@ func (d *DateDiff) WithChildren(children ...sql.Expression) (sql.Expression, err
 
 // Eval implements the sql.Expression interface.
 func (d *DateDiff) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	if d.Left == nil || d.Right == nil {
+		return nil, nil
+	}
+
 	expr1, err := d.Left.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -289,6 +279,13 @@ func (t *TimestampDiff) WithChildren(children ...sql.Expression) (sql.Expression
 
 // Eval implements the sql.Expression interface.
 func (t *TimestampDiff) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	if t.unit == nil {
+		return nil, errors.NewKind("unit cannot be null").New(t.unit)
+	}
+	if t.expr1 == nil || t.expr2 == nil {
+		return nil, nil
+	}
+
 	expr1, err := t.expr1.Eval(ctx, row)
 	if err != nil {
 		return nil, err
@@ -320,7 +317,7 @@ func (t *TimestampDiff) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 		return nil, err
 	}
 	if unit == nil {
-		return nil, nil
+		return nil, errors.NewKind("unit cannot be null").New(unit)
 	}
 
 	unit = strings.TrimPrefix(strings.ToLower(unit.(string)), "sql_tsi_")

--- a/sql/expression/function/timediff_test.go
+++ b/sql/expression/function/timediff_test.go
@@ -126,6 +126,27 @@ func TestTimeDiff(t *testing.T) {
 			toTimespan("-24:00:00"),
 			false,
 		},
+		{
+			"first argument is null",
+			nil,
+			expression.NewLiteral("2008-12-30 00:00:00", sql.Text),
+			nil,
+			false,
+		},
+		{
+			"second argument is null",
+			expression.NewLiteral("2008-12-30 00:00:00", sql.Text),
+			nil,
+			nil,
+			false,
+		},
+		{
+			"both arguments are null",
+			nil,
+			nil,
+			nil,
+			false,
+		},
 	}
 
 	for _, tt := range testCases {
@@ -165,6 +186,9 @@ func TestDateDiff(t *testing.T) {
 		{"text types, format with /", sql.Text, sql.Text, sql.NewRow("2007/12/22", "2007/12/20"), int64(2), nil},
 		{"text types, positive result", sql.Text, sql.Text, sql.NewRow("2007-12-31", "2007-12-29 23:59:59"), int64(2), nil},
 		{"text types, negative result", sql.Text, sql.Text, sql.NewRow("2010-11-02", "2010-11-30 23:59:59"), int64(-28), nil},
+		{"first argument is null", sql.Text, sql.Text, sql.NewRow(nil, "2010-11-02"), nil, nil},
+		{"second argument is null", sql.Text, sql.Text, sql.NewRow("2010-11-02", nil), nil, nil},
+		{"both arguments are null", sql.Text, sql.Text, sql.NewRow(nil, nil), nil, nil},
 	}
 
 	for _, tt := range testCases {
@@ -227,6 +251,10 @@ func TestTimestampDiff(t *testing.T) {
 		{"year", sql.Text, sql.Text, sql.Text, sql.NewRow("YEAR", "2016-09-04 00:00:01", "2021-09-04 00:00:00"), int64(4), false},
 		{"year - ", sql.Text, sql.Text, sql.Text, sql.NewRow("YEAR", "2016-09-04 01:00:01", "2021-09-04 02:00:02"), int64(5), false},
 		{"year - negative", sql.Text, sql.Text, sql.Text, sql.NewRow("SQL_TSI_YEAR", "2016-09-05 00:00:00", "2006-09-04 23:59:59"), int64(-10), false},
+		{"unit is null", sql.Text, sql.Text, sql.Text, sql.NewRow(nil, "2016-09-05 00:00:00", "2006-09-04 23:59:59"), nil, true},
+		{"first timestamp is null", sql.Text, sql.Text, sql.Text, sql.NewRow("YEAR", nil, "2021-09-04 02:00:02"), nil, false},
+		{"second timestamp is null", sql.Text, sql.Text, sql.Text, sql.NewRow("YEAR", "2016-09-04 00:00:01", nil), nil, false},
+		{"both timestamps are null", sql.Text, sql.Text, sql.Text, sql.NewRow("YEAR", nil, nil), nil, false},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
- added unit tests for null arguments for TIMEDIFF
- added unit tests for null arguments for DATEDIFF
- updated TIMESTAMPDIFF to throw an error when given a `null` unit
- added unit tests for null arguments for TIMESTAMPDIFF 