### PR TITLE
Catch missed antijoins

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -5566,17 +5566,13 @@ inner join pq on true
 			"     ├─ columns: [t1.pk:0!null, t2.pk2:7!null, Subquery\n" +
 			"     │   ├─ cacheable: true\n" +
 			"     │   └─ Limit(1)\n" +
-			"     │       └─ Filter\n" +
-			"     │           ├─ Eq\n" +
-			"     │           │   ├─ one_pk.pk:13!null\n" +
-			"     │           │   └─ 1 (tinyint)\n" +
-			"     │           └─ IndexedTableAccess\n" +
-			"     │               ├─ index: [one_pk.pk]\n" +
-			"     │               ├─ static: [{[1, 1]}]\n" +
-			"     │               ├─ columns: [pk]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: one_pk\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │       └─ IndexedTableAccess\n" +
+			"     │           ├─ index: [one_pk.pk]\n" +
+			"     │           ├─ static: [{[1, 1]}]\n" +
+			"     │           ├─ columns: [pk]\n" +
+			"     │           └─ Table\n" +
+			"     │               ├─ name: one_pk\n" +
+			"     │               └─ projections: [0]\n" +
 			"     │   as (SELECT pk from one_pk where pk = 1 limit 1)]\n" +
 			"     └─ CrossJoin\n" +
 			"         ├─ Filter\n" +
