### PR TITLE
Varchars don't error for failed IN cast to smaller varchar

### DIFF
--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -87,7 +87,7 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		// convert left to right's type
 		nLeft, err := typ.Convert(left)
 		if err != nil {
-			return nil, err
+			return false, nil
 		}
 
 		key, err := sql.HashOf(sql.NewRow(nLeft))
@@ -105,7 +105,7 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 		val, err = typ.Convert(val)
 		if err != nil {
-			return nil, err
+			return false, nil
 		}
 
 		cmp, err := typ.Compare(left, val)

--- a/sql/plan/insubquery_test.go
+++ b/sql/plan/insubquery_test.go
@@ -17,10 +17,9 @@ package plan_test
 import (
 	"testing"
 
+	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-errors.v1"
-
-	"github.com/dolthub/vitess/go/sqltypes"
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"


### PR DESCRIPTION
This does not address conversions between strings and non-string types, and type casting for index lookups, which look somewhat more complex in mysql.