### PR TITLE
if privilegeSet is nil, return empty row for info schema tables

### DIFF
--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -877,6 +877,9 @@ func columnStatisticsRowIter(ctx *Context, c Catalog) (RowIter, error) {
 	}
 
 	privSet, privSetCount := ctx.GetPrivilegeSet()
+	if privSet == nil {
+		return RowsToRowIter(rows...), nil
+	}
 	for _, db := range c.AllDatabases(ctx) {
 		dbName := db.Name()
 		privSetDb := privSet.Database(dbName)
@@ -1492,6 +1495,9 @@ func triggersRowIter(ctx *Context, c Catalog) (RowIter, error) {
 		return nil, ErrSystemVariableCodeFail.New("sql_mode", sysVal)
 	}
 	privSet, _ := ctx.GetPrivilegeSet()
+	if privSet == nil {
+		return RowsToRowIter(rows...), nil
+	}
 	hasGlobalTriggerPriv := privSet.Has(PrivilegeType_Trigger)
 	for _, db := range c.AllDatabases(ctx) {
 		triggerDb, ok := db.(TriggerDatabase)
@@ -1598,6 +1604,9 @@ func triggersRowIter(ctx *Context, c Catalog) (RowIter, error) {
 func viewsRowIter(ctx *Context, catalog Catalog) (RowIter, error) {
 	var rows []Row
 	privSet, _ := ctx.GetPrivilegeSet()
+	if privSet == nil {
+		return RowsToRowIter(rows...), nil
+	}
 	hasGlobalShowViewPriv := privSet.Has(PrivilegeType_ShowView)
 	for _, db := range catalog.AllDatabases(ctx) {
 		dbName := db.Name()

--- a/sql/mysql_db/privilege_set.go
+++ b/sql/mysql_db/privilege_set.go
@@ -40,13 +40,8 @@ func NewPrivilegeSet() PrivilegeSet {
 	}
 }
 
-// NewPrivilegeSetWithAllGlobalPrivileges returns a new PrivilegeSet with all global privileges granted.
-func NewPrivilegeSetWithAllGlobalPrivileges() PrivilegeSet {
-	return newPrivilegeSetWithAllPrivileges()
-}
-
-// newPrivilegeSetWithAllPrivileges returns a new PrivilegeSet with every global static privilege added.
-func newPrivilegeSetWithAllPrivileges() PrivilegeSet {
+// NewPrivilegeSetWithAllPrivileges returns a new PrivilegeSet with every global static privilege added.
+func NewPrivilegeSetWithAllPrivileges() PrivilegeSet {
 	return PrivilegeSet{
 		map[sql.PrivilegeType]struct{}{
 			sql.PrivilegeType_Select:            {},

--- a/sql/mysql_db/privilege_set.go
+++ b/sql/mysql_db/privilege_set.go
@@ -40,6 +40,11 @@ func NewPrivilegeSet() PrivilegeSet {
 	}
 }
 
+// NewPrivilegeSetWithAllGlobalPrivileges returns a new PrivilegeSet with all global privileges granted.
+func NewPrivilegeSetWithAllGlobalPrivileges() PrivilegeSet {
+	return newPrivilegeSetWithAllPrivileges()
+}
+
 // newPrivilegeSetWithAllPrivileges returns a new PrivilegeSet with every global static privilege added.
 func newPrivilegeSetWithAllPrivileges() PrivilegeSet {
 	return PrivilegeSet{

--- a/sql/mysql_db/user_table.go
+++ b/sql/mysql_db/user_table.go
@@ -238,7 +238,7 @@ func addSuperUser(userTable *mysqlTable, username string, host string, password 
 	err := userTable.data.Put(sql.NewEmptyContext(), &User{
 		User:                username,
 		Host:                host,
-		PrivilegeSet:        newPrivilegeSetWithAllPrivileges(),
+		PrivilegeSet:        NewPrivilegeSetWithAllPrivileges(),
 		Plugin:              "mysql_native_password",
 		Password:            password,
 		PasswordLastChanged: time.Unix(1, 0).UTC(),


### PR DESCRIPTION
- privilegeSet was nil for `ld` repository tests as there were no privileges granted and was trying to test on information_schema.views table. 
- the now exported method is used in `ld` to grant all privileges for the test user

fixes test in https://github.com/dolthub/ld/pull/12642