@@ -8468,53 +8464,57 @@ var IntegrationPlanTests = []QueryPlanTest{
 			"     │   └─ Distinct\n" +
 			"     │       └─ Project\n" +
 			"     │           ├─ columns: [YLKSY.id:5!null as FDL23]\n" +
-			"     │           └─ Filter\n" +
-			"     │               ├─ (NOT(InSubquery\n" +
-			"     │               │   ├─ left: YLKSY.id:5!null\n" +
-			"     │               │   └─ right: Subquery\n" +
-			"     │               │       ├─ cacheable: true\n" +
-			"     │               │       └─ Filter\n" +
-			"     │               │           ├─ (NOT(FLQLP.NRURT:38 IS NULL))\n" +
-			"     │               │           └─ IndexedTableAccess\n" +
-			"     │               │               ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │               ├─ static: [{(NULL, ∞)}]\n" +
-			"     │               │               ├─ columns: [nrurt]\n" +
+			"     │           └─ LookupJoin\n" +
+			"     │               ├─ Eq\n" +
+			"     │               │   ├─ aac.BTXC5:36\n" +
+			"     │               │   └─ YLKSY.LJLUM:10\n" +
+			"     │               ├─ HashJoin\n" +
+			"     │               │   ├─ Eq\n" +
+			"     │               │   │   ├─ nd.ZH72S:25\n" +
+			"     │               │   │   └─ YLKSY.ZH72S:7\n" +
+			"     │               │   ├─ AntiJoin\n" +
+			"     │               │   │   ├─ Eq\n" +
+			"     │               │   │   │   ├─ YLKSY.id:5!null\n" +
+			"     │               │   │   │   └─ applySubq0.NRURT:18\n" +
+			"     │               │   │   ├─ LookupJoin\n" +
+			"     │               │   │   │   ├─ Eq\n" +
+			"     │               │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
+			"     │               │   │   │   │   └─ YLKSY.FTQLQ:6\n" +
+			"     │               │   │   │   ├─ TableAlias(ci)\n" +
+			"     │               │   │   │   │   └─ Table\n" +
+			"     │               │   │   │   │       └─ name: JDLNA\n" +
+			"     │               │   │   │   └─ Filter\n" +
+			"     │               │   │   │       ├─ (NOT(YLKSY.LJLUM LIKE '%|%'))\n" +
+			"     │               │   │   │       └─ TableAlias(YLKSY)\n" +
+			"     │               │   │   │           └─ IndexedTableAccess\n" +
+			"     │               │   │   │               ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │               │   │   │               └─ Table\n" +
+			"     │               │   │   │                   └─ name: OUBDL\n" +
+			"     │               │   │   └─ SubqueryAlias\n" +
+			"     │               │   │       ├─ name: applySubq0\n" +
+			"     │               │   │       ├─ outerVisibility: false\n" +
+			"     │               │   │       ├─ cacheable: true\n" +
+			"     │               │   │       └─ Filter\n" +
+			"     │               │   │           ├─ (NOT(FLQLP.NRURT:0 IS NULL))\n" +
+			"     │               │   │           └─ IndexedTableAccess\n" +
+			"     │               │   │               ├─ index: [FLQLP.NRURT]\n" +
+			"     │               │   │               ├─ static: [{(NULL, ∞)}]\n" +
+			"     │               │   │               ├─ columns: [nrurt]\n" +
+			"     │               │   │               └─ Table\n" +
+			"     │               │   │                   ├─ name: FLQLP\n" +
+			"     │               │   │                   └─ projections: [5]\n" +
+			"     │               │   └─ HashLookup\n" +
+			"     │               │       ├─ source: TUPLE(YLKSY.ZH72S:7)\n" +
+			"     │               │       ├─ target: TUPLE(nd.ZH72S:7)\n" +
+			"     │               │       └─ CachedResults\n" +
+			"     │               │           └─ TableAlias(nd)\n" +
 			"     │               │               └─ Table\n" +
-			"     │               │                   ├─ name: FLQLP\n" +
-			"     │               │                   └─ projections: [5]\n" +
-			"     │               │  ))\n" +
-			"     │               └─ LookupJoin\n" +
-			"     │                   ├─ Eq\n" +
-			"     │                   │   ├─ aac.BTXC5:36\n" +
-			"     │                   │   └─ YLKSY.LJLUM:10\n" +
-			"     │                   ├─ LookupJoin\n" +
-			"     │                   │   ├─ Eq\n" +
-			"     │                   │   │   ├─ nd.ZH72S:25\n" +
-			"     │                   │   │   └─ YLKSY.ZH72S:7\n" +
-			"     │                   │   ├─ LookupJoin\n" +
-			"     │                   │   │   ├─ Eq\n" +
-			"     │                   │   │   │   ├─ ci.FTQLQ:1!null\n" +
-			"     │                   │   │   │   └─ YLKSY.FTQLQ:6\n" +
-			"     │                   │   │   ├─ TableAlias(ci)\n" +
-			"     │                   │   │   │   └─ Table\n" +
-			"     │                   │   │   │       └─ name: JDLNA\n" +
-			"     │                   │   │   └─ Filter\n" +
-			"     │                   │   │       ├─ (NOT(YLKSY.LJLUM LIKE '%|%'))\n" +
-			"     │                   │   │       └─ TableAlias(YLKSY)\n" +
-			"     │                   │   │           └─ IndexedTableAccess\n" +
-			"     │                   │   │               ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │                   │   │               └─ Table\n" +
-			"     │                   │   │                   └─ name: OUBDL\n" +
-			"     │                   │   └─ TableAlias(nd)\n" +
-			"     │                   │       └─ IndexedTableAccess\n" +
-			"     │                   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                   │           └─ Table\n" +
-			"     │                   │               └─ name: E2I7U\n" +
-			"     │                   └─ TableAlias(aac)\n" +
-			"     │                       └─ IndexedTableAccess\n" +
-			"     │                           ├─ index: [TPXBU.BTXC5]\n" +
-			"     │                           └─ Table\n" +
-			"     │                               └─ name: TPXBU\n" +
+			"     │               │                   └─ name: E2I7U\n" +
+			"     │               └─ TableAlias(aac)\n" +
+			"     │                   └─ IndexedTableAccess\n" +
+			"     │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"     │                       └─ Table\n" +
+			"     │                           └─ name: TPXBU\n" +
 			"     └─ TableAlias(uct)\n" +
 			"         └─ IndexedTableAccess\n" +
 			"             ├─ index: [OUBDL.id]\n" +
@@ -9085,43 +9085,41 @@ var IntegrationPlanTests = []QueryPlanTest{
 	`,
 		ExpectedPlan: "Distinct\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (NOT(InSubquery\n" +
-			"         │   ├─ left: ufc.id:0!null\n" +
-			"         │   └─ right: Subquery\n" +
-			"         │       ├─ cacheable: true\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: AMYXQ\n" +
-			"         │           └─ columns: [kkgn5]\n" +
-			"         │  ))\n" +
-			"         └─ LookupJoin\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ cla.FTQLQ:29!null\n" +
-			"             │   └─ ufc.T4IBQ:1\n" +
-			"             ├─ MergeJoin\n" +
-			"             │   ├─ Eq\n" +
-			"             │   │   ├─ ufc.ZH72S:2\n" +
-			"             │   │   └─ nd.ZH72S:18\n" +
-			"             │   ├─ TableAlias(ufc)\n" +
-			"             │   │   └─ IndexedTableAccess\n" +
-			"             │   │       ├─ index: [SISUT.ZH72S]\n" +
-			"             │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"             │   │       └─ Table\n" +
-			"             │   │           └─ name: SISUT\n" +
-			"             │   └─ Filter\n" +
-			"             │       ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
-			"             │       └─ TableAlias(nd)\n" +
-			"             │           └─ IndexedTableAccess\n" +
-			"             │               ├─ index: [E2I7U.ZH72S]\n" +
-			"             │               ├─ static: [{[NULL, ∞)}]\n" +
-			"             │               └─ Table\n" +
-			"             │                   └─ name: E2I7U\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ IndexedTableAccess\n" +
-			"                     ├─ index: [YK2GW.FTQLQ]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: YK2GW\n" +
+			"     ├─ columns: [ufc.id:17!null, ufc.T4IBQ:18, ufc.ZH72S:19, ufc.AMYXQ:20, ufc.KTNZ2:21, ufc.HIID2:22, ufc.DN3OQ:23, ufc.VVKNB:24, ufc.SH7TP:25, ufc.SRZZO:26, ufc.QZ6VT:27]\n" +
+			"     └─ AntiLookupJoin\n" +
+			"         ├─ Eq\n" +
+			"         │   ├─ ufc.id:17!null\n" +
+			"         │   └─ applySubq0.KKGN5:58\n" +
+			"         ├─ LookupJoin\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ cla.FTQLQ:29!null\n" +
+			"         │   │   └─ ufc.T4IBQ:18\n" +
+			"         │   ├─ LookupJoin\n" +
+			"         │   │   ├─ Eq\n" +
+			"         │   │   │   ├─ nd.ZH72S:7\n" +
+			"         │   │   │   └─ ufc.ZH72S:19\n" +
+			"         │   │   ├─ Filter\n" +
+			"         │   │   │   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
+			"         │   │   │   └─ TableAlias(nd)\n" +
+			"         │   │   │       └─ Table\n" +
+			"         │   │   │           └─ name: E2I7U\n" +
+			"         │   │   └─ TableAlias(ufc)\n" +
+			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │   │           └─ Table\n" +
+			"         │   │               └─ name: SISUT\n" +
+			"         │   └─ TableAlias(cla)\n" +
+			"         │       └─ IndexedTableAccess\n" +
+			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
+			"         │           └─ Table\n" +
+			"         │               └─ name: YK2GW\n" +
+			"         └─ TableAlias(applySubq0)\n" +
+			"             └─ IndexedTableAccess\n" +
+			"                 ├─ index: [AMYXQ.KKGN5]\n" +
+			"                 ├─ columns: [kkgn5]\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: AMYXQ\n" +
+			"                     └─ projections: [7]\n" +
 			"",
 	},
 	{
@@ -9146,41 +9144,40 @@ var IntegrationPlanTests = []QueryPlanTest{
 		ExpectedPlan: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id:17!null, ufc.T4IBQ:18, ufc.ZH72S:19, ufc.AMYXQ:20, ufc.KTNZ2:21, ufc.HIID2:22, ufc.DN3OQ:23, ufc.VVKNB:24, ufc.SH7TP:25, ufc.SRZZO:26, ufc.QZ6VT:27]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (NOT(InSubquery\n" +
-			"         │   ├─ left: ufc.id:17!null\n" +
-			"         │   └─ right: Subquery\n" +
-			"         │       ├─ cacheable: true\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: AMYXQ\n" +
-			"         │           └─ columns: [kkgn5]\n" +
-			"         │  ))\n" +
-			"         └─ LookupJoin\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ cla.FTQLQ:29!null\n" +
-			"             │   └─ ufc.T4IBQ:18\n" +
-			"             ├─ LookupJoin\n" +
-			"             │   ├─ Eq\n" +
-			"             │   │   ├─ nd.ZH72S:7\n" +
-			"             │   │   └─ ufc.ZH72S:19\n" +
-			"             │   ├─ Filter\n" +
-			"             │   │   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
-			"             │   │   └─ TableAlias(nd)\n" +
-			"             │   │       └─ IndexedTableAccess\n" +
-			"             │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"             │   │           ├─ static: [{(NULL, ∞)}]\n" +
-			"             │   │           └─ Table\n" +
-			"             │   │               └─ name: E2I7U\n" +
-			"             │   └─ TableAlias(ufc)\n" +
-			"             │       └─ IndexedTableAccess\n" +
-			"             │           ├─ index: [SISUT.ZH72S]\n" +
-			"             │           └─ Table\n" +
-			"             │               └─ name: SISUT\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ IndexedTableAccess\n" +
-			"                     ├─ index: [YK2GW.FTQLQ]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: YK2GW\n" +
+			"     └─ AntiLookupJoin\n" +
+			"         ├─ Eq\n" +
+			"         │   ├─ ufc.id:17!null\n" +
+			"         │   └─ applySubq0.KKGN5:58\n" +
+			"         ├─ LookupJoin\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ cla.FTQLQ:29!null\n" +
+			"         │   │   └─ ufc.T4IBQ:18\n" +
+			"         │   ├─ LookupJoin\n" +
+			"         │   │   ├─ Eq\n" +
+			"         │   │   │   ├─ nd.ZH72S:7\n" +
+			"         │   │   │   └─ ufc.ZH72S:19\n" +
+			"         │   │   ├─ Filter\n" +
+			"         │   │   │   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
+			"         │   │   │   └─ TableAlias(nd)\n" +
+			"         │   │   │       └─ Table\n" +
+			"         │   │   │           └─ name: E2I7U\n" +
+			"         │   │   └─ TableAlias(ufc)\n" +
+			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │   │           └─ Table\n" +
+			"         │   │               └─ name: SISUT\n" +
+			"         │   └─ TableAlias(cla)\n" +
+			"         │       └─ IndexedTableAccess\n" +
+			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
+			"         │           └─ Table\n" +
+			"         │               └─ name: YK2GW\n" +
+			"         └─ TableAlias(applySubq0)\n" +
+			"             └─ IndexedTableAccess\n" +
+			"                 ├─ index: [AMYXQ.KKGN5]\n" +
+			"                 ├─ columns: [kkgn5]\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: AMYXQ\n" +
+			"                     └─ projections: [7]\n" +
 			"",
 	},
 	{
@@ -9198,27 +9195,29 @@ var IntegrationPlanTests = []QueryPlanTest{
 	`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6]\n" +
-			" └─ Filter\n" +
-			"     ├─ (NOT(InSubquery\n" +
-			"     │   ├─ left: ums.id:0!null\n" +
-			"     │   └─ right: Subquery\n" +
-			"     │       ├─ cacheable: true\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: SZQWJ\n" +
-			"     │           └─ columns: [jogi6]\n" +
-			"     │  ))\n" +
-			"     └─ LookupJoin\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ cla.FTQLQ:8!null\n" +
-			"         │   └─ ums.T4IBQ:1\n" +
-			"         ├─ TableAlias(ums)\n" +
-			"         │   └─ Table\n" +
-			"         │       └─ name: FG26Y\n" +
-			"         └─ TableAlias(cla)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [YK2GW.FTQLQ]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: YK2GW\n" +
+			" └─ AntiLookupJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ ums.id:0!null\n" +
+			"     │   └─ applySubq0.JOGI6:37\n" +
+			"     ├─ LookupJoin\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ cla.FTQLQ:8!null\n" +
+			"     │   │   └─ ums.T4IBQ:1\n" +
+			"     │   ├─ TableAlias(ums)\n" +
+			"     │   │   └─ Table\n" +
+			"     │   │       └─ name: FG26Y\n" +
+			"     │   └─ TableAlias(cla)\n" +
+			"     │       └─ IndexedTableAccess\n" +
+			"     │           ├─ index: [YK2GW.FTQLQ]\n" +
+			"     │           └─ Table\n" +
+			"     │               └─ name: YK2GW\n" +
+			"     └─ TableAlias(applySubq0)\n" +
+			"         └─ IndexedTableAccess\n" +
+			"             ├─ index: [SZQWJ.JOGI6]\n" +
+			"             ├─ columns: [jogi6]\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: SZQWJ\n" +
+			"                 └─ projections: [4]\n" +
 			"",
 	},
 	{
@@ -9440,43 +9439,45 @@ var IntegrationPlanTests = []QueryPlanTest{
 	`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [umf.id:30!null, umf.T4IBQ:31, umf.FGG57:32, umf.SSHPJ:33, umf.NLA6O:34, umf.SFJ6L:35, umf.TJPT7:36, umf.ARN5P:37, umf.SYPKF:38, umf.IVFMK:39, umf.IDE43:40, umf.AZ6SP:41, umf.FSDY2:42, umf.XOSD4:43, umf.HMW4H:44, umf.S76OM:45, umf.vaf:46, umf.ZROH6:47, umf.QCGTS:48, umf.LNFM6:49, umf.TVAWL:50, umf.HDLCL:51, umf.BHHW6:52, umf.FHCYT:53, umf.QZ6VT:54]\n" +
-			" └─ Filter\n" +
-			"     ├─ (NOT(InSubquery\n" +
-			"     │   ├─ left: umf.id:30!null\n" +
-			"     │   └─ right: Subquery\n" +
-			"     │       ├─ cacheable: true\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: HGMQ6\n" +
-			"     │           └─ columns: [teuja]\n" +
-			"     │  ))\n" +
-			"     └─ LookupJoin\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ nd.FGG57:61\n" +
-			"         │   └─ umf.FGG57:32\n" +
-			"         ├─ LookupJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ cla.FTQLQ:1!null\n" +
-			"         │   │   └─ umf.T4IBQ:31\n" +
-			"         │   ├─ TableAlias(cla)\n" +
-			"         │   │   └─ Table\n" +
-			"         │   │       └─ name: YK2GW\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ (NOT(Eq\n" +
-			"         │       │   ├─ umf.ARN5P:7\n" +
-			"         │       │   └─ N/A (longtext)\n" +
-			"         │       │  ))\n" +
-			"         │       └─ TableAlias(umf)\n" +
-			"         │           └─ IndexedTableAccess\n" +
-			"         │               ├─ index: [NZKPM.T4IBQ]\n" +
-			"         │               └─ Table\n" +
-			"         │                   └─ name: NZKPM\n" +
-			"         └─ Filter\n" +
-			"             ├─ (NOT(nd.FGG57:6 IS NULL))\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess\n" +
-			"                     ├─ index: [E2I7U.FGG57]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: E2I7U\n" +
+			" └─ AntiLookupJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ umf.id:30!null\n" +
+			"     │   └─ applySubq0.TEUJA:72\n" +
+			"     ├─ LookupJoin\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ nd.FGG57:61\n" +
+			"     │   │   └─ umf.FGG57:32\n" +
+			"     │   ├─ LookupJoin\n" +
+			"     │   │   ├─ Eq\n" +
+			"     │   │   │   ├─ cla.FTQLQ:1!null\n" +
+			"     │   │   │   └─ umf.T4IBQ:31\n" +
+			"     │   │   ├─ TableAlias(cla)\n" +
+			"     │   │   │   └─ Table\n" +
+			"     │   │   │       └─ name: YK2GW\n" +
+			"     │   │   └─ Filter\n" +
+			"     │   │       ├─ (NOT(Eq\n" +
+			"     │   │       │   ├─ umf.ARN5P:7\n" +
+			"     │   │       │   └─ N/A (longtext)\n" +
+			"     │   │       │  ))\n" +
+			"     │   │       └─ TableAlias(umf)\n" +
+			"     │   │           └─ IndexedTableAccess\n" +
+			"     │   │               ├─ index: [NZKPM.T4IBQ]\n" +
+			"     │   │               └─ Table\n" +
+			"     │   │                   └─ name: NZKPM\n" +
+			"     │   └─ Filter\n" +
+			"     │       ├─ (NOT(nd.FGG57:6 IS NULL))\n" +
+			"     │       └─ TableAlias(nd)\n" +
+			"     │           └─ IndexedTableAccess\n" +
+			"     │               ├─ index: [E2I7U.FGG57]\n" +
+			"     │               └─ Table\n" +
+			"     │                   └─ name: E2I7U\n" +
+			"     └─ TableAlias(applySubq0)\n" +
+			"         └─ IndexedTableAccess\n" +
+			"             ├─ index: [HGMQ6.TEUJA]\n" +
+			"             ├─ columns: [teuja]\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: HGMQ6\n" +
+			"                 └─ projections: [14]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -7630,6 +7630,32 @@ var QueryPlanTODOs = []QueryPlanTest{
 var IntegrationPlanTests = []QueryPlanTest{
 	{
 		Query: `
+SELECT
+    id, FTQLQ
+FROM
+    YK2GW
+WHERE
+    id NOT IN (SELECT IXUXU FROM THNTS)
+;`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [YK2GW.id:0!null, YK2GW.FTQLQ:1!null]\n" +
+			" └─ AntiLookupJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ YK2GW.id:0!null\n" +
+			"     │   └─ applySubq0.IXUXU:30\n" +
+			"     ├─ Table\n" +
+			"     │   └─ name: YK2GW\n" +
+			"     └─ TableAlias(applySubq0)\n" +
+			"         └─ IndexedTableAccess\n" +
+			"             ├─ index: [THNTS.IXUXU]\n" +
+			"             ├─ columns: [ixuxu]\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: THNTS\n" +
+			"                 └─ projections: [2]\n" +
+			"",
+	},
+	{
+		Query: `
 	SELECT
 	   PBMRX.id AS id,
 	   PBMRX.TW55N AS TEYBZ,

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -837,6 +837,9 @@ func indexColumns(_ *sql.Context, _ *Analyzer, n sql.Node, scope *Scope) (map[ta
 	// Index the columns in the outer scope, outer to inner. This means inner scope columns will overwrite the outer
 	// ones of the same name. This matches the MySQL scope precedence rules.
 	indexSchema(scope.Schema())
+	if !scope.IsEmpty() && len(columns) == 0 {
+		return nil, nil
+	}
 
 	// For the innermost scope (the node being evaluated), look at the schemas of the children instead of this node
 	// itself. Skip this for DDL nodes that handle indexing separately.

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -766,6 +766,9 @@ func resolveColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
+		if len(columns) == 0 {
+			return n, transform.SameTree, nil
+		}
 
 		return transform.OneNodeExprsWithNode(n, func(n sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			uc, ok := e.(column)

--- a/sql/analyzer/scope.go
+++ b/sql/analyzer/scope.go
@@ -41,6 +41,14 @@ func (s *Scope) IsEmpty() bool {
 	return s == nil || len(s.nodes) == 0
 }
 
+// OuterRelUnresolved returns true if the relations in the
+// outer scope are not qualified and resolved.
+// note: a subquery in the outer scope is itself a scope,
+// and by definition not an outer relation
+func (s *Scope) OuterRelUnresolved() bool {
+	return !s.IsEmpty() && s.Schema() == nil
+}
+
 // newScope creates a new Scope object with the additional innermost Node context. When constructing with a subquery,
 // the Node given should be the sibling Node of the subquery.
 func (s *Scope) newScope(node sql.Node) *Scope {


### PR DESCRIPTION
A resolve irregularity tries to resolve subqueries before resolving the outer scope. The result was subscopes with off-by-scope index field counts. Add a skip to delay this so we can catch more cacheable subqueries for decorrelation. A proper fix will need to rewrite resolve and field setting rules.

The runtime for the query of interest reduces from 29 min -> 18 min, despite the second breaking the join hint order.