### PR TITLE
adding setter function for queryTime in sqlContext

### DIFF
--- a/sql/session.go
+++ b/sql/session.go
@@ -364,6 +364,11 @@ func (c *Context) QueryTime() time.Time {
 	return c.queryTime
 }
 
+// SetQueryTime updates the queryTime to the given time
+func (c *Context) SetQueryTime(t time.Time) {
+	c.queryTime = t
+}
+
 // Span creates a new tracing span with the given context.
 // It will return the span and a new context that should be passed to all
 // children of this span.


### PR DESCRIPTION
adds setter function for the `queryTime` field in `sqlContext` so that the correct starting time for queries can be updated

related: https://github.com/dolthub/dolt/pull/5291
fixes: https://github.com/dolthub/dolt/issues/5241