### PR TITLE
Fixed stored procedure panics

### DIFF
--- a/enginetest/queries/external_procedure_queries.go
+++ b/enginetest/queries/external_procedure_queries.go
@@ -18,7 +18,7 @@ import "github.com/dolthub/go-mysql-server/sql"
 
 var ExternalProcedureTests = []ScriptTest{
 	{
-		Name: "call external stored procedure that does not exist",
+		Name: "Call external stored procedure that does not exist",
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:       "CALL procedure_does_not_exist('foo');",
@@ -36,6 +36,30 @@ var ExternalProcedureTests = []ScriptTest{
 			{
 				Query:    "SELECT @outparam;",
 				Expected: []sql.Row{{16}},
+			},
+		},
+	},
+	{
+		Name: "Handle setting uninitialized user variables",
+		SetUpScript: []string{
+			"CALL memory_inout_set_unitialized(@uservar12, @uservar13, @uservar14, @uservar15);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT @uservar12;",
+				Expected: []sql.Row{{5}},
+			},
+			{
+				Query:    "SELECT @uservar13;",
+				Expected: []sql.Row{{uint(5)}},
+			},
+			{
+				Query:    "SELECT @uservar14;",
+				Expected: []sql.Row{{"5"}},
+			},
+			{
+				Query:    "SELECT @uservar15;",
+				Expected: []sql.Row{{0}},
 			},
 		},
 	},
@@ -80,6 +104,11 @@ var ExternalProcedureTests = []ScriptTest{
 				Query: "CALL memory_overloaded_type_test(false, 'hi', 'A', '2020-02-20 12:00:00', 123.456," +
 					"true, 'bye', 'B', '2022-02-02 12:00:00', 654.32);",
 				Expected: []sql.Row{{`aa:false,ba:true,ab:"hi",bb:"bye",ac:[65],bc:[66],ad:2020-02-20,bd:2022-02-02,ae:123.456,be:654.32`}},
+			},
+			{
+				Query: "CALL memory_type_test3(1, 100, 10000, 1000000, 100000000, 3, 300," +
+					"10, 1000, 100000, 10000000, 1000000000, 30, 3000);",
+				Expected: []sql.Row{{uint64(1111114444)}},
 			},
 		},
 	},

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1031,6 +1031,71 @@ END;`,
 		},
 	},
 	{
+		Name: "Handle setting an uninitialized user variable",
+		SetUpScript: []string{
+			`CREATE PROCEDURE p1(INOUT param VARCHAR(10))
+BEGIN
+	SELECT param;
+	SET param = '5';
+END`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CALL p1(@uservar4);",
+				Expected: []sql.Row{
+					{nil},
+				},
+			},
+			{
+				Query: "SELECT @uservar4;",
+				Expected: []sql.Row{
+					{"5"},
+				},
+			},
+		},
+	},
+	{
+		Name: "Dolt Issue #4980",
+		SetUpScript: []string{
+			`CREATE TABLE person_cal_entries (id VARCHAR(36) PRIMARY KEY, cal_entry_id_fk VARCHAR(36), person_id_fk VARCHAR(36));`,
+			`CREATE TABLE personnel (id VARCHAR(36) PRIMARY KEY, event_id VARCHAR(36));`,
+			`CREATE TABLE season_participants (person_id_fk VARCHAR(36), season_id_fk VARCHAR(36));`,
+			`CREATE TABLE cal_entries (id VARCHAR(36) PRIMARY KEY, season_id_fk VARCHAR(36));`,
+			`INSERT INTO personnel VALUES ('6140e23e-7b9b-11ed-a1eb-0242ac120002', 'c546abc4-7b9b-11ed-a1eb-0242ac120002');`,
+			`INSERT INTO season_participants VALUES ('6140e23e-7b9b-11ed-a1eb-0242ac120002', '46d7041e-7b9b-11ed-a1eb-0242ac120002');`,
+			`INSERT INTO cal_entries VALUES ('cb8ba301-6c27-4bf8-b99b-617082d72621', '46d7041e-7b9b-11ed-a1eb-0242ac120002');`,
+			`CREATE PROCEDURE create_cal_entries_for_event(IN event_id VARCHAR(36))
+BEGIN
+    INSERT INTO person_cal_entries (id, cal_entry_id_fk, person_id_fk)
+    SELECT 'd17cb898-7b9b-11ed-a1eb-0242ac120002' as id, event_id as cal_entry_id_fk, id as person_id_fk
+    FROM personnel
+    WHERE id IN (
+        SELECT person_id_fk
+        FROM season_participants
+        WHERE season_id_fk = (
+            SELECT season_id_fk
+            FROM cal_entries
+            WHERE id = event_id
+        )
+    );
+END`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "call create_cal_entries_for_event('cb8ba301-6c27-4bf8-b99b-617082d72621');",
+				Expected: []sql.Row{
+					{sql.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "SELECT * FROM person_cal_entries;",
+				Expected: []sql.Row{
+					{"d17cb898-7b9b-11ed-a1eb-0242ac120002", "cb8ba301-6c27-4bf8-b99b-617082d72621", "6140e23e-7b9b-11ed-a1eb-0242ac120002"},
+				},
+			},
+		},
+	},
+	{
 		Name:        "Duplicate parameter names",
 		Query:       "CREATE PROCEDURE p1(abc DATETIME, abc DOUBLE) SELECT abc",
 		ExpectedErr: sql.ErrDeclareVariableDuplicate,

--- a/sql/core.go
+++ b/sql/core.go
@@ -1044,7 +1044,8 @@ type ExternalStoredProcedureDetails struct {
 	// It is valid to return a nil RowIter if there are no rows to be returned.
 	//
 	// Each parameter, by default, is an IN parameter. If the parameter type is a pointer, e.g. `*int32`, then it
-	// becomes an INOUT parameter. There is no way to set a parameter as an OUT parameter.
+	// becomes an INOUT parameter. INOUT parameters will be given their zero value if the parameter's value is nil.
+	// There is no way to set a parameter as an OUT parameter.
 	//
 	// Values are converted to their nearest type before being passed in, following the conversion rules of their
 	// related SQL types. The exceptions are `time.Time` (treated as a `DATETIME`), string (treated as a `LONGTEXT` with

--- a/sql/expression/collatedexpr.go
+++ b/sql/expression/collatedexpr.go
@@ -209,6 +209,10 @@ func ResolveCoercibility(leftCollation sql.CollationID, leftCoercibility int, ri
 		return rightCollation, nil
 	} else if leftCollation == rightCollation {
 		return leftCollation, nil
+	} else if leftCollation == sql.Collation_Unspecified {
+		return rightCollation, nil
+	} else if rightCollation == sql.Collation_Unspecified {
+		return leftCollation, nil
 	} else { // Collations are not equal
 		leftCharset := leftCollation.CharacterSet()
 		rightCharset := rightCollation.CharacterSet()


### PR DESCRIPTION
This fixes two panics that were discovered for stored procedures. The first comes from this issue: https://github.com/dolthub/dolt/issues/4980. The second deals with an issue with external stored procedures, where the usage of an uninitialized user variable would throw a panic over the nil value.