### PR TITLE
Fix panic by rewriting how we move filter conditions up.

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -657,6 +657,42 @@ select * from (
 			{1, 2, 2, 2},
 			{1, 2, 3, 3}},
 	},
+	{
+		Query: "select * from (ab JOIN pq) where a in (select a from ab)",
+		Expected: []sql.Row{
+			{0, 2, 0, 0},
+			{0, 2, 1, 1},
+			{0, 2, 2, 2},
+			{0, 2, 3, 3},
+			{1, 2, 0, 0},
+			{1, 2, 1, 1},
+			{1, 2, 2, 2},
+			{1, 2, 3, 3},
+			{2, 2, 0, 0},
+			{2, 2, 1, 1},
+			{2, 2, 2, 2},
+			{2, 2, 3, 3},
+			{3, 1, 0, 0},
+			{3, 1, 1, 1},
+			{3, 1, 2, 2},
+			{3, 1, 3, 3}},
+	},
+	{
+		Query: "select * from (ab JOIN pq ON (a = 1)) where a in (1,2,3)",
+		Expected: []sql.Row{
+			{1, 2, 0, 0},
+			{1, 2, 1, 1},
+			{1, 2, 2, 2},
+			{1, 2, 3, 3}},
+	},
+	{
+		Query: "select * from (ab JOIN pq ON (a = 1)) where a in (select a from ab)",
+		Expected: []sql.Row{
+			{1, 2, 0, 0},
+			{1, 2, 1, 1},
+			{1, 2, 2, 2},
+			{1, 2, 3, 3}},
+	},
 }
 
 var JoinScriptTests = []ScriptTest{

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -693,6 +693,23 @@ select * from (
 			{1, 2, 2, 2},
 			{1, 2, 3, 3}},
 	},
+	{
+		// verify this troublesome query from dolt with a syntactically similar query:
+		// SELECT count(*) from dolt_log('main') join dolt_diff(@Commit1, @Commit2, 't') where commit_hash = to_commit;
+		Query: `SELECT count(*)
+FROM
+JSON_TABLE(
+	'[{"a":1.5, "b":2.25},{"a":3.125, "b":4.0625}]',
+	'$[*]' COLUMNS(x float path '$.a', y float path '$.b')
+) as t1
+join
+JSON_TABLE(
+	'[{"c":2, "d":3},{"c":4, "d":5}]',
+	'$[*]' COLUMNS(z float path '$.c', w float path '$.d')
+) as t2
+on w = 0;`,
+		Expected: []sql.Row{{0}},
+	},
 }
 
 var JoinScriptTests = []ScriptTest{

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -633,6 +633,30 @@ select * from (
 			{3, 1, 1, 1, 2, 2},
 		},
 	},
