### PR TITLE
fixes handling of null set values

### DIFF
--- a/sql/types/set.go
+++ b/sql/types/set.go
@@ -329,6 +329,9 @@ func (t SetType) convertBitFieldToString(bitField uint64) (string, error) {
 			if !ok {
 				return "", sql.ErrInvalidSetValue.New(bitField)
 			}
+			if len(val) == 0 {
+				continue
+			}
 			if writeCommas {
 				strBuilder.WriteByte(',')
 			} else {
@@ -348,9 +351,6 @@ func (t SetType) convertStringToBitField(str string) (uint64, error) {
 	var bitField uint64
 	vals := strings.Split(str, ",")
 	for _, val := range vals {
-		if len(val) == 0 {
-			continue
-		}
 		compareVal := val
 		if t.collation != sql.Collation_binary {
 			compareVal = strings.TrimRight(compareVal, " ")

--- a/sql/types/set_test.go
+++ b/sql/types/set_test.go
@@ -172,6 +172,7 @@ func TestSetConvert(t *testing.T) {
 		{[]string{"one", "two"}, sql.Collation_utf8mb4_general_ci, "ONE", "one", false},
 		{[]string{"ONE", "two"}, sql.Collation_utf8mb4_general_ci, "one", "ONE", false},
 
+		{[]string{"one", "two"}, sql.Collation_Default, ",one,two", nil, true},
 		{[]string{"one", "two"}, sql.Collation_Default, 4, nil, true},
 		{[]string{"one", "two"}, sql.Collation_Default, "three", nil, true},
 		{[]string{"one", "two"}, sql.Collation_Default, "one,two,three", nil, true},
@@ -255,4 +256,32 @@ func TestSetString(t *testing.T) {
 func TestSetZero(t *testing.T) {
 	setType := MustCreateSetType([]string{"a", "b"}, sql.Collation_Default)
 	require.Equal(t, uint64(0), setType.Zero())
+}
+
+func TestSetConvertToString(t *testing.T) {
+	tests := []struct {
+		vals        []string
+		collation   sql.CollationID
+		val         string
+		bit         uint64
+		expectedStr string
+	}{
+		{[]string{"", "a", "b", "c"}, sql.Collation_Default, ",a,b,c", 15, "a,b,c"},
+		{[]string{"", "a", "b", "c"}, sql.Collation_Default, "a,,b,c", 15, "a,b,c"},
+		{[]string{"", "a", "b", "c"}, sql.Collation_Default, "a,b,c", 14, "a,b,c"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v %v", test.vals, test.collation), func(t *testing.T) {
+			typ, err := CreateSetType(test.vals, test.collation)
+			require.NoError(t, err)
+			concreteType, ok := typ.(SetType)
+			require.True(t, ok)
+			assert.True(t, test.collation.Equals(typ.Collation()))
+			str, err := concreteType.convertBitFieldToString(test.bit)
+			if assert.NoError(t, err) {
+				assert.Equal(t, test.expectedStr, str)
+			}
+		})
+	}
 }

--- a/sql/types/set_test.go
+++ b/sql/types/set_test.go
@@ -171,6 +171,9 @@ func TestSetConvert(t *testing.T) {
 		{[]string{"a", "b", "c"}, sql.Collation_Default, "b,c  ,a", "a,b,c", false},
 		{[]string{"one", "two"}, sql.Collation_utf8mb4_general_ci, "ONE", "one", false},
 		{[]string{"ONE", "two"}, sql.Collation_utf8mb4_general_ci, "one", "ONE", false},
+		{[]string{"", "one", "two"}, sql.Collation_Default, "", "", false},
+		{[]string{"", "one", "two"}, sql.Collation_Default, ",one,two", ",one,two", false},
+		{[]string{"", "one", "two"}, sql.Collation_Default, "one,,two", ",one,two", false},
 
 		{[]string{"one", "two"}, sql.Collation_Default, ",one,two", nil, true},
 		{[]string{"one", "two"}, sql.Collation_Default, 4, nil, true},
@@ -262,13 +265,11 @@ func TestSetConvertToString(t *testing.T) {
 	tests := []struct {
 		vals        []string
 		collation   sql.CollationID
-		val         string
 		bit         uint64
 		expectedStr string
 	}{
-		{[]string{"", "a", "b", "c"}, sql.Collation_Default, ",a,b,c", 15, "a,b,c"},
-		{[]string{"", "a", "b", "c"}, sql.Collation_Default, "a,,b,c", 15, "a,b,c"},
-		{[]string{"", "a", "b", "c"}, sql.Collation_Default, "a,b,c", 14, "a,b,c"},
+		{[]string{"", "a", "b", "c"}, sql.Collation_Default, 15, "a,b,c"},
+		{[]string{"", "a", "b", "c"}, sql.Collation_Default, 14, "a,b,c"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Null set values were being ignored completely. This PR fixes this issue and addresses the display issue which shows an extra comma when null set values are present in multi-member set values. 

fixes: https://github.com/dolthub/dolt/issues/4966