### PR TITLE
bringing back assert prepared

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -132,10 +132,7 @@ func TestScriptWithEnginePrepared(t *testing.T, e *sqle.Engine, harness Harness,
 				t.Skip()
 			}
 		}
-		// TODO: why prepare set up queries?
 		RunQueryWithContext(t, e, harness, ctx, statement)
-		//_, _, err := runQueryPreparedWithCtx(t, ctx, e, statement)
-		//require.NoError(t, err)
 		validateEngine(t, ctx, harness, e)
 	}
 

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -160,11 +160,11 @@ func TestScriptWithEnginePrepared(t *testing.T, e *sqle.Engine, harness Harness,
 
 		if assertion.ExpectedErr != nil {
 			t.Run(assertion.Query, func(t *testing.T) {
-				AssertErr(t, e, harness, assertion.Query, assertion.ExpectedErr)
+				AssertErrPrepared(t, e, harness, assertion.Query, assertion.ExpectedErr)
 			})
 		} else if assertion.ExpectedErrStr != "" {
 			t.Run(assertion.Query, func(t *testing.T) {
-				AssertErr(t, e, harness, assertion.Query, nil, assertion.ExpectedErrStr)
+				AssertErrPrepared(t, e, harness, assertion.Query, nil, assertion.ExpectedErrStr)
 			})
 		} else if assertion.ExpectedWarning != 0 {
 			t.Run(assertion.Query, func(t *testing.T) {
@@ -623,6 +623,27 @@ func AssertErrWithCtx(t *testing.T, e *sqle.Engine, harness Harness, ctx *sql.Co
 	if err == nil {
 		_, err = sql.RowIterToRows(ctx, sch, iter)
 	}
+	require.Error(t, err)
+	if expectedErrKind != nil {
+		err = sql.UnwrapError(err)
+		require.True(t, expectedErrKind.Is(err), "Expected error of type %s but got %s", expectedErrKind, err)
+	}
+	// If there are multiple error strings then we only match against the first
+	if len(errStrs) >= 1 {
+		require.Equal(t, errStrs[0], err.Error())
+	}
+	validateEngine(t, ctx, harness, e)
+}
+
+// AssertErrPrepared asserts that the given query returns an error during its execution, optionally specifying a type of error.
+func AssertErrPrepared(t *testing.T, e *sqle.Engine, harness Harness, query string, expectedErrKind *errors.Kind, errStrs ...string) {
+	AssertErrPreparedWithCtx(t, e, harness, NewContext(harness), query, expectedErrKind, errStrs...)
+}
+
+// AssertErrPreparedWithCtx is the same as AssertErr, but uses the context given instead of creating one from a harness
+func AssertErrPreparedWithCtx(t *testing.T, e *sqle.Engine, harness Harness, ctx *sql.Context, query string, expectedErrKind *errors.Kind, errStrs ...string) {
+	ctx = ctx.WithQuery(query)
+	_, _, err := runQueryPreparedWithCtx(t, ctx, e, query)
 	require.Error(t, err)
 	if expectedErrKind != nil {
 		err = sql.UnwrapError(err)

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -132,8 +132,10 @@ func TestScriptWithEnginePrepared(t *testing.T, e *sqle.Engine, harness Harness,
 				t.Skip()
 			}
 		}
-		_, _, err := runQueryPreparedWithCtx(t, ctx, e, statement)
-		require.NoError(t, err)
+		// TODO: why prepare set up queries?
+		RunQueryWithContext(t, e, harness, ctx, statement)
+		//_, _, err := runQueryPreparedWithCtx(t, ctx, e, statement)
+		//require.NoError(t, err)
 		validateEngine(t, ctx, harness, e)
 	}
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -189,13 +189,14 @@ func TestSingleScript(t *testing.T) {
 		{
 			Name: "DELETE ME",
 			SetUpScript: []string{
-				"create table t (o_id int, attribute longtext, value longtext)",
-				"INSERT INTO t VALUES (2, 'color', 'red'), (2, 'fabric', 'silk')",
+				"create table numbers (val int);",
+				"insert into numbers values (1), (2), (3);",
+				"insert into numbers values (2), (4);",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:       `SELECT group_concat((SELECT * FROM t LIMIT 1)) from t`,
-					ExpectedErr: sql.ErrInvalidOperandColumns,
+					Query:    "select t1.val as a from numbers as t1 group by 1 having a = t1.val;",
+					Expected: []sql.Row{{1}, {2}, {3}, {4}},
 				},
 			},
 		},
@@ -220,13 +221,14 @@ func TestSingleScriptPrepared(t *testing.T) {
 	var script = queries.ScriptTest{
 		Name: "DELETE ME",
 		SetUpScript: []string{
-			"create table t (o_id int, attribute longtext, value longtext)",
-			"INSERT INTO t VALUES (2, 'color', 'red'), (2, 'fabric', 'silk')",
+			"create table numbers (val int);",
+			"insert into numbers values (1), (2), (3);",
+			"insert into numbers values (2), (4);",
 		},
 		Assertions: []queries.ScriptTestAssertion{
 			{
-				Query:       `SELECT group_concat((SELECT * FROM t LIMIT 1)) from t`,
-				ExpectedErr: sql.ErrInvalidOperandColumns,
+				Query:    "select t1.val as a from numbers as t1 group by 1 having a = t1.val;",
+				Expected: []sql.Row{{1}, {2}, {3}, {4}},
 			},
 		},
 	}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -187,16 +187,12 @@ func TestSingleScript(t *testing.T) {
 
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "DELETE ME",
-			SetUpScript: []string{
-				"create table numbers (val int);",
-				"insert into numbers values (1), (2), (3);",
-				"insert into numbers values (2), (4);",
-			},
+			Name:        "DELETE ME",
+			SetUpScript: []string{},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "select t1.val as a from numbers as t1 group by 1 having a = t1.val;",
-					Expected: []sql.Row{{1}, {2}, {3}, {4}},
+					Query:    `SELECT i AS i FROM mytable GROUP BY s ORDER BY 1`,
+					Expected: []sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 				},
 			},
 		},
@@ -204,6 +200,7 @@ func TestSingleScript(t *testing.T) {
 
 	for _, test := range scripts {
 		harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
+		harness.Setup(setup.SimpleSetup...)
 		engine, err := harness.NewEngine(t)
 		if err != nil {
 			panic(err)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -183,27 +183,19 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "create table as select distinct",
+			Name: "DELETE ME",
 			SetUpScript: []string{
-				"CREATE TABLE t1 (a int, b varchar(10));",
-				"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
+				"create table t (o_id int, attribute longtext, value longtext)",
+				"INSERT INTO t VALUES (2, 'color', 'red'), (2, 'fabric', 'silk')",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "create table t2 as select distinct b, a from t1;",
-					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
-				},
-				{
-					Query: "select * from t2 order by a;",
-					Expected: []sql.Row{
-						{"a", 1},
-						{"b", 2},
-						{"c", 3},
-					},
+					Query:       `SELECT group_concat((SELECT * FROM t LIMIT 1)) from t`,
+					ExpectedErr: sql.ErrInvalidOperandColumns,
 				},
 			},
 		},
@@ -215,11 +207,36 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		engine.Analyzer.Debug = true
-		engine.Analyzer.Verbose = true
+		//engine.Analyzer.Debug = true
+		//engine.Analyzer.Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
+}
+
+// Convenience test for debugging a single query. Unskip and set to the desired query.
+func TestSingleScriptPrepared(t *testing.T) {
+	//t.Skip()
+	var script = queries.ScriptTest{
+		Name: "DELETE ME",
+		SetUpScript: []string{
+			"create table t (o_id int, attribute longtext, value longtext)",
+			"INSERT INTO t VALUES (2, 'color', 'red'), (2, 'fabric', 'silk')",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:       `SELECT group_concat((SELECT * FROM t LIMIT 1)) from t`,
+				ExpectedErr: sql.ErrInvalidOperandColumns,
+			},
+		},
+	}
+	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
+	engine, err := harness.NewEngine(t)
+	if err != nil {
+		panic(err)
+	}
+	enginetest.TestScriptWithEnginePrepared(t, engine, harness, script)
+	//enginetest.TestScriptWithEngine(t, engine, harness, script)
 }
 
 func TestUnbuildableIndex(t *testing.T) {

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -820,7 +820,7 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:    "select max(pk),c2 from one_pk group by c1 order by 1",
+		Query:    "select max(pk),c1+1 from one_pk group by c1 order by 1",
 		Expected: []sql.Row{{0, 1}, {1, 11}, {2, 21}, {3, 31}},
 	},
 	{
@@ -5292,11 +5292,11 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
-		Query:    `SELECT i AS i FROM mytable GROUP BY s ORDER BY 1`,
+		Query:    `SELECT i AS i FROM mytable GROUP BY i, s ORDER BY 1`,
 		Expected: []sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
-		Query:    `SELECT i AS x FROM mytable GROUP BY s ORDER BY x`,
+		Query:    `SELECT i AS x FROM mytable GROUP BY i, s ORDER BY x`,
 		Expected: []sql.Row{{int64(1)}, {int64(2)}, {int64(3)}},
 	},
 	{
@@ -5350,7 +5350,7 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{"secon"}},
 	},
 	{
-		Query: "SELECT s,  i FROM mytable GROUP BY i ORDER BY SUBSTRING(s, 1, 1) DESC",
+		Query: "SELECT s, i FROM mytable GROUP BY i ORDER BY SUBSTRING(s, 1, 1) DESC",
 		Expected: []sql.Row{
 			{string("third row"), int64(3)},
 			{string("second row"), int64(2)},

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -439,17 +439,20 @@ func prePrepareRuleSelector(id RuleId) bool {
 		resolvePreparedInsertId,
 
 		// DefaultValidation
-		validateResolvedId,
-		validateOrderById,
 		validateGroupById,
-		validateSchemaSourceId,
-		validateIndexCreationId,
-		validateOperandsId,
-		validateIntervalUsageId,
-		validateSubqueryColumnsId,
-		validateUnionSchemasMatchId,
-		validateAggregationsId,
-		validateExplodeUsageId,
+
+
+		//validateResolvedId,
+		//validateOrderById,
+
+		//validateSchemaSourceId,
+		//validateIndexCreationId,
+		//validateOperandsId,
+		//validateIntervalUsageId,
+		//validateSubqueryColumnsId,
+		//validateUnionSchemasMatchId,
+		//validateAggregationsId,
+		//validateExplodeUsageId,
 
 		// OnceAfterAll
 		TrackProcessId:
@@ -500,6 +503,7 @@ func postPrepareRuleSelector(id RuleId) bool {
 
 		// DefaultValidationRules
 		validateOperandsId,
+		validateGroupById,
 
 		// OnceAfterAll
 		TrackProcessId:

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -439,6 +439,7 @@ func prePrepareRuleSelector(id RuleId) bool {
 		resolvePreparedInsertId,
 
 		// DefaultValidation
+		validateResolvedId,
 		validateGroupById,
 		validateUnionSchemasMatchId,
 		validateOperandsId,
@@ -491,6 +492,7 @@ func postPrepareRuleSelector(id RuleId) bool {
 		resolvePreparedInsertId,
 
 		// DefaultValidationRules
+		validateResolvedId,
 		validateGroupById,
 		validateOperandsId,
 		//validateUnionSchemasMatchId, // TODO: we never validate UnionSchemasMatchId :)

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -441,6 +441,7 @@ func prePrepareRuleSelector(id RuleId) bool {
 		// DefaultValidation
 		validateGroupById,
 		validateUnionSchemasMatchId,
+		validateOperandsId,
 
 		// OnceAfterAll
 		TrackProcessId:
@@ -490,8 +491,9 @@ func postPrepareRuleSelector(id RuleId) bool {
 		resolvePreparedInsertId,
 
 		// DefaultValidationRules
-		validateOperandsId,
 		validateGroupById,
+		validateOperandsId,
+		//validateUnionSchemasMatchId, // TODO: we never validate UnionSchemasMatchId :)
 
 		// OnceAfterAll
 		TrackProcessId:

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -440,18 +440,7 @@ func prePrepareRuleSelector(id RuleId) bool {
 
 		// DefaultValidation
 		validateGroupById,
-
-		//validateResolvedId,
-		//validateOrderById,
-
-		//validateSchemaSourceId,
-		//validateIndexCreationId,
-		//validateOperandsId,
-		//validateIntervalUsageId,
-		//validateSubqueryColumnsId,
-		//validateUnionSchemasMatchId,
-		//validateAggregationsId,
-		//validateExplodeUsageId,
+		validateUnionSchemasMatchId,
 
 		// OnceAfterAll
 		TrackProcessId:

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -499,6 +499,7 @@ func postPrepareRuleSelector(id RuleId) bool {
 		resolvePreparedInsertId,
 
 		// DefaultValidationRules
+		validateOperandsId,
 
 		// OnceAfterAll
 		TrackProcessId:

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -245,9 +245,7 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, se
 		}
 
 		switch parent.(type) {
-		case *plan.Having:
-			return true
-		case *plan.Project, *plan.Sort:
+		case *plan.Having, *plan.Project, *plan.Sort:
 			// TODO: these shouldn't be skipped; you can group by primary key without problem b/c only one value
 			// https://dev.mysql.com/doc/refman/8.0/en/group-by-handling.html#:~:text=The%20query%20is%20valid%20if%20name%20is%20a%20primary%20key
 			return true

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -235,37 +235,43 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, se
 	var err error
 	var parent sql.Node
 	transform.Inspect(n, func(n sql.Node) bool {
-		if gb, ok := n.(*plan.GroupBy); ok {
-			if _, ok := parent.(*plan.Having); ok {
-				return true
-			}
-			if _, ok := parent.(*plan.Project); ok {
-				return true
-			}
-			if _, ok := parent.(*plan.Sort); ok {
-				return true
-			}
-			// Allow the parser use the GroupBy node to eval the aggregation functions
-			// for sql statements that don't make use of the GROUP BY expression.
-			if len(gb.GroupByExprs) == 0 {
-				return true
-			}
+		defer func() {
+			parent = n
+		}()
 
-			var groupBys []string
-			for _, expr := range gb.GroupByExprs {
-				groupBys = append(groupBys, expr.String())
-			}
+		gb, ok := n.(*plan.GroupBy)
+		if !ok {
+			return true
+		}
 
-			for _, expr := range gb.SelectedExprs {
-				if _, ok := expr.(sql.Aggregation); !ok {
-					if !expressionReferencesOnlyGroupBys(groupBys, expr) {
-						err = ErrValidationGroupBy.New(expr.String())
-						return false
-					}
+		switch parent.(type) {
+		case *plan.Having:
+			return true
+		case *plan.Project, *plan.Sort:
+			// TODO: these shouldn't be skipped; you can group by primary key without problem b/c only one value
+			// https://dev.mysql.com/doc/refman/8.0/en/group-by-handling.html#:~:text=The%20query%20is%20valid%20if%20name%20is%20a%20primary%20key
+			return true
+		}
+
+		// Allow the parser use the GroupBy node to eval the aggregation functions
+		// for sql statements that don't make use of the GROUP BY expression.
+		if len(gb.GroupByExprs) == 0 {
+			return true
+		}
+
+		var groupBys []string
+		for _, expr := range gb.GroupByExprs {
+			groupBys = append(groupBys, expr.String())
+		}
+
+		for _, expr := range gb.SelectedExprs {
+			if _, ok := expr.(sql.Aggregation); !ok {
+				if !expressionReferencesOnlyGroupBys(groupBys, expr) {
+					err = ErrValidationGroupBy.New(expr.String())
+					return false
 				}
 			}
 		}
-		parent = n
 		return true
 	})
 

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -239,6 +239,12 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, se
 			if _, ok := parent.(*plan.Having); ok {
 				return true
 			}
+			if _, ok := parent.(*plan.Project); ok {
+				return true
+			}
+			if _, ok := parent.(*plan.Sort); ok {
+				return true
+			}
 			// Allow the parser use the GroupBy node to eval the aggregation functions
 			// for sql statements that don't make use of the GROUP BY expression.
 			if len(gb.GroupByExprs) == 0 {

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -284,6 +284,9 @@ func (e *Equals) WithChildren(children ...sql.Expression) (sql.Expression, error
 }
 
 func (e *Equals) String() string {
+	if e == nil {
+		return ""
+	}
 	return fmt.Sprintf("(%s = %s)", e.Left(), e.Right())
 }
 


### PR DESCRIPTION
For some reason, I deleted `AssertErrPrepared`, which  allowed many tests to incorrectly pass.
This PR adds that back and fixes the failing tests. 
There were a couple validation rules that were never run, which seems wrong (`validateUnionSchemasMatch` is still never run for prepared queries).
I also added a helper `TestSingleScriptPrepared` to more easily debug prepared script tests

There are prepared tests in dolt that also fail because of these changes, so I also had to fix them
Companion PR: https://github.com/dolthub/dolt/pull/4968
