### PR TITLE
aggregation: add support for constant aggregations

### DIFF
--- a/sql/expression/function/aggregation/const_test.go
+++ b/sql/expression/function/aggregation/const_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020-2021 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+func TestConst(t *testing.T) {
+	testCases := []struct {
+		name     string
+		rows     []sql.Row
+		expected interface{}
+	}{
+		{"no rows", nil, "const"},
+		{"one row", []sql.Row{{"first"}}, "const"},
+		{"three rows", []sql.Row{{"first"}, {"second"}, {"last"}}, "const"},
+	}
+
+	agg := NewConst(expression.NewLiteral("const", sql.Text))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			result := aggregate(t, agg, tt.rows...)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/sql/expression/function/aggregation/unary_agg_buffers.go
+++ b/sql/expression/function/aggregation/unary_agg_buffers.go
@@ -166,6 +166,30 @@ func (l *lastBuffer) Dispose() {
 	expression.Dispose(l.expr)
 }
 
+type constBuffer struct {
+	expr sql.Expression
+}
+
+func NewConstBuffer(child sql.Expression) *constBuffer {
+	return &constBuffer{child}
+}
+
+// Update implements the AggregationBuffer interface.
+func (l *constBuffer) Update(*sql.Context, sql.Row) error {
+	// noop
+	return nil
+}
+
+// Eval implements the AggregationBuffer interface.
+func (l *constBuffer) Eval(ctx *sql.Context) (interface{}, error) {
+	return l.expr.Eval(ctx, nil)
+}
+
+// Dispose implements the Disposable interface.
+func (l *constBuffer) Dispose() {
+	expression.Dispose(l.expr)
+}
+
 type avgBuffer struct {
 	sum  *sumBuffer // sum is either decimal.Decimal or float64
 	rows int64

--- a/sql/expression/function/aggregation/unary_aggs.go
+++ b/sql/expression/function/aggregation/unary_aggs.go
@@ -31,6 +31,10 @@ var UnaryAggDefs support.GenDefs = []support.AggDef{ // alphabetically sorted
 		RetType: "sql.Uint64",
 	},
 	{
+		Name: "Const",
+		Desc: "returns a constant value regardless of the sequence of elements of an aggregation",
+	},
+	{
 		Name:    "Count",
 		Desc:    "returns a count of the number of non-NULL values of expr in the rows retrieved by a SELECT statement.",
 		RetType: "sql.Int64",

--- a/sql/expression/function/aggregation/unary_aggs.og.go
+++ b/sql/expression/function/aggregation/unary_aggs.og.go
@@ -306,6 +306,62 @@ func (a *BitXor) NewWindowFunction() (sql.WindowFunction, error) {
 	return NewBitXorAgg(child).WithWindow(a.Window())
 }
 
+type Const struct {
+	unaryAggBase
+}
+
+var _ sql.FunctionExpression = (*Const)(nil)
+var _ sql.Aggregation = (*Const)(nil)
+var _ sql.WindowAdaptableExpression = (*Const)(nil)
+
+func NewConst(e sql.Expression) *Const {
+	return &Const{
+		unaryAggBase{
+			UnaryExpression: expression.UnaryExpression{Child: e},
+			functionName:    "Const",
+			description:     "returns a constant value regardless of the sequence of elements of an aggregation",
+		},
+	}
+}
+
+func (a *Const) Type() sql.Type {
+	return a.Child.Type()
+}
+
+func (a *Const) IsNullable() bool {
+	return false
+}
+
+func (a *Const) String() string {
+	return fmt.Sprintf("CONST(%s)", a.Child)
+}
+
+func (a *Const) WithWindow(window *sql.WindowDefinition) (sql.Aggregation, error) {
+	res, err := a.unaryAggBase.WithWindow(window)
+	return &Const{unaryAggBase: *res.(*unaryAggBase)}, err
+}
+
+func (a *Const) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	res, err := a.unaryAggBase.WithChildren(children...)
+	return &Const{unaryAggBase: *res.(*unaryAggBase)}, err
+}
+
+func (a *Const) NewBuffer() (sql.AggregationBuffer, error) {
+	child, err := transform.Clone(a.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewConstBuffer(child), nil
+}
+
+func (a *Const) NewWindowFunction() (sql.WindowFunction, error) {
+	child, err := transform.Clone(a.Child)
+	if err != nil {
+		return nil, err
+	}
+	return NewConstAgg(child).WithWindow(a.Window())
+}
+
 type Count struct {
 	unaryAggBase
 }

--- a/sql/plan/group_by_test.go
+++ b/sql/plan/group_by_test.go
@@ -157,6 +157,35 @@ func TestGroupByAggregationGrouping(t *testing.T) {
 	require.Equal(expected, rows)
 }
 
+func TestGroupByLiterals(t *testing.T) {
+	require := require.New(t)
+	ctx := sql.NewEmptyContext()
+
+	childSchema := sql.Schema{
+		{Name: "col1", Type: sql.LongText},
+	}
+
+	child := memory.NewTable("test", sql.NewPrimaryKeySchema(childSchema), nil)
+
+	p := NewGroupBy(
+		[]sql.Expression{
+			aggregation.NewConst(expression.NewLiteral(int64(420), sql.Int64)),
+			aggregation.NewCount(expression.NewGetField(0, sql.LongText, "col1", true)),
+		},
+		nil,
+		NewResolvedTable(child, nil, nil),
+	)
+
+	rows, err := sql.NodeToRows(ctx, p)
+	require.NoError(err)
+
+	expected := []sql.Row{
+		{int64(420), int64(0)},
+	}
+
+	require.Equal(expected, rows)
+}
+
 func BenchmarkGroupBy(b *testing.B) {
 	table := benchmarkTable(b)
 


### PR DESCRIPTION
Hey doltfriends! Here's a bug report and a (potential) fix I'd like to discuss.

The issue exists in non-aggregated expressions inside an aggregation. `go-mysql-server` currently implements the non-aggregated columns using "first" semantics (i.e. the first value seen in any of the scanned rows), which is MySQL-compatible... as long as there are rows to scan!

Consider this very simple SQL query:

```sql
SELECT 420, count(*) from test
```

If the underlying `test` table is empty, `go-mysql-server` returns `NULL, 0`, an obviously incorrect result that doesn't match MySQL's. The issue is that the aggregator buffer for the first column is never updated, because no rows have been scanned, so its evaluated result is `nil`. The `First` semantics do not apply here because the selected expression is constant, not sourced from any of the underlying rows in the table; with no underlying rows, the `420` expression is simply not evaluated.

How to fix this? Here's a proposed solution that implements a new `Const` aggregator. The `Const` aggregator is initialized with a constant expression, and evaluating it always returns the result of evaluating this expression -- regardless of how many rows have been scanned.

I think this is an elegant solution. The only thing I'm unsure about is the code in `group_by.go` `newAggregationBuffer` that decides on the type of the aggregation buffer. Here, we need to return a `Const` buffer for constant expressions, but there's no clear API that can take an `sql.Expression` and verify whether its constant. I've worked around it by evaluating the expression with a `nil` row, which can only succeed for constant expressions, but I don't love the solution.

I would love to hear your thoughts on this fix! Thanks in advance!