+	{
+		Query: "select * from (ab JOIN pq ON (a = 1)) where a in (1,2,3)",
+		Expected: []sql.Row{
+			{1, 2, 0, 0},
+			{1, 2, 1, 1},
+			{1, 2, 2, 2},
+			{1, 2, 3, 3}},
+	},
+	{
+		Query: "select * from (ab JOIN pq ON (a = p)) where a in (select a from ab)",
+		Expected: []sql.Row{
+			{0, 2, 0, 0},
+			{1, 2, 1, 1},
+			{2, 2, 2, 2},
+			{3, 1, 3, 3}},
+	},
+	{
+		Query: "select * from (ab JOIN pq ON (a = 1)) where a in (select a from ab)",
+		Expected: []sql.Row{
+			{1, 2, 0, 0},
+			{1, 2, 1, 1},
+			{1, 2, 2, 2},
+			{1, 2, 3, 3}},
+	},
 }
 
 var JoinScriptTests = []ScriptTest{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -7737,20 +7737,12 @@ WHERE
 			"     │   ├─ cacheable: true\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ AND\n" +
-			"     │       │   ├─ AND\n" +
-			"     │       │   │   ├─ Eq\n" +
-			"     │       │   │   │   ├─ TTDPM:2!null\n" +
-			"     │       │   │   │   └─ 0 (tinyint)\n" +
-			"     │       │   │   └─ GreaterThan\n" +
-			"     │       │   │       ├─ FBSRS:3!null\n" +
-			"     │       │   │       └─ 0 (tinyint)\n" +
-			"     │       │   └─ AND\n" +
-			"     │       │       ├─ Eq\n" +
-			"     │       │       │   ├─ TTDPM:2!null\n" +
-			"     │       │       │   └─ 0 (tinyint)\n" +
-			"     │       │       └─ GreaterThan\n" +
-			"     │       │           ├─ FBSRS:3!null\n" +
-			"     │       │           └─ 0 (tinyint)\n" +
+			"     │       │   ├─ Eq\n" +
+			"     │       │   │   ├─ TTDPM:2!null\n" +
+			"     │       │   │   └─ 0 (tinyint)\n" +
+			"     │       │   └─ GreaterThan\n" +
+			"     │       │       ├─ FBSRS:3!null\n" +
+			"     │       │       └─ 0 (tinyint)\n" +
 			"     │       └─ Having\n" +
 			"     │           ├─ GreaterThan\n" +
 			"     │           │   ├─ JTOA7:1!null\n" +
@@ -7788,11 +7780,13 @@ WHERE
 			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               └─ name: E2I7U\n" +
-			"     └─ TableAlias(PBMRX)\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [E2I7U.ZH72S]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: E2I7U\n" +
+			"     └─ Filter\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         └─ TableAlias(PBMRX)\n" +
+			"             └─ IndexedTableAccess\n" +
+			"                 ├─ index: [E2I7U.ZH72S]\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: E2I7U\n" +
 			"",
 	},
 	{
@@ -8236,20 +8230,12 @@ WHERE
 			"     │   ├─ cacheable: true\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ AND\n" +
-			"     │       │   ├─ AND\n" +
-			"     │       │   │   ├─ Eq\n" +
-			"     │       │   │   │   ├─ BADTB:2!null\n" +
-			"     │       │   │   │   └─ 0 (tinyint)\n" +
-			"     │       │   │   └─ GreaterThan\n" +
-			"     │       │   │       ├─ FLHXH:3!null\n" +
-			"     │       │   │       └─ 0 (tinyint)\n" +
-			"     │       │   └─ AND\n" +
-			"     │       │       ├─ Eq\n" +
-			"     │       │       │   ├─ BADTB:2!null\n" +
-			"     │       │       │   └─ 0 (tinyint)\n" +
-			"     │       │       └─ GreaterThan\n" +
-			"     │       │           ├─ FLHXH:3!null\n" +
-			"     │       │           └─ 0 (tinyint)\n" +
+			"     │       │   ├─ Eq\n" +
+			"     │       │   │   ├─ BADTB:2!null\n" +
+			"     │       │   │   └─ 0 (tinyint)\n" +
+			"     │       │   └─ GreaterThan\n" +
+			"     │       │       ├─ FLHXH:3!null\n" +
+			"     │       │       └─ 0 (tinyint)\n" +
 			"     │       └─ Having\n" +
 			"     │           ├─ GreaterThan\n" +
 			"     │           │   ├─ JTOA7:1!null\n" +
@@ -8287,11 +8273,13 @@ WHERE
 			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               └─ name: E2I7U\n" +
-			"     └─ TableAlias(PBMRX)\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [E2I7U.ZH72S]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: E2I7U\n" +
+			"     └─ Filter\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         └─ TableAlias(PBMRX)\n" +
+			"             └─ IndexedTableAccess\n" +
+			"                 ├─ index: [E2I7U.ZH72S]\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: E2I7U\n" +
 			"",
 	},
 	{
@@ -9056,20 +9044,12 @@ WHERE
 			"     │   ├─ cacheable: true\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ AND\n" +
-			"     │       │   ├─ AND\n" +
-			"     │       │   │   ├─ Eq\n" +
-			"     │       │   │   │   ├─ B4OVH:2!null\n" +
-			"     │       │   │   │   └─ 0 (tinyint)\n" +
-			"     │       │   │   └─ GreaterThan\n" +
-			"     │       │   │       ├─ R5CKX:3!null\n" +
-			"     │       │   │       └─ 0 (tinyint)\n" +
-			"     │       │   └─ AND\n" +
-			"     │       │       ├─ Eq\n" +
-			"     │       │       │   ├─ B4OVH:2!null\n" +
-			"     │       │       │   └─ 0 (tinyint)\n" +
-			"     │       │       └─ GreaterThan\n" +
-			"     │       │           ├─ R5CKX:3!null\n" +
-			"     │       │           └─ 0 (tinyint)\n" +
+			"     │       │   ├─ Eq\n" +
+			"     │       │   │   ├─ B4OVH:2!null\n" +
+			"     │       │   │   └─ 0 (tinyint)\n" +
+			"     │       │   └─ GreaterThan\n" +
+			"     │       │       ├─ R5CKX:3!null\n" +
+			"     │       │       └─ 0 (tinyint)\n" +
 			"     │       └─ Having\n" +
 			"     │           ├─ GreaterThan\n" +
 			"     │           │   ├─ JTOA7:1!null\n" +
@@ -9107,11 +9087,13 @@ WHERE
 			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               └─ name: E2I7U\n" +
-			"     └─ TableAlias(PBMRX)\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [E2I7U.ZH72S]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: E2I7U\n" +
+			"     └─ Filter\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         └─ TableAlias(PBMRX)\n" +
+			"             └─ IndexedTableAccess\n" +
+			"                 ├─ index: [E2I7U.ZH72S]\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: E2I7U\n" +
 			"",
 	},
 	{
@@ -9715,73 +9697,69 @@ WHERE
 			" │                       │   ├─ cacheable: true\n" +
 			" │                       │   └─ Project\n" +
 			" │                       │       ├─ columns: [KHJJO.BDNYB:24!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:8!null as M22QN, cec.ADURZ:21!null as ADURZ, cec.NO52D:18!null as NO52D, ct.S3Q3Y:14!null as IDPK7]\n" +
-			" │                       │       └─ Filter\n" +
-			" │                       │           ├─ HashIn\n" +
-			" │                       │           │   ├─ ci.FTQLQ:1!null\n" +
-			" │                       │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │                       │           └─ HashJoin\n" +
-			" │                       │               ├─ AND\n" +
-			" │                       │               │   ├─ Eq\n" +
-			" │                       │               │   │   ├─ ct.M22QN:8!null\n" +
-			" │                       │               │   │   └─ KHJJO.M22QN:23!null\n" +
-			" │                       │               │   └─ Eq\n" +
-			" │                       │               │       ├─ ct.LUEVY:7!null\n" +
-			" │                       │               │       └─ KHJJO.LUEVY:25!null\n" +
-			" │                       │               ├─ LookupJoin\n" +
-			" │                       │               │   ├─ Eq\n" +
-			" │                       │               │   │   ├─ cec.id:17!null\n" +
-			" │                       │               │   │   └─ ct.OVE3E:9!null\n" +
-			" │                       │               │   ├─ LookupJoin\n" +
-			" │                       │               │   │   ├─ Eq\n" +
-			" │                       │               │   │   │   ├─ ci.id:0!null\n" +
-			" │                       │               │   │   │   └─ ct.FZ2R5:6!null\n" +
-			" │                       │               │   │   ├─ Filter\n" +
-			" │                       │               │   │   │   ├─ HashIn\n" +
-			" │                       │               │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
-			" │                       │               │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │                       │               │   │   │   └─ TableAlias(ci)\n" +
-			" │                       │               │   │   │       └─ IndexedTableAccess\n" +
-			" │                       │               │   │   │           ├─ index: [JDLNA.FTQLQ]\n" +
-			" │                       │               │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			" │                       │               │   │   │           └─ Table\n" +
-			" │                       │               │   │   │               └─ name: JDLNA\n" +
-			" │                       │               │   │   └─ Filter\n" +
-			" │                       │               │   │       ├─ Eq\n" +
-			" │                       │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
-			" │                       │               │   │       │   └─ = (longtext)\n" +
-			" │                       │               │   │       └─ TableAlias(ct)\n" +
-			" │                       │               │   │           └─ IndexedTableAccess\n" +
-			" │                       │               │   │               ├─ index: [FLQLP.FZ2R5]\n" +
-			" │                       │               │   │               └─ Table\n" +
-			" │                       │               │   │                   └─ name: FLQLP\n" +
-			" │                       │               │   └─ TableAlias(cec)\n" +
-			" │                       │               │       └─ IndexedTableAccess\n" +
-			" │                       │               │           ├─ index: [SFEGG.id]\n" +
-			" │                       │               │           └─ Table\n" +
-			" │                       │               │               └─ name: SFEGG\n" +
-			" │                       │               └─ HashLookup\n" +
-			" │                       │                   ├─ source: TUPLE(ct.M22QN:8!null, ct.LUEVY:7!null)\n" +
-			" │                       │                   ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
-			" │                       │                   └─ CachedResults\n" +
-			" │                       │                       └─ SubqueryAlias\n" +
-			" │                       │                           ├─ name: KHJJO\n" +
-			" │                       │                           ├─ outerVisibility: false\n" +
-			" │                       │                           ├─ cacheable: true\n" +
-			" │                       │                           └─ Distinct\n" +
-			" │                       │                               └─ Project\n" +
-			" │                       │                                   ├─ columns: [mf.M22QN:13!null as M22QN, sn.id:0!null as BDNYB, mf.LUEVY:12!null as LUEVY]\n" +
-			" │                       │                                   └─ LookupJoin\n" +
-			" │                       │                                       ├─ Eq\n" +
-			" │                       │                                       │   ├─ sn.BRQP2:1!null\n" +
-			" │                       │                                       │   └─ mf.LUEVY:12!null\n" +
-			" │                       │                                       ├─ TableAlias(sn)\n" +
-			" │                       │                                       │   └─ Table\n" +
-			" │                       │                                       │       └─ name: NOXN3\n" +
-			" │                       │                                       └─ TableAlias(mf)\n" +
-			" │                       │                                           └─ IndexedTableAccess\n" +
-			" │                       │                                               ├─ index: [HGMQ6.LUEVY]\n" +
-			" │                       │                                               └─ Table\n" +
-			" │                       │                                                   └─ name: HGMQ6\n" +
+			" │                       │       └─ HashJoin\n" +
+			" │                       │           ├─ AND\n" +
+			" │                       │           │   ├─ Eq\n" +
+			" │                       │           │   │   ├─ ct.M22QN:8!null\n" +
+			" │                       │           │   │   └─ KHJJO.M22QN:23!null\n" +
+			" │                       │           │   └─ Eq\n" +
+			" │                       │           │       ├─ ct.LUEVY:7!null\n" +
+			" │                       │           │       └─ KHJJO.LUEVY:25!null\n" +
+			" │                       │           ├─ LookupJoin\n" +
+			" │                       │           │   ├─ Eq\n" +
+			" │                       │           │   │   ├─ cec.id:17!null\n" +
+			" │                       │           │   │   └─ ct.OVE3E:9!null\n" +
+			" │                       │           │   ├─ LookupJoin\n" +
+			" │                       │           │   │   ├─ Eq\n" +
+			" │                       │           │   │   │   ├─ ci.id:0!null\n" +
+			" │                       │           │   │   │   └─ ct.FZ2R5:6!null\n" +
+			" │                       │           │   │   ├─ Filter\n" +
+			" │                       │           │   │   │   ├─ HashIn\n" +
+			" │                       │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
+			" │                       │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			" │                       │           │   │   │   └─ TableAlias(ci)\n" +
+			" │                       │           │   │   │       └─ IndexedTableAccess\n" +
+			" │                       │           │   │   │           ├─ index: [JDLNA.FTQLQ]\n" +
+			" │                       │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
+			" │                       │           │   │   │           └─ Table\n" +
+			" │                       │           │   │   │               └─ name: JDLNA\n" +
+			" │                       │           │   │   └─ Filter\n" +
+			" │                       │           │   │       ├─ Eq\n" +
+			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
+			" │                       │           │   │       │   └─ = (longtext)\n" +
+			" │                       │           │   │       └─ TableAlias(ct)\n" +
+			" │                       │           │   │           └─ IndexedTableAccess\n" +
+			" │                       │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
+			" │                       │           │   │               └─ Table\n" +
+			" │                       │           │   │                   └─ name: FLQLP\n" +
+			" │                       │           │   └─ TableAlias(cec)\n" +
+			" │                       │           │       └─ IndexedTableAccess\n" +
+			" │                       │           │           ├─ index: [SFEGG.id]\n" +
+			" │                       │           │           └─ Table\n" +
+			" │                       │           │               └─ name: SFEGG\n" +
+			" │                       │           └─ HashLookup\n" +
+			" │                       │               ├─ source: TUPLE(ct.M22QN:8!null, ct.LUEVY:7!null)\n" +
+			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
+			" │                       │               └─ CachedResults\n" +
+			" │                       │                   └─ SubqueryAlias\n" +
+			" │                       │                       ├─ name: KHJJO\n" +
+			" │                       │                       ├─ outerVisibility: false\n" +
+			" │                       │                       ├─ cacheable: true\n" +
+			" │                       │                       └─ Distinct\n" +
+			" │                       │                           └─ Project\n" +
+			" │                       │                               ├─ columns: [mf.M22QN:13!null as M22QN, sn.id:0!null as BDNYB, mf.LUEVY:12!null as LUEVY]\n" +
+			" │                       │                               └─ LookupJoin\n" +
+			" │                       │                                   ├─ Eq\n" +
+			" │                       │                                   │   ├─ sn.BRQP2:1!null\n" +
+			" │                       │                                   │   └─ mf.LUEVY:12!null\n" +
+			" │                       │                                   ├─ TableAlias(sn)\n" +
+			" │                       │                                   │   └─ Table\n" +
+			" │                       │                                   │       └─ name: NOXN3\n" +
+			" │                       │                                   └─ TableAlias(mf)\n" +
+			" │                       │                                       └─ IndexedTableAccess\n" +
+			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │                       │                                           └─ Table\n" +
+			" │                       │                                               └─ name: HGMQ6\n" +
 			" │                       └─ TableAlias(sn)\n" +
 			" │                           └─ IndexedTableAccess\n" +
 			" │                               ├─ index: [NOXN3.id]\n" +
@@ -9822,26 +9800,22 @@ WHERE
 			"             │           │   └─ Project\n" +
 			"             │           │       ├─ columns: [sn.id:23!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
 			"             │           │       └─ Filter\n" +
-			"             │           │           ├─ AND\n" +
-			"             │           │           │   ├─ HashIn\n" +
-			"             │           │           │   │   ├─ ci.FTQLQ:19!null\n" +
-			"             │           │           │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"             │           │           │   └─ Eq\n" +
-			"             │           │           │       ├─ ct.M22QN:9!null\n" +
-			"             │           │           │       └─ Subquery\n" +
-			"             │           │           │           ├─ cacheable: true\n" +
-			"             │           │           │           └─ Project\n" +
-			"             │           │           │               ├─ columns: [aac.id:33!null]\n" +
-			"             │           │           │               └─ Filter\n" +
-			"             │           │           │                   ├─ Eq\n" +
-			"             │           │           │                   │   ├─ aac.BTXC5:34\n" +
-			"             │           │           │                   │   └─ WT (longtext)\n" +
-			"             │           │           │                   └─ TableAlias(aac)\n" +
-			"             │           │           │                       └─ IndexedTableAccess\n" +
-			"             │           │           │                           ├─ index: [TPXBU.BTXC5]\n" +
-			"             │           │           │                           ├─ static: [{[WT, WT]}]\n" +
-			"             │           │           │                           └─ Table\n" +
-			"             │           │           │                               └─ name: TPXBU\n" +
+			"             │           │           ├─ Eq\n" +
+			"             │           │           │   ├─ ct.M22QN:9!null\n" +
+			"             │           │           │   └─ Subquery\n" +
+			"             │           │           │       ├─ cacheable: true\n" +
+			"             │           │           │       └─ Project\n" +
+			"             │           │           │           ├─ columns: [aac.id:33!null]\n" +
+			"             │           │           │           └─ Filter\n" +
+			"             │           │           │               ├─ Eq\n" +
+			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
+			"             │           │           │               │   └─ WT (longtext)\n" +
+			"             │           │           │               └─ TableAlias(aac)\n" +
+			"             │           │           │                   └─ IndexedTableAccess\n" +
+			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
+			"             │           │           │                       └─ Table\n" +
+			"             │           │           │                           └─ name: TPXBU\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
 			"             │           │               │   ├─ ct.LUEVY:8!null\n" +
@@ -10070,70 +10044,66 @@ WHERE
 			" │                       │   ├─ cacheable: true\n" +
 			" │                       │   └─ Project\n" +
 			" │                       │       ├─ columns: [KHJJO.BDNYB:24!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
-			" │                       │       └─ Filter\n" +
-			" │                       │           ├─ HashIn\n" +
-			" │                       │           │   ├─ ci.FTQLQ:19!null\n" +
-			" │                       │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │                       │           └─ HashJoin\n" +
-			" │                       │               ├─ AND\n" +
-			" │                       │               │   ├─ Eq\n" +
-			" │                       │               │   │   ├─ ct.M22QN:9!null\n" +
-			" │                       │               │   │   └─ KHJJO.M22QN:23!null\n" +
-			" │                       │               │   └─ Eq\n" +
-			" │                       │               │       ├─ ct.LUEVY:8!null\n" +
-			" │                       │               │       └─ KHJJO.LUEVY:25!null\n" +
-			" │                       │               ├─ LookupJoin\n" +
-			" │                       │               │   ├─ Eq\n" +
-			" │                       │               │   │   ├─ ci.id:18!null\n" +
-			" │                       │               │   │   └─ ct.FZ2R5:7!null\n" +
-			" │                       │               │   ├─ LookupJoin\n" +
-			" │                       │               │   │   ├─ Eq\n" +
-			" │                       │               │   │   │   ├─ cec.id:0!null\n" +
-			" │                       │               │   │   │   └─ ct.OVE3E:10!null\n" +
-			" │                       │               │   │   ├─ TableAlias(cec)\n" +
-			" │                       │               │   │   │   └─ Table\n" +
-			" │                       │               │   │   │       └─ name: SFEGG\n" +
-			" │                       │               │   │   └─ Filter\n" +
-			" │                       │               │   │       ├─ Eq\n" +
-			" │                       │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
-			" │                       │               │   │       │   └─ = (longtext)\n" +
-			" │                       │               │   │       └─ TableAlias(ct)\n" +
-			" │                       │               │   │           └─ IndexedTableAccess\n" +
-			" │                       │               │   │               ├─ index: [FLQLP.OVE3E]\n" +
-			" │                       │               │   │               └─ Table\n" +
-			" │                       │               │   │                   └─ name: FLQLP\n" +
-			" │                       │               │   └─ Filter\n" +
-			" │                       │               │       ├─ HashIn\n" +
-			" │                       │               │       │   ├─ ci.FTQLQ:1!null\n" +
-			" │                       │               │       │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │                       │               │       └─ TableAlias(ci)\n" +
-			" │                       │               │           └─ IndexedTableAccess\n" +
-			" │                       │               │               ├─ index: [JDLNA.id]\n" +
-			" │                       │               │               └─ Table\n" +
-			" │                       │               │                   └─ name: JDLNA\n" +
-			" │                       │               └─ HashLookup\n" +
-			" │                       │                   ├─ source: TUPLE(ct.M22QN:9!null, ct.LUEVY:8!null)\n" +
-			" │                       │                   ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
-			" │                       │                   └─ CachedResults\n" +
-			" │                       │                       └─ SubqueryAlias\n" +
-			" │                       │                           ├─ name: KHJJO\n" +
-			" │                       │                           ├─ outerVisibility: false\n" +
-			" │                       │                           ├─ cacheable: true\n" +
-			" │                       │                           └─ Distinct\n" +
-			" │                       │                               └─ Project\n" +
-			" │                       │                                   ├─ columns: [mf.M22QN:13!null as M22QN, sn.id:0!null as BDNYB, mf.LUEVY:12!null as LUEVY]\n" +
-			" │                       │                                   └─ LookupJoin\n" +
-			" │                       │                                       ├─ Eq\n" +
-			" │                       │                                       │   ├─ sn.BRQP2:1!null\n" +
-			" │                       │                                       │   └─ mf.LUEVY:12!null\n" +
-			" │                       │                                       ├─ TableAlias(sn)\n" +
-			" │                       │                                       │   └─ Table\n" +
-			" │                       │                                       │       └─ name: NOXN3\n" +
-			" │                       │                                       └─ TableAlias(mf)\n" +
-			" │                       │                                           └─ IndexedTableAccess\n" +
-			" │                       │                                               ├─ index: [HGMQ6.LUEVY]\n" +
-			" │                       │                                               └─ Table\n" +
-			" │                       │                                                   └─ name: HGMQ6\n" +
+			" │                       │       └─ HashJoin\n" +
+			" │                       │           ├─ AND\n" +
+			" │                       │           │   ├─ Eq\n" +
+			" │                       │           │   │   ├─ ct.M22QN:9!null\n" +
+			" │                       │           │   │   └─ KHJJO.M22QN:23!null\n" +
+			" │                       │           │   └─ Eq\n" +
+			" │                       │           │       ├─ ct.LUEVY:8!null\n" +
+			" │                       │           │       └─ KHJJO.LUEVY:25!null\n" +
+			" │                       │           ├─ LookupJoin\n" +
+			" │                       │           │   ├─ Eq\n" +
+			" │                       │           │   │   ├─ ci.id:18!null\n" +
+			" │                       │           │   │   └─ ct.FZ2R5:7!null\n" +
+			" │                       │           │   ├─ LookupJoin\n" +
+			" │                       │           │   │   ├─ Eq\n" +
+			" │                       │           │   │   │   ├─ cec.id:0!null\n" +
+			" │                       │           │   │   │   └─ ct.OVE3E:10!null\n" +
+			" │                       │           │   │   ├─ TableAlias(cec)\n" +
+			" │                       │           │   │   │   └─ Table\n" +
+			" │                       │           │   │   │       └─ name: SFEGG\n" +
+			" │                       │           │   │   └─ Filter\n" +
+			" │                       │           │   │       ├─ Eq\n" +
+			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
+			" │                       │           │   │       │   └─ = (longtext)\n" +
+			" │                       │           │   │       └─ TableAlias(ct)\n" +
+			" │                       │           │   │           └─ IndexedTableAccess\n" +
+			" │                       │           │   │               ├─ index: [FLQLP.OVE3E]\n" +
+			" │                       │           │   │               └─ Table\n" +
+			" │                       │           │   │                   └─ name: FLQLP\n" +
+			" │                       │           │   └─ Filter\n" +
+			" │                       │           │       ├─ HashIn\n" +
+			" │                       │           │       │   ├─ ci.FTQLQ:1!null\n" +
+			" │                       │           │       │   └─ TUPLE(SQ1 (longtext))\n" +
+			" │                       │           │       └─ TableAlias(ci)\n" +
+			" │                       │           │           └─ IndexedTableAccess\n" +
+			" │                       │           │               ├─ index: [JDLNA.id]\n" +
+			" │                       │           │               └─ Table\n" +
+			" │                       │           │                   └─ name: JDLNA\n" +
+			" │                       │           └─ HashLookup\n" +
+			" │                       │               ├─ source: TUPLE(ct.M22QN:9!null, ct.LUEVY:8!null)\n" +
+			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
+			" │                       │               └─ CachedResults\n" +
+			" │                       │                   └─ SubqueryAlias\n" +
+			" │                       │                       ├─ name: KHJJO\n" +
+			" │                       │                       ├─ outerVisibility: false\n" +
+			" │                       │                       ├─ cacheable: true\n" +
+			" │                       │                       └─ Distinct\n" +
+			" │                       │                           └─ Project\n" +
+			" │                       │                               ├─ columns: [mf.M22QN:13!null as M22QN, sn.id:0!null as BDNYB, mf.LUEVY:12!null as LUEVY]\n" +
+			" │                       │                               └─ LookupJoin\n" +
+			" │                       │                                   ├─ Eq\n" +
+			" │                       │                                   │   ├─ sn.BRQP2:1!null\n" +
+			" │                       │                                   │   └─ mf.LUEVY:12!null\n" +
+			" │                       │                                   ├─ TableAlias(sn)\n" +
+			" │                       │                                   │   └─ Table\n" +
+			" │                       │                                   │       └─ name: NOXN3\n" +
+			" │                       │                                   └─ TableAlias(mf)\n" +
+			" │                       │                                       └─ IndexedTableAccess\n" +
+			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │                       │                                           └─ Table\n" +
+			" │                       │                                               └─ name: HGMQ6\n" +
 			" │                       └─ TableAlias(sn)\n" +
 			" │                           └─ IndexedTableAccess\n" +
 			" │                               ├─ index: [NOXN3.id]\n" +
@@ -10174,26 +10144,22 @@ WHERE
 			"             │           │   └─ Project\n" +
 			"             │           │       ├─ columns: [sn.id:23!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
 			"             │           │       └─ Filter\n" +
-			"             │           │           ├─ AND\n" +
-			"             │           │           │   ├─ HashIn\n" +
-			"             │           │           │   │   ├─ ci.FTQLQ:19!null\n" +
-			"             │           │           │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"             │           │           │   └─ Eq\n" +
-			"             │           │           │       ├─ ct.M22QN:9!null\n" +
-			"             │           │           │       └─ Subquery\n" +
-			"             │           │           │           ├─ cacheable: true\n" +
-			"             │           │           │           └─ Project\n" +
-			"             │           │           │               ├─ columns: [aac.id:33!null]\n" +
-			"             │           │           │               └─ Filter\n" +
-			"             │           │           │                   ├─ Eq\n" +
-			"             │           │           │                   │   ├─ aac.BTXC5:34\n" +
-			"             │           │           │                   │   └─ WT (longtext)\n" +
-			"             │           │           │                   └─ TableAlias(aac)\n" +
-			"             │           │           │                       └─ IndexedTableAccess\n" +
-			"             │           │           │                           ├─ index: [TPXBU.BTXC5]\n" +
-			"             │           │           │                           ├─ static: [{[WT, WT]}]\n" +
-			"             │           │           │                           └─ Table\n" +
-			"             │           │           │                               └─ name: TPXBU\n" +
+			"             │           │           ├─ Eq\n" +
+			"             │           │           │   ├─ ct.M22QN:9!null\n" +
+			"             │           │           │   └─ Subquery\n" +
+			"             │           │           │       ├─ cacheable: true\n" +
+			"             │           │           │       └─ Project\n" +
+			"             │           │           │           ├─ columns: [aac.id:33!null]\n" +
+			"             │           │           │           └─ Filter\n" +
+			"             │           │           │               ├─ Eq\n" +
+			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
+			"             │           │           │               │   └─ WT (longtext)\n" +
+			"             │           │           │               └─ TableAlias(aac)\n" +
+			"             │           │           │                   └─ IndexedTableAccess\n" +
+			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
+			"             │           │           │                       └─ Table\n" +
+			"             │           │           │                           └─ name: TPXBU\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
 			"             │           │               │   ├─ ct.LUEVY:8!null\n" +

--- a/sql/analyzer/join_order_builder.go
+++ b/sql/analyzer/join_order_builder.go
@@ -79,7 +79,7 @@ import (
 //
 // Applicability rules:
 //
-// We build applicibility rules before exhaustive enumeration to filter valid
+// We build applicability rules before exhaustive enumeration to filter valid
 // plans. We consider a reordering valid by checking:
 //
 // 1) Transform compatibility: a lookup table between two join operator types

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -190,12 +190,16 @@ func moveJoinConditionsToFilter(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 		}
 	})
 
