### PR TITLE
Truncate now checks system variable foreign_key_checks

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -1226,12 +1226,20 @@ var ForeignKeyTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
+				Query:       "TRUNCATE parent;",
+				ExpectedErr: sql.ErrTruncateReferencedFromForeignKey,
+			},
+			{
 				Query:       "DROP TABLE parent;",
 				ExpectedErr: sql.ErrForeignKeyDropTable,
 			},
 			{
 				Query:    "SET FOREIGN_KEY_CHECKS=0;",
 				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    "TRUNCATE parent;",
+				Expected: []sql.Row{{sql.NewOkResult(0)}},
 			},
 			{
 				Query:    "DROP TABLE parent;",

--- a/sql/analyzer/process_truncate.go
+++ b/sql/analyzer/process_truncate.go
@@ -162,9 +162,17 @@ func validateTruncate(ctx *sql.Context, db sql.Database, tbl sql.Node) (bool, er
 			if err != nil {
 				return true, err
 			}
-			for _, fk := range fks {
-				if strings.ToLower(fk.ParentTable) == tableName {
-					return false, sql.ErrTruncateReferencedFromForeignKey.New(tableName, fk.Name, tableNameToCheck)
+
+			fkChecks, err := ctx.GetSessionVariable(ctx, "foreign_key_checks")
+			if err != nil {
+				return true, err
+			}
+
+			if fkChecks.(int8) == 1 {
+				for _, fk := range fks {
+					if strings.ToLower(fk.ParentTable) == tableName {
+						return false, sql.ErrTruncateReferencedFromForeignKey.New(tableName, fk.Name, tableNameToCheck)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Truncate now checks system variable foreign_key_checks and does not throw if the variable is not 1.

This fixes https://github.com/dolthub/dolt/issues/5007