### PR TITLE
Subquery caching correctness

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -8916,7 +8916,7 @@ WHERE
 			"     │   ├─ cacheable: true\n" +
 			"     │   └─ Project\n" +
 			"     │       ├─ columns: [Subquery\n" +
-			"     │       │   ├─ cacheable: true\n" +
+			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   └─ Limit(1)\n" +
 			"     │       │       └─ TopN(Limit: [1 (tinyint)]; TDRVG.id:2!null ASC nullsFirst)\n" +
 			"     │       │           └─ Project\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -27,8 +27,7 @@ var PlanTests = []QueryPlanTest{
 	{
 		Query: `select x from xy where x in (
 	select (select u from uv where u = sq.p)
-    from (select p from pq) sq
-    where sq.p not in (select a from ab));
+    from (select p from pq) sq);
 `,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [xy.x:0!null]\n" +
@@ -54,24 +53,13 @@ var PlanTests = []QueryPlanTest{
 			"     │       │               ├─ name: uv\n" +
 			"     │       │               └─ projections: [0]\n" +
 			"     │       │   as (select u from uv where u = sq.p)]\n" +
-			"     │       └─ AntiLookupJoin\n" +
-			"     │           ├─ Eq\n" +
-			"     │           │   ├─ sq.p:0!null\n" +
-			"     │           │   └─ applySubq0.a:1!null\n" +
-			"     │           ├─ SubqueryAlias\n" +
-			"     │           │   ├─ name: sq\n" +
-			"     │           │   ├─ outerVisibility: true\n" +
-			"     │           │   ├─ cacheable: true\n" +
-			"     │           │   └─ Table\n" +
-			"     │           │       ├─ name: pq\n" +
-			"     │           │       └─ columns: [p]\n" +
-			"     │           └─ TableAlias(applySubq0)\n" +
-			"     │               └─ IndexedTableAccess\n" +
-			"     │                   ├─ index: [ab.a]\n" +
-			"     │                   ├─ columns: [a]\n" +
-			"     │                   └─ Table\n" +
-			"     │                       ├─ name: ab\n" +
-			"     │                       └─ projections: [0]\n" +
+			"     │       └─ SubqueryAlias\n" +
+			"     │           ├─ name: sq\n" +
+			"     │           ├─ outerVisibility: true\n" +
+			"     │           ├─ cacheable: true\n" +
+			"     │           └─ Table\n" +
+			"     │               ├─ name: pq\n" +
+			"     │               └─ columns: [p]\n" +
 			"     └─ IndexedTableAccess\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         └─ Table\n" +

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -408,6 +408,7 @@ func NewFinalizeSubquerySel(sel RuleSelector) RuleSelector {
 			resolveUnionsId,
 			// skip redundant finalize rules
 			finalizeSubqueriesId,
+			cacheSubqueryResultsId,
 			TrackProcessId:
 			return false
 		}

--- a/sql/analyzer/prune_columns.go
+++ b/sql/analyzer/prune_columns.go
@@ -79,7 +79,7 @@ func pruneColumns(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope, se
 		return nil, transform.SameTree, err
 	}
 
-	n, sameFi, err := fixRemainingFieldsIndexes(ctx, a, n, scope)
+	n, sameFi, err := FixFieldIndexesForNode(a, scope, n)
 	return n, sameC && sameSq && sameFi, err
 }
 
@@ -334,66 +334,4 @@ func shouldPruneExpr(e sql.Expression, cols usedColumns) bool {
 	}
 
 	return !cols.has(gf.Table(), gf.Name())
-}
-
-func fixRemainingFieldsIndexes(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope) (sql.Node, transform.TreeIdentity, error) {
-	return transform.NodeWithCtx(node, canPruneChild, func(c transform.Context) (sql.Node, transform.TreeIdentity, error) {
-		switch n := c.Node.(type) {
-		case sql.SchemaTarget:
-			// do nothing, column defaults have already been resolved
-			return node, transform.SameTree, nil
-		case *plan.SubqueryAlias:
-			if !n.OuterScopeVisibility {
-				return n, transform.SameTree, nil
-			}
-			child, same, err := fixRemainingFieldsIndexes(ctx, a, n.Child, scope)
-			if err != nil {
-				return nil, transform.SameTree, err
-			}
-			if same {
-				return n, transform.SameTree, nil
-			}
-
-			node, err := n.WithChildren(child)
-			if err != nil {
-				return nil, transform.SameTree, err
-			}
-			return node, transform.NewTree, nil
-		default:
-			if _, ok := n.(sql.Expressioner); !ok {
-				return n, transform.SameTree, nil
-			}
-
-			indexedCols, err := indexColumns(ctx, a, n, scope)
-			if err != nil {
-				return nil, transform.SameTree, err
-			}
-
-			if len(indexedCols) == 0 {
-				return n, transform.SameTree, nil
-			}
-
-			// IndexedTableAccess contains expressions in its lookupBuilder that we don't need to fix up, so skip them
-			if _, ok := n.(*plan.IndexedTableAccess); ok {
-				return n, transform.SameTree, nil
-			}
-
-			return transform.OneNodeExprsWithNode(n, func(_ sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-				gf, ok := e.(*expression.GetField)
-				if !ok {
-					return e, transform.SameTree, nil
-				}
-
-				idx, ok := indexedCols[newTableCol(gf.Table(), gf.Name())]
-				if !ok {
-					return nil, transform.SameTree, sql.ErrTableColumnNotFound.New(gf.Table(), gf.Name())
-				}
-
-				if idx.index == gf.Index() {
-					return e, transform.SameTree, nil
-				}
-				return gf.WithIndex(idx.index), transform.NewTree, nil
-			})
-		}
-	})
 }

--- a/sql/expression/function/substring.go
+++ b/sql/expression/function/substring.go
@@ -481,6 +481,17 @@ func (r Right) String() string {
 	return fmt.Sprintf("RIGHT(%s, %s)", r.str, r.len)
 }
 
+func (r Right) DebugString() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("RIGHT")
+	children := []string{
+		fmt.Sprintf("str: %s", sql.DebugString(r.str)),
+		fmt.Sprintf("len: %s", sql.DebugString(r.len)),
+	}
+	_ = pr.WriteChildren(children...)
+	return pr.String()
+}
+
 // Resolved implements the Expression interface.
 func (r Right) Resolved() bool {
 	return r.str.Resolved() && r.len.Resolved()

--- a/sql/plan/join_iters.go
+++ b/sql/plan/join_iters.go
@@ -251,24 +251,6 @@ type existsIter struct {
 	nullRej   bool
 }
 
-func (i *existsIter) loadPrimary(ctx *sql.Context) error {
-	if i.primaryRow == nil {
-		r, err := i.primary.Next(ctx)
-		if err != nil {
-			return err
-		}
-
-		i.primaryRow = i.parentRow.Append(r)
-	}
-
-	return nil
-}
-
-func (i *existsIter) loadSecondary(ctx *sql.Context, left sql.Row) (row sql.Row, err error) {
-	iter, err := i.secondaryProvider.RowIter(ctx, left)
-	return iter.Next(ctx)
-}
-
 type existsState uint8
 
 const (


### PR DESCRIPTION
Rerunning cacheSubqueries recursively on subquery expressions led to an incorrect cacheability labelling. The rule should only be run once on a top-level tree.