+	if err != nil {
+		return nil, transform.SameTree, err
+	}
+
 	// if there are still nonJoinFilters left, it means we removed them but failed to re-insert them
 	if len(nonJoinFilters) > 0 {
 		return nil, transform.SameTree, sql.ErrDroppedJoinFilters.New()
 	}
 
-	return resultNode, resultIdentity, err
+	return resultNode, resultIdentity, nil
 }
 
 // removeUnnecessaryConverts removes any Convert expressions that don't alter the type of the expression.

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -149,21 +149,53 @@ func moveJoinConditionsToFilter(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 		return node, transform.SameTree, nil
 	}
 
-	return transform.NodeWithCtx(node, func(transform.Context) bool { return true }, func(c transform.Context) (sql.Node, transform.TreeIdentity, error) {
-		if c.Node != topJoin {
-			return c.Node, transform.SameTree, nil
+	if node == topJoin {
+		return plan.NewFilter(expression.JoinAnd(nonJoinFilters...), node), transform.NewTree, nil
+	}
+
+	resultNode, resultIdentity, err := transform.Node(node, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
+		children := n.Children()
+		if len(children) == 0 {
+			return n, transform.SameTree, nil
 		}
-		switch n := c.Parent.(type) {
+
+		indexOfTopJoin := -1
+		for idx, child := range children {
+			if child == topJoin {
+				indexOfTopJoin = idx
+				break
+			}
+		}
+		if indexOfTopJoin == -1 {
+			return n, transform.SameTree, nil
+		}
+
+		switch n := n.(type) {
 		case *plan.Filter:
-			return plan.NewFilter(
-				expression.JoinAnd(append([]sql.Expression{n.Expression}, nonJoinFilters...)...),
-				n.Child), transform.NewTree, nil
+			nonJoinFilters = append(nonJoinFilters, n.Expression)
+			newExpression := expression.JoinAnd(nonJoinFilters...)
+			newFilter := plan.NewFilter(newExpression, topJoin)
+			nonJoinFilters = nil // clear nonJoinFilters so we know they were used
+			return newFilter, transform.NewTree, nil
 		default:
-			return plan.NewFilter(
-				expression.JoinAnd(nonJoinFilters...),
-				c.Node), transform.NewTree, nil
+			newExpression := expression.JoinAnd(nonJoinFilters...)
+			newFilter := plan.NewFilter(newExpression, topJoin)
+			children[indexOfTopJoin] = newFilter
+			updatedNode, err := n.WithChildren(children...)
+			if err != nil {
+				return nil, transform.SameTree, err
+			}
+			nonJoinFilters = nil // clear nonJoinFilters so we know they were used
+			return updatedNode, transform.NewTree, nil
 		}
 	})
+
+	// if there are still nonJoinFilters left, it means we removed them but failed to re-insert them
+	if len(nonJoinFilters) > 0 {
+		return nil, transform.SameTree, sql.ErrDroppedJoinFilters.New()
+	}
+
+	return resultNode, resultIdentity, err
 }
 
 // removeUnnecessaryConverts removes any Convert expressions that don't alter the type of the expression.

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -759,6 +759,9 @@ var (
 
 	// ErrNoJoinFilters is returned when we attempt to build a filtered join without filters
 	ErrNoJoinFilters = errors.NewKind("join expected non-nil filters")
+
+	// ErrDroppedJoinFilters is returned when we removed filters from a join, but failed to re-insert them
+	ErrDroppedJoinFilters = errors.NewKind("dropped filters from join, but failed to re-insert them")
 )
 
 // CastSQLError returns a *mysql.SQLError with the error code and in some cases, also a SQL state, populated for the


### PR DESCRIPTION
Attempt #2, this fix properly includes the new filter between topJoin and its parent.

Fixes dolthub/dolt#5214