### PR TITLE
Fix empty cachedResult/existIter issues

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -295,6 +295,27 @@ order by 1;`,
 			},
 		},
 	},
+	{
+		name: "empty join tests",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int);",
+			"CREATE table uv (u int primary key, v int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+		},
+		tests: []JoinOpTest{
+			{
+				q:     "select * from xy where y-1 = (select u from uv limit 1 offset 5);",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{},
+			},
+			{
+				q:     "select * from xy where x != (select u from uv limit 1 offset 5);",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{},
+			},
+		},
+	},
 }
 
 func TestJoinOps(t *testing.T, harness Harness) {

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -33,24 +33,23 @@ var PlanTests = []QueryPlanTest{
 			"     │   ├─ mytable.i:1!null\n" +
 			"     │   └─ applySubq0.i2:0!null\n" +
 			"     ├─ Max1Row\n" +
-			"     │   └─ CachedResults\n" +
-			"     │       └─ SubqueryAlias\n" +
-			"     │           ├─ name: applySubq0\n" +
-			"     │           ├─ outerVisibility: false\n" +
-			"     │           ├─ cacheable: true\n" +
-			"     │           └─ Project\n" +
-			"     │               ├─ columns: [othertable.i2:1!null]\n" +
-			"     │               └─ Filter\n" +
-			"     │                   ├─ Eq\n" +
-			"     │                   │   ├─ othertable.s2:0!null\n" +
-			"     │                   │   └─ second (longtext)\n" +
-			"     │                   └─ IndexedTableAccess\n" +
-			"     │                       ├─ index: [othertable.s2]\n" +
-			"     │                       ├─ static: [{[second, second]}]\n" +
-			"     │                       ├─ columns: [s2 i2]\n" +
-			"     │                       └─ Table\n" +
-			"     │                           ├─ name: othertable\n" +
-			"     │                           └─ projections: [0 1]\n" +
+			"     │   └─ SubqueryAlias\n" +
+			"     │       ├─ name: applySubq0\n" +
+			"     │       ├─ outerVisibility: false\n" +
+			"     │       ├─ cacheable: true\n" +
+			"     │       └─ Project\n" +
+			"     │           ├─ columns: [othertable.i2:1!null]\n" +
+			"     │           └─ Filter\n" +
+			"     │               ├─ Eq\n" +
+			"     │               │   ├─ othertable.s2:0!null\n" +
+			"     │               │   └─ second (longtext)\n" +
+			"     │               └─ IndexedTableAccess\n" +
+			"     │                   ├─ index: [othertable.s2]\n" +
+			"     │                   ├─ static: [{[second, second]}]\n" +
+			"     │                   ├─ columns: [s2 i2]\n" +
+			"     │                   └─ Table\n" +
+			"     │                       ├─ name: othertable\n" +
+			"     │                       └─ projections: [0 1]\n" +
 			"     └─ IndexedTableAccess\n" +
 			"         ├─ index: [mytable.i]\n" +
 			"         └─ Table\n" +
@@ -3420,15 +3419,14 @@ inner join pq on true
 			" │   ├─ mytable.i:1!null\n" +
 			" │   └─ applySubq0.i2:0!null\n" +
 			" ├─ Max1Row\n" +
-			" │   └─ CachedResults\n" +
-			" │       └─ SubqueryAlias\n" +
-			" │           ├─ name: applySubq0\n" +
-			" │           ├─ outerVisibility: false\n" +
-			" │           ├─ cacheable: true\n" +
-			" │           └─ Limit(1)\n" +
-			" │               └─ Table\n" +
-			" │                   ├─ name: othertable\n" +
-			" │                   └─ columns: [i2]\n" +
+			" │   └─ SubqueryAlias\n" +
+			" │       ├─ name: applySubq0\n" +
+			" │       ├─ outerVisibility: false\n" +
+			" │       ├─ cacheable: true\n" +
+			" │       └─ Limit(1)\n" +
+			" │           └─ Table\n" +
+			" │               ├─ name: othertable\n" +
+			" │               └─ columns: [i2]\n" +
 			" └─ IndexedTableAccess\n" +
 			"     ├─ index: [mytable.i]\n" +
 			"     └─ Table\n" +

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -353,6 +353,7 @@ func cacheSubqueryAliasesInJoins(ctx *sql.Context, a *Analyzer, n sql.Node, scop
 		_, isOp := n.(sql.OpaqueNode)
 		var isCacheableSq bool
 		var isCachedRs bool
+		var isMax1Row bool
 		switch n := n.(type) {
 		case *plan.JoinNode:
 			if !inJoin {
@@ -365,6 +366,8 @@ func cacheSubqueryAliasesInJoins(ctx *sql.Context, a *Analyzer, n sql.Node, scop
 			}
 		case *plan.CachedResults:
 			isCachedRs = true
+		case *plan.Max1RowSubquery:
+			isMax1Row = true
 		default:
 		}
 
@@ -383,7 +386,7 @@ func cacheSubqueryAliasesInJoins(ctx *sql.Context, a *Analyzer, n sql.Node, scop
 		children := n.Children()
 		var newChildren []sql.Node
 		for i, c := range children {
-			child, same, _ := recurse(c, doCache || isCachedRs, childInJoin, foundFirstRel)
+			child, same, _ := recurse(c, doCache || isCachedRs || isMax1Row, childInJoin, foundFirstRel)
 			if !same {
 				if newChildren == nil {
 					newChildren = make([]sql.Node, len(children))

--- a/sql/plan/cached_results.go
+++ b/sql/plan/cached_results.go
@@ -17,11 +17,10 @@ package plan
 import (
 	"errors"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
 	"io"
 	"sync"
 	"sync/atomic"
-
-	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // cachedResultsGlobalCache manages the caches created by CachedResults nodes.
@@ -85,10 +84,7 @@ func (n *CachedResults) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error
 	} else if n.noCache {
 		return n.UnaryNode.Child.RowIter(ctx, r)
 	} else if n.finalized {
-		// Parents of CachedResults should handle the edge case
-		// where the cache is empty, and we return ErrEmptyCachedResult
-		// instead of performing a potentially expensive re-computation.
-		return nil, ErrEmptyCachedResult
+		return emptyIter, nil
 	}
 
 	ci, err := n.UnaryNode.Child.RowIter(ctx, r)
@@ -184,6 +180,20 @@ func (i *cachedResultsIter) Close(ctx *sql.Context) error {
 	i.cleanUp()
 	return i.iter.Close(ctx)
 }
+
+var emptyIter = &emptyCacheIter{}
+
+func isEmptyIter(i sql.RowIter) bool {
+	return i == emptyIter
+}
+
+type emptyCacheIter struct{}
+
+var _ sql.RowIter = (*emptyCacheIter)(nil)
+
+func (i *emptyCacheIter) Next(ctx *sql.Context) (sql.Row, error) { return nil, io.EOF }
+
+func (i *emptyCacheIter) Close(ctx *sql.Context) error { return nil }
 
 // cachedResultsManager manages the saved results collected by CachedResults nodes. It is necessary to do this outside
 // of the CachedResult node instances themselves, since executing a query plan can make transient transforms that are

--- a/sql/plan/cached_results.go
+++ b/sql/plan/cached_results.go
@@ -17,10 +17,11 @@ package plan
 import (
 	"errors"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql"
 	"io"
 	"sync"
 	"sync/atomic"
+
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // cachedResultsGlobalCache manages the caches created by CachedResults nodes.

--- a/sql/plan/join_iters.go
+++ b/sql/plan/join_iters.go
@@ -97,7 +97,9 @@ func (i *joinIter) loadSecondary(ctx *sql.Context) (sql.Row, error) {
 		if err != nil {
 			return nil, err
 		}
-
+		if isEmptyIter(rowIter) {
+			return nil, ErrEmptyCachedResult
+		}
 		i.secondary = rowIter
 	}
 
@@ -260,6 +262,10 @@ func (i *existsIter) Next(ctx *sql.Context) (sql.Row, error) {
 		if err != nil {
 			return nil, err
 		}
+		if isEmptyIter(rIter) {
+			return nil, io.EOF
+		}
+
 		for {
 			right, err := rIter.Next(ctx)
 			if err != nil {

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -15,6 +15,7 @@
 package plan
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -265,13 +266,16 @@ func prependRowInPlan(row sql.Row) func(n sql.Node) (sql.Node, transform.TreeIde
 }
 
 func NewMax1Row(n sql.Node) *Max1RowSubquery {
-	return &Max1RowSubquery{Child: n}
+	return &Max1RowSubquery{Child: n, mu: &sync.Mutex{}}
 }
 
 // Max1RowSubquery throws a runtime error if its child (usually subquery) tries
 // to return more than one row.
 type Max1RowSubquery struct {
-	Child sql.Node
+	Child       sql.Node
+	result      sql.Row
+	mu          *sync.Mutex
+	emptyResult bool
 }
 
 var _ sql.Node = (*Max1RowSubquery)(nil)
@@ -319,11 +323,50 @@ func (m *Max1RowSubquery) DebugString() string {
 }
 
 func (m *Max1RowSubquery) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	
+	if !m.hasResults() {
+		err := m.populateResults(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	switch {
+	case m.emptyResult:
+		return emptyIter, nil
+	case m.result != nil:
+		return sql.RowsToRowIter(m.result), nil
+	default:
+		return nil, fmt.Errorf("failed to load Max1Row")
+	}
+}
+
+func (m *Max1RowSubquery) populateResults(ctx *sql.Context, row sql.Row) error {
 	i, err := m.Child.RowIter(ctx, row)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return &max1RowIter{i: i}, nil
+	r1, err := i.Next(ctx)
+	if errors.Is(err, io.EOF) {
+		m.emptyResult = true
+	} else if err != nil {
+		return err
+	}
+
+	_, err = i.Next(ctx)
+	if err == nil {
+		return sql.ErrExpectedSingleRow.New()
+	} else if !errors.Is(err, io.EOF) {
+		return err
+	}
+	m.result = r1
+	return nil
+}
+
+func (m *Max1RowSubquery) hasResults() bool {
+	return m.result != nil || m.emptyResult
 }
 
 func (m *Max1RowSubquery) WithChildren(children ...sql.Node) (sql.Node, error) {
@@ -338,29 +381,6 @@ func (m *Max1RowSubquery) WithChildren(children ...sql.Node) (sql.Node, error) {
 
 func (m *Max1RowSubquery) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return m.Child.CheckPrivileges(ctx, opChecker)
-}
-
-type max1RowIter struct {
-	i          sql.RowIter
-	seenOneRow bool
-}
-
-var _ sql.RowIter = (*max1RowIter)(nil)
-
-func (m *max1RowIter) Next(ctx *sql.Context) (sql.Row, error) {
-	row, err := m.i.Next(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if m.seenOneRow {
-		return nil, sql.ErrExpectedSingleRow.New()
-	}
-	m.seenOneRow = true
-	return row, nil
-}
-
-func (m *max1RowIter) Close(ctx *sql.Context) error {
-	return m.i.Close(ctx)
 }
 
 // EvalMultiple returns all rows returned by a subquery.


### PR DESCRIPTION
MAX_1_ROW no longer uses a CachedResult, and eagerly loads its child on the first call RowIter(). Three things can happen:

1) the child returns one row, which we cache in the node state
2) the child returns zero rows, which we note with a flag in the node state
3) the child returns more than one row, and we error

RowIter returns the result row or an `emptyIter` if no child rows were returned. The `emptyIter` sentinal is important for antiJoin correctness and join short-circuit performance.

Original error from system table benchmarks:
```
 error running query {connectTime=2023-01-07T01:12:10Z, connectionDb=sbtest, error=attempted to call RowIter() on a disposed Node: *plan.CachedResults, query=select * from dolt_commit_ancestors where commit_hash = (select commit_hash from dolt_log limit 1 offset 599)}
 ```