### PR TITLE
Merge join panicked with non-comparator filter expression

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -84,6 +84,11 @@ var JoinOpTests = []struct {
 				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 1, 0}, {2, 0, 1, 0}},
 			},
 			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s and y = r order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}},
+			},
+			{
 				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y+10 = s order by 1, 3",
 				types: []plan.JoinType{plan.JoinTypeHash},
 				exp:   []sql.Row{},

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -737,6 +737,12 @@ var (
 	ErrTooLargeForSet    = errors.NewKind(`value "%v" is too large for this set`)
 	ErrNotPoint          = errors.NewKind("value of type %T is not a point")
 	ErrNotLineString     = errors.NewKind("value of type %T is not a linestring")
+
+	// ErrMergeJoinExpectsComparerFilters is returned when we attempt to build a merge join with an invalid filter.
+	ErrMergeJoinExpectsComparerFilters = errors.NewKind("merge join expects expression.Comparer filters, found: %T")
+
+	// ErrNoJoinFilters is returned when we attempt to build a filtered join without filters
+	ErrNoJoinFilters = errors.NewKind("join expected non-nil filters")
 )
 
 // CastSQLError returns a *mysql.SQLError with the error code and in some cases, also a SQL state, populated for the

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -47,6 +47,22 @@ func JoinAnd(exprs ...sql.Expression) sql.Expression {
 	}
 }
 
+// SplitConjunction breaks AND expressions into their left and right parts, recursively
+func SplitConjunction(expr sql.Expression) []sql.Expression {
+	if expr == nil {
+		return nil
+	}
+	and, ok := expr.(*And)
+	if !ok {
+		return []sql.Expression{expr}
+	}
+
+	return append(
+		SplitConjunction(and.Left),
+		SplitConjunction(and.Right)...,
+	)
+}
+
 func (a *And) String() string {
 	return fmt.Sprintf("(%s AND %s)", a.Left, a.Right)
 }


### PR DESCRIPTION
Merge joins are only created with a subset of `expression.Comparer` filters today (EQUALS). We previously expected a single comparer filter at exec time. But when there are multiple filters, the parent filter expression will be an AND, and the type cast fails.

Instead of force casting the filter to a comparer during exec iter building, we will now expect a conjunction of comparers. For simplicity, we join on the first filter and add a parent filter iter with the rest. Alternatively, we could limit merge joins to single filters, or expend the memo to accommodate filters moved out of join conditions during join exploration.