### PR TITLE
not perform optimization_rule on like clause for `utf8mb3` charset

### DIFF
--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -16279,20 +16279,10 @@ var IndexPlanTests = []QueryPlanTest{
 	{
 		Query: `select * from comp_index_t3 where v1 like 'a%'`,
 		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThanOrEqual\n" +
-			" │   │   ├─ comp_index_t3.v1:1\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThanOrEqual\n" +
-			" │       ├─ comp_index_t3.v1:1\n" +
-			" │       └─ aÿ (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
-			"     ├─ index: [comp_index_t3.v1]\n" +
-			"     ├─ static: [{[a, aÿ]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t3\n" +
-			"         └─ projections: [0 1 2]\n" +
+			" ├─ comp_index_t3.v1 LIKE 'a%'\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t3\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -16309,13 +16299,7 @@ var IndexPlanTests = []QueryPlanTest{
 	{
 		Query: `select * from comp_index_t3 where v2 like 'a%'`,
 		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThanOrEqual\n" +
-			" │   │   ├─ comp_index_t3.v2:2\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThanOrEqual\n" +
-			" │       ├─ comp_index_t3.v2:2\n" +
-			" │       └─ aÿ (longtext)\n" +
+			" ├─ comp_index_t3.v2 LIKE 'a%'\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t3\n" +
 			"     └─ columns: [pk v1 v2]\n" +

--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -654,6 +654,22 @@ var SkippedInfoSchemaQueries = []QueryTest{
 
 var InfoSchemaScripts = []ScriptTest{
 	{
+		Name: "query does not use optimization rule on LIKE clause because info_schema db charset is utf8mb3",
+		SetUpScript: []string{
+			"CREATE TABLE t1 (a int, condition_choose varchar(10));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select column_name from information_schema.columns where column_name like 'condition%';",
+				Expected: []sql.Row{{"condition_choose"}},
+			},
+			{
+				Query:    "select column_name from information_schema.columns where column_name like '%condition%';",
+				Expected: []sql.Row{{"ACTION_CONDITION"}, {"condition_choose"}},
+			},
+		},
+	},
+	{
 		Name: "test databases created with non default collation and charset",
 		SetUpScript: []string{
 			"CREATE DATABASE test_db CHARACTER SET utf8mb3 COLLATE utf8mb3_bin;",

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -328,7 +328,7 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 				return e, transform.SameTree, nil
 			case *expression.Like:
 				// if the charset is not utf8mb4, the last character used in optimization rule does not work
-				charset := getCollation(ctx, e.Left)
+				charset := getCharsetInUse(ctx, e.Left)
 				if charset != sql.CharacterSet_utf8mb4 {
 					return e, transform.SameTree, nil
 				}
@@ -413,7 +413,8 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 	})
 }
 
-func getCollation(ctx *sql.Context, expr sql.Expression) sql.CharacterSetID {
+// getCharsetInUse returns charset used in given expression.
+func getCharsetInUse(ctx *sql.Context, expr sql.Expression) sql.CharacterSetID {
 	var charset = sql.CharacterSet_Unspecified
 
 	_ = transform.InspectExpr(expr, func(e sql.Expression) bool {

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -327,9 +327,10 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 
 				return e, transform.SameTree, nil
 			case *expression.Like:
-				// if the charset is utf8mb3, the last character used in optimization rule does not work
-				charset := getCharsetInUse(ctx, e.Left)
-				if charset == sql.CharacterSet_utf8mb3 {
+				// if the charset is not utf8mb4, the last character used in optimization rule does not work
+				coll, _ := expression.GetCollationViaCoercion(e.Left)
+				charset := coll.CharacterSet()
+				if charset != sql.CharacterSet_utf8mb4 {
 					return e, transform.SameTree, nil
 				}
 				// TODO: maybe more cases to simplify

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -414,25 +414,6 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 	})
 }
 
-// getCharsetInUse returns charset used in given expression.
-func getCharsetInUse(ctx *sql.Context, expr sql.Expression) sql.CharacterSetID {
-	var charset = sql.CharacterSet_Unspecified
-
-	_ = transform.InspectExpr(expr, func(e sql.Expression) bool {
-		switch et := e.Type().(type) {
-		case sql.TypeWithCollation:
-			charset = et.Collation().CharacterSet()
-		}
-		return true
-	})
-
-	if charset == sql.CharacterSet_Unspecified {
-		charset = ctx.GetCharacterSetResults()
-	}
-
-	return charset
-}
-
 func isFalse(e sql.Expression) bool {
 	lit, ok := e.(*expression.Literal)
 	if ok && lit != nil && lit.Type() == types.Boolean && lit.Value() != nil {

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -327,9 +327,9 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 
 				return e, transform.SameTree, nil
 			case *expression.Like:
-				// if the charset is not utf8mb4, the last character used in optimization rule does not work
+				// if the charset is utf8mb3, the last character used in optimization rule does not work
 				charset := getCharsetInUse(ctx, e.Left)
-				if charset != sql.CharacterSet_utf8mb4 {
+				if charset == sql.CharacterSet_utf8mb3 {
 					return e, transform.SameTree, nil
 				}
 				// TODO: maybe more cases to simplify


### PR DESCRIPTION
optimization rule uses `ÿ` last character in the charset `utf8mb4`, which does not work for `utf8mb3` charset values.