### PR TITLE
Fix dolt panic when dealing with top-most left join

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -620,6 +620,19 @@ inner join pq on true order by 1,2,3,4,5,6,7,8 limit 5;`,
 		Query:    "with recursive a(x,y) as (select i,i from mytable where i < 4 union select a.x, mytable.i from a join mytable on a.x+1 = mytable.i limit 2) select * from a;",
 		Expected: []sql.Row{{1, 1}, {2, 2}},
 	},
+	{
+		Query: `
+select * from (
+    (ab JOIN pq ON (1 = p))
+	LEFT OUTER JOIN uv on (2 = u)
+);`,
+		Expected: []sql.Row{
+			{0, 2, 1, 1, 2, 2},
+			{1, 2, 1, 1, 2, 2},
+			{2, 2, 1, 1, 2, 2},
+			{3, 1, 1, 1, 2, 2},
+		},
+	},
 }
 
 var JoinScriptTests = []ScriptTest{

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -87,7 +87,16 @@ func moveJoinConditionsToFilter(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 	var topJoin sql.Node
 	node, same, err := transform.Node(n, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		join, ok := n.(*plan.JoinNode)
-		if !ok || !join.JoinType().IsInner() || join.JoinType().IsDegenerate() {
+		if !ok {
+			// no join
+			return n, transform.SameTree, nil
+		}
+
+		// update top join to be current join
+		topJoin = n
+
+		// no filter or left join: nothing to do to the tree
+		if join.JoinType().IsDegenerate() || !join.JoinType().IsInner() {
 			return n, transform.SameTree, nil
 		}
 

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -119,7 +119,6 @@ func moveJoinConditionsToFilter(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 		}
 
 		if filtersMoved == 0 {
-			topJoin = n
 			return topJoin, transform.SameTree, nil
 		}
 


### PR DESCRIPTION
When moving join conditions to filter, update top join even if a join is left or degenerate.

Fixes https://github.com/dolthub/dolt/issues/5136