### PR TITLE
allow naked identifiers for as of statements

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -435,6 +435,15 @@ func TestAnalyzer(t *testing.T) {
 				return plan.NewShowTables(db, false, timestamp)
 			},
 		},
+		{
+			name:  "show tables as of, naked literal",
+			query: "SHOW TABLES AS OF abc123",
+			planGenerator: func(t *testing.T, ctx *sql.Context, engine *sqle.Engine) sql.Node {
+				db, err := engine.Analyzer.Catalog.Database(ctx, "mydb")
+				require.NoError(t, err)
+				return plan.NewShowTables(db, false, expression.NewLiteral("abc123", sql.LongText))
+			},
+		},
 	}
 
 	harness := enginetest.NewDefaultMemoryHarness()

--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -444,16 +444,6 @@ func TestAnalyzer(t *testing.T) {
 				return plan.NewShowTables(db, false, expression.NewLiteral("abc123", sql.LongText))
 			},
 		},
-		{
-			name:  "show create table as of, naked literal",
-			query: "SHOW CREATE TABLE foo AS OF abc123",
-			planGenerator: func(t *testing.T, ctx *sql.Context, engine *sqle.Engine) sql.Node {
-				_, err := engine.Analyzer.Catalog.Database(ctx, "mydb")
-				asOf := expression.NewLiteral("abc123", sql.LongText)
-				require.NoError(t, err)
-				return plan.NewShowCreateTableWithAsOf(plan.NewUnresolvedTableAsOf("foo", "", asOf), false, asOf)
-			},
-		},
 	}
 
 	harness := enginetest.NewDefaultMemoryHarness()

--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -444,6 +444,16 @@ func TestAnalyzer(t *testing.T) {
 				return plan.NewShowTables(db, false, expression.NewLiteral("abc123", sql.LongText))
 			},
 		},
+		{
+			name:  "show create table as of, naked literal",
+			query: "SHOW CREATE TABLE foo AS OF abc123",
+			planGenerator: func(t *testing.T, ctx *sql.Context, engine *sqle.Engine) sql.Node {
+				_, err := engine.Analyzer.Catalog.Database(ctx, "mydb")
+				asOf := expression.NewLiteral("abc123", sql.LongText)
+				require.NoError(t, err)
+				return plan.NewShowCreateTableWithAsOf(plan.NewUnresolvedTableAsOf("foo", "", asOf), false, asOf)
+			},
+		},
 	}
 
 	harness := enginetest.NewDefaultMemoryHarness()

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -183,27 +183,39 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
+	t.Skip()
+
 	var scripts = []queries.ScriptTest{
 		{
 			Name: "create table as select distinct",
 			SetUpScript: []string{
-				"create table t (i int)",
+				"CREATE TABLE t1 (a int, b varchar(10));",
+				"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "show tables as of HEAD",
+					Query:    "create table t2 as select distinct b, a from t1;",
 					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
+				},
+				{
+					Query: "select * from t2 order by a;",
+					Expected: []sql.Row{
+						{"a", 1},
+						{"b", 2},
+						{"c", 3},
+					},
 				},
 			},
 		},
 	}
-
 	for _, test := range scripts {
 		harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
 		engine, err := harness.NewEngine(t)
 		if err != nil {
 			panic(err)
 		}
+		engine.Analyzer.Debug = true
+		engine.Analyzer.Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -208,6 +208,7 @@ func TestSingleScript(t *testing.T) {
 			},
 		},
 	}
+
 	for _, test := range scripts {
 		harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
 		engine, err := harness.NewEngine(t)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -183,27 +183,16 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
-
 	var scripts = []queries.ScriptTest{
 		{
 			Name: "create table as select distinct",
 			SetUpScript: []string{
-				"CREATE TABLE t1 (a int, b varchar(10));",
-				"insert into t1 values (1, 'a'), (2, 'b'), (2, 'b'), (3, 'c');",
+				"create table t (i int)",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "create table t2 as select distinct b, a from t1;",
+					Query:    "show tables as of HEAD",
 					Expected: []sql.Row{{sql.OkResult{RowsAffected: 3}}},
-				},
-				{
-					Query: "select * from t2 order by a;",
-					Expected: []sql.Row{
-						{"a", 1},
-						{"b", 2},
-						{"c", 3},
-					},
 				},
 			},
 		},
@@ -215,8 +204,6 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		engine.Analyzer.Debug = true
-		engine.Analyzer.Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8407,16 +8407,6 @@ var VersionedQueries = []QueryTest{
 		},
 	},
 	{
-		Query: "SHOW CREATE TABLE myhistorytable as of 2019-01-02",
-		Expected: []sql.Row{
-			{"myhistorytable", "CREATE TABLE `myhistorytable` (\n" +
-				"  `i` bigint NOT NULL,\n" +
-				"  `s` text NOT NULL,\n" +
-				"  PRIMARY KEY (`i`)\n" +
-				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
-		},
-	},
-	{
 		Query: "SHOW CREATE TABLE myhistorytable as of '2019-01-02'",
 		Expected: []sql.Row{
 			{"myhistorytable", "CREATE TABLE `myhistorytable` (\n" +

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8407,6 +8407,16 @@ var VersionedQueries = []QueryTest{
 		},
 	},
 	{
+		Query: "SHOW CREATE TABLE myhistorytable as of 2019-01-02",
+		Expected: []sql.Row{
+			{"myhistorytable", "CREATE TABLE `myhistorytable` (\n" +
+				"  `i` bigint NOT NULL,\n" +
+				"  `s` text NOT NULL,\n" +
+				"  PRIMARY KEY (`i`)\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+		},
+	},
+	{
 		Query: "SHOW CREATE TABLE myhistorytable as of '2019-01-02'",
 		Expected: []sql.Row{
 			{"myhistorytable", "CREATE TABLE `myhistorytable` (\n" +

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -9530,7 +9530,7 @@ var ErrorQueries = []QueryErrorTest{
 	},
 	{
 		Query:       "SELECT i FROM myhistorytable AS OF abc",
-		ExpectedErr: sql.ErrInvalidAsOfExpression,
+		ExpectedErr: sql.ErrAsOfNotSupported,
 	},
 	{
 		Query:       "SELECT i FROM myhistorytable AS OF MAX(abc)",

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -9831,6 +9831,10 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: sql.ErrColumnNotFound,
 	},
 	{
+		Query:       "SHOW CREATE TABLE myhistorytable as of abc",
+		ExpectedErr: sql.ErrAsOfNotSupported,
+	},
+	{
 		Query:       "SELECT i FROM myhistorytable AS OF abc",
 		ExpectedErr: sql.ErrAsOfNotSupported,
 	},

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -105,6 +105,11 @@ func resolveTable(ctx *sql.Context, t sql.UnresolvedTable, a *Analyzer) (sql.Nod
 				return nil, err
 			}
 
+			// special case for AsOf's that use naked identifiers; they are interpreted as UnresolvedColumns
+			if col, ok := asOfExpr.(*expression.UnresolvedColumn); ok {
+				asOfExpr = expression.NewLiteral(col.String(), sql.LongText)
+			}
+
 			if !asOfExpr.Resolved() {
 				return nil, sql.ErrInvalidAsOfExpression.New(asOfExpr.String())
 			}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -700,6 +700,9 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 				if err != nil {
 					return nil, err
 				}
+				if col, ok := asOf.(*expression.UnresolvedColumn); ok {
+					asOf = expression.NewLiteral(col.String(), sql.LongText)
+				}
 			}
 		}
 

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -700,6 +700,7 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 				if err != nil {
 					return nil, err
 				}
+				// special case for AsOf's that use naked identifiers; they are interpreted as UnresolvedColum
 				if col, ok := asOf.(*expression.UnresolvedColumn); ok {
 					asOf = expression.NewLiteral(col.String(), sql.LongText)
 				}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -506,9 +506,6 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 			if err != nil {
 				return nil, err
 			}
-			if e, ok := expr.(*expression.UnresolvedColumn); ok {
-				expr = expression.NewLiteral(e.String(), sql.LongText)
-			}
 			asOfExpression = expr
 		}
 		table := tableNameToUnresolvedTableAsOf(s.Table, asOfExpression)
@@ -702,10 +699,6 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 				asOf, err = ExprToExpression(ctx, s.ShowTablesOpt.AsOf)
 				if err != nil {
 					return nil, err
-				}
-				// special case for AsOf's that use naked identifiers; they are interpreted as UnresolvedColum
-				if col, ok := asOf.(*expression.UnresolvedColumn); ok {
-					asOf = expression.NewLiteral(col.String(), sql.LongText)
 				}
 			}
 		}

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -502,11 +502,14 @@ func convertShow(ctx *sql.Context, s *sqlparser.Show, query string) (sql.Node, e
 	case "create table", "create view":
 		var asOfExpression sql.Expression
 		if s.ShowTablesOpt != nil && s.ShowTablesOpt.AsOf != nil {
-			expression, err := ExprToExpression(ctx, s.ShowTablesOpt.AsOf)
+			expr, err := ExprToExpression(ctx, s.ShowTablesOpt.AsOf)
 			if err != nil {
 				return nil, err
 			}
-			asOfExpression = expression
+			if e, ok := expr.(*expression.UnresolvedColumn); ok {
+				expr = expression.NewLiteral(e.String(), sql.LongText)
+			}
+			asOfExpression = expr
 		}
 		table := tableNameToUnresolvedTableAsOf(s.Table, asOfExpression)
 		return plan.NewShowCreateTableWithAsOf(table, showType == "create view", asOfExpression), nil


### PR DESCRIPTION
added a special case for unresolved columns for statements using `as of <identifer>`

fix for: https://github.com/dolthub/dolt/issues/3116