### PR TITLE
/{go.sum, sql}: allow time conversions for golang zero time

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -846,6 +846,18 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "INSERT zero date DATETIME NOT NULL is valid",
+		SetUpScript: []string{
+			"CREATE TABLE t1 (dt datetime not null)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "INSERT INTO t1 (dt) VALUES ('0001-01-01 00:00:00');",
+				Expected: []sql.Row{{sql.NewOkResult(1)}},
+			},
+		},
+	},
+	{
 		Name: "insert into sparse auto_increment table",
 		SetUpScript: []string{
 			"create table auto (pk int primary key auto_increment)",

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474 h1:xTrR+l5l+1Lfq0
 github.com/dolthub/jsonpath v0.0.0-20210609232853-d49537a30474/go.mod h1:kMz7uXOXq4qRriCEyZ/LUeTqraLJCjf0WVZcUi6TxUY=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20221213234424-b21f99e8027d h1:SFBb6boDelnyNAA/wefNvqKtxlITLGNBMO1cagUZPVw=
-github.com/dolthub/vitess v0.0.0-20221213234424-b21f99e8027d/go.mod h1:oVFIBdqMFEkt4Xz2fzFJBNtzKhDEjwdCF0dzde39iKs=
 github.com/dolthub/vitess v0.0.0-20221221215514-0a479c28185a h1:u2q5qV6s3RF7Nqp7NEeNUHfPmsXBEvKz3VBwBOS4YgE=
 github.com/dolthub/vitess v0.0.0-20221221215514-0a479c28185a/go.mod h1:oVFIBdqMFEkt4Xz2fzFJBNtzKhDEjwdCF0dzde39iKs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/sql/datetimetype.go
+++ b/sql/datetimetype.go
@@ -166,12 +166,12 @@ func (t datetimeType) Compare(a interface{}, b interface{}) (int, error) {
 
 // Convert implements Type interface.
 func (t datetimeType) Convert(v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
 	res, err := ConvertToTime(v, t)
 	if err != nil {
 		return nil, err
-	}
-	if res.IsZero() {
-		return nil, nil
 	}
 	return res, nil
 }


### PR DESCRIPTION
https://go.dev/play/p/nzS0vAAI5yd

remove call of `time.IsZero()` to allow `0001-01-01 00:00:00` as valid datetime.