### PR TITLE
Unnest IN_SUBQUERY GROUP_BY into partial join

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -35,31 +35,32 @@ var PlanTests = []QueryPlanTest{
 			"     ├─ Eq\n" +
 			"     │   ├─ xy.x:1!null\n" +
 			"     │   └─ applySubq0.(select u from uv where u = sq.p):0\n" +
-			"     ├─ SubqueryAlias\n" +
-			"     │   ├─ name: applySubq0\n" +
-			"     │   ├─ outerVisibility: false\n" +
-			"     │   ├─ cacheable: true\n" +
-			"     │   └─ Project\n" +
-			"     │       ├─ columns: [Subquery\n" +
-			"     │       │   ├─ cacheable: false\n" +
-			"     │       │   └─ Filter\n" +
-			"     │       │       ├─ Eq\n" +
-			"     │       │       │   ├─ uv.u:1!null\n" +
-			"     │       │       │   └─ sq.p:0!null\n" +
-			"     │       │       └─ IndexedTableAccess\n" +
-			"     │       │           ├─ index: [uv.u]\n" +
-			"     │       │           ├─ columns: [u]\n" +
-			"     │       │           └─ Table\n" +
-			"     │       │               ├─ name: uv\n" +
-			"     │       │               └─ projections: [0]\n" +
-			"     │       │   as (select u from uv where u = sq.p)]\n" +
-			"     │       └─ SubqueryAlias\n" +
-			"     │           ├─ name: sq\n" +
-			"     │           ├─ outerVisibility: true\n" +
-			"     │           ├─ cacheable: true\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: pq\n" +
-			"     │               └─ columns: [p]\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ SubqueryAlias\n" +
+			"     │       ├─ name: applySubq0\n" +
+			"     │       ├─ outerVisibility: false\n" +
+			"     │       ├─ cacheable: true\n" +
+			"     │       └─ Project\n" +
+			"     │           ├─ columns: [Subquery\n" +
+			"     │           │   ├─ cacheable: false\n" +
+			"     │           │   └─ Filter\n" +
+			"     │           │       ├─ Eq\n" +
+			"     │           │       │   ├─ uv.u:1!null\n" +
+			"     │           │       │   └─ sq.p:0!null\n" +
+			"     │           │       └─ IndexedTableAccess\n" +
+			"     │           │           ├─ index: [uv.u]\n" +
+			"     │           │           ├─ columns: [u]\n" +
+			"     │           │           └─ Table\n" +
+			"     │           │               ├─ name: uv\n" +
+			"     │           │               └─ projections: [0]\n" +
+			"     │           │   as (select u from uv where u = sq.p)]\n" +
+			"     │           └─ SubqueryAlias\n" +
+			"     │               ├─ name: sq\n" +
+			"     │               ├─ outerVisibility: true\n" +
+			"     │               ├─ cacheable: true\n" +
+			"     │               └─ Table\n" +
+			"     │                   ├─ name: pq\n" +
+			"     │                   └─ columns: [p]\n" +
 			"     └─ IndexedTableAccess\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         └─ Table\n" +
@@ -99,10 +100,11 @@ var PlanTests = []QueryPlanTest{
 			"         ├─ Eq\n" +
 			"         │   ├─ mytable.i:1!null\n" +
 			"         │   └─ applySubq0.i2:0!null\n" +
-			"         ├─ TableAlias(applySubq0)\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: othertable\n" +
-			"         │       └─ columns: [i2]\n" +
+			"         ├─ Distinct\n" +
+			"         │   └─ TableAlias(applySubq0)\n" +
+			"         │       └─ Table\n" +
+			"         │           ├─ name: othertable\n" +
+			"         │           └─ columns: [i2]\n" +
 			"         └─ IndexedTableAccess\n" +
 			"             ├─ index: [mytable.i]\n" +
 			"             └─ Table\n" +
@@ -804,9 +806,10 @@ var PlanTests = []QueryPlanTest{
 			" │               ├─ Eq\n" +
 			" │               │   ├─ ab.a:4!null\n" +
 			" │               │   └─ uv.u:2!null\n" +
-			" │               ├─ Table\n" +
-			" │               │   ├─ name: uv\n" +
-			" │               │   └─ columns: [u v]\n" +
+			" │               ├─ Distinct\n" +
+			" │               │   └─ Table\n" +
+			" │               │       ├─ name: uv\n" +
+			" │               │       └─ columns: [u v]\n" +
 			" │               └─ IndexedTableAccess\n" +
 			" │                   ├─ index: [ab.a]\n" +
 			" │                   └─ Table\n" +
@@ -898,9 +901,10 @@ var PlanTests = []QueryPlanTest{
 			"         ├─ Eq\n" +
 			"         │   ├─ xy.x:0!null\n" +
 			"         │   └─ ab.a:2!null\n" +
-			"         ├─ Table\n" +
-			"         │   ├─ name: xy\n" +
-			"         │   └─ columns: [x y]\n" +
+			"         ├─ Distinct\n" +
+			"         │   └─ Table\n" +
+			"         │       ├─ name: xy\n" +
+			"         │       └─ columns: [x y]\n" +
 			"         └─ IndexedTableAccess\n" +
 			"             ├─ index: [ab.a]\n" +
 			"             └─ Table\n" +
@@ -913,13 +917,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ cte.a:0!null\n" +
 			" │   └─ xy.x:2!null\n" +
-			" ├─ SubqueryAlias\n" +
-			" │   ├─ name: cte\n" +
-			" │   ├─ outerVisibility: true\n" +
-			" │   ├─ cacheable: true\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: ab\n" +
-			" │       └─ columns: [a b]\n" +
+			" ├─ Distinct\n" +
+			" │   └─ SubqueryAlias\n" +
+			" │       ├─ name: cte\n" +
+			" │       ├─ outerVisibility: true\n" +
+			" │       ├─ cacheable: true\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: ab\n" +
+			" │           └─ columns: [a b]\n" +
 			" └─ IndexedTableAccess\n" +
 			"     ├─ index: [xy.x]\n" +
 			"     └─ Table\n" +
@@ -1016,19 +1021,20 @@ where exists
 			" ├─ Eq\n" +
 			" │   ├─ ab.a:4!null\n" +
 			" │   └─ uv.u:0!null\n" +
-			" ├─ LeftOuterLookupJoin\n" +
-			" │   ├─ Eq\n" +
-			" │   │   ├─ uv.u:0!null\n" +
-			" │   │   └─ pq.p:2!null\n" +
-			" │   ├─ Table\n" +
-			" │   │   ├─ name: uv\n" +
-			" │   │   └─ columns: [u v]\n" +
-			" │   └─ IndexedTableAccess\n" +
-			" │       ├─ index: [pq.p]\n" +
-			" │       ├─ columns: [p q]\n" +
-			" │       └─ Table\n" +
-			" │           ├─ name: pq\n" +
-			" │           └─ projections: [0 1]\n" +
+			" ├─ Distinct\n" +
+			" │   └─ LeftOuterLookupJoin\n" +
+			" │       ├─ Eq\n" +
+			" │       │   ├─ uv.u:0!null\n" +
+			" │       │   └─ pq.p:2!null\n" +
+			" │       ├─ Table\n" +
+			" │       │   ├─ name: uv\n" +
+			" │       │   └─ columns: [u v]\n" +
+			" │       └─ IndexedTableAccess\n" +
+			" │           ├─ index: [pq.p]\n" +
+			" │           ├─ columns: [p q]\n" +
+			" │           └─ Table\n" +
+			" │               ├─ name: pq\n" +
+			" │               └─ projections: [0 1]\n" +
 			" └─ IndexedTableAccess\n" +
 			"     ├─ index: [ab.a]\n" +
 			"     └─ Table\n" +
@@ -1184,10 +1190,11 @@ inner join pq on true
 			"     ├─ Eq\n" +
 			"     │   ├─ a.i:1!null\n" +
 			"     │   └─ b.i:0!null\n" +
-			"     ├─ TableAlias(b)\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: mytable\n" +
-			"     │       └─ columns: [i]\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ TableAlias(b)\n" +
+			"     │       └─ Table\n" +
+			"     │           ├─ name: mytable\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess\n" +
 			"             ├─ index: [mytable.i]\n" +
@@ -3473,10 +3480,11 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ mytable.i:1!null\n" +
 			" │   └─ applySubq0.i2:0!null\n" +
-			" ├─ TableAlias(applySubq0)\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: othertable\n" +
-			" │       └─ columns: [i2]\n" +
+			" ├─ Distinct\n" +
+			" │   └─ TableAlias(applySubq0)\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: othertable\n" +
+			" │           └─ columns: [i2]\n" +
 			" └─ IndexedTableAccess\n" +
 			"     ├─ index: [mytable.i]\n" +
 			"     └─ Table\n" +
@@ -8021,56 +8029,57 @@ WHERE
 			" │   ├─ Eq\n" +
 			" │   │   ├─ TIZHK.id:1!null\n" +
 			" │   │   └─ applySubq0.id:0!null\n" +
-			" │   ├─ SubqueryAlias\n" +
-			" │   │   ├─ name: applySubq0\n" +
-			" │   │   ├─ outerVisibility: false\n" +
-			" │   │   ├─ cacheable: true\n" +
-			" │   │   └─ Distinct\n" +
-			" │   │       └─ Project\n" +
-			" │   │           ├─ columns: [TIZHK.id:17!null]\n" +
-			" │   │           └─ Filter\n" +
-			" │   │               ├─ Eq\n" +
-			" │   │               │   ├─ aac.BTXC5:62\n" +
-			" │   │               │   └─ TIZHK.SYPKF:20\n" +
-			" │   │               └─ LookupJoin\n" +
+			" │   ├─ Distinct\n" +
+			" │   │   └─ SubqueryAlias\n" +
+			" │   │       ├─ name: applySubq0\n" +
+			" │   │       ├─ outerVisibility: false\n" +
+			" │   │       ├─ cacheable: true\n" +
+			" │   │       └─ Distinct\n" +
+			" │   │           └─ Project\n" +
+			" │   │               ├─ columns: [TIZHK.id:17!null]\n" +
+			" │   │               └─ Filter\n" +
 			" │   │                   ├─ Eq\n" +
-			" │   │                   │   ├─ aac.id:61!null\n" +
-			" │   │                   │   └─ mf.M22QN:47!null\n" +
-			" │   │                   ├─ LookupJoin\n" +
-			" │   │                   │   ├─ Eq\n" +
-			" │   │                   │   │   ├─ mf.LUEVY:46!null\n" +
-			" │   │                   │   │   └─ J4JYP.id:0!null\n" +
-			" │   │                   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   ├─ RHUZN.ZH72S:34\n" +
-			" │   │                   │   │   │   └─ TIZHK.ZHITY:19\n" +
-			" │   │                   │   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   │   ├─ J4JYP.ZH72S:7\n" +
-			" │   │                   │   │   │   │   └─ TIZHK.TVNW2:18\n" +
-			" │   │                   │   │   │   ├─ TableAlias(J4JYP)\n" +
-			" │   │                   │   │   │   │   └─ Table\n" +
-			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
-			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
-			" │   │                   │   │   │           └─ Table\n" +
-			" │   │                   │   │   │               └─ name: WRZVO\n" +
-			" │   │                   │   │   └─ TableAlias(RHUZN)\n" +
-			" │   │                   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                   │   │           └─ Table\n" +
-			" │   │                   │   │               └─ name: E2I7U\n" +
-			" │   │                   │   └─ TableAlias(mf)\n" +
-			" │   │                   │       └─ IndexedTableAccess\n" +
-			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                   │           └─ Table\n" +
-			" │   │                   │               └─ name: HGMQ6\n" +
-			" │   │                   └─ TableAlias(aac)\n" +
-			" │   │                       └─ IndexedTableAccess\n" +
-			" │   │                           ├─ index: [TPXBU.id]\n" +
-			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: TPXBU\n" +
+			" │   │                   │   ├─ aac.BTXC5:62\n" +
+			" │   │                   │   └─ TIZHK.SYPKF:20\n" +
+			" │   │                   └─ LookupJoin\n" +
+			" │   │                       ├─ Eq\n" +
+			" │   │                       │   ├─ aac.id:61!null\n" +
+			" │   │                       │   └─ mf.M22QN:47!null\n" +
+			" │   │                       ├─ LookupJoin\n" +
+			" │   │                       │   ├─ Eq\n" +
+			" │   │                       │   │   ├─ mf.LUEVY:46!null\n" +
+			" │   │                       │   │   └─ J4JYP.id:0!null\n" +
+			" │   │                       │   ├─ LookupJoin\n" +
+			" │   │                       │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   ├─ RHUZN.ZH72S:34\n" +
+			" │   │                       │   │   │   └─ TIZHK.ZHITY:19\n" +
+			" │   │                       │   │   ├─ LookupJoin\n" +
+			" │   │                       │   │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   │   ├─ J4JYP.ZH72S:7\n" +
+			" │   │                       │   │   │   │   └─ TIZHK.TVNW2:18\n" +
+			" │   │                       │   │   │   ├─ TableAlias(J4JYP)\n" +
+			" │   │                       │   │   │   │   └─ Table\n" +
+			" │   │                       │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                       │   │   │   └─ TableAlias(TIZHK)\n" +
+			" │   │                       │   │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
+			" │   │                       │   │   │           └─ Table\n" +
+			" │   │                       │   │   │               └─ name: WRZVO\n" +
+			" │   │                       │   │   └─ TableAlias(RHUZN)\n" +
+			" │   │                       │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			" │   │                       │   │           └─ Table\n" +
+			" │   │                       │   │               └─ name: E2I7U\n" +
+			" │   │                       │   └─ TableAlias(mf)\n" +
+			" │   │                       │       └─ IndexedTableAccess\n" +
+			" │   │                       │           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                       │           └─ Table\n" +
+			" │   │                       │               └─ name: HGMQ6\n" +
+			" │   │                       └─ TableAlias(aac)\n" +
+			" │   │                           └─ IndexedTableAccess\n" +
+			" │   │                               ├─ index: [TPXBU.id]\n" +
+			" │   │                               └─ Table\n" +
+			" │   │                                   └─ name: TPXBU\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
 			" │       └─ IndexedTableAccess\n" +
 			" │           ├─ index: [WRZVO.id]\n" +
@@ -8123,56 +8132,57 @@ WHERE
 			" │   ├─ Eq\n" +
 			" │   │   ├─ TIZHK.id:1!null\n" +
 			" │   │   └─ applySubq0.id:0!null\n" +
-			" │   ├─ SubqueryAlias\n" +
-			" │   │   ├─ name: applySubq0\n" +
-			" │   │   ├─ outerVisibility: false\n" +
-			" │   │   ├─ cacheable: true\n" +
-			" │   │   └─ Distinct\n" +
-			" │   │       └─ Project\n" +
-			" │   │           ├─ columns: [TIZHK.id:17!null]\n" +
-			" │   │           └─ Filter\n" +
-			" │   │               ├─ Eq\n" +
-			" │   │               │   ├─ aac.BTXC5:62\n" +
-			" │   │               │   └─ TIZHK.SYPKF:20\n" +
-			" │   │               └─ LookupJoin\n" +
+			" │   ├─ Distinct\n" +
+			" │   │   └─ SubqueryAlias\n" +
+			" │   │       ├─ name: applySubq0\n" +
+			" │   │       ├─ outerVisibility: false\n" +
+			" │   │       ├─ cacheable: true\n" +
+			" │   │       └─ Distinct\n" +
+			" │   │           └─ Project\n" +
+			" │   │               ├─ columns: [TIZHK.id:17!null]\n" +
+			" │   │               └─ Filter\n" +
 			" │   │                   ├─ Eq\n" +
-			" │   │                   │   ├─ aac.id:61!null\n" +
-			" │   │                   │   └─ mf.M22QN:47!null\n" +
-			" │   │                   ├─ LookupJoin\n" +
-			" │   │                   │   ├─ Eq\n" +
-			" │   │                   │   │   ├─ mf.LUEVY:46!null\n" +
-			" │   │                   │   │   └─ J4JYP.id:27!null\n" +
-			" │   │                   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   ├─ J4JYP.ZH72S:34\n" +
-			" │   │                   │   │   │   └─ TIZHK.TVNW2:18\n" +
-			" │   │                   │   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   │   ├─ RHUZN.ZH72S:7\n" +
-			" │   │                   │   │   │   │   └─ TIZHK.ZHITY:19\n" +
-			" │   │                   │   │   │   ├─ TableAlias(RHUZN)\n" +
-			" │   │                   │   │   │   │   └─ Table\n" +
-			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
-			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │   │           ├─ index: [WRZVO.ZHITY]\n" +
-			" │   │                   │   │   │           └─ Table\n" +
-			" │   │                   │   │   │               └─ name: WRZVO\n" +
-			" │   │                   │   │   └─ TableAlias(J4JYP)\n" +
-			" │   │                   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                   │   │           └─ Table\n" +
-			" │   │                   │   │               └─ name: E2I7U\n" +
-			" │   │                   │   └─ TableAlias(mf)\n" +
-			" │   │                   │       └─ IndexedTableAccess\n" +
-			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                   │           └─ Table\n" +
-			" │   │                   │               └─ name: HGMQ6\n" +
-			" │   │                   └─ TableAlias(aac)\n" +
-			" │   │                       └─ IndexedTableAccess\n" +
-			" │   │                           ├─ index: [TPXBU.id]\n" +
-			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: TPXBU\n" +
+			" │   │                   │   ├─ aac.BTXC5:62\n" +
+			" │   │                   │   └─ TIZHK.SYPKF:20\n" +
+			" │   │                   └─ LookupJoin\n" +
+			" │   │                       ├─ Eq\n" +
+			" │   │                       │   ├─ aac.id:61!null\n" +
+			" │   │                       │   └─ mf.M22QN:47!null\n" +
+			" │   │                       ├─ LookupJoin\n" +
+			" │   │                       │   ├─ Eq\n" +
+			" │   │                       │   │   ├─ mf.LUEVY:46!null\n" +
+			" │   │                       │   │   └─ J4JYP.id:27!null\n" +
+			" │   │                       │   ├─ LookupJoin\n" +
+			" │   │                       │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   ├─ J4JYP.ZH72S:34\n" +
+			" │   │                       │   │   │   └─ TIZHK.TVNW2:18\n" +
+			" │   │                       │   │   ├─ LookupJoin\n" +
+			" │   │                       │   │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   │   ├─ RHUZN.ZH72S:7\n" +
+			" │   │                       │   │   │   │   └─ TIZHK.ZHITY:19\n" +
+			" │   │                       │   │   │   ├─ TableAlias(RHUZN)\n" +
+			" │   │                       │   │   │   │   └─ Table\n" +
+			" │   │                       │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                       │   │   │   └─ TableAlias(TIZHK)\n" +
+			" │   │                       │   │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │   │           ├─ index: [WRZVO.ZHITY]\n" +
+			" │   │                       │   │   │           └─ Table\n" +
+			" │   │                       │   │   │               └─ name: WRZVO\n" +
+			" │   │                       │   │   └─ TableAlias(J4JYP)\n" +
+			" │   │                       │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			" │   │                       │   │           └─ Table\n" +
+			" │   │                       │   │               └─ name: E2I7U\n" +
+			" │   │                       │   └─ TableAlias(mf)\n" +
+			" │   │                       │       └─ IndexedTableAccess\n" +
+			" │   │                       │           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                       │           └─ Table\n" +
+			" │   │                       │               └─ name: HGMQ6\n" +
+			" │   │                       └─ TableAlias(aac)\n" +
+			" │   │                           └─ IndexedTableAccess\n" +
+			" │   │                               ├─ index: [TPXBU.id]\n" +
+			" │   │                               └─ Table\n" +
+			" │   │                                   └─ name: TPXBU\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
 			" │       └─ IndexedTableAccess\n" +
 			" │           ├─ index: [WRZVO.id]\n" +
@@ -8952,55 +8962,56 @@ WHERE
 			"     ├─ Eq\n" +
 			"     │   ├─ TDRVG.id:1!null\n" +
 			"     │   └─ applySubq0.id:0\n" +
-			"     ├─ SubqueryAlias\n" +
-			"     │   ├─ name: applySubq0\n" +
-			"     │   ├─ outerVisibility: false\n" +
-			"     │   ├─ cacheable: true\n" +
-			"     │   └─ Project\n" +
-			"     │       ├─ columns: [Subquery\n" +
-			"     │       │   ├─ cacheable: false\n" +
-			"     │       │   └─ Limit(1)\n" +
-			"     │       │       └─ TopN(Limit: [1 (tinyint)]; TDRVG.id:2!null ASC nullsFirst)\n" +
-			"     │       │           └─ Project\n" +
-			"     │       │               ├─ columns: [TDRVG.id:2!null]\n" +
-			"     │       │               └─ Filter\n" +
-			"     │       │                   ├─ Eq\n" +
-			"     │       │                   │   ├─ TDRVG.SSHPJ:3!null\n" +
-			"     │       │                   │   └─ S7BYT.SSHPJ:0!null\n" +
-			"     │       │                   └─ Table\n" +
-			"     │       │                       ├─ name: TDRVG\n" +
-			"     │       │                       └─ columns: [id sshpj]\n" +
-			"     │       │   as id]\n" +
-			"     │       └─ AntiLookupJoin\n" +
-			"     │           ├─ Eq\n" +
-			"     │           │   ├─ S7BYT.SSHPJ:0!null\n" +
-			"     │           │   └─ applySubq0.SSHPJ:2!null\n" +
-			"     │           ├─ SubqueryAlias\n" +
-			"     │           │   ├─ name: S7BYT\n" +
-			"     │           │   ├─ outerVisibility: true\n" +
-			"     │           │   ├─ cacheable: true\n" +
-			"     │           │   └─ Distinct\n" +
-			"     │           │       └─ Project\n" +
-			"     │           │           ├─ columns: [S5KBM.SSHPJ:19!null as SSHPJ, S5KBM.SFJ6L:20!null as SFJ6L]\n" +
-			"     │           │           └─ LookupJoin\n" +
-			"     │           │               ├─ Eq\n" +
-			"     │           │               │   ├─ nd.FGG57:6\n" +
-			"     │           │               │   └─ S5KBM.FGG57:18!null\n" +
-			"     │           │               ├─ TableAlias(nd)\n" +
-			"     │           │               │   └─ Table\n" +
-			"     │           │               │       └─ name: E2I7U\n" +
-			"     │           │               └─ TableAlias(S5KBM)\n" +
-			"     │           │                   └─ IndexedTableAccess\n" +
-			"     │           │                       ├─ index: [TDRVG.FGG57]\n" +
-			"     │           │                       └─ Table\n" +
-			"     │           │                           └─ name: TDRVG\n" +
-			"     │           └─ TableAlias(applySubq0)\n" +
-			"     │               └─ IndexedTableAccess\n" +
-			"     │                   ├─ index: [WE72E.SSHPJ]\n" +
-			"     │                   ├─ columns: [sshpj]\n" +
-			"     │                   └─ Table\n" +
-			"     │                       ├─ name: WE72E\n" +
-			"     │                       └─ projections: [2]\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ SubqueryAlias\n" +
+			"     │       ├─ name: applySubq0\n" +
+			"     │       ├─ outerVisibility: false\n" +
+			"     │       ├─ cacheable: true\n" +
+			"     │       └─ Project\n" +
+			"     │           ├─ columns: [Subquery\n" +
+			"     │           │   ├─ cacheable: false\n" +
+			"     │           │   └─ Limit(1)\n" +
+			"     │           │       └─ TopN(Limit: [1 (tinyint)]; TDRVG.id:2!null ASC nullsFirst)\n" +
+			"     │           │           └─ Project\n" +
+			"     │           │               ├─ columns: [TDRVG.id:2!null]\n" +
+			"     │           │               └─ Filter\n" +
+			"     │           │                   ├─ Eq\n" +
+			"     │           │                   │   ├─ TDRVG.SSHPJ:3!null\n" +
+			"     │           │                   │   └─ S7BYT.SSHPJ:0!null\n" +
+			"     │           │                   └─ Table\n" +
+			"     │           │                       ├─ name: TDRVG\n" +
+			"     │           │                       └─ columns: [id sshpj]\n" +
+			"     │           │   as id]\n" +
+			"     │           └─ AntiLookupJoin\n" +
+			"     │               ├─ Eq\n" +
+			"     │               │   ├─ S7BYT.SSHPJ:0!null\n" +
+			"     │               │   └─ applySubq0.SSHPJ:2!null\n" +
+			"     │               ├─ SubqueryAlias\n" +
+			"     │               │   ├─ name: S7BYT\n" +
+			"     │               │   ├─ outerVisibility: true\n" +
+			"     │               │   ├─ cacheable: true\n" +
+			"     │               │   └─ Distinct\n" +
+			"     │               │       └─ Project\n" +
+			"     │               │           ├─ columns: [S5KBM.SSHPJ:19!null as SSHPJ, S5KBM.SFJ6L:20!null as SFJ6L]\n" +
+			"     │               │           └─ LookupJoin\n" +
+			"     │               │               ├─ Eq\n" +
+			"     │               │               │   ├─ nd.FGG57:6\n" +
+			"     │               │               │   └─ S5KBM.FGG57:18!null\n" +
+			"     │               │               ├─ TableAlias(nd)\n" +
+			"     │               │               │   └─ Table\n" +
+			"     │               │               │       └─ name: E2I7U\n" +
+			"     │               │               └─ TableAlias(S5KBM)\n" +
+			"     │               │                   └─ IndexedTableAccess\n" +
+			"     │               │                       ├─ index: [TDRVG.FGG57]\n" +
+			"     │               │                       └─ Table\n" +
+			"     │               │                           └─ name: TDRVG\n" +
+			"     │               └─ TableAlias(applySubq0)\n" +
+			"     │                   └─ IndexedTableAccess\n" +
+			"     │                       ├─ index: [WE72E.SSHPJ]\n" +
+			"     │                       ├─ columns: [sshpj]\n" +
+			"     │                       └─ Table\n" +
+			"     │                           ├─ name: WE72E\n" +
+			"     │                           └─ projections: [2]\n" +
 			"     └─ IndexedTableAccess\n" +
 			"         ├─ index: [TDRVG.id]\n" +
 			"         └─ Table\n" +
@@ -14369,25 +14380,26 @@ ORDER BY cla.FTQLQ ASC`,
 			"             ├─ Eq\n" +
 			"             │   ├─ cla.id:4!null\n" +
 			"             │   └─ applySubq0.IXUXU:2\n" +
-			"             ├─ Filter\n" +
-			"             │   ├─ AND\n" +
-			"             │   │   ├─ InSubquery\n" +
-			"             │   │   │   ├─ left: applySubq0.id:0!null\n" +
-			"             │   │   │   └─ right: Subquery\n" +
-			"             │   │   │       ├─ cacheable: true\n" +
-			"             │   │   │       └─ Table\n" +
-			"             │   │   │           ├─ name: HGMQ6\n" +
-			"             │   │   │           └─ columns: [gxlub]\n" +
-			"             │   │   └─ InSubquery\n" +
-			"             │   │       ├─ left: applySubq0.id:0!null\n" +
-			"             │   │       └─ right: Subquery\n" +
-			"             │   │           ├─ cacheable: true\n" +
-			"             │   │           └─ Table\n" +
-			"             │   │               ├─ name: AMYXQ\n" +
-			"             │   │               └─ columns: [gxlub]\n" +
-			"             │   └─ TableAlias(applySubq0)\n" +
-			"             │       └─ Table\n" +
-			"             │           └─ name: THNTS\n" +
+			"             ├─ Distinct\n" +
+			"             │   └─ Filter\n" +
+			"             │       ├─ AND\n" +
+			"             │       │   ├─ InSubquery\n" +
+			"             │       │   │   ├─ left: applySubq0.id:0!null\n" +
+			"             │       │   │   └─ right: Subquery\n" +
+			"             │       │   │       ├─ cacheable: true\n" +
+			"             │       │   │       └─ Table\n" +
+			"             │       │   │           ├─ name: HGMQ6\n" +
+			"             │       │   │           └─ columns: [gxlub]\n" +
+			"             │       │   └─ InSubquery\n" +
+			"             │       │       ├─ left: applySubq0.id:0!null\n" +
+			"             │       │       └─ right: Subquery\n" +
+			"             │       │           ├─ cacheable: true\n" +
+			"             │       │           └─ Table\n" +
+			"             │       │               ├─ name: AMYXQ\n" +
+			"             │       │               └─ columns: [gxlub]\n" +
+			"             │       └─ TableAlias(applySubq0)\n" +
+			"             │           └─ Table\n" +
+			"             │               └─ name: THNTS\n" +
 			"             └─ TableAlias(cla)\n" +
 			"                 └─ IndexedTableAccess\n" +
 			"                     ├─ index: [YK2GW.id]\n" +

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -164,10 +164,22 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *Scope) (
 	j := newJoinOrderBuilder(m)
 	j.reorderJoin(n)
 
-	addRightSemiJoins(m)
-	addLookupJoins(m)
-	addHashJoins(m)
-	addMergeJoins(m)
+	err = addRightSemiJoins(m)
+	if err != nil {
+		return nil, err
+	}
+	err = addLookupJoins(m)
+	if err != nil {
+		return nil, err
+	}
+	err = addHashJoins(m)
+	if err != nil {
+		return nil, err
+	}
+	err = addMergeJoins(m)
+	if err != nil {
+		return nil, err
+	}
 
 	if a.Verbose && a.Debug {
 		a.Log(m.String())
@@ -179,7 +191,10 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *Scope) (
 		m.WithJoinOrder(hint)
 	}
 
-	m.optimizeRoot()
+	err = m.optimizeRoot()
+	if err != nil {
+		return nil, err
+	}
 	return m.bestRootPlan()
 }
 


### PR DESCRIPTION
Resolving group by expressions used to happen in two phases, and now happens in one so that we can detect cacheable groupby subqueries at applyJoin time.

Fix a miscellaneous bug in RightSemiLookupJoin. The right left node has to return distinct results, otherwise we will duplicate results.

Dolt tests pass locally.