### PR TITLE
Changed how empty set of projected columns is handled

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -153,7 +153,7 @@ func TestSingleQuery(t *testing.T) {
 	t.Skip()
 	var test queries.QueryTest
 	test = queries.QueryTest{
-		Query: `SELECT t1.timestamp FROM reservedWordsTable t1 JOIN reservedWordsTable t2 ON t1.TIMESTAMP = t2.tImEstamp`,
+		Query:    `SELECT t1.timestamp FROM reservedWordsTable t1 JOIN reservedWordsTable t2 ON t1.TIMESTAMP = t2.tImEstamp`,
 		Expected: []sql.Row{},
 	}
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -153,17 +153,8 @@ func TestSingleQuery(t *testing.T) {
 	t.Skip()
 	var test queries.QueryTest
 	test = queries.QueryTest{
-		Query: "SELECT pk, count(*) over (order by v2) FROM one_pk_three_idx ORDER BY pk",
-		Expected: []sql.Row{
-			{0, 4},
-			{1, 4},
-			{2, 5},
-			{3, 6},
-			{4, 4},
-			{5, 4},
-			{6, 7},
-			{7, 8},
-		},
+		Query: "explain SELECT 1 FROM mytable",
+		Expected: []sql.Row{},
 	}
 
 	fmt.Sprintf("%v", test)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -153,7 +153,7 @@ func TestSingleQuery(t *testing.T) {
 	t.Skip()
 	var test queries.QueryTest
 	test = queries.QueryTest{
-		Query: "explain SELECT 1 FROM mytable",
+		Query: `SELECT t1.timestamp FROM reservedWordsTable t1 JOIN reservedWordsTable t2 ON t1.TIMESTAMP = t2.tImEstamp`,
 		Expected: []sql.Row{},
 	}
 

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -21,13 +21,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t4.v1:1\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -36,13 +33,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t4.v1:1\n" +
 			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -51,13 +45,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t4.v1:1\n" +
 			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -70,13 +61,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t4.v1:1\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -89,13 +77,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t4.v2:2\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -107,11 +92,9 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t4.v1:1\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t4)\n" +
 			"                 ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t4\n" +
+			"                 └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -122,11 +105,9 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t4.v1:1\n" +
 			"         │   └─ a (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t4)\n" +
 			"             ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t4\n" +
+			"             └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -135,13 +116,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t3.v1:0\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -150,13 +128,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t3.v1:0\n" +
 			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -165,13 +140,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t3.v1:0\n" +
 			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -184,13 +156,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t3.v1:0\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -203,13 +172,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t3.v2:1\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -221,11 +187,9 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t3.v1:0\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t3)\n" +
 			"                 ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t3\n" +
+			"                 └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -236,11 +200,9 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t3.v1:0\n" +
 			"         │   └─ a (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t3)\n" +
 			"             ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t3\n" +
+			"             └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -249,13 +211,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t2.v1:1\n" +
 			" │   └─ A (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{[A, A], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -264,13 +223,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t2.v1:1\n" +
 			" │   └─ ABC (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{[ABC, ABC], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -279,13 +235,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t2.v1:1\n" +
 			" │   └─ ABCD (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -298,13 +251,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t2.v1:1\n" +
 			" │       └─ ABCDE (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{(A, ABCDE), [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -317,13 +267,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t2.v2:2\n" +
 			" │       └─ ABCDE (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{(A, ∞), (NULL, ABCDE)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -335,11 +282,9 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t2.v1:1\n" +
 			"             │   └─ A (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t2)\n" +
 			"                 ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"                 ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t2\n" +
+			"                 └─ static: [{[A, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -350,11 +295,9 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t2.v1:1\n" +
 			"         │   └─ A (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t2)\n" +
 			"             ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"             ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t2\n" +
+			"             └─ static: [{[A, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -363,13 +306,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t1.v1:1\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -378,13 +318,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t1.v1:1\n" +
 			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -393,13 +330,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t1.v1:1\n" +
 			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -412,13 +346,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t1.v1:1\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -431,13 +362,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t1.v2:2\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -448,11 +376,9 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t1.v1:1\n" +
 			"         │   └─ a (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t1)\n" +
 			"             ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t1\n" +
+			"             └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -464,66 +390,49 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t1.v1:1\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t1)\n" +
 			"                 ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t1\n" +
+			"                 └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<25) OR (v1>24));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=99 AND v2<>83) OR (v1>=1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[1, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=38 AND v2<41) OR (v1>60)) OR (v1<22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 22), [NULL, ∞)}, {[22, 38], (NULL, 41)}, {(60, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>92 AND v2>25) OR (v1 BETWEEN 6 AND 24 AND v2=80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[6, 24], [80, 80]}, {(92, ∞), (25, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=29) OR (v1=49 AND v2<48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 29], [NULL, ∞)}, {[49, 49], (NULL, 48)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -537,13 +446,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 11 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 75), [NULL, ∞)}, {(75, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -557,13 +463,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 9 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[87, 87], (NULL, 45]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -581,35 +484,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 96 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 96), [NULL, ∞)}, {(96, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=97) OR (v1 BETWEEN 36 AND 98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 98], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=86 AND v2>41) OR (v1<>6 AND v2>16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 6), (16, ∞)}, {(6, ∞), (16, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -632,79 +526,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 34 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<11) OR (v1>=66 AND v2=22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞)}, {[66, ∞), [22, 22]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>45 AND v2>37) OR (v1<98 AND v2<=35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 45), (37, ∞)}, {(NULL, 98), (NULL, 35]}, {(45, ∞), (37, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=16 AND v2>96) OR (v1<80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 80), [NULL, ∞)}, {[80, ∞), (96, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=98) OR (v1<85 AND v2>60)) OR (v1<>53 AND v2 BETWEEN 82 AND 89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 98], [NULL, ∞)}, {(98, ∞), [82, 89]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((((v1<71 AND v2<7) OR (v1<=21 AND v2<=48)) OR (v1=44 AND v2 BETWEEN 21 AND 83)) OR (v1<=72 AND v2<>27)) OR (v1=35 AND v2 BETWEEN 78 AND 89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 21], (NULL, ∞)}, {(21, 44), (NULL, 27)}, {(21, 44), (27, ∞)}, {[44, 44], (NULL, ∞)}, {(44, 72], (NULL, 27)}, {(44, 72], (27, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=16) OR (v1>=77 AND v2>77)) OR (v1>19 AND v2>27));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 16], [NULL, ∞)}, {(19, ∞), (27, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -731,68 +604,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[33, 46), (NULL, 39)}, {[33, 46), (39, ∞)}, {[46, ∞), (NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<39 AND v2<10) OR (v1>64 AND v2<=15)) AND (v1>=41);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(64, ∞), (NULL, 15]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=91) OR (v1<70 AND v2>=23)) OR (v1>23 AND v2<38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 91], [NULL, ∞)}, {(91, ∞), (NULL, 38)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<>45 AND v2=70) OR (v1 BETWEEN 40 AND 96 AND v2 BETWEEN 48 AND 96)) OR (v1<>87 AND v2<31)) OR (v1<>62 AND v2=51)) AND (v1>=47 AND v2<29);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[47, 87), (NULL, 29)}, {(87, ∞), (NULL, 29)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<71) OR (v1 BETWEEN 46 AND 79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 79], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>52) OR (v1<=14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 14], [NULL, ∞)}, {(52, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -811,35 +666,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 54 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 74), [NULL, ∞)}, {[74, 74], [54, ∞)}, {(74, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=69 AND v2<24) OR (v1<77 AND v2<=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 77), (NULL, 53]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=78 AND v2=87) OR (v1 BETWEEN 37 AND 58 AND v2>=30)) AND (v1=86 AND v2 BETWEEN 0 AND 70);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -853,68 +699,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 52 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 94), [NULL, ∞)}, {(94, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>23 AND v2>64) OR (v1>73 AND v2<=66)) OR (v1 BETWEEN 39 AND 69 AND v2>84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 23), (64, ∞)}, {(23, 73], (64, ∞)}, {(73, ∞), (NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>54 AND v2<16) OR (v1<74 AND v2>29)) AND (v1 BETWEEN 34 AND 48);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[34, 48], (29, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>44 AND v2>12) OR (v1<=5 AND v2>27));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 44), (12, ∞)}, {(44, ∞), (12, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=54 AND v2<>13) OR (v1>84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 54], (NULL, 13)}, {(NULL, 54], (13, ∞)}, {(84, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>1 AND v2<>51) OR (v1=28));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(1, 28), (NULL, 51)}, {(1, 28), (51, ∞)}, {[28, 28], [NULL, ∞)}, {(28, ∞), (NULL, 51)}, {(28, ∞), (51, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -930,24 +758,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 98 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=16 AND v2=57) OR (v1<46 AND v2 BETWEEN 78 AND 89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 46), [78, 89]}, {[16, 16], [57, 57]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -969,13 +791,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 23 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 23], (NULL, 10)}, {(23, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1008,35 +827,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 34 AND 34 AND v2 BETWEEN 0 AND 91) OR (v1 BETWEEN 54 AND 77 AND v2>92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[34, 34], [0, 91]}, {[54, 77], (92, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((((v1<=55) OR (v1>=46 AND v2<=26)) OR (v1 BETWEEN 8 AND 54)) OR (v1>26 AND v2 BETWEEN 62 AND 89)) OR (v1<31 AND v2=11)) OR (v1>9 AND v2=60));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 55], [NULL, ∞)}, {(55, ∞), (NULL, 26]}, {(55, ∞), [60, 60]}, {(55, ∞), [62, 89]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1060,90 +870,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 50 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 50), [NULL, ∞)}, {(50, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>39 AND v2>66) OR (v1=99));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(39, 99), (66, ∞)}, {[99, 99], [NULL, ∞)}, {(99, ∞), (66, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 24 AND 66) OR (v1<=81 AND v2<>29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 24), (NULL, 29)}, {(NULL, 24), (29, ∞)}, {[24, 66], [NULL, ∞)}, {(66, 81], (NULL, 29)}, {(66, 81], (29, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>18 AND v2<>8) OR (v1>=10 AND v2>3)) OR (v1=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 10), (NULL, 8)}, {(NULL, 10), (8, ∞)}, {[10, 18), (NULL, ∞)}, {[18, 18], (3, ∞)}, {(18, 53), (NULL, ∞)}, {[53, 53], [NULL, ∞)}, {(53, ∞), (NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=42 AND v2>34) OR (v1<=40 AND v2<=49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 40], (NULL, 49]}, {[42, ∞), (34, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 8 AND 38) OR (v1>=23 AND v2 BETWEEN 36 AND 49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[8, 38], [NULL, ∞)}, {(38, ∞), [36, 49]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>57 AND v2 BETWEEN 2 AND 93) OR (v1=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 52), [2, 93]}, {[52, 52], [NULL, ∞)}, {(52, 57), [2, 93]}, {(57, ∞), [2, 93]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<24) OR (v1<41)) OR (v1<12 AND v2=2)) OR (v1=3 AND v2<>66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 41), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1176,68 +962,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 56 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 31), (NULL, 56)}, {(NULL, 31), (56, ∞)}, {[31, 31], [54, 54]}, {(31, ∞), (NULL, 56)}, {(31, ∞), (56, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>52 AND v2<90) OR (v1 BETWEEN 27 AND 77 AND v2 BETWEEN 49 AND 83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 52), (NULL, 90)}, {[52, 52], [49, 83]}, {(52, ∞), (NULL, 90)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>2) OR (v1<72 AND v2>=21)) AND (v1=69 AND v2 BETWEEN 44 AND 48);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[69, 69], [44, 48]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>77) OR (v1=57)) OR (v1>9 AND v2>80)) OR (v1=22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(9, 22), (80, ∞)}, {[22, 22], [NULL, ∞)}, {(22, 57), (80, ∞)}, {[57, 57], [NULL, ∞)}, {(57, 77], (80, ∞)}, {(77, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>28) OR (v1<=30 AND v2=30)) OR (v1<29)) OR (v1 BETWEEN 54 AND 74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>30 AND v2 BETWEEN 20 AND 41) OR (v1>=69 AND v2=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 30), [20, 41]}, {(30, ∞), [20, 41]}, {[69, ∞), [51, 51]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1251,35 +1019,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 55 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[67, 67], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<20 AND v2<=46) OR (v1<>4 AND v2=26)) OR (v1>36 AND v2<>13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 20), (NULL, 46]}, {[20, 36], [26, 26]}, {(36, ∞), (NULL, 13)}, {(36, ∞), (13, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=5 AND v2>66) OR (v1<=0)) OR (v1 BETWEEN 10 AND 87));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 0], [NULL, ∞)}, {(0, 5], (66, ∞)}, {[10, 87], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1330,24 +1089,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 86 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[15, 47], (NULL, 69)}, {[15, 47], (69, ∞)}, {(55, 86], (85, ∞)}, {(86, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<37) OR (v1<=48 AND v2<=54)) OR (v1=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 37), [NULL, ∞)}, {[37, 48], (NULL, 54]}, {[88, 88], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1370,13 +1123,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1394,13 +1144,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 64 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1414,24 +1161,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 11 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>40) OR (v1>=49 AND v2>=92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(40, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1456,24 +1197,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 9 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(9, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=53 AND v2<=79) OR (v1>50 AND v2>26)) AND (v1>26) AND (v1>43 AND v2<7);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(43, 53], (NULL, 7)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1493,57 +1228,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 30 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=45) OR (v1=28));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[28, 28], [NULL, ∞)}, {[45, 45], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (v1 BETWEEN 11 AND 18) AND (v1>31 AND v2 BETWEEN 38 AND 88);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>95 AND v2>5) OR (v1>16 AND v2>=38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(16, 95], [38, ∞)}, {(95, ∞), (5, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=23) OR (v1=47 AND v2>23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[23, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1557,57 +1277,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 67 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 67), [NULL, ∞)}, {(67, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=30 AND v2>=67) OR (v1<=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 52], [NULL, ∞)}, {(52, ∞), [67, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 48 AND 86 AND v2>=29) OR (v1<>82 AND v2<=93)) OR (v1 BETWEEN 79 AND 87 AND v2 BETWEEN 13 AND 69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 48), (NULL, 93]}, {[48, 82), (NULL, ∞)}, {[82, 82], [13, ∞)}, {(82, 86], (NULL, ∞)}, {(86, ∞), (NULL, 93]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 3 AND 95 AND v2>=36) OR (v1>=40 AND v2<13)) OR (v1 BETWEEN 4 AND 8 AND v2=50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[3, 95], [36, ∞)}, {[40, ∞), (NULL, 13)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<11 AND v2<>32) OR (v1 BETWEEN 35 AND 41)) OR (v1>=76));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 11), (NULL, 32)}, {(NULL, 11), (32, ∞)}, {[35, 41], [NULL, ∞)}, {[76, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1626,24 +1331,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │       ├─ comp_index_t0.v1:1\n" +
 			" │   │       └─ 2 (tinyint)\n" +
 			" │   └─ (comp_index_t0.v1:1 BETWEEN 50 (tinyint) AND 97 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[15, 15], [8, 8]}, {[50, 97], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<67 AND v2<>39) OR (v1>36));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 36], (NULL, 39)}, {(NULL, 36], (39, ∞)}, {(36, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1657,57 +1356,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 50 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 66), [NULL, ∞)}, {(66, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 5 AND 19) OR (v1<>50 AND v2>=51)) OR (v1>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 5), [51, ∞)}, {[5, 19], [NULL, ∞)}, {(19, 50), [51, ∞)}, {(50, 55], [51, ∞)}, {(55, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 16 AND 65) OR (v1<>18 AND v2>=81)) OR (v1 BETWEEN 6 AND 48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 6), [81, ∞)}, {[6, 65], [NULL, ∞)}, {(65, ∞), [81, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1>=31 AND v2>=55) OR (v1 BETWEEN 1 AND 28)) OR (v1 BETWEEN 26 AND 41 AND v2<=15));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[1, 28], [NULL, ∞)}, {(28, 41], (NULL, 15]}, {[31, ∞), [55, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=77 AND v2 BETWEEN 4 AND 26) OR (v1<=1 AND v2<>20)) OR (v1>8 AND v2>40));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 1], (NULL, ∞)}, {(1, 77], [4, 26]}, {(8, ∞), (40, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1752,13 +1436,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 4), [NULL, ∞)}, {[4, 4], (NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1778,211 +1459,154 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t0.v1:1\n" +
 			" │       │   └─ 28 (tinyint)\n" +
 			" │       └─ (comp_index_t0.v2:2 BETWEEN 30 (tinyint) AND 85 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=94) OR (v1<=87));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 94], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>56 AND v2<93) OR (v1<73 AND v2<=70));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 56), (NULL, 93)}, {[56, 56], (NULL, 70]}, {(56, ∞), (NULL, 93)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>=85) OR (v1=91)) OR (v1<88 AND v2<42)) OR (v1<>42 AND v2<=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 85), (NULL, 42)}, {[85, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>42 AND v2<=13) OR (v1=7));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[7, 7], [NULL, ∞)}, {(42, ∞), (NULL, 13]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1=63) OR (v1 BETWEEN 55 AND 82 AND v2 BETWEEN 0 AND 6)) OR (v1=46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[46, 46], [NULL, ∞)}, {[55, 63), [0, 6]}, {[63, 63], [NULL, ∞)}, {(63, 82], [0, 6]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 20 AND 77 AND v2>=49) OR (v1<13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 13), [NULL, ∞)}, {[20, 77], [49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1>=72) OR (v1<49 AND v2<>36)) OR (v1>=10 AND v2<1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 49), (NULL, 36)}, {(NULL, 49), (36, ∞)}, {[49, 72), (NULL, 1)}, {[72, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 18 AND 87) OR (v1>=42 AND v2>44)) OR (v1<26 AND v2<=55)) AND (v1<=21);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 18), (NULL, 55]}, {[18, 21], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>98 AND v2<75) OR (v1=47));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[47, 47], [NULL, ∞)}, {(98, ∞), (NULL, 75)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=57 AND v2>=43) OR (v1<27 AND v2<>3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 27), (NULL, 3)}, {(NULL, 27), (3, ∞)}, {[27, 57], [43, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 16 AND 45 AND v2=22) OR (v1>=87 AND v2=48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[16, 45], [22, 22]}, {[87, ∞), [48, 48]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 45 AND 74 AND v2<=74) OR (v1<>48 AND v2>58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 45), (58, ∞)}, {[45, 48), (NULL, ∞)}, {[48, 48], (NULL, 74]}, {(48, 74], (NULL, ∞)}, {(74, ∞), (58, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<32 AND v2>=79) OR (v1<=28)) OR (v1 BETWEEN 46 AND 72)) OR (v1>16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<10) OR (v1<89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 89), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=64 AND v2>=69) OR (v1>=2));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[2, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=65) OR (v1<64));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 65], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=46) OR (v1>9 AND v2>=22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(9, 46), [22, ∞)}, {[46, 46], [NULL, ∞)}, {(46, ∞), [22, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 21 AND 33 AND v2>25) OR (v1<0));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 0), [NULL, ∞)}, {[21, 33], (25, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2000,13 +1624,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 39), [8, 33], [NULL, ∞)}, {[39, 69], [NULL, ∞), [NULL, ∞)}, {(69, 87), [8, 33], [NULL, ∞)}, {(87, ∞), [8, 33], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2034,35 +1655,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 15 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[15, 15], [NULL, ∞), [NULL, ∞)}, {[55, ∞), [72, 80], [63, 63]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<93 AND v2<39 AND v3 BETWEEN 30 AND 97) OR (v1>54)) OR (v1<66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>59 AND v2<=15) OR (v1 BETWEEN 2 AND 51)) OR (v1>15 AND v2 BETWEEN 31 AND 81));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 15], [NULL, ∞)}, {[2, 51], [NULL, ∞), [NULL, ∞)}, {(51, 59), (NULL, 15], [NULL, ∞)}, {(51, ∞), [31, 81], [NULL, ∞)}, {(59, ∞), (NULL, 15], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2086,13 +1698,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 49 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 41], (40, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2119,35 +1728,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 48 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[53, 75), [36, 53], (48, ∞)}, {[75, 85], [NULL, ∞), [NULL, ∞)}, {(85, ∞), [36, 53], (48, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<6 AND v2<>44) OR (v1 BETWEEN 27 AND 96)) OR (v1>22 AND v2<>30 AND v3<49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), (NULL, 44), [NULL, ∞)}, {(NULL, 6), (44, ∞), [NULL, ∞)}, {(22, 27), (NULL, 30), (NULL, 49)}, {(22, 27), (30, ∞), (NULL, 49)}, {[27, 96], [NULL, ∞), [NULL, ∞)}, {(96, ∞), (NULL, 30), (NULL, 49)}, {(96, ∞), (30, ∞), (NULL, 49)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>29 AND v2=40) OR (v1<=74)) OR (v1<13 AND v2 BETWEEN 27 AND 82 AND v3<82));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 74], [NULL, ∞), [NULL, ∞)}, {(74, ∞), [40, 40], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2173,13 +1773,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 10 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 6), (NULL, 0), (NULL, 10)}, {(NULL, 6), [0, 97], [NULL, ∞)}, {(NULL, 6), (97, ∞), (NULL, 10)}, {[6, 6], (NULL, 10), (NULL, 10)}, {[6, 6], (10, ∞), (NULL, 10)}, {(6, 40), (NULL, 0), (NULL, 10)}, {(6, 40), (97, ∞), (NULL, 10)}, {(6, ∞), [0, 97], [NULL, ∞)}, {(40, ∞), (NULL, 0), (NULL, 10)}, {(40, ∞), (97, ∞), (NULL, 10)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2205,13 +1802,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 28 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 28), [NULL, ∞), [NULL, ∞)}, {(28, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2244,13 +1838,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 13 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 41), [NULL, ∞), [NULL, ∞)}, {[41, 41], (NULL, 13), [14, 74]}, {[41, 41], (13, ∞), [14, 74]}, {(41, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2284,13 +1875,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t1.v2:2\n" +
 			" │       │       └─ 32 (tinyint)\n" +
 			" │       └─ (comp_index_t1.v3:3 BETWEEN 3 (tinyint) AND 7 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 1), (NULL, 32], [3, 7]}, {[1, 11], [NULL, ∞), [NULL, ∞)}, {(11, 34), [28, 84], (NULL, 93]}, {(11, 80), (NULL, 28), [3, 7]}, {[34, 52], [28, 73), (NULL, 93]}, {[34, 52], [73, 73], [NULL, ∞)}, {[34, 52], (73, 84], (NULL, 93]}, {(52, ∞), [28, 84], (NULL, 93]}, {(80, ∞), (NULL, 28), [3, 7]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2316,13 +1904,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 72), [NULL, ∞), [NULL, ∞)}, {[72, 72], (59, ∞), [NULL, ∞)}, {(72, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2359,24 +1944,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 54 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[53, ∞), (69, ∞), (54, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>9) OR (v1>14 AND v2>10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(9, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2403,13 +1982,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 39], [17, 34], [NULL, ∞)}, {[89, 89], (58, ∞), (49, ∞)}, {(97, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2436,46 +2012,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 7), (NULL, 43), [NULL, ∞)}, {(NULL, 7), (43, ∞), [NULL, ∞)}, {[7, ∞), (NULL, 1), (NULL, 0)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1>30 AND v2 BETWEEN 23 AND 60 AND v3=58) OR (v1<=3 AND v2 BETWEEN 68 AND 72)) OR (v1<=17)) OR (v1>6 AND v2>=24)) AND (v1<89 AND v2=73);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 89), [73, 73], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>27) OR (v1>=22 AND v2>99 AND v3>=43));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[22, 27], (99, ∞), [43, ∞)}, {(27, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25 AND v2 BETWEEN 1 AND 82) OR (v1>31 AND v2=86));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(25, ∞), [1, 82], [NULL, ∞)}, {(31, ∞), [86, 86], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2514,13 +2078,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12), (NULL, 60), [91, 91]}, {(12, 35], (NULL, 60), [91, 91]}, {(35, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2541,24 +2102,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 26 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[62, ∞), (NULL, 96], (28, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>30 AND v2=40 AND v3 BETWEEN 35 AND 35) OR (v1 BETWEEN 20 AND 77 AND v2>=56 AND v3>62));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[20, 77], [56, ∞), (62, ∞)}, {(30, ∞), [40, 40], [35, 35]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2606,68 +2161,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 47 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 6), [9, ∞), [0, 0]}, {[6, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=15 AND v2>28) OR (v1<=84 AND v2<>91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 15], (NULL, ∞), [NULL, ∞)}, {(15, 84], (NULL, 91), [NULL, ∞)}, {(15, 84], (91, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=49 AND v2<=52 AND v3 BETWEEN 23 AND 38) OR (v1 BETWEEN 30 AND 84 AND v2=94));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[30, 84], [94, 94], [NULL, ∞)}, {[49, 49], (NULL, 52], [23, 38]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 8 AND 18) OR (v1=27 AND v2<=4 AND v3<14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[8, 18], [NULL, ∞), [NULL, ∞)}, {[27, 27], (NULL, 4], (NULL, 14)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=4) OR (v1=0 AND v2<=63));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[0, 0], (NULL, 63], [NULL, ∞)}, {[4, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<=99 AND v2<>86) AND (v1>=21 AND v2>36);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[21, 99], (86, ∞), [NULL, ∞)}, {[21, 99], (36, 86), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2681,57 +2218,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 43), [NULL, ∞), [NULL, ∞)}, {(43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1 BETWEEN 21 AND 44 AND v2 BETWEEN 18 AND 88 AND v3=42) AND (v1>=52 AND v2>37 AND v3 BETWEEN 26 AND 91);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>29 AND v2>93 AND v3<64) OR (v1<>54 AND v2>35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 54), (35, ∞), [NULL, ∞)}, {[54, 54], (93, ∞), (NULL, 64)}, {(54, ∞), (35, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<88) OR (v1<>45 AND v2<89)) AND (v1=98 AND v2<=81 AND v3 BETWEEN 34 AND 77);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[98, 98], (NULL, 81], [34, 77]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>65 AND v2<>86 AND v3<=2) OR (v1<>37 AND v2<=96));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 37), (NULL, 96], [NULL, ∞)}, {(37, ∞), (NULL, 96], [NULL, ∞)}, {(65, ∞), (96, ∞), (NULL, 2]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2776,35 +2298,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 23 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12), (NULL, 17), (NULL, 23]}, {(NULL, 12), (17, ∞), (NULL, 23]}, {(NULL, 42), (NULL, 34), [25, ∞)}, {(12, ∞), (NULL, 17), (NULL, 23]}, {(12, ∞), (17, ∞), (NULL, 23]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<81 AND v2>=28) OR (v1=19 AND v2 BETWEEN 9 AND 57));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 19), [28, ∞), [NULL, ∞)}, {[19, 19], [9, ∞), [NULL, ∞)}, {(19, 81), [28, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<32) OR (v1>=52)) OR (v1>=98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 32), [NULL, ∞), [NULL, ∞)}, {[52, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2818,24 +2331,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 25 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 25), [NULL, ∞), [NULL, ∞)}, {(25, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>27 AND v2<=80 AND v3 BETWEEN 11 AND 37) AND (v1=87 AND v2<54) AND (v1>29);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[87, 87], (NULL, 54), [11, 37]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2865,35 +2372,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 36 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 85], [NULL, ∞), [NULL, ∞)}, {(85, ∞), [52, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=12 AND v2>=65) OR (v1=11 AND v2<1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[11, 11], (NULL, 1), [NULL, ∞)}, {[12, ∞), [65, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=92 AND v2<=42) OR (v1>=58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 58), (NULL, 42], [NULL, ∞)}, {[58, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2915,13 +2413,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 52 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 0), [NULL, ∞), [NULL, ∞)}, {[0, 0], [70, ∞), [NULL, ∞)}, {(0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2940,35 +2435,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ (comp_index_t1.v1:1 BETWEEN 77 (tinyint) AND 85 (tinyint))\n" +
 			" │       │   └─ (comp_index_t1.v3:3 BETWEEN 16 (tinyint) AND 21 (tinyint))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 10 (tinyint) AND 42 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(5, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>43 AND v2<53 AND v3<=20) OR (v1<7 AND v2<>79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 7), (NULL, 79), [NULL, ∞)}, {(NULL, 7), (79, ∞), [NULL, ∞)}, {[7, 43), (NULL, 53), (NULL, 20]}, {(43, ∞), (NULL, 53), (NULL, 20]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>=17 AND v2 BETWEEN 17 AND 78 AND v3=10) AND (v1<=67) AND (v1>=81 AND v2<=88 AND v3>=70);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3021,13 +2507,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 45 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 34), (NULL, 21], (NULL, 45]}, {[85, 85], (0, 81], (NULL, 23)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3076,90 +2559,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 27 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 75], [NULL, ∞), [NULL, ∞)}, {(75, ∞), (NULL, 10), [NULL, ∞)}, {(75, ∞), [27, 27], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<=76) AND (v1<=94);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 76], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<>40 AND v2>1) OR (v1>3 AND v2<=42)) OR (v1=99 AND v2>62)) OR (v1<17 AND v2<>75 AND v3=6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 3], (NULL, 1], [6, 6]}, {(NULL, 3], (1, ∞), [NULL, ∞)}, {(3, 40), (NULL, ∞), [NULL, ∞)}, {[40, 40], (NULL, 42], [NULL, ∞)}, {(40, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1=39) OR (v1=40 AND v2<>49)) OR (v1<>35 AND v2>4 AND v3>26)) OR (v1=32 AND v2<>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 32), (4, ∞), (26, ∞)}, {[32, 32], (NULL, 55), [NULL, ∞)}, {[32, 32], [55, 55], (26, ∞)}, {[32, 32], (55, ∞), [NULL, ∞)}, {(32, 35), (4, ∞), (26, ∞)}, {(35, 39), (4, ∞), (26, ∞)}, {[39, 39], [NULL, ∞), [NULL, ∞)}, {(39, 40), (4, ∞), (26, ∞)}, {[40, 40], (NULL, 49), [NULL, ∞)}, {[40, 40], [49, 49], (26, ∞)}, {[40, 40], (49, ∞), [NULL, ∞)}, {(40, ∞), (4, ∞), (26, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=16 AND v2<>25 AND v3<>3) OR (v1>=4 AND v2 BETWEEN 4 AND 93 AND v3>39));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[4, 16), [4, 93], (39, ∞)}, {[16, 16], (NULL, 25), (NULL, 3)}, {[16, 16], (NULL, 25), (3, ∞)}, {[16, 16], [25, 25], (39, ∞)}, {[16, 16], (25, ∞), (NULL, 3)}, {[16, 16], (25, ∞), (3, ∞)}, {(16, ∞), [4, 93], (39, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1>=51 AND v2<83) OR (v1>=15 AND v2>=3)) OR (v1<=49)) OR (v1<69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 69), [NULL, ∞), [NULL, ∞)}, {[69, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<>43 AND v2>10) AND (v1>30 AND v2 BETWEEN 18 AND 78 AND v3 BETWEEN 75 AND 81);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(30, 43), [18, 78], [75, 81]}, {(43, ∞), [18, 78], [75, 81]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>1) OR (v1<34 AND v2>=57 AND v3 BETWEEN 15 AND 67));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 1], [57, ∞), [15, 67]}, {(1, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3184,35 +2643,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 3], [5, ∞), [27, ∞)}, {(3, 26], [5, 32], [27, ∞)}, {(3, ∞), (32, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25 AND v2<>70 AND v3<=51) OR (v1<=71 AND v2>59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 71], (59, ∞), [NULL, ∞)}, {(25, 71], (NULL, 59], (NULL, 51]}, {(71, ∞), (NULL, 70), (NULL, 51]}, {(71, ∞), (70, ∞), (NULL, 51]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1 BETWEEN 0 AND 61 AND v2<0) OR (v1 BETWEEN 0 AND 38 AND v2>34)) OR (v1>=13 AND v2>=41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[0, 38], (34, ∞), [NULL, ∞)}, {[0, 61], (NULL, 0), [NULL, ∞)}, {(38, ∞), [41, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3252,24 +2702,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 44 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 0], [28, 45], [24, 98]}, {(0, 44), (NULL, 28), [69, ∞)}, {(0, 44), [28, 45], [24, ∞)}, {(0, 44), (45, 47), [69, ∞)}, {(0, 44), (47, ∞), [69, ∞)}, {[44, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=48 AND v2 BETWEEN 33 AND 66) OR (v1>=91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 48], [33, 66], [NULL, ∞)}, {[91, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3305,90 +2749,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12], (NULL, 4), (53, ∞)}, {(NULL, 12], (4, 5), (53, ∞)}, {(NULL, 12], [5, 5], (NULL, ∞)}, {(NULL, 12], (5, ∞), (53, ∞)}, {(12, 17), [5, 5], (NULL, 94)}, {[17, 52], (NULL, 96), [NULL, ∞)}, {(52, 98), [5, 5], (NULL, 94)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>26 AND v2 BETWEEN 66 AND 79 AND v3<=94) OR (v1 BETWEEN 16 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 16), [66, 79], (NULL, 94]}, {[16, 55], [NULL, ∞), [NULL, ∞)}, {(55, ∞), [66, 79], (NULL, 94]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1 BETWEEN 36 AND 67 AND v3<74 AND v2=26) AND (v1 BETWEEN 9 AND 10 AND v2=96) AND (v1<=11 AND v2<>63 AND v3>=62);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 28 AND 49 AND v2<47) OR (v1>37 AND v2 BETWEEN 45 AND 61 AND v3<73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[28, 49], (NULL, 47), [NULL, ∞)}, {(37, 49], [47, 61], (NULL, 73)}, {(49, ∞), [45, 61], (NULL, 73)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<37 AND v2>=26 AND v3<=14) OR (v1<64)) OR (v1 BETWEEN 31 AND 53 AND v2>55 AND v3<=55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 64), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=77) OR (v1<50)) AND (v1<=53 AND v2>35 AND v3<>98);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 50), (35, ∞), (NULL, 98)}, {(NULL, 50), (35, ∞), (98, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1=2 AND v2=40 AND v3 BETWEEN 18 AND 67) OR (v1=14 AND v2<=24 AND v3<=87)) OR (v1 BETWEEN 8 AND 31 AND v2>86)) OR (v1>30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[2, 2], [40, 40], [18, 67]}, {[8, 30], (86, ∞), [NULL, ∞)}, {[14, 14], (NULL, 24], (NULL, 87]}, {(30, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>46 AND v2<>49 AND v3<=44) OR (v1 BETWEEN 64 AND 80 AND v2=41 AND v3<=68));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(46, 64), (NULL, 49), (NULL, 44]}, {(46, ∞), (49, ∞), (NULL, 44]}, {[64, 80], (NULL, 41), (NULL, 44]}, {[64, 80], [41, 41], (NULL, 68]}, {[64, 80], (41, 49), (NULL, 44]}, {(80, ∞), (NULL, 49), (NULL, 44]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3411,24 +2831,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 83 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[11, 36], (NULL, 83], [NULL, ∞)}, {[95, 95], [97, ∞), (NULL, 47)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=65 AND v2=39 AND v3 BETWEEN 49 AND 67) OR (v1<57 AND v2>35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 57), (35, ∞), [NULL, ∞)}, {[65, ∞), [39, 39], [49, 67]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3474,13 +2888,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 80 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 5), (NULL, 50), [34, 67]}, {(NULL, 16), (50, ∞), [34, 67]}, {[5, 16), (4, 50), [34, 67]}, {[5, 47], (NULL, 4), [34, 67]}, {[5, 47], [4, 4], [13, 76]}, {[16, 16], (4, 29), [34, 67]}, {[16, 16], [29, ∞), (NULL, 80)}, {[16, 16], [29, ∞), (80, ∞)}, {(16, 47], (4, 50), [34, 67]}, {(16, 85), (50, ∞), [34, 67]}, {(47, 71], (NULL, 50), [34, 67]}, {(71, 85), (NULL, 33), [34, 67]}, {(71, 85), (33, 50), [34, 67]}, {(71, ∞), [33, 33], [NULL, ∞)}, {(85, ∞), (NULL, 33), [34, 67]}, {(85, ∞), (33, 50), [34, 67]}, {(85, ∞), (50, ∞), [34, 67]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3502,24 +2913,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 38 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 38), [NULL, ∞), [NULL, ∞)}, {(38, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=4 AND v2=26) OR (v1>21 AND v2 BETWEEN 14 AND 64));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[4, 21], [26, 26], [NULL, ∞)}, {(21, ∞), [14, 64], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3541,112 +2946,82 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 10 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 50), [NULL, ∞), [NULL, ∞)}, {[50, 50], (NULL, 95], [NULL, ∞)}, {(50, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<=21 AND v2<>95) OR (v1<>23 AND v2 BETWEEN 15 AND 22)) OR (v1<=53 AND v2>=6)) OR (v1<=13 AND v2<>93 AND v3<15));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 21], (NULL, ∞), [NULL, ∞)}, {(21, 53], [6, ∞), [NULL, ∞)}, {(53, ∞), [15, 22], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<64 AND v2>=90 AND v3>41) AND (v1>=14 AND v2 BETWEEN 30 AND 70 AND v3>=25);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<27 AND v2<=43) OR (v1<62 AND v2<=99)) OR (v1<>48 AND v2<29 AND v3<>69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 62), (NULL, 99], [NULL, ∞)}, {[62, ∞), (NULL, 29), (NULL, 69)}, {[62, ∞), (NULL, 29), (69, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<11 AND v2<70 AND v3>27) OR (v1>=80 AND v2<31 AND v3<65)) OR (v1>=98 AND v2 BETWEEN 30 AND 85 AND v3>=30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 11), (NULL, 70), (27, ∞)}, {[80, 98), (NULL, 31), (NULL, 65)}, {[98, ∞), (NULL, 30), (NULL, 65)}, {[98, ∞), [30, 31), (NULL, ∞)}, {[98, ∞), [31, 85], [30, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<>44 AND v2>=10) AND (v1=47 AND v2=14 AND v3<30);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[47, 47], [14, 14], (NULL, 30)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>6 AND v2=50) OR (v1>=16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(6, 16), [50, 50], [NULL, ∞)}, {[16, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=31) OR (v1>53 AND v2<>11 AND v3<>94)) OR (v1>48 AND v2 BETWEEN 11 AND 29 AND v3 BETWEEN 68 AND 72));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[31, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 55 AND 59) OR (v1<=10 AND v2>=24)) AND (v1>93 AND v3<70 AND v2 BETWEEN 44 AND 79) AND (v1>=22 AND v2=27);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=43 AND v2<28 AND v3<>24) OR (v1<36 AND v2=14 AND v3 BETWEEN 16 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 36), [14, 14], [16, 55]}, {[43, ∞), (NULL, 28), (NULL, 24)}, {[43, ∞), (NULL, 28), (24, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3669,35 +3044,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(48, ∞), (NULL, 80], [NULL, ∞)}, {[72, 72], [98, 98], [45, 52]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>=98 AND v2=51) AND (v1>34);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[98, ∞), [51, 51], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>2) OR (v1<=30)) OR (v1<>35 AND v2 BETWEEN 6 AND 61 AND v3>=16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3712,57 +3078,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 48 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 12 AND 42 AND v2<=12) OR (v1<34 AND v2 BETWEEN 30 AND 47 AND v3<>50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 34), [30, 47], (NULL, 50)}, {(NULL, 34), [30, 47], (50, ∞)}, {[12, 42], (NULL, 12], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((((v1>=6) OR (v1>7)) OR (v1<88 AND v2<=34 AND v3<=47)) OR (v1>=10)) OR (v1=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), (NULL, 34], (NULL, 47]}, {[6, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=74) OR (v1>=1)) OR (v1=54 AND v2>=38 AND v3>2)) AND (v1>5);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(5, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=45 AND v2>18) OR (v1<64 AND v2=25 AND v3>97));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 45), [25, 25], (97, ∞)}, {[45, ∞), (18, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3788,24 +3139,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 87 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 37), [NULL, ∞), [NULL, ∞)}, {(38, ∞), [87, 87], (NULL, 57)}, {(38, ∞), [87, 87], (57, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<96 AND v2>11 AND v3<76) OR (v1<=14 AND v2=23)) OR (v1<=15 AND v2<21 AND v3<91)) OR (v1=45 AND v2<11 AND v3=1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 14], [21, 23), (NULL, 76)}, {(NULL, 14], [23, 23], [NULL, ∞)}, {(NULL, 14], (23, ∞), (NULL, 76)}, {(NULL, 15], (NULL, 21), (NULL, 91)}, {(14, 15], [21, ∞), (NULL, 76)}, {(15, 96), (11, ∞), (NULL, 76)}, {[45, 45], (NULL, 11), [1, 1]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3828,46 +3173,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 25 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 23), [NULL, ∞), [NULL, ∞)}, {[23, 23], [25, 25], [NULL, ∞)}, {(23, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<=12 AND v2>=65) AND (v1<6 AND v2>=92);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), [92, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=62 AND v2<>32) OR (v1>=55 AND v2=41 AND v3>73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[55, 62), [41, 41], (73, ∞)}, {[62, 62], (NULL, 32), [NULL, ∞)}, {[62, 62], (32, ∞), [NULL, ∞)}, {(62, ∞), [41, 41], (73, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>34 AND v2<=62) OR (v1>5 AND v2 BETWEEN 59 AND 98 AND v3<69)) OR (v1>34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 34), (NULL, 62], [NULL, ∞)}, {(5, 34), (62, 98], (NULL, 69)}, {[34, 34], [59, 98], (NULL, 69)}, {(34, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3896,46 +3229,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 67 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 61), (NULL, 67), [7, 63]}, {[61, 61], (NULL, 10), [7, 63]}, {[61, 61], [10, 22], (NULL, 63]}, {[61, 61], (22, 67), [7, 63]}, {(61, 68), (NULL, 67), [7, 63]}, {[68, 68], [NULL, ∞), [NULL, ∞)}, {(68, 97], (NULL, 67), [7, 63]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=42) OR (v1 BETWEEN 13 AND 30 AND v2<50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 42], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 16 AND 49) OR (v1<=69 AND v2>9 AND v3<=8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 16), (9, ∞), (NULL, 8]}, {[16, 49], [NULL, ∞), [NULL, ∞)}, {(49, 69], (9, ∞), (NULL, 8]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>71 AND v2>44) OR (v1<76 AND v2>=10)) OR (v1>=44 AND v2=66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 76), [10, ∞), [NULL, ∞)}, {[76, ∞), (44, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3980,24 +3301,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 0 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 0), [NULL, ∞), [NULL, ∞)}, {[0, 0], [0, 54], [NULL, ∞)}, {(0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=99 AND v2<66) OR (v1 BETWEEN 1 AND 47)) OR (v1<>2 AND v2<30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 1), (NULL, 30), [NULL, ∞)}, {[1, 47], [NULL, ∞), [NULL, ∞)}, {(47, 99), (NULL, 30), [NULL, ∞)}, {[99, ∞), (NULL, 66), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4023,24 +3338,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 46), [NULL, ∞), [NULL, ∞)}, {[46, 63], [18, 18], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<=20 AND v2<=62) OR (v1>45 AND v2=33 AND v3<=4)) OR (v1>29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 20], (NULL, 62], [NULL, ∞)}, {(29, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4081,13 +3390,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 73 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 55], [82, 96], [13, ∞)}, {[7, 74], (NULL, 73], [NULL, ∞)}, {[89, 98), (NULL, 18), (NULL, 19)}, {[98, 98], [NULL, ∞), [NULL, ∞)}, {(98, ∞), (NULL, 18), (NULL, 19)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4114,13 +3420,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 63 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[47, 47], [6, 67), (NULL, 7)}, {(63, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4134,13 +3437,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 33 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 33), [NULL, ∞), [NULL, ∞)}, {(33, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4186,46 +3486,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ AND\n" +
 			" │       ├─ (comp_index_t1.v1:1 BETWEEN 22 (tinyint) AND 23 (tinyint))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 14 (tinyint) AND 46 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 94], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<9 AND v2=94 AND v3>8) OR (v1>=63));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 9), [94, 94], (8, ∞)}, {[63, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<43) OR (v1 BETWEEN 40 AND 49 AND v2>26 AND v3 BETWEEN 22 AND 80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 43), [NULL, ∞), [NULL, ∞)}, {[43, 49], (26, ∞), [22, 80]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 4 AND 85 AND v2<>45 AND v3<=41) OR (v1>67 AND v2<25));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[4, 67], (NULL, 45), (NULL, 41]}, {[4, 85], (45, ∞), (NULL, 41]}, {(67, 85], [25, 45), (NULL, 41]}, {(67, ∞), (NULL, 25), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4259,24 +3547,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 6 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 77), [NULL, ∞), [NULL, ∞)}, {[77, 77], (NULL, 30), [6, 6]}, {(77, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1 BETWEEN 21 AND 53 AND v2=0 AND v3>32) OR (v1=93 AND v2>=94 AND v3<1)) OR (v1<26)) OR (v1<>11 AND v2<>32 AND v3=6)) AND (v1>=45);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[45, 53], [0, 0], (32, ∞)}, {[45, ∞), (NULL, 32), [6, 6]}, {[45, ∞), (32, ∞), [6, 6]}, {[93, 93], [94, ∞), (NULL, 1)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4290,24 +3572,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 71 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=41) OR (v1>29 AND v2<>31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(29, 41), (NULL, 31), [NULL, ∞)}, {(29, 41), (31, ∞), [NULL, ∞)}, {[41, 41], [NULL, ∞), [NULL, ∞)}, {(41, ∞), (NULL, 31), [NULL, ∞)}, {(41, ∞), (31, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4338,13 +3614,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 40 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[5, 40), [21, 29], (18, ∞)}, {[40, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4367,13 +3640,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t1.v1:1\n" +
 			" │       │   └─ 12 (tinyint)\n" +
 			" │       └─ (comp_index_t1.v3:3 BETWEEN 25 (tinyint) AND 30 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12], [NULL, ∞), [NULL, ∞)}, {(12, ∞), (NULL, 76), (NULL, 35]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4413,57 +3683,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 48 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 48), [NULL, ∞), [NULL, ∞)}, {[48, 48], (NULL, 94], [NULL, ∞)}, {(48, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=24) OR (v1>=47 AND v2<=75 AND v3<=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[24, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=21 AND v2<>70) OR (v1<=77 AND v2>4)) OR (v1<28 AND v2<=3 AND v3<>21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 21), (NULL, 3], (NULL, 21)}, {(NULL, 21), (NULL, 3], (21, ∞)}, {(NULL, 21), (4, ∞), [NULL, ∞)}, {[21, 77], (NULL, ∞), [NULL, ∞)}, {(77, ∞), (NULL, 70), [NULL, ∞)}, {(77, ∞), (70, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=60 AND v2>91) OR (v1<=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 10], [NULL, ∞), [NULL, ∞)}, {[60, ∞), (91, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>98 AND v2<52) OR (v1 BETWEEN 65 AND 67)) OR (v1 BETWEEN 18 AND 54)) AND (v1>=14 AND v2=27);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[14, 98), [27, 27], [NULL, ∞)}, {(98, ∞), [27, 27], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4496,46 +3751,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   └─ 68 (tinyint)\n" +
 			" │       │  ))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 42 (tinyint) AND 46 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 68), [42, 46], [NULL, ∞)}, {(68, ∞), [42, 46], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>=19 AND v2<2) AND (v1<4 AND v3>23 AND v2<>53);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 34 AND 40) OR (v1<=80 AND v2<>53)) AND (v1=81 AND v2=17 AND v3<>12);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>34 AND v2 BETWEEN 18 AND 67 AND v3<67) OR (v1>21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(21, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4571,90 +3814,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 45 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 45), [NULL, ∞), [NULL, ∞)}, {[45, 45], (NULL, 45), (NULL, 32]}, {[45, 45], (45, ∞), (NULL, 32]}, {(45, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=48) OR (v1<38 AND v2>=26)) AND (v1<=45 AND v2>21) AND (v1=83 AND v2=20);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25) OR (v1<53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<95 AND v2>=12) OR (v1 BETWEEN 41 AND 55 AND v2<=81 AND v3<46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 95), [12, ∞), [NULL, ∞)}, {[41, 55], (NULL, 12), (NULL, 46)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>39 AND v2 BETWEEN 53 AND 73 AND v3<=11) OR (v1<=31 AND v2=68 AND v3>=71)) OR (v1<>18 AND v2<=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 18), (NULL, 51], [NULL, ∞)}, {(NULL, 31], [68, 68], [71, ∞)}, {(18, ∞), (NULL, 51], [NULL, ∞)}, {(39, ∞), [53, 73], (NULL, 11]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>4) AND (v1=3 AND v2 BETWEEN 4 AND 34 AND v3<=40);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>36 AND v2>82) OR (v1 BETWEEN 22 AND 59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[22, 59], [NULL, ∞), [NULL, ∞)}, {(59, ∞), (82, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=0) OR (v1 BETWEEN 17 AND 45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 0], [NULL, ∞), [NULL, ∞)}, {[17, 45], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4674,24 +3893,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 70 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 1), [NULL, ∞), [NULL, ∞)}, {[2, 57], (NULL, 70), [NULL, ∞)}, {[2, 57], (70, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>4) AND (v1 BETWEEN 8 AND 35 AND v2>=94 AND v3=32) AND (v1>=12);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[12, 35], [94, ∞), [32, 32]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4725,68 +3938,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 33 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>12) OR (v1>=26 AND v2 BETWEEN 77 AND 87 AND v3<19)) OR (v1<=89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1=27 AND v2=16 AND v3>=8) OR (v1<20 AND v2>=1 AND v3 BETWEEN 28 AND 47)) OR (v1 BETWEEN 15 AND 43 AND v2>30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 15), [1, ∞), [28, 47]}, {[15, 20), [1, 30], [28, 47]}, {[15, 43], (30, ∞), [NULL, ∞)}, {[27, 27], [16, 16], [8, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=67 AND v2<>69) OR (v1<28 AND v2<62 AND v3>=99));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 28), (NULL, 62), [99, ∞)}, {[67, 67], (NULL, 69), [NULL, ∞)}, {[67, 67], (69, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<45 AND v2>5 AND v3>20) OR (v1<17));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 17), [NULL, ∞), [NULL, ∞)}, {[17, 45), (5, ∞), (20, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=40 AND v2<>18) OR (v1<>97 AND v2<>17 AND v3<>48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 40), (NULL, 17), (NULL, 48)}, {(NULL, 40), (NULL, 17), (48, ∞)}, {(NULL, 40), (17, ∞), (NULL, 48)}, {(NULL, 40), (17, ∞), (48, ∞)}, {[40, 40], (NULL, 18), [NULL, ∞)}, {[40, 40], [18, 18], (NULL, 48)}, {[40, 40], [18, 18], (48, ∞)}, {[40, 40], (18, ∞), [NULL, ∞)}, {(40, 97), (NULL, 17), (NULL, 48)}, {(40, 97), (NULL, 17), (48, ∞)}, {(40, 97), (17, ∞), (NULL, 48)}, {(40, 97), (17, ∞), (48, ∞)}, {(97, ∞), (NULL, 17), (NULL, 48)}, {(97, ∞), (NULL, 17), (48, ∞)}, {(97, ∞), (17, ∞), (NULL, 48)}, {(97, ∞), (17, ∞), (48, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4816,35 +4011,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 45 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[38, 38], (45, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=6) OR (v1>0 AND v2 BETWEEN 3 AND 50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6], [NULL, ∞), [NULL, ∞)}, {(6, ∞), [3, 50], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 5 AND 35 AND v2<=3 AND v3<>14) OR (v1>11));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[5, 11], (NULL, 3], (NULL, 14)}, {[5, 11], (NULL, 3], (14, ∞)}, {(11, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4874,13 +4060,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 65 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 19), [10, ∞), [NULL, ∞)}, {[19, 36), (10, ∞), (NULL, 65)}, {[19, 36), (10, ∞), (65, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4914,24 +4097,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 31 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[10, 21), [62, ∞), [NULL, ∞)}, {[21, 31], (NULL, ∞), [NULL, ∞)}, {(31, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<20 AND v2>=1 AND v3=26) OR (v1=12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 12), [1, ∞), [26, 26]}, {[12, 12], [NULL, ∞), [NULL, ∞)}, {(12, 20), [1, ∞), [26, 26]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4962,68 +4139,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 4), (NULL, 47), [77, ∞)}, {(4, 41], (NULL, 47), [77, ∞)}, {(41, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<35) OR (v1>=58 AND v2>=0));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 35), [NULL, ∞), [NULL, ∞)}, {[58, ∞), [0, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>28 AND v2<95) OR (v1<91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 91), [NULL, ∞), [NULL, ∞)}, {[91, ∞), (NULL, 95), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1=99 AND v2<=41 AND v3>=61) AND (v1=34 AND v2>68 AND v3<=42);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=74 AND v2<=18) OR (v1>=72)) AND (v1=95 AND v2=31 AND v3 BETWEEN 5 AND 19);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[95, 95], [31, 31], [5, 19]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=64) OR (v1>=49 AND v2<9 AND v3<=49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[49, 64), (NULL, 9), (NULL, 49]}, {[64, 64], [NULL, ∞), [NULL, ∞)}, {(64, ∞), (NULL, 9), (NULL, 49]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5052,35 +4211,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t1.v1:1\n" +
 			" │       │   └─ 55 (tinyint)\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 11 (tinyint) AND 84 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[55, ∞), [11, 84], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=7) OR (v1<54));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 54), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=95 AND v2=55 AND v3>34) OR (v1=19));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 19), [55, 55], (34, ∞)}, {[19, 19], [NULL, ∞), [NULL, ∞)}, {(19, 95], [55, 55], (34, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5117,24 +4267,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 12 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 50), [NULL, ∞), [NULL, ∞)}, {[50, 50], (56, ∞), [NULL, ∞)}, {(50, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<=90 AND v2<=17) OR (v1=2)) OR (v1<>70 AND v2>=84 AND v3<>42)) OR (v1<11 AND v2<>47 AND v3<55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 17], [NULL, ∞)}, {(NULL, 2), (17, 47), (NULL, 55)}, {(NULL, 2), (47, 84), (NULL, 55)}, {(NULL, 2), [84, ∞), (NULL, ∞)}, {[2, 2], [NULL, ∞), [NULL, ∞)}, {(2, 11), (17, 47), (NULL, 55)}, {(2, 11), (47, 84), (NULL, 55)}, {(2, 11), [84, ∞), (NULL, ∞)}, {(2, 90], (NULL, 17], [NULL, ∞)}, {[11, 70), [84, ∞), (NULL, 42)}, {[11, 70), [84, ∞), (42, ∞)}, {(70, ∞), [84, ∞), (NULL, 42)}, {(70, ∞), [84, ∞), (42, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5154,24 +4298,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 46 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[23, 50), (NULL, 46), [87, ∞)}, {[23, 50), (46, ∞), [87, ∞)}, {[50, 59], [NULL, ∞), [NULL, ∞)}, {(59, ∞), (NULL, 46), [87, ∞)}, {(59, ∞), (46, ∞), [87, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<53) OR (v1<=3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 53), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5203,13 +4341,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 7 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[16, 17), [66, 94], [NULL, ∞)}, {[17, 17], [7, ∞), [NULL, ∞)}, {(17, 91), [66, 94], [NULL, ∞)}, {(70, 91), (NULL, 3], [NULL, ∞)}, {(91, ∞), (NULL, 3], [NULL, ∞)}, {(91, ∞), [66, 94], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5230,13 +4365,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 59), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5261,13 +4393,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(19, 42), (84, ∞), (94, ∞)}, {[42, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5293,13 +4422,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5318,46 +4444,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 68 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>15 AND v2>=22 AND v3<=51) OR (v1<>40 AND v2>26 AND v3<95));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 15), [22, 26], (NULL, 51]}, {(NULL, 40), (26, ∞), (NULL, 95)}, {(15, 40), [22, 26], (NULL, 51]}, {[40, 40], [22, ∞), (NULL, 51]}, {(40, ∞), [22, 26], (NULL, 51]}, {(40, ∞), (26, ∞), (NULL, 95)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>6) OR (v1<=67 AND v2<>67 AND v3>=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6], (NULL, 67), [88, ∞)}, {(NULL, 6], (67, ∞), [88, ∞)}, {(6, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<=0) OR (v1<=53)) OR (v1<=38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 53], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5380,35 +4494,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 26 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[1, 49], [NULL, ∞), [NULL, ∞)}, {[60, 60], [10, 69], [2, 13]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1 BETWEEN 14 AND 20 AND v2<>70) OR (v1>78 AND v2 BETWEEN 31 AND 52 AND v3>16)) OR (v1 BETWEEN 77 AND 78));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[14, 20], (NULL, 70), [NULL, ∞)}, {[14, 20], (70, ∞), [NULL, ∞)}, {[77, 78], [NULL, ∞), [NULL, ∞)}, {(78, ∞), [31, 52], (16, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<80 AND v2 BETWEEN 41 AND 74) OR (v1>=36 AND v2=32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 80), [41, 74], [NULL, ∞)}, {[36, ∞), [32, 32], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5438,13 +4543,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 90 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 15), [12, 25], [51, 51]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5474,13 +4576,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 52 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 90), [NULL, ∞), [NULL, ∞)}, {(90, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5505,68 +4604,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 84 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[6, 74], [52, 52], [NULL, ∞)}, {(44, 74], [17, 52), [15, ∞)}, {(44, 74], (52, 94], [15, ∞)}, {(74, 84], [17, 94], [15, ∞)}, {(84, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=38) OR (v1=13)) OR (v1=25 AND v2<=32 AND v3 BETWEEN 12 AND 92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[13, 13], [NULL, ∞), [NULL, ∞)}, {[25, 25], (NULL, 32], [12, 92]}, {[38, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<=84) OR (v1=41)) OR (v1<83 AND v2=13 AND v3=58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 84], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<36 AND v2<=79 AND v3>47) OR (v1 BETWEEN 24 AND 89 AND v2<29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 24), (NULL, 79], (47, ∞)}, {[24, 36), [29, 79], (47, ∞)}, {[24, 89], (NULL, 29), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 3 AND 19 AND v2<=57 AND v3>61) OR (v1<=58 AND v2>=36 AND v3=31)) AND (v1>94);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<78 AND v2 BETWEEN 55 AND 64 AND v3>=0) OR (v1<74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 74), [NULL, ∞), [NULL, ∞)}, {[74, 78), [55, 64], [0, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5601,35 +4682,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 9 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 38], [NULL, ∞), [NULL, ∞)}, {(38, 74], [88, 88], (NULL, 33)}, {(74, ∞), [9, ∞), (NULL, 55)}, {(74, ∞), [9, ∞), (55, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 15 AND 96 AND v2<>73) OR (v1>=16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[15, 16), (NULL, 73), [NULL, ∞)}, {[15, 16), (73, ∞), [NULL, ∞)}, {[16, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=72 AND v2<>19 AND v3 BETWEEN 9 AND 12) OR (v1<=77 AND v2=30 AND v3<=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 72), [30, 30], (NULL, 10]}, {[72, 77], (19, 30), [9, 12]}, {[72, 77], [30, 30], (NULL, 12]}, {[72, 77], (30, ∞), [9, 12]}, {[72, ∞), (NULL, 19), [9, 12]}, {(77, ∞), (19, ∞), [9, 12]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5670,13 +4742,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 43 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 36), [NULL, ∞), [NULL, ∞)}, {[47, 47], [0, 92], (NULL, 43]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5697,24 +4766,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 78 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(68, 78], [1, 79], [23, 44]}, {(78, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1=47 AND v2=7) OR (v1>=7 AND v2<>87)) OR (v1<>6 AND v2<=84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), (NULL, 84], [NULL, ∞)}, {(6, 7), (NULL, 84], [NULL, ∞)}, {[7, ∞), (NULL, 87), [NULL, ∞)}, {[7, ∞), (87, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5765,35 +4828,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(30, ∞), [66, ∞), [NULL, ∞)}, {[49, ∞), (53, 66), (NULL, 12)}, {[49, ∞), (53, 66), (12, ∞)}, {[62, 62], (NULL, 22], [37, ∞)}, {[95, 95], (NULL, 1), (NULL, 89)}, {[95, 95], (NULL, 1), (89, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1=24 AND v2<81) OR (v1<=22 AND v2>34 AND v3<55)) OR (v1=45 AND v2>=94 AND v3>17));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 22], (34, ∞), (NULL, 55)}, {[24, 24], (NULL, 81), [NULL, ∞)}, {[45, 45], [94, ∞), (17, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1>38) OR (v1<51 AND v2>=28 AND v3=44)) OR (v1 BETWEEN 23 AND 61 AND v2 BETWEEN 54 AND 75 AND v3<>44)) OR (v1>72));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 38], [28, ∞), [44, 44]}, {[23, 38], [54, 75], (NULL, 44)}, {[23, 38], [54, 75], (44, ∞)}, {(38, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5833,13 +4887,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 74 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 57), [NULL, ∞), [NULL, ∞)}, {[57, 57], [26, 30], [NULL, ∞)}, {(57, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5870,24 +4921,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   └─ 46 (tinyint)\n" +
 			" │       │  ))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 4 (tinyint) AND 26 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 11), [4, 26], [NULL, ∞)}, {[11, 47), [NULL, ∞), [NULL, ∞)}, {[47, 47], [4, 26], [NULL, ∞)}, {(47, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1 BETWEEN 41 AND 98 AND v2>54) OR (v1<29)) OR (v1<32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 32), [NULL, ∞), [NULL, ∞)}, {[41, 98], (54, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5907,13 +4952,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 94 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[50, 50], [16, 38], (NULL, 94)}, {[50, 50], [16, 38], (94, ∞)}, {[79, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5947,35 +4989,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 79), [NULL, ∞), [NULL, ∞)}, {[79, 79], (NULL, 4), [NULL, ∞)}, {(79, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=2 AND v2 BETWEEN 32 AND 59 AND v3 BETWEEN 50 AND 52) OR (v1<26)) OR (v1<>2 AND v2>11)) AND (v1>32 AND v2<=92) AND (v1>45 AND v2<>5 AND v3<>49);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(45, ∞), (11, 92], (NULL, 49)}, {(45, ∞), (11, 92], (49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=19) AND (v1<=73) OR (v1=9 AND v2=5 AND v3<=5));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[9, 9], [5, 5], (NULL, 5]}, {[19, 73], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6011,79 +5044,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 94 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 28), (51, ∞), [29, 30]}, {[28, 57], (62, ∞), [29, 30]}, {[28, 94), (NULL, 62], (NULL, 76)}, {[28, 94), (NULL, 62], (76, ∞)}, {[94, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>21) OR (v1>=86 AND v2>2 AND v3>=67));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(21, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=94) OR (v1>=57 AND v2<>53 AND v3>22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[57, 94), (NULL, 53), (22, ∞)}, {[57, 94), (53, ∞), (22, ∞)}, {[94, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<40 AND v2=9) OR (v1<11 AND v2=15 AND v3<>55 AND v4<>95));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [15, 15], (NULL, 55), (NULL, 95)}, {(NULL, 11), [15, 15], (NULL, 55), (95, ∞)}, {(NULL, 11), [15, 15], (55, ∞), (NULL, 95)}, {(NULL, 11), [15, 15], (55, ∞), (95, ∞)}, {(NULL, 40), [9, 9], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=82 AND v2=74 AND v3=98) OR (v1=27 AND v2 BETWEEN 16 AND 46 AND v3<>27)) OR (v1>=80 AND v2<>42 AND v3>=47));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 80), [74, 74], [98, 98], [NULL, ∞)}, {[27, 27], [16, 46], (NULL, 27), [NULL, ∞)}, {[27, 27], [16, 46], (27, ∞), [NULL, ∞)}, {[80, ∞), (NULL, 42), [47, ∞), [NULL, ∞)}, {[80, ∞), (42, ∞), [47, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1>=47 AND v2<=37 AND v3<90 AND v4=25) OR (v1<42 AND v2>=96 AND v3=38)) OR (v1>26)) OR (v1>=80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 26], [96, ∞), [38, 38], [NULL, ∞)}, {(26, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>33 AND v2>=16) OR (v1>=24));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[24, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6120,13 +5132,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 94 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 60], (NULL, 1), [NULL, ∞), [NULL, ∞)}, {[51, 51], (62, ∞), (NULL, 43), [36, 55]}, {[51, 51], [98, ∞), [94, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6161,35 +5170,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 98], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(98, ∞), [6, 11], (NULL, 4], (44, 95)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=12 AND v2<=78 AND v3 BETWEEN 28 AND 63 AND v4 BETWEEN 46 AND 95) OR (v1=87 AND v2<=44)) OR (v1<14 AND v2<>37 AND v3 BETWEEN 6 AND 32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 14), (NULL, 37), [6, 32], [NULL, ∞)}, {(NULL, 14), (37, ∞), [6, 32], [NULL, ∞)}, {[12, 14), (NULL, 37), (32, 63], [46, 95]}, {[12, 14), [37, 37], [28, 63], [46, 95]}, {[12, 14), (37, 78], (32, 63], [46, 95]}, {[14, 87), (NULL, 78], [28, 63], [46, 95]}, {[87, 87], (NULL, 44], [NULL, ∞), [NULL, ∞)}, {[87, 87], (44, 78], [28, 63], [46, 95]}, {(87, ∞), (NULL, 78], [28, 63], [46, 95]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=80 AND v2=72 AND v3>19) OR (v1<>38 AND v2>=86 AND v3=7)) OR (v1<=52 AND v2=25 AND v3 BETWEEN 7 AND 32 AND v4<=31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 38), [86, ∞), [7, 7], [NULL, ∞)}, {(NULL, 52], [25, 25], [7, 32], (NULL, 31]}, {(NULL, 80], [72, 72], (19, ∞), [NULL, ∞)}, {(38, ∞), [86, ∞), [7, 7], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6204,13 +5204,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 38 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 25 (tinyint) AND 30 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[38, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6232,35 +5229,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 38 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 33], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>14 AND v2<51 AND v3 BETWEEN 67 AND 78 AND v4=8) OR (v1>=44 AND v2<>35 AND v3<35 AND v4>=12)) OR (v1>=63 AND v2<=3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(14, 63), (NULL, 51), [67, 78], [8, 8]}, {[44, 63), (NULL, 35), (NULL, 35), [12, ∞)}, {[44, ∞), (35, ∞), (NULL, 35), [12, ∞)}, {[63, ∞), (NULL, 3], [NULL, ∞), [NULL, ∞)}, {[63, ∞), (3, 35), (NULL, 35), [12, ∞)}, {[63, ∞), (3, 51), [67, 78], [8, 8]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=6 AND v2<=25 AND v3>39) OR (v1 BETWEEN 17 AND 94 AND v2>96));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[6, 6], (NULL, 25], (39, ∞), [NULL, ∞)}, {[17, 94], (96, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6307,35 +5295,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 44 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[72, 75), [48, 48], (NULL, 10], [NULL, ∞)}, {[75, 75], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(75, 88], [48, 48], (NULL, 10], [NULL, ∞)}, {[91, ∞), [43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=31) OR (v1<84 AND v2<=73 AND v3<>2 AND v4<=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 31), (NULL, 73], (NULL, 2), (NULL, 51]}, {(NULL, 31), (NULL, 73], (2, ∞), (NULL, 51]}, {[31, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(31, 84), (NULL, 73], (NULL, 2), (NULL, 51]}, {(31, 84), (NULL, 73], (2, ∞), (NULL, 51]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=20 AND v2<=29 AND v3<52 AND v4<>34) OR (v1<>46 AND v2<>98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 46), (NULL, 98), [NULL, ∞), [NULL, ∞)}, {(NULL, 46), (98, ∞), [NULL, ∞), [NULL, ∞)}, {(46, ∞), (NULL, 98), [NULL, ∞), [NULL, ∞)}, {(46, ∞), (98, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6377,59 +5356,44 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 10 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44], (NULL, 98), [NULL, ∞), [NULL, ∞)}, {(NULL, 44], [98, 99], [39, 57], [13, 13]}, {(44, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=40) OR (v1=27)) OR (v1>90 AND v2>50 AND v3=66 AND v4<83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[27, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[40, 40], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(90, ∞), (50, ∞), [66, 66], (NULL, 83)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<=92 AND v4 BETWEEN 8 AND 90) AND (v1 BETWEEN 39 AND 42);`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (comp_index_t2.v4:4 BETWEEN 8 (tinyint) AND 90 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[39, 42], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 23 AND 85 AND v2<=51 AND v3<>68) OR (v1 BETWEEN 30 AND 58 AND v2<>75));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[23, 30), (NULL, 51], (NULL, 68), [NULL, ∞)}, {[23, 30), (NULL, 51], (68, ∞), [NULL, ∞)}, {[30, 58], (NULL, 75), [NULL, ∞), [NULL, ∞)}, {[30, 58], (75, ∞), [NULL, ∞), [NULL, ∞)}, {(58, 85], (NULL, 51], (NULL, 68), [NULL, ∞)}, {(58, 85], (NULL, 51], (68, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=67 AND v2<=17 AND v3<>91 AND v4<82) OR (v1>28 AND v2 BETWEEN 17 AND 71 AND v3<12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(28, ∞), [17, 71], (NULL, 12), [NULL, ∞)}, {[67, ∞), (NULL, 17), (NULL, 91), (NULL, 82)}, {[67, ∞), (NULL, 17], (91, ∞), (NULL, 82)}, {[67, ∞), [17, 17], [12, 91), (NULL, 82)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6457,26 +5421,20 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 60 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[41, 77], (21, ∞), (60, ∞), [NULL, ∞)}, {[41, 80], (NULL, 21), (60, ∞), [NULL, ∞)}, {(77, 80], (21, 96), (60, ∞), [NULL, ∞)}, {(77, ∞), [96, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=28 AND v4 BETWEEN 44 AND 50) AND (v1>=49);`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (comp_index_t2.v4:4 BETWEEN 44 (tinyint) AND 50 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6517,13 +5475,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 27), (NULL, 8), (35, ∞), [NULL, ∞)}, {(NULL, 27), (8, ∞), (35, ∞), [NULL, ∞)}, {(28, ∞), (NULL, 62), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6559,13 +5514,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 73 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(65, 82), [64, 64], [NULL, ∞), [NULL, ∞)}, {[68, 82), [3, 3], [1, 51], (NULL, 73]}, {[82, 82], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(82, ∞), [3, 3], [1, 51], (NULL, 73]}, {(82, ∞), [64, 64], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6587,13 +5539,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 43 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(27, 70), (NULL, 43), [NULL, ∞), [NULL, ∞)}, {(27, 70), (43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6631,35 +5580,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   │       └─ 23 (tinyint)\n" +
 			" │       │   └─ (comp_index_t2.v3:3 BETWEEN 17 (tinyint) AND 37 (tinyint))\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 21 (tinyint) AND 38 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 42], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(42, 59), [23, 89), [17, 37], [21, 38]}, {(42, ∞), [89, ∞), [14, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=52 AND v2>=55) OR (v1<73 AND v2<=1 AND v3>75 AND v4<=36)) OR (v1>=45 AND v2>=49 AND v3<=26 AND v4 BETWEEN 40 AND 83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 73), (NULL, 1], (75, ∞), (NULL, 36]}, {[45, 52), [49, ∞), (NULL, 26], [40, 83]}, {[52, ∞), [49, 55), (NULL, 26], [40, 83]}, {[52, ∞), [55, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>0 AND v2=94 AND v3<>0) OR (v1>=83 AND v2<69 AND v3<84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(0, ∞), [94, 94], (NULL, 0), [NULL, ∞)}, {(0, ∞), [94, 94], (0, ∞), [NULL, ∞)}, {[83, ∞), (NULL, 69), (NULL, 84), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6677,35 +5617,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 30 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<92) OR (v1 BETWEEN 6 AND 39 AND v2=47 AND v3>=63));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 92), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=98) OR (v1<=2 AND v2<5));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2], (NULL, 5), [NULL, ∞), [NULL, ∞)}, {[98, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6752,24 +5683,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 22 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 4), (NULL, 70), (NULL, 20], [NULL, ∞)}, {[4, 29], (22, 70), (NULL, 20], [NULL, ∞)}, {[4, ∞), (NULL, 22], [NULL, ∞), [NULL, ∞)}, {[7, 29], [33, ∞), (78, ∞), [NULL, ∞)}, {(29, 61], [33, 63), (78, ∞), [NULL, ∞)}, {(29, 70), (22, 63), (NULL, 20], [NULL, ∞)}, {(29, ∞), [63, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=12) OR (v1=28));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 12], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[28, 28], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6806,24 +5731,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 45 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[52, 98], (NULL, 71), (NULL, 45), [NULL, ∞)}, {[52, 98], (NULL, 71), (45, ∞), [NULL, ∞)}, {[84, 84], [13, 71), [45, 45], (NULL, 36)}, {[84, 84], [13, 71), [45, 45], (36, ∞)}, {[84, 84], [71, ∞), (NULL, 46], (NULL, 36)}, {[84, 84], [71, ∞), (NULL, 46], (36, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>64) OR (v1<>55 AND v2=85 AND v3<=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 55), [85, 85], (NULL, 88], [NULL, ∞)}, {(55, 64], [85, 85], (NULL, 88], [NULL, ∞)}, {(64, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6861,24 +5780,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 2 AND 23) OR (v1 BETWEEN 7 AND 14 AND v2<=27 AND v3<=82)) OR (v1>61));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[2, 23], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(61, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6919,24 +5832,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v4:4\n" +
 			" │       └─ 32 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=85 AND v2<12) AND (v1>=25);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[85, ∞), (NULL, 12), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6964,24 +5871,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 0), [27, 69], [14, 14], (9, ∞)}, {[0, 0], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(0, 31), [27, 69], [14, 14], (9, ∞)}, {[31, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(31, 73), [27, 69], [14, 14], (9, ∞)}, {(73, ∞), [27, 69], [14, 14], (9, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=42 AND v2=41 AND v3 BETWEEN 29 AND 94 AND v4<71) OR (v1>=71 AND v2 BETWEEN 67 AND 87 AND v3>=9)) OR (v1<2 AND v2<=1 AND v3<36 AND v4>41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 1], (NULL, 36), (41, ∞)}, {[42, ∞), [41, 41], [29, 94], (NULL, 71)}, {[71, ∞), [67, 87], [9, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7020,13 +5921,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 58 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3], (NULL, 16), (NULL, 74), [69, ∞)}, {(NULL, 3], (NULL, 16), (74, ∞), [69, ∞)}, {(NULL, 3], (16, 57), (NULL, 74), [69, ∞)}, {(NULL, 3], (16, 57), (74, ∞), [69, ∞)}, {(NULL, 44), [16, 16], [NULL, ∞), [NULL, ∞)}, {[44, 44], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(44, 66), [16, 16], [NULL, ∞), [NULL, ∞)}, {(66, ∞), [16, 16], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7063,13 +5961,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 87 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 10), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[10, 10], (NULL, 41], [NULL, ∞), [NULL, ∞)}, {(10, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7108,13 +6003,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 19 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 13], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(13, 18), [47, ∞), (NULL, 11), [NULL, ∞)}, {[18, 19], (11, ∞), (22, ∞), [NULL, ∞)}, {(19, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7134,35 +6026,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 32 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 68), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(68, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 20 AND 93) AND (v1=66 AND v2<>21 AND v3 BETWEEN 43 AND 94);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[66, 66], (21, ∞), [43, 94], [NULL, ∞)}, {[66, 66], (NULL, 21), [43, 94], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>83 AND v2<>16 AND v3=22) AND (v1=34) AND (v1=79 AND v2<=45 AND v3=49);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7192,13 +6075,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 54 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44), [1, 1], (NULL, 54), [NULL, ∞)}, {(NULL, 44), [1, 1], (54, ∞), [NULL, ∞)}, {[44, 44], (NULL, 98], [NULL, ∞), [NULL, ∞)}, {(44, 45], [1, 1], (NULL, 54), [NULL, ∞)}, {(44, 45], [1, 1], (54, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7235,13 +6115,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 69 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 20), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[20, 31), [6, 6], (NULL, 69], [2, 16]}, {[20, 38), (24, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7297,24 +6174,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v4:4\n" +
 			" │   │           └─ 27 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 37 (tinyint) AND 62 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(62, 63), [35, ∞), [96, ∞), [NULL, ∞)}, {(62, ∞), [52, 52], [86, 86], (NULL, 27]}, {[63, 63], [35, 55), [96, ∞), [NULL, ∞)}, {[63, 63], [55, 55], (NULL, 46), [NULL, ∞)}, {[63, 63], [55, 55], (46, ∞), [NULL, ∞)}, {[63, 63], (55, ∞), [96, ∞), [NULL, ∞)}, {(63, 72], [35, ∞), [96, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=52) OR (v1>=59 AND v2<=30 AND v3=98 AND v4 BETWEEN 43 AND 74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[52, 52], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[59, ∞), (NULL, 30], [98, 98], [43, 74]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7359,13 +6230,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 11 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[59, 59], (NULL, 56], [NULL, ∞), [NULL, ∞)}, {[83, ∞), (NULL, 11], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7409,13 +6277,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 50 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 9), (16, ∞), (NULL, 44), [3, 31]}, {[9, 9], (NULL, 50), [NULL, ∞), [NULL, ∞)}, {[9, 9], [50, ∞), (NULL, 44), [3, 31]}, {(9, 39), (16, ∞), (NULL, 44), [3, 31]}, {(39, 72], (16, ∞), (NULL, 44), [3, 31]}, {(72, ∞), (16, 73), (NULL, 44), [3, 31]}, {(72, ∞), [73, 73], (NULL, 37), (NULL, 43]}, {(72, ∞), [73, 73], [37, 44), [3, 31]}, {(72, ∞), (73, ∞), (NULL, 44), [3, 31]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7445,13 +6310,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 35 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7471,13 +6333,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 42 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 89 (tinyint) AND 94 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3), [89, 94], [NULL, ∞), [NULL, ∞)}, {(3, 13], [89, 94], [NULL, ∞), [NULL, ∞)}, {(13, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7532,35 +6391,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(27, ∞), [8, ∞), (NULL, 24), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<77 AND v2 BETWEEN 5 AND 22 AND v3<>91 AND v4<34) OR (v1=68 AND v2=50)) OR (v1<44 AND v2>84 AND v3<37 AND v4>=67));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 44), (84, ∞), (NULL, 37), [67, ∞)}, {(NULL, 77), [5, 22], (NULL, 91), (NULL, 34)}, {(NULL, 77), [5, 22], (91, ∞), (NULL, 34)}, {[68, 68], [50, 50], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<4 AND v2>=71) OR (v1<18 AND v2=57));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4), [71, ∞), [NULL, ∞), [NULL, ∞)}, {(NULL, 18), [57, 57], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7586,13 +6436,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 97), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(97, ∞), [46, 51], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7616,13 +6463,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 59 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 25 (tinyint) AND 58 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[4, 47), [19, 65], [NULL, ∞), [NULL, ∞)}, {(47, 71], [19, 65], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7663,13 +6507,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 76), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[76, 76], [53, 67], [39, ∞), [NULL, ∞)}, {(76, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7725,24 +6566,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 34 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22], (76, ∞), [38, 42], (NULL, 40)}, {(NULL, 22], (76, ∞), [38, 42], (40, ∞)}, {(NULL, 33), (NULL, 93), [83, ∞), [NULL, ∞)}, {[8, 33), (NULL, 31], [30, 46], [28, ∞)}, {[33, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 13 AND 40 AND v2>=0) OR (v1<>3 AND v2>47 AND v3<44 AND v4>49)) OR (v1=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 3), (47, ∞), (NULL, 44), (49, ∞)}, {(3, 13), (47, ∞), (NULL, 44), (49, ∞)}, {[13, 23), [0, ∞), [NULL, ∞), [NULL, ∞)}, {[23, 23], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(23, 40], [0, ∞), [NULL, ∞), [NULL, ∞)}, {(40, ∞), (47, ∞), (NULL, 44), (49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7779,13 +6614,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 31 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 30], [6, 61], (NULL, 95], (5, ∞)}, {(31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7838,13 +6670,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 13 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 6], (NULL, 3], [6, 6], (NULL, 77]}, {(6, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7876,35 +6705,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 5], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[95, ∞), (NULL, 72), [22, 22], [28, 28]}, {[95, ∞), (72, ∞), [22, 22], [28, 28]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=95 AND v2<1 AND v3 BETWEEN 49 AND 61 AND v4=51) OR (v1>29 AND v2>=9 AND v3>=63 AND v4<=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(29, ∞), [9, ∞), [63, ∞), (NULL, 88]}, {[95, 95], (NULL, 1), [49, 61], [51, 51]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>30 AND v2 BETWEEN 20 AND 64) AND (v1<=29) AND (v1>=25 AND v2<>0);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7933,35 +6753,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ AND\n" +
 			" │       ├─ (comp_index_t2.v1:1 BETWEEN 10 (tinyint) AND 46 (tinyint))\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 18 (tinyint) AND 76 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[10, 46], [18, 76], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=44 AND v2>=45 AND v3>=34 AND v4>1) OR (v1=33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[33, 33], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[44, 44], [45, ∞), [34, ∞), (1, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1<>12 AND v2<=6) OR (v1>99 AND v2<>51 AND v3=38)) OR (v1>60)) OR (v1 BETWEEN 69 AND 77 AND v2>=49 AND v3>=43));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 12), (NULL, 6], [NULL, ∞), [NULL, ∞)}, {(12, 60], (NULL, 6], [NULL, ∞), [NULL, ∞)}, {(60, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7995,24 +6806,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 22 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[7, 45], (NULL, 11], [NULL, ∞), [NULL, ∞)}, {[16, 45], (11, 53), (NULL, 15), (22, ∞)}, {[16, 45], (11, 53), (15, ∞), (22, ∞)}, {(45, 65], (NULL, 53), (NULL, 15), (22, ∞)}, {(45, 65], (NULL, 53), (15, ∞), (22, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<11) OR (v1<=38 AND v2>=93 AND v3<=34 AND v4>7));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[11, 38], [93, ∞), (NULL, 34], (7, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8037,13 +6842,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 97 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 97], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8068,24 +6870,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 84 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 64], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(64, ∞), [0, 58], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 24 AND 98 AND v2>0 AND v3>=87) OR (v1 BETWEEN 2 AND 3 AND v2 BETWEEN 15 AND 78));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[2, 3], [15, 78], [NULL, ∞), [NULL, ∞)}, {[24, 98], (0, ∞), [87, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8132,35 +6928,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 37), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[37, 37], (NULL, 24), (NULL, 46), [NULL, ∞)}, {[37, 37], (24, 53), (NULL, 46), [NULL, ∞)}, {[37, 37], [53, 65], (NULL, ∞), [NULL, ∞)}, {[37, 37], (65, ∞), (NULL, 46), [NULL, ∞)}, {(37, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>21 AND v2>27 AND v3>=97 AND v4 BETWEEN 25 AND 67) OR (v1>=66 AND v2<=56)) OR (v1=37));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 21), (27, ∞), [97, ∞), [25, 67]}, {(21, 37), (27, ∞), [97, ∞), [25, 67]}, {[37, 37], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(37, 66), (27, ∞), [97, ∞), [25, 67]}, {[66, ∞), (NULL, 56], [NULL, ∞), [NULL, ∞)}, {[66, ∞), (56, ∞), [97, ∞), [25, 67]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=43 AND v2<48 AND v3<16 AND v4<=75) OR (v1<71));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 71), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8189,13 +6976,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8227,13 +7011,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 97 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(8, ∞), (NULL, 43], (NULL, 97), [NULL, ∞)}, {(8, ∞), (NULL, 43], (97, ∞), [NULL, ∞)}, {[54, 54], [3, 8], [97, 97], (30, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8266,46 +7047,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 23 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 23), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(23, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<20 AND v2<>84 AND v3<25 AND v4>=93) OR (v1<13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 13), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[13, 20), (NULL, 84), (NULL, 25), [93, ∞)}, {[13, 20), (84, ∞), (NULL, 25), [93, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=81 AND v2 BETWEEN 55 AND 77 AND v3=64) OR (v1=20 AND v2=21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[20, 20], [21, 21], [NULL, ∞), [NULL, ∞)}, {[81, ∞), [55, 77], [64, 64], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>30 AND v2 BETWEEN 58 AND 72 AND v3<=35) OR (v1 BETWEEN 28 AND 28 AND v2>=76)) OR (v1=74 AND v2<26));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[28, 28], [76, ∞), [NULL, ∞), [NULL, ∞)}, {(30, ∞), [58, 72], (NULL, 35], [NULL, ∞)}, {[74, 74], (NULL, 26), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8369,24 +7138,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[1, 1], [64, 81], (46, ∞), (NULL, 29)}, {[1, 1], [64, 81], (46, ∞), (29, ∞)}, {(5, 11], (8, 35), (NULL, 10], (NULL, 76)}, {[22, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=49) OR (v1<43 AND v2>=34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 43), [34, ∞), [NULL, ∞), [NULL, ∞)}, {[49, 49], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8427,24 +7190,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 10 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 11 (tinyint) AND 93 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 17), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(17, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<2 AND v2<>94) OR (v1<>76 AND v2=27 AND v3<=31 AND v4<38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 94), [NULL, ∞), [NULL, ∞)}, {(NULL, 2), (94, ∞), [NULL, ∞), [NULL, ∞)}, {[2, 76), [27, 27], (NULL, 31], (NULL, 38)}, {(76, ∞), [27, 27], (NULL, 31], (NULL, 38)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8504,13 +7261,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 30 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(62, ∞), (NULL, 96), [4, 29], [65, ∞)}, {(62, ∞), (47, ∞), [67, ∞), [29, 29]}, {(62, ∞), (96, ∞), [4, 29], [65, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8543,13 +7297,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 50 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 17), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[17, 17], (NULL, 5), [38, ∞), (91, ∞)}, {(17, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8581,13 +7332,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 70 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 86), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8624,24 +7372,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v3:3\n" +
 			" │   │           └─ 28 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 36 (tinyint) AND 40 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[36, 40], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=24 AND v2=61 AND v3<49 AND v4<82) OR (v1<4 AND v2>51 AND v3=9));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4), (51, ∞), [9, 9], [NULL, ∞)}, {[24, ∞), [61, 61], (NULL, 49), (NULL, 82)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8678,35 +7420,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 44 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1), (NULL, 11), (NULL, 44), (NULL, 66)}, {(NULL, 1), (NULL, 11), (44, ∞), (NULL, 66)}, {[0, 87], [44, ∞), (NULL, 68), [50, 50]}, {[0, 87], [44, ∞), (68, ∞), [50, 50]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<17 AND v2<54) AND (v1>=70 AND v2 BETWEEN 53 AND 53 AND v3>10 AND v4=17);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1=21 AND v2>25 AND v3>=7) OR (v1 BETWEEN 23 AND 88 AND v2<=26 AND v3>=87 AND v4 BETWEEN 42 AND 95)) OR (v1<4 AND v2>=66 AND v3<=24 AND v4=10)) OR (v1>69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4), [66, ∞), (NULL, 24], [10, 10]}, {[21, 21], (25, ∞), [7, ∞), [NULL, ∞)}, {[23, 69], (NULL, 26], [87, ∞), [42, 95]}, {(69, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8721,13 +7454,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 90 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 39], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8761,24 +7491,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 71 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[2, 71), (NULL, 78), (NULL, 29), (NULL, 63)}, {[2, 71), (NULL, 78), (NULL, 29), (63, ∞)}, {[2, 71), (NULL, 78), (29, ∞), (NULL, 63)}, {[2, 71), (NULL, 78), (29, ∞), (63, ∞)}, {[2, 71), (78, ∞), (29, ∞), (NULL, 63)}, {[2, 71), (78, ∞), (29, ∞), (63, ∞)}, {[2, 86], (78, ∞), (NULL, 29), (NULL, 63)}, {[2, 86], (78, ∞), (NULL, 29), (63, ∞)}, {[71, 71], (1, 53), (29, 56], (NULL, 63)}, {[71, 71], (1, 53), (29, 56], (63, ∞)}, {[71, 71], (1, 78), (NULL, 29), (NULL, 63)}, {[71, 71], (1, 78), (NULL, 29), (63, ∞)}, {[71, 71], [53, 53], (29, ∞), (NULL, 63)}, {[71, 71], [53, 53], (29, ∞), (63, ∞)}, {[71, 71], (53, 78), (29, 56], (NULL, 63)}, {[71, 71], (53, 78), (29, 56], (63, ∞)}, {[71, 71], (78, ∞), (29, 56], (NULL, 63)}, {[71, 71], (78, ∞), (29, 56], (63, ∞)}, {(71, 86], (NULL, 78), (NULL, 29), (NULL, 63)}, {(71, 86], (NULL, 78), (NULL, 29), (63, ∞)}, {(71, 86], (NULL, 78), (29, ∞), (NULL, 63)}, {(71, 86], (NULL, 78), (29, ∞), (63, ∞)}, {(71, 86], (78, ∞), (29, ∞), (NULL, 63)}, {(71, 86], (78, ∞), (29, ∞), (63, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=5) OR (v1=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 5], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[53, 53], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8787,24 +7511,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ GreaterThan\n" +
 			" │   ├─ comp_index_t2.v3:3\n" +
 			" │   └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(34, 88], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(88, ∞), [27, 46], [19, 27], [50, ∞)}, {(88, ∞), (84, ∞), [90, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=82) OR (v1<=95 AND v2<>23 AND v3<18 AND v4<>50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 82), (NULL, 23), (NULL, 18), (NULL, 50)}, {(NULL, 82), (NULL, 23), (NULL, 18), (50, ∞)}, {(NULL, 82), (23, ∞), (NULL, 18), (NULL, 50)}, {(NULL, 82), (23, ∞), (NULL, 18), (50, ∞)}, {[82, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8833,13 +7551,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 34 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(5, ∞), (NULL, 34), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8875,13 +7590,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(4, 24), (NULL, 21], [15, ∞), [NULL, ∞)}, {[24, 86], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(86, 93), (NULL, 21], [15, ∞), [NULL, ∞)}, {[93, 93], (NULL, 1), [15, ∞), [NULL, ∞)}, {[93, 93], [1, 21], (NULL, ∞), [NULL, ∞)}, {[93, 93], (21, ∞), (NULL, 63), [NULL, ∞)}, {[93, 93], (21, ∞), (63, ∞), [NULL, ∞)}, {(93, ∞), (NULL, 21], [15, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8917,13 +7629,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 21 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 18), (NULL, 21), [14, ∞), [NULL, ∞)}, {(NULL, 18), [21, ∞), [NULL, ∞), [NULL, ∞)}, {[18, 18], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(18, 23), (NULL, 21), [14, ∞), [NULL, ∞)}, {(18, 23), [21, ∞), [NULL, ∞), [NULL, ∞)}, {[23, 63), (NULL, 32), [14, ∞), [NULL, ∞)}, {[23, 63), (32, ∞), [14, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8970,13 +7679,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 17 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 36], (NULL, 17), [NULL, ∞), [NULL, ∞)}, {(NULL, 36], (17, ∞), [NULL, ∞), [NULL, ∞)}, {(36, 47), (42, 48), [27, 47], (NULL, 11]}, {(47, ∞), (42, 48), [27, 47], (NULL, 11]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9010,13 +7716,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 31 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 56], [50, 50], [0, 5], (NULL, 31)}, {(NULL, 56], [50, 50], [0, 5], (31, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9046,13 +7749,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 93], (NULL, 5), [NULL, ∞), [NULL, ∞)}, {(NULL, 93], (5, ∞), [NULL, ∞), [NULL, ∞)}, {(93, ∞), (33, ∞), (NULL, 99), [9, 9]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9098,13 +7798,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 2 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[1, 1], [43, 43], (NULL, 2], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9129,13 +7826,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 86 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 4], [51, ∞), [NULL, ∞), [NULL, ∞)}, {[58, 58], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, 82], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9184,13 +7878,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 70 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 8), (NULL, 76), [36, 70], [NULL, ∞)}, {(NULL, 8), (76, ∞), [36, 70], [NULL, ∞)}, {[42, 70), (NULL, 8), (NULL, 3), (NULL, 85)}, {[70, 70], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(70, 78), (NULL, 8), (NULL, 3), (NULL, 85)}, {[78, ∞), (NULL, 28), (NULL, 52), [NULL, ∞)}, {[78, ∞), (28, ∞), (NULL, 52), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9204,13 +7895,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 43 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9254,57 +7942,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 58 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 25), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[39, 50), (21, ∞), [27, 35), (18, ∞)}, {[39, 50), (21, ∞), (35, 90], (18, ∞)}, {(50, 76], (21, ∞), [27, 35), (18, ∞)}, {(50, 76], (21, ∞), (35, 90], (18, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=62) OR (v1 BETWEEN 24 AND 36 AND v2>=94 AND v3 BETWEEN 10 AND 55 AND v4>=89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[24, 36], [94, ∞), [10, 55], [89, ∞)}, {[62, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=31) OR (v1<=95 AND v2<=26 AND v3 BETWEEN 40 AND 72)) OR (v1<51 AND v2=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 31), (NULL, 23), [40, 72], [NULL, ∞)}, {(NULL, 31), [23, 23], [NULL, ∞), [NULL, ∞)}, {(NULL, 31), (23, 26], [40, 72], [NULL, ∞)}, {[31, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(31, 51), (NULL, 23), [40, 72], [NULL, ∞)}, {(31, 51), [23, 23], [NULL, ∞), [NULL, ∞)}, {(31, 51), (23, 26], [40, 72], [NULL, ∞)}, {[51, 95], (NULL, 26], [40, 72], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=3) OR (v1>40)) AND (v1>66 AND v2>33);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(66, ∞), (33, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=69 AND v2=61 AND v3=87 AND v4 BETWEEN 63 AND 87) OR (v1 BETWEEN 48 AND 62)) OR (v1<>81 AND v2<=67 AND v3<>43));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 48), (NULL, 67], (NULL, 43), [NULL, ∞)}, {(NULL, 48), (NULL, 67], (43, ∞), [NULL, ∞)}, {[48, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(62, 81), (NULL, 67], (NULL, 43), [NULL, ∞)}, {(62, 81), (NULL, 67], (43, ∞), [NULL, ∞)}, {[81, 81], [61, 61], [87, 87], [63, 87]}, {(81, ∞), (NULL, 67], (NULL, 43), [NULL, ∞)}, {(81, ∞), (NULL, 67], (43, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9335,13 +8008,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[12, 19), (NULL, 43), (NULL, 59), [1, ∞)}, {[19, 19], (NULL, 2), (NULL, 59), [1, ∞)}, {[19, 19], [2, ∞), [NULL, ∞), [NULL, ∞)}, {(19, 53], (NULL, 43), (NULL, 59), [1, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9371,13 +8041,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 14], (NULL, 1), (NULL, 62), [NULL, ∞)}, {(NULL, 14], (1, ∞), (NULL, 62), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9404,13 +8071,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v3:3\n" +
 			" │       └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 51), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(51, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9449,13 +8113,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 26 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[26, 26], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[36, 36], (NULL, 77), (94, ∞), [NULL, ∞)}, {(97, ∞), (NULL, 45), (NULL, 77), [30, 30]}, {(97, ∞), (NULL, 45), (77, ∞), [30, 30]}, {(97, ∞), (45, ∞), (NULL, 77), [30, 30]}, {(97, ∞), (45, ∞), (77, ∞), [30, 30]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9480,35 +8141,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 72 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[34, 37], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[43, 81], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=17 AND v2<>19) OR (v1>45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[17, 45], (NULL, 19), [NULL, ∞), [NULL, ∞)}, {[17, 45], (19, ∞), [NULL, ∞), [NULL, ∞)}, {(45, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=57) OR (v1>=1 AND v2<=5 AND v3>=10 AND v4<5)) OR (v1>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[1, 55], (NULL, 5], [10, ∞), (NULL, 5)}, {(55, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9553,13 +8205,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 62 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[23, 23], (NULL, 48], [NULL, ∞), [NULL, ∞)}, {(41, ∞), [46, ∞), [11, 29], [NULL, ∞)}, {[70, 70], (NULL, 46), (NULL, 54), (NULL, 47]}, {[70, 70], [46, 62), (NULL, 11), (NULL, 47]}, {[70, 70], [46, 62), (29, 54), (NULL, 47]}, {[70, 70], (62, ∞), (NULL, 11), (NULL, 47]}, {[70, 70], (62, ∞), (29, 54), (NULL, 47]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9619,13 +8268,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 41 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 56 (tinyint) AND 93 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 34), (11, 95), [17, 81], (48, ∞)}, {(5, 34), (11, 95), (81, 89], (48, 53]}, {(5, 34), [95, ∞), [43, 89], (48, 53]}, {[34, 41), (11, ∞), [43, 89], (48, 53]}, {[41, 41], (11, 56), [43, 89], (48, 53]}, {[41, 41], [56, 93], [NULL, ∞), [NULL, ∞)}, {[41, 41], (93, ∞), [43, 89], (48, 53]}, {(41, 68], (11, ∞), [43, 89], (48, 53]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9652,13 +8298,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 8 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[3, 3], (NULL, 16), (NULL, 8), [NULL, ∞)}, {(3, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9691,57 +8334,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 83], [34, ∞), [59, 59], [NULL, ∞)}, {(67, 88), (NULL, 5), (40, ∞), (NULL, 27]}, {[88, 97], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(97, ∞), (NULL, 5), (40, ∞), (NULL, 27]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>96 AND v2<=2 AND v3=17 AND v4<79) OR (v1=67 AND v2=30 AND v3=38 AND v4=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 96), (NULL, 2], [17, 17], (NULL, 79)}, {[67, 67], [30, 30], [38, 38], [53, 53]}, {(96, ∞), (NULL, 2], [17, 17], (NULL, 79)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>45 AND v2>76) OR (v1=30 AND v2=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 45), (76, ∞), [NULL, ∞), [NULL, ∞)}, {[30, 30], [53, 53], [NULL, ∞), [NULL, ∞)}, {(45, ∞), (76, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 3 AND 34 AND v2>39) OR (v1>1 AND v2>=92 AND v3=99)) OR (v1>=36 AND v2<>65 AND v3=69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(1, 3), [92, ∞), [99, 99], [NULL, ∞)}, {[3, 34], (39, ∞), [NULL, ∞), [NULL, ∞)}, {(34, ∞), [92, ∞), [99, 99], [NULL, ∞)}, {[36, ∞), (NULL, 65), [69, 69], [NULL, ∞)}, {[36, ∞), (65, ∞), [69, 69], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=54 AND v2=38 AND v3>=64 AND v4>36) OR (v1<=48)) OR (v1<37 AND v2=13 AND v3<20));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 48], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[54, ∞), [38, 38], [64, ∞), (36, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9770,13 +8398,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 42 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 70), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[70, 70], (79, ∞), (NULL, 6), (NULL, 42)}, {[70, 70], (79, ∞), (NULL, 6), (42, ∞)}, {[70, 70], (79, ∞), (6, ∞), (NULL, 42)}, {[70, 70], (79, ∞), (6, ∞), (42, ∞)}, {(70, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9806,13 +8431,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 61 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(22, 61), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9860,46 +8482,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 30 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 41), (0, 11), [95, 95], (NULL, 2]}, {(NULL, 41), [11, 35], [NULL, ∞), [NULL, ∞)}, {(NULL, 41), (35, ∞), [95, 95], (NULL, 2]}, {[11, 11], (NULL, 11), [51, 51], (NULL, 30)}, {[11, 11], (NULL, 11), [51, 51], (30, ∞)}, {[41, 53], (0, ∞), [95, 95], (NULL, 2]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=32 AND v2>6 AND v3=55) OR (v1=87 AND v2<=80)) OR (v1=88 AND v2<=87 AND v3>=45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 32], (6, ∞), [55, 55], [NULL, ∞)}, {[87, 87], (NULL, 80], [NULL, ∞), [NULL, ∞)}, {[88, 88], (NULL, 87], [45, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>8) OR (v1 BETWEEN 16 AND 25 AND v2<>79 AND v3>=55 AND v4<=5));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(8, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=45 AND v2>55 AND v3<90) OR (v1>26 AND v2>=2 AND v3<>85 AND v4<=74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(26, 45), [2, ∞), (NULL, 85), (NULL, 74]}, {(26, 45), [2, ∞), (85, ∞), (NULL, 74]}, {[45, 45], [2, 55], (NULL, 85), (NULL, 74]}, {[45, 45], [2, 55], (85, ∞), (NULL, 74]}, {[45, 45], (55, ∞), (NULL, 90), [NULL, ∞)}, {[45, 45], (55, ∞), [90, ∞), (NULL, 74]}, {(45, ∞), [2, ∞), (NULL, 85), (NULL, 74]}, {(45, ∞), [2, ∞), (85, ∞), (NULL, 74]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9919,13 +8529,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 6 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 14 (tinyint) AND 82 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 59), [14, 82], [NULL, ∞), [NULL, ∞)}, {[59, 59], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(59, 85), [14, 82], [NULL, ∞), [NULL, ∞)}, {(85, ∞), [14, 82], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9958,35 +8565,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[39, 39], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(51, ∞), [46, ∞), [NULL, ∞), [NULL, ∞)}, {[94, ∞), (32, 46), (61, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=89) OR (v1<=28 AND v2=13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 28], [13, 13], [NULL, ∞), [NULL, ∞)}, {[89, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=5 AND v2<65 AND v3<64 AND v4=81) OR (v1<=75)) AND (v1=87);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10025,13 +8623,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 33 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 35), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(35, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10088,13 +8683,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 67 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 37), (21, ∞), (NULL, 25], [32, 33]}, {[37, 48), (21, 42), (NULL, 25], [32, 33]}, {[37, 48), [42, 42], (14, 25], [32, 33]}, {[37, 48), (42, ∞), (NULL, 25], [32, 33]}, {[37, 51), [42, 42], (NULL, 14], [NULL, ∞)}, {(48, 51), (21, 42), (NULL, 25], [32, 33]}, {(48, 51), [42, 42], (14, 25], [32, 33]}, {(48, 51), (42, ∞), (NULL, 25], [32, 33]}, {[51, 88], (NULL, 67), [NULL, ∞), [NULL, ∞)}, {[51, 88], [67, 67], (NULL, 25], [32, 33]}, {[51, 88], (67, ∞), [NULL, ∞), [NULL, ∞)}, {(88, ∞), (21, 85), (NULL, 25], [32, 33]}, {(88, ∞), [85, 85], [NULL, ∞), [NULL, ∞)}, {(88, ∞), (85, 89), (NULL, 25], [32, 33]}, {(88, ∞), [89, 89], (NULL, 12], [32, 33]}, {(88, ∞), [89, 89], (12, ∞), [NULL, ∞)}, {(88, ∞), (89, ∞), (NULL, 25], [32, 33]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10127,35 +8719,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 85 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(27, ∞), [7, 79], [9, 29], (NULL, 85)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=41 AND v2<13 AND v3 BETWEEN 62 AND 87) AND (v1<=67 AND v2>68 AND v3=56 AND v4>28);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 23 AND 34 AND v2 BETWEEN 4 AND 75 AND v3<91) OR (v1>=31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[23, 31), [4, 75], (NULL, 91), [NULL, ∞)}, {[31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10183,35 +8766,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 29 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 86], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(86, 90), [43, 43], [29, 29], [NULL, ∞)}, {(90, ∞), [43, 43], [29, 29], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=1 AND v2<34) OR (v1<78));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 78), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[78, ∞), (NULL, 34), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=10 AND v2<>64 AND v3>25 AND v4<29) OR (v1>39));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[10, 10], (NULL, 64), (25, ∞), (NULL, 29)}, {[10, 10], (64, ∞), (25, ∞), (NULL, 29)}, {(39, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10261,13 +8835,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 16 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 14), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[14, 14], [14, ∞), (NULL, 65), (NULL, 9)}, {[14, 14], [14, ∞), (NULL, 65), (9, ∞)}, {(14, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10288,57 +8859,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(12, 36), (NULL, 0), [NULL, ∞), [NULL, ∞)}, {[36, 36], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(36, ∞), (NULL, 0), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=83 AND v3>=72 AND v4<=74) AND (v1>61 AND v2 BETWEEN 32 AND 44);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[83, 83], [32, 44], [72, ∞), (NULL, 74]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=78 AND v2>28 AND v3<=47) AND (v1<35 AND v2=69 AND v3>16);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 31 AND 49 AND v2=20 AND v3 BETWEEN 8 AND 46) AND (v1<>57 AND v2<5);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=39 AND v2<>3) OR (v1=97 AND v2<>37));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 39], (NULL, 3), [NULL, ∞), [NULL, ∞)}, {(NULL, 39], (3, ∞), [NULL, ∞), [NULL, ∞)}, {[97, 97], (NULL, 37), [NULL, ∞), [NULL, ∞)}, {[97, 97], (37, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10370,24 +8926,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 23 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 6 (tinyint) AND 43 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[19, 37), (NULL, 19), (NULL, 29), (NULL, 62)}, {[19, 37), (NULL, 19), (NULL, 29), (62, ∞)}, {[19, 37), (NULL, 19), (29, ∞), (NULL, 62)}, {[19, 37), (NULL, 19), (29, ∞), (62, ∞)}, {[19, 37), (19, ∞), (NULL, 29), (NULL, 62)}, {[19, 37), (19, ∞), (NULL, 29), (62, ∞)}, {[19, 37), (19, ∞), (29, ∞), (NULL, 62)}, {[19, 37), (19, ∞), (29, ∞), (62, ∞)}, {[37, 75], (NULL, 6), (NULL, 29), (NULL, 62)}, {[37, 75], (NULL, 6), (NULL, 29), (62, ∞)}, {[37, 75], (NULL, 6), (29, ∞), (NULL, 62)}, {[37, 75], (NULL, 6), (29, ∞), (62, ∞)}, {[37, 75], [6, 43], [NULL, ∞), [NULL, ∞)}, {[37, 75], (43, ∞), (NULL, 29), (NULL, 62)}, {[37, 75], (43, ∞), (NULL, 29), (62, ∞)}, {[37, 75], (43, ∞), (29, ∞), (NULL, 62)}, {[37, 75], (43, ∞), (29, ∞), (62, ∞)}, {(75, ∞), (NULL, 19), (NULL, 29), (NULL, 62)}, {(75, ∞), (NULL, 19), (NULL, 29), (62, ∞)}, {(75, ∞), (NULL, 19), (29, ∞), (NULL, 62)}, {(75, ∞), (NULL, 19), (29, ∞), (62, ∞)}, {(75, ∞), (19, ∞), (NULL, 29), (NULL, 62)}, {(75, ∞), (19, ∞), (NULL, 29), (62, ∞)}, {(75, ∞), (19, ∞), (29, ∞), (NULL, 62)}, {(75, ∞), (19, ∞), (29, ∞), (62, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<8 AND v2<=33 AND v3 BETWEEN 54 AND 85) OR (v1=46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 8), (NULL, 33], [54, 85], [NULL, ∞)}, {[46, 46], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10422,13 +8972,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 71 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[0, 0], [71, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10452,35 +8999,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v3:3\n" +
 			" │   │           └─ 76 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 31 (tinyint) AND 71 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 71], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>37 AND v2<>5 AND v3=8 AND v4 BETWEEN 26 AND 50) OR (v1>=53)) AND (v1 BETWEEN 5 AND 80);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(37, 53), (NULL, 5), [8, 8], [26, 50]}, {(37, 53), (5, ∞), [8, 8], [26, 50]}, {[53, 80], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=25) OR (v1<=87));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 87], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10515,46 +9053,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 79 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 6], [36, 68], (62, ∞), [79, 79]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 30 AND 32 AND v2<68 AND v3<24) AND (v1>=32);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[32, 32], (NULL, 68), (NULL, 24), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>62 AND v2>0) OR (v1<>80 AND v2>55 AND v3=10 AND v4=91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 62], (55, ∞), [10, 10], [91, 91]}, {(62, ∞), (0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=7 AND v2 BETWEEN 55 AND 81) OR (v1<>56 AND v2<=76 AND v3<>36)) AND (v1<56 AND v2<>69 AND v3=25);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 7], (69, 81], [25, 25], [NULL, ∞)}, {(NULL, 56), (NULL, 69), [25, 25], [NULL, ∞)}, {(7, 56), (69, 76], [25, 25], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10580,24 +9106,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 80 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 18), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(18, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=27) OR (v1<23 AND v2>=41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10647,13 +9167,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 71 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 31), [33, ∞), (58, ∞), [NULL, ∞)}, {(NULL, 31), [89, 89], [46, 58], (NULL, 32]}, {[31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10686,35 +9203,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 8 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[9, 40], [43, ∞), (NULL, 43], [62, 62]}, {[61, 61], (12, ∞), [0, 13], [8, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1<58) OR (v1 BETWEEN 17 AND 20 AND v2<>99 AND v3<=76)) OR (v1 BETWEEN 48 AND 87)) OR (v1<39 AND v2 BETWEEN 48 AND 94 AND v3<>0));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 87], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=33) OR (v1 BETWEEN 7 AND 41 AND v2<82 AND v3<53 AND v4<>3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[7, 33), (NULL, 82), (NULL, 53), (NULL, 3)}, {[7, 33), (NULL, 82), (NULL, 53), (3, ∞)}, {[33, 33], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(33, 41], (NULL, 82), (NULL, 53), (NULL, 3)}, {(33, 41], (NULL, 82), (NULL, 53), (3, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10735,13 +9243,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 96 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 9], [95, ∞), [NULL, ∞), [NULL, ∞)}, {(96, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10770,13 +9275,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 48 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 56], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(56, 91), (20, ∞), [NULL, ∞), [NULL, ∞)}, {[91, 91], (NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(91, ∞), (20, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10799,79 +9301,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 75], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(75, ∞), [16, 25], [99, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 2 AND 64) OR (v1>=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[2, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=26 AND v2<1 AND v3=82 AND v4<=42) OR (v1 BETWEEN 42 AND 73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 26], (NULL, 1), [82, 82], (NULL, 42]}, {[42, 73], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=23 AND v2<=10) AND (v1>=75 AND v4 BETWEEN 24 AND 68) AND (v1>44 AND v2>8 AND v3<=16);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[75, ∞), (8, 10], (NULL, 16], [24, 68]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((((v1>6 AND v2>61 AND v3=0 AND v4>=76) OR (v1<23)) OR (v1<>46 AND v2=29 AND v3>4)) OR (v1>=59)) OR (v1=87 AND v2<=98 AND v3>=47));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 23), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[23, 46), [29, 29], (4, ∞), [NULL, ∞)}, {[23, 59), (61, ∞), [0, 0], [76, ∞)}, {(46, 59), [29, 29], (4, ∞), [NULL, ∞)}, {[59, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=59 AND v2 BETWEEN 15 AND 53 AND v3<>17 AND v4>=10) OR (v1 BETWEEN 37 AND 95 AND v2<=32 AND v3>=81));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[37, 95], (NULL, 32], [81, ∞), [NULL, ∞)}, {[59, 59], [15, 32], (17, 81), [10, ∞)}, {[59, 59], [15, 53], (NULL, 17), [10, ∞)}, {[59, 59], (32, 53], (17, ∞), [10, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 6 AND 92 AND v2=75 AND v3>79) OR (v1>=10)) OR (v1<=35 AND v2<=42)) AND (v1<>65);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), (NULL, 42], [NULL, ∞), [NULL, ∞)}, {[6, 10), [75, 75], (79, ∞), [NULL, ∞)}, {[10, 65), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(65, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10909,13 +9390,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 76 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(78, ∞), (NULL, 1), [98, 98], [76, ∞)}, {(78, ∞), (1, ∞), [98, 98], [76, ∞)}, {(84, ∞), [77, 77], [40, ∞), (NULL, 53]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10936,24 +9414,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │       └─ 13 (tinyint)\n" +
 			" │   │      ))\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 4 (tinyint) AND 67 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>34) OR (v1<35 AND v2>=93)) OR (v1>8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 8], [93, ∞), [NULL, ∞), [NULL, ∞)}, {(8, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10996,13 +9468,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 28 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11037,13 +9506,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 35 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11073,13 +9539,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v2:2\n" +
 			" │       │       └─ 93 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 34 (tinyint) AND 41 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 34), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[34, 62], [1, 41], [NULL, ∞), [NULL, ∞)}, {[65, ∞), [93, ∞), [34, 41], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11096,46 +9559,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(8, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>57) OR (v1<87 AND v2<>91 AND v3 BETWEEN 47 AND 98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 57], (NULL, 91), [47, 98], [NULL, ∞)}, {(NULL, 57], (91, ∞), [47, 98], [NULL, ∞)}, {(57, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=57) OR (v1=88 AND v2 BETWEEN 72 AND 93));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[57, 57], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[88, 88], [72, 93], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>10 AND v2=20 AND v3<=21 AND v4<>88) OR (v1<28 AND v2 BETWEEN 38 AND 59 AND v3<>98 AND v4>=26));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), [20, 20], (NULL, 21], (NULL, 88)}, {(NULL, 10), [20, 20], (NULL, 21], (88, ∞)}, {(NULL, 28), [38, 59], (NULL, 98), [26, ∞)}, {(NULL, 28), [38, 59], (98, ∞), [26, ∞)}, {(10, ∞), [20, 20], (NULL, 21], (NULL, 88)}, {(10, ∞), [20, 20], (NULL, 21], (88, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11162,24 +9613,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 94 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 5), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[5, 5], (NULL, 94), [NULL, ∞), [NULL, ∞)}, {(5, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<52 AND v2 BETWEEN 33 AND 75 AND v3=32) OR (v1<=98 AND v2<=41 AND v3<>87 AND v4<>83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 52), (NULL, 33), (NULL, 87), (NULL, 83)}, {(NULL, 52), (NULL, 33), (NULL, 87), (83, ∞)}, {(NULL, 52), [33, 41], (NULL, 32), (NULL, 83)}, {(NULL, 52), [33, 41], (NULL, 32), (83, ∞)}, {(NULL, 52), [33, 41], (32, 87), (NULL, 83)}, {(NULL, 52), [33, 41], (32, 87), (83, ∞)}, {(NULL, 52), [33, 75], [32, 32], [NULL, ∞)}, {(NULL, 98], (NULL, 41], (87, ∞), (NULL, 83)}, {(NULL, 98], (NULL, 41], (87, ∞), (83, ∞)}, {[52, 98], (NULL, 41], (NULL, 87), (NULL, 83)}, {[52, 98], (NULL, 41], (NULL, 87), (83, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11223,24 +9668,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 58 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22], (58, ∞), [NULL, ∞), [NULL, ∞)}, {(28, 72), [13, 62), (29, 41], (57, ∞)}, {(72, ∞), [13, 62), (29, 41], (57, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=13 AND v2<=52 AND v3=28 AND v4>88) OR (v1<>5 AND v2<=42));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 5), (NULL, 42], [NULL, ∞), [NULL, ∞)}, {(NULL, 5), (42, 52], [28, 28], (88, ∞)}, {[5, 5], (NULL, 52], [28, 28], (88, ∞)}, {(5, 13], (42, 52], [28, 28], (88, ∞)}, {(5, ∞), (NULL, 42], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11270,46 +9709,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 27 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(13, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=26) OR (v1<59 AND v2 BETWEEN 2 AND 30 AND v3>=69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 26), [2, 30], [69, ∞), [NULL, ∞)}, {[26, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<11) OR (v1<>9 AND v2 BETWEEN 51 AND 62 AND v3=98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[11, ∞), [51, 62], [98, 98], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=92 AND v2>25) OR (v1=91 AND v2=21 AND v3<=18 AND v4<>15)) OR (v1=79 AND v2>67 AND v3<>48 AND v4<42));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[79, 79], (67, ∞), (NULL, 48), (NULL, 42)}, {[79, 79], (67, ∞), (48, ∞), (NULL, 42)}, {[91, 91], [21, 21], (NULL, 18], (NULL, 15)}, {[91, 91], [21, 21], (NULL, 18], (15, ∞)}, {[92, 92], (25, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11349,24 +9776,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 80 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 80], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(80, ∞), (24, ∞), (NULL, 5), [NULL, ∞)}, {[86, 86], (NULL, 5), (NULL, 36), (NULL, 81)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>67) OR (v1>69 AND v2>11 AND v3=13 AND v4=20));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(67, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11390,13 +9811,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 31), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[31, 31], [71, 71], [38, 38], [1, 1]}, {(31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11425,13 +9843,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 28 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 52], [71, ∞), [28, 28], [NULL, ∞)}, {(2, 52], [6, 23], [46, 52], [0, 0]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11440,13 +9855,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ GreaterThanOrEqual\n" +
 			" │   ├─ comp_index_t2.v4:4\n" +
 			" │   └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11491,35 +9903,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(17, 46), [34, ∞), (NULL, 68), (NULL, 13]}, {(17, 46), [34, ∞), (68, ∞), (NULL, 13]}, {[46, 46], (NULL, 12), [NULL, ∞), [NULL, ∞)}, {[46, 46], (12, ∞), [NULL, ∞), [NULL, ∞)}, {(46, 98), [34, ∞), (NULL, 68), (NULL, 13]}, {(46, 98), [34, ∞), (68, ∞), (NULL, 13]}, {[98, ∞), [34, 39), (NULL, 68), (NULL, 13]}, {[98, ∞), [34, 39), (68, ∞), (NULL, 13]}, {[98, ∞), [39, 39], [NULL, ∞), [NULL, ∞)}, {[98, ∞), (39, ∞), (NULL, 68), (NULL, 13]}, {[98, ∞), (39, ∞), (68, ∞), (NULL, 13]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=12 AND v2<>4 AND v3 BETWEEN 18 AND 42) OR (v1>=73)) OR (v1<60 AND v2=93 AND v3>=79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 12], (NULL, 4), [18, 42], [NULL, ∞)}, {(NULL, 12], (4, ∞), [18, 42], [NULL, ∞)}, {(NULL, 60), [93, 93], [79, ∞), [NULL, ∞)}, {[73, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=55 AND v2>50) OR (v1<>51 AND v2>=37));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 51), [37, ∞), [NULL, ∞), [NULL, ∞)}, {(51, ∞), [37, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11561,46 +9964,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 42 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44), (NULL, 50], [36, 36], (NULL, 42]}, {[66, 76], [84, ∞), (1, ∞), [71, 95]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=21 AND v2=44 AND v3>=68) OR (v1>=38 AND v2>=15));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 21], [44, 44], [68, ∞), [NULL, ∞)}, {[38, ∞), [15, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<>37 AND v2>67 AND v3>52) AND (v1<48 AND v2<>73 AND v3=25 AND v4=22);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 57 AND 62 AND v2>=99) OR (v1>31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11627,13 +10018,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(22, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11658,46 +10046,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 16 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 16], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(63, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1<=39 AND v2<>82 AND v3>=33 AND v4>=84) OR (v1=57 AND v2<25 AND v3<>55 AND v4<=82)) OR (v1>10 AND v2>28 AND v3>=65)) OR (v1<=13 AND v2=66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10], (NULL, 66), [33, ∞), [84, ∞)}, {(NULL, 10], (66, 82), [33, ∞), [84, ∞)}, {(NULL, 10], (82, ∞), [33, ∞), [84, ∞)}, {(NULL, 13], [66, 66], [NULL, ∞), [NULL, ∞)}, {(10, 13], (28, 66), [33, 65), [84, ∞)}, {(10, 13], (28, 66), [65, ∞), [NULL, ∞)}, {(10, 13], (66, 82), [33, 65), [84, ∞)}, {(10, 13], (66, ∞), [65, ∞), [NULL, ∞)}, {(10, 39], (NULL, 28], [33, ∞), [84, ∞)}, {(10, 39], (82, ∞), [33, 65), [84, ∞)}, {(13, 39], (28, 82), [33, 65), [84, ∞)}, {(13, ∞), (28, ∞), [65, ∞), [NULL, ∞)}, {[57, 57], (NULL, 25), (NULL, 55), (NULL, 82]}, {[57, 57], (NULL, 25), (55, ∞), (NULL, 82]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=60 AND v2<=25 AND v3<>9) OR (v1 BETWEEN 19 AND 92 AND v2>=33 AND v3<=40 AND v4=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 60], (NULL, 25], (NULL, 9), [NULL, ∞)}, {(NULL, 60], (NULL, 25], (9, ∞), [NULL, ∞)}, {[19, 92], [33, ∞), (NULL, 40], [53, 53]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=21 AND v2<=27 AND v3>=86 AND v4>99) OR (v1<76 AND v2<>97));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 76), (NULL, 97), [NULL, ∞), [NULL, ∞)}, {(NULL, 76), (97, ∞), [NULL, ∞), [NULL, ∞)}, {[76, ∞), (NULL, 27], [86, ∞), (99, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11720,35 +10096,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 18 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[4, 8], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[12, ∞), [0, ∞), [18, 18], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1>65 AND v2<=52 AND v3>37) OR (v1>11)) OR (v1<=54 AND v2 BETWEEN 30 AND 85 AND v3 BETWEEN 14 AND 27 AND v4>=35)) OR (v1>44 AND v2<>76 AND v3>=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11], [30, 85], [14, 27], [35, ∞)}, {(11, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=54) OR (v1<17 AND v2=34 AND v3>=59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 17), [34, 34], [59, ∞), [NULL, ∞)}, {[54, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11777,46 +10144,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 2 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 3 (tinyint) AND 70 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 2), [3, 70], [NULL, ∞), [NULL, ∞)}, {(NULL, 9), [98, 98], (NULL, 1), (NULL, 61)}, {(NULL, 9), [98, 98], (NULL, 1), (61, ∞)}, {(9, ∞), [98, 98], (NULL, 1), (NULL, 61)}, {(9, ∞), [98, 98], (NULL, 1), (61, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=6 AND v2>93) OR (v1 BETWEEN 38 AND 46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 6], (93, ∞), [NULL, ∞), [NULL, ∞)}, {[38, 46], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1 BETWEEN 16 AND 72) OR (v1=20)) OR (v1>61 AND v2<>48 AND v3<>83 AND v4=46)) OR (v1=5 AND v2=59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[5, 5], [59, 59], [NULL, ∞), [NULL, ∞)}, {[16, 72], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(72, ∞), (NULL, 48), (NULL, 83), [46, 46]}, {(72, ∞), (NULL, 48), (83, ∞), [46, 46]}, {(72, ∞), (48, ∞), (NULL, 83), [46, 46]}, {(72, ∞), (48, ∞), (83, ∞), [46, 46]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>41 AND v2>74 AND v3>37 AND v4<38) OR (v1=58 AND v2>=1)) OR (v1<=4 AND v2>0 AND v3 BETWEEN 39 AND 72 AND v4>=29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4], (0, ∞), [39, 72], [29, ∞)}, {(41, 58), (74, ∞), (37, ∞), (NULL, 38)}, {[58, 58], [1, ∞), [NULL, ∞), [NULL, ∞)}, {(58, ∞), (74, ∞), (37, ∞), (NULL, 38)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11848,13 +10203,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 71 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 53), (NULL, 31), [NULL, ∞), [NULL, ∞)}, {(NULL, 53), (31, ∞), [NULL, ∞), [NULL, ∞)}, {[53, 53], (70, ∞), [71, ∞), [NULL, ∞)}, {(53, ∞), (NULL, 31), [NULL, ∞), [NULL, ∞)}, {(53, ∞), (31, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11877,24 +10229,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 27 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1], [40, 74], [27, ∞), [NULL, ∞)}, {(1, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=92 AND v2>=64 AND v3=39 AND v4 BETWEEN 16 AND 53) OR (v1<54 AND v2 BETWEEN 8 AND 17 AND v3=21 AND v4=86));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 54), [8, 17], [21, 21], [86, 86]}, {[92, ∞), [64, ∞), [39, 39], [16, 53]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11919,13 +10265,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 83 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[16, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[40, 40], (NULL, 35], [51, ∞), [83, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11960,35 +10303,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 36 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(36, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 33 AND 71 AND v2<=61 AND v3<=32 AND v4 BETWEEN 18 AND 73) AND (v1<3) AND (v1<=59 AND v2=47 AND v3<49 AND v4>36);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<77 AND v2=43 AND v3<92 AND v4=13) OR (v1=38 AND v2<=46)) OR (v1 BETWEEN 10 AND 79 AND v2>=11 AND v3 BETWEEN 14 AND 14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), [43, 43], (NULL, 92), [13, 13]}, {[10, 38), [11, ∞), [14, 14], [NULL, ∞)}, {[10, 38), [43, 43], (NULL, 14), [13, 13]}, {[10, 38), [43, 43], (14, 92), [13, 13]}, {[38, 38], (NULL, 46], [NULL, ∞), [NULL, ∞)}, {[38, 38], (46, ∞), [14, 14], [NULL, ∞)}, {(38, 77), [43, 43], (NULL, 14), [13, 13]}, {(38, 77), [43, 43], (14, 92), [13, 13]}, {(38, 79], [11, ∞), [14, 14], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12027,13 +10361,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[40, ∞), [25, 25], (66, ∞), [98, 98]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12050,24 +10381,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 98), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=75 AND v2 BETWEEN 45 AND 51 AND v3<15) OR (v1>=74 AND v2>=37 AND v3<76));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[74, ∞), [37, ∞), (NULL, 76), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12085,13 +10410,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 32), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(32, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12114,46 +10436,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 80 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(63, 80], [89, ∞), [43, 50], (NULL, 29)}, {(80, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=81) OR (v1>=27 AND v2>=21 AND v3 BETWEEN 1 AND 63 AND v4>=92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[27, 81), [21, ∞), [1, 63], [92, ∞)}, {[81, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>13) OR (v1>72 AND v2=2 AND v3<=40)) OR (v1>77 AND v2<21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(13, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>54 AND v2>23 AND v3 BETWEEN 28 AND 48 AND v4>=37) OR (v1>93 AND v2>=51 AND v3<9 AND v4<>49)) OR (v1>=71 AND v2<>33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 54), (23, ∞), [28, 48], [37, ∞)}, {(54, 71), (23, ∞), [28, 48], [37, ∞)}, {[71, ∞), (NULL, 33), [NULL, ∞), [NULL, ∞)}, {[71, ∞), [33, 33], [28, 48], [37, ∞)}, {[71, ∞), (33, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12191,13 +10501,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 37 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 37), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[37, 37], (NULL, 43], [NULL, ∞), [NULL, ∞)}, {(37, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12222,13 +10529,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 91 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 91), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(91, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12257,24 +10561,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 31 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 79], [31, 31], [NULL, ∞), [NULL, ∞)}, {[21, 21], (NULL, 31), [39, ∞), [NULL, ∞)}, {[21, 21], (31, 50), [39, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>78) OR (v1>=9 AND v2<>84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[9, 78], (NULL, 84), [NULL, ∞), [NULL, ∞)}, {[9, 78], (84, ∞), [NULL, ∞), [NULL, ∞)}, {(78, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12296,24 +10594,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 63 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(16, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=16 AND v2>=9 AND v3<>48) OR (v1>=76 AND v2<>86)) OR (v1<28 AND v2=1 AND v3<=23 AND v4 BETWEEN 13 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 28), [1, 1], (NULL, 23], [13, 55]}, {[16, 16], [9, ∞), (NULL, 48), [NULL, ∞)}, {[16, 16], [9, ∞), (48, ∞), [NULL, ∞)}, {[76, ∞), (NULL, 86), [NULL, ∞), [NULL, ∞)}, {[76, ∞), (86, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12331,13 +10623,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 55 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 55), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(55, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12361,68 +10650,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 20 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 72), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[72, 72], (NULL, 5), [53, 61], [NULL, ∞)}, {(72, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=58 AND v2<=89 AND v3=78 AND v4<=58) OR (v1>39)) AND (v1<>25 AND v2>1 AND v3<18);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(39, ∞), (1, ∞), (NULL, 18), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>94) OR (v1=33 AND v2 BETWEEN 53 AND 60 AND v3 BETWEEN 37 AND 73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[33, 33], [53, 60], [37, 73], [NULL, ∞)}, {(94, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=40 AND v2<>8 AND v3<=69) OR (v1<=72)) OR (v1 BETWEEN 87 AND 89 AND v2 BETWEEN 52 AND 58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 72], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[87, 89], [52, 58], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<9 AND v2=97 AND v3<>54 AND v4>71) OR (v1>48 AND v2 BETWEEN 7 AND 23 AND v3<>95 AND v4>86)) OR (v1 BETWEEN 36 AND 90));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 9), [97, 97], (NULL, 54), (71, ∞)}, {(NULL, 9), [97, 97], (54, ∞), (71, ∞)}, {[36, 90], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(90, ∞), [7, 23], (NULL, 95), (86, ∞)}, {(90, ∞), [7, 23], (95, ∞), (86, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=38 AND v2<70) OR (v1>79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[38, 79], (NULL, 70), [NULL, ∞), [NULL, ∞)}, {(79, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12441,13 +10712,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 42 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 42), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12483,46 +10751,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 6 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 29), (52, ∞), (NULL, 55), [NULL, ∞)}, {(NULL, 29), (52, ∞), (55, ∞), [NULL, ∞)}, {[16, 28], [9, 52], [43, 43], (NULL, 6)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<56 AND v2<=52) OR (v1>=30 AND v2<73 AND v3>40 AND v4>=13)) AND (v1<30 AND v4<>25 AND v2<>82 AND v3 BETWEEN 80 AND 88);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 30), (NULL, 52], [80, 88], (NULL, 25)}, {(NULL, 30), (NULL, 52], [80, 88], (25, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 9 AND 53 AND v2 BETWEEN 26 AND 56) OR (v1 BETWEEN 29 AND 72 AND v2<18 AND v3=73 AND v4<=12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[9, 53], [26, 56], [NULL, ∞), [NULL, ∞)}, {[29, 72], (NULL, 18), [73, 73], (NULL, 12]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>96 AND v2<27) OR (v1<82)) AND (v1>=80 AND v2 BETWEEN 14 AND 53);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[80, 82), [14, 53], [NULL, ∞), [NULL, ∞)}, {(96, ∞), [14, 27), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12539,13 +10795,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 9 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[48, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12574,24 +10827,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 16), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[41, 41], [79, 79], (NULL, 16), [2, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=69 AND v2 BETWEEN 38 AND 45) AND (v1<>35 AND v2<28 AND v3>14);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12649,13 +10896,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 69), (NULL, 48], (NULL, 65), [51, ∞)}, {(NULL, 69), (NULL, 48], (65, ∞), [51, ∞)}, {[37, 57], (48, 57], (NULL, 40), [98, 98]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12669,13 +10913,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 60 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 60), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(60, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12707,24 +10948,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       └─ 44 (tinyint)\n" +
 			" │       │      ))\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 4 (tinyint) AND 51 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 97), (NULL, 47], [91, 91], [NULL, ∞)}, {[74, 74], (NULL, 44), [4, 51], (72, ∞)}, {[74, 74], (44, ∞), [4, 51], (72, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 26 AND 60 AND v2>53 AND v3<=9 AND v4<8) OR (v1>0 AND v2<=69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(0, ∞), (NULL, 69], [NULL, ∞), [NULL, ∞)}, {[26, 60], (69, ∞), (NULL, 9], (NULL, 8)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12768,35 +11003,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 64 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[20, 33), (NULL, 7), [95, 96], [34, 41]}, {[20, 95], (7, ∞), [95, 96], [34, 41]}, {[27, 33), (NULL, 43], (NULL, 64], (NULL, 28)}, {[27, 33), (NULL, 43], (NULL, 64], (28, ∞)}, {[33, 33], (NULL, 2), (NULL, 63), [NULL, ∞)}, {[33, 33], (NULL, 2), [63, 63], (NULL, 28)}, {[33, 33], (NULL, 2), [63, 63], (28, ∞)}, {[33, 33], (NULL, 2), (63, ∞), [NULL, ∞)}, {[33, 33], [2, 7), [95, 96], [34, 41]}, {[33, 33], [2, 43], (NULL, 64], (NULL, 28)}, {[33, 33], [2, 43], (NULL, 64], (28, ∞)}, {(33, 44], (NULL, 43], (NULL, 64], (NULL, 28)}, {(33, 44], (NULL, 43], (NULL, 64], (28, ∞)}, {(33, 95], (NULL, 7), [95, 96], [34, 41]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1 BETWEEN 13 AND 36 AND v2>40) OR (v1<>28 AND v2<29)) OR (v1 BETWEEN 36 AND 89 AND v2>=92 AND v3>39 AND v4<16)) OR (v1<=1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 1], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(1, 28), (NULL, 29), [NULL, ∞), [NULL, ∞)}, {[13, 36], (40, ∞), [NULL, ∞), [NULL, ∞)}, {(28, ∞), (NULL, 29), [NULL, ∞), [NULL, ∞)}, {(36, 89], [92, ∞), (39, ∞), (NULL, 16)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=68 AND v2=49) OR (v1<=35 AND v2>=59 AND v3>=88 AND v4 BETWEEN 1 AND 62));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 35], [59, ∞), [88, ∞), [1, 62]}, {[68, 68], [49, 49], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12817,24 +11043,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 23), [41, ∞), [NULL, ∞), [NULL, ∞)}, {(33, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=78 AND v2=26 AND v3 BETWEEN 70 AND 89) OR (v1 BETWEEN 12 AND 78 AND v2>41 AND v3 BETWEEN 2 AND 11 AND v4 BETWEEN 12 AND 97)) OR (v1>16 AND v2=85 AND v3<56 AND v4<19));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[12, 16], (41, ∞), [2, 11], [12, 97]}, {(16, 78], (41, 85), [2, 11], [12, 97]}, {(16, 78], [85, 85], (NULL, 2), (NULL, 19)}, {(16, 78], [85, 85], [2, 11], (NULL, 97]}, {(16, 78], [85, 85], (11, 56), (NULL, 19)}, {(16, 78], (85, ∞), [2, 11], [12, 97]}, {[78, ∞), [26, 26], [70, 89], [NULL, ∞)}, {(78, ∞), [85, 85], (NULL, 56), (NULL, 19)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12863,13 +11083,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(25, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12909,13 +11126,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 51 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1), (NULL, 1), (NULL, 34], [NULL, ∞)}, {(NULL, 1), (1, 33), (NULL, 34], [NULL, ∞)}, {(NULL, 1), [33, 33], [NULL, ∞), [NULL, ∞)}, {(NULL, 1), (33, ∞), (NULL, 34], [NULL, ∞)}, {[1, 4), (51, ∞), (NULL, 34], [NULL, ∞)}, {[1, 80], (NULL, 51], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12947,13 +11161,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v4:4\n" +
 			" │       └─ 31 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 85), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(85, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12981,35 +11192,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 17 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[18, 35), [17, ∞), [NULL, ∞), [NULL, ∞)}, {[35, 35], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(35, 70], [17, ∞), [NULL, ∞), [NULL, ∞)}, {[82, 82], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>45 AND v2<=55 AND v3>=2 AND v4<46) OR (v1>=0 AND v2<>6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 0), (NULL, 55], [2, ∞), (NULL, 46)}, {[0, 45), [6, 6], [2, ∞), (NULL, 46)}, {[0, ∞), (NULL, 6), [NULL, ∞), [NULL, ∞)}, {[0, ∞), (6, ∞), [NULL, ∞), [NULL, ∞)}, {(45, ∞), [6, 6], [2, ∞), (NULL, 46)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=85 AND v2>=46 AND v3=87 AND v4>3) OR (v1=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 52), [46, ∞), [87, 87], (3, ∞)}, {[52, 52], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(52, 85], [46, ∞), [87, 87], (3, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13039,13 +11241,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 90), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[90, ∞), (NULL, 17], [68, 68], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13068,13 +11267,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v3:3\n" +
 			" │   │           └─ 23 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 18 (tinyint) AND 57 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[18, 57], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13098,13 +11294,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 80 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[32, 50], (NULL, 89), [39, ∞), [NULL, ∞)}, {[32, 50], (89, ∞), [39, ∞), [NULL, ∞)}, {(50, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13135,35 +11328,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 76 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 76), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[76, 76], (NULL, 12], (65, ∞), (NULL, 47)}, {(76, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 29 AND 37) OR (v1<>54 AND v2<=65 AND v3<=1 AND v4<>10)) OR (v1<>55 AND v2 BETWEEN 49 AND 56 AND v3>=25 AND v4<=8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29), (NULL, 65], (NULL, 1], (NULL, 10)}, {(NULL, 29), (NULL, 65], (NULL, 1], (10, ∞)}, {(NULL, 29), [49, 56], [25, ∞), (NULL, 8]}, {[29, 37], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(37, 54), (NULL, 65], (NULL, 1], (NULL, 10)}, {(37, 54), (NULL, 65], (NULL, 1], (10, ∞)}, {(37, 55), [49, 56], [25, ∞), (NULL, 8]}, {(54, ∞), (NULL, 65], (NULL, 1], (NULL, 10)}, {(54, ∞), (NULL, 65], (NULL, 1], (10, ∞)}, {(55, ∞), [49, 56], [25, ∞), (NULL, 8]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=80 AND v2<95 AND v3>6) OR (v1 BETWEEN 7 AND 14 AND v2 BETWEEN 27 AND 49 AND v3>57 AND v4 BETWEEN 28 AND 60));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[7, 14], [27, 49], (57, ∞), [28, 60]}, {[80, 80], (NULL, 95), (6, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13190,13 +11374,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 22 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 71], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(71, ∞), (NULL, 43), (NULL, 15), [NULL, ∞)}, {(71, ∞), (NULL, 43), (15, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13224,13 +11405,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v4:4\n" +
 			" │       └─ 49 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[18, 36], [13, 96], [NULL, ∞), [NULL, ∞)}, {[63, 76), (NULL, 96], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13285,13 +11463,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 17], [41, ∞), [NULL, ∞), [NULL, ∞)}, {[22, 22], (NULL, 16), [NULL, ∞), [NULL, ∞)}, {[22, 22], [16, 16], (NULL, 46), (76, ∞)}, {[22, 22], [16, 16], (46, ∞), (76, ∞)}, {[22, 22], (16, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13314,13 +11489,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 73 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 73), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[73, ∞), [11, 23], [23, 23], (50, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13344,24 +11516,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 43 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 41], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(84, ∞), (NULL, 43), [NULL, ∞), [NULL, ∞)}, {(84, ∞), (43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=24 AND v2 BETWEEN 43 AND 84) OR (v1>=90 AND v2>1 AND v3<>70)) OR (v1>=66 AND v2<95));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[24, 24], [43, 84], [NULL, ∞), [NULL, ∞)}, {[66, ∞), (NULL, 95), [NULL, ∞), [NULL, ∞)}, {[90, ∞), [95, ∞), (NULL, 70), [NULL, ∞)}, {[90, ∞), [95, ∞), (70, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13412,35 +11578,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 18], (NULL, 70], [NULL, ∞), [NULL, ∞)}, {(18, 58), (NULL, 32), (97, ∞), [NULL, ∞)}, {(55, 58), (52, ∞), (NULL, 70), [NULL, ∞)}, {(55, 58), (52, ∞), (70, ∞), [NULL, ∞)}, {[58, 58], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(58, ∞), (NULL, 32), (97, ∞), [NULL, ∞)}, {(58, ∞), (52, ∞), (NULL, 70), [NULL, ∞)}, {(58, ∞), (52, ∞), (70, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=9 AND v2>69) AND (v1 BETWEEN 39 AND 73);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[39, 73], (69, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<87 AND v2 BETWEEN 2 AND 34 AND v3=87 AND v4>=76) OR (v1<>77 AND v2<=44 AND v3>34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 77), (NULL, 44], (34, ∞), [NULL, ∞)}, {[77, 77], [2, 34], [87, 87], [76, ∞)}, {(77, ∞), (NULL, 44], (34, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13473,57 +11630,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 61 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 5], (NULL, 69), (NULL, 15], [61, ∞)}, {[9, 9], (21, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=22) OR (v1>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[22, 22], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(55, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 47 AND 57 AND v2>=83) OR (v1=91 AND v2>34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[47, 57], [83, ∞), [NULL, ∞), [NULL, ∞)}, {[91, 91], (34, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 23 AND 25) AND (v1<98 AND v2>=20 AND v3>37);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[23, 25], [20, ∞), (37, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=6) OR (v1>61 AND v2<=34)) OR (v1>10 AND v2<>50 AND v3<>62 AND v4<=84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[6, 6], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(10, 61], (NULL, 50), (NULL, 62), (NULL, 84]}, {(10, 61], (NULL, 50), (62, ∞), (NULL, 84]}, {(10, ∞), (50, ∞), (NULL, 62), (NULL, 84]}, {(10, ∞), (50, ∞), (62, ∞), (NULL, 84]}, {(61, ∞), (NULL, 34], [NULL, ∞), [NULL, ∞)}, {(61, ∞), (34, 50), (NULL, 62), (NULL, 84]}, {(61, ∞), (34, 50), (62, ∞), (NULL, 84]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13542,13 +11684,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 91 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[8, 74), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[74, 74], (NULL, 91], [NULL, ∞), [NULL, ∞)}, {(74, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13577,68 +11716,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 78 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=25) OR (v1>40 AND v2 BETWEEN 26 AND 40 AND v3<76));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[25, 25], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(40, ∞), [26, 40], (NULL, 76), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=13 AND v2<85) OR (v1=23 AND v2<>68 AND v3=33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[13, 13], (NULL, 85), [NULL, ∞), [NULL, ∞)}, {[23, 23], (NULL, 68), [33, 33], [NULL, ∞)}, {[23, 23], (68, ∞), [33, 33], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<42 AND v2>95 AND v3>17 AND v4<>97) OR (v1>=13 AND v2<>10 AND v3 BETWEEN 73 AND 85 AND v4=48)) OR (v1>55 AND v2=85 AND v3>30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 42), (95, ∞), (17, ∞), (NULL, 97)}, {(NULL, 42), (95, ∞), (17, ∞), (97, ∞)}, {[13, 42), (10, 95], [73, 85], [48, 48]}, {[13, ∞), (NULL, 10), [73, 85], [48, 48]}, {[42, 55], (10, ∞), [73, 85], [48, 48]}, {(55, ∞), (10, 85), [73, 85], [48, 48]}, {(55, ∞), [85, 85], (30, ∞), [NULL, ∞)}, {(55, ∞), (85, ∞), [73, 85], [48, 48]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 5 AND 32) OR (v1>7)) OR (v1=34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[5, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=34 AND v2<>61 AND v3<>3) AND (v1 BETWEEN 69 AND 93) AND (v1=36 AND v2>14);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13655,24 +11776,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   └─ 74 (tinyint)\n" +
 			" │       │  ))\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 29 (tinyint) AND 73 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<>91 AND v3=27 AND v4=22 AND v2<>68) AND (v1<=88);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 88], (NULL, 68), [27, 27], [22, 22]}, {(NULL, 88], (68, ∞), [27, 27], [22, 22]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13726,13 +11841,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 4), [37, ∞), (NULL, 26], (NULL, 67)}, {(NULL, 4), [37, ∞), (NULL, 26], (67, ∞)}, {(NULL, 18), (NULL, 90), (95, ∞), [NULL, ∞)}, {(NULL, 18), (90, ∞), (95, ∞), [NULL, ∞)}, {(NULL, 36), (NULL, 15], [25, 36], (NULL, 14]}, {(18, 44), (NULL, 90), (95, ∞), [NULL, ∞)}, {(18, 44), (90, ∞), (95, ∞), [NULL, ∞)}, {[44, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13761,24 +11873,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 30), (NULL, 24], [NULL, ∞), [NULL, ∞)}, {[44, 87], (NULL, 52), (NULL, 52), (NULL, 1)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>48 AND v2<=83) OR (v1>28 AND v2 BETWEEN 9 AND 87 AND v3<>73)) OR (v1>=53 AND v2>=91 AND v3 BETWEEN 33 AND 97));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(28, 48], [9, 87], (NULL, 73), [NULL, ∞)}, {(28, 48], [9, 87], (73, ∞), [NULL, ∞)}, {(48, ∞), (NULL, 83], [NULL, ∞), [NULL, ∞)}, {(48, ∞), (83, 87], (NULL, 73), [NULL, ∞)}, {(48, ∞), (83, 87], (73, ∞), [NULL, ∞)}, {[53, ∞), [91, ∞), [33, 97], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13795,46 +11901,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 54 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 54), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[54, 54], [34, 48], [NULL, ∞), [NULL, ∞)}, {(54, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=78 AND v2<74 AND v3<42 AND v4>=34) OR (v1<=29 AND v2<=27 AND v3>31 AND v4 BETWEEN 35 AND 41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29], (NULL, 27], [42, ∞), [35, 41]}, {(NULL, 78], (NULL, 74), (NULL, 42), [34, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 9 AND 35 AND v4<=69 AND v2 BETWEEN 34 AND 53 AND v3<>28) AND (v1 BETWEEN 12 AND 48);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[12, 35], [34, 53], (28, ∞), (NULL, 69]}, {[12, 35], [34, 53], (NULL, 28), (NULL, 69]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 13 AND 77 AND v2>75 AND v3<73 AND v4>=6) AND (v1<=58 AND v2=48 AND v3 BETWEEN 33 AND 73);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13869,13 +11963,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 82), (NULL, 17], (NULL, 17), [46, ∞)}, {(47, ∞), [26, 26], (47, ∞), [51, 86]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13917,57 +12008,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 10 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 14], (NULL, 57), (NULL, 10), [NULL, ∞)}, {[52, 82], (NULL, 47), [37, 37], [NULL, ∞)}, {[52, 82], (47, ∞), [37, 37], [NULL, ∞)}, {(82, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=99 AND v3<=41) AND (v1<>38 AND v2<94 AND v3 BETWEEN 83 AND 95 AND v4>=86);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>78) AND (v1>32 AND v2>11 AND v3>=78);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(78, ∞), (11, ∞), [78, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<>3 AND v2=26 AND v3=22 AND v4<=76) AND (v1 BETWEEN 59 AND 92 AND v2 BETWEEN 36 AND 80);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>10) OR (v1=12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(10, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14012,24 +12088,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 21 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>10 AND v2<=75 AND v3>=70) OR (v1<89 AND v2<=32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), (32, 75], [70, ∞), [NULL, ∞)}, {(NULL, 89), (NULL, 32], [NULL, ∞), [NULL, ∞)}, {(10, 89), (32, 75], [70, ∞), [NULL, ∞)}, {[89, ∞), (NULL, 75], [70, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14056,24 +12126,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 95 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[14, 15), (NULL, 53), [95, 95], (55, ∞)}, {[15, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>48 AND v2 BETWEEN 4 AND 84 AND v3<=3 AND v4<>31) AND (v1 BETWEEN 2 AND 15 AND v3>75);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14116,13 +12180,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ AND\n" +
 			" │       ├─ (comp_index_t2.v1:1 BETWEEN 45 (tinyint) AND 65 (tinyint))\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 4 (tinyint) AND 68 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 33), (77, ∞), [41, 41], [9, 9]}, {[33, 75], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(75, ∞), [48, ∞), [13, 13], (61, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14169,35 +12230,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 55 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 88 (tinyint) AND 97 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=55 AND v2<13 AND v3<=96 AND v4>=49) OR (v1 BETWEEN 39 AND 98 AND v2=77 AND v3>85));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[39, 98], [77, 77], (85, ∞), [NULL, ∞)}, {[55, 55], (NULL, 13), (NULL, 96], [49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=74 AND v2<>13 AND v3<67 AND v4 BETWEEN 1 AND 70) OR (v1 BETWEEN 30 AND 50 AND v2<27 AND v3>=35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[30, 50], (NULL, 27), [35, ∞), [NULL, ∞)}, {[74, 74], (NULL, 13), (NULL, 67), [1, 70]}, {[74, 74], (13, ∞), (NULL, 67), [1, 70]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14240,24 +12292,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[10, 10], [47, 47], [6, 21], (97, ∞)}, {(22, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>38 AND v2>98) OR (v1<>29 AND v2=75)) OR (v1>58 AND v2<>49 AND v3 BETWEEN 25 AND 58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29), [75, 75], [NULL, ∞), [NULL, ∞)}, {(29, ∞), [75, 75], [NULL, ∞), [NULL, ∞)}, {(38, ∞), (98, ∞), [NULL, ∞), [NULL, ∞)}, {(58, ∞), (NULL, 49), [25, 58], [NULL, ∞)}, {(58, ∞), (49, 75), [25, 58], [NULL, ∞)}, {(58, ∞), (75, 98], [25, 58], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14293,35 +12339,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 0 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 82), [8, 8], [43, ∞), [74, 74]}, {[1, 1], [54, ∞), [41, 91], [0, ∞)}, {(82, ∞), [8, 8], [43, ∞), [74, 74]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=26 AND v2<=94 AND v3<=76) OR (v1<34 AND v2 BETWEEN 5 AND 20));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 34), [5, 20], [NULL, ∞), [NULL, ∞)}, {[26, 26], (NULL, 5), (NULL, 76], [NULL, ∞)}, {[26, 26], (20, 94], (NULL, 76], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>74 AND v2<=3 AND v3>51 AND v4<1) OR (v1>=92 AND v2<=2));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(74, 92), (NULL, 3], (51, ∞), (NULL, 1)}, {[92, ∞), (NULL, 2], [NULL, ∞), [NULL, ∞)}, {[92, ∞), (2, 3], (51, ∞), (NULL, 1)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14389,35 +12426,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 47 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3], (NULL, 4), (NULL, 8), (NULL, 54)}, {(NULL, 7), [4, ∞), (NULL, 47], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<35) OR (v1>=5 AND v2>=10 AND v3=65));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 35), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[35, ∞), [10, ∞), [65, 65], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>31 AND v2<=37 AND v3>56 AND v4 BETWEEN 10 AND 31) OR (v1>8)) AND (v1>=27 AND v2<>44);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[27, ∞), (NULL, 44), [NULL, ∞), [NULL, ∞)}, {[27, ∞), (44, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14446,13 +12474,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 33 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 21), (NULL, 61), [13, 13], [NULL, ∞)}, {(52, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14493,24 +12518,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 32 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 9), (NULL, 95), [54, 54], (NULL, 31)}, {(NULL, 9), (NULL, 95), [54, 54], (31, ∞)}, {(NULL, 9), (95, ∞), [54, 54], (NULL, 31)}, {(NULL, 9), (95, ∞), [54, 54], (31, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=48) OR (v1 BETWEEN 2 AND 81));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 81], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14545,13 +12564,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v2:2\n" +
 			" │       │       └─ 3 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 1 (tinyint) AND 74 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 36), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[36, 36], (NULL, 3], [1, 74], [NULL, ∞)}, {[36, 36], [23, 39], [NULL, ∞), [NULL, ∞)}, {(36, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14583,13 +12599,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 42 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[2, 23], [34, ∞), [NULL, ∞), [NULL, ∞)}, {(30, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14639,68 +12652,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 15 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 27), (NULL, 81), (NULL, 34), (NULL, 33)}, {(NULL, 27), (NULL, 81), (NULL, 34), (33, ∞)}, {(NULL, 27), [79, 81), [34, ∞), [34, 99]}, {(NULL, 27), [81, ∞), [9, ∞), [34, 99]}, {[27, 27], (NULL, 79), [34, ∞), [20, 41]}, {[27, 27], (NULL, 81), (NULL, 15), (NULL, 33)}, {[27, 27], (NULL, 81), (NULL, 15), (33, ∞)}, {[27, 27], (NULL, 81), [15, 34), (NULL, ∞)}, {[27, 27], [79, 81), [34, ∞), [20, 99]}, {[27, 27], [81, 98), [9, 15), [34, 99]}, {[27, 27], [81, 98), [15, ∞), [20, 99]}, {[27, 27], [98, ∞), [9, ∞), [34, 99]}, {(27, 68), (NULL, 81), (NULL, 34), (NULL, 33)}, {(27, 68), (NULL, 81), (NULL, 34), (33, ∞)}, {(27, 68), [79, 81), [34, ∞), [34, 99]}, {(27, 68), [81, ∞), [9, ∞), [34, 99]}, {[68, 78], [79, ∞), [9, ∞), [34, 99]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<23 AND v2<=45 AND v3<0) OR (v1>=31)) OR (v1>=50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 23), (NULL, 45], (NULL, 0), [NULL, ∞)}, {[31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<16) OR (v1>=19 AND v2<25 AND v3>77));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 16), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[19, ∞), (NULL, 25), (77, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<29 AND v2 BETWEEN 81 AND 92) OR (v1>20 AND v2>=53 AND v3 BETWEEN 20 AND 68));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29), [81, 92], [NULL, ∞), [NULL, ∞)}, {(20, 29), [53, 81), [20, 68], [NULL, ∞)}, {(20, 29), (92, ∞), [20, 68], [NULL, ∞)}, {[29, ∞), [53, ∞), [20, 68], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1 BETWEEN 25 AND 59 AND v2=1 AND v3<93 AND v4<=16) OR (v1<40 AND v2 BETWEEN 14 AND 37 AND v3>62 AND v4<58)) OR (v1<>17 AND v2<>36)) OR (v1 BETWEEN 7 AND 99 AND v2<>6 AND v3=43 AND v4<89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 17), (NULL, 36), [NULL, ∞), [NULL, ∞)}, {(NULL, 17), [36, 36], (62, ∞), (NULL, 58)}, {(NULL, 17), (36, ∞), [NULL, ∞), [NULL, ∞)}, {[7, 17), [36, 36], [43, 43], (NULL, 89)}, {[17, 17], (NULL, 6), [43, 43], (NULL, 89)}, {[17, 17], (6, ∞), [43, 43], (NULL, 89)}, {[17, 17], [14, 37], (62, ∞), (NULL, 58)}, {(17, 40), [36, 36], (62, ∞), (NULL, 58)}, {(17, 99], [36, 36], [43, 43], (NULL, 89)}, {(17, ∞), (NULL, 36), [NULL, ∞), [NULL, ∞)}, {(17, ∞), (36, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=46) AND (v1>=93 AND v3<>51 AND v4=93 AND v2=8);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14752,13 +12747,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 79 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 79), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[79, ∞), (NULL, 39), [70, ∞), (NULL, 24)}, {[79, ∞), (NULL, 39), [70, ∞), (24, ∞)}, {[79, ∞), (39, ∞), [70, ∞), (NULL, 24)}, {[79, ∞), (39, ∞), [70, ∞), (24, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14802,24 +12794,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 69 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44], (NULL, 42], [NULL, ∞), [NULL, ∞)}, {(NULL, 44], (42, ∞), (NULL, 69), [NULL, ∞)}, {(44, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=29 AND v2 BETWEEN 50 AND 86 AND v3<=6 AND v4 BETWEEN 8 AND 48) OR (v1>86 AND v2 BETWEEN 62 AND 70 AND v3=33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29], [50, 86], (NULL, 6], [8, 48]}, {(86, ∞), [62, 70], [33, 33], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14844,13 +12830,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 50 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 15 (tinyint) AND 54 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[15, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14907,46 +12890,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 18 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 88], [76, ∞), (NULL, 40), (NULL, 18]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=27) OR (v1>=11 AND v2<97 AND v3<97 AND v4<44));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[11, 27), (NULL, 97), (NULL, 97), (NULL, 44)}, {[27, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(27, ∞), (NULL, 97), (NULL, 97), (NULL, 44)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=89 AND v2<=93) OR (v1<=54));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 54], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(54, 89], (NULL, 93], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=74 AND v2<=31) OR (v1<11)) OR (v1 BETWEEN 26 AND 38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[26, 38], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[74, 74], (NULL, 31], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14975,24 +12946,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[10, 99), (NULL, 12), [54, 54], (89, ∞)}, {[99, 99], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(99, ∞), (NULL, 12), [54, 54], (89, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=50 AND v2<50) OR (v1<19)) OR (v1=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 19), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[19, 50], (NULL, 50), [NULL, ∞), [NULL, ∞)}, {[51, 51], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15021,24 +12986,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 49 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1], (49, ∞), [NULL, ∞), [NULL, ∞)}, {[62, 62], [19, 89), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<=61 AND v2<=64) AND (v1>=0);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[0, 61], (NULL, 64], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15061,35 +13020,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 63 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 5), [25, ∞), [63, 63], (NULL, 14)}, {[5, 69], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=21 AND v2<>0 AND v3<49) OR (v1<=70 AND v2>16 AND v3<=89 AND v4>=27)) OR (v1>=14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 14), (16, ∞), (NULL, 89], [27, ∞)}, {[14, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>14) OR (v1>=82));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(14, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15114,13 +13064,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 19), (99, ∞), [NULL, ∞), [NULL, ∞)}, {[19, 19], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(19, 36], (99, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15142,13 +13089,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(43, ∞), [83, 97], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15188,24 +13132,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 31), (NULL, 96], (NULL, 20], (NULL, 14]}, {(31, ∞), (NULL, 96], (NULL, 20], (NULL, 14]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 52 AND 55) OR (v1>1 AND v2>36 AND v3<=47)) OR (v1 BETWEEN 0 AND 38 AND v2<=49 AND v3>=8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[0, 1], (NULL, 49], [8, ∞), [NULL, ∞)}, {(1, 38], (NULL, 36], [8, ∞), [NULL, ∞)}, {(1, 38], (36, 49], (NULL, ∞), [NULL, ∞)}, {(1, 38], (49, ∞), (NULL, 47], [NULL, ∞)}, {(38, 52), (36, ∞), (NULL, 47], [NULL, ∞)}, {[52, 55], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(55, ∞), (36, ∞), (NULL, 47], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15244,24 +13182,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 79 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 11], [41, ∞), [9, 9], (NULL, 24)}, {(48, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=23 AND v4>=52 AND v2>=61) AND (v1<>85 AND v3>2 AND v4<15);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15294,24 +13226,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 55 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[32, 51], [46, 46], [31, ∞), [5, 14]}, {[32, ∞), (NULL, 26], (52, ∞), (55, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=16 AND v2<59 AND v3<=43) OR (v1=17 AND v2<=4 AND v3>71));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[16, ∞), (NULL, 59), (NULL, 43], [NULL, ∞)}, {[17, 17], (NULL, 4], (71, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15358,13 +13284,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 30 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 92 (tinyint) AND 93 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[20, 28), (96, ∞), (NULL, 28), [NULL, ∞)}, {[20, 28), (96, ∞), (28, ∞), [NULL, ∞)}, {[28, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15409,13 +13332,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 56 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 54), (48, ∞), [NULL, ∞), [NULL, ∞)}, {[54, ∞), [56, 56], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15444,24 +13364,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 76), [39, 39], (NULL, 59], (NULL, 36]}, {[79, 79], (24, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=15 AND v2 BETWEEN 21 AND 76 AND v3=23) OR (v1 BETWEEN 2 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), [21, 76], [23, 23], [NULL, ∞)}, {[2, 55], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15492,13 +13406,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 57 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(56, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15550,13 +13461,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 5], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(5, 11), [75, ∞), [NULL, ∞), [NULL, ∞)}, {[11, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15605,13 +13513,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 82 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 82), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, 82], [34, 39], [34, 71], [15, ∞)}, {[82, 82], [46, 46], [4, 4], [NULL, ∞)}, {(82, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15629,13 +13534,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v3:3\n" +
 			" │       └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(1, 50], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15670,79 +13572,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 82 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[66, 82), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, ∞), [72, 72], (NULL, 31), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=84 AND v2<85 AND v3 BETWEEN 75 AND 86 AND v4<=34) OR (v1>=37 AND v2<59 AND v3 BETWEEN 2 AND 26 AND v4>6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[37, ∞), (NULL, 59), [2, 26], (6, ∞)}, {[84, 84], (NULL, 85), [75, 86], (NULL, 34]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>10 AND v2=42) OR (v1>=85 AND v2<>6 AND v3=34 AND v4<=45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(10, ∞), [42, 42], [NULL, ∞), [NULL, ∞)}, {[85, ∞), (NULL, 6), [34, 34], (NULL, 45]}, {[85, ∞), (6, 42), [34, 34], (NULL, 45]}, {[85, ∞), (42, ∞), [34, 34], (NULL, 45]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=24 AND v2<>33 AND v3=77 AND v4<>63) OR (v1<>22 AND v2<=58 AND v3>71 AND v4>=87)) OR (v1<=85 AND v2>18 AND v3<=40));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 22), (NULL, 58], (71, ∞), [87, ∞)}, {(NULL, 85], (18, ∞), (NULL, 40], [NULL, ∞)}, {(22, 24), (NULL, 58], (71, ∞), [87, ∞)}, {[24, 24], (NULL, 33), (71, 77), [87, ∞)}, {[24, 24], (NULL, 33), [77, 77], (NULL, 63)}, {[24, 24], (NULL, 33), [77, 77], (63, ∞)}, {[24, 24], (NULL, 33), (77, ∞), [87, ∞)}, {[24, 24], [33, 33], (71, ∞), [87, ∞)}, {[24, 24], (33, 58], (71, 77), [87, ∞)}, {[24, 24], (33, 58], (77, ∞), [87, ∞)}, {[24, 24], (33, ∞), [77, 77], (NULL, 63)}, {[24, 24], (33, ∞), [77, 77], (63, ∞)}, {(24, ∞), (NULL, 58], (71, ∞), [87, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<72 AND v2>=67) OR (v1<>88 AND v2<>23 AND v3=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 72), (23, 67), [23, 23], [NULL, ∞)}, {(NULL, 72), [67, ∞), [NULL, ∞), [NULL, ∞)}, {(NULL, 88), (NULL, 23), [23, 23], [NULL, ∞)}, {[72, 88), (23, ∞), [23, 23], [NULL, ∞)}, {(88, ∞), (NULL, 23), [23, 23], [NULL, ∞)}, {(88, ∞), (23, ∞), [23, 23], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=11 AND v2>=99) OR (v1<18 AND v2>=34 AND v3<53)) OR (v1>68));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [34, ∞), (NULL, 53), [NULL, ∞)}, {[11, 11], [34, 99), (NULL, 53), [NULL, ∞)}, {[11, 11], [99, ∞), [NULL, ∞), [NULL, ∞)}, {(11, 18), [34, ∞), (NULL, 53), [NULL, ∞)}, {(68, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=40 AND v2<0) OR (v1>=35 AND v2<=95 AND v3<>61)) OR (v1>49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 40], (NULL, 0), [NULL, ∞), [NULL, ∞)}, {[35, 40], [0, 95], (NULL, 61), [NULL, ∞)}, {[35, 40], [0, 95], (61, ∞), [NULL, ∞)}, {(40, 49], (NULL, 95], (NULL, 61), [NULL, ∞)}, {(40, 49], (NULL, 95], (61, ∞), [NULL, ∞)}, {(49, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15771,13 +13652,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           └─ 43 (tinyint)\n" +
 			" │   │          ))\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 15 (tinyint) AND 67 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[37, 55], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15817,13 +13695,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 53 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[52, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15855,13 +13730,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 91 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(5, ∞), [62, ∞), [NULL, ∞), [NULL, ∞)}, {[91, ∞), [28, 62), [83, ∞), (NULL, 91)}, {[91, ∞), [28, 62), [83, ∞), (91, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15883,24 +13755,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 74 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 87), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(87, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 1 AND 19 AND v2 BETWEEN 22 AND 48) AND (v1 BETWEEN 6 AND 47 AND v2>=25 AND v3<27);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[6, 19], [25, 48], (NULL, 27), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15961,24 +13827,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 84 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 95], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>42 AND v2=44 AND v3<>73) OR (v1>24 AND v2>49 AND v3>=7));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(24, ∞), (49, ∞), [7, ∞), [NULL, ∞)}, {(42, ∞), [44, 44], (NULL, 73), [NULL, ∞)}, {(42, ∞), [44, 44], (73, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16003,13 +13863,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 63), (NULL, 66), [NULL, ∞), [NULL, ∞)}, {[79, 79], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16040,13 +13897,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 75 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 66), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[66, 66], (53, ∞), (NULL, 73), (NULL, 75)}, {(66, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16069,13 +13923,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 98 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 70 (tinyint) AND 85 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[15, 15], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(36, ∞), [70, 85], [13, 13], (NULL, 98]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16099,13 +13950,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │       │      ))\n" +
 			" │   │       └─ (comp_index_t2.v3:3 BETWEEN 30 (tinyint) AND 53 (tinyint))\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 41 (tinyint) AND 95 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[23, 95], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(95, ∞), (NULL, 6), [30, 53], [NULL, ∞)}, {(95, ∞), (6, ∞), [30, 53], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16141,13 +13989,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 3 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 21), [17, ∞), (NULL, 3], [NULL, ∞)}, {(6, ∞), (NULL, 77), [81, ∞), (NULL, 9)}, {(6, ∞), (NULL, 77), [81, ∞), (9, ∞)}, {(6, ∞), (77, ∞), [81, ∞), (NULL, 9)}, {(6, ∞), (77, ∞), [81, ∞), (9, ∞)}, {(21, ∞), [17, ∞), (NULL, 3], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16186,79 +14031,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 23 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[50, 97], (NULL, 12), (23, ∞), [NULL, ∞)}, {[94, 97], (4, 12), (NULL, 23], (NULL, 59]}, {[94, 97], [12, ∞), (NULL, 94), (NULL, 59]}, {(97, 99], (4, ∞), (NULL, 94), (NULL, 59]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>19 AND v2>46 AND v3=26 AND v4>=47) OR (v1>18 AND v2<=79 AND v3=45 AND v4<=7)) OR (v1 BETWEEN 2 AND 21 AND v2>32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), (46, ∞), [26, 26], [47, ∞)}, {[2, 21], (32, ∞), [NULL, ∞), [NULL, ∞)}, {(18, 21], (NULL, 32], [45, 45], (NULL, 7]}, {(21, ∞), (NULL, 79], [45, 45], (NULL, 7]}, {(21, ∞), (46, ∞), [26, 26], [47, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=5) AND (v1=50 AND v2<=50);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[50, 50], (NULL, 50], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=82 AND v2 BETWEEN 34 AND 50 AND v3<26 AND v4 BETWEEN 48 AND 76) OR (v1<=6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 6], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, ∞), [34, 50], (NULL, 26), [48, 76]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>29) OR (v1<>94 AND v2>=56 AND v3=14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29], [56, ∞), [14, 14], [NULL, ∞)}, {(29, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>8 AND v2<97 AND v3=51 AND v4<=26) OR (v1>87)) OR (v1<10 AND v2<=45 AND v3>=73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), (NULL, 45], [73, ∞), [NULL, ∞)}, {(8, 87], (NULL, 97), [51, 51], (NULL, 26]}, {(87, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>15 AND v2>1) OR (v1<46)) OR (v1>47 AND v2>=9 AND v3 BETWEEN 39 AND 87 AND v4>=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 46), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[46, ∞), (1, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16267,13 +14091,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ comp_index_t3.v1:1\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t3)\n" +
 			"     ├─ index: [comp_index_t3.v1]\n" +
 			"     ├─ static: [{[a, a]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t3\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -16286,13 +14107,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t3.v1:1\n" +
 			" │       └─ aÿ (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t3)\n" +
 			"     ├─ index: [comp_index_t3.v1]\n" +
 			"     ├─ static: [{[a, aÿ]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t3\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -94,7 +94,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"             │   └─ a (longtext)\n" +
 			"             └─ IndexedTableAccess(pref_index_t4)\n" +
 			"                 ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"                 └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -107,7 +108,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t4)\n" +
 			"             ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"             └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -189,7 +191,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"             │   └─ a (longtext)\n" +
 			"             └─ IndexedTableAccess(pref_index_t3)\n" +
 			"                 ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"                 └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -202,7 +205,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t3)\n" +
 			"             ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"             └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -284,7 +288,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"             │   └─ A (longtext)\n" +
 			"             └─ IndexedTableAccess(pref_index_t2)\n" +
 			"                 ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"                 └─ static: [{[A, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
+			"                 └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -297,7 +302,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │   └─ A (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t2)\n" +
 			"             ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"             └─ static: [{[A, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -378,7 +384,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t1)\n" +
 			"             ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"             └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -392,7 +399,8 @@ var IndexPlanTests = []QueryPlanTest{
 			"             │   └─ a (longtext)\n" +
 			"             └─ IndexedTableAccess(pref_index_t1)\n" +
 			"                 ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"                 └─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -21,13 +21,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t4.v1:1\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -36,13 +33,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t4.v1:1\n" +
 			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -51,13 +45,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t4.v1:1\n" +
 			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -70,13 +61,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t4.v1:1\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -89,13 +77,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t4.v2:2\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
 			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -107,11 +92,10 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t4.v1:1\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t4)\n" +
 			"                 ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t4\n" +
+			"                 └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -122,11 +106,10 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t4.v1:1\n" +
 			"         │   └─ a (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t4)\n" +
 			"             ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t4\n" +
+			"             └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -135,13 +118,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t3.v1:0\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -150,13 +130,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t3.v1:0\n" +
 			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -165,13 +142,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t3.v1:0\n" +
 			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -184,13 +158,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t3.v1:0\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -203,13 +174,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t3.v2:1\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
 			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ columns: [v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -221,11 +189,10 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t3.v1:0\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t3)\n" +
 			"                 ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t3\n" +
+			"                 └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -236,11 +203,10 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t3.v1:0\n" +
 			"         │   └─ a (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t3)\n" +
 			"             ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t3\n" +
+			"             └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -249,13 +215,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t2.v1:1\n" +
 			" │   └─ A (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{[A, A], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -264,13 +227,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t2.v1:1\n" +
 			" │   └─ ABC (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{[ABC, ABC], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -279,13 +239,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t2.v1:1\n" +
 			" │   └─ ABCD (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -298,13 +255,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t2.v1:1\n" +
 			" │       └─ ABCDE (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{(A, ABCDE), [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -317,13 +271,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t2.v2:2\n" +
 			" │       └─ ABCDE (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
 			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"     ├─ static: [{(A, ∞), (NULL, ABCDE)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -335,11 +286,10 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t2.v1:1\n" +
 			"             │   └─ A (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t2)\n" +
 			"                 ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"                 ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t2\n" +
+			"                 └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -350,11 +300,10 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t2.v1:1\n" +
 			"         │   └─ A (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t2)\n" +
 			"             ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"             ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t2\n" +
+			"             └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -363,13 +312,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t1.v1:1\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -378,13 +324,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t1.v1:1\n" +
 			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -393,13 +336,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ pref_index_t1.v1:1\n" +
 			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -412,13 +352,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t1.v1:1\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -431,13 +368,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ pref_index_t1.v2:2\n" +
 			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
 			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ columns: [i v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -448,11 +382,10 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ pref_index_t1.v1:1\n" +
 			"         │   └─ a (longtext)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(pref_index_t1)\n" +
 			"             ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: pref_index_t1\n" +
+			"             └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -464,66 +397,50 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ GreaterThanOrEqual\n" +
 			"             │   ├─ pref_index_t1.v1:1\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(pref_index_t1)\n" +
 			"                 ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: pref_index_t1\n" +
+			"                 └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<25) OR (v1>24));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=99 AND v2<>83) OR (v1>=1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[1, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=38 AND v2<41) OR (v1>60)) OR (v1<22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 22), [NULL, ∞)}, {[22, 38], (NULL, 41)}, {(60, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>92 AND v2>25) OR (v1 BETWEEN 6 AND 24 AND v2=80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[6, 24], [80, 80]}, {(92, ∞), (25, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=29) OR (v1=49 AND v2<48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 29], [NULL, ∞)}, {[49, 49], (NULL, 48)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -537,13 +454,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 11 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 75), [NULL, ∞)}, {(75, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -557,13 +471,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 9 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[87, 87], (NULL, 45]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -581,35 +492,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 96 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 96), [NULL, ∞)}, {(96, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=97) OR (v1 BETWEEN 36 AND 98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 98], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=86 AND v2>41) OR (v1<>6 AND v2>16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 6), (16, ∞)}, {(6, ∞), (16, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -632,79 +534,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 34 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<11) OR (v1>=66 AND v2=22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞)}, {[66, ∞), [22, 22]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>45 AND v2>37) OR (v1<98 AND v2<=35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 45), (37, ∞)}, {(NULL, 98), (NULL, 35]}, {(45, ∞), (37, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=16 AND v2>96) OR (v1<80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 80), [NULL, ∞)}, {[80, ∞), (96, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=98) OR (v1<85 AND v2>60)) OR (v1<>53 AND v2 BETWEEN 82 AND 89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 98], [NULL, ∞)}, {(98, ∞), [82, 89]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((((v1<71 AND v2<7) OR (v1<=21 AND v2<=48)) OR (v1=44 AND v2 BETWEEN 21 AND 83)) OR (v1<=72 AND v2<>27)) OR (v1=35 AND v2 BETWEEN 78 AND 89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 21], (NULL, ∞)}, {(21, 44), (NULL, 27)}, {(21, 44), (27, ∞)}, {[44, 44], (NULL, ∞)}, {(44, 72], (NULL, 27)}, {(44, 72], (27, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=16) OR (v1>=77 AND v2>77)) OR (v1>19 AND v2>27));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 16], [NULL, ∞)}, {(19, ∞), (27, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -731,68 +612,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[33, 46), (NULL, 39)}, {[33, 46), (39, ∞)}, {[46, ∞), (NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<39 AND v2<10) OR (v1>64 AND v2<=15)) AND (v1>=41);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(64, ∞), (NULL, 15]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=91) OR (v1<70 AND v2>=23)) OR (v1>23 AND v2<38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 91], [NULL, ∞)}, {(91, ∞), (NULL, 38)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<>45 AND v2=70) OR (v1 BETWEEN 40 AND 96 AND v2 BETWEEN 48 AND 96)) OR (v1<>87 AND v2<31)) OR (v1<>62 AND v2=51)) AND (v1>=47 AND v2<29);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[47, 87), (NULL, 29)}, {(87, ∞), (NULL, 29)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<71) OR (v1 BETWEEN 46 AND 79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 79], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>52) OR (v1<=14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 14], [NULL, ∞)}, {(52, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -811,35 +674,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 54 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 74), [NULL, ∞)}, {[74, 74], [54, ∞)}, {(74, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=69 AND v2<24) OR (v1<77 AND v2<=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 77), (NULL, 53]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=78 AND v2=87) OR (v1 BETWEEN 37 AND 58 AND v2>=30)) AND (v1=86 AND v2 BETWEEN 0 AND 70);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -853,68 +707,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 52 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 94), [NULL, ∞)}, {(94, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>23 AND v2>64) OR (v1>73 AND v2<=66)) OR (v1 BETWEEN 39 AND 69 AND v2>84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 23), (64, ∞)}, {(23, 73], (64, ∞)}, {(73, ∞), (NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>54 AND v2<16) OR (v1<74 AND v2>29)) AND (v1 BETWEEN 34 AND 48);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[34, 48], (29, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>44 AND v2>12) OR (v1<=5 AND v2>27));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 44), (12, ∞)}, {(44, ∞), (12, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=54 AND v2<>13) OR (v1>84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 54], (NULL, 13)}, {(NULL, 54], (13, ∞)}, {(84, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>1 AND v2<>51) OR (v1=28));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(1, 28), (NULL, 51)}, {(1, 28), (51, ∞)}, {[28, 28], [NULL, ∞)}, {(28, ∞), (NULL, 51)}, {(28, ∞), (51, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -930,24 +766,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 98 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=16 AND v2=57) OR (v1<46 AND v2 BETWEEN 78 AND 89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 46), [78, 89]}, {[16, 16], [57, 57]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -969,13 +799,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 23 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 23], (NULL, 10)}, {(23, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1008,35 +835,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 34 AND 34 AND v2 BETWEEN 0 AND 91) OR (v1 BETWEEN 54 AND 77 AND v2>92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[34, 34], [0, 91]}, {[54, 77], (92, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((((v1<=55) OR (v1>=46 AND v2<=26)) OR (v1 BETWEEN 8 AND 54)) OR (v1>26 AND v2 BETWEEN 62 AND 89)) OR (v1<31 AND v2=11)) OR (v1>9 AND v2=60));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 55], [NULL, ∞)}, {(55, ∞), (NULL, 26]}, {(55, ∞), [60, 60]}, {(55, ∞), [62, 89]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1060,90 +878,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 50 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 50), [NULL, ∞)}, {(50, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>39 AND v2>66) OR (v1=99));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(39, 99), (66, ∞)}, {[99, 99], [NULL, ∞)}, {(99, ∞), (66, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 24 AND 66) OR (v1<=81 AND v2<>29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 24), (NULL, 29)}, {(NULL, 24), (29, ∞)}, {[24, 66], [NULL, ∞)}, {(66, 81], (NULL, 29)}, {(66, 81], (29, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>18 AND v2<>8) OR (v1>=10 AND v2>3)) OR (v1=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 10), (NULL, 8)}, {(NULL, 10), (8, ∞)}, {[10, 18), (NULL, ∞)}, {[18, 18], (3, ∞)}, {(18, 53), (NULL, ∞)}, {[53, 53], [NULL, ∞)}, {(53, ∞), (NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=42 AND v2>34) OR (v1<=40 AND v2<=49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 40], (NULL, 49]}, {[42, ∞), (34, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 8 AND 38) OR (v1>=23 AND v2 BETWEEN 36 AND 49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[8, 38], [NULL, ∞)}, {(38, ∞), [36, 49]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>57 AND v2 BETWEEN 2 AND 93) OR (v1=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 52), [2, 93]}, {[52, 52], [NULL, ∞)}, {(52, 57), [2, 93]}, {(57, ∞), [2, 93]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<24) OR (v1<41)) OR (v1<12 AND v2=2)) OR (v1=3 AND v2<>66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 41), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1176,68 +970,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 56 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 31), (NULL, 56)}, {(NULL, 31), (56, ∞)}, {[31, 31], [54, 54]}, {(31, ∞), (NULL, 56)}, {(31, ∞), (56, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>52 AND v2<90) OR (v1 BETWEEN 27 AND 77 AND v2 BETWEEN 49 AND 83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 52), (NULL, 90)}, {[52, 52], [49, 83]}, {(52, ∞), (NULL, 90)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>2) OR (v1<72 AND v2>=21)) AND (v1=69 AND v2 BETWEEN 44 AND 48);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[69, 69], [44, 48]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>77) OR (v1=57)) OR (v1>9 AND v2>80)) OR (v1=22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(9, 22), (80, ∞)}, {[22, 22], [NULL, ∞)}, {(22, 57), (80, ∞)}, {[57, 57], [NULL, ∞)}, {(57, 77], (80, ∞)}, {(77, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>28) OR (v1<=30 AND v2=30)) OR (v1<29)) OR (v1 BETWEEN 54 AND 74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>30 AND v2 BETWEEN 20 AND 41) OR (v1>=69 AND v2=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 30), [20, 41]}, {(30, ∞), [20, 41]}, {[69, ∞), [51, 51]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1251,35 +1027,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 55 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[67, 67], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<20 AND v2<=46) OR (v1<>4 AND v2=26)) OR (v1>36 AND v2<>13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 20), (NULL, 46]}, {[20, 36], [26, 26]}, {(36, ∞), (NULL, 13)}, {(36, ∞), (13, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=5 AND v2>66) OR (v1<=0)) OR (v1 BETWEEN 10 AND 87));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 0], [NULL, ∞)}, {(0, 5], (66, ∞)}, {[10, 87], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1330,24 +1097,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 86 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[15, 47], (NULL, 69)}, {[15, 47], (69, ∞)}, {(55, 86], (85, ∞)}, {(86, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<37) OR (v1<=48 AND v2<=54)) OR (v1=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 37), [NULL, ∞)}, {[37, 48], (NULL, 54]}, {[88, 88], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1370,13 +1131,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1394,13 +1152,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 64 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1414,24 +1169,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 11 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>40) OR (v1>=49 AND v2>=92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(40, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1456,24 +1205,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 9 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(9, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=53 AND v2<=79) OR (v1>50 AND v2>26)) AND (v1>26) AND (v1>43 AND v2<7);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(43, 53], (NULL, 7)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1493,57 +1236,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 30 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=45) OR (v1=28));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[28, 28], [NULL, ∞)}, {[45, 45], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (v1 BETWEEN 11 AND 18) AND (v1>31 AND v2 BETWEEN 38 AND 88);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>95 AND v2>5) OR (v1>16 AND v2>=38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(16, 95], [38, ∞)}, {(95, ∞), (5, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=23) OR (v1=47 AND v2>23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[23, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1557,57 +1285,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 67 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 67), [NULL, ∞)}, {(67, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=30 AND v2>=67) OR (v1<=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 52], [NULL, ∞)}, {(52, ∞), [67, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 48 AND 86 AND v2>=29) OR (v1<>82 AND v2<=93)) OR (v1 BETWEEN 79 AND 87 AND v2 BETWEEN 13 AND 69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 48), (NULL, 93]}, {[48, 82), (NULL, ∞)}, {[82, 82], [13, ∞)}, {(82, 86], (NULL, ∞)}, {(86, ∞), (NULL, 93]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 3 AND 95 AND v2>=36) OR (v1>=40 AND v2<13)) OR (v1 BETWEEN 4 AND 8 AND v2=50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[3, 95], [36, ∞)}, {[40, ∞), (NULL, 13)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<11 AND v2<>32) OR (v1 BETWEEN 35 AND 41)) OR (v1>=76));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 11), (NULL, 32)}, {(NULL, 11), (32, ∞)}, {[35, 41], [NULL, ∞)}, {[76, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1626,24 +1339,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │       ├─ comp_index_t0.v1:1\n" +
 			" │   │       └─ 2 (tinyint)\n" +
 			" │   └─ (comp_index_t0.v1:1 BETWEEN 50 (tinyint) AND 97 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{[15, 15], [8, 8]}, {[50, 97], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<67 AND v2<>39) OR (v1>36));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 36], (NULL, 39)}, {(NULL, 36], (39, ∞)}, {(36, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1657,57 +1364,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t0.v1:1\n" +
 			" │       └─ 50 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 66), [NULL, ∞)}, {(66, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 5 AND 19) OR (v1<>50 AND v2>=51)) OR (v1>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 5), [51, ∞)}, {[5, 19], [NULL, ∞)}, {(19, 50), [51, ∞)}, {(50, 55], [51, ∞)}, {(55, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 16 AND 65) OR (v1<>18 AND v2>=81)) OR (v1 BETWEEN 6 AND 48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 6), [81, ∞)}, {[6, 65], [NULL, ∞)}, {(65, ∞), [81, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1>=31 AND v2>=55) OR (v1 BETWEEN 1 AND 28)) OR (v1 BETWEEN 26 AND 41 AND v2<=15));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[1, 28], [NULL, ∞)}, {(28, 41], (NULL, 15]}, {[31, ∞), [55, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=77 AND v2 BETWEEN 4 AND 26) OR (v1<=1 AND v2<>20)) OR (v1>8 AND v2>40));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 1], (NULL, ∞)}, {(1, 77], [4, 26]}, {(8, ∞), (40, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1752,13 +1444,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t0.v2:2\n" +
 			" │           └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, 4), [NULL, ∞)}, {[4, 4], (NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1778,211 +1467,154 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t0.v1:1\n" +
 			" │       │   └─ 28 (tinyint)\n" +
 			" │       └─ (comp_index_t0.v2:2 BETWEEN 30 (tinyint) AND 85 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
 			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=94) OR (v1<=87));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 94], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>56 AND v2<93) OR (v1<73 AND v2<=70));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 56), (NULL, 93)}, {[56, 56], (NULL, 70]}, {(56, ∞), (NULL, 93)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>=85) OR (v1=91)) OR (v1<88 AND v2<42)) OR (v1<>42 AND v2<=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 85), (NULL, 42)}, {[85, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>42 AND v2<=13) OR (v1=7));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[7, 7], [NULL, ∞)}, {(42, ∞), (NULL, 13]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1=63) OR (v1 BETWEEN 55 AND 82 AND v2 BETWEEN 0 AND 6)) OR (v1=46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[46, 46], [NULL, ∞)}, {[55, 63), [0, 6]}, {[63, 63], [NULL, ∞)}, {(63, 82], [0, 6]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 20 AND 77 AND v2>=49) OR (v1<13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 13), [NULL, ∞)}, {[20, 77], [49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1>=72) OR (v1<49 AND v2<>36)) OR (v1>=10 AND v2<1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 49), (NULL, 36)}, {(NULL, 49), (36, ∞)}, {[49, 72), (NULL, 1)}, {[72, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 18 AND 87) OR (v1>=42 AND v2>44)) OR (v1<26 AND v2<=55)) AND (v1<=21);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 18), (NULL, 55]}, {[18, 21], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>98 AND v2<75) OR (v1=47));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[47, 47], [NULL, ∞)}, {(98, ∞), (NULL, 75)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=57 AND v2>=43) OR (v1<27 AND v2<>3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 27), (NULL, 3)}, {(NULL, 27), (3, ∞)}, {[27, 57], [43, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 16 AND 45 AND v2=22) OR (v1>=87 AND v2=48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[16, 45], [22, 22]}, {[87, ∞), [48, 48]}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 45 AND 74 AND v2<=74) OR (v1<>48 AND v2>58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 45), (58, ∞)}, {[45, 48), (NULL, ∞)}, {[48, 48], (NULL, 74]}, {(48, 74], (NULL, ∞)}, {(74, ∞), (58, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<32 AND v2>=79) OR (v1<=28)) OR (v1 BETWEEN 46 AND 72)) OR (v1>16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<10) OR (v1<89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 89), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1>=64 AND v2>=69) OR (v1>=2));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{[2, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<=65) OR (v1<64));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 65], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1=46) OR (v1>9 AND v2>=22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(9, 46), [22, ∞)}, {[46, 46], [NULL, ∞)}, {(46, ∞), [22, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1 BETWEEN 21 AND 33 AND v2>25) OR (v1<0));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
 			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
 			" ├─ static: [{(NULL, 0), [NULL, ∞)}, {[21, 33], (25, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2000,13 +1632,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 39), [8, 33], [NULL, ∞)}, {[39, 69], [NULL, ∞), [NULL, ∞)}, {(69, 87), [8, 33], [NULL, ∞)}, {(87, ∞), [8, 33], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2034,35 +1663,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 15 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[15, 15], [NULL, ∞), [NULL, ∞)}, {[55, ∞), [72, 80], [63, 63]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<93 AND v2<39 AND v3 BETWEEN 30 AND 97) OR (v1>54)) OR (v1<66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>59 AND v2<=15) OR (v1 BETWEEN 2 AND 51)) OR (v1>15 AND v2 BETWEEN 31 AND 81));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 15], [NULL, ∞)}, {[2, 51], [NULL, ∞), [NULL, ∞)}, {(51, 59), (NULL, 15], [NULL, ∞)}, {(51, ∞), [31, 81], [NULL, ∞)}, {(59, ∞), (NULL, 15], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2086,13 +1706,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 49 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 41], (40, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2119,35 +1736,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 48 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[53, 75), [36, 53], (48, ∞)}, {[75, 85], [NULL, ∞), [NULL, ∞)}, {(85, ∞), [36, 53], (48, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<6 AND v2<>44) OR (v1 BETWEEN 27 AND 96)) OR (v1>22 AND v2<>30 AND v3<49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), (NULL, 44), [NULL, ∞)}, {(NULL, 6), (44, ∞), [NULL, ∞)}, {(22, 27), (NULL, 30), (NULL, 49)}, {(22, 27), (30, ∞), (NULL, 49)}, {[27, 96], [NULL, ∞), [NULL, ∞)}, {(96, ∞), (NULL, 30), (NULL, 49)}, {(96, ∞), (30, ∞), (NULL, 49)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>29 AND v2=40) OR (v1<=74)) OR (v1<13 AND v2 BETWEEN 27 AND 82 AND v3<82));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 74], [NULL, ∞), [NULL, ∞)}, {(74, ∞), [40, 40], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2173,13 +1781,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 10 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 6), (NULL, 0), (NULL, 10)}, {(NULL, 6), [0, 97], [NULL, ∞)}, {(NULL, 6), (97, ∞), (NULL, 10)}, {[6, 6], (NULL, 10), (NULL, 10)}, {[6, 6], (10, ∞), (NULL, 10)}, {(6, 40), (NULL, 0), (NULL, 10)}, {(6, 40), (97, ∞), (NULL, 10)}, {(6, ∞), [0, 97], [NULL, ∞)}, {(40, ∞), (NULL, 0), (NULL, 10)}, {(40, ∞), (97, ∞), (NULL, 10)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2205,13 +1810,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 28 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 28), [NULL, ∞), [NULL, ∞)}, {(28, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2244,13 +1846,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 13 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 41), [NULL, ∞), [NULL, ∞)}, {[41, 41], (NULL, 13), [14, 74]}, {[41, 41], (13, ∞), [14, 74]}, {(41, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2284,13 +1883,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t1.v2:2\n" +
 			" │       │       └─ 32 (tinyint)\n" +
 			" │       └─ (comp_index_t1.v3:3 BETWEEN 3 (tinyint) AND 7 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 1), (NULL, 32], [3, 7]}, {[1, 11], [NULL, ∞), [NULL, ∞)}, {(11, 34), [28, 84], (NULL, 93]}, {(11, 80), (NULL, 28), [3, 7]}, {[34, 52], [28, 73), (NULL, 93]}, {[34, 52], [73, 73], [NULL, ∞)}, {[34, 52], (73, 84], (NULL, 93]}, {(52, ∞), [28, 84], (NULL, 93]}, {(80, ∞), (NULL, 28), [3, 7]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2316,13 +1912,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 72), [NULL, ∞), [NULL, ∞)}, {[72, 72], (59, ∞), [NULL, ∞)}, {(72, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2359,24 +1952,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 54 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[53, ∞), (69, ∞), (54, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>9) OR (v1>14 AND v2>10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(9, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2403,13 +1990,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 39], [17, 34], [NULL, ∞)}, {[89, 89], (58, ∞), (49, ∞)}, {(97, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2436,46 +2020,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 7), (NULL, 43), [NULL, ∞)}, {(NULL, 7), (43, ∞), [NULL, ∞)}, {[7, ∞), (NULL, 1), (NULL, 0)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1>30 AND v2 BETWEEN 23 AND 60 AND v3=58) OR (v1<=3 AND v2 BETWEEN 68 AND 72)) OR (v1<=17)) OR (v1>6 AND v2>=24)) AND (v1<89 AND v2=73);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 89), [73, 73], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>27) OR (v1>=22 AND v2>99 AND v3>=43));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[22, 27], (99, ∞), [43, ∞)}, {(27, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25 AND v2 BETWEEN 1 AND 82) OR (v1>31 AND v2=86));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(25, ∞), [1, 82], [NULL, ∞)}, {(31, ∞), [86, 86], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2514,13 +2086,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12), (NULL, 60), [91, 91]}, {(12, 35], (NULL, 60), [91, 91]}, {(35, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2541,24 +2110,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 26 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[62, ∞), (NULL, 96], (28, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>30 AND v2=40 AND v3 BETWEEN 35 AND 35) OR (v1 BETWEEN 20 AND 77 AND v2>=56 AND v3>62));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[20, 77], [56, ∞), (62, ∞)}, {(30, ∞), [40, 40], [35, 35]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2606,68 +2169,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 47 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 6), [9, ∞), [0, 0]}, {[6, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=15 AND v2>28) OR (v1<=84 AND v2<>91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 15], (NULL, ∞), [NULL, ∞)}, {(15, 84], (NULL, 91), [NULL, ∞)}, {(15, 84], (91, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=49 AND v2<=52 AND v3 BETWEEN 23 AND 38) OR (v1 BETWEEN 30 AND 84 AND v2=94));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[30, 84], [94, 94], [NULL, ∞)}, {[49, 49], (NULL, 52], [23, 38]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 8 AND 18) OR (v1=27 AND v2<=4 AND v3<14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[8, 18], [NULL, ∞), [NULL, ∞)}, {[27, 27], (NULL, 4], (NULL, 14)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=4) OR (v1=0 AND v2<=63));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[0, 0], (NULL, 63], [NULL, ∞)}, {[4, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<=99 AND v2<>86) AND (v1>=21 AND v2>36);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[21, 99], (86, ∞), [NULL, ∞)}, {[21, 99], (36, 86), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2681,57 +2226,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 43), [NULL, ∞), [NULL, ∞)}, {(43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1 BETWEEN 21 AND 44 AND v2 BETWEEN 18 AND 88 AND v3=42) AND (v1>=52 AND v2>37 AND v3 BETWEEN 26 AND 91);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>29 AND v2>93 AND v3<64) OR (v1<>54 AND v2>35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 54), (35, ∞), [NULL, ∞)}, {[54, 54], (93, ∞), (NULL, 64)}, {(54, ∞), (35, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<88) OR (v1<>45 AND v2<89)) AND (v1=98 AND v2<=81 AND v3 BETWEEN 34 AND 77);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[98, 98], (NULL, 81], [34, 77]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>65 AND v2<>86 AND v3<=2) OR (v1<>37 AND v2<=96));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 37), (NULL, 96], [NULL, ∞)}, {(37, ∞), (NULL, 96], [NULL, ∞)}, {(65, ∞), (96, ∞), (NULL, 2]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2776,35 +2306,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 23 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12), (NULL, 17), (NULL, 23]}, {(NULL, 12), (17, ∞), (NULL, 23]}, {(NULL, 42), (NULL, 34), [25, ∞)}, {(12, ∞), (NULL, 17), (NULL, 23]}, {(12, ∞), (17, ∞), (NULL, 23]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<81 AND v2>=28) OR (v1=19 AND v2 BETWEEN 9 AND 57));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 19), [28, ∞), [NULL, ∞)}, {[19, 19], [9, ∞), [NULL, ∞)}, {(19, 81), [28, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<32) OR (v1>=52)) OR (v1>=98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 32), [NULL, ∞), [NULL, ∞)}, {[52, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2818,24 +2339,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 25 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 25), [NULL, ∞), [NULL, ∞)}, {(25, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>27 AND v2<=80 AND v3 BETWEEN 11 AND 37) AND (v1=87 AND v2<54) AND (v1>29);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[87, 87], (NULL, 54), [11, 37]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2865,35 +2380,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 36 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 85], [NULL, ∞), [NULL, ∞)}, {(85, ∞), [52, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=12 AND v2>=65) OR (v1=11 AND v2<1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[11, 11], (NULL, 1), [NULL, ∞)}, {[12, ∞), [65, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=92 AND v2<=42) OR (v1>=58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 58), (NULL, 42], [NULL, ∞)}, {[58, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2915,13 +2421,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 52 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 0), [NULL, ∞), [NULL, ∞)}, {[0, 0], [70, ∞), [NULL, ∞)}, {(0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -2940,35 +2443,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ (comp_index_t1.v1:1 BETWEEN 77 (tinyint) AND 85 (tinyint))\n" +
 			" │       │   └─ (comp_index_t1.v3:3 BETWEEN 16 (tinyint) AND 21 (tinyint))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 10 (tinyint) AND 42 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(5, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>43 AND v2<53 AND v3<=20) OR (v1<7 AND v2<>79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 7), (NULL, 79), [NULL, ∞)}, {(NULL, 7), (79, ∞), [NULL, ∞)}, {[7, 43), (NULL, 53), (NULL, 20]}, {(43, ∞), (NULL, 53), (NULL, 20]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>=17 AND v2 BETWEEN 17 AND 78 AND v3=10) AND (v1<=67) AND (v1>=81 AND v2<=88 AND v3>=70);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3021,13 +2515,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 45 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 34), (NULL, 21], (NULL, 45]}, {[85, 85], (0, 81], (NULL, 23)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3076,90 +2567,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 27 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 75], [NULL, ∞), [NULL, ∞)}, {(75, ∞), (NULL, 10), [NULL, ∞)}, {(75, ∞), [27, 27], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<=76) AND (v1<=94);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 76], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<>40 AND v2>1) OR (v1>3 AND v2<=42)) OR (v1=99 AND v2>62)) OR (v1<17 AND v2<>75 AND v3=6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 3], (NULL, 1], [6, 6]}, {(NULL, 3], (1, ∞), [NULL, ∞)}, {(3, 40), (NULL, ∞), [NULL, ∞)}, {[40, 40], (NULL, 42], [NULL, ∞)}, {(40, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1=39) OR (v1=40 AND v2<>49)) OR (v1<>35 AND v2>4 AND v3>26)) OR (v1=32 AND v2<>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 32), (4, ∞), (26, ∞)}, {[32, 32], (NULL, 55), [NULL, ∞)}, {[32, 32], [55, 55], (26, ∞)}, {[32, 32], (55, ∞), [NULL, ∞)}, {(32, 35), (4, ∞), (26, ∞)}, {(35, 39), (4, ∞), (26, ∞)}, {[39, 39], [NULL, ∞), [NULL, ∞)}, {(39, 40), (4, ∞), (26, ∞)}, {[40, 40], (NULL, 49), [NULL, ∞)}, {[40, 40], [49, 49], (26, ∞)}, {[40, 40], (49, ∞), [NULL, ∞)}, {(40, ∞), (4, ∞), (26, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=16 AND v2<>25 AND v3<>3) OR (v1>=4 AND v2 BETWEEN 4 AND 93 AND v3>39));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[4, 16), [4, 93], (39, ∞)}, {[16, 16], (NULL, 25), (NULL, 3)}, {[16, 16], (NULL, 25), (3, ∞)}, {[16, 16], [25, 25], (39, ∞)}, {[16, 16], (25, ∞), (NULL, 3)}, {[16, 16], (25, ∞), (3, ∞)}, {(16, ∞), [4, 93], (39, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1>=51 AND v2<83) OR (v1>=15 AND v2>=3)) OR (v1<=49)) OR (v1<69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 69), [NULL, ∞), [NULL, ∞)}, {[69, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<>43 AND v2>10) AND (v1>30 AND v2 BETWEEN 18 AND 78 AND v3 BETWEEN 75 AND 81);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(30, 43), [18, 78], [75, 81]}, {(43, ∞), [18, 78], [75, 81]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>1) OR (v1<34 AND v2>=57 AND v3 BETWEEN 15 AND 67));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 1], [57, ∞), [15, 67]}, {(1, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3184,35 +2651,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 3], [5, ∞), [27, ∞)}, {(3, 26], [5, 32], [27, ∞)}, {(3, ∞), (32, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25 AND v2<>70 AND v3<=51) OR (v1<=71 AND v2>59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 71], (59, ∞), [NULL, ∞)}, {(25, 71], (NULL, 59], (NULL, 51]}, {(71, ∞), (NULL, 70), (NULL, 51]}, {(71, ∞), (70, ∞), (NULL, 51]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1 BETWEEN 0 AND 61 AND v2<0) OR (v1 BETWEEN 0 AND 38 AND v2>34)) OR (v1>=13 AND v2>=41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[0, 38], (34, ∞), [NULL, ∞)}, {[0, 61], (NULL, 0), [NULL, ∞)}, {(38, ∞), [41, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3252,24 +2710,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 44 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 0], [28, 45], [24, 98]}, {(0, 44), (NULL, 28), [69, ∞)}, {(0, 44), [28, 45], [24, ∞)}, {(0, 44), (45, 47), [69, ∞)}, {(0, 44), (47, ∞), [69, ∞)}, {[44, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=48 AND v2 BETWEEN 33 AND 66) OR (v1>=91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 48], [33, 66], [NULL, ∞)}, {[91, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3305,90 +2757,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12], (NULL, 4), (53, ∞)}, {(NULL, 12], (4, 5), (53, ∞)}, {(NULL, 12], [5, 5], (NULL, ∞)}, {(NULL, 12], (5, ∞), (53, ∞)}, {(12, 17), [5, 5], (NULL, 94)}, {[17, 52], (NULL, 96), [NULL, ∞)}, {(52, 98), [5, 5], (NULL, 94)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>26 AND v2 BETWEEN 66 AND 79 AND v3<=94) OR (v1 BETWEEN 16 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 16), [66, 79], (NULL, 94]}, {[16, 55], [NULL, ∞), [NULL, ∞)}, {(55, ∞), [66, 79], (NULL, 94]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1 BETWEEN 36 AND 67 AND v3<74 AND v2=26) AND (v1 BETWEEN 9 AND 10 AND v2=96) AND (v1<=11 AND v2<>63 AND v3>=62);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 28 AND 49 AND v2<47) OR (v1>37 AND v2 BETWEEN 45 AND 61 AND v3<73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[28, 49], (NULL, 47), [NULL, ∞)}, {(37, 49], [47, 61], (NULL, 73)}, {(49, ∞), [45, 61], (NULL, 73)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<37 AND v2>=26 AND v3<=14) OR (v1<64)) OR (v1 BETWEEN 31 AND 53 AND v2>55 AND v3<=55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 64), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=77) OR (v1<50)) AND (v1<=53 AND v2>35 AND v3<>98);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 50), (35, ∞), (NULL, 98)}, {(NULL, 50), (35, ∞), (98, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1=2 AND v2=40 AND v3 BETWEEN 18 AND 67) OR (v1=14 AND v2<=24 AND v3<=87)) OR (v1 BETWEEN 8 AND 31 AND v2>86)) OR (v1>30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[2, 2], [40, 40], [18, 67]}, {[8, 30], (86, ∞), [NULL, ∞)}, {[14, 14], (NULL, 24], (NULL, 87]}, {(30, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>46 AND v2<>49 AND v3<=44) OR (v1 BETWEEN 64 AND 80 AND v2=41 AND v3<=68));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(46, 64), (NULL, 49), (NULL, 44]}, {(46, ∞), (49, ∞), (NULL, 44]}, {[64, 80], (NULL, 41), (NULL, 44]}, {[64, 80], [41, 41], (NULL, 68]}, {[64, 80], (41, 49), (NULL, 44]}, {(80, ∞), (NULL, 49), (NULL, 44]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3411,24 +2839,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 83 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[11, 36], (NULL, 83], [NULL, ∞)}, {[95, 95], [97, ∞), (NULL, 47)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=65 AND v2=39 AND v3 BETWEEN 49 AND 67) OR (v1<57 AND v2>35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 57), (35, ∞), [NULL, ∞)}, {[65, ∞), [39, 39], [49, 67]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3474,13 +2896,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 80 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 5), (NULL, 50), [34, 67]}, {(NULL, 16), (50, ∞), [34, 67]}, {[5, 16), (4, 50), [34, 67]}, {[5, 47], (NULL, 4), [34, 67]}, {[5, 47], [4, 4], [13, 76]}, {[16, 16], (4, 29), [34, 67]}, {[16, 16], [29, ∞), (NULL, 80)}, {[16, 16], [29, ∞), (80, ∞)}, {(16, 47], (4, 50), [34, 67]}, {(16, 85), (50, ∞), [34, 67]}, {(47, 71], (NULL, 50), [34, 67]}, {(71, 85), (NULL, 33), [34, 67]}, {(71, 85), (33, 50), [34, 67]}, {(71, ∞), [33, 33], [NULL, ∞)}, {(85, ∞), (NULL, 33), [34, 67]}, {(85, ∞), (33, 50), [34, 67]}, {(85, ∞), (50, ∞), [34, 67]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3502,24 +2921,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 38 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 38), [NULL, ∞), [NULL, ∞)}, {(38, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=4 AND v2=26) OR (v1>21 AND v2 BETWEEN 14 AND 64));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[4, 21], [26, 26], [NULL, ∞)}, {(21, ∞), [14, 64], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3541,112 +2954,82 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 10 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 50), [NULL, ∞), [NULL, ∞)}, {[50, 50], (NULL, 95], [NULL, ∞)}, {(50, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<=21 AND v2<>95) OR (v1<>23 AND v2 BETWEEN 15 AND 22)) OR (v1<=53 AND v2>=6)) OR (v1<=13 AND v2<>93 AND v3<15));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 21], (NULL, ∞), [NULL, ∞)}, {(21, 53], [6, ∞), [NULL, ∞)}, {(53, ∞), [15, 22], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<64 AND v2>=90 AND v3>41) AND (v1>=14 AND v2 BETWEEN 30 AND 70 AND v3>=25);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<27 AND v2<=43) OR (v1<62 AND v2<=99)) OR (v1<>48 AND v2<29 AND v3<>69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 62), (NULL, 99], [NULL, ∞)}, {[62, ∞), (NULL, 29), (NULL, 69)}, {[62, ∞), (NULL, 29), (69, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<11 AND v2<70 AND v3>27) OR (v1>=80 AND v2<31 AND v3<65)) OR (v1>=98 AND v2 BETWEEN 30 AND 85 AND v3>=30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 11), (NULL, 70), (27, ∞)}, {[80, 98), (NULL, 31), (NULL, 65)}, {[98, ∞), (NULL, 30), (NULL, 65)}, {[98, ∞), [30, 31), (NULL, ∞)}, {[98, ∞), [31, 85], [30, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<>44 AND v2>=10) AND (v1=47 AND v2=14 AND v3<30);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[47, 47], [14, 14], (NULL, 30)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>6 AND v2=50) OR (v1>=16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(6, 16), [50, 50], [NULL, ∞)}, {[16, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=31) OR (v1>53 AND v2<>11 AND v3<>94)) OR (v1>48 AND v2 BETWEEN 11 AND 29 AND v3 BETWEEN 68 AND 72));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[31, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 55 AND 59) OR (v1<=10 AND v2>=24)) AND (v1>93 AND v3<70 AND v2 BETWEEN 44 AND 79) AND (v1>=22 AND v2=27);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=43 AND v2<28 AND v3<>24) OR (v1<36 AND v2=14 AND v3 BETWEEN 16 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 36), [14, 14], [16, 55]}, {[43, ∞), (NULL, 28), (NULL, 24)}, {[43, ∞), (NULL, 28), (24, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3669,35 +3052,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(48, ∞), (NULL, 80], [NULL, ∞)}, {[72, 72], [98, 98], [45, 52]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>=98 AND v2=51) AND (v1>34);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[98, ∞), [51, 51], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>2) OR (v1<=30)) OR (v1<>35 AND v2 BETWEEN 6 AND 61 AND v3>=16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3712,57 +3086,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 48 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 12 AND 42 AND v2<=12) OR (v1<34 AND v2 BETWEEN 30 AND 47 AND v3<>50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 34), [30, 47], (NULL, 50)}, {(NULL, 34), [30, 47], (50, ∞)}, {[12, 42], (NULL, 12], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((((v1>=6) OR (v1>7)) OR (v1<88 AND v2<=34 AND v3<=47)) OR (v1>=10)) OR (v1=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), (NULL, 34], (NULL, 47]}, {[6, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=74) OR (v1>=1)) OR (v1=54 AND v2>=38 AND v3>2)) AND (v1>5);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(5, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=45 AND v2>18) OR (v1<64 AND v2=25 AND v3>97));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 45), [25, 25], (97, ∞)}, {[45, ∞), (18, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3788,24 +3147,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 87 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 37), [NULL, ∞), [NULL, ∞)}, {(38, ∞), [87, 87], (NULL, 57)}, {(38, ∞), [87, 87], (57, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<96 AND v2>11 AND v3<76) OR (v1<=14 AND v2=23)) OR (v1<=15 AND v2<21 AND v3<91)) OR (v1=45 AND v2<11 AND v3=1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 14], [21, 23), (NULL, 76)}, {(NULL, 14], [23, 23], [NULL, ∞)}, {(NULL, 14], (23, ∞), (NULL, 76)}, {(NULL, 15], (NULL, 21), (NULL, 91)}, {(14, 15], [21, ∞), (NULL, 76)}, {(15, 96), (11, ∞), (NULL, 76)}, {[45, 45], (NULL, 11), [1, 1]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3828,46 +3181,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 25 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 23), [NULL, ∞), [NULL, ∞)}, {[23, 23], [25, 25], [NULL, ∞)}, {(23, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<=12 AND v2>=65) AND (v1<6 AND v2>=92);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), [92, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=62 AND v2<>32) OR (v1>=55 AND v2=41 AND v3>73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[55, 62), [41, 41], (73, ∞)}, {[62, 62], (NULL, 32), [NULL, ∞)}, {[62, 62], (32, ∞), [NULL, ∞)}, {(62, ∞), [41, 41], (73, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>34 AND v2<=62) OR (v1>5 AND v2 BETWEEN 59 AND 98 AND v3<69)) OR (v1>34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 34), (NULL, 62], [NULL, ∞)}, {(5, 34), (62, 98], (NULL, 69)}, {[34, 34], [59, 98], (NULL, 69)}, {(34, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3896,46 +3237,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 67 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 61), (NULL, 67), [7, 63]}, {[61, 61], (NULL, 10), [7, 63]}, {[61, 61], [10, 22], (NULL, 63]}, {[61, 61], (22, 67), [7, 63]}, {(61, 68), (NULL, 67), [7, 63]}, {[68, 68], [NULL, ∞), [NULL, ∞)}, {(68, 97], (NULL, 67), [7, 63]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=42) OR (v1 BETWEEN 13 AND 30 AND v2<50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 42], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 16 AND 49) OR (v1<=69 AND v2>9 AND v3<=8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 16), (9, ∞), (NULL, 8]}, {[16, 49], [NULL, ∞), [NULL, ∞)}, {(49, 69], (9, ∞), (NULL, 8]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>71 AND v2>44) OR (v1<76 AND v2>=10)) OR (v1>=44 AND v2=66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 76), [10, ∞), [NULL, ∞)}, {[76, ∞), (44, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -3980,24 +3309,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 0 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 0), [NULL, ∞), [NULL, ∞)}, {[0, 0], [0, 54], [NULL, ∞)}, {(0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=99 AND v2<66) OR (v1 BETWEEN 1 AND 47)) OR (v1<>2 AND v2<30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 1), (NULL, 30), [NULL, ∞)}, {[1, 47], [NULL, ∞), [NULL, ∞)}, {(47, 99), (NULL, 30), [NULL, ∞)}, {[99, ∞), (NULL, 66), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4023,24 +3346,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 46), [NULL, ∞), [NULL, ∞)}, {[46, 63], [18, 18], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<=20 AND v2<=62) OR (v1>45 AND v2=33 AND v3<=4)) OR (v1>29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 20], (NULL, 62], [NULL, ∞)}, {(29, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4081,13 +3398,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 73 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 55], [82, 96], [13, ∞)}, {[7, 74], (NULL, 73], [NULL, ∞)}, {[89, 98), (NULL, 18), (NULL, 19)}, {[98, 98], [NULL, ∞), [NULL, ∞)}, {(98, ∞), (NULL, 18), (NULL, 19)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4114,13 +3428,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 63 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[47, 47], [6, 67), (NULL, 7)}, {(63, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4134,13 +3445,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 33 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 33), [NULL, ∞), [NULL, ∞)}, {(33, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4186,46 +3494,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ AND\n" +
 			" │       ├─ (comp_index_t1.v1:1 BETWEEN 22 (tinyint) AND 23 (tinyint))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 14 (tinyint) AND 46 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 94], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<9 AND v2=94 AND v3>8) OR (v1>=63));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 9), [94, 94], (8, ∞)}, {[63, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<43) OR (v1 BETWEEN 40 AND 49 AND v2>26 AND v3 BETWEEN 22 AND 80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 43), [NULL, ∞), [NULL, ∞)}, {[43, 49], (26, ∞), [22, 80]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 4 AND 85 AND v2<>45 AND v3<=41) OR (v1>67 AND v2<25));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[4, 67], (NULL, 45), (NULL, 41]}, {[4, 85], (45, ∞), (NULL, 41]}, {(67, 85], [25, 45), (NULL, 41]}, {(67, ∞), (NULL, 25), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4259,24 +3555,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 6 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 77), [NULL, ∞), [NULL, ∞)}, {[77, 77], (NULL, 30), [6, 6]}, {(77, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1 BETWEEN 21 AND 53 AND v2=0 AND v3>32) OR (v1=93 AND v2>=94 AND v3<1)) OR (v1<26)) OR (v1<>11 AND v2<>32 AND v3=6)) AND (v1>=45);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[45, 53], [0, 0], (32, ∞)}, {[45, ∞), (NULL, 32), [6, 6]}, {[45, ∞), (32, ∞), [6, 6]}, {[93, 93], [94, ∞), (NULL, 1)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4290,24 +3580,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 71 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=41) OR (v1>29 AND v2<>31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(29, 41), (NULL, 31), [NULL, ∞)}, {(29, 41), (31, ∞), [NULL, ∞)}, {[41, 41], [NULL, ∞), [NULL, ∞)}, {(41, ∞), (NULL, 31), [NULL, ∞)}, {(41, ∞), (31, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4338,13 +3622,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 40 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[5, 40), [21, 29], (18, ∞)}, {[40, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4367,13 +3648,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t1.v1:1\n" +
 			" │       │   └─ 12 (tinyint)\n" +
 			" │       └─ (comp_index_t1.v3:3 BETWEEN 25 (tinyint) AND 30 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 12], [NULL, ∞), [NULL, ∞)}, {(12, ∞), (NULL, 76), (NULL, 35]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4413,57 +3691,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 48 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 48), [NULL, ∞), [NULL, ∞)}, {[48, 48], (NULL, 94], [NULL, ∞)}, {(48, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=24) OR (v1>=47 AND v2<=75 AND v3<=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[24, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=21 AND v2<>70) OR (v1<=77 AND v2>4)) OR (v1<28 AND v2<=3 AND v3<>21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 21), (NULL, 3], (NULL, 21)}, {(NULL, 21), (NULL, 3], (21, ∞)}, {(NULL, 21), (4, ∞), [NULL, ∞)}, {[21, 77], (NULL, ∞), [NULL, ∞)}, {(77, ∞), (NULL, 70), [NULL, ∞)}, {(77, ∞), (70, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=60 AND v2>91) OR (v1<=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 10], [NULL, ∞), [NULL, ∞)}, {[60, ∞), (91, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>98 AND v2<52) OR (v1 BETWEEN 65 AND 67)) OR (v1 BETWEEN 18 AND 54)) AND (v1>=14 AND v2=27);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[14, 98), [27, 27], [NULL, ∞)}, {(98, ∞), [27, 27], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4496,46 +3759,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   └─ 68 (tinyint)\n" +
 			" │       │  ))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 42 (tinyint) AND 46 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 68), [42, 46], [NULL, ∞)}, {(68, ∞), [42, 46], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>=19 AND v2<2) AND (v1<4 AND v3>23 AND v2<>53);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 34 AND 40) OR (v1<=80 AND v2<>53)) AND (v1=81 AND v2=17 AND v3<>12);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>34 AND v2 BETWEEN 18 AND 67 AND v3<67) OR (v1>21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(21, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4571,90 +3822,66 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 45 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 45), [NULL, ∞), [NULL, ∞)}, {[45, 45], (NULL, 45), (NULL, 32]}, {[45, 45], (45, ∞), (NULL, 32]}, {(45, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=48) OR (v1<38 AND v2>=26)) AND (v1<=45 AND v2>21) AND (v1=83 AND v2=20);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25) OR (v1<53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<95 AND v2>=12) OR (v1 BETWEEN 41 AND 55 AND v2<=81 AND v3<46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 95), [12, ∞), [NULL, ∞)}, {[41, 55], (NULL, 12), (NULL, 46)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>39 AND v2 BETWEEN 53 AND 73 AND v3<=11) OR (v1<=31 AND v2=68 AND v3>=71)) OR (v1<>18 AND v2<=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 18), (NULL, 51], [NULL, ∞)}, {(NULL, 31], [68, 68], [71, ∞)}, {(18, ∞), (NULL, 51], [NULL, ∞)}, {(39, ∞), [53, 73], (NULL, 11]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>4) AND (v1=3 AND v2 BETWEEN 4 AND 34 AND v3<=40);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>36 AND v2>82) OR (v1 BETWEEN 22 AND 59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[22, 59], [NULL, ∞), [NULL, ∞)}, {(59, ∞), (82, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=0) OR (v1 BETWEEN 17 AND 45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 0], [NULL, ∞), [NULL, ∞)}, {[17, 45], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4674,24 +3901,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 70 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 1), [NULL, ∞), [NULL, ∞)}, {[2, 57], (NULL, 70), [NULL, ∞)}, {[2, 57], (70, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1>4) AND (v1 BETWEEN 8 AND 35 AND v2>=94 AND v3=32) AND (v1>=12);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[12, 35], [94, ∞), [32, 32]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4725,68 +3946,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 33 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>12) OR (v1>=26 AND v2 BETWEEN 77 AND 87 AND v3<19)) OR (v1<=89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1=27 AND v2=16 AND v3>=8) OR (v1<20 AND v2>=1 AND v3 BETWEEN 28 AND 47)) OR (v1 BETWEEN 15 AND 43 AND v2>30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 15), [1, ∞), [28, 47]}, {[15, 20), [1, 30], [28, 47]}, {[15, 43], (30, ∞), [NULL, ∞)}, {[27, 27], [16, 16], [8, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=67 AND v2<>69) OR (v1<28 AND v2<62 AND v3>=99));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 28), (NULL, 62), [99, ∞)}, {[67, 67], (NULL, 69), [NULL, ∞)}, {[67, 67], (69, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<45 AND v2>5 AND v3>20) OR (v1<17));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 17), [NULL, ∞), [NULL, ∞)}, {[17, 45), (5, ∞), (20, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=40 AND v2<>18) OR (v1<>97 AND v2<>17 AND v3<>48));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 40), (NULL, 17), (NULL, 48)}, {(NULL, 40), (NULL, 17), (48, ∞)}, {(NULL, 40), (17, ∞), (NULL, 48)}, {(NULL, 40), (17, ∞), (48, ∞)}, {[40, 40], (NULL, 18), [NULL, ∞)}, {[40, 40], [18, 18], (NULL, 48)}, {[40, 40], [18, 18], (48, ∞)}, {[40, 40], (18, ∞), [NULL, ∞)}, {(40, 97), (NULL, 17), (NULL, 48)}, {(40, 97), (NULL, 17), (48, ∞)}, {(40, 97), (17, ∞), (NULL, 48)}, {(40, 97), (17, ∞), (48, ∞)}, {(97, ∞), (NULL, 17), (NULL, 48)}, {(97, ∞), (NULL, 17), (48, ∞)}, {(97, ∞), (17, ∞), (NULL, 48)}, {(97, ∞), (17, ∞), (48, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4816,35 +4019,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 45 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[38, 38], (45, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=6) OR (v1>0 AND v2 BETWEEN 3 AND 50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6], [NULL, ∞), [NULL, ∞)}, {(6, ∞), [3, 50], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 5 AND 35 AND v2<=3 AND v3<>14) OR (v1>11));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[5, 11], (NULL, 3], (NULL, 14)}, {[5, 11], (NULL, 3], (14, ∞)}, {(11, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4874,13 +4068,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 65 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 19), [10, ∞), [NULL, ∞)}, {[19, 36), (10, ∞), (NULL, 65)}, {[19, 36), (10, ∞), (65, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4914,24 +4105,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 31 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[10, 21), [62, ∞), [NULL, ∞)}, {[21, 31], (NULL, ∞), [NULL, ∞)}, {(31, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<20 AND v2>=1 AND v3=26) OR (v1=12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 12), [1, ∞), [26, 26]}, {[12, 12], [NULL, ∞), [NULL, ∞)}, {(12, 20), [1, ∞), [26, 26]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4962,68 +4147,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 4), (NULL, 47), [77, ∞)}, {(4, 41], (NULL, 47), [77, ∞)}, {(41, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<35) OR (v1>=58 AND v2>=0));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 35), [NULL, ∞), [NULL, ∞)}, {[58, ∞), [0, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>28 AND v2<95) OR (v1<91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 91), [NULL, ∞), [NULL, ∞)}, {[91, ∞), (NULL, 95), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1=99 AND v2<=41 AND v3>=61) AND (v1=34 AND v2>68 AND v3<=42);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=74 AND v2<=18) OR (v1>=72)) AND (v1=95 AND v2=31 AND v3 BETWEEN 5 AND 19);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[95, 95], [31, 31], [5, 19]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1=64) OR (v1>=49 AND v2<9 AND v3<=49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[49, 64), (NULL, 9), (NULL, 49]}, {[64, 64], [NULL, ∞), [NULL, ∞)}, {(64, ∞), (NULL, 9), (NULL, 49]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5052,35 +4219,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t1.v1:1\n" +
 			" │       │   └─ 55 (tinyint)\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 11 (tinyint) AND 84 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[55, ∞), [11, 84], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=7) OR (v1<54));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 54), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<=95 AND v2=55 AND v3>34) OR (v1=19));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 19), [55, 55], (34, ∞)}, {[19, 19], [NULL, ∞), [NULL, ∞)}, {(19, 95], [55, 55], (34, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5117,24 +4275,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 12 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 50), [NULL, ∞), [NULL, ∞)}, {[50, 50], (56, ∞), [NULL, ∞)}, {(50, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1<=90 AND v2<=17) OR (v1=2)) OR (v1<>70 AND v2>=84 AND v3<>42)) OR (v1<11 AND v2<>47 AND v3<55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 17], [NULL, ∞)}, {(NULL, 2), (17, 47), (NULL, 55)}, {(NULL, 2), (47, 84), (NULL, 55)}, {(NULL, 2), [84, ∞), (NULL, ∞)}, {[2, 2], [NULL, ∞), [NULL, ∞)}, {(2, 11), (17, 47), (NULL, 55)}, {(2, 11), (47, 84), (NULL, 55)}, {(2, 11), [84, ∞), (NULL, ∞)}, {(2, 90], (NULL, 17], [NULL, ∞)}, {[11, 70), [84, ∞), (NULL, 42)}, {[11, 70), [84, ∞), (42, ∞)}, {(70, ∞), [84, ∞), (NULL, 42)}, {(70, ∞), [84, ∞), (42, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5154,24 +4306,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 46 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[23, 50), (NULL, 46), [87, ∞)}, {[23, 50), (46, ∞), [87, ∞)}, {[50, 59], [NULL, ∞), [NULL, ∞)}, {(59, ∞), (NULL, 46), [87, ∞)}, {(59, ∞), (46, ∞), [87, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<53) OR (v1<=3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 53), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5203,13 +4349,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 7 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[16, 17), [66, 94], [NULL, ∞)}, {[17, 17], [7, ∞), [NULL, ∞)}, {(17, 91), [66, 94], [NULL, ∞)}, {(70, 91), (NULL, 3], [NULL, ∞)}, {(91, ∞), (NULL, 3], [NULL, ∞)}, {(91, ∞), [66, 94], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5230,13 +4373,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 59), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5261,13 +4401,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(19, 42), (84, ∞), (94, ∞)}, {[42, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5293,13 +4430,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5318,46 +4452,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 68 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>15 AND v2>=22 AND v3<=51) OR (v1<>40 AND v2>26 AND v3<95));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 15), [22, 26], (NULL, 51]}, {(NULL, 40), (26, ∞), (NULL, 95)}, {(15, 40), [22, 26], (NULL, 51]}, {[40, 40], [22, ∞), (NULL, 51]}, {(40, ∞), [22, 26], (NULL, 51]}, {(40, ∞), (26, ∞), (NULL, 95)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>6) OR (v1<=67 AND v2<>67 AND v3>=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6], (NULL, 67), [88, ∞)}, {(NULL, 6], (67, ∞), [88, ∞)}, {(6, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<=0) OR (v1<=53)) OR (v1<=38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 53], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5380,35 +4502,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 26 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[1, 49], [NULL, ∞), [NULL, ∞)}, {[60, 60], [10, 69], [2, 13]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1 BETWEEN 14 AND 20 AND v2<>70) OR (v1>78 AND v2 BETWEEN 31 AND 52 AND v3>16)) OR (v1 BETWEEN 77 AND 78));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[14, 20], (NULL, 70), [NULL, ∞)}, {[14, 20], (70, ∞), [NULL, ∞)}, {[77, 78], [NULL, ∞), [NULL, ∞)}, {(78, ∞), [31, 52], (16, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<80 AND v2 BETWEEN 41 AND 74) OR (v1>=36 AND v2=32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 80), [41, 74], [NULL, ∞)}, {[36, ∞), [32, 32], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5438,13 +4551,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 90 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 15), [12, 25], [51, 51]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5474,13 +4584,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 52 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 90), [NULL, ∞), [NULL, ∞)}, {(90, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5505,68 +4612,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 84 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[6, 74], [52, 52], [NULL, ∞)}, {(44, 74], [17, 52), [15, ∞)}, {(44, 74], (52, 94], [15, ∞)}, {(74, 84], [17, 94], [15, ∞)}, {(84, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=38) OR (v1=13)) OR (v1=25 AND v2<=32 AND v3 BETWEEN 12 AND 92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[13, 13], [NULL, ∞), [NULL, ∞)}, {[25, 25], (NULL, 32], [12, 92]}, {[38, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<=84) OR (v1=41)) OR (v1<83 AND v2=13 AND v3=58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 84], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<36 AND v2<=79 AND v3>47) OR (v1 BETWEEN 24 AND 89 AND v2<29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 24), (NULL, 79], (47, ∞)}, {[24, 36), [29, 79], (47, ∞)}, {[24, 89], (NULL, 29), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 3 AND 19 AND v2<=57 AND v3>61) OR (v1<=58 AND v2>=36 AND v3=31)) AND (v1>94);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<78 AND v2 BETWEEN 55 AND 64 AND v3>=0) OR (v1<74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 74), [NULL, ∞), [NULL, ∞)}, {[74, 78), [55, 64], [0, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5601,35 +4690,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 9 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 38], [NULL, ∞), [NULL, ∞)}, {(38, 74], [88, 88], (NULL, 33)}, {(74, ∞), [9, ∞), (NULL, 55)}, {(74, ∞), [9, ∞), (55, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1 BETWEEN 15 AND 96 AND v2<>73) OR (v1>=16));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[15, 16), (NULL, 73), [NULL, ∞)}, {[15, 16), (73, ∞), [NULL, ∞)}, {[16, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=72 AND v2<>19 AND v3 BETWEEN 9 AND 12) OR (v1<=77 AND v2=30 AND v3<=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 72), [30, 30], (NULL, 10]}, {[72, 77], (19, 30), [9, 12]}, {[72, 77], [30, 30], (NULL, 12]}, {[72, 77], (30, ∞), [9, 12]}, {[72, ∞), (NULL, 19), [9, 12]}, {(77, ∞), (19, ∞), [9, 12]}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5670,13 +4750,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 43 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 36), [NULL, ∞), [NULL, ∞)}, {[47, 47], [0, 92], (NULL, 43]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5697,24 +4774,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 78 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(68, 78], [1, 79], [23, 44]}, {(78, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1=47 AND v2=7) OR (v1>=7 AND v2<>87)) OR (v1<>6 AND v2<=84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 6), (NULL, 84], [NULL, ∞)}, {(6, 7), (NULL, 84], [NULL, ∞)}, {[7, ∞), (NULL, 87), [NULL, ∞)}, {[7, ∞), (87, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5765,35 +4836,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(30, ∞), [66, ∞), [NULL, ∞)}, {[49, ∞), (53, 66), (NULL, 12)}, {[49, ∞), (53, 66), (12, ∞)}, {[62, 62], (NULL, 22], [37, ∞)}, {[95, 95], (NULL, 1), (NULL, 89)}, {[95, 95], (NULL, 1), (89, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1=24 AND v2<81) OR (v1<=22 AND v2>34 AND v3<55)) OR (v1=45 AND v2>=94 AND v3>17));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 22], (34, ∞), (NULL, 55)}, {[24, 24], (NULL, 81), [NULL, ∞)}, {[45, 45], [94, ∞), (17, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1>38) OR (v1<51 AND v2>=28 AND v3=44)) OR (v1 BETWEEN 23 AND 61 AND v2 BETWEEN 54 AND 75 AND v3<>44)) OR (v1>72));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 38], [28, ∞), [44, 44]}, {[23, 38], [54, 75], (NULL, 44)}, {[23, 38], [54, 75], (44, ∞)}, {(38, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5833,13 +4895,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 74 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 57), [NULL, ∞), [NULL, ∞)}, {[57, 57], [26, 30], [NULL, ∞)}, {(57, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5870,24 +4929,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   └─ 46 (tinyint)\n" +
 			" │       │  ))\n" +
 			" │       └─ (comp_index_t1.v2:2 BETWEEN 4 (tinyint) AND 26 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 11), [4, 26], [NULL, ∞)}, {[11, 47), [NULL, ∞), [NULL, ∞)}, {[47, 47], [4, 26], [NULL, ∞)}, {(47, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1 BETWEEN 41 AND 98 AND v2>54) OR (v1<29)) OR (v1<32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(NULL, 32), [NULL, ∞), [NULL, ∞)}, {[41, 98], (54, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5907,13 +4960,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t1.v3:3\n" +
 			" │           └─ 94 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{[50, 50], [16, 38], (NULL, 94)}, {[50, 50], [16, 38], (94, ∞)}, {[79, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5947,35 +4997,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t1.v2:2\n" +
 			" │           └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 79), [NULL, ∞), [NULL, ∞)}, {[79, 79], (NULL, 4), [NULL, ∞)}, {(79, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=2 AND v2 BETWEEN 32 AND 59 AND v3 BETWEEN 50 AND 52) OR (v1<26)) OR (v1<>2 AND v2>11)) AND (v1>32 AND v2<=92) AND (v1>45 AND v2<>5 AND v3<>49);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(45, ∞), (11, 92], (NULL, 49)}, {(45, ∞), (11, 92], (49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=19) AND (v1<=73) OR (v1=9 AND v2=5 AND v3<=5));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[9, 9], [5, 5], (NULL, 5]}, {[19, 73], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6011,79 +5052,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t1.v1:1\n" +
 			" │       └─ 94 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t1)\n" +
 			"     ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			"     ├─ static: [{(NULL, 28), (51, ∞), [29, 30]}, {[28, 57], (62, ∞), [29, 30]}, {[28, 94), (NULL, 62], (NULL, 76)}, {[28, 94), (NULL, 62], (76, ∞)}, {[94, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>21) OR (v1>=86 AND v2>2 AND v3>=67));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{(21, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>=94) OR (v1>=57 AND v2<>53 AND v3>22));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
 			" ├─ static: [{[57, 94), (NULL, 53), (22, ∞)}, {[57, 94), (53, ∞), (22, ∞)}, {[94, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<40 AND v2=9) OR (v1<11 AND v2=15 AND v3<>55 AND v4<>95));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [15, 15], (NULL, 55), (NULL, 95)}, {(NULL, 11), [15, 15], (NULL, 55), (95, ∞)}, {(NULL, 11), [15, 15], (55, ∞), (NULL, 95)}, {(NULL, 11), [15, 15], (55, ∞), (95, ∞)}, {(NULL, 40), [9, 9], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=82 AND v2=74 AND v3=98) OR (v1=27 AND v2 BETWEEN 16 AND 46 AND v3<>27)) OR (v1>=80 AND v2<>42 AND v3>=47));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 80), [74, 74], [98, 98], [NULL, ∞)}, {[27, 27], [16, 46], (NULL, 27), [NULL, ∞)}, {[27, 27], [16, 46], (27, ∞), [NULL, ∞)}, {[80, ∞), (NULL, 42), [47, ∞), [NULL, ∞)}, {[80, ∞), (42, ∞), [47, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1>=47 AND v2<=37 AND v3<90 AND v4=25) OR (v1<42 AND v2>=96 AND v3=38)) OR (v1>26)) OR (v1>=80));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 26], [96, ∞), [38, 38], [NULL, ∞)}, {(26, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>33 AND v2>=16) OR (v1>=24));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[24, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6120,13 +5140,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 94 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 60], (NULL, 1), [NULL, ∞), [NULL, ∞)}, {[51, 51], (62, ∞), (NULL, 43), [36, 55]}, {[51, 51], [98, ∞), [94, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6161,35 +5178,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 98], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(98, ∞), [6, 11], (NULL, 4], (44, 95)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=12 AND v2<=78 AND v3 BETWEEN 28 AND 63 AND v4 BETWEEN 46 AND 95) OR (v1=87 AND v2<=44)) OR (v1<14 AND v2<>37 AND v3 BETWEEN 6 AND 32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 14), (NULL, 37), [6, 32], [NULL, ∞)}, {(NULL, 14), (37, ∞), [6, 32], [NULL, ∞)}, {[12, 14), (NULL, 37), (32, 63], [46, 95]}, {[12, 14), [37, 37], [28, 63], [46, 95]}, {[12, 14), (37, 78], (32, 63], [46, 95]}, {[14, 87), (NULL, 78], [28, 63], [46, 95]}, {[87, 87], (NULL, 44], [NULL, ∞), [NULL, ∞)}, {[87, 87], (44, 78], [28, 63], [46, 95]}, {(87, ∞), (NULL, 78], [28, 63], [46, 95]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=80 AND v2=72 AND v3>19) OR (v1<>38 AND v2>=86 AND v3=7)) OR (v1<=52 AND v2=25 AND v3 BETWEEN 7 AND 32 AND v4<=31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 38), [86, ∞), [7, 7], [NULL, ∞)}, {(NULL, 52], [25, 25], [7, 32], (NULL, 31]}, {(NULL, 80], [72, 72], (19, ∞), [NULL, ∞)}, {(38, ∞), [86, ∞), [7, 7], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6204,13 +5212,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 38 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 25 (tinyint) AND 30 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[38, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6232,35 +5237,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 38 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 33], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>14 AND v2<51 AND v3 BETWEEN 67 AND 78 AND v4=8) OR (v1>=44 AND v2<>35 AND v3<35 AND v4>=12)) OR (v1>=63 AND v2<=3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(14, 63), (NULL, 51), [67, 78], [8, 8]}, {[44, 63), (NULL, 35), (NULL, 35), [12, ∞)}, {[44, ∞), (35, ∞), (NULL, 35), [12, ∞)}, {[63, ∞), (NULL, 3], [NULL, ∞), [NULL, ∞)}, {[63, ∞), (3, 35), (NULL, 35), [12, ∞)}, {[63, ∞), (3, 51), [67, 78], [8, 8]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=6 AND v2<=25 AND v3>39) OR (v1 BETWEEN 17 AND 94 AND v2>96));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[6, 6], (NULL, 25], (39, ∞), [NULL, ∞)}, {[17, 94], (96, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6307,35 +5303,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 44 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[72, 75), [48, 48], (NULL, 10], [NULL, ∞)}, {[75, 75], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(75, 88], [48, 48], (NULL, 10], [NULL, ∞)}, {[91, ∞), [43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=31) OR (v1<84 AND v2<=73 AND v3<>2 AND v4<=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 31), (NULL, 73], (NULL, 2), (NULL, 51]}, {(NULL, 31), (NULL, 73], (2, ∞), (NULL, 51]}, {[31, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(31, 84), (NULL, 73], (NULL, 2), (NULL, 51]}, {(31, 84), (NULL, 73], (2, ∞), (NULL, 51]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=20 AND v2<=29 AND v3<52 AND v4<>34) OR (v1<>46 AND v2<>98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 46), (NULL, 98), [NULL, ∞), [NULL, ∞)}, {(NULL, 46), (98, ∞), [NULL, ∞), [NULL, ∞)}, {(46, ∞), (NULL, 98), [NULL, ∞), [NULL, ∞)}, {(46, ∞), (98, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6377,59 +5364,44 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 10 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44], (NULL, 98), [NULL, ∞), [NULL, ∞)}, {(NULL, 44], [98, 99], [39, 57], [13, 13]}, {(44, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=40) OR (v1=27)) OR (v1>90 AND v2>50 AND v3=66 AND v4<83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[27, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[40, 40], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(90, ∞), (50, ∞), [66, 66], (NULL, 83)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<=92 AND v4 BETWEEN 8 AND 90) AND (v1 BETWEEN 39 AND 42);`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (comp_index_t2.v4:4 BETWEEN 8 (tinyint) AND 90 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[39, 42], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 23 AND 85 AND v2<=51 AND v3<>68) OR (v1 BETWEEN 30 AND 58 AND v2<>75));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[23, 30), (NULL, 51], (NULL, 68), [NULL, ∞)}, {[23, 30), (NULL, 51], (68, ∞), [NULL, ∞)}, {[30, 58], (NULL, 75), [NULL, ∞), [NULL, ∞)}, {[30, 58], (75, ∞), [NULL, ∞), [NULL, ∞)}, {(58, 85], (NULL, 51], (NULL, 68), [NULL, ∞)}, {(58, 85], (NULL, 51], (68, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=67 AND v2<=17 AND v3<>91 AND v4<82) OR (v1>28 AND v2 BETWEEN 17 AND 71 AND v3<12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(28, ∞), [17, 71], (NULL, 12), [NULL, ∞)}, {[67, ∞), (NULL, 17), (NULL, 91), (NULL, 82)}, {[67, ∞), (NULL, 17], (91, ∞), (NULL, 82)}, {[67, ∞), [17, 17], [12, 91), (NULL, 82)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6457,26 +5429,20 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 60 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[41, 77], (21, ∞), (60, ∞), [NULL, ∞)}, {[41, 80], (NULL, 21), (60, ∞), [NULL, ∞)}, {(77, 80], (21, 96), (60, ∞), [NULL, ∞)}, {(77, ∞), [96, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=28 AND v4 BETWEEN 44 AND 50) AND (v1>=49);`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (comp_index_t2.v4:4 BETWEEN 44 (tinyint) AND 50 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6517,13 +5483,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 27), (NULL, 8), (35, ∞), [NULL, ∞)}, {(NULL, 27), (8, ∞), (35, ∞), [NULL, ∞)}, {(28, ∞), (NULL, 62), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6559,13 +5522,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 73 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(65, 82), [64, 64], [NULL, ∞), [NULL, ∞)}, {[68, 82), [3, 3], [1, 51], (NULL, 73]}, {[82, 82], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(82, ∞), [3, 3], [1, 51], (NULL, 73]}, {(82, ∞), [64, 64], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6587,13 +5547,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 43 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(27, 70), (NULL, 43), [NULL, ∞), [NULL, ∞)}, {(27, 70), (43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6631,35 +5588,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   │       └─ 23 (tinyint)\n" +
 			" │       │   └─ (comp_index_t2.v3:3 BETWEEN 17 (tinyint) AND 37 (tinyint))\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 21 (tinyint) AND 38 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 42], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(42, 59), [23, 89), [17, 37], [21, 38]}, {(42, ∞), [89, ∞), [14, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=52 AND v2>=55) OR (v1<73 AND v2<=1 AND v3>75 AND v4<=36)) OR (v1>=45 AND v2>=49 AND v3<=26 AND v4 BETWEEN 40 AND 83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 73), (NULL, 1], (75, ∞), (NULL, 36]}, {[45, 52), [49, ∞), (NULL, 26], [40, 83]}, {[52, ∞), [49, 55), (NULL, 26], [40, 83]}, {[52, ∞), [55, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>0 AND v2=94 AND v3<>0) OR (v1>=83 AND v2<69 AND v3<84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(0, ∞), [94, 94], (NULL, 0), [NULL, ∞)}, {(0, ∞), [94, 94], (0, ∞), [NULL, ∞)}, {[83, ∞), (NULL, 69), (NULL, 84), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6677,35 +5625,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 30 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<92) OR (v1 BETWEEN 6 AND 39 AND v2=47 AND v3>=63));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 92), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=98) OR (v1<=2 AND v2<5));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2], (NULL, 5), [NULL, ∞), [NULL, ∞)}, {[98, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6752,24 +5691,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 22 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 4), (NULL, 70), (NULL, 20], [NULL, ∞)}, {[4, 29], (22, 70), (NULL, 20], [NULL, ∞)}, {[4, ∞), (NULL, 22], [NULL, ∞), [NULL, ∞)}, {[7, 29], [33, ∞), (78, ∞), [NULL, ∞)}, {(29, 61], [33, 63), (78, ∞), [NULL, ∞)}, {(29, 70), (22, 63), (NULL, 20], [NULL, ∞)}, {(29, ∞), [63, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=12) OR (v1=28));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 12], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[28, 28], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6806,24 +5739,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 45 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[52, 98], (NULL, 71), (NULL, 45), [NULL, ∞)}, {[52, 98], (NULL, 71), (45, ∞), [NULL, ∞)}, {[84, 84], [13, 71), [45, 45], (NULL, 36)}, {[84, 84], [13, 71), [45, 45], (36, ∞)}, {[84, 84], [71, ∞), (NULL, 46], (NULL, 36)}, {[84, 84], [71, ∞), (NULL, 46], (36, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>64) OR (v1<>55 AND v2=85 AND v3<=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 55), [85, 85], (NULL, 88], [NULL, ∞)}, {(55, 64], [85, 85], (NULL, 88], [NULL, ∞)}, {(64, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6861,24 +5788,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 2 AND 23) OR (v1 BETWEEN 7 AND 14 AND v2<=27 AND v3<=82)) OR (v1>61));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[2, 23], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(61, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6919,24 +5840,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v4:4\n" +
 			" │       └─ 32 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=85 AND v2<12) AND (v1>=25);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[85, ∞), (NULL, 12), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -6964,24 +5879,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 0), [27, 69], [14, 14], (9, ∞)}, {[0, 0], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(0, 31), [27, 69], [14, 14], (9, ∞)}, {[31, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(31, 73), [27, 69], [14, 14], (9, ∞)}, {(73, ∞), [27, 69], [14, 14], (9, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=42 AND v2=41 AND v3 BETWEEN 29 AND 94 AND v4<71) OR (v1>=71 AND v2 BETWEEN 67 AND 87 AND v3>=9)) OR (v1<2 AND v2<=1 AND v3<36 AND v4>41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 1], (NULL, 36), (41, ∞)}, {[42, ∞), [41, 41], [29, 94], (NULL, 71)}, {[71, ∞), [67, 87], [9, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7020,13 +5929,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 58 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3], (NULL, 16), (NULL, 74), [69, ∞)}, {(NULL, 3], (NULL, 16), (74, ∞), [69, ∞)}, {(NULL, 3], (16, 57), (NULL, 74), [69, ∞)}, {(NULL, 3], (16, 57), (74, ∞), [69, ∞)}, {(NULL, 44), [16, 16], [NULL, ∞), [NULL, ∞)}, {[44, 44], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(44, 66), [16, 16], [NULL, ∞), [NULL, ∞)}, {(66, ∞), [16, 16], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7063,13 +5969,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 87 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 10), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[10, 10], (NULL, 41], [NULL, ∞), [NULL, ∞)}, {(10, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7108,13 +6011,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 19 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 13], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(13, 18), [47, ∞), (NULL, 11), [NULL, ∞)}, {[18, 19], (11, ∞), (22, ∞), [NULL, ∞)}, {(19, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7134,35 +6034,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 32 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 68), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(68, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 20 AND 93) AND (v1=66 AND v2<>21 AND v3 BETWEEN 43 AND 94);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[66, 66], (21, ∞), [43, 94], [NULL, ∞)}, {[66, 66], (NULL, 21), [43, 94], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>83 AND v2<>16 AND v3=22) AND (v1=34) AND (v1=79 AND v2<=45 AND v3=49);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7192,13 +6083,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 54 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44), [1, 1], (NULL, 54), [NULL, ∞)}, {(NULL, 44), [1, 1], (54, ∞), [NULL, ∞)}, {[44, 44], (NULL, 98], [NULL, ∞), [NULL, ∞)}, {(44, 45], [1, 1], (NULL, 54), [NULL, ∞)}, {(44, 45], [1, 1], (54, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7235,13 +6123,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 69 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 20), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[20, 31), [6, 6], (NULL, 69], [2, 16]}, {[20, 38), (24, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7297,24 +6182,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v4:4\n" +
 			" │   │           └─ 27 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 37 (tinyint) AND 62 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(62, 63), [35, ∞), [96, ∞), [NULL, ∞)}, {(62, ∞), [52, 52], [86, 86], (NULL, 27]}, {[63, 63], [35, 55), [96, ∞), [NULL, ∞)}, {[63, 63], [55, 55], (NULL, 46), [NULL, ∞)}, {[63, 63], [55, 55], (46, ∞), [NULL, ∞)}, {[63, 63], (55, ∞), [96, ∞), [NULL, ∞)}, {(63, 72], [35, ∞), [96, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=52) OR (v1>=59 AND v2<=30 AND v3=98 AND v4 BETWEEN 43 AND 74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[52, 52], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[59, ∞), (NULL, 30], [98, 98], [43, 74]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7359,13 +6238,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 11 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[59, 59], (NULL, 56], [NULL, ∞), [NULL, ∞)}, {[83, ∞), (NULL, 11], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7409,13 +6285,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 50 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 9), (16, ∞), (NULL, 44), [3, 31]}, {[9, 9], (NULL, 50), [NULL, ∞), [NULL, ∞)}, {[9, 9], [50, ∞), (NULL, 44), [3, 31]}, {(9, 39), (16, ∞), (NULL, 44), [3, 31]}, {(39, 72], (16, ∞), (NULL, 44), [3, 31]}, {(72, ∞), (16, 73), (NULL, 44), [3, 31]}, {(72, ∞), [73, 73], (NULL, 37), (NULL, 43]}, {(72, ∞), [73, 73], [37, 44), [3, 31]}, {(72, ∞), (73, ∞), (NULL, 44), [3, 31]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7445,13 +6318,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 35 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7471,13 +6341,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 42 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 89 (tinyint) AND 94 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3), [89, 94], [NULL, ∞), [NULL, ∞)}, {(3, 13], [89, 94], [NULL, ∞), [NULL, ∞)}, {(13, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7532,35 +6399,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(27, ∞), [8, ∞), (NULL, 24), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<77 AND v2 BETWEEN 5 AND 22 AND v3<>91 AND v4<34) OR (v1=68 AND v2=50)) OR (v1<44 AND v2>84 AND v3<37 AND v4>=67));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 44), (84, ∞), (NULL, 37), [67, ∞)}, {(NULL, 77), [5, 22], (NULL, 91), (NULL, 34)}, {(NULL, 77), [5, 22], (91, ∞), (NULL, 34)}, {[68, 68], [50, 50], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<4 AND v2>=71) OR (v1<18 AND v2=57));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4), [71, ∞), [NULL, ∞), [NULL, ∞)}, {(NULL, 18), [57, 57], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7586,13 +6444,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 97), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(97, ∞), [46, 51], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7616,13 +6471,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 59 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 25 (tinyint) AND 58 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[4, 47), [19, 65], [NULL, ∞), [NULL, ∞)}, {(47, 71], [19, 65], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7663,13 +6515,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 76), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[76, 76], [53, 67], [39, ∞), [NULL, ∞)}, {(76, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7725,24 +6574,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 34 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22], (76, ∞), [38, 42], (NULL, 40)}, {(NULL, 22], (76, ∞), [38, 42], (40, ∞)}, {(NULL, 33), (NULL, 93), [83, ∞), [NULL, ∞)}, {[8, 33), (NULL, 31], [30, 46], [28, ∞)}, {[33, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 13 AND 40 AND v2>=0) OR (v1<>3 AND v2>47 AND v3<44 AND v4>49)) OR (v1=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 3), (47, ∞), (NULL, 44), (49, ∞)}, {(3, 13), (47, ∞), (NULL, 44), (49, ∞)}, {[13, 23), [0, ∞), [NULL, ∞), [NULL, ∞)}, {[23, 23], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(23, 40], [0, ∞), [NULL, ∞), [NULL, ∞)}, {(40, ∞), (47, ∞), (NULL, 44), (49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7779,13 +6622,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 31 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 30], [6, 61], (NULL, 95], (5, ∞)}, {(31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7838,13 +6678,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 13 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 6], (NULL, 3], [6, 6], (NULL, 77]}, {(6, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7876,35 +6713,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 5], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[95, ∞), (NULL, 72), [22, 22], [28, 28]}, {[95, ∞), (72, ∞), [22, 22], [28, 28]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=95 AND v2<1 AND v3 BETWEEN 49 AND 61 AND v4=51) OR (v1>29 AND v2>=9 AND v3>=63 AND v4<=88));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(29, ∞), [9, ∞), [63, ∞), (NULL, 88]}, {[95, 95], (NULL, 1), [49, 61], [51, 51]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>30 AND v2 BETWEEN 20 AND 64) AND (v1<=29) AND (v1>=25 AND v2<>0);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7933,35 +6761,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ AND\n" +
 			" │       ├─ (comp_index_t2.v1:1 BETWEEN 10 (tinyint) AND 46 (tinyint))\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 18 (tinyint) AND 76 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[10, 46], [18, 76], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=44 AND v2>=45 AND v3>=34 AND v4>1) OR (v1=33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[33, 33], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[44, 44], [45, ∞), [34, ∞), (1, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1<>12 AND v2<=6) OR (v1>99 AND v2<>51 AND v3=38)) OR (v1>60)) OR (v1 BETWEEN 69 AND 77 AND v2>=49 AND v3>=43));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 12), (NULL, 6], [NULL, ∞), [NULL, ∞)}, {(12, 60], (NULL, 6], [NULL, ∞), [NULL, ∞)}, {(60, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -7995,24 +6814,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 22 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[7, 45], (NULL, 11], [NULL, ∞), [NULL, ∞)}, {[16, 45], (11, 53), (NULL, 15), (22, ∞)}, {[16, 45], (11, 53), (15, ∞), (22, ∞)}, {(45, 65], (NULL, 53), (NULL, 15), (22, ∞)}, {(45, 65], (NULL, 53), (15, ∞), (22, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<11) OR (v1<=38 AND v2>=93 AND v3<=34 AND v4>7));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[11, 38], [93, ∞), (NULL, 34], (7, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8037,13 +6850,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 97 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 97], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8068,24 +6878,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 84 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 64], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(64, ∞), [0, 58], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 24 AND 98 AND v2>0 AND v3>=87) OR (v1 BETWEEN 2 AND 3 AND v2 BETWEEN 15 AND 78));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[2, 3], [15, 78], [NULL, ∞), [NULL, ∞)}, {[24, 98], (0, ∞), [87, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8132,35 +6936,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 37), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[37, 37], (NULL, 24), (NULL, 46), [NULL, ∞)}, {[37, 37], (24, 53), (NULL, 46), [NULL, ∞)}, {[37, 37], [53, 65], (NULL, ∞), [NULL, ∞)}, {[37, 37], (65, ∞), (NULL, 46), [NULL, ∞)}, {(37, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>21 AND v2>27 AND v3>=97 AND v4 BETWEEN 25 AND 67) OR (v1>=66 AND v2<=56)) OR (v1=37));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 21), (27, ∞), [97, ∞), [25, 67]}, {(21, 37), (27, ∞), [97, ∞), [25, 67]}, {[37, 37], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(37, 66), (27, ∞), [97, ∞), [25, 67]}, {[66, ∞), (NULL, 56], [NULL, ∞), [NULL, ∞)}, {[66, ∞), (56, ∞), [97, ∞), [25, 67]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=43 AND v2<48 AND v3<16 AND v4<=75) OR (v1<71));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 71), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8189,13 +6984,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8227,13 +7019,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 97 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(8, ∞), (NULL, 43], (NULL, 97), [NULL, ∞)}, {(8, ∞), (NULL, 43], (97, ∞), [NULL, ∞)}, {[54, 54], [3, 8], [97, 97], (30, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8266,46 +7055,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 23 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 23), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(23, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<20 AND v2<>84 AND v3<25 AND v4>=93) OR (v1<13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 13), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[13, 20), (NULL, 84), (NULL, 25), [93, ∞)}, {[13, 20), (84, ∞), (NULL, 25), [93, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=81 AND v2 BETWEEN 55 AND 77 AND v3=64) OR (v1=20 AND v2=21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[20, 20], [21, 21], [NULL, ∞), [NULL, ∞)}, {[81, ∞), [55, 77], [64, 64], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>30 AND v2 BETWEEN 58 AND 72 AND v3<=35) OR (v1 BETWEEN 28 AND 28 AND v2>=76)) OR (v1=74 AND v2<26));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[28, 28], [76, ∞), [NULL, ∞), [NULL, ∞)}, {(30, ∞), [58, 72], (NULL, 35], [NULL, ∞)}, {[74, 74], (NULL, 26), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8369,24 +7146,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[1, 1], [64, 81], (46, ∞), (NULL, 29)}, {[1, 1], [64, 81], (46, ∞), (29, ∞)}, {(5, 11], (8, 35), (NULL, 10], (NULL, 76)}, {[22, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=49) OR (v1<43 AND v2>=34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 43), [34, ∞), [NULL, ∞), [NULL, ∞)}, {[49, 49], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8427,24 +7198,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 10 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 11 (tinyint) AND 93 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 17), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(17, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<2 AND v2<>94) OR (v1<>76 AND v2=27 AND v3<=31 AND v4<38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), (NULL, 94), [NULL, ∞), [NULL, ∞)}, {(NULL, 2), (94, ∞), [NULL, ∞), [NULL, ∞)}, {[2, 76), [27, 27], (NULL, 31], (NULL, 38)}, {(76, ∞), [27, 27], (NULL, 31], (NULL, 38)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8504,13 +7269,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 30 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(62, ∞), (NULL, 96), [4, 29], [65, ∞)}, {(62, ∞), (47, ∞), [67, ∞), [29, 29]}, {(62, ∞), (96, ∞), [4, 29], [65, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8543,13 +7305,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 50 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 17), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[17, 17], (NULL, 5), [38, ∞), (91, ∞)}, {(17, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8581,13 +7340,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 70 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 86), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8624,24 +7380,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v3:3\n" +
 			" │   │           └─ 28 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 36 (tinyint) AND 40 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[36, 40], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=24 AND v2=61 AND v3<49 AND v4<82) OR (v1<4 AND v2>51 AND v3=9));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4), (51, ∞), [9, 9], [NULL, ∞)}, {[24, ∞), [61, 61], (NULL, 49), (NULL, 82)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8678,35 +7428,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 44 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1), (NULL, 11), (NULL, 44), (NULL, 66)}, {(NULL, 1), (NULL, 11), (44, ∞), (NULL, 66)}, {[0, 87], [44, ∞), (NULL, 68), [50, 50]}, {[0, 87], [44, ∞), (68, ∞), [50, 50]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<17 AND v2<54) AND (v1>=70 AND v2 BETWEEN 53 AND 53 AND v3>10 AND v4=17);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1=21 AND v2>25 AND v3>=7) OR (v1 BETWEEN 23 AND 88 AND v2<=26 AND v3>=87 AND v4 BETWEEN 42 AND 95)) OR (v1<4 AND v2>=66 AND v3<=24 AND v4=10)) OR (v1>69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4), [66, ∞), (NULL, 24], [10, 10]}, {[21, 21], (25, ∞), [7, ∞), [NULL, ∞)}, {[23, 69], (NULL, 26], [87, ∞), [42, 95]}, {(69, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8721,13 +7462,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 90 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 39], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8761,24 +7499,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 71 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[2, 71), (NULL, 78), (NULL, 29), (NULL, 63)}, {[2, 71), (NULL, 78), (NULL, 29), (63, ∞)}, {[2, 71), (NULL, 78), (29, ∞), (NULL, 63)}, {[2, 71), (NULL, 78), (29, ∞), (63, ∞)}, {[2, 71), (78, ∞), (29, ∞), (NULL, 63)}, {[2, 71), (78, ∞), (29, ∞), (63, ∞)}, {[2, 86], (78, ∞), (NULL, 29), (NULL, 63)}, {[2, 86], (78, ∞), (NULL, 29), (63, ∞)}, {[71, 71], (1, 53), (29, 56], (NULL, 63)}, {[71, 71], (1, 53), (29, 56], (63, ∞)}, {[71, 71], (1, 78), (NULL, 29), (NULL, 63)}, {[71, 71], (1, 78), (NULL, 29), (63, ∞)}, {[71, 71], [53, 53], (29, ∞), (NULL, 63)}, {[71, 71], [53, 53], (29, ∞), (63, ∞)}, {[71, 71], (53, 78), (29, 56], (NULL, 63)}, {[71, 71], (53, 78), (29, 56], (63, ∞)}, {[71, 71], (78, ∞), (29, 56], (NULL, 63)}, {[71, 71], (78, ∞), (29, 56], (63, ∞)}, {(71, 86], (NULL, 78), (NULL, 29), (NULL, 63)}, {(71, 86], (NULL, 78), (NULL, 29), (63, ∞)}, {(71, 86], (NULL, 78), (29, ∞), (NULL, 63)}, {(71, 86], (NULL, 78), (29, ∞), (63, ∞)}, {(71, 86], (78, ∞), (29, ∞), (NULL, 63)}, {(71, 86], (78, ∞), (29, ∞), (63, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=5) OR (v1=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 5], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[53, 53], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8787,24 +7519,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ GreaterThan\n" +
 			" │   ├─ comp_index_t2.v3:3\n" +
 			" │   └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(34, 88], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(88, ∞), [27, 46], [19, 27], [50, ∞)}, {(88, ∞), (84, ∞), [90, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=82) OR (v1<=95 AND v2<>23 AND v3<18 AND v4<>50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 82), (NULL, 23), (NULL, 18), (NULL, 50)}, {(NULL, 82), (NULL, 23), (NULL, 18), (50, ∞)}, {(NULL, 82), (23, ∞), (NULL, 18), (NULL, 50)}, {(NULL, 82), (23, ∞), (NULL, 18), (50, ∞)}, {[82, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8833,13 +7559,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 34 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(5, ∞), (NULL, 34), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8875,13 +7598,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 5 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(4, 24), (NULL, 21], [15, ∞), [NULL, ∞)}, {[24, 86], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(86, 93), (NULL, 21], [15, ∞), [NULL, ∞)}, {[93, 93], (NULL, 1), [15, ∞), [NULL, ∞)}, {[93, 93], [1, 21], (NULL, ∞), [NULL, ∞)}, {[93, 93], (21, ∞), (NULL, 63), [NULL, ∞)}, {[93, 93], (21, ∞), (63, ∞), [NULL, ∞)}, {(93, ∞), (NULL, 21], [15, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8917,13 +7637,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 21 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 18), (NULL, 21), [14, ∞), [NULL, ∞)}, {(NULL, 18), [21, ∞), [NULL, ∞), [NULL, ∞)}, {[18, 18], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(18, 23), (NULL, 21), [14, ∞), [NULL, ∞)}, {(18, 23), [21, ∞), [NULL, ∞), [NULL, ∞)}, {[23, 63), (NULL, 32), [14, ∞), [NULL, ∞)}, {[23, 63), (32, ∞), [14, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -8970,13 +7687,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 17 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 36], (NULL, 17), [NULL, ∞), [NULL, ∞)}, {(NULL, 36], (17, ∞), [NULL, ∞), [NULL, ∞)}, {(36, 47), (42, 48), [27, 47], (NULL, 11]}, {(47, ∞), (42, 48), [27, 47], (NULL, 11]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9010,13 +7724,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 31 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 56], [50, 50], [0, 5], (NULL, 31)}, {(NULL, 56], [50, 50], [0, 5], (31, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9046,13 +7757,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 93], (NULL, 5), [NULL, ∞), [NULL, ∞)}, {(NULL, 93], (5, ∞), [NULL, ∞), [NULL, ∞)}, {(93, ∞), (33, ∞), (NULL, 99), [9, 9]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9098,13 +7806,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 2 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[1, 1], [43, 43], (NULL, 2], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9129,13 +7834,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 86 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 4], [51, ∞), [NULL, ∞), [NULL, ∞)}, {[58, 58], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, 82], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9184,13 +7886,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 70 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 8), (NULL, 76), [36, 70], [NULL, ∞)}, {(NULL, 8), (76, ∞), [36, 70], [NULL, ∞)}, {[42, 70), (NULL, 8), (NULL, 3), (NULL, 85)}, {[70, 70], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(70, 78), (NULL, 8), (NULL, 3), (NULL, 85)}, {[78, ∞), (NULL, 28), (NULL, 52), [NULL, ∞)}, {[78, ∞), (28, ∞), (NULL, 52), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9204,13 +7903,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 43 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9254,57 +7950,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 58 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 25), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[39, 50), (21, ∞), [27, 35), (18, ∞)}, {[39, 50), (21, ∞), (35, 90], (18, ∞)}, {(50, 76], (21, ∞), [27, 35), (18, ∞)}, {(50, 76], (21, ∞), (35, 90], (18, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=62) OR (v1 BETWEEN 24 AND 36 AND v2>=94 AND v3 BETWEEN 10 AND 55 AND v4>=89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[24, 36], [94, ∞), [10, 55], [89, ∞)}, {[62, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=31) OR (v1<=95 AND v2<=26 AND v3 BETWEEN 40 AND 72)) OR (v1<51 AND v2=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 31), (NULL, 23), [40, 72], [NULL, ∞)}, {(NULL, 31), [23, 23], [NULL, ∞), [NULL, ∞)}, {(NULL, 31), (23, 26], [40, 72], [NULL, ∞)}, {[31, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(31, 51), (NULL, 23), [40, 72], [NULL, ∞)}, {(31, 51), [23, 23], [NULL, ∞), [NULL, ∞)}, {(31, 51), (23, 26], [40, 72], [NULL, ∞)}, {[51, 95], (NULL, 26], [40, 72], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=3) OR (v1>40)) AND (v1>66 AND v2>33);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(66, ∞), (33, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=69 AND v2=61 AND v3=87 AND v4 BETWEEN 63 AND 87) OR (v1 BETWEEN 48 AND 62)) OR (v1<>81 AND v2<=67 AND v3<>43));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 48), (NULL, 67], (NULL, 43), [NULL, ∞)}, {(NULL, 48), (NULL, 67], (43, ∞), [NULL, ∞)}, {[48, 62], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(62, 81), (NULL, 67], (NULL, 43), [NULL, ∞)}, {(62, 81), (NULL, 67], (43, ∞), [NULL, ∞)}, {[81, 81], [61, 61], [87, 87], [63, 87]}, {(81, ∞), (NULL, 67], (NULL, 43), [NULL, ∞)}, {(81, ∞), (NULL, 67], (43, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9335,13 +8016,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[12, 19), (NULL, 43), (NULL, 59), [1, ∞)}, {[19, 19], (NULL, 2), (NULL, 59), [1, ∞)}, {[19, 19], [2, ∞), [NULL, ∞), [NULL, ∞)}, {(19, 53], (NULL, 43), (NULL, 59), [1, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9371,13 +8049,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 62 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 14], (NULL, 1), (NULL, 62), [NULL, ∞)}, {(NULL, 14], (1, ∞), (NULL, 62), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9404,13 +8079,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v3:3\n" +
 			" │       └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 51), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(51, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9449,13 +8121,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 26 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[26, 26], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[36, 36], (NULL, 77), (94, ∞), [NULL, ∞)}, {(97, ∞), (NULL, 45), (NULL, 77), [30, 30]}, {(97, ∞), (NULL, 45), (77, ∞), [30, 30]}, {(97, ∞), (45, ∞), (NULL, 77), [30, 30]}, {(97, ∞), (45, ∞), (77, ∞), [30, 30]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9480,35 +8149,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 72 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[34, 37], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[43, 81], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=17 AND v2<>19) OR (v1>45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[17, 45], (NULL, 19), [NULL, ∞), [NULL, ∞)}, {[17, 45], (19, ∞), [NULL, ∞), [NULL, ∞)}, {(45, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=57) OR (v1>=1 AND v2<=5 AND v3>=10 AND v4<5)) OR (v1>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[1, 55], (NULL, 5], [10, ∞), (NULL, 5)}, {(55, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9553,13 +8213,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 62 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[23, 23], (NULL, 48], [NULL, ∞), [NULL, ∞)}, {(41, ∞), [46, ∞), [11, 29], [NULL, ∞)}, {[70, 70], (NULL, 46), (NULL, 54), (NULL, 47]}, {[70, 70], [46, 62), (NULL, 11), (NULL, 47]}, {[70, 70], [46, 62), (29, 54), (NULL, 47]}, {[70, 70], (62, ∞), (NULL, 11), (NULL, 47]}, {[70, 70], (62, ∞), (29, 54), (NULL, 47]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9619,13 +8276,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 41 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 56 (tinyint) AND 93 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 34), (11, 95), [17, 81], (48, ∞)}, {(5, 34), (11, 95), (81, 89], (48, 53]}, {(5, 34), [95, ∞), [43, 89], (48, 53]}, {[34, 41), (11, ∞), [43, 89], (48, 53]}, {[41, 41], (11, 56), [43, 89], (48, 53]}, {[41, 41], [56, 93], [NULL, ∞), [NULL, ∞)}, {[41, 41], (93, ∞), [43, 89], (48, 53]}, {(41, 68], (11, ∞), [43, 89], (48, 53]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9652,13 +8306,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 8 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[3, 3], (NULL, 16), (NULL, 8), [NULL, ∞)}, {(3, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9691,57 +8342,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 83], [34, ∞), [59, 59], [NULL, ∞)}, {(67, 88), (NULL, 5), (40, ∞), (NULL, 27]}, {[88, 97], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(97, ∞), (NULL, 5), (40, ∞), (NULL, 27]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>96 AND v2<=2 AND v3=17 AND v4<79) OR (v1=67 AND v2=30 AND v3=38 AND v4=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 96), (NULL, 2], [17, 17], (NULL, 79)}, {[67, 67], [30, 30], [38, 38], [53, 53]}, {(96, ∞), (NULL, 2], [17, 17], (NULL, 79)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>45 AND v2>76) OR (v1=30 AND v2=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 45), (76, ∞), [NULL, ∞), [NULL, ∞)}, {[30, 30], [53, 53], [NULL, ∞), [NULL, ∞)}, {(45, ∞), (76, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 3 AND 34 AND v2>39) OR (v1>1 AND v2>=92 AND v3=99)) OR (v1>=36 AND v2<>65 AND v3=69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(1, 3), [92, ∞), [99, 99], [NULL, ∞)}, {[3, 34], (39, ∞), [NULL, ∞), [NULL, ∞)}, {(34, ∞), [92, ∞), [99, 99], [NULL, ∞)}, {[36, ∞), (NULL, 65), [69, 69], [NULL, ∞)}, {[36, ∞), (65, ∞), [69, 69], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=54 AND v2=38 AND v3>=64 AND v4>36) OR (v1<=48)) OR (v1<37 AND v2=13 AND v3<20));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 48], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[54, ∞), [38, 38], [64, ∞), (36, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9770,13 +8406,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 42 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 70), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[70, 70], (79, ∞), (NULL, 6), (NULL, 42)}, {[70, 70], (79, ∞), (NULL, 6), (42, ∞)}, {[70, 70], (79, ∞), (6, ∞), (NULL, 42)}, {[70, 70], (79, ∞), (6, ∞), (42, ∞)}, {(70, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9806,13 +8439,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 61 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(22, 61), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9860,46 +8490,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 30 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 41), (0, 11), [95, 95], (NULL, 2]}, {(NULL, 41), [11, 35], [NULL, ∞), [NULL, ∞)}, {(NULL, 41), (35, ∞), [95, 95], (NULL, 2]}, {[11, 11], (NULL, 11), [51, 51], (NULL, 30)}, {[11, 11], (NULL, 11), [51, 51], (30, ∞)}, {[41, 53], (0, ∞), [95, 95], (NULL, 2]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=32 AND v2>6 AND v3=55) OR (v1=87 AND v2<=80)) OR (v1=88 AND v2<=87 AND v3>=45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 32], (6, ∞), [55, 55], [NULL, ∞)}, {[87, 87], (NULL, 80], [NULL, ∞), [NULL, ∞)}, {[88, 88], (NULL, 87], [45, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>8) OR (v1 BETWEEN 16 AND 25 AND v2<>79 AND v3>=55 AND v4<=5));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(8, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=45 AND v2>55 AND v3<90) OR (v1>26 AND v2>=2 AND v3<>85 AND v4<=74));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(26, 45), [2, ∞), (NULL, 85), (NULL, 74]}, {(26, 45), [2, ∞), (85, ∞), (NULL, 74]}, {[45, 45], [2, 55], (NULL, 85), (NULL, 74]}, {[45, 45], [2, 55], (85, ∞), (NULL, 74]}, {[45, 45], (55, ∞), (NULL, 90), [NULL, ∞)}, {[45, 45], (55, ∞), [90, ∞), (NULL, 74]}, {(45, ∞), [2, ∞), (NULL, 85), (NULL, 74]}, {(45, ∞), [2, ∞), (85, ∞), (NULL, 74]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9919,13 +8537,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 6 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 14 (tinyint) AND 82 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 59), [14, 82], [NULL, ∞), [NULL, ∞)}, {[59, 59], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(59, 85), [14, 82], [NULL, ∞), [NULL, ∞)}, {(85, ∞), [14, 82], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9958,35 +8573,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ Eq\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[39, 39], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(51, ∞), [46, ∞), [NULL, ∞), [NULL, ∞)}, {[94, ∞), (32, 46), (61, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=89) OR (v1<=28 AND v2=13));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 28], [13, 13], [NULL, ∞), [NULL, ∞)}, {[89, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=5 AND v2<65 AND v3<64 AND v4=81) OR (v1<=75)) AND (v1=87);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10025,13 +8631,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 33 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 35), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(35, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10088,13 +8691,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 67 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 37), (21, ∞), (NULL, 25], [32, 33]}, {[37, 48), (21, 42), (NULL, 25], [32, 33]}, {[37, 48), [42, 42], (14, 25], [32, 33]}, {[37, 48), (42, ∞), (NULL, 25], [32, 33]}, {[37, 51), [42, 42], (NULL, 14], [NULL, ∞)}, {(48, 51), (21, 42), (NULL, 25], [32, 33]}, {(48, 51), [42, 42], (14, 25], [32, 33]}, {(48, 51), (42, ∞), (NULL, 25], [32, 33]}, {[51, 88], (NULL, 67), [NULL, ∞), [NULL, ∞)}, {[51, 88], [67, 67], (NULL, 25], [32, 33]}, {[51, 88], (67, ∞), [NULL, ∞), [NULL, ∞)}, {(88, ∞), (21, 85), (NULL, 25], [32, 33]}, {(88, ∞), [85, 85], [NULL, ∞), [NULL, ∞)}, {(88, ∞), (85, 89), (NULL, 25], [32, 33]}, {(88, ∞), [89, 89], (NULL, 12], [32, 33]}, {(88, ∞), [89, 89], (12, ∞), [NULL, ∞)}, {(88, ∞), (89, ∞), (NULL, 25], [32, 33]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10127,35 +8727,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 85 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(27, ∞), [7, 79], [9, 29], (NULL, 85)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=41 AND v2<13 AND v3 BETWEEN 62 AND 87) AND (v1<=67 AND v2>68 AND v3=56 AND v4>28);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 23 AND 34 AND v2 BETWEEN 4 AND 75 AND v3<91) OR (v1>=31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[23, 31), [4, 75], (NULL, 91), [NULL, ∞)}, {[31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10183,35 +8774,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 29 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 86], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(86, 90), [43, 43], [29, 29], [NULL, ∞)}, {(90, ∞), [43, 43], [29, 29], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=1 AND v2<34) OR (v1<78));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 78), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[78, ∞), (NULL, 34), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=10 AND v2<>64 AND v3>25 AND v4<29) OR (v1>39));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[10, 10], (NULL, 64), (25, ∞), (NULL, 29)}, {[10, 10], (64, ∞), (25, ∞), (NULL, 29)}, {(39, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10261,13 +8843,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 16 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 14), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[14, 14], [14, ∞), (NULL, 65), (NULL, 9)}, {[14, 14], [14, ∞), (NULL, 65), (9, ∞)}, {(14, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10288,57 +8867,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(12, 36), (NULL, 0), [NULL, ∞), [NULL, ∞)}, {[36, 36], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(36, ∞), (NULL, 0), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=83 AND v3>=72 AND v4<=74) AND (v1>61 AND v2 BETWEEN 32 AND 44);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[83, 83], [32, 44], [72, ∞), (NULL, 74]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=78 AND v2>28 AND v3<=47) AND (v1<35 AND v2=69 AND v3>16);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 31 AND 49 AND v2=20 AND v3 BETWEEN 8 AND 46) AND (v1<>57 AND v2<5);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=39 AND v2<>3) OR (v1=97 AND v2<>37));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 39], (NULL, 3), [NULL, ∞), [NULL, ∞)}, {(NULL, 39], (3, ∞), [NULL, ∞), [NULL, ∞)}, {[97, 97], (NULL, 37), [NULL, ∞), [NULL, ∞)}, {[97, 97], (37, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10370,24 +8934,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 23 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 6 (tinyint) AND 43 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[19, 37), (NULL, 19), (NULL, 29), (NULL, 62)}, {[19, 37), (NULL, 19), (NULL, 29), (62, ∞)}, {[19, 37), (NULL, 19), (29, ∞), (NULL, 62)}, {[19, 37), (NULL, 19), (29, ∞), (62, ∞)}, {[19, 37), (19, ∞), (NULL, 29), (NULL, 62)}, {[19, 37), (19, ∞), (NULL, 29), (62, ∞)}, {[19, 37), (19, ∞), (29, ∞), (NULL, 62)}, {[19, 37), (19, ∞), (29, ∞), (62, ∞)}, {[37, 75], (NULL, 6), (NULL, 29), (NULL, 62)}, {[37, 75], (NULL, 6), (NULL, 29), (62, ∞)}, {[37, 75], (NULL, 6), (29, ∞), (NULL, 62)}, {[37, 75], (NULL, 6), (29, ∞), (62, ∞)}, {[37, 75], [6, 43], [NULL, ∞), [NULL, ∞)}, {[37, 75], (43, ∞), (NULL, 29), (NULL, 62)}, {[37, 75], (43, ∞), (NULL, 29), (62, ∞)}, {[37, 75], (43, ∞), (29, ∞), (NULL, 62)}, {[37, 75], (43, ∞), (29, ∞), (62, ∞)}, {(75, ∞), (NULL, 19), (NULL, 29), (NULL, 62)}, {(75, ∞), (NULL, 19), (NULL, 29), (62, ∞)}, {(75, ∞), (NULL, 19), (29, ∞), (NULL, 62)}, {(75, ∞), (NULL, 19), (29, ∞), (62, ∞)}, {(75, ∞), (19, ∞), (NULL, 29), (NULL, 62)}, {(75, ∞), (19, ∞), (NULL, 29), (62, ∞)}, {(75, ∞), (19, ∞), (29, ∞), (NULL, 62)}, {(75, ∞), (19, ∞), (29, ∞), (62, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<8 AND v2<=33 AND v3 BETWEEN 54 AND 85) OR (v1=46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 8), (NULL, 33], [54, 85], [NULL, ∞)}, {[46, 46], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10422,13 +8980,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 71 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[0, 0], [71, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10452,35 +9007,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v3:3\n" +
 			" │   │           └─ 76 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 31 (tinyint) AND 71 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 71], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>37 AND v2<>5 AND v3=8 AND v4 BETWEEN 26 AND 50) OR (v1>=53)) AND (v1 BETWEEN 5 AND 80);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(37, 53), (NULL, 5), [8, 8], [26, 50]}, {(37, 53), (5, ∞), [8, 8], [26, 50]}, {[53, 80], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=25) OR (v1<=87));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 87], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10515,46 +9061,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 79 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 6], [36, 68], (62, ∞), [79, 79]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 30 AND 32 AND v2<68 AND v3<24) AND (v1>=32);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[32, 32], (NULL, 68), (NULL, 24), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>62 AND v2>0) OR (v1<>80 AND v2>55 AND v3=10 AND v4=91));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 62], (55, ∞), [10, 10], [91, 91]}, {(62, ∞), (0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=7 AND v2 BETWEEN 55 AND 81) OR (v1<>56 AND v2<=76 AND v3<>36)) AND (v1<56 AND v2<>69 AND v3=25);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 7], (69, 81], [25, 25], [NULL, ∞)}, {(NULL, 56), (NULL, 69), [25, 25], [NULL, ∞)}, {(7, 56), (69, 76], [25, 25], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10580,24 +9114,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 80 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 18), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(18, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=27) OR (v1<23 AND v2>=41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10647,13 +9175,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 71 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 31), [33, ∞), (58, ∞), [NULL, ∞)}, {(NULL, 31), [89, 89], [46, 58], (NULL, 32]}, {[31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10686,35 +9211,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 8 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[9, 40], [43, ∞), (NULL, 43], [62, 62]}, {[61, 61], (12, ∞), [0, 13], [8, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1<58) OR (v1 BETWEEN 17 AND 20 AND v2<>99 AND v3<=76)) OR (v1 BETWEEN 48 AND 87)) OR (v1<39 AND v2 BETWEEN 48 AND 94 AND v3<>0));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 87], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=33) OR (v1 BETWEEN 7 AND 41 AND v2<82 AND v3<53 AND v4<>3));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[7, 33), (NULL, 82), (NULL, 53), (NULL, 3)}, {[7, 33), (NULL, 82), (NULL, 53), (3, ∞)}, {[33, 33], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(33, 41], (NULL, 82), (NULL, 53), (NULL, 3)}, {(33, 41], (NULL, 82), (NULL, 53), (3, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10735,13 +9251,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 96 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 9], [95, ∞), [NULL, ∞), [NULL, ∞)}, {(96, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10770,13 +9283,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 48 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 56], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(56, 91), (20, ∞), [NULL, ∞), [NULL, ∞)}, {[91, 91], (NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(91, ∞), (20, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10799,79 +9309,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 75], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(75, ∞), [16, 25], [99, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 2 AND 64) OR (v1>=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[2, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=26 AND v2<1 AND v3=82 AND v4<=42) OR (v1 BETWEEN 42 AND 73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 26], (NULL, 1), [82, 82], (NULL, 42]}, {[42, 73], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=23 AND v2<=10) AND (v1>=75 AND v4 BETWEEN 24 AND 68) AND (v1>44 AND v2>8 AND v3<=16);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[75, ∞), (8, 10], (NULL, 16], [24, 68]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((((v1>6 AND v2>61 AND v3=0 AND v4>=76) OR (v1<23)) OR (v1<>46 AND v2=29 AND v3>4)) OR (v1>=59)) OR (v1=87 AND v2<=98 AND v3>=47));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 23), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[23, 46), [29, 29], (4, ∞), [NULL, ∞)}, {[23, 59), (61, ∞), [0, 0], [76, ∞)}, {(46, 59), [29, 29], (4, ∞), [NULL, ∞)}, {[59, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=59 AND v2 BETWEEN 15 AND 53 AND v3<>17 AND v4>=10) OR (v1 BETWEEN 37 AND 95 AND v2<=32 AND v3>=81));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[37, 95], (NULL, 32], [81, ∞), [NULL, ∞)}, {[59, 59], [15, 32], (17, 81), [10, ∞)}, {[59, 59], [15, 53], (NULL, 17), [10, ∞)}, {[59, 59], (32, 53], (17, ∞), [10, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 6 AND 92 AND v2=75 AND v3>79) OR (v1>=10)) OR (v1<=35 AND v2<=42)) AND (v1<>65);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), (NULL, 42], [NULL, ∞), [NULL, ∞)}, {[6, 10), [75, 75], (79, ∞), [NULL, ∞)}, {[10, 65), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(65, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10909,13 +9398,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 76 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(78, ∞), (NULL, 1), [98, 98], [76, ∞)}, {(78, ∞), (1, ∞), [98, 98], [76, ∞)}, {(84, ∞), [77, 77], [40, ∞), (NULL, 53]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10936,24 +9422,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │       └─ 13 (tinyint)\n" +
 			" │   │      ))\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 4 (tinyint) AND 67 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>34) OR (v1<35 AND v2>=93)) OR (v1>8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 8], [93, ∞), [NULL, ∞), [NULL, ∞)}, {(8, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10996,13 +9476,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 28 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11037,13 +9514,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 35 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11073,13 +9547,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v2:2\n" +
 			" │       │       └─ 93 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 34 (tinyint) AND 41 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 34), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[34, 62], [1, 41], [NULL, ∞), [NULL, ∞)}, {[65, ∞), [93, ∞), [34, 41], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11096,46 +9567,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(8, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>57) OR (v1<87 AND v2<>91 AND v3 BETWEEN 47 AND 98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 57], (NULL, 91), [47, 98], [NULL, ∞)}, {(NULL, 57], (91, ∞), [47, 98], [NULL, ∞)}, {(57, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=57) OR (v1=88 AND v2 BETWEEN 72 AND 93));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[57, 57], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[88, 88], [72, 93], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>10 AND v2=20 AND v3<=21 AND v4<>88) OR (v1<28 AND v2 BETWEEN 38 AND 59 AND v3<>98 AND v4>=26));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), [20, 20], (NULL, 21], (NULL, 88)}, {(NULL, 10), [20, 20], (NULL, 21], (88, ∞)}, {(NULL, 28), [38, 59], (NULL, 98), [26, ∞)}, {(NULL, 28), [38, 59], (98, ∞), [26, ∞)}, {(10, ∞), [20, 20], (NULL, 21], (NULL, 88)}, {(10, ∞), [20, 20], (NULL, 21], (88, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11162,24 +9621,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 94 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 5), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[5, 5], (NULL, 94), [NULL, ∞), [NULL, ∞)}, {(5, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<52 AND v2 BETWEEN 33 AND 75 AND v3=32) OR (v1<=98 AND v2<=41 AND v3<>87 AND v4<>83));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 52), (NULL, 33), (NULL, 87), (NULL, 83)}, {(NULL, 52), (NULL, 33), (NULL, 87), (83, ∞)}, {(NULL, 52), [33, 41], (NULL, 32), (NULL, 83)}, {(NULL, 52), [33, 41], (NULL, 32), (83, ∞)}, {(NULL, 52), [33, 41], (32, 87), (NULL, 83)}, {(NULL, 52), [33, 41], (32, 87), (83, ∞)}, {(NULL, 52), [33, 75], [32, 32], [NULL, ∞)}, {(NULL, 98], (NULL, 41], (87, ∞), (NULL, 83)}, {(NULL, 98], (NULL, 41], (87, ∞), (83, ∞)}, {[52, 98], (NULL, 41], (NULL, 87), (NULL, 83)}, {[52, 98], (NULL, 41], (NULL, 87), (83, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11223,24 +9676,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 58 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22], (58, ∞), [NULL, ∞), [NULL, ∞)}, {(28, 72), [13, 62), (29, 41], (57, ∞)}, {(72, ∞), [13, 62), (29, 41], (57, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=13 AND v2<=52 AND v3=28 AND v4>88) OR (v1<>5 AND v2<=42));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 5), (NULL, 42], [NULL, ∞), [NULL, ∞)}, {(NULL, 5), (42, 52], [28, 28], (88, ∞)}, {[5, 5], (NULL, 52], [28, 28], (88, ∞)}, {(5, 13], (42, 52], [28, 28], (88, ∞)}, {(5, ∞), (NULL, 42], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11270,46 +9717,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 27 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(13, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=26) OR (v1<59 AND v2 BETWEEN 2 AND 30 AND v3>=69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 26), [2, 30], [69, ∞), [NULL, ∞)}, {[26, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<11) OR (v1<>9 AND v2 BETWEEN 51 AND 62 AND v3=98));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[11, ∞), [51, 62], [98, 98], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=92 AND v2>25) OR (v1=91 AND v2=21 AND v3<=18 AND v4<>15)) OR (v1=79 AND v2>67 AND v3<>48 AND v4<42));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[79, 79], (67, ∞), (NULL, 48), (NULL, 42)}, {[79, 79], (67, ∞), (48, ∞), (NULL, 42)}, {[91, 91], [21, 21], (NULL, 18], (NULL, 15)}, {[91, 91], [21, 21], (NULL, 18], (15, ∞)}, {[92, 92], (25, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11349,24 +9784,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 80 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 80], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(80, ∞), (24, ∞), (NULL, 5), [NULL, ∞)}, {[86, 86], (NULL, 5), (NULL, 36), (NULL, 81)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>67) OR (v1>69 AND v2>11 AND v3=13 AND v4=20));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(67, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11390,13 +9819,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 31), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[31, 31], [71, 71], [38, 38], [1, 1]}, {(31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11425,13 +9851,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 28 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 52], [71, ∞), [28, 28], [NULL, ∞)}, {(2, 52], [6, 23], [46, 52], [0, 0]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11440,13 +9863,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ GreaterThanOrEqual\n" +
 			" │   ├─ comp_index_t2.v4:4\n" +
 			" │   └─ 4 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11491,35 +9911,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(17, 46), [34, ∞), (NULL, 68), (NULL, 13]}, {(17, 46), [34, ∞), (68, ∞), (NULL, 13]}, {[46, 46], (NULL, 12), [NULL, ∞), [NULL, ∞)}, {[46, 46], (12, ∞), [NULL, ∞), [NULL, ∞)}, {(46, 98), [34, ∞), (NULL, 68), (NULL, 13]}, {(46, 98), [34, ∞), (68, ∞), (NULL, 13]}, {[98, ∞), [34, 39), (NULL, 68), (NULL, 13]}, {[98, ∞), [34, 39), (68, ∞), (NULL, 13]}, {[98, ∞), [39, 39], [NULL, ∞), [NULL, ∞)}, {[98, ∞), (39, ∞), (NULL, 68), (NULL, 13]}, {[98, ∞), (39, ∞), (68, ∞), (NULL, 13]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=12 AND v2<>4 AND v3 BETWEEN 18 AND 42) OR (v1>=73)) OR (v1<60 AND v2=93 AND v3>=79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 12], (NULL, 4), [18, 42], [NULL, ∞)}, {(NULL, 12], (4, ∞), [18, 42], [NULL, ∞)}, {(NULL, 60), [93, 93], [79, ∞), [NULL, ∞)}, {[73, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=55 AND v2>50) OR (v1<>51 AND v2>=37));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 51), [37, ∞), [NULL, ∞), [NULL, ∞)}, {(51, ∞), [37, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11561,46 +9972,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 42 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44), (NULL, 50], [36, 36], (NULL, 42]}, {[66, 76], [84, ∞), (1, ∞), [71, 95]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=21 AND v2=44 AND v3>=68) OR (v1>=38 AND v2>=15));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 21], [44, 44], [68, ∞), [NULL, ∞)}, {[38, ∞), [15, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<>37 AND v2>67 AND v3>52) AND (v1<48 AND v2<>73 AND v3=25 AND v4=22);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 57 AND 62 AND v2>=99) OR (v1>31));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11627,13 +10026,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 22), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(22, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11658,46 +10054,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 16 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 16], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(63, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1<=39 AND v2<>82 AND v3>=33 AND v4>=84) OR (v1=57 AND v2<25 AND v3<>55 AND v4<=82)) OR (v1>10 AND v2>28 AND v3>=65)) OR (v1<=13 AND v2=66));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10], (NULL, 66), [33, ∞), [84, ∞)}, {(NULL, 10], (66, 82), [33, ∞), [84, ∞)}, {(NULL, 10], (82, ∞), [33, ∞), [84, ∞)}, {(NULL, 13], [66, 66], [NULL, ∞), [NULL, ∞)}, {(10, 13], (28, 66), [33, 65), [84, ∞)}, {(10, 13], (28, 66), [65, ∞), [NULL, ∞)}, {(10, 13], (66, 82), [33, 65), [84, ∞)}, {(10, 13], (66, ∞), [65, ∞), [NULL, ∞)}, {(10, 39], (NULL, 28], [33, ∞), [84, ∞)}, {(10, 39], (82, ∞), [33, 65), [84, ∞)}, {(13, 39], (28, 82), [33, 65), [84, ∞)}, {(13, ∞), (28, ∞), [65, ∞), [NULL, ∞)}, {[57, 57], (NULL, 25), (NULL, 55), (NULL, 82]}, {[57, 57], (NULL, 25), (55, ∞), (NULL, 82]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=60 AND v2<=25 AND v3<>9) OR (v1 BETWEEN 19 AND 92 AND v2>=33 AND v3<=40 AND v4=53));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 60], (NULL, 25], (NULL, 9), [NULL, ∞)}, {(NULL, 60], (NULL, 25], (9, ∞), [NULL, ∞)}, {[19, 92], [33, ∞), (NULL, 40], [53, 53]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=21 AND v2<=27 AND v3>=86 AND v4>99) OR (v1<76 AND v2<>97));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 76), (NULL, 97), [NULL, ∞), [NULL, ∞)}, {(NULL, 76), (97, ∞), [NULL, ∞), [NULL, ∞)}, {[76, ∞), (NULL, 27], [86, ∞), (99, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11720,35 +10104,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 18 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[4, 8], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[12, ∞), [0, ∞), [18, 18], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1>65 AND v2<=52 AND v3>37) OR (v1>11)) OR (v1<=54 AND v2 BETWEEN 30 AND 85 AND v3 BETWEEN 14 AND 27 AND v4>=35)) OR (v1>44 AND v2<>76 AND v3>=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11], [30, 85], [14, 27], [35, ∞)}, {(11, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=54) OR (v1<17 AND v2=34 AND v3>=59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 17), [34, 34], [59, ∞), [NULL, ∞)}, {[54, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11777,46 +10152,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   ├─ comp_index_t2.v1:1\n" +
 			" │       │   └─ 2 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 3 (tinyint) AND 70 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 2), [3, 70], [NULL, ∞), [NULL, ∞)}, {(NULL, 9), [98, 98], (NULL, 1), (NULL, 61)}, {(NULL, 9), [98, 98], (NULL, 1), (61, ∞)}, {(9, ∞), [98, 98], (NULL, 1), (NULL, 61)}, {(9, ∞), [98, 98], (NULL, 1), (61, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=6 AND v2>93) OR (v1 BETWEEN 38 AND 46));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 6], (93, ∞), [NULL, ∞), [NULL, ∞)}, {[38, 46], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1 BETWEEN 16 AND 72) OR (v1=20)) OR (v1>61 AND v2<>48 AND v3<>83 AND v4=46)) OR (v1=5 AND v2=59));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[5, 5], [59, 59], [NULL, ∞), [NULL, ∞)}, {[16, 72], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(72, ∞), (NULL, 48), (NULL, 83), [46, 46]}, {(72, ∞), (NULL, 48), (83, ∞), [46, 46]}, {(72, ∞), (48, ∞), (NULL, 83), [46, 46]}, {(72, ∞), (48, ∞), (83, ∞), [46, 46]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>41 AND v2>74 AND v3>37 AND v4<38) OR (v1=58 AND v2>=1)) OR (v1<=4 AND v2>0 AND v3 BETWEEN 39 AND 72 AND v4>=29));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 4], (0, ∞), [39, 72], [29, ∞)}, {(41, 58), (74, ∞), (37, ∞), (NULL, 38)}, {[58, 58], [1, ∞), [NULL, ∞), [NULL, ∞)}, {(58, ∞), (74, ∞), (37, ∞), (NULL, 38)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11848,13 +10211,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 71 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 53), (NULL, 31), [NULL, ∞), [NULL, ∞)}, {(NULL, 53), (31, ∞), [NULL, ∞), [NULL, ∞)}, {[53, 53], (70, ∞), [71, ∞), [NULL, ∞)}, {(53, ∞), (NULL, 31), [NULL, ∞), [NULL, ∞)}, {(53, ∞), (31, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11877,24 +10237,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 27 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1], [40, 74], [27, ∞), [NULL, ∞)}, {(1, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=92 AND v2>=64 AND v3=39 AND v4 BETWEEN 16 AND 53) OR (v1<54 AND v2 BETWEEN 8 AND 17 AND v3=21 AND v4=86));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 54), [8, 17], [21, 21], [86, 86]}, {[92, ∞), [64, ∞), [39, 39], [16, 53]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11919,13 +10273,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 83 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[16, 31], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[40, 40], (NULL, 35], [51, ∞), [83, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11960,35 +10311,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 36 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(36, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 33 AND 71 AND v2<=61 AND v3<=32 AND v4 BETWEEN 18 AND 73) AND (v1<3) AND (v1<=59 AND v2=47 AND v3<49 AND v4>36);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<77 AND v2=43 AND v3<92 AND v4=13) OR (v1=38 AND v2<=46)) OR (v1 BETWEEN 10 AND 79 AND v2>=11 AND v3 BETWEEN 14 AND 14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), [43, 43], (NULL, 92), [13, 13]}, {[10, 38), [11, ∞), [14, 14], [NULL, ∞)}, {[10, 38), [43, 43], (NULL, 14), [13, 13]}, {[10, 38), [43, 43], (14, 92), [13, 13]}, {[38, 38], (NULL, 46], [NULL, ∞), [NULL, ∞)}, {[38, 38], (46, ∞), [14, 14], [NULL, ∞)}, {(38, 77), [43, 43], (NULL, 14), [13, 13]}, {(38, 77), [43, 43], (14, 92), [13, 13]}, {(38, 79], [11, ∞), [14, 14], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12027,13 +10369,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[40, ∞), [25, 25], (66, ∞), [98, 98]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12050,24 +10389,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 98), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=75 AND v2 BETWEEN 45 AND 51 AND v3<15) OR (v1>=74 AND v2>=37 AND v3<76));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[74, ∞), [37, ∞), (NULL, 76), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12085,13 +10418,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 32), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(32, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12114,46 +10444,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 80 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(63, 80], [89, ∞), [43, 50], (NULL, 29)}, {(80, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=81) OR (v1>=27 AND v2>=21 AND v3 BETWEEN 1 AND 63 AND v4>=92));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[27, 81), [21, ∞), [1, 63], [92, ∞)}, {[81, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>13) OR (v1>72 AND v2=2 AND v3<=40)) OR (v1>77 AND v2<21));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(13, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>54 AND v2>23 AND v3 BETWEEN 28 AND 48 AND v4>=37) OR (v1>93 AND v2>=51 AND v3<9 AND v4<>49)) OR (v1>=71 AND v2<>33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 54), (23, ∞), [28, 48], [37, ∞)}, {(54, 71), (23, ∞), [28, 48], [37, ∞)}, {[71, ∞), (NULL, 33), [NULL, ∞), [NULL, ∞)}, {[71, ∞), [33, 33], [28, 48], [37, ∞)}, {[71, ∞), (33, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12191,13 +10509,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 37 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 37), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[37, 37], (NULL, 43], [NULL, ∞), [NULL, ∞)}, {(37, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12222,13 +10537,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 91 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 91), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(91, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12257,24 +10569,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 31 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 79], [31, 31], [NULL, ∞), [NULL, ∞)}, {[21, 21], (NULL, 31), [39, ∞), [NULL, ∞)}, {[21, 21], (31, 50), [39, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>78) OR (v1>=9 AND v2<>84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[9, 78], (NULL, 84), [NULL, ∞), [NULL, ∞)}, {[9, 78], (84, ∞), [NULL, ∞), [NULL, ∞)}, {(78, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12296,24 +10602,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 63 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(16, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=16 AND v2>=9 AND v3<>48) OR (v1>=76 AND v2<>86)) OR (v1<28 AND v2=1 AND v3<=23 AND v4 BETWEEN 13 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 28), [1, 1], (NULL, 23], [13, 55]}, {[16, 16], [9, ∞), (NULL, 48), [NULL, ∞)}, {[16, 16], [9, ∞), (48, ∞), [NULL, ∞)}, {[76, ∞), (NULL, 86), [NULL, ∞), [NULL, ∞)}, {[76, ∞), (86, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12331,13 +10631,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 55 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 55), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(55, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12361,68 +10658,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 20 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 72), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[72, 72], (NULL, 5), [53, 61], [NULL, ∞)}, {(72, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=58 AND v2<=89 AND v3=78 AND v4<=58) OR (v1>39)) AND (v1<>25 AND v2>1 AND v3<18);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(39, ∞), (1, ∞), (NULL, 18), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>94) OR (v1=33 AND v2 BETWEEN 53 AND 60 AND v3 BETWEEN 37 AND 73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[33, 33], [53, 60], [37, 73], [NULL, ∞)}, {(94, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=40 AND v2<>8 AND v3<=69) OR (v1<=72)) OR (v1 BETWEEN 87 AND 89 AND v2 BETWEEN 52 AND 58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 72], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[87, 89], [52, 58], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<9 AND v2=97 AND v3<>54 AND v4>71) OR (v1>48 AND v2 BETWEEN 7 AND 23 AND v3<>95 AND v4>86)) OR (v1 BETWEEN 36 AND 90));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 9), [97, 97], (NULL, 54), (71, ∞)}, {(NULL, 9), [97, 97], (54, ∞), (71, ∞)}, {[36, 90], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(90, ∞), [7, 23], (NULL, 95), (86, ∞)}, {(90, ∞), [7, 23], (95, ∞), (86, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=38 AND v2<70) OR (v1>79));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[38, 79], (NULL, 70), [NULL, ∞), [NULL, ∞)}, {(79, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12441,13 +10720,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 42 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 42), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12483,46 +10759,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 6 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 29), (52, ∞), (NULL, 55), [NULL, ∞)}, {(NULL, 29), (52, ∞), (55, ∞), [NULL, ∞)}, {[16, 28], [9, 52], [43, 43], (NULL, 6)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<56 AND v2<=52) OR (v1>=30 AND v2<73 AND v3>40 AND v4>=13)) AND (v1<30 AND v4<>25 AND v2<>82 AND v3 BETWEEN 80 AND 88);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 30), (NULL, 52], [80, 88], (NULL, 25)}, {(NULL, 30), (NULL, 52], [80, 88], (25, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 9 AND 53 AND v2 BETWEEN 26 AND 56) OR (v1 BETWEEN 29 AND 72 AND v2<18 AND v3=73 AND v4<=12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[9, 53], [26, 56], [NULL, ∞), [NULL, ∞)}, {[29, 72], (NULL, 18), [73, 73], (NULL, 12]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>96 AND v2<27) OR (v1<82)) AND (v1>=80 AND v2 BETWEEN 14 AND 53);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[80, 82), [14, 53], [NULL, ∞), [NULL, ∞)}, {(96, ∞), [14, 27), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12539,13 +10803,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 9 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[48, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12574,24 +10835,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 59 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 16), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[41, 41], [79, 79], (NULL, 16), [2, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=69 AND v2 BETWEEN 38 AND 45) AND (v1<>35 AND v2<28 AND v3>14);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12649,13 +10904,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 98 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 69), (NULL, 48], (NULL, 65), [51, ∞)}, {(NULL, 69), (NULL, 48], (65, ∞), [51, ∞)}, {[37, 57], (48, 57], (NULL, 40), [98, 98]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12669,13 +10921,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 60 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 60), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(60, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12707,24 +10956,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       └─ 44 (tinyint)\n" +
 			" │       │      ))\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 4 (tinyint) AND 51 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 97), (NULL, 47], [91, 91], [NULL, ∞)}, {[74, 74], (NULL, 44), [4, 51], (72, ∞)}, {[74, 74], (44, ∞), [4, 51], (72, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 26 AND 60 AND v2>53 AND v3<=9 AND v4<8) OR (v1>0 AND v2<=69));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(0, ∞), (NULL, 69], [NULL, ∞), [NULL, ∞)}, {[26, 60], (69, ∞), (NULL, 9], (NULL, 8)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12768,35 +11011,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 64 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[20, 33), (NULL, 7), [95, 96], [34, 41]}, {[20, 95], (7, ∞), [95, 96], [34, 41]}, {[27, 33), (NULL, 43], (NULL, 64], (NULL, 28)}, {[27, 33), (NULL, 43], (NULL, 64], (28, ∞)}, {[33, 33], (NULL, 2), (NULL, 63), [NULL, ∞)}, {[33, 33], (NULL, 2), [63, 63], (NULL, 28)}, {[33, 33], (NULL, 2), [63, 63], (28, ∞)}, {[33, 33], (NULL, 2), (63, ∞), [NULL, ∞)}, {[33, 33], [2, 7), [95, 96], [34, 41]}, {[33, 33], [2, 43], (NULL, 64], (NULL, 28)}, {[33, 33], [2, 43], (NULL, 64], (28, ∞)}, {(33, 44], (NULL, 43], (NULL, 64], (NULL, 28)}, {(33, 44], (NULL, 43], (NULL, 64], (28, ∞)}, {(33, 95], (NULL, 7), [95, 96], [34, 41]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1 BETWEEN 13 AND 36 AND v2>40) OR (v1<>28 AND v2<29)) OR (v1 BETWEEN 36 AND 89 AND v2>=92 AND v3>39 AND v4<16)) OR (v1<=1));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 1], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(1, 28), (NULL, 29), [NULL, ∞), [NULL, ∞)}, {[13, 36], (40, ∞), [NULL, ∞), [NULL, ∞)}, {(28, ∞), (NULL, 29), [NULL, ∞), [NULL, ∞)}, {(36, 89], [92, ∞), (39, ∞), (NULL, 16)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=68 AND v2=49) OR (v1<=35 AND v2>=59 AND v3>=88 AND v4 BETWEEN 1 AND 62));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 35], [59, ∞), [88, ∞), [1, 62]}, {[68, 68], [49, 49], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12817,24 +11051,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 23), [41, ∞), [NULL, ∞), [NULL, ∞)}, {(33, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>=78 AND v2=26 AND v3 BETWEEN 70 AND 89) OR (v1 BETWEEN 12 AND 78 AND v2>41 AND v3 BETWEEN 2 AND 11 AND v4 BETWEEN 12 AND 97)) OR (v1>16 AND v2=85 AND v3<56 AND v4<19));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[12, 16], (41, ∞), [2, 11], [12, 97]}, {(16, 78], (41, 85), [2, 11], [12, 97]}, {(16, 78], [85, 85], (NULL, 2), (NULL, 19)}, {(16, 78], [85, 85], [2, 11], (NULL, 97]}, {(16, 78], [85, 85], (11, 56), (NULL, 19)}, {(16, 78], (85, ∞), [2, 11], [12, 97]}, {[78, ∞), [26, 26], [70, 89], [NULL, ∞)}, {(78, ∞), [85, 85], (NULL, 56), (NULL, 19)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12863,13 +11091,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(25, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12909,13 +11134,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 51 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1), (NULL, 1), (NULL, 34], [NULL, ∞)}, {(NULL, 1), (1, 33), (NULL, 34], [NULL, ∞)}, {(NULL, 1), [33, 33], [NULL, ∞), [NULL, ∞)}, {(NULL, 1), (33, ∞), (NULL, 34], [NULL, ∞)}, {[1, 4), (51, ∞), (NULL, 34], [NULL, ∞)}, {[1, 80], (NULL, 51], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12947,13 +11169,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v4:4\n" +
 			" │       └─ 31 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 85), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(85, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -12981,35 +11200,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 17 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[18, 35), [17, ∞), [NULL, ∞), [NULL, ∞)}, {[35, 35], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(35, 70], [17, ∞), [NULL, ∞), [NULL, ∞)}, {[82, 82], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>45 AND v2<=55 AND v3>=2 AND v4<46) OR (v1>=0 AND v2<>6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 0), (NULL, 55], [2, ∞), (NULL, 46)}, {[0, 45), [6, 6], [2, ∞), (NULL, 46)}, {[0, ∞), (NULL, 6), [NULL, ∞), [NULL, ∞)}, {[0, ∞), (6, ∞), [NULL, ∞), [NULL, ∞)}, {(45, ∞), [6, 6], [2, ∞), (NULL, 46)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=85 AND v2>=46 AND v3=87 AND v4>3) OR (v1=52));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 52), [46, ∞), [87, 87], (3, ∞)}, {[52, 52], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(52, 85], [46, ∞), [87, 87], (3, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13039,13 +11249,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 90), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[90, ∞), (NULL, 17], [68, 68], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13068,13 +11275,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           ├─ comp_index_t2.v3:3\n" +
 			" │   │           └─ 23 (tinyint)\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 18 (tinyint) AND 57 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[18, 57], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13098,13 +11302,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 80 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[32, 50], (NULL, 89), [39, ∞), [NULL, ∞)}, {[32, 50], (89, ∞), [39, ∞), [NULL, ∞)}, {(50, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13135,35 +11336,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 76 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 76), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[76, 76], (NULL, 12], (65, ∞), (NULL, 47)}, {(76, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 29 AND 37) OR (v1<>54 AND v2<=65 AND v3<=1 AND v4<>10)) OR (v1<>55 AND v2 BETWEEN 49 AND 56 AND v3>=25 AND v4<=8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29), (NULL, 65], (NULL, 1], (NULL, 10)}, {(NULL, 29), (NULL, 65], (NULL, 1], (10, ∞)}, {(NULL, 29), [49, 56], [25, ∞), (NULL, 8]}, {[29, 37], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(37, 54), (NULL, 65], (NULL, 1], (NULL, 10)}, {(37, 54), (NULL, 65], (NULL, 1], (10, ∞)}, {(37, 55), [49, 56], [25, ∞), (NULL, 8]}, {(54, ∞), (NULL, 65], (NULL, 1], (NULL, 10)}, {(54, ∞), (NULL, 65], (NULL, 1], (10, ∞)}, {(55, ∞), [49, 56], [25, ∞), (NULL, 8]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=80 AND v2<95 AND v3>6) OR (v1 BETWEEN 7 AND 14 AND v2 BETWEEN 27 AND 49 AND v3>57 AND v4 BETWEEN 28 AND 60));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[7, 14], [27, 49], (57, ∞), [28, 60]}, {[80, 80], (NULL, 95), (6, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13190,13 +11382,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 22 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 71], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(71, ∞), (NULL, 43), (NULL, 15), [NULL, ∞)}, {(71, ∞), (NULL, 43), (15, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13224,13 +11413,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v4:4\n" +
 			" │       └─ 49 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[18, 36], [13, 96], [NULL, ∞), [NULL, ∞)}, {[63, 76), (NULL, 96], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13285,13 +11471,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 41 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 17], [41, ∞), [NULL, ∞), [NULL, ∞)}, {[22, 22], (NULL, 16), [NULL, ∞), [NULL, ∞)}, {[22, 22], [16, 16], (NULL, 46), (76, ∞)}, {[22, 22], [16, 16], (46, ∞), (76, ∞)}, {[22, 22], (16, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13314,13 +11497,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 73 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 73), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[73, ∞), [11, 23], [23, 23], (50, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13344,24 +11524,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 43 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 41], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(84, ∞), (NULL, 43), [NULL, ∞), [NULL, ∞)}, {(84, ∞), (43, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=24 AND v2 BETWEEN 43 AND 84) OR (v1>=90 AND v2>1 AND v3<>70)) OR (v1>=66 AND v2<95));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[24, 24], [43, 84], [NULL, ∞), [NULL, ∞)}, {[66, ∞), (NULL, 95), [NULL, ∞), [NULL, ∞)}, {[90, ∞), [95, ∞), (NULL, 70), [NULL, ∞)}, {[90, ∞), [95, ∞), (70, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13412,35 +11586,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 18], (NULL, 70], [NULL, ∞), [NULL, ∞)}, {(18, 58), (NULL, 32), (97, ∞), [NULL, ∞)}, {(55, 58), (52, ∞), (NULL, 70), [NULL, ∞)}, {(55, 58), (52, ∞), (70, ∞), [NULL, ∞)}, {[58, 58], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(58, ∞), (NULL, 32), (97, ∞), [NULL, ∞)}, {(58, ∞), (52, ∞), (NULL, 70), [NULL, ∞)}, {(58, ∞), (52, ∞), (70, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=9 AND v2>69) AND (v1 BETWEEN 39 AND 73);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[39, 73], (69, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<87 AND v2 BETWEEN 2 AND 34 AND v3=87 AND v4>=76) OR (v1<>77 AND v2<=44 AND v3>34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 77), (NULL, 44], (34, ∞), [NULL, ∞)}, {[77, 77], [2, 34], [87, 87], [76, ∞)}, {(77, ∞), (NULL, 44], (34, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13473,57 +11638,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 61 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[5, 5], (NULL, 69), (NULL, 15], [61, ∞)}, {[9, 9], (21, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=22) OR (v1>55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[22, 22], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(55, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1 BETWEEN 47 AND 57 AND v2>=83) OR (v1=91 AND v2>34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[47, 57], [83, ∞), [NULL, ∞), [NULL, ∞)}, {[91, 91], (34, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 23 AND 25) AND (v1<98 AND v2>=20 AND v3>37);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[23, 25], [20, ∞), (37, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=6) OR (v1>61 AND v2<=34)) OR (v1>10 AND v2<>50 AND v3<>62 AND v4<=84));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[6, 6], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(10, 61], (NULL, 50), (NULL, 62), (NULL, 84]}, {(10, 61], (NULL, 50), (62, ∞), (NULL, 84]}, {(10, ∞), (50, ∞), (NULL, 62), (NULL, 84]}, {(10, ∞), (50, ∞), (62, ∞), (NULL, 84]}, {(61, ∞), (NULL, 34], [NULL, ∞), [NULL, ∞)}, {(61, ∞), (34, 50), (NULL, 62), (NULL, 84]}, {(61, ∞), (34, 50), (62, ∞), (NULL, 84]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13542,13 +11692,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 91 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[8, 74), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[74, 74], (NULL, 91], [NULL, ∞), [NULL, ∞)}, {(74, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13577,68 +11724,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 78 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=25) OR (v1>40 AND v2 BETWEEN 26 AND 40 AND v3<76));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[25, 25], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(40, ∞), [26, 40], (NULL, 76), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=13 AND v2<85) OR (v1=23 AND v2<>68 AND v3=33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[13, 13], (NULL, 85), [NULL, ∞), [NULL, ∞)}, {[23, 23], (NULL, 68), [33, 33], [NULL, ∞)}, {[23, 23], (68, ∞), [33, 33], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<42 AND v2>95 AND v3>17 AND v4<>97) OR (v1>=13 AND v2<>10 AND v3 BETWEEN 73 AND 85 AND v4=48)) OR (v1>55 AND v2=85 AND v3>30));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 42), (95, ∞), (17, ∞), (NULL, 97)}, {(NULL, 42), (95, ∞), (17, ∞), (97, ∞)}, {[13, 42), (10, 95], [73, 85], [48, 48]}, {[13, ∞), (NULL, 10), [73, 85], [48, 48]}, {[42, 55], (10, ∞), [73, 85], [48, 48]}, {(55, ∞), (10, 85), [73, 85], [48, 48]}, {(55, ∞), [85, 85], (30, ∞), [NULL, ∞)}, {(55, ∞), (85, ∞), [73, 85], [48, 48]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 5 AND 32) OR (v1>7)) OR (v1=34));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[5, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=34 AND v2<>61 AND v3<>3) AND (v1 BETWEEN 69 AND 93) AND (v1=36 AND v2>14);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13655,24 +11784,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │   └─ 74 (tinyint)\n" +
 			" │       │  ))\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 29 (tinyint) AND 73 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<>91 AND v3=27 AND v4=22 AND v2<>68) AND (v1<=88);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 88], (NULL, 68), [27, 27], [22, 22]}, {(NULL, 88], (68, ∞), [27, 27], [22, 22]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13726,13 +11849,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 4), [37, ∞), (NULL, 26], (NULL, 67)}, {(NULL, 4), [37, ∞), (NULL, 26], (67, ∞)}, {(NULL, 18), (NULL, 90), (95, ∞), [NULL, ∞)}, {(NULL, 18), (90, ∞), (95, ∞), [NULL, ∞)}, {(NULL, 36), (NULL, 15], [25, 36], (NULL, 14]}, {(18, 44), (NULL, 90), (95, ∞), [NULL, ∞)}, {(18, 44), (90, ∞), (95, ∞), [NULL, ∞)}, {[44, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13761,24 +11881,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 30), (NULL, 24], [NULL, ∞), [NULL, ∞)}, {[44, 87], (NULL, 52), (NULL, 52), (NULL, 1)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>48 AND v2<=83) OR (v1>28 AND v2 BETWEEN 9 AND 87 AND v3<>73)) OR (v1>=53 AND v2>=91 AND v3 BETWEEN 33 AND 97));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(28, 48], [9, 87], (NULL, 73), [NULL, ∞)}, {(28, 48], [9, 87], (73, ∞), [NULL, ∞)}, {(48, ∞), (NULL, 83], [NULL, ∞), [NULL, ∞)}, {(48, ∞), (83, 87], (NULL, 73), [NULL, ∞)}, {(48, ∞), (83, 87], (73, ∞), [NULL, ∞)}, {[53, ∞), [91, ∞), [33, 97], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13795,46 +11909,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 54 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 54), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[54, 54], [34, 48], [NULL, ∞), [NULL, ∞)}, {(54, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=78 AND v2<74 AND v3<42 AND v4>=34) OR (v1<=29 AND v2<=27 AND v3>31 AND v4 BETWEEN 35 AND 41));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29], (NULL, 27], [42, ∞), [35, 41]}, {(NULL, 78], (NULL, 74), (NULL, 42), [34, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 9 AND 35 AND v4<=69 AND v2 BETWEEN 34 AND 53 AND v3<>28) AND (v1 BETWEEN 12 AND 48);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[12, 35], [34, 53], (28, ∞), (NULL, 69]}, {[12, 35], [34, 53], (NULL, 28), (NULL, 69]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 13 AND 77 AND v2>75 AND v3<73 AND v4>=6) AND (v1<=58 AND v2=48 AND v3 BETWEEN 33 AND 73);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13869,13 +11971,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 46 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 82), (NULL, 17], (NULL, 17), [46, ∞)}, {(47, ∞), [26, 26], (47, ∞), [51, 86]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -13917,57 +12016,42 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 10 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 14], (NULL, 57), (NULL, 10), [NULL, ∞)}, {[52, 82], (NULL, 47), [37, 37], [NULL, ∞)}, {[52, 82], (47, ∞), [37, 37], [NULL, ∞)}, {(82, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=99 AND v3<=41) AND (v1<>38 AND v2<94 AND v3 BETWEEN 83 AND 95 AND v4>=86);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>78) AND (v1>32 AND v2>11 AND v3>=78);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(78, ∞), (11, ∞), [78, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<>3 AND v2=26 AND v3=22 AND v4<=76) AND (v1 BETWEEN 59 AND 92 AND v2 BETWEEN 36 AND 80);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>10) OR (v1=12));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(10, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14012,24 +12096,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 21 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>10 AND v2<=75 AND v3>=70) OR (v1<89 AND v2<=32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), (32, 75], [70, ∞), [NULL, ∞)}, {(NULL, 89), (NULL, 32], [NULL, ∞), [NULL, ∞)}, {(10, 89), (32, 75], [70, ∞), [NULL, ∞)}, {[89, ∞), (NULL, 75], [70, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14056,24 +12134,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 95 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[14, 15), (NULL, 53), [95, 95], (55, ∞)}, {[15, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>48 AND v2 BETWEEN 4 AND 84 AND v3<=3 AND v4<>31) AND (v1 BETWEEN 2 AND 15 AND v3>75);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14116,13 +12188,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ AND\n" +
 			" │       ├─ (comp_index_t2.v1:1 BETWEEN 45 (tinyint) AND 65 (tinyint))\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 4 (tinyint) AND 68 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 33), (77, ∞), [41, 41], [9, 9]}, {[33, 75], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(75, ∞), [48, ∞), [13, 13], (61, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14169,35 +12238,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 55 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 88 (tinyint) AND 97 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=55 AND v2<13 AND v3<=96 AND v4>=49) OR (v1 BETWEEN 39 AND 98 AND v2=77 AND v3>85));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[39, 98], [77, 77], (85, ∞), [NULL, ∞)}, {[55, 55], (NULL, 13), (NULL, 96], [49, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=74 AND v2<>13 AND v3<67 AND v4 BETWEEN 1 AND 70) OR (v1 BETWEEN 30 AND 50 AND v2<27 AND v3>=35));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[30, 50], (NULL, 27), [35, ∞), [NULL, ∞)}, {[74, 74], (NULL, 13), (NULL, 67), [1, 70]}, {[74, 74], (13, ∞), (NULL, 67), [1, 70]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14240,24 +12300,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 97 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[10, 10], [47, 47], [6, 21], (97, ∞)}, {(22, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>38 AND v2>98) OR (v1<>29 AND v2=75)) OR (v1>58 AND v2<>49 AND v3 BETWEEN 25 AND 58));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29), [75, 75], [NULL, ∞), [NULL, ∞)}, {(29, ∞), [75, 75], [NULL, ∞), [NULL, ∞)}, {(38, ∞), (98, ∞), [NULL, ∞), [NULL, ∞)}, {(58, ∞), (NULL, 49), [25, 58], [NULL, ∞)}, {(58, ∞), (49, 75), [25, 58], [NULL, ∞)}, {(58, ∞), (75, 98], [25, 58], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14293,35 +12347,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 0 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 82), [8, 8], [43, ∞), [74, 74]}, {[1, 1], [54, ∞), [41, 91], [0, ∞)}, {(82, ∞), [8, 8], [43, ∞), [74, 74]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=26 AND v2<=94 AND v3<=76) OR (v1<34 AND v2 BETWEEN 5 AND 20));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 34), [5, 20], [NULL, ∞), [NULL, ∞)}, {[26, 26], (NULL, 5), (NULL, 76], [NULL, ∞)}, {[26, 26], (20, 94], (NULL, 76], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>74 AND v2<=3 AND v3>51 AND v4<1) OR (v1>=92 AND v2<=2));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(74, 92), (NULL, 3], (51, ∞), (NULL, 1)}, {[92, ∞), (NULL, 2], [NULL, ∞), [NULL, ∞)}, {[92, ∞), (2, 3], (51, ∞), (NULL, 1)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14389,35 +12434,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 47 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 3], (NULL, 4), (NULL, 8), (NULL, 54)}, {(NULL, 7), [4, ∞), (NULL, 47], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<35) OR (v1>=5 AND v2>=10 AND v3=65));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 35), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[35, ∞), [10, ∞), [65, 65], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>31 AND v2<=37 AND v3>56 AND v4 BETWEEN 10 AND 31) OR (v1>8)) AND (v1>=27 AND v2<>44);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[27, ∞), (NULL, 44), [NULL, ∞), [NULL, ∞)}, {[27, ∞), (44, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14446,13 +12482,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 33 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 21), (NULL, 61), [13, 13], [NULL, ∞)}, {(52, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14493,24 +12526,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 32 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 9), (NULL, 95), [54, 54], (NULL, 31)}, {(NULL, 9), (NULL, 95), [54, 54], (31, ∞)}, {(NULL, 9), (95, ∞), [54, 54], (NULL, 31)}, {(NULL, 9), (95, ∞), [54, 54], (31, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=48) OR (v1 BETWEEN 2 AND 81));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 81], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14545,13 +12572,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v2:2\n" +
 			" │       │       └─ 3 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v3:3 BETWEEN 1 (tinyint) AND 74 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 36), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[36, 36], (NULL, 3], [1, 74], [NULL, ∞)}, {[36, 36], [23, 39], [NULL, ∞), [NULL, ∞)}, {(36, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14583,13 +12607,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 42 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[2, 23], [34, ∞), [NULL, ∞), [NULL, ∞)}, {(30, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14639,68 +12660,50 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 15 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 27), (NULL, 81), (NULL, 34), (NULL, 33)}, {(NULL, 27), (NULL, 81), (NULL, 34), (33, ∞)}, {(NULL, 27), [79, 81), [34, ∞), [34, 99]}, {(NULL, 27), [81, ∞), [9, ∞), [34, 99]}, {[27, 27], (NULL, 79), [34, ∞), [20, 41]}, {[27, 27], (NULL, 81), (NULL, 15), (NULL, 33)}, {[27, 27], (NULL, 81), (NULL, 15), (33, ∞)}, {[27, 27], (NULL, 81), [15, 34), (NULL, ∞)}, {[27, 27], [79, 81), [34, ∞), [20, 99]}, {[27, 27], [81, 98), [9, 15), [34, 99]}, {[27, 27], [81, 98), [15, ∞), [20, 99]}, {[27, 27], [98, ∞), [9, ∞), [34, 99]}, {(27, 68), (NULL, 81), (NULL, 34), (NULL, 33)}, {(27, 68), (NULL, 81), (NULL, 34), (33, ∞)}, {(27, 68), [79, 81), [34, ∞), [34, 99]}, {(27, 68), [81, ∞), [9, ∞), [34, 99]}, {[68, 78], [79, ∞), [9, ∞), [34, 99]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<23 AND v2<=45 AND v3<0) OR (v1>=31)) OR (v1>=50));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 23), (NULL, 45], (NULL, 0), [NULL, ∞)}, {[31, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<16) OR (v1>=19 AND v2<25 AND v3>77));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 16), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[19, ∞), (NULL, 25), (77, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<29 AND v2 BETWEEN 81 AND 92) OR (v1>20 AND v2>=53 AND v3 BETWEEN 20 AND 68));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29), [81, 92], [NULL, ∞), [NULL, ∞)}, {(20, 29), [53, 81), [20, 68], [NULL, ∞)}, {(20, 29), (92, ∞), [20, 68], [NULL, ∞)}, {[29, ∞), [53, ∞), [20, 68], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1 BETWEEN 25 AND 59 AND v2=1 AND v3<93 AND v4<=16) OR (v1<40 AND v2 BETWEEN 14 AND 37 AND v3>62 AND v4<58)) OR (v1<>17 AND v2<>36)) OR (v1 BETWEEN 7 AND 99 AND v2<>6 AND v3=43 AND v4<89));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 17), (NULL, 36), [NULL, ∞), [NULL, ∞)}, {(NULL, 17), [36, 36], (62, ∞), (NULL, 58)}, {(NULL, 17), (36, ∞), [NULL, ∞), [NULL, ∞)}, {[7, 17), [36, 36], [43, 43], (NULL, 89)}, {[17, 17], (NULL, 6), [43, 43], (NULL, 89)}, {[17, 17], (6, ∞), [43, 43], (NULL, 89)}, {[17, 17], [14, 37], (62, ∞), (NULL, 58)}, {(17, 40), [36, 36], (62, ∞), (NULL, 58)}, {(17, 99], [36, 36], [43, 43], (NULL, 89)}, {(17, ∞), (NULL, 36), [NULL, ∞), [NULL, ∞)}, {(17, ∞), (36, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=46) AND (v1>=93 AND v3<>51 AND v4=93 AND v2=8);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14752,13 +12755,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 79 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 79), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[79, ∞), (NULL, 39), [70, ∞), (NULL, 24)}, {[79, ∞), (NULL, 39), [70, ∞), (24, ∞)}, {[79, ∞), (39, ∞), [70, ∞), (NULL, 24)}, {[79, ∞), (39, ∞), [70, ∞), (24, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14802,24 +12802,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 69 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 44], (NULL, 42], [NULL, ∞), [NULL, ∞)}, {(NULL, 44], (42, ∞), (NULL, 69), [NULL, ∞)}, {(44, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=29 AND v2 BETWEEN 50 AND 86 AND v3<=6 AND v4 BETWEEN 8 AND 48) OR (v1>86 AND v2 BETWEEN 62 AND 70 AND v3=33));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29], [50, 86], (NULL, 6], [8, 48]}, {(86, ∞), [62, 70], [33, 33], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14844,13 +12838,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 50 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 15 (tinyint) AND 54 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[15, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14907,46 +12898,34 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 18 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 88], [76, ∞), (NULL, 40), (NULL, 18]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=27) OR (v1>=11 AND v2<97 AND v3<97 AND v4<44));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[11, 27), (NULL, 97), (NULL, 97), (NULL, 44)}, {[27, 27], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(27, ∞), (NULL, 97), (NULL, 97), (NULL, 44)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=89 AND v2<=93) OR (v1<=54));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 54], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(54, 89], (NULL, 93], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=74 AND v2<=31) OR (v1<11)) OR (v1 BETWEEN 26 AND 38));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[26, 38], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[74, 74], (NULL, 31], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -14975,24 +12954,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 37 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[10, 99), (NULL, 12), [54, 54], (89, ∞)}, {[99, 99], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(99, ∞), (NULL, 12), [54, 54], (89, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=50 AND v2<50) OR (v1<19)) OR (v1=51));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 19), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[19, 50], (NULL, 50), [NULL, ∞), [NULL, ∞)}, {[51, 51], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15021,24 +12994,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 49 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 1], (49, ∞), [NULL, ∞), [NULL, ∞)}, {[62, 62], [19, 89), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1<=61 AND v2<=64) AND (v1>=0);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[0, 61], (NULL, 64], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15061,35 +13028,26 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 63 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 5), [25, ∞), [63, 63], (NULL, 14)}, {[5, 69], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=21 AND v2<>0 AND v3<49) OR (v1<=70 AND v2>16 AND v3<=89 AND v4>=27)) OR (v1>=14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 14), (16, ∞), (NULL, 89], [27, ∞)}, {[14, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>14) OR (v1>=82));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(14, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15114,13 +13072,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 99 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 19), (99, ∞), [NULL, ∞), [NULL, ∞)}, {[19, 19], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(19, 36], (99, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15142,13 +13097,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(43, ∞), [83, 97], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15188,24 +13140,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 14 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 31), (NULL, 96], (NULL, 20], (NULL, 14]}, {(31, ∞), (NULL, 96], (NULL, 20], (NULL, 14]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1 BETWEEN 52 AND 55) OR (v1>1 AND v2>36 AND v3<=47)) OR (v1 BETWEEN 0 AND 38 AND v2<=49 AND v3>=8));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[0, 1], (NULL, 49], [8, ∞), [NULL, ∞)}, {(1, 38], (NULL, 36], [8, ∞), [NULL, ∞)}, {(1, 38], (36, 49], (NULL, ∞), [NULL, ∞)}, {(1, 38], (49, ∞), (NULL, 47], [NULL, ∞)}, {(38, 52), (36, ∞), (NULL, 47], [NULL, ∞)}, {[52, 55], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(55, ∞), (36, ∞), (NULL, 47], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15244,24 +13190,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 79 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 11], [41, ∞), [9, 9], (NULL, 24)}, {(48, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1=23 AND v4>=52 AND v2>=61) AND (v1<>85 AND v3>2 AND v4<15);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(∞, ∞), (∞, ∞), (∞, ∞), (∞, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15294,24 +13234,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 55 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[32, 51], [46, 46], [31, ∞), [5, 14]}, {[32, ∞), (NULL, 26], (52, ∞), (55, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=16 AND v2<59 AND v3<=43) OR (v1=17 AND v2<=4 AND v3>71));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[16, ∞), (NULL, 59), (NULL, 43], [NULL, ∞)}, {[17, 17], (NULL, 4], (71, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15358,13 +13292,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v3:3\n" +
 			" │       │       └─ 30 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v4:4 BETWEEN 92 (tinyint) AND 93 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[20, 28), (96, ∞), (NULL, 28), [NULL, ∞)}, {[20, 28), (96, ∞), (28, ∞), [NULL, ∞)}, {[28, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15409,13 +13340,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 56 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 54), (48, ∞), [NULL, ∞), [NULL, ∞)}, {[54, ∞), [56, 56], [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15444,24 +13372,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ Eq\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 76), [39, 39], (NULL, 59], (NULL, 36]}, {[79, 79], (24, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<=15 AND v2 BETWEEN 21 AND 76 AND v3=23) OR (v1 BETWEEN 2 AND 55));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), [21, 76], [23, 23], [NULL, ∞)}, {[2, 55], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15492,13 +13414,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ GreaterThanOrEqual\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 57 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(56, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15550,13 +13469,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 39 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 5], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(5, 11), [75, ∞), [NULL, ∞), [NULL, ∞)}, {[11, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15605,13 +13521,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 82 (tinyint)\n" +
 			" │      ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 82), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, 82], [34, 39], [34, 71], [15, ∞)}, {[82, 82], [46, 46], [4, 4], [NULL, ∞)}, {(82, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15629,13 +13542,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v3:3\n" +
 			" │       └─ 24 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(1, 50], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15670,79 +13580,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   └─ LessThan\n" +
 			" │       ├─ comp_index_t2.v1:1\n" +
 			" │       └─ 82 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[66, 82), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, ∞), [72, 72], (NULL, 31), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1=84 AND v2<85 AND v3 BETWEEN 75 AND 86 AND v4<=34) OR (v1>=37 AND v2<59 AND v3 BETWEEN 2 AND 26 AND v4>6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[37, ∞), (NULL, 59), [2, 26], (6, ∞)}, {[84, 84], (NULL, 85), [75, 86], (NULL, 34]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>10 AND v2=42) OR (v1>=85 AND v2<>6 AND v3=34 AND v4<=45));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(10, ∞), [42, 42], [NULL, ∞), [NULL, ∞)}, {[85, ∞), (NULL, 6), [34, 34], (NULL, 45]}, {[85, ∞), (6, 42), [34, 34], (NULL, 45]}, {[85, ∞), (42, ∞), [34, 34], (NULL, 45]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=24 AND v2<>33 AND v3=77 AND v4<>63) OR (v1<>22 AND v2<=58 AND v3>71 AND v4>=87)) OR (v1<=85 AND v2>18 AND v3<=40));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 22), (NULL, 58], (71, ∞), [87, ∞)}, {(NULL, 85], (18, ∞), (NULL, 40], [NULL, ∞)}, {(22, 24), (NULL, 58], (71, ∞), [87, ∞)}, {[24, 24], (NULL, 33), (71, 77), [87, ∞)}, {[24, 24], (NULL, 33), [77, 77], (NULL, 63)}, {[24, 24], (NULL, 33), [77, 77], (63, ∞)}, {[24, 24], (NULL, 33), (77, ∞), [87, ∞)}, {[24, 24], [33, 33], (71, ∞), [87, ∞)}, {[24, 24], (33, 58], (71, 77), [87, ∞)}, {[24, 24], (33, 58], (77, ∞), [87, ∞)}, {[24, 24], (33, ∞), [77, 77], (NULL, 63)}, {[24, 24], (33, ∞), [77, 77], (63, ∞)}, {(24, ∞), (NULL, 58], (71, ∞), [87, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<72 AND v2>=67) OR (v1<>88 AND v2<>23 AND v3=23));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 72), (23, 67), [23, 23], [NULL, ∞)}, {(NULL, 72), [67, ∞), [NULL, ∞), [NULL, ∞)}, {(NULL, 88), (NULL, 23), [23, 23], [NULL, ∞)}, {[72, 88), (23, ∞), [23, 23], [NULL, ∞)}, {(88, ∞), (NULL, 23), [23, 23], [NULL, ∞)}, {(88, ∞), (23, ∞), [23, 23], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1=11 AND v2>=99) OR (v1<18 AND v2>=34 AND v3<53)) OR (v1>68));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 11), [34, ∞), (NULL, 53), [NULL, ∞)}, {[11, 11], [34, 99), (NULL, 53), [NULL, ∞)}, {[11, 11], [99, ∞), [NULL, ∞), [NULL, ∞)}, {(11, 18), [34, ∞), (NULL, 53), [NULL, ∞)}, {(68, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<=40 AND v2<0) OR (v1>=35 AND v2<=95 AND v3<>61)) OR (v1>49));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 40], (NULL, 0), [NULL, ∞), [NULL, ∞)}, {[35, 40], [0, 95], (NULL, 61), [NULL, ∞)}, {[35, 40], [0, 95], (61, ∞), [NULL, ∞)}, {(40, 49], (NULL, 95], (NULL, 61), [NULL, ∞)}, {(40, 49], (NULL, 95], (61, ∞), [NULL, ∞)}, {(49, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15771,13 +13660,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │           └─ 43 (tinyint)\n" +
 			" │   │          ))\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 15 (tinyint) AND 67 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[37, 55], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15817,13 +13703,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 53 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[52, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15855,13 +13738,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 91 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(5, ∞), [62, ∞), [NULL, ∞), [NULL, ∞)}, {[91, ∞), [28, 62), [83, ∞), (NULL, 91)}, {[91, ∞), [28, 62), [83, ∞), (91, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15883,24 +13763,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 74 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 87), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(87, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 1 AND 19 AND v2 BETWEEN 22 AND 48) AND (v1 BETWEEN 6 AND 47 AND v2>=25 AND v3<27);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[6, 19], [25, 48], (NULL, 27), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -15961,24 +13835,18 @@ var IndexPlanTests = []QueryPlanTest{
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 84 (tinyint)\n" +
 			" │          ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 95], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>42 AND v2=44 AND v3<>73) OR (v1>24 AND v2>49 AND v3>=7));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(24, ∞), (49, ∞), [7, ∞), [NULL, ∞)}, {(42, ∞), [44, 44], (NULL, 73), [NULL, ∞)}, {(42, ∞), [44, 44], (73, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16003,13 +13871,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v2:2\n" +
 			" │           └─ 66 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 63), (NULL, 66), [NULL, ∞), [NULL, ∞)}, {[79, 79], [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16040,13 +13905,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThan\n" +
 			" │           ├─ comp_index_t2.v4:4\n" +
 			" │           └─ 75 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 66), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[66, 66], (53, ∞), (NULL, 73), (NULL, 75)}, {(66, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16069,13 +13931,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       │       ├─ comp_index_t2.v4:4\n" +
 			" │       │       └─ 98 (tinyint)\n" +
 			" │       └─ (comp_index_t2.v2:2 BETWEEN 70 (tinyint) AND 85 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[15, 15], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(36, ∞), [70, 85], [13, 13], (NULL, 98]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16099,13 +13958,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │   │       │      ))\n" +
 			" │   │       └─ (comp_index_t2.v3:3 BETWEEN 30 (tinyint) AND 53 (tinyint))\n" +
 			" │   └─ (comp_index_t2.v1:1 BETWEEN 41 (tinyint) AND 95 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[23, 95], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {(95, ∞), (NULL, 6), [30, 53], [NULL, ∞)}, {(95, ∞), (6, ∞), [30, 53], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16141,13 +13997,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ LessThanOrEqual\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 3 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{(NULL, 21), [17, ∞), (NULL, 3], [NULL, ∞)}, {(6, ∞), (NULL, 77), [81, ∞), (NULL, 9)}, {(6, ∞), (NULL, 77), [81, ∞), (9, ∞)}, {(6, ∞), (77, ∞), [81, ∞), (NULL, 9)}, {(6, ∞), (77, ∞), [81, ∞), (9, ∞)}, {(21, ∞), [17, ∞), (NULL, 3], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16186,79 +14039,58 @@ var IndexPlanTests = []QueryPlanTest{
 			" │       └─ GreaterThan\n" +
 			" │           ├─ comp_index_t2.v3:3\n" +
 			" │           └─ 23 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t2)\n" +
 			"     ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			"     ├─ static: [{[50, 97], (NULL, 12), (23, ∞), [NULL, ∞)}, {[94, 97], (4, 12), (NULL, 23], (NULL, 59]}, {[94, 97], [12, ∞), (NULL, 94), (NULL, 59]}, {(97, 99], (4, ∞), (NULL, 94), (NULL, 59]}]\n" +
-			"     ├─ columns: [pk v1 v2 v3 v4]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>19 AND v2>46 AND v3=26 AND v4>=47) OR (v1>18 AND v2<=79 AND v3=45 AND v4<=7)) OR (v1 BETWEEN 2 AND 21 AND v2>32));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 2), (46, ∞), [26, 26], [47, ∞)}, {[2, 21], (32, ∞), [NULL, ∞), [NULL, ∞)}, {(18, 21], (NULL, 32], [45, 45], (NULL, 7]}, {(21, ∞), (NULL, 79], [45, 45], (NULL, 7]}, {(21, ∞), (46, ∞), [26, 26], [47, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1>=5) AND (v1=50 AND v2<=50);`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{[50, 50], (NULL, 50], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>=82 AND v2 BETWEEN 34 AND 50 AND v3<26 AND v4 BETWEEN 48 AND 76) OR (v1<=6));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 6], [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[82, ∞), [34, 50], (NULL, 26), [48, 76]}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1>29) OR (v1<>94 AND v2>=56 AND v3=14));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 29], [56, ∞), [14, 14], [NULL, ∞)}, {(29, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>8 AND v2<97 AND v3=51 AND v4<=26) OR (v1>87)) OR (v1<10 AND v2<=45 AND v3>=73));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 10), (NULL, 45], [73, ∞), [NULL, ∞)}, {(8, 87], (NULL, 97), [51, 51], (NULL, 26]}, {(87, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>15 AND v2>1) OR (v1<46)) OR (v1>47 AND v2>=9 AND v3 BETWEEN 39 AND 87 AND v4>=10));`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
 			" ├─ static: [{(NULL, 46), [NULL, ∞), [NULL, ∞), [NULL, ∞)}, {[46, ∞), (1, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3 v4]\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ projections: [0 1 2 3 4]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16267,13 +14099,10 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ comp_index_t3.v1:1\n" +
 			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(comp_index_t3)\n" +
 			"     ├─ index: [comp_index_t3.v1]\n" +
 			"     ├─ static: [{[a, a]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t3\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -47,12 +47,9 @@ var PlanTests = []QueryPlanTest{
 			"     │           │       ├─ Eq\n" +
 			"     │           │       │   ├─ uv.u:1!null\n" +
 			"     │           │       │   └─ sq.p:0!null\n" +
-			"     │           │       └─ IndexedTableAccess\n" +
+			"     │           │       └─ IndexedTableAccess(uv)\n" +
 			"     │           │           ├─ index: [uv.u]\n" +
-			"     │           │           ├─ columns: [u]\n" +
-			"     │           │           └─ Table\n" +
-			"     │           │               ├─ name: uv\n" +
-			"     │           │               └─ projections: [0]\n" +
+			"     │           │           └─ columns: [u]\n" +
 			"     │           │   as (select u from uv where u = sq.p)]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: sq\n" +
@@ -61,10 +58,9 @@ var PlanTests = []QueryPlanTest{
 			"     │               └─ Table\n" +
 			"     │                   ├─ name: pq\n" +
 			"     │                   └─ columns: [p]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         └─ Table\n" +
-			"             └─ name: xy\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -85,10 +81,9 @@ var PlanTests = []QueryPlanTest{
 			"     │               └─ Table\n" +
 			"     │                   ├─ name: othertable\n" +
 			"     │                   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -105,10 +100,9 @@ var PlanTests = []QueryPlanTest{
 			"         │       └─ Table\n" +
 			"         │           ├─ name: othertable\n" +
 			"         │           └─ columns: [i2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: mytable\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -118,20 +112,14 @@ var PlanTests = []QueryPlanTest{
 			"     ├─ cmp: Eq\n" +
 			"     │   ├─ rs.s:1\n" +
 			"     │   └─ xy.y:3\n" +
-			"     ├─ IndexedTableAccess\n" +
+			"     ├─ IndexedTableAccess(rs)\n" +
 			"     │   ├─ index: [rs.s]\n" +
 			"     │   ├─ static: [{[NULL, ∞)}]\n" +
-			"     │   ├─ columns: [r s]\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: rs\n" +
-			"     │       └─ projections: [0 1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   └─ columns: [r s]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.y]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
-			"         ├─ columns: [x y]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: xy\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -150,26 +138,17 @@ var PlanTests = []QueryPlanTest{
 			"     │       ├─ cmp: Eq\n" +
 			"     │       │   ├─ ab.a:0!null\n" +
 			"     │       │   └─ xy.y:3\n" +
-			"     │       ├─ IndexedTableAccess\n" +
+			"     │       ├─ IndexedTableAccess(ab)\n" +
 			"     │       │   ├─ index: [ab.a]\n" +
 			"     │       │   ├─ static: [{[NULL, ∞)}]\n" +
-			"     │       │   ├─ columns: [a b]\n" +
-			"     │       │   └─ Table\n" +
-			"     │       │       ├─ name: ab\n" +
-			"     │       │       └─ projections: [0 1]\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       │   └─ columns: [a b]\n" +
+			"     │       └─ IndexedTableAccess(xy)\n" +
 			"     │           ├─ index: [xy.y]\n" +
 			"     │           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           ├─ columns: [x y]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: xy\n" +
-			"     │               └─ projections: [0 1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │           └─ columns: [x y]\n" +
+			"     └─ IndexedTableAccess(uv)\n" +
 			"         ├─ index: [uv.u]\n" +
-			"         ├─ columns: [u v]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: uv\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [u v]\n" +
 			"",
 	},
 	{
@@ -178,20 +157,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ cmp: Eq\n" +
 			" │   ├─ ab.a:0!null\n" +
 			" │   └─ xy.y:3\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(ab)\n" +
 			" │   ├─ index: [ab.a]\n" +
 			" │   ├─ static: [{[NULL, ∞)}]\n" +
-			" │   ├─ columns: [a b]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: ab\n" +
-			" │       └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [a b]\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.y]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -201,20 +174,14 @@ var PlanTests = []QueryPlanTest{
 			"     ├─ cmp: Eq\n" +
 			"     │   ├─ rs.s:1\n" +
 			"     │   └─ xy.y:3\n" +
-			"     ├─ IndexedTableAccess\n" +
+			"     ├─ IndexedTableAccess(rs)\n" +
 			"     │   ├─ index: [rs.s]\n" +
 			"     │   ├─ static: [{[NULL, ∞)}]\n" +
-			"     │   ├─ columns: [r s]\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: rs\n" +
-			"     │       └─ projections: [0 1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   └─ columns: [r s]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.y]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
-			"         ├─ columns: [x y]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: xy\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -223,20 +190,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ cmp: Eq\n" +
 			" │   ├─ rs.s:1\n" +
 			" │   └─ xy.y:3\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(rs)\n" +
 			" │   ├─ index: [rs.s]\n" +
 			" │   ├─ static: [{[NULL, ∞)}]\n" +
-			" │   ├─ columns: [r s]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: rs\n" +
-			" │       └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [r s]\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.y]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -245,20 +206,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ cmp: Eq\n" +
 			" │   ├─ rs.s:1\n" +
 			" │   └─ (xy.y:3 + 10 (tinyint))\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(rs)\n" +
 			" │   ├─ index: [rs.s]\n" +
 			" │   ├─ static: [{[NULL, ∞)}]\n" +
-			" │   ├─ columns: [r s]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: rs\n" +
-			" │       └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [r s]\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.y]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -293,16 +248,15 @@ var PlanTests = []QueryPlanTest{
 			" │               │           ├─ Eq\n" +
 			" │               │           │   ├─ uv.u:4!null\n" +
 			" │               │           │   └─ ab.a:0!null\n" +
-			" │               │           └─ IndexedTableAccess\n" +
+			" │               │           └─ IndexedTableAccess(uv)\n" +
 			" │               │               ├─ index: [uv.u]\n" +
-			" │               │               ├─ columns: [u]\n" +
-			" │               │               └─ Table\n" +
-			" │               │                   ├─ name: uv\n" +
-			" │               │                   └─ projections: [0]\n" +
+			" │               │               └─ columns: [u]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: xy\n" +
+			" │                   ├─ name: xy\n" +
+			" │                   └─ columns: [x y]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -327,9 +281,11 @@ var PlanTests = []QueryPlanTest{
 			" │               │               ├─ name: uv\n" +
 			" │               │               └─ columns: [v]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: xy\n" +
+			" │                   ├─ name: xy\n" +
+			" │                   └─ columns: [x y]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -354,9 +310,11 @@ var PlanTests = []QueryPlanTest{
 			" │               │               ├─ name: uv\n" +
 			" │               │               └─ columns: [v]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: xy\n" +
+			" │                   ├─ name: xy\n" +
+			" │                   └─ columns: [x y]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -384,17 +342,18 @@ var PlanTests = []QueryPlanTest{
 			"         │               │               ├─ name: uv\n" +
 			"         │               │               └─ columns: [v]\n" +
 			"         │               └─ Table\n" +
-			"         │                   └─ name: xy\n" +
+			"         │                   ├─ name: xy\n" +
+			"         │                   └─ columns: [x y]\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ ab.a:2!null\n" +
 			"             │   └─ pq.p:0!null\n" +
 			"             ├─ Table\n" +
-			"             │   └─ name: pq\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   ├─ name: pq\n" +
+			"             │   └─ columns: [p q]\n" +
+			"             └─ IndexedTableAccess(ab)\n" +
 			"                 ├─ index: [ab.a]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: ab\n" +
+			"                 └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -413,23 +372,20 @@ var PlanTests = []QueryPlanTest{
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ uv.u:4!null\n" +
 			"     │           │       └─ xy.x:2!null\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(uv)\n" +
 			"     │               ├─ index: [uv.u]\n" +
-			"     │               ├─ columns: [u]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: uv\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [u]\n" +
 			"     │   as is_one]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ xy.x:2!null\n" +
 			"         │   └─ uv.v:1\n" +
 			"         ├─ Table\n" +
-			"         │   └─ name: uv\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   ├─ name: uv\n" +
+			"         │   └─ columns: [u v]\n" +
+			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: xy\n" +
+			"             └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -449,18 +405,19 @@ var PlanTests = []QueryPlanTest{
 			"         │           │   ├─ xy.y:3\n" +
 			"         │           │   └─ 1 (tinyint)\n" +
 			"         │           └─ Table\n" +
-			"         │               └─ name: \n" +
+			"         │               ├─ name: \n" +
+			"         │               └─ columns: []\n" +
 			"         │   as is_one]\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ xy.x:2!null\n" +
 			"             │   └─ uv.v:1\n" +
 			"             ├─ Table\n" +
-			"             │   └─ name: uv\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   ├─ name: uv\n" +
+			"             │   └─ columns: [u v]\n" +
+			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: xy\n" +
+			"                 └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -475,18 +432,19 @@ var PlanTests = []QueryPlanTest{
 			" │           │   ├─ xy.y:3\n" +
 			" │           │   └─ 1 (tinyint)\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" │   as is_one]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ xy.x:2!null\n" +
 			"     │   └─ uv.v:1\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: uv\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   ├─ name: uv\n" +
+			"     │   └─ columns: [u v]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         └─ Table\n" +
-			"             └─ name: xy\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -525,13 +483,10 @@ var PlanTests = []QueryPlanTest{
 			"             │       ├─ Eq\n" +
 			"             │       │   ├─ bus_routes.origin:0!null\n" +
 			"             │       │   └─ New York (longtext)\n" +
-			"             │       └─ IndexedTableAccess\n" +
+			"             │       └─ IndexedTableAccess(bus_routes)\n" +
 			"             │           ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
 			"             │           ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
-			"             │           ├─ columns: [origin]\n" +
-			"             │           └─ Table\n" +
-			"             │               ├─ name: bus_routes\n" +
-			"             │               └─ projections: [0]\n" +
+			"             │           └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst:2!null]\n" +
 			"                 └─ HashJoin\n" +
@@ -556,7 +511,8 @@ var PlanTests = []QueryPlanTest{
 			"     │   ├─ xy.x:0!null\n" +
 			"     │   └─ applySubq0.u:2!null\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: xy\n" +
+			"     │   ├─ name: xy\n" +
+			"     │   └─ columns: [x y]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -597,12 +553,9 @@ var PlanTests = []QueryPlanTest{
 			"                                                 ├─ HashIn\n" +
 			"                                                 │   ├─ uv.u:0!null\n" +
 			"                                                 │   └─ TUPLE(2 (tinyint), 3 (tinyint))\n" +
-			"                                                 └─ IndexedTableAccess\n" +
+			"                                                 └─ IndexedTableAccess(uv)\n" +
 			"                                                     ├─ index: [uv.u]\n" +
-			"                                                     ├─ columns: [u v]\n" +
-			"                                                     └─ Table\n" +
-			"                                                         ├─ name: uv\n" +
-			"                                                         └─ projections: [0 1]\n" +
+			"                                                     └─ columns: [u v]\n" +
 			"",
 	},
 	{
@@ -655,19 +608,13 @@ var PlanTests = []QueryPlanTest{
 			"                 │   ├─ Eq\n" +
 			"                 │   │   ├─ uv.u:0!null\n" +
 			"                 │   │   └─ -1 (tinyint)\n" +
-			"                 │   └─ IndexedTableAccess\n" +
+			"                 │   └─ IndexedTableAccess(uv)\n" +
 			"                 │       ├─ index: [uv.u]\n" +
 			"                 │       ├─ static: [{[-1, -1]}]\n" +
-			"                 │       ├─ columns: [u v]\n" +
-			"                 │       └─ Table\n" +
-			"                 │           ├─ name: uv\n" +
-			"                 │           └─ projections: [0 1]\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 │       └─ columns: [u v]\n" +
+			"                 └─ IndexedTableAccess(xy)\n" +
 			"                     ├─ index: [xy.y]\n" +
-			"                     ├─ columns: [x y]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: xy\n" +
-			"                         └─ projections: [0 1]\n" +
+			"                     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -691,12 +638,9 @@ var PlanTests = []QueryPlanTest{
 			"     │           ├─ Table\n" +
 			"     │           │   ├─ name: pq\n" +
 			"     │           │   └─ columns: [p q]\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(xy)\n" +
 			"     │               ├─ index: [xy.x]\n" +
-			"     │               ├─ columns: [x]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: xy\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [x]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(xq.x:0!null)\n" +
 			"         ├─ target: TUPLE(av.v:1)\n" +
@@ -714,12 +658,9 @@ var PlanTests = []QueryPlanTest{
 			"                         ├─ Table\n" +
 			"                         │   ├─ name: uv\n" +
 			"                         │   └─ columns: [u v]\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(ab)\n" +
 			"                             ├─ index: [ab.a]\n" +
-			"                             ├─ columns: [a]\n" +
-			"                             └─ Table\n" +
-			"                                 ├─ name: ab\n" +
-			"                                 └─ projections: [0]\n" +
+			"                             └─ columns: [a]\n" +
 			"",
 	},
 	{
@@ -772,25 +713,16 @@ var PlanTests = []QueryPlanTest{
 			"     │   ├─ name: ab\n" +
 			"     │   └─ columns: [a]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(xy)\n" +
 			"         │   ├─ index: [xy.x]\n" +
-			"         │   ├─ columns: [x]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: xy\n" +
-			"         │       └─ projections: [0]\n" +
+			"         │   └─ columns: [x]\n" +
 			"         └─ Concat\n" +
-			"             ├─ IndexedTableAccess\n" +
+			"             ├─ IndexedTableAccess(xy)\n" +
 			"             │   ├─ index: [xy.x]\n" +
-			"             │   ├─ columns: [x]\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: xy\n" +
-			"             │       └─ projections: [0]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   └─ columns: [x]\n" +
+			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ columns: [x]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: xy\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [x]\n" +
 			"",
 	},
 	{
@@ -810,13 +742,13 @@ var PlanTests = []QueryPlanTest{
 			" │               │   └─ Table\n" +
 			" │               │       ├─ name: uv\n" +
 			" │               │       └─ columns: [u v]\n" +
-			" │               └─ IndexedTableAccess\n" +
+			" │               └─ IndexedTableAccess(ab)\n" +
 			" │                   ├─ index: [ab.a]\n" +
-			" │                   └─ Table\n" +
-			" │                       └─ name: ab\n" +
+			" │                   └─ columns: [a b]\n" +
 			" │   as s]\n" +
 			" └─ Table\n" +
-			"     └─ name: xy\n" +
+			"     ├─ name: xy\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -837,7 +769,8 @@ var PlanTests = []QueryPlanTest{
 			" │   ├─ ab.a:0!null\n" +
 			" │   └─ 1 (tinyint)\n" +
 			" ├─ Table\n" +
-			" │   └─ name: ab\n" +
+			" │   ├─ name: ab\n" +
+			" │   └─ columns: [a b]\n" +
 			" └─ Table\n" +
 			"     ├─ name: uv\n" +
 			"     └─ columns: [u v]\n" +
@@ -853,7 +786,8 @@ var PlanTests = []QueryPlanTest{
 			" │       ├─ filters: [{[1, 1]}]\n" +
 			" │       └─ columns: [a b]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -868,7 +802,8 @@ var PlanTests = []QueryPlanTest{
 			" │       └─ 1 (tinyint)\n" +
 			" ├─ TableAlias(s)\n" +
 			" │   └─ Table\n" +
-			" │       └─ name: ab\n" +
+			" │       ├─ name: ab\n" +
+			" │       └─ columns: [a b]\n" +
 			" └─ Table\n" +
 			"     ├─ name: ab\n" +
 			"     └─ columns: [a b]\n" +
@@ -881,13 +816,11 @@ var PlanTests = []QueryPlanTest{
 			" │   ├─ uv.u:0!null\n" +
 			" │   └─ ab.a:2!null\n" +
 			" ├─ Table\n" +
-			" │   └─ name: uv\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   ├─ name: uv\n" +
+			" │   └─ columns: [u v]\n" +
+			" └─ IndexedTableAccess(ab)\n" +
 			"     ├─ index: [ab.a]\n" +
-			"     ├─ columns: [a]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: ab\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [a]\n" +
 			"",
 	},
 	{
@@ -905,10 +838,9 @@ var PlanTests = []QueryPlanTest{
 			"         │   └─ Table\n" +
 			"         │       ├─ name: xy\n" +
 			"         │       └─ columns: [x y]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(ab)\n" +
 			"             ├─ index: [ab.a]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: ab\n" +
+			"             └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -925,10 +857,9 @@ var PlanTests = []QueryPlanTest{
 			" │       └─ Table\n" +
 			" │           ├─ name: ab\n" +
 			" │           └─ columns: [a b]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.x]\n" +
-			"     └─ Table\n" +
-			"         └─ name: xy\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -939,13 +870,11 @@ var PlanTests = []QueryPlanTest{
 			"     │   ├─ ab.a:2!null\n" +
 			"     │   └─ xy.x:0!null\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: xy\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   ├─ name: xy\n" +
+			"     │   └─ columns: [x y]\n" +
+			"     └─ IndexedTableAccess(ab)\n" +
 			"         ├─ index: [ab.a]\n" +
-			"         ├─ columns: [a b]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: ab\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -957,13 +886,11 @@ var PlanTests = []QueryPlanTest{
 			"         │   ├─ ab.a:2!null\n" +
 			"         │   └─ xy.x:0!null\n" +
 			"         ├─ Table\n" +
-			"         │   └─ name: xy\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   ├─ name: xy\n" +
+			"         │   └─ columns: [x y]\n" +
+			"         └─ IndexedTableAccess(ab)\n" +
 			"             ├─ index: [ab.a]\n" +
-			"             ├─ columns: [a b]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: ab\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -992,20 +919,17 @@ inner join xy on a = x;`,
 			" │       │   │   ├─ ab.a:0!null\n" +
 			" │       │   │   └─ uv.u:2!null\n" +
 			" │       │   ├─ Table\n" +
-			" │       │   │   └─ name: ab\n" +
-			" │       │   └─ IndexedTableAccess\n" +
+			" │       │   │   ├─ name: ab\n" +
+			" │       │   │   └─ columns: [a b]\n" +
+			" │       │   └─ IndexedTableAccess(uv)\n" +
 			" │       │       ├─ index: [uv.u]\n" +
-			" │       │       └─ Table\n" +
-			" │       │           └─ name: uv\n" +
+			" │       │       └─ columns: [u v]\n" +
 			" │       └─ Table\n" +
 			" │           ├─ name: pq\n" +
 			" │           └─ columns: [p q]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.x]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -1029,16 +953,12 @@ where exists
 			" │       ├─ Table\n" +
 			" │       │   ├─ name: uv\n" +
 			" │       │   └─ columns: [u v]\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(pq)\n" +
 			" │           ├─ index: [pq.p]\n" +
-			" │           ├─ columns: [p q]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: pq\n" +
-			" │               └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │           └─ columns: [p q]\n" +
+			" └─ IndexedTableAccess(ab)\n" +
 			"     ├─ index: [ab.a]\n" +
-			"     └─ Table\n" +
-			"         └─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -1063,19 +983,14 @@ where exists (select * from pq where a = p)
 			" │       │   ├─ ab.a:0!null\n" +
 			" │       │   └─ uv.u:2!null\n" +
 			" │       ├─ Table\n" +
-			" │       │   └─ name: ab\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       │   ├─ name: ab\n" +
+			" │       │   └─ columns: [a b]\n" +
+			" │       └─ IndexedTableAccess(uv)\n" +
 			" │           ├─ index: [uv.u]\n" +
-			" │           ├─ columns: [u v]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: uv\n" +
-			" │               └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │           └─ columns: [u v]\n" +
+			" └─ IndexedTableAccess(pq)\n" +
 			"     ├─ index: [pq.p]\n" +
-			"     ├─ columns: [p q]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pq\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [p q]\n" +
 			"",
 	},
 	{
@@ -1097,12 +1012,9 @@ full join pq on a = p
 			"     │   ├─ Table\n" +
 			"     │   │   ├─ name: uv\n" +
 			"     │   │   └─ columns: [u v]\n" +
-			"     │   └─ IndexedTableAccess\n" +
+			"     │   └─ IndexedTableAccess(ab)\n" +
 			"     │       ├─ index: [ab.a]\n" +
-			"     │       ├─ columns: [a b]\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: ab\n" +
-			"     │           └─ projections: [0 1]\n" +
+			"     │       └─ columns: [a b]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: pq\n" +
 			"         └─ columns: [p q]\n" +
@@ -1166,17 +1078,14 @@ inner join pq on true
 			" │   │       │   ├─ ab.a:0!null\n" +
 			" │   │       │   └─ xy.x:2!null\n" +
 			" │   │       ├─ Table\n" +
-			" │   │       │   └─ name: ab\n" +
-			" │   │       └─ IndexedTableAccess\n" +
+			" │   │       │   ├─ name: ab\n" +
+			" │   │       │   └─ columns: [a b]\n" +
+			" │   │       └─ IndexedTableAccess(xy)\n" +
 			" │   │           ├─ index: [xy.x]\n" +
-			" │   │           ├─ columns: [x y]\n" +
-			" │   │           └─ Table\n" +
-			" │   │               ├─ name: xy\n" +
-			" │   │               └─ projections: [0 1]\n" +
-			" │   └─ IndexedTableAccess\n" +
+			" │   │           └─ columns: [x y]\n" +
+			" │   └─ IndexedTableAccess(pq)\n" +
 			" │       ├─ index: [pq.p]\n" +
-			" │       └─ Table\n" +
-			" │           └─ name: pq\n" +
+			" │       └─ columns: [p q]\n" +
 			" └─ Table\n" +
 			"     ├─ name: uv\n" +
 			"     └─ columns: [u v]\n" +
@@ -1196,10 +1105,9 @@ inner join pq on true
 			"     │           ├─ name: mytable\n" +
 			"     │           └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: mytable\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -1212,14 +1120,12 @@ inner join pq on true
 			"     │   └─ b.i:2!null\n" +
 			"     ├─ TableAlias(a)\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: mytable\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1254,78 +1160,57 @@ inner join pq on true
 			"         │   ├─ Table\n" +
 			"         │   │   ├─ name: othertable\n" +
 			"         │   │   └─ columns: [i2]\n" +
-			"         │   └─ IndexedTableAccess\n" +
+			"         │   └─ IndexedTableAccess(mytable)\n" +
 			"         │       ├─ index: [mytable.i]\n" +
-			"         │       ├─ columns: [i]\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: mytable\n" +
-			"         │           └─ projections: [0]\n" +
+			"         │       └─ columns: [i]\n" +
 			"         └─ TableAlias(T4)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.i2]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk ORDER BY pk`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
 			" ├─ static: [{[NULL, ∞)}]\n" +
-			" ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: one_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5]\n" +
+			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM two_pk ORDER BY pk1, pk2`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: two_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5 6]\n" +
+			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM two_pk ORDER BY pk1`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: two_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5 6]\n" +
+			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
 		Query: `SELECT pk1 AS one, pk2 AS two FROM two_pk ORDER BY pk1, pk2`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT pk1 AS one, pk2 AS two FROM two_pk ORDER BY one, two`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -1341,24 +1226,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1377,25 +1256,19 @@ inner join pq on true
 			"             ├─ Table\n" +
 			"             │   ├─ name: othertable\n" +
 			"             │   └─ columns: [i2]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk_two_idx WHERE v1 < 2 AND v2 IS NOT NULL`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (NOT(one_pk_two_idx.v2:2 IS NULL))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
 			"     ├─ static: [{(NULL, 2), (NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_two_idx\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1404,24 +1277,18 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ one_pk_two_idx.v1:1\n" +
 			" │   └─ TUPLE(1 (tinyint), 2 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
 			"     ├─ static: [{[2, 2], (NULL, 2]}, {[1, 1], (NULL, 2]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_two_idx\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk_three_idx WHERE v1 > 2 AND v2 = 3`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(one_pk_three_idx)\n" +
 			" ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			" ├─ static: [{(2, ∞), [3, 3], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: one_pk_three_idx\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -1430,13 +1297,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ one_pk_three_idx.v3:3\n" +
 			" │   └─ 3 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			"     ├─ static: [{(2, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_three_idx\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -1461,12 +1325,9 @@ inner join pq on true
 			"                 ├─ Eq\n" +
 			"                 │   ├─ mytable.i:0!null\n" +
 			"                 │   └─ 2 (tinyint)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(mytable)\n" +
 			"                     ├─ index: [mytable.i]\n" +
-			"                     ├─ columns: [i]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: mytable\n" +
-			"                         └─ projections: [0]\n" +
+			"                     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1475,7 +1336,8 @@ inner join pq on true
 			" └─ Insert(i, s)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: mytable\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [i:0!null, s:1!null]\n" +
 			"         └─ Project\n" +
@@ -1489,24 +1351,18 @@ inner join pq on true
 			"                 │   │   ├─ t2.i:0!null\n" +
 			"                 │   │   └─ 1 (tinyint)\n" +
 			"                 │   └─ TableAlias(t2)\n" +
-			"                 │       └─ IndexedTableAccess\n" +
+			"                 │       └─ IndexedTableAccess(mytable)\n" +
 			"                 │           ├─ index: [mytable.i]\n" +
 			"                 │           ├─ static: [{[1, 1]}]\n" +
-			"                 │           ├─ columns: [i]\n" +
-			"                 │           └─ Table\n" +
-			"                 │               ├─ name: mytable\n" +
-			"                 │               └─ projections: [0]\n" +
+			"                 │           └─ columns: [i]\n" +
 			"                 └─ Filter\n" +
 			"                     ├─ Eq\n" +
 			"                     │   ├─ t1.i:0!null\n" +
 			"                     │   └─ 2 (tinyint)\n" +
 			"                     └─ TableAlias(t1)\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(mytable)\n" +
 			"                             ├─ index: [mytable.i]\n" +
-			"                             ├─ columns: [i]\n" +
-			"                             └─ Table\n" +
-			"                                 ├─ name: mytable\n" +
-			"                                 └─ projections: [0]\n" +
+			"                             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1522,25 +1378,19 @@ inner join pq on true
 			"     │   │   ├─ t1.i:0!null\n" +
 			"     │   │   └─ 2 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t2.i:0!null\n" +
 			"         │   └─ 1 (tinyint)\n" +
 			"         └─ TableAlias(t2)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
 			"                 ├─ static: [{[NULL, ∞)}]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1556,24 +1406,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1589,24 +1433,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1622,24 +1460,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1653,12 +1485,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1677,18 +1506,12 @@ inner join pq on true
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(mytable)\n" +
 			"         │   ├─ index: [mytable.s,mytable.i]\n" +
-			"         │   ├─ columns: [i s]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: mytable\n" +
-			"         │       └─ projections: [0 1]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   └─ columns: [i s]\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -1708,18 +1531,12 @@ inner join pq on true
 			"     │       ├─ name: othertable\n" +
 			"     │       └─ columns: [s2 i2]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(mytable)\n" +
 			"         │   ├─ index: [mytable.s,mytable.i]\n" +
-			"         │   ├─ columns: [i s]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: mytable\n" +
-			"         │       └─ projections: [0 1]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   └─ columns: [i s]\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -1738,18 +1555,12 @@ inner join pq on true
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i s]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(othertable)\n" +
 			"         │   ├─ index: [othertable.s2]\n" +
-			"         │   ├─ columns: [s2 i2]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: othertable\n" +
-			"         │       └─ projections: [0 1]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   └─ columns: [s2 i2]\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1772,25 +1583,16 @@ inner join pq on true
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i s]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(othertable)\n" +
 			"         │   ├─ index: [othertable.s2]\n" +
-			"         │   ├─ columns: [s2 i2]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: othertable\n" +
-			"         │       └─ projections: [0 1]\n" +
+			"         │   └─ columns: [s2 i2]\n" +
 			"         └─ Concat\n" +
-			"             ├─ IndexedTableAccess\n" +
+			"             ├─ IndexedTableAccess(othertable)\n" +
 			"             │   ├─ index: [othertable.s2]\n" +
-			"             │   ├─ columns: [s2 i2]\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: othertable\n" +
-			"             │       └─ projections: [0 1]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   └─ columns: [s2 i2]\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.i2]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1805,12 +1607,9 @@ inner join pq on true
 			" │       ├─ Table\n" +
 			" │       │   ├─ name: othertable\n" +
 			" │       │   └─ columns: [s2 i2]\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(mytable)\n" +
 			" │           ├─ index: [mytable.i]\n" +
-			" │           ├─ columns: [i]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: mytable\n" +
-			" │               └─ projections: [0]\n" +
+			" │           └─ columns: [i]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [mytable.i:2!null, othertable.i2:1!null, othertable.s2:0!null]\n" +
 			"     └─ LookupJoin\n" +
@@ -1820,12 +1619,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: othertable\n" +
 			"         │   └─ columns: [s2 i2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1849,19 +1645,13 @@ inner join pq on true
 			"     │           ├─ Table\n" +
 			"     │           │   ├─ name: othertable\n" +
 			"     │           │   └─ columns: [s2 i2]\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ TableAlias(ot)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1885,19 +1675,13 @@ inner join pq on true
 			"     │           ├─ Table\n" +
 			"     │           │   ├─ name: othertable\n" +
 			"     │           │   └─ columns: [s2 i2]\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ TableAlias(ot)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1913,13 +1697,10 @@ inner join pq on true
 			"     │   │   ├─ ot.i2:1!null\n" +
 			"     │   │   └─ 0 (tinyint)\n" +
 			"     │   └─ TableAlias(ot)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(othertable)\n" +
 			"     │           ├─ index: [othertable.i2]\n" +
 			"     │           ├─ static: [{(0, ∞)}]\n" +
-			"     │           ├─ columns: [s2 i2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: othertable\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [s2 i2]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(ot.i2:1!null)\n" +
 			"         ├─ target: TUPLE(sub.i:0!null)\n" +
@@ -1944,12 +1725,9 @@ inner join pq on true
 			"                         │   └─ Table\n" +
 			"                         │       ├─ name: othertable\n" +
 			"                         │       └─ columns: [s2 i2]\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(mytable)\n" +
 			"                             ├─ index: [mytable.i]\n" +
-			"                             ├─ columns: [i]\n" +
-			"                             └─ Table\n" +
-			"                                 ├─ name: mytable\n" +
-			"                                 └─ projections: [0]\n" +
+			"                             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1967,12 +1745,9 @@ inner join pq on true
 			" │   │       ├─ name: one_pk\n" +
 			" │   │       └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" │   └─ TableAlias(k)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(one_pk)\n" +
 			" │           ├─ index: [one_pk.pk]\n" +
-			" │           ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: one_pk\n" +
-			" │               └─ projections: [0 1 2 3 4 5]\n" +
+			" │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" └─ HashLookup\n" +
 			"     ├─ source: TUPLE(i.pk:0!null)\n" +
 			"     ├─ target: TUPLE(j.pk:0!null)\n" +
@@ -2003,12 +1778,9 @@ inner join pq on true
 			" │   │       ├─ name: one_pk\n" +
 			" │   │       └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" │   └─ TableAlias(k)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(one_pk)\n" +
 			" │           ├─ index: [one_pk.pk]\n" +
-			" │           ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: one_pk\n" +
-			" │               └─ projections: [0 1 2 3 4 5]\n" +
+			" │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" └─ HashLookup\n" +
 			"     ├─ source: TUPLE(i.pk:0!null)\n" +
 			"     ├─ target: TUPLE(j.pk:0!null)\n" +
@@ -2030,7 +1802,8 @@ inner join pq on true
 			" └─ Insert(i, s)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: mytable\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [i:0!null, s:1!null]\n" +
 			"         └─ Project\n" +
@@ -2052,19 +1825,13 @@ inner join pq on true
 			"                 │           ├─ Table\n" +
 			"                 │           │   ├─ name: othertable\n" +
 			"                 │           │   └─ columns: [s2 i2]\n" +
-			"                 │           └─ IndexedTableAccess\n" +
+			"                 │           └─ IndexedTableAccess(mytable)\n" +
 			"                 │               ├─ index: [mytable.i]\n" +
-			"                 │               ├─ columns: [i]\n" +
-			"                 │               └─ Table\n" +
-			"                 │                   ├─ name: mytable\n" +
-			"                 │                   └─ projections: [0]\n" +
+			"                 │               └─ columns: [i]\n" +
 			"                 └─ TableAlias(ot)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(othertable)\n" +
 			"                         ├─ index: [othertable.i2]\n" +
-			"                         ├─ columns: [s2 i2]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: othertable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2081,11 +1848,11 @@ inner join pq on true
 			"     │   │   └─ selfjoin.i:0!null\n" +
 			"     │   ├─ TableAlias(selfjoin)\n" +
 			"     │   │   └─ Table\n" +
-			"     │   │       └─ name: mytable\n" +
-			"     │   └─ IndexedTableAccess\n" +
+			"     │   │       ├─ name: mytable\n" +
+			"     │   │       └─ columns: [i s]\n" +
+			"     │   └─ IndexedTableAccess(mytable)\n" +
 			"     │       ├─ index: [mytable.i]\n" +
-			"     │       └─ Table\n" +
-			"     │           └─ name: mytable\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -2093,7 +1860,8 @@ inner join pq on true
 			"         └─ Project\n" +
 			"             ├─ columns: [1 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -2105,12 +1873,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: othertable\n" +
 			" │   └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2124,12 +1889,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.i2]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2143,12 +1905,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.i2]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2162,12 +1921,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.i2]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2182,12 +1938,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: mytable\n" +
 			"         │   └─ columns: [i]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2201,12 +1954,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2218,12 +1968,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: othertable\n" +
 			" │   └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2239,12 +1986,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2263,12 +2007,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2284,12 +2025,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2307,12 +2045,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2331,12 +2066,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2420,13 +2152,10 @@ inner join pq on true
 		ExpectedPlan: "Filter\n" +
 			" ├─ (NOT(a.s:1!null IS NULL))\n" +
 			" └─ TableAlias(a)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.s]\n" +
 			"         ├─ static: [{(NULL, ∞)}]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2444,12 +2173,9 @@ inner join pq on true
 			"     └─ Filter\n" +
 			"         ├─ (NOT(a.s:1!null IS NULL))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2467,12 +2193,9 @@ inner join pq on true
 			"     └─ Filter\n" +
 			"         ├─ (NOT(a.s:1!null IS NULL))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2493,12 +2216,9 @@ inner join pq on true
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext), 4 (longtext))\n" +
 			"         │  ))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2518,12 +2238,9 @@ inner join pq on true
 			"         │   ├─ a.i:0!null\n" +
 			"         │   └─ TUPLE(1 (tinyint), 2 (tinyint), 3 (tinyint), 4 (tinyint))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2532,13 +2249,10 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(1 (tinyint), 2 (tinyint), 3 (tinyint), 4 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
 			"     ├─ static: [{[2, 2]}, {[3, 3]}, {[4, 4]}, {[1, 1]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2547,24 +2261,18 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(NULL (bigint), 2 (tinyint), 3 (tinyint), 4 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
 			"     ├─ static: [{[3, 3]}, {[4, 4]}, {[2, 2]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM mytable WHERE i in (1+2)`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(mytable)\n" +
 			" ├─ index: [mytable.i]\n" +
 			" ├─ static: [{[3, 3]}]\n" +
-			" ├─ columns: [i s]\n" +
-			" └─ Table\n" +
-			"     ├─ name: mytable\n" +
-			"     └─ projections: [0 1]\n" +
+			" └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2704,13 +2412,10 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.s:1!null\n" +
 			" │   └─ TUPLE(first row (longtext))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s]\n" +
 			"     ├─ static: [{[first row, first row]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2719,13 +2424,10 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.s:1!null\n" +
 			" │   └─ TUPLE(second row (longtext), FIRST ROW (longtext))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s]\n" +
 			"     ├─ static: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2755,12 +2457,9 @@ inner join pq on true
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2848,42 +2547,37 @@ inner join pq on true
 	},
 	{
 		Query: `SELECT a.* FROM mytable a, mytable b where a.i = a.s`,
-		ExpectedPlan: "Project\n" +
-			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ CrossJoin\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ Eq\n" +
-			"     │   │   ├─ a.i:0!null\n" +
-			"     │   │   └─ a.s:1!null\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: mytable\n" +
-			"     │           └─ columns: [i s]\n" +
-			"     └─ TableAlias(b)\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+		ExpectedPlan: "CrossJoin\n" +
+			" ├─ Filter\n" +
+			" │   ├─ Eq\n" +
+			" │   │   ├─ a.i:0!null\n" +
+			" │   │   └─ a.s:1!null\n" +
+			" │   └─ TableAlias(a)\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: mytable\n" +
+			" │           └─ columns: [i s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
 		Query: `SELECT a.* FROM mytable a, mytable b where a.i in (2, 432, 7)`,
-		ExpectedPlan: "Project\n" +
-			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ CrossJoin\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ HashIn\n" +
-			"     │   │   ├─ a.i:0!null\n" +
-			"     │   │   └─ TUPLE(2 (tinyint), 432 (smallint), 7 (tinyint))\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
-			"     │           ├─ index: [mytable.i]\n" +
-			"     │           ├─ static: [{[432, 432]}, {[7, 7]}, {[2, 2]}]\n" +
-			"     │           ├─ columns: [i s]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0 1]\n" +
-			"     └─ TableAlias(b)\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+		ExpectedPlan: "CrossJoin\n" +
+			" ├─ Filter\n" +
+			" │   ├─ HashIn\n" +
+			" │   │   ├─ a.i:0!null\n" +
+			" │   │   └─ TUPLE(2 (tinyint), 432 (smallint), 7 (tinyint))\n" +
+			" │   └─ TableAlias(a)\n" +
+			" │       └─ IndexedTableAccess(mytable)\n" +
+			" │           ├─ index: [mytable.i]\n" +
+			" │           ├─ static: [{[432, 432]}, {[7, 7]}, {[2, 2]}]\n" +
+			" │           └─ columns: [i s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -2907,12 +2601,9 @@ inner join pq on true
 			"     │       │   ├─ c.i:0!null\n" +
 			"     │       │   └─ 2 (tinyint)\n" +
 			"     │       └─ TableAlias(c)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(c.i:1!null)\n" +
 			"         ├─ target: TUPLE(b.i:0!null)\n" +
@@ -2926,12 +2617,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2971,12 +2659,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2997,22 +2682,17 @@ inner join pq on true
 			"     │   │   │       ├─ name: mytable\n" +
 			"     │   │   │       └─ columns: [i]\n" +
 			"     │   │   └─ TableAlias(b)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
-			"     │   │           ├─ columns: [i]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [i]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
-			"     │           ├─ columns: [i s]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -3028,12 +2708,9 @@ inner join pq on true
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3054,18 +2731,12 @@ inner join pq on true
 			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ Concat\n" +
-			"             ├─ IndexedTableAccess\n" +
+			"             ├─ IndexedTableAccess(mytable)\n" +
 			"             │   ├─ index: [mytable.i]\n" +
-			"             │   ├─ columns: [i s]\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: mytable\n" +
-			"             │       └─ projections: [0 1]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   └─ columns: [i s]\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3131,20 +2802,19 @@ inner join pq on true
 	},
 	{
 		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = a.i`,
-		ExpectedPlan: "Project\n" +
-			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ CrossJoin\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ Eq\n" +
-			"     │   │   ├─ a.i:0!null\n" +
-			"     │   │   └─ a.i:0!null\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: mytable\n" +
-			"     │           └─ columns: [i s]\n" +
-			"     └─ TableAlias(b)\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+		ExpectedPlan: "CrossJoin\n" +
+			" ├─ Filter\n" +
+			" │   ├─ Eq\n" +
+			" │   │   ├─ a.i:0!null\n" +
+			" │   │   └─ a.i:0!null\n" +
+			" │   └─ TableAlias(a)\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: mytable\n" +
+			" │           └─ columns: [i s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -3168,12 +2838,9 @@ inner join pq on true
 			"     │       │   ├─ c.i:0!null\n" +
 			"     │       │   └─ 2 (tinyint)\n" +
 			"     │       └─ TableAlias(c)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(c.i:1!null)\n" +
 			"         ├─ target: TUPLE(b.i:0!null)\n" +
@@ -3187,12 +2854,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3232,12 +2896,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3258,22 +2919,17 @@ inner join pq on true
 			"     │   │   │       ├─ name: mytable\n" +
 			"     │   │   │       └─ columns: [s]\n" +
 			"     │   │   └─ TableAlias(b)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.s]\n" +
-			"     │   │           ├─ columns: [i s]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0 1]\n" +
+			"     │   │           └─ columns: [i s]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
-			"     │           ├─ columns: [i s]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -3291,12 +2947,9 @@ inner join pq on true
 			"     └─ Filter\n" +
 			"         ├─ (a.i:0!null BETWEEN 10 (tinyint) AND 20 (tinyint))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3349,12 +3002,9 @@ inner join pq on true
 			" │   └─ Table\n" +
 			" │       ├─ name: othertable\n" +
 			" │       └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3370,12 +3020,9 @@ inner join pq on true
 			" │   └─ Table\n" +
 			" │       ├─ name: othertable\n" +
 			" │       └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3388,13 +3035,10 @@ inner join pq on true
 			"     ├─ Eq\n" +
 			"     │   ├─ othertable.s2:0!null\n" +
 			"     │   └─ a (longtext)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.s2]\n" +
 			"         ├─ static: [{[a, a]}]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3415,13 +3059,10 @@ inner join pq on true
 			"             ├─ Eq\n" +
 			"             │   ├─ othertable.s2:0!null\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.s2]\n" +
 			"                 ├─ static: [{[a, a]}]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3438,19 +3079,13 @@ inner join pq on true
 			" │       ├─ GreaterThan\n" +
 			" │       │   ├─ othertable.s2:0!null\n" +
 			" │       │   └─ a (longtext)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(othertable)\n" +
 			" │           ├─ index: [othertable.s2]\n" +
 			" │           ├─ static: [{(a, ∞)}]\n" +
-			" │           ├─ columns: [s2 i2]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: othertable\n" +
-			" │               └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │           └─ columns: [s2 i2]\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3468,10 +3103,9 @@ inner join pq on true
 			" │           └─ Table\n" +
 			" │               ├─ name: othertable\n" +
 			" │               └─ columns: [i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     └─ Table\n" +
-			"         └─ name: mytable\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3485,10 +3119,9 @@ inner join pq on true
 			" │       └─ Table\n" +
 			" │           ├─ name: othertable\n" +
 			" │           └─ columns: [i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     └─ Table\n" +
-			"         └─ name: mytable\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3502,14 +3135,12 @@ inner join pq on true
 			" │           ├─ Eq\n" +
 			" │           │   ├─ mytable.i:0!null\n" +
 			" │           │   └─ othertable.i2:2!null\n" +
-			" │           └─ IndexedTableAccess\n" +
+			" │           └─ IndexedTableAccess(othertable)\n" +
 			" │               ├─ index: [othertable.i2]\n" +
-			" │               ├─ columns: [i2]\n" +
-			" │               └─ Table\n" +
-			" │                   ├─ name: othertable\n" +
-			" │                   └─ projections: [1]\n" +
+			" │               └─ columns: [i2]\n" +
 			" └─ Table\n" +
-			"     └─ name: mytable\n" +
+			"     ├─ name: mytable\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3529,12 +3160,9 @@ inner join pq on true
 			"         │   ├─ mt.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(mt)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3552,12 +3180,9 @@ inner join pq on true
 			" │       ├─ name: mytable\n" +
 			" │       └─ columns: [i s]\n" +
 			" └─ TableAlias(o)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0 1 2 3 4 5]\n" +
+			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -3571,12 +3196,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3596,12 +3218,9 @@ inner join pq on true
 			"         │       ├─ name: othertable\n" +
 			"         │       └─ columns: [s2 i2]\n" +
 			"         └─ TableAlias(mt)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3611,13 +3230,15 @@ inner join pq on true
 			" └─ InnerJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ t1.Timestamp:0!null\n" +
-			"     │   └─ t2.Timestamp:4!null\n" +
+			"     │   └─ t2.Timestamp:1!null\n" +
 			"     ├─ TableAlias(t1)\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: reservedWordsTable\n" +
+			"     │       ├─ name: reservedWordsTable\n" +
+			"     │       └─ columns: [timestamp]\n" +
 			"     └─ TableAlias(t2)\n" +
 			"         └─ Table\n" +
-			"             └─ name: reservedWordsTable\n" +
+			"             ├─ name: reservedWordsTable\n" +
+			"             └─ columns: [timestamp]\n" +
 			"",
 	},
 	{
@@ -3633,12 +3254,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3680,12 +3298,9 @@ inner join pq on true
 			" │       ├─ name: one_pk\n" +
 			" │       └─ columns: [pk]\n" +
 			" └─ TableAlias(tpk)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3701,12 +3316,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3720,12 +3332,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3739,12 +3348,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3756,12 +3362,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3779,12 +3382,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: two_pk\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -3793,13 +3393,10 @@ inner join pq on true
 			" ├─ name: othertable_alias\n" +
 			" ├─ outerVisibility: false\n" +
 			" ├─ cacheable: true\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
 			"     ├─ index: [othertable.i2]\n" +
 			"     ├─ static: [{[1, 1]}]\n" +
-			"     ├─ columns: [s2 i2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: othertable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3808,13 +3405,10 @@ inner join pq on true
 			" ├─ name: othertable_alias\n" +
 			" ├─ outerVisibility: false\n" +
 			" ├─ cacheable: true\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
 			"     ├─ index: [othertable.i2]\n" +
 			"     ├─ static: [{[1, 1]}]\n" +
-			"     ├─ columns: [s2 i2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: othertable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3850,13 +3444,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ datetime_table.date_col:1\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.date_col]\n" +
 			"     ├─ static: [{[2020-01-01, 2020-01-01]}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3865,13 +3456,10 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ datetime_table.date_col:1\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.date_col]\n" +
 			"     ├─ static: [{(2020-01-01, ∞)}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3880,13 +3468,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ datetime_table.datetime_col:2\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.datetime_col]\n" +
 			"     ├─ static: [{[2020-01-01, 2020-01-01]}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3895,13 +3480,10 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ datetime_table.datetime_col:2\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.datetime_col]\n" +
 			"     ├─ static: [{(2020-01-01, ∞)}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3910,13 +3492,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ datetime_table.timestamp_col:3\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.timestamp_col]\n" +
 			"     ├─ static: [{[2020-01-01, 2020-01-01]}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3925,13 +3504,10 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ datetime_table.timestamp_col:3\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.timestamp_col]\n" +
 			"     ├─ static: [{(2020-01-01, ∞)}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3947,12 +3523,9 @@ inner join pq on true
 			"     │       ├─ name: datetime_table\n" +
 			"     │       └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"     └─ TableAlias(dt1)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(datetime_table)\n" +
 			"             ├─ index: [datetime_table.timestamp_col]\n" +
-			"             ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: datetime_table\n" +
-			"                 └─ projections: [0 1 2 3 4]\n" +
+			"             └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3968,12 +3541,9 @@ inner join pq on true
 			"     │       ├─ name: datetime_table\n" +
 			"     │       └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"     └─ TableAlias(dt1)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(datetime_table)\n" +
 			"             ├─ index: [datetime_table.date_col]\n" +
-			"             ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: datetime_table\n" +
-			"                 └─ projections: [0 1 2 3 4]\n" +
+			"             └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3989,12 +3559,9 @@ inner join pq on true
 			"     │       ├─ name: datetime_table\n" +
 			"     │       └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"     └─ TableAlias(dt1)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(datetime_table)\n" +
 			"             ├─ index: [datetime_table.datetime_col]\n" +
-			"             ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: datetime_table\n" +
-			"                 └─ projections: [0 1 2 3 4]\n" +
+			"             └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -4013,12 +3580,9 @@ inner join pq on true
 			"         │       ├─ name: datetime_table\n" +
 			"         │       └─ columns: [timestamp_col]\n" +
 			"         └─ TableAlias(dt1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(datetime_table)\n" +
 			"                 ├─ index: [datetime_table.date_col]\n" +
-			"                 ├─ columns: [i date_col]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: datetime_table\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i date_col]\n" +
 			"",
 	},
 	{
@@ -4059,12 +3623,9 @@ inner join pq on true
 			"             │       ├─ name: datetime_table\n" +
 			"             │       └─ columns: [timestamp_col]\n" +
 			"             └─ TableAlias(dt1)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(datetime_table)\n" +
 			"                     ├─ index: [datetime_table.date_col]\n" +
-			"                     ├─ columns: [i date_col]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: datetime_table\n" +
-			"                         └─ projections: [0 1]\n" +
+			"                     └─ columns: [i date_col]\n" +
 			"",
 	},
 	{
@@ -4093,19 +3654,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4135,19 +3690,13 @@ inner join pq on true
 			"     │   │   └─ Table\n" +
 			"     │   │       ├─ name: two_pk\n" +
 			"     │   │       └─ columns: [pk1 pk2]\n" +
-			"     │   └─ IndexedTableAccess\n" +
+			"     │   └─ IndexedTableAccess(one_pk)\n" +
 			"     │       ├─ index: [one_pk.pk]\n" +
-			"     │       ├─ columns: [pk]\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: one_pk\n" +
-			"     │           └─ projections: [0]\n" +
+			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4177,19 +3726,13 @@ inner join pq on true
 			"     │   │   └─ Table\n" +
 			"     │   │       ├─ name: two_pk\n" +
 			"     │   │       └─ columns: [pk1 pk2]\n" +
-			"     │   └─ IndexedTableAccess\n" +
+			"     │   └─ IndexedTableAccess(one_pk)\n" +
 			"     │       ├─ index: [one_pk.pk]\n" +
-			"     │       ├─ columns: [pk]\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: one_pk\n" +
-			"     │           └─ projections: [0]\n" +
+			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4220,19 +3763,13 @@ inner join pq on true
 			"         │   │   ├─ name: one_pk\n" +
 			"         │   │   └─ columns: [pk]\n" +
 			"         │   └─ TableAlias(tpk2)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(two_pk)\n" +
 			"         │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │           ├─ columns: [pk1 pk2]\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: two_pk\n" +
-			"         │               └─ projections: [0 1]\n" +
+			"         │           └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(tpk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4261,19 +3798,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4302,19 +3833,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4343,19 +3868,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4392,12 +3911,9 @@ inner join pq on true
 			"                 │   └─ Table\n" +
 			"                 │       ├─ name: two_pk\n" +
 			"                 │       └─ columns: [pk1 pk2]\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(one_pk)\n" +
 			"                     ├─ index: [one_pk.pk]\n" +
-			"                     ├─ columns: [pk]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: one_pk\n" +
-			"                         └─ projections: [0]\n" +
+			"                     └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4413,12 +3929,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: mytable\n" +
 			" │   └─ columns: [i]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4430,12 +3943,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4447,12 +3957,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i]\n" +
-			"     ├─ columns: [i f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4466,12 +3973,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: niltable\n" +
 			"     │   └─ columns: [i f]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4500,12 +4004,9 @@ inner join pq on true
 			"                 │   └─ Table\n" +
 			"                 │       ├─ name: niltable\n" +
 			"                 │       └─ columns: [i]\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(one_pk)\n" +
 			"                     ├─ index: [one_pk.pk]\n" +
-			"                     ├─ columns: [pk]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: one_pk\n" +
-			"                         └─ projections: [0]\n" +
+			"                     └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4519,12 +4020,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i]\n" +
-			"     ├─ columns: [i f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4542,12 +4040,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: niltable\n" +
 			"     │   └─ columns: [i f]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4561,12 +4056,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4584,12 +4076,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: one_pk\n" +
 			"         │   └─ columns: [pk]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 3]\n" +
+			"             └─ columns: [i i2 f]\n" +
 			"",
 	},
 	{
@@ -4605,12 +4094,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4628,12 +4114,9 @@ inner join pq on true
 			"     │   └─ Table\n" +
 			"     │       ├─ name: one_pk\n" +
 			"     │       └─ columns: [pk c1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4649,12 +4132,9 @@ inner join pq on true
 			"     │   └─ Table\n" +
 			"     │       ├─ name: niltable\n" +
 			"     │       └─ columns: [i f]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4663,19 +4143,13 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ one_pk.pk:0!null\n" +
 			" │   └─ niltable.i:1!null\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(one_pk)\n" +
 			" │   ├─ index: [one_pk.pk]\n" +
 			" │   ├─ static: [{(1, ∞)}]\n" +
-			" │   ├─ columns: [pk]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: one_pk\n" +
-			" │       └─ projections: [0]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [pk]\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i]\n" +
-			"     ├─ columns: [i f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4690,12 +4164,9 @@ inner join pq on true
 			"         │       ├─ name: niltable\n" +
 			"         │       └─ columns: [i2]\n" +
 			"         └─ TableAlias(l)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(niltable)\n" +
 			"                 ├─ index: [niltable.i2]\n" +
-			"                 ├─ columns: [i i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: niltable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i i2]\n" +
 			"",
 	},
 	{
@@ -4713,12 +4184,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: niltable\n" +
 			"         │   └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4732,12 +4200,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: two_pk\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4751,12 +4216,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: two_pk\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4777,12 +4239,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4803,12 +4262,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4829,12 +4285,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4853,12 +4306,9 @@ inner join pq on true
 			"     │       ├─ name: two_pk\n" +
 			"     │       └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4879,12 +4329,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4905,12 +4352,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4925,12 +4369,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: two_pk\n" +
 			"         │   └─ columns: [pk1 pk2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk c5]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0 5]\n" +
+			"             └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -4947,12 +4388,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(opk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk c5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0 5]\n" +
+			"                 └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -4969,12 +4407,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(opk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk c5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0 5]\n" +
+			"                 └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -4991,12 +4426,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(opk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk c5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0 5]\n" +
+			"                 └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -5011,12 +4443,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: two_pk\n" +
 			"         │   └─ columns: [pk1 pk2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk c5]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0 5]\n" +
+			"             └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -5025,13 +4454,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ niltable.i2:1\n" +
 			" │   └─ NULL (null)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{(∞, ∞)}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -5041,13 +4467,10 @@ inner join pq on true
 			" │   ├─ niltable.i2:1\n" +
 			" │   └─ NULL (null)\n" +
 			" │  ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{(∞, ∞)}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -5056,26 +4479,20 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ niltable.i2:1\n" +
 			" │   └─ NULL (null)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{(∞, ∞)}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM niltable WHERE i2 <=> NULL`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (niltable.i2:1 <=> NULL (null))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{[NULL, NULL]}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -5088,12 +4505,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -5108,12 +4522,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: one_pk\n" +
 			"         │   └─ columns: [pk]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 3]\n" +
+			"             └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -5123,19 +4534,13 @@ inner join pq on true
 			"     ├─ Eq\n" +
 			"     │   ├─ one_pk.pk:0!null\n" +
 			"     │   └─ niltable.i:1!null\n" +
-			"     ├─ IndexedTableAccess\n" +
+			"     ├─ IndexedTableAccess(one_pk)\n" +
 			"     │   ├─ index: [one_pk.pk]\n" +
 			"     │   ├─ static: [{(1, ∞)}]\n" +
-			"     │   ├─ columns: [pk]\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: one_pk\n" +
-			"     │       └─ projections: [0]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   └─ columns: [pk]\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -5150,12 +4555,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: niltable\n" +
 			"         │   └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5172,12 +4574,9 @@ inner join pq on true
 			"         │   └─ Table\n" +
 			"         │       ├─ name: niltable\n" +
 			"         │       └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5196,12 +4595,9 @@ inner join pq on true
 			"             ├─ Table\n" +
 			"             │   ├─ name: niltable\n" +
 			"             │   └─ columns: [i f]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5220,12 +4616,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: niltable\n" +
 			"         │   └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5242,12 +4635,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5294,12 +4684,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5312,12 +4699,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5336,12 +4720,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: two_pk\n" +
 			"         │   └─ columns: [pk1 pk2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5360,12 +4741,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk\n" +
 			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5384,12 +4762,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk\n" +
 			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5467,13 +4842,10 @@ inner join pq on true
 			"     │   │   ├─ t1.pk:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t2.pk2:0!null\n" +
@@ -5493,13 +4865,10 @@ inner join pq on true
 			"     │   │   ├─ t1.pk:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ Filter\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
@@ -5509,13 +4878,10 @@ inner join pq on true
 			"         │       ├─ t2.pk1:0!null\n" +
 			"         │       └─ 1 (tinyint)\n" +
 			"         └─ TableAlias(t2)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"                 ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5532,13 +4898,10 @@ inner join pq on true
 			"     │   │       ├─ Eq\n" +
 			"     │   │       │   ├─ mytable.i:2!null\n" +
 			"     │   │       │   └─ mt.i:0!null\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
 			"     │   │           ├─ static: [{(2, ∞)}]\n" +
-			"     │   │           ├─ columns: [i]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [i]\n" +
 			"     │   │   IS NULL))\n" +
 			"     │   └─ (NOT(Subquery\n" +
 			"     │       ├─ cacheable: false\n" +
@@ -5546,16 +4909,14 @@ inner join pq on true
 			"     │           ├─ Eq\n" +
 			"     │           │   ├─ othertable.i2:2!null\n" +
 			"     │           │   └─ mt.i:0!null\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(othertable)\n" +
 			"     │               ├─ index: [othertable.i2]\n" +
-			"     │               ├─ columns: [i2]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: othertable\n" +
-			"     │                   └─ projections: [1]\n" +
+			"     │               └─ columns: [i2]\n" +
 			"     │       IS NULL))\n" +
 			"     └─ TableAlias(mt)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -5572,12 +4933,9 @@ inner join pq on true
 			"     │   │       ├─ Eq\n" +
 			"     │   │       │   ├─ mytable.i:2!null\n" +
 			"     │   │       │   └─ mt.i:0!null\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
-			"     │   │           ├─ columns: [i]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [i]\n" +
 			"     │   │   IS NULL))\n" +
 			"     │   └─ (NOT(Subquery\n" +
 			"     │       ├─ cacheable: false\n" +
@@ -5589,16 +4947,14 @@ inner join pq on true
 			"     │           │   └─ GreaterThan\n" +
 			"     │           │       ├─ mt.i:0!null\n" +
 			"     │           │       └─ 2 (tinyint)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(othertable)\n" +
 			"     │               ├─ index: [othertable.i2]\n" +
-			"     │               ├─ columns: [i2]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: othertable\n" +
-			"     │                   └─ projections: [1]\n" +
+			"     │               └─ columns: [i2]\n" +
 			"     │       IS NULL))\n" +
 			"     └─ TableAlias(mt)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -5608,13 +4964,10 @@ inner join pq on true
 			"     ├─ columns: [t1.pk:0!null, t2.pk2:7!null, Subquery\n" +
 			"     │   ├─ cacheable: true\n" +
 			"     │   └─ Limit(1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     │   as (SELECT pk from one_pk where pk = 1 limit 1)]\n" +
 			"     └─ CrossJoin\n" +
 			"         ├─ Filter\n" +
@@ -5622,18 +4975,18 @@ inner join pq on true
 			"         │   │   ├─ t1.pk:0!null\n" +
 			"         │   │   └─ 1 (tinyint)\n" +
 			"         │   └─ TableAlias(t1)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(one_pk)\n" +
 			"         │           ├─ index: [one_pk.pk]\n" +
 			"         │           ├─ static: [{[1, 1]}]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: one_pk\n" +
+			"         │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"         └─ Filter\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ t2.pk2:1!null\n" +
 			"             │   └─ 1 (tinyint)\n" +
 			"             └─ TableAlias(t2)\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: two_pk\n" +
+			"                     ├─ name: two_pk\n" +
+			"                     └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5650,13 +5003,10 @@ inner join pq on true
 			"             │   ├─ othertable.s2:0!null\n" +
 			"             │   └─ second (longtext)\n" +
 			"             │  ))\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.s2]\n" +
 			"                 ├─ static: [{(second, ∞)}, {(NULL, second)}]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -5691,13 +5041,10 @@ inner join pq on true
 			"         ├─ row_number() over ( order by othertable.s2 ASC)\n" +
 			"         ├─ othertable.i2:1!null\n" +
 			"         ├─ othertable.s2:0!null\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
 			"             ├─ static: [{(NULL, 2)}, {(2, ∞)}]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -5772,18 +5119,18 @@ inner join pq on true
 			"         │   ├─ two_pk.c1:2!null\n" +
 			"         │   └─ 1 (tinyint)\n" +
 			"         └─ Table\n" +
-			"             └─ name: two_pk\n" +
+			"             ├─ name: two_pk\n" +
+			"             └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
 		Query: `DELETE FROM two_pk WHERE pk1 = 1 AND pk2 = 2`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"         ├─ static: [{[1, 1], [2, 2]}]\n" +
-			"         └─ Table\n" +
-			"             └─ name: two_pk\n" +
+			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5796,7 +5143,8 @@ inner join pq on true
 			"             │   ├─ two_pk.c1:2!null\n" +
 			"             │   └─ 1 (tinyint)\n" +
 			"             └─ Table\n" +
-			"                 └─ name: two_pk\n" +
+			"                 ├─ name: two_pk\n" +
+			"                 └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5804,11 +5152,10 @@ inner join pq on true
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET two_pk.c1:2!null = 1 (tinyint))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"             ├─ static: [{[1, 1], [2, 2]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: two_pk\n" +
+			"             └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5861,12 +5208,9 @@ inner join pq on true
 			"     │       ├─ name: invert_pk\n" +
 			"     │       └─ columns: [z]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ columns: [x y z]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: invert_pk\n" +
-			"                 └─ projections: [0 1 2]\n" +
+			"             └─ columns: [x y z]\n" +
 			"",
 	},
 	{
@@ -5886,56 +5230,41 @@ inner join pq on true
 			"         │   ├─ a.z:2!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(invert_pk)\n" +
 			"                 ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"                 ├─ columns: [x y z]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: invert_pk\n" +
-			"                     └─ projections: [0 1 2]\n" +
+			"                 └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM invert_pk WHERE y = 0`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
 			" ├─ static: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [x y z]\n" +
-			" └─ Table\n" +
-			"     ├─ name: invert_pk\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM invert_pk WHERE y >= 0`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
 			" ├─ static: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [x y z]\n" +
-			" └─ Table\n" +
-			"     ├─ name: invert_pk\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM invert_pk WHERE y >= 0 AND z < 1`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
 			" ├─ static: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
-			" ├─ columns: [x y z]\n" +
-			" └─ Table\n" +
-			"     ├─ name: invert_pk\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk WHERE pk IN (1)`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
 			" ├─ static: [{[1, 1]}]\n" +
-			" ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: one_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5]\n" +
+			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5960,12 +5289,9 @@ inner join pq on true
 			"     │           ├─ name: one_pk\n" +
 			"     │           └─ columns: [pk]\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6016,19 +5342,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk\n" +
 			"     │   │       └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1 2 3 4 5]\n" +
+			"     │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"     └─ TableAlias(c)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6053,19 +5373,13 @@ inner join pq on true
 			"     │   │           ├─ name: one_pk\n" +
 			"     │   │           └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(c)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ TableAlias(d)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6114,12 +5428,9 @@ inner join pq on true
 			"     │           ├─ name: mytable\n" +
 			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(ot)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -6179,13 +5490,10 @@ inner join pq on true
 			"     │       │   ├─ b.pk:0!null\n" +
 			"     │       │   └─ 0 (tinyint)\n" +
 			"     │       └─ TableAlias(b)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     │               ├─ index: [one_pk_three_idx.pk]\n" +
 			"     │               ├─ static: [{[0, 0]}]\n" +
-			"     │               ├─ columns: [pk]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: one_pk_three_idx\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [pk]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(b.pk:2!null)\n" +
 			"         ├─ target: TUPLE(c.v1:0)\n" +
@@ -6216,16 +5524,15 @@ inner join pq on true
 			"                 ├─ name: a\n" +
 			"                 ├─ outerVisibility: false\n" +
 			"                 ├─ cacheable: true\n" +
-			"                 └─ Project\n" +
-			"                     ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			"                     └─ CrossJoin\n" +
-			"                         ├─ TableAlias(a)\n" +
-			"                         │   └─ Table\n" +
-			"                         │       ├─ name: mytable\n" +
-			"                         │       └─ columns: [i s]\n" +
-			"                         └─ TableAlias(b)\n" +
-			"                             └─ Table\n" +
-			"                                 └─ name: mytable\n" +
+			"                 └─ CrossJoin\n" +
+			"                     ├─ TableAlias(a)\n" +
+			"                     │   └─ Table\n" +
+			"                     │       ├─ name: mytable\n" +
+			"                     │       └─ columns: [i s]\n" +
+			"                     └─ TableAlias(b)\n" +
+			"                         └─ Table\n" +
+			"                             ├─ name: mytable\n" +
+			"                             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6257,12 +5564,9 @@ inner join pq on true
 			"                 │   │       ├─ name: mytable\n" +
 			"                 │   │       └─ columns: [i]\n" +
 			"                 │   └─ TableAlias(a)\n" +
-			"                 │       └─ IndexedTableAccess\n" +
+			"                 │       └─ IndexedTableAccess(mytable)\n" +
 			"                 │           ├─ index: [mytable.i]\n" +
-			"                 │           ├─ columns: [i s]\n" +
-			"                 │           └─ Table\n" +
-			"                 │               ├─ name: mytable\n" +
-			"                 │               └─ projections: [0 1]\n" +
+			"                 │           └─ columns: [i s]\n" +
 			"                 └─ HashLookup\n" +
 			"                     ├─ source: TUPLE(a.i:2)\n" +
 			"                     ├─ target: TUPLE((c.i:0!null - 1 (tinyint)))\n" +
@@ -6294,12 +5598,9 @@ inner join pq on true
 			"     │   │   │       ├─ name: othertable\n" +
 			"     │   │   │       └─ columns: [s2 i2]\n" +
 			"     │   │   └─ TableAlias(a)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
-			"     │   │           ├─ columns: [i s]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0 1]\n" +
+			"     │   │           └─ columns: [i s]\n" +
 			"     │   └─ HashLookup\n" +
 			"     │       ├─ source: TUPLE(a.i:2)\n" +
 			"     │       ├─ target: TUPLE((c.i:0!null - 1 (tinyint)))\n" +
@@ -6309,12 +5610,9 @@ inner join pq on true
 			"     │                   ├─ name: mytable\n" +
 			"     │                   └─ columns: [i]\n" +
 			"     └─ TableAlias(d)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [1]\n" +
+			"             └─ columns: [i2]\n" +
 			"",
 	},
 	{
@@ -6346,19 +5644,13 @@ inner join pq on true
 			"     │               │       ├─ name: othertable\n" +
 			"     │               │       └─ columns: [s2 i2]\n" +
 			"     │               └─ TableAlias(a)\n" +
-			"     │                   └─ IndexedTableAccess\n" +
+			"     │                   └─ IndexedTableAccess(mytable)\n" +
 			"     │                       ├─ index: [mytable.i]\n" +
-			"     │                       ├─ columns: [i s]\n" +
-			"     │                       └─ Table\n" +
-			"     │                           ├─ name: mytable\n" +
-			"     │                           └─ projections: [0 1]\n" +
+			"     │                       └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [1]\n" +
+			"             └─ columns: [i2]\n" +
 			"",
 	},
 	{
@@ -6374,12 +5666,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk_two_idx\n" +
 			"     │       └─ columns: [pk v1]\n" +
 			"     └─ TableAlias(j)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"             ├─ index: [one_pk_three_idx.pk]\n" +
-			"             ├─ columns: [pk v3]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_three_idx\n" +
-			"                 └─ projections: [0 3]\n" +
+			"             └─ columns: [pk v3]\n" +
 			"",
 	},
 	{
@@ -6399,19 +5688,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk_three_idx\n" +
 			"     │   │       └─ columns: [pk v3]\n" +
 			"     │   └─ TableAlias(k)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk c1]\n" +
 			"     └─ TableAlias(i)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"             ├─ index: [one_pk_two_idx.v1]\n" +
-			"             ├─ columns: [pk v1]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_two_idx\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk v1]\n" +
 			"",
 	},
 	{
@@ -6427,12 +5710,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk_two_idx\n" +
 			"     │       └─ columns: [pk v1]\n" +
 			"     └─ TableAlias(j)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"             ├─ index: [one_pk_three_idx.pk]\n" +
-			"             ├─ columns: [pk v3]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_three_idx\n" +
-			"                 └─ projections: [0 3]\n" +
+			"             └─ columns: [pk v3]\n" +
 			"",
 	},
 	{
@@ -6452,19 +5732,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk_three_idx\n" +
 			"     │   │       └─ columns: [pk v3]\n" +
 			"     │   └─ TableAlias(k)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk c1]\n" +
 			"     └─ TableAlias(i)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"             ├─ index: [one_pk_two_idx.v1]\n" +
-			"             ├─ columns: [pk v1]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_two_idx\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk v1]\n" +
 			"",
 	},
 	{
@@ -6484,19 +5758,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk_three_idx\n" +
 			"     │   │       └─ columns: [pk v3]\n" +
 			"     │   └─ TableAlias(k)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk c1]\n" +
 			"     └─ TableAlias(i)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"             ├─ index: [one_pk_two_idx.v1]\n" +
-			"             ├─ columns: [pk v1]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_two_idx\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk v1]\n" +
 			"",
 	},
 	{
@@ -6520,19 +5788,13 @@ inner join pq on true
 			"     │   │   │       ├─ name: one_pk_two_idx\n" +
 			"     │   │   │       └─ columns: [v1]\n" +
 			"     │   │   └─ TableAlias(j)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     │   │           ├─ index: [one_pk_three_idx.pk]\n" +
-			"     │   │           ├─ columns: [pk]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: one_pk_three_idx\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"     │           ├─ index: [one_pk_two_idx.pk]\n" +
-			"     │           ├─ columns: [pk v1 v2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk_two_idx\n" +
-			"     │               └─ projections: [0 1 2]\n" +
+			"     │           └─ columns: [pk v1 v2]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(a.pk:2)\n" +
 			"         ├─ target: TUPLE(l.v2:2)\n" +
@@ -6546,12 +5808,9 @@ inner join pq on true
 			"                 │       ├─ name: one_pk_two_idx\n" +
 			"                 │       └─ columns: [v1]\n" +
 			"                 └─ TableAlias(l)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"                         ├─ index: [one_pk_three_idx.pk]\n" +
-			"                         ├─ columns: [pk v2]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: one_pk_three_idx\n" +
-			"                             └─ projections: [0 2]\n" +
+			"                         └─ columns: [pk v2]\n" +
 			"",
 	},
 	{
@@ -6603,12 +5862,9 @@ inner join pq on true
 			"                             │       ├─ name: one_pk_three_idx\n" +
 			"                             │       └─ columns: [v3]\n" +
 			"                             └─ TableAlias(i)\n" +
-			"                                 └─ IndexedTableAccess\n" +
+			"                                 └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"                                     ├─ index: [one_pk_two_idx.pk]\n" +
-			"                                     ├─ columns: [pk]\n" +
-			"                                     └─ Table\n" +
-			"                                         ├─ name: one_pk_two_idx\n" +
-			"                                         └─ projections: [0]\n" +
+			"                                     └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6628,12 +5884,9 @@ inner join pq on true
 			"         │   ├─ a.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -6649,12 +5902,9 @@ inner join pq on true
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -6663,13 +5913,10 @@ inner join pq on true
 			" ├─ LessThan\n" +
 			" │   ├─ one_pk_three_idx.pk:0!null\n" +
 			" │   └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_three_idx\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6678,13 +5925,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ one_pk_three_idx.pk:0!null\n" +
 			" │   └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_three_idx\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6700,12 +5944,9 @@ inner join pq on true
 			" └─ Filter\n" +
 			"     ├─ (b.b:2 <=> NULL (null))\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 b f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 2 3]\n" +
+			"             └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6721,12 +5962,9 @@ inner join pq on true
 			" └─ Filter\n" +
 			"     ├─ (NOT(b.b:2 IS NULL))\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 b f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 2 3]\n" +
+			"             └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6745,12 +5983,9 @@ inner join pq on true
 			"     │   └─ 0 (tinyint)\n" +
 			"     │  ))\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 b f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 2 3]\n" +
+			"             └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6762,20 +5997,14 @@ inner join pq on true
 			" ├─ Filter\n" +
 			" │   ├─ (NOT(a.s:1!null IS NULL))\n" +
 			" │   └─ TableAlias(a)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(mytable)\n" +
 			" │           ├─ index: [mytable.s]\n" +
 			" │           ├─ static: [{(NULL, ∞)}]\n" +
-			" │           ├─ columns: [i s]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: mytable\n" +
-			" │               └─ projections: [0 1]\n" +
+			" │           └─ columns: [i s]\n" +
 			" └─ TableAlias(b)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i i2 b f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 1 2 3]\n" +
+			"         └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6838,13 +6067,16 @@ inner join pq on true
 			"         │               ├─ Project\n" +
 			"         │               │   ├─ columns: [1 (tinyint)]\n" +
 			"         │               │   └─ Table\n" +
-			"         │               │       └─ name: \n" +
+			"         │               │       ├─ name: \n" +
+			"         │               │       └─ columns: []\n" +
 			"         │               └─ Project\n" +
 			"         │                   ├─ columns: [2 (tinyint)]\n" +
 			"         │                   └─ Table\n" +
-			"         │                       └─ name: \n" +
+			"         │                       ├─ name: \n" +
+			"         │                       └─ columns: []\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6856,13 +6088,10 @@ inner join pq on true
 			"     │   │   ├─ t1.pk:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ Filter\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
@@ -6872,13 +6101,10 @@ inner join pq on true
 			"         │       ├─ t2.pk1:0!null\n" +
 			"         │       └─ 1 (tinyint)\n" +
 			"         └─ TableAlias(t2)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"                 ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -6893,11 +6119,13 @@ inner join pq on true
 			" │       ├─ Project\n" +
 			" │       │   ├─ columns: [1 (tinyint)]\n" +
 			" │       │   └─ Table\n" +
-			" │       │       └─ name: \n" +
+			" │       │       ├─ name: \n" +
+			" │       │       └─ columns: []\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6906,11 +6134,13 @@ inner join pq on true
 			"         ├─ Project\n" +
 			"         │   ├─ columns: [1 (tinyint)]\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: \n" +
+			"         │       ├─ name: \n" +
+			"         │       └─ columns: []\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [2 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6928,11 +6158,13 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [1 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [2 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ Having\n" +
 			"     ├─ GreaterThan\n" +
 			"     │   ├─ a.x:0!null\n" +
@@ -6945,11 +6177,13 @@ inner join pq on true
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1 (tinyint)]\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: \n" +
+			"             │       ├─ name: \n" +
+			"             │       └─ columns: []\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [2 (tinyint)]\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: \n" +
+			"                     ├─ name: \n" +
+			"                     └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6967,11 +6201,13 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [1 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [2 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6984,11 +6220,13 @@ inner join pq on true
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1 (tinyint)]\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: \n" +
+			"             │       ├─ name: \n" +
+			"             │       └─ columns: []\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [2 (tinyint)]\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: \n" +
+			"                     ├─ name: \n" +
+			"                     └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7002,11 +6240,13 @@ inner join pq on true
 			" │       ├─ Project\n" +
 			" │       │   ├─ columns: [1 (tinyint)]\n" +
 			" │       │   └─ Table\n" +
-			" │       │       └─ name: \n" +
+			" │       │       ├─ name: \n" +
+			" │       │       └─ columns: []\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: a.x:0!null\n" +
 			"     ├─ group: a.x:0!null\n" +
@@ -7018,11 +6258,13 @@ inner join pq on true
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1 (tinyint)]\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: \n" +
+			"             │       ├─ name: \n" +
+			"             │       └─ columns: []\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [2 (tinyint)]\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: \n" +
+			"                     ├─ name: \n" +
+			"                     └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7037,11 +6279,13 @@ inner join pq on true
 			" │       ├─ Project\n" +
 			" │       │   ├─ columns: [1 (tinyint)]\n" +
 			" │       │   └─ Table\n" +
-			" │       │       └─ name: \n" +
+			" │       │       ├─ name: \n" +
+			" │       │       └─ columns: []\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -7050,11 +6294,13 @@ inner join pq on true
 			"         ├─ Project\n" +
 			"         │   ├─ columns: [1 (tinyint)]\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: \n" +
+			"         │       ├─ name: \n" +
+			"         │       └─ columns: []\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [2 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7074,7 +6320,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i:0!null + 1 (tinyint))]\n" +
 			"                     └─ Filter\n" +
@@ -7100,7 +6347,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i + 1):0!null]\n" +
 			"                     └─ Having\n" +
@@ -7131,7 +6379,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i + 1):0!null]\n" +
 			"                     └─ Having\n" +
@@ -7165,7 +6414,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i:0!null + 1 (tinyint))]\n" +
 			"                     └─ Filter\n" +
@@ -7196,13 +6446,16 @@ inner join pq on true
 			"         │               ├─ Project\n" +
 			"         │               │   ├─ columns: [1 (tinyint)]\n" +
 			"         │               │   └─ Table\n" +
-			"         │               │       └─ name: \n" +
+			"         │               │       ├─ name: \n" +
+			"         │               │       └─ columns: []\n" +
 			"         │               └─ Project\n" +
 			"         │                   ├─ columns: [2 (tinyint)]\n" +
 			"         │                   └─ Table\n" +
-			"         │                       └─ name: \n" +
+			"         │                       ├─ name: \n" +
+			"         │                       └─ columns: []\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7212,7 +6465,8 @@ inner join pq on true
 			" │   ├─ Project\n" +
 			" │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │   └─ Table\n" +
-			" │   │       └─ name: \n" +
+			" │   │       ├─ name: \n" +
+			" │   │       └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: a\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -7221,15 +6475,18 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [2 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [3 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [4 (tinyint)]\n" +
 			"     └─ Table\n" +
-			"         └─ name: \n" +
+			"         ├─ name: \n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7239,7 +6496,8 @@ inner join pq on true
 			" │   ├─ Project\n" +
 			" │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │   └─ Table\n" +
-			" │   │       └─ name: \n" +
+			" │   │       ├─ name: \n" +
+			" │   │       └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: a\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -7248,15 +6506,18 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [2 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [3 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [4 (tinyint)]\n" +
 			"     └─ Table\n" +
-			"         └─ name: \n" +
+			"         ├─ name: \n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7277,11 +6538,13 @@ inner join pq on true
 			"                 │   │   ├─ Project\n" +
 			"                 │   │   │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   │   │   └─ Table\n" +
-			"                 │   │   │       └─ name: \n" +
+			"                 │   │   │       ├─ name: \n" +
+			"                 │   │   │       └─ columns: []\n" +
 			"                 │   │   └─ Project\n" +
 			"                 │   │       ├─ columns: [4 (tinyint)]\n" +
 			"                 │   │       └─ Table\n" +
-			"                 │   │           └─ name: \n" +
+			"                 │   │           ├─ name: \n" +
+			"                 │   │           └─ columns: []\n" +
 			"                 │   └─ SubqueryAlias\n" +
 			"                 │       ├─ name: b\n" +
 			"                 │       ├─ outerVisibility: false\n" +
@@ -7290,11 +6553,13 @@ inner join pq on true
 			"                 │           ├─ Project\n" +
 			"                 │           │   ├─ columns: [2 (tinyint)]\n" +
 			"                 │           │   └─ Table\n" +
-			"                 │           │       └─ name: \n" +
+			"                 │           │       ├─ name: \n" +
+			"                 │           │       └─ columns: []\n" +
 			"                 │           └─ Project\n" +
 			"                 │               ├─ columns: [3 (tinyint)]\n" +
 			"                 │               └─ Table\n" +
-			"                 │                   └─ name: \n" +
+			"                 │                   ├─ name: \n" +
+			"                 │                   └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(a.x:0!null + 1 (tinyint))]\n" +
 			"                     └─ Filter\n" +
@@ -7315,7 +6580,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ Sort(b.i:0!null DESC nullsFirst)\n" +
 			" │       └─ SubqueryAlias\n" +
 			" │           ├─ name: b\n" +
@@ -7324,7 +6590,8 @@ inner join pq on true
 			" │           └─ Project\n" +
 			" │               ├─ columns: [2 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -7332,7 +6599,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7354,7 +6622,8 @@ inner join pq on true
 			" │   │       │   └─ Project\n" +
 			" │   │       │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       │       └─ Table\n" +
-			" │   │       │           └─ name: \n" +
+			" │   │       │           ├─ name: \n" +
+			" │   │       │           └─ columns: []\n" +
 			" │   │       └─ HashLookup\n" +
 			" │   │           ├─ source: TUPLE(t2.j:0!null)\n" +
 			" │   │           ├─ target: TUPLE(t1.j:0!null)\n" +
@@ -7366,7 +6635,8 @@ inner join pq on true
 			" │   │                   └─ Project\n" +
 			" │   │                       ├─ columns: [1 (tinyint)]\n" +
 			" │   │                       └─ Table\n" +
-			" │   │                           └─ name: \n" +
+			" │   │                           ├─ name: \n" +
+			" │   │                           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -7374,7 +6644,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -7382,7 +6653,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7406,15 +6678,18 @@ inner join pq on true
 			" │   │       │       │   ├─ Project\n" +
 			" │   │       │       │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │       │       │   │   └─ Table\n" +
-			" │   │       │       │   │       └─ name: \n" +
+			" │   │       │       │   │       ├─ name: \n" +
+			" │   │       │       │   │       └─ columns: []\n" +
 			" │   │       │       │   └─ Project\n" +
 			" │   │       │       │       ├─ columns: [2 (tinyint)]\n" +
 			" │   │       │       │       └─ Table\n" +
-			" │   │       │       │           └─ name: \n" +
+			" │   │       │       │           ├─ name: \n" +
+			" │   │       │       │           └─ columns: []\n" +
 			" │   │       │       └─ Project\n" +
 			" │   │       │           ├─ columns: [3 (tinyint)]\n" +
 			" │   │       │           └─ Table\n" +
-			" │   │       │               └─ name: \n" +
+			" │   │       │               ├─ name: \n" +
+			" │   │       │               └─ columns: []\n" +
 			" │   │       └─ HashLookup\n" +
 			" │   │           ├─ source: TUPLE(t2.j:0!null)\n" +
 			" │   │           ├─ target: TUPLE(t1.j:0!null)\n" +
@@ -7428,15 +6703,18 @@ inner join pq on true
 			" │   │                       │   ├─ Project\n" +
 			" │   │                       │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │                       │   │   └─ Table\n" +
-			" │   │                       │   │       └─ name: \n" +
+			" │   │                       │   │       ├─ name: \n" +
+			" │   │                       │   │       └─ columns: []\n" +
 			" │   │                       │   └─ Project\n" +
 			" │   │                       │       ├─ columns: [2 (tinyint)]\n" +
 			" │   │                       │       └─ Table\n" +
-			" │   │                       │           └─ name: \n" +
+			" │   │                       │           ├─ name: \n" +
+			" │   │                       │           └─ columns: []\n" +
 			" │   │                       └─ Project\n" +
 			" │   │                           ├─ columns: [3 (tinyint)]\n" +
 			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: \n" +
+			" │   │                               ├─ name: \n" +
+			" │   │                               └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -7445,11 +6723,13 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [2 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [3 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -7459,15 +6739,18 @@ inner join pq on true
 			"         │   ├─ Project\n" +
 			"         │   │   ├─ columns: [1 (tinyint)]\n" +
 			"         │   │   └─ Table\n" +
-			"         │   │       └─ name: \n" +
+			"         │   │       ├─ name: \n" +
+			"         │   │       └─ columns: []\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [2 (tinyint)]\n" +
 			"         │       └─ Table\n" +
-			"         │           └─ name: \n" +
+			"         │           ├─ name: \n" +
+			"         │           └─ columns: []\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [3 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7483,7 +6766,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -7491,7 +6775,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -7499,7 +6784,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7515,7 +6801,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -7523,7 +6810,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -7531,7 +6819,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7545,7 +6834,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -7553,7 +6843,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [1 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -7561,7 +6852,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -7611,20 +6903,14 @@ With c as (
 			"             │   │       │   ├─ t2.i:0!null\n" +
 			"             │   │       │   └─ TUPLE(1 (tinyint), 2 (tinyint))\n" +
 			"             │   │       └─ TableAlias(t2)\n" +
-			"             │   │           └─ IndexedTableAccess\n" +
+			"             │   │           └─ IndexedTableAccess(mytable)\n" +
 			"             │   │               ├─ index: [mytable.i]\n" +
 			"             │   │               ├─ static: [{[2, 2]}, {[1, 1]}]\n" +
-			"             │   │               ├─ columns: [i s]\n" +
-			"             │   │               └─ Table\n" +
-			"             │   │                   ├─ name: mytable\n" +
-			"             │   │                   └─ projections: [0 1]\n" +
+			"             │   │               └─ columns: [i s]\n" +
 			"             │   └─ TableAlias(a)\n" +
-			"             │       └─ IndexedTableAccess\n" +
+			"             │       └─ IndexedTableAccess(mytable)\n" +
 			"             │           ├─ index: [mytable.i]\n" +
-			"             │           ├─ columns: [i s]\n" +
-			"             │           └─ Table\n" +
-			"             │               ├─ name: mytable\n" +
-			"             │               └─ projections: [0 1]\n" +
+			"             │           └─ columns: [i s]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(b.i:0!null)\n" +
 			"                 ├─ target: TUPLE(e.i:0!null)\n" +
@@ -7638,13 +6924,10 @@ With c as (
 			"                             │   ├─ t1.i:0!null\n" +
 			"                             │   └─ TUPLE(2 (tinyint), 3 (tinyint))\n" +
 			"                             └─ TableAlias(t1)\n" +
-			"                                 └─ IndexedTableAccess\n" +
+			"                                 └─ IndexedTableAccess(mytable)\n" +
 			"                                     ├─ index: [mytable.i]\n" +
 			"                                     ├─ static: [{[3, 3]}, {[2, 2]}]\n" +
-			"                                     ├─ columns: [i s]\n" +
-			"                                     └─ Table\n" +
-			"                                         ├─ name: mytable\n" +
-			"                                         └─ projections: [0 1]\n" +
+			"                                     └─ columns: [i s]\n" +
 			"",
 	},
 }
@@ -7686,14 +6969,12 @@ WHERE
 			"     │   ├─ YK2GW.id:0!null\n" +
 			"     │   └─ applySubq0.IXUXU:30\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: YK2GW\n" +
+			"     │   ├─ name: YK2GW\n" +
+			"     │   └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(THNTS)\n" +
 			"             ├─ index: [THNTS.IXUXU]\n" +
-			"             ├─ columns: [ixuxu]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: THNTS\n" +
-			"                 └─ projections: [2]\n" +
+			"             └─ columns: [ixuxu]\n" +
 			"",
 	},
 	{
@@ -7734,10 +7015,10 @@ WHERE
 	       CL3DT.FBSRS > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:7!null as TEYBZ, PBMRX.ZH72S:11 as FB6N7]\n" +
+			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:5!null as TEYBZ, PBMRX.ZH72S:6 as FB6N7]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ PBMRX.ZH72S:11\n" +
+			"     │   ├─ PBMRX.ZH72S:6\n" +
 			"     │   └─ CL3DT.ZH72S:0\n" +
 			"     ├─ SubqueryAlias\n" +
 			"     │   ├─ name: CL3DT\n" +
@@ -7785,18 +7066,16 @@ WHERE
 			"     │                               └─ Filter\n" +
 			"     │                                   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
 			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ Filter\n" +
-			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
 			"                 ├─ index: [E2I7U.ZH72S]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"                 └─ columns: [id tw55n zh72s]\n" +
 			"",
 	},
 	{
@@ -7869,14 +7148,15 @@ WHERE
 			" │   │       │   ├─ Subquery\n" +
 			" │   │       │   │   ├─ cacheable: false\n" +
 			" │   │       │   │   └─ Project\n" +
-			" │   │       │   │       ├─ columns: [NHMXW.SWCQV:16!null]\n" +
+			" │   │       │   │       ├─ columns: [NHMXW.SWCQV:10!null]\n" +
 			" │   │       │   │       └─ Filter\n" +
 			" │   │       │   │           ├─ Eq\n" +
 			" │   │       │   │           │   ├─ NHMXW.id:9!null\n" +
 			" │   │       │   │           │   └─ ism.PRUV2:6\n" +
 			" │   │       │   │           └─ TableAlias(NHMXW)\n" +
 			" │   │       │   │               └─ Table\n" +
-			" │   │       │   │                   └─ name: WGSDC\n" +
+			" │   │       │   │                   ├─ name: WGSDC\n" +
+			" │   │       │   │                   └─ columns: [id swcqv]\n" +
 			" │   │       │   └─ 1 (tinyint)\n" +
 			" │   │       └─ Or\n" +
 			" │   │           ├─ AND\n" +
@@ -7892,17 +7172,19 @@ WHERE
 			" │   │           │       │           │   └─ Subquery\n" +
 			" │   │           │       │           │       ├─ cacheable: false\n" +
 			" │   │           │       │           │       └─ Project\n" +
-			" │   │           │       │           │           ├─ columns: [NHMXW.FZXV5:31]\n" +
+			" │   │           │       │           │           ├─ columns: [NHMXW.FZXV5:27]\n" +
 			" │   │           │       │           │           └─ Filter\n" +
 			" │   │           │       │           │               ├─ Eq\n" +
 			" │   │           │       │           │               │   ├─ NHMXW.id:26!null\n" +
 			" │   │           │       │           │               │   └─ ism.PRUV2:6\n" +
 			" │   │           │       │           │               └─ TableAlias(NHMXW)\n" +
 			" │   │           │       │           │                   └─ Table\n" +
-			" │   │           │       │           │                       └─ name: WGSDC\n" +
+			" │   │           │       │           │                       ├─ name: WGSDC\n" +
+			" │   │           │       │           │                       └─ columns: [id fzxv5]\n" +
 			" │   │           │       │           └─ TableAlias(nd)\n" +
 			" │   │           │       │               └─ Table\n" +
-			" │   │           │       │                   └─ name: E2I7U\n" +
+			" │   │           │       │                   ├─ name: E2I7U\n" +
+			" │   │           │       │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │           │       └─ ism.FV24E:1!null\n" +
 			" │   │           │      ))\n" +
 			" │   │           └─ AND\n" +
@@ -7918,17 +7200,19 @@ WHERE
 			" │   │                   │           │   └─ Subquery\n" +
 			" │   │                   │           │       ├─ cacheable: false\n" +
 			" │   │                   │           │       └─ Project\n" +
-			" │   │                   │           │           ├─ columns: [NHMXW.DQYGV:32]\n" +
+			" │   │                   │           │           ├─ columns: [NHMXW.DQYGV:27]\n" +
 			" │   │                   │           │           └─ Filter\n" +
 			" │   │                   │           │               ├─ Eq\n" +
 			" │   │                   │           │               │   ├─ NHMXW.id:26!null\n" +
 			" │   │                   │           │               │   └─ ism.PRUV2:6\n" +
 			" │   │                   │           │               └─ TableAlias(NHMXW)\n" +
 			" │   │                   │           │                   └─ Table\n" +
-			" │   │                   │           │                       └─ name: WGSDC\n" +
+			" │   │                   │           │                       ├─ name: WGSDC\n" +
+			" │   │                   │           │                       └─ columns: [id dqygv]\n" +
 			" │   │                   │           └─ TableAlias(nd)\n" +
 			" │   │                   │               └─ Table\n" +
-			" │   │                   │                   └─ name: E2I7U\n" +
+			" │   │                   │                   ├─ name: E2I7U\n" +
+			" │   │                   │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                   └─ ism.UJ6XY:2!null\n" +
 			" │   │                  ))\n" +
 			" │   └─ AND\n" +
@@ -7946,13 +7230,10 @@ WHERE
 			" │                       │       ├─ cacheable: true\n" +
 			" │                       │       └─ Filter\n" +
 			" │                       │           ├─ (NOT(HDDVB.PRUV2:29 IS NULL))\n" +
-			" │                       │           └─ IndexedTableAccess\n" +
+			" │                       │           └─ IndexedTableAccess(HDDVB)\n" +
 			" │                       │               ├─ index: [HDDVB.PRUV2]\n" +
 			" │                       │               ├─ static: [{(NULL, ∞)}]\n" +
-			" │                       │               ├─ columns: [pruv2]\n" +
-			" │                       │               └─ Table\n" +
-			" │                       │                   ├─ name: HDDVB\n" +
-			" │                       │                   └─ projections: [6]\n" +
+			" │                       │               └─ columns: [pruv2]\n" +
 			" │                       │  ))\n" +
 			" │                       └─ LookupJoin\n" +
 			" │                           ├─ AND\n" +
@@ -7976,15 +7257,16 @@ WHERE
 			" │                           │   │   └─ 0 (tinyint)\n" +
 			" │                           │   └─ TableAlias(NHMXW)\n" +
 			" │                           │       └─ Table\n" +
-			" │                           │           └─ name: WGSDC\n" +
+			" │                           │           ├─ name: WGSDC\n" +
+			" │                           │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			" │                           └─ TableAlias(TIZHK)\n" +
-			" │                               └─ IndexedTableAccess\n" +
+			" │                               └─ IndexedTableAccess(WRZVO)\n" +
 			" │                                   ├─ index: [WRZVO.TVNW2]\n" +
-			" │                                   └─ Table\n" +
-			" │                                       └─ name: WRZVO\n" +
+			" │                                   └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ Table\n" +
-			"         └─ name: HDDVB\n" +
+			"         ├─ name: HDDVB\n" +
+			"         └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -8055,39 +7337,32 @@ WHERE
 			" │   │                       │   │   │   │   └─ TIZHK.TVNW2:18\n" +
 			" │   │                       │   │   │   ├─ TableAlias(J4JYP)\n" +
 			" │   │                       │   │   │   │   └─ Table\n" +
-			" │   │                       │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                       │   │   │   │       ├─ name: E2I7U\n" +
+			" │   │                       │   │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                       │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                       │   │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
 			" │   │                       │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
-			" │   │                       │   │   │           └─ Table\n" +
-			" │   │                       │   │   │               └─ name: WRZVO\n" +
+			" │   │                       │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" │   │                       │   │   └─ TableAlias(RHUZN)\n" +
-			" │   │                       │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			" │   │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                       │   │           └─ Table\n" +
-			" │   │                       │   │               └─ name: E2I7U\n" +
+			" │   │                       │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                       │   └─ TableAlias(mf)\n" +
-			" │   │                       │       └─ IndexedTableAccess\n" +
+			" │   │                       │       └─ IndexedTableAccess(HGMQ6)\n" +
 			" │   │                       │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                       │           └─ Table\n" +
-			" │   │                       │               └─ name: HGMQ6\n" +
+			" │   │                       │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │   │                       └─ TableAlias(aac)\n" +
-			" │   │                           └─ IndexedTableAccess\n" +
+			" │   │                           └─ IndexedTableAccess(TPXBU)\n" +
 			" │   │                               ├─ index: [TPXBU.id]\n" +
-			" │   │                               └─ Table\n" +
-			" │   │                                   └─ name: TPXBU\n" +
+			" │   │                               └─ columns: [id btxc5 fhcyt]\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(WRZVO)\n" +
 			" │           ├─ index: [WRZVO.id]\n" +
-			" │           └─ Table\n" +
-			" │               └─ name: WRZVO\n" +
+			" │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" └─ TableAlias(applySubq1)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(HDDVB)\n" +
 			"         ├─ index: [HDDVB.ETPQV]\n" +
-			"         ├─ columns: [etpqv]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: HDDVB\n" +
-			"             └─ projections: [5]\n" +
+			"         └─ columns: [etpqv]\n" +
 			"",
 	},
 	{
@@ -8158,39 +7433,32 @@ WHERE
 			" │   │                       │   │   │   │   └─ TIZHK.ZHITY:19\n" +
 			" │   │                       │   │   │   ├─ TableAlias(RHUZN)\n" +
 			" │   │                       │   │   │   │   └─ Table\n" +
-			" │   │                       │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                       │   │   │   │       ├─ name: E2I7U\n" +
+			" │   │                       │   │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                       │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                       │   │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
 			" │   │                       │   │   │           ├─ index: [WRZVO.ZHITY]\n" +
-			" │   │                       │   │   │           └─ Table\n" +
-			" │   │                       │   │   │               └─ name: WRZVO\n" +
+			" │   │                       │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" │   │                       │   │   └─ TableAlias(J4JYP)\n" +
-			" │   │                       │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			" │   │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                       │   │           └─ Table\n" +
-			" │   │                       │   │               └─ name: E2I7U\n" +
+			" │   │                       │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                       │   └─ TableAlias(mf)\n" +
-			" │   │                       │       └─ IndexedTableAccess\n" +
+			" │   │                       │       └─ IndexedTableAccess(HGMQ6)\n" +
 			" │   │                       │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                       │           └─ Table\n" +
-			" │   │                       │               └─ name: HGMQ6\n" +
+			" │   │                       │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │   │                       └─ TableAlias(aac)\n" +
-			" │   │                           └─ IndexedTableAccess\n" +
+			" │   │                           └─ IndexedTableAccess(TPXBU)\n" +
 			" │   │                               ├─ index: [TPXBU.id]\n" +
-			" │   │                               └─ Table\n" +
-			" │   │                                   └─ name: TPXBU\n" +
+			" │   │                               └─ columns: [id btxc5 fhcyt]\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(WRZVO)\n" +
 			" │           ├─ index: [WRZVO.id]\n" +
-			" │           └─ Table\n" +
-			" │               └─ name: WRZVO\n" +
+			" │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" └─ TableAlias(applySubq1)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(HDDVB)\n" +
 			"         ├─ index: [HDDVB.ETPQV]\n" +
-			"         ├─ columns: [etpqv]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: HDDVB\n" +
-			"             └─ projections: [5]\n" +
+			"         └─ columns: [etpqv]\n" +
 			"",
 	},
 	{
@@ -8231,10 +7499,10 @@ WHERE
 	       CL3DT.FLHXH > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:7!null as TEYBZ, PBMRX.ZH72S:11 as FB6N7]\n" +
+			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:5!null as TEYBZ, PBMRX.ZH72S:6 as FB6N7]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ PBMRX.ZH72S:11\n" +
+			"     │   ├─ PBMRX.ZH72S:6\n" +
 			"     │   └─ CL3DT.ZH72S:0\n" +
 			"     ├─ SubqueryAlias\n" +
 			"     │   ├─ name: CL3DT\n" +
@@ -8282,18 +7550,16 @@ WHERE
 			"     │                               └─ Filter\n" +
 			"     │                                   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
 			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ Filter\n" +
-			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
 			"                 ├─ index: [E2I7U.ZH72S]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"                 └─ columns: [id tw55n zh72s]\n" +
 			"",
 	},
 	{
@@ -8369,14 +7635,15 @@ WHERE
 			"     │   │       │   ├─ Subquery\n" +
 			"     │   │       │   │   ├─ cacheable: false\n" +
 			"     │   │       │   │   └─ Project\n" +
-			"     │   │       │   │       ├─ columns: [I7HCR.SWCQV:42!null]\n" +
+			"     │   │       │   │       ├─ columns: [I7HCR.SWCQV:38!null]\n" +
 			"     │   │       │   │       └─ Filter\n" +
 			"     │   │       │   │           ├─ Eq\n" +
 			"     │   │       │   │           │   ├─ I7HCR.id:37!null\n" +
 			"     │   │       │   │           │   └─ ct.OCA7E:11\n" +
 			"     │   │       │   │           └─ TableAlias(I7HCR)\n" +
 			"     │   │       │   │               └─ Table\n" +
-			"     │   │       │   │                   └─ name: EPZU6\n" +
+			"     │   │       │   │                   ├─ name: EPZU6\n" +
+			"     │   │       │   │                   └─ columns: [id swcqv]\n" +
 			"     │   │       │   └─ 1 (tinyint)\n" +
 			"     │   │       └─ (NOT(Eq\n" +
 			"     │   │           ├─ Subquery\n" +
@@ -8389,17 +7656,19 @@ WHERE
 			"     │   │           │           │   └─ Subquery\n" +
 			"     │   │           │           │       ├─ cacheable: false\n" +
 			"     │   │           │           │       └─ Project\n" +
-			"     │   │           │           │           ├─ columns: [I7HCR.FVUCX:58!null]\n" +
+			"     │   │           │           │           ├─ columns: [I7HCR.FVUCX:55!null]\n" +
 			"     │   │           │           │           └─ Filter\n" +
 			"     │   │           │           │               ├─ Eq\n" +
 			"     │   │           │           │               │   ├─ I7HCR.id:54!null\n" +
 			"     │   │           │           │               │   └─ ct.OCA7E:11\n" +
 			"     │   │           │           │               └─ TableAlias(I7HCR)\n" +
 			"     │   │           │           │                   └─ Table\n" +
-			"     │   │           │           │                       └─ name: EPZU6\n" +
+			"     │   │           │           │                       ├─ name: EPZU6\n" +
+			"     │   │           │           │                       └─ columns: [id fvucx]\n" +
 			"     │   │           │           └─ TableAlias(nd)\n" +
 			"     │   │           │               └─ Table\n" +
-			"     │   │           │                   └─ name: E2I7U\n" +
+			"     │   │           │                   ├─ name: E2I7U\n" +
+			"     │   │           │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │   │           └─ ct.LUEVY:7!null\n" +
 			"     │   │          ))\n" +
 			"     │   └─ AND\n" +
@@ -8417,13 +7686,10 @@ WHERE
 			"     │                       │       ├─ cacheable: true\n" +
 			"     │                       │       └─ Filter\n" +
 			"     │                       │           ├─ (NOT(FLQLP.OCA7E:58 IS NULL))\n" +
-			"     │                       │           └─ IndexedTableAccess\n" +
+			"     │                       │           └─ IndexedTableAccess(FLQLP)\n" +
 			"     │                       │               ├─ index: [FLQLP.OCA7E]\n" +
 			"     │                       │               ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                       │               ├─ columns: [oca7e]\n" +
-			"     │                       │               └─ Table\n" +
-			"     │                       │                   ├─ name: FLQLP\n" +
-			"     │                       │                   └─ projections: [6]\n" +
+			"     │                       │               └─ columns: [oca7e]\n" +
 			"     │                       │  ))\n" +
 			"     │                       └─ LookupJoin\n" +
 			"     │                           ├─ AND\n" +
@@ -8443,12 +7709,12 @@ WHERE
 			"     │                           │   │   └─ 0 (tinyint)\n" +
 			"     │                           │   └─ TableAlias(I7HCR)\n" +
 			"     │                           │       └─ Table\n" +
-			"     │                           │           └─ name: EPZU6\n" +
+			"     │                           │           ├─ name: EPZU6\n" +
+			"     │                           │           └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"     │                           └─ TableAlias(uct)\n" +
-			"     │                               └─ IndexedTableAccess\n" +
+			"     │                               └─ IndexedTableAccess(OUBDL)\n" +
 			"     │                                   ├─ index: [OUBDL.ZH72S]\n" +
-			"     │                                   └─ Table\n" +
-			"     │                                       └─ name: OUBDL\n" +
+			"     │                                   └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ aac.id:34!null\n" +
@@ -8463,22 +7729,20 @@ WHERE
 			"         │   │   │   └─ ct.FZ2R5:6!null\n" +
 			"         │   │   ├─ TableAlias(ci)\n" +
 			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: JDLNA\n" +
+			"         │   │   │       ├─ name: JDLNA\n" +
+			"         │   │   │       └─ columns: [id ftqlq fwwiq o3qxw fhcyt]\n" +
 			"         │   │   └─ TableAlias(ct)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(FLQLP)\n" +
 			"         │   │           ├─ index: [FLQLP.FZ2R5]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: FLQLP\n" +
+			"         │   │           └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"         │   └─ TableAlias(nd)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         └─ TableAlias(aac)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(TPXBU)\n" +
 			"                 ├─ index: [TPXBU.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: TPXBU\n" +
+			"                 └─ columns: [id btxc5 fhcyt]\n" +
 			"",
 	},
 	{
@@ -8544,40 +7808,32 @@ WHERE
 			"     │               │   │   │   │   └─ YLKSY.FTQLQ:6\n" +
 			"     │               │   │   │   ├─ TableAlias(ci)\n" +
 			"     │               │   │   │   │   └─ Table\n" +
-			"     │               │   │   │   │       └─ name: JDLNA\n" +
+			"     │               │   │   │   │       ├─ name: JDLNA\n" +
+			"     │               │   │   │   │       └─ columns: [id ftqlq fwwiq o3qxw fhcyt]\n" +
 			"     │               │   │   │   └─ Filter\n" +
 			"     │               │   │   │       ├─ (NOT(YLKSY.LJLUM LIKE '%|%'))\n" +
 			"     │               │   │   │       └─ TableAlias(YLKSY)\n" +
-			"     │               │   │   │           └─ IndexedTableAccess\n" +
+			"     │               │   │   │           └─ IndexedTableAccess(OUBDL)\n" +
 			"     │               │   │   │               ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │               │   │   │               └─ Table\n" +
-			"     │               │   │   │                   └─ name: OUBDL\n" +
+			"     │               │   │   │               └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"     │               │   │   └─ TableAlias(nd)\n" +
-			"     │               │   │       └─ IndexedTableAccess\n" +
+			"     │               │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │               │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │               │   │           └─ Table\n" +
-			"     │               │   │               └─ name: E2I7U\n" +
+			"     │               │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │               │   └─ Filter\n" +
 			"     │               │       ├─ (NOT(applySubq0.NRURT:0 IS NULL))\n" +
 			"     │               │       └─ TableAlias(applySubq0)\n" +
-			"     │               │           └─ IndexedTableAccess\n" +
+			"     │               │           └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │               ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │               ├─ columns: [nrurt]\n" +
-			"     │               │               └─ Table\n" +
-			"     │               │                   ├─ name: FLQLP\n" +
-			"     │               │                   └─ projections: [5]\n" +
+			"     │               │               └─ columns: [nrurt]\n" +
 			"     │               └─ TableAlias(aac)\n" +
-			"     │                   └─ IndexedTableAccess\n" +
+			"     │                   └─ IndexedTableAccess(TPXBU)\n" +
 			"     │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"     │                       └─ Table\n" +
-			"     │                           └─ name: TPXBU\n" +
+			"     │                       └─ columns: [id btxc5 fhcyt]\n" +
 			"     └─ TableAlias(uct)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(OUBDL)\n" +
 			"             ├─ index: [OUBDL.id]\n" +
-			"             ├─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: OUBDL\n" +
-			"                 └─ projections: [0 1 2 3 4 5 6 7 8 9 10 11 12]\n" +
+			"             └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"",
 	},
 	{
@@ -8612,50 +7868,47 @@ WHERE
 	   TVTJS.SWCQV = 1
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [ct.id:13!null as id, ci.FTQLQ:26!null as VCGT3, nd.TW55N:33!null as UWBAI, aac.BTXC5:48 as TPXBU, ct.V5DPX:21!null as V5DPX, ct.S3Q3Y:22!null as S3Q3Y, ct.ZRV3B:23!null as ZRV3B]\n" +
+			" ├─ columns: [ct.id:2!null as id, ci.FTQLQ:11!null as VCGT3, nd.TW55N:13!null as UWBAI, aac.BTXC5:15 as TPXBU, ct.V5DPX:7!null as V5DPX, ct.S3Q3Y:8!null as S3Q3Y, ct.ZRV3B:9!null as ZRV3B]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ aac.id:47!null\n" +
-			"     │   └─ ct.M22QN:16!null\n" +
+			"     │   ├─ aac.id:14!null\n" +
+			"     │   └─ ct.M22QN:5!null\n" +
 			"     ├─ LookupJoin\n" +
 			"     │   ├─ Eq\n" +
-			"     │   │   ├─ nd.id:30!null\n" +
-			"     │   │   └─ ct.LUEVY:15!null\n" +
+			"     │   │   ├─ nd.id:12!null\n" +
+			"     │   │   └─ ct.LUEVY:4!null\n" +
 			"     │   ├─ LookupJoin\n" +
 			"     │   │   ├─ Eq\n" +
-			"     │   │   │   ├─ ci.id:25!null\n" +
-			"     │   │   │   └─ ct.FZ2R5:14!null\n" +
+			"     │   │   │   ├─ ci.id:10!null\n" +
+			"     │   │   │   └─ ct.FZ2R5:3!null\n" +
 			"     │   │   ├─ LookupJoin\n" +
 			"     │   │   │   ├─ Eq\n" +
 			"     │   │   │   │   ├─ TVTJS.id:0!null\n" +
-			"     │   │   │   │   └─ ct.XMM6Q:20\n" +
+			"     │   │   │   │   └─ ct.XMM6Q:6\n" +
 			"     │   │   │   ├─ Filter\n" +
 			"     │   │   │   │   ├─ Eq\n" +
-			"     │   │   │   │   │   ├─ TVTJS.SWCQV:10!null\n" +
+			"     │   │   │   │   │   ├─ TVTJS.SWCQV:1!null\n" +
 			"     │   │   │   │   │   └─ 1 (tinyint)\n" +
 			"     │   │   │   │   └─ TableAlias(TVTJS)\n" +
 			"     │   │   │   │       └─ Table\n" +
-			"     │   │   │   │           └─ name: HU5A5\n" +
+			"     │   │   │   │           ├─ name: HU5A5\n" +
+			"     │   │   │   │           └─ columns: [id swcqv]\n" +
 			"     │   │   │   └─ TableAlias(ct)\n" +
-			"     │   │   │       └─ IndexedTableAccess\n" +
+			"     │   │   │       └─ IndexedTableAccess(FLQLP)\n" +
 			"     │   │   │           ├─ index: [FLQLP.XMM6Q]\n" +
-			"     │   │   │           └─ Table\n" +
-			"     │   │   │               └─ name: FLQLP\n" +
+			"     │   │   │           └─ columns: [id fz2r5 luevy m22qn xmm6q v5dpx s3q3y zrv3b]\n" +
 			"     │   │   └─ TableAlias(ci)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(JDLNA)\n" +
 			"     │   │           ├─ index: [JDLNA.id]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               └─ name: JDLNA\n" +
+			"     │   │           └─ columns: [id ftqlq]\n" +
 			"     │   └─ TableAlias(nd)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │           ├─ index: [E2I7U.id]\n" +
-			"     │           └─ Table\n" +
-			"     │               └─ name: E2I7U\n" +
+			"     │           └─ columns: [id tw55n]\n" +
 			"     └─ TableAlias(aac)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(TPXBU)\n" +
 			"             ├─ index: [TPXBU.id]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: TPXBU\n" +
+			"             └─ columns: [id btxc5]\n" +
 			"",
 	},
 	{
@@ -8685,16 +7938,14 @@ WHERE
 			" │   │   ├─ HU5A5.SWCQV:10!null\n" +
 			" │   │   └─ 0 (tinyint)\n" +
 			" │   └─ Table\n" +
-			" │       └─ name: HU5A5\n" +
+			" │       ├─ name: HU5A5\n" +
+			" │       └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			" └─ Filter\n" +
 			"     ├─ (NOT(applySubq0.XMM6Q:0 IS NULL))\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.XMM6Q]\n" +
-			"             ├─ columns: [xmm6q]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: FLQLP\n" +
-			"                 └─ projections: [7]\n" +
+			"             └─ columns: [xmm6q]\n" +
 			"",
 	},
 	{
@@ -8736,76 +7987,73 @@ WHERE
 	       PV6R5.NUMK2 <> 1
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [rn.id:44!null as id, concat(NSPLT.TW55N:3!null,FDNCN (longtext),LQNCX.TW55N:30!null) as X37NA, concat(XLZA5.TW55N:53!null,FDNCN (longtext),AFJMD.TW55N:80!null) as THWCS, rn.HVHRZ:47!null as HVHRZ]\n" +
+			" ├─ columns: [rn.id:8!null as id, concat(NSPLT.TW55N:1!null,FDNCN (longtext),LQNCX.TW55N:7!null) as X37NA, concat(XLZA5.TW55N:13!null,FDNCN (longtext),AFJMD.TW55N:18!null) as THWCS, rn.HVHRZ:11!null as HVHRZ]\n" +
 			" └─ Filter\n" +
 			"     ├─ Or\n" +
 			"     │   ├─ (NOT(Eq\n" +
-			"     │   │   ├─ PV6R5.FFTBJ:19!null\n" +
-			"     │   │   └─ ZYUTC.BRQP2:68!null\n" +
+			"     │   │   ├─ PV6R5.FFTBJ:4!null\n" +
+			"     │   │   └─ ZYUTC.BRQP2:15!null\n" +
 			"     │   │  ))\n" +
 			"     │   └─ (NOT(Eq\n" +
-			"     │       ├─ PV6R5.NUMK2:23!null\n" +
+			"     │       ├─ PV6R5.NUMK2:5!null\n" +
 			"     │       └─ 1 (tinyint)\n" +
 			"     │      ))\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ rn.HHVLX:46!null\n" +
-			"         │   └─ ZYUTC.id:67!null\n" +
+			"         │   ├─ rn.HHVLX:10!null\n" +
+			"         │   └─ ZYUTC.id:14!null\n" +
 			"         ├─ LookupJoin\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ rn.WNUNU:45!null\n" +
-			"         │   │   └─ PV6R5.id:17!null\n" +
+			"         │   │   ├─ rn.WNUNU:9!null\n" +
+			"         │   │   └─ PV6R5.id:2!null\n" +
 			"         │   ├─ LookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ LQNCX.id:27!null\n" +
-			"         │   │   │   └─ PV6R5.FFTBJ:19!null\n" +
+			"         │   │   │   ├─ LQNCX.id:6!null\n" +
+			"         │   │   │   └─ PV6R5.FFTBJ:4!null\n" +
 			"         │   │   ├─ LookupJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ NSPLT.id:0!null\n" +
-			"         │   │   │   │   └─ PV6R5.BRQP2:18!null\n" +
+			"         │   │   │   │   └─ PV6R5.BRQP2:3!null\n" +
 			"         │   │   │   ├─ TableAlias(NSPLT)\n" +
 			"         │   │   │   │   └─ Table\n" +
-			"         │   │   │   │       └─ name: E2I7U\n" +
+			"         │   │   │   │       ├─ name: E2I7U\n" +
+			"         │   │   │   │       └─ columns: [id tw55n]\n" +
 			"         │   │   │   └─ TableAlias(PV6R5)\n" +
-			"         │   │   │       └─ IndexedTableAccess\n" +
+			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │   │   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │   │           └─ Table\n" +
-			"         │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │           └─ columns: [id brqp2 fftbj numk2]\n" +
 			"         │   │   └─ TableAlias(LQNCX)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ TableAlias(rn)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(QYWQD)\n" +
 			"         │           ├─ index: [QYWQD.WNUNU]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: QYWQD\n" +
+			"         │           └─ columns: [id wnunu hhvlx hvhrz]\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ source: TUPLE(rn.HHVLX:46!null)\n" +
-			"             ├─ target: TUPLE(ZYUTC.id:17!null)\n" +
+			"             ├─ source: TUPLE(rn.HHVLX:10!null)\n" +
+			"             ├─ target: TUPLE(ZYUTC.id:2!null)\n" +
 			"             └─ CachedResults\n" +
 			"                 └─ LookupJoin\n" +
 			"                     ├─ Eq\n" +
-			"                     │   ├─ AFJMD.id:77!null\n" +
-			"                     │   └─ ZYUTC.FFTBJ:69!null\n" +
+			"                     │   ├─ AFJMD.id:17!null\n" +
+			"                     │   └─ ZYUTC.FFTBJ:16!null\n" +
 			"                     ├─ LookupJoin\n" +
 			"                     │   ├─ Eq\n" +
-			"                     │   │   ├─ XLZA5.id:50!null\n" +
-			"                     │   │   └─ ZYUTC.BRQP2:68!null\n" +
+			"                     │   │   ├─ XLZA5.id:12!null\n" +
+			"                     │   │   └─ ZYUTC.BRQP2:15!null\n" +
 			"                     │   ├─ TableAlias(XLZA5)\n" +
 			"                     │   │   └─ Table\n" +
-			"                     │   │       └─ name: E2I7U\n" +
+			"                     │   │       ├─ name: E2I7U\n" +
+			"                     │   │       └─ columns: [id tw55n]\n" +
 			"                     │   └─ TableAlias(ZYUTC)\n" +
-			"                     │       └─ IndexedTableAccess\n" +
+			"                     │       └─ IndexedTableAccess(NOXN3)\n" +
 			"                     │           ├─ index: [NOXN3.BRQP2]\n" +
-			"                     │           └─ Table\n" +
-			"                     │               └─ name: NOXN3\n" +
+			"                     │           └─ columns: [id brqp2 fftbj]\n" +
 			"                     └─ TableAlias(AFJMD)\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(E2I7U)\n" +
 			"                             ├─ index: [E2I7U.id]\n" +
-			"                             └─ Table\n" +
-			"                                 └─ name: E2I7U\n" +
+			"                             └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -8850,78 +8098,75 @@ WHERE
 	       rn.WNUNU IS NULL AND rn.HHVLX IS NULL
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sn.id:61!null as DRIWM, concat(OE56M.TW55N:47!null,FDNCN (longtext),CGFRZ.TW55N:74!null) as GRVSE, SKPM6.id:17!null as JIEVY, concat(V5SAY.TW55N:3!null,FDNCN (longtext),FQTHF.TW55N:30!null) as ENCM3, 1 (decimal(2,1)) as OHD3R]\n" +
+			" ├─ columns: [sn.id:9!null as DRIWM, concat(OE56M.TW55N:8!null,FDNCN (longtext),CGFRZ.TW55N:14!null) as GRVSE, SKPM6.id:2!null as JIEVY, concat(V5SAY.TW55N:1!null,FDNCN (longtext),FQTHF.TW55N:6!null) as ENCM3, 1 (decimal(2,1)) as OHD3R]\n" +
 			" └─ Filter\n" +
 			"     ├─ AND\n" +
-			"     │   ├─ rn.WNUNU:89 IS NULL\n" +
-			"     │   └─ rn.HHVLX:90 IS NULL\n" +
+			"     │   ├─ rn.WNUNU:15 IS NULL\n" +
+			"     │   └─ rn.HHVLX:16 IS NULL\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ rn.WNUNU:89!null\n" +
-			"         │   │   └─ sn.id:61!null\n" +
+			"         │   │   ├─ rn.WNUNU:15!null\n" +
+			"         │   │   └─ sn.id:9!null\n" +
 			"         │   └─ Eq\n" +
-			"         │       ├─ rn.HHVLX:90!null\n" +
-			"         │       └─ SKPM6.id:17!null\n" +
+			"         │       ├─ rn.HHVLX:16!null\n" +
+			"         │       └─ SKPM6.id:2!null\n" +
 			"         ├─ HashJoin\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ SKPM6.BRQP2:18!null\n" +
-			"         │   │   └─ sn.FFTBJ:63!null\n" +
+			"         │   │   ├─ SKPM6.BRQP2:3!null\n" +
+			"         │   │   └─ sn.FFTBJ:11!null\n" +
 			"         │   ├─ LookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ FQTHF.id:27!null\n" +
-			"         │   │   │   └─ SKPM6.FFTBJ:19!null\n" +
+			"         │   │   │   ├─ FQTHF.id:5!null\n" +
+			"         │   │   │   └─ SKPM6.FFTBJ:4!null\n" +
 			"         │   │   ├─ LookupJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ V5SAY.id:0!null\n" +
-			"         │   │   │   │   └─ SKPM6.BRQP2:18!null\n" +
+			"         │   │   │   │   └─ SKPM6.BRQP2:3!null\n" +
 			"         │   │   │   ├─ TableAlias(V5SAY)\n" +
 			"         │   │   │   │   └─ Table\n" +
-			"         │   │   │   │       └─ name: E2I7U\n" +
+			"         │   │   │   │       ├─ name: E2I7U\n" +
+			"         │   │   │   │       └─ columns: [id tw55n]\n" +
 			"         │   │   │   └─ TableAlias(SKPM6)\n" +
-			"         │   │   │       └─ IndexedTableAccess\n" +
+			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │   │   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │   │           └─ Table\n" +
-			"         │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │           └─ columns: [id brqp2 fftbj]\n" +
 			"         │   │   └─ TableAlias(FQTHF)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ HashLookup\n" +
-			"         │       ├─ source: TUPLE(SKPM6.BRQP2:18!null)\n" +
-			"         │       ├─ target: TUPLE(sn.FFTBJ:19!null)\n" +
+			"         │       ├─ source: TUPLE(SKPM6.BRQP2:3!null)\n" +
+			"         │       ├─ target: TUPLE(sn.FFTBJ:4!null)\n" +
 			"         │       └─ CachedResults\n" +
 			"         │           └─ LookupJoin\n" +
 			"         │               ├─ Eq\n" +
-			"         │               │   ├─ CGFRZ.id:71!null\n" +
-			"         │               │   └─ sn.FFTBJ:63!null\n" +
+			"         │               │   ├─ CGFRZ.id:13!null\n" +
+			"         │               │   └─ sn.FFTBJ:11!null\n" +
 			"         │               ├─ LookupJoin\n" +
 			"         │               │   ├─ Eq\n" +
-			"         │               │   │   ├─ OE56M.id:44!null\n" +
-			"         │               │   │   └─ sn.BRQP2:62!null\n" +
+			"         │               │   │   ├─ OE56M.id:7!null\n" +
+			"         │               │   │   └─ sn.BRQP2:10!null\n" +
 			"         │               │   ├─ TableAlias(OE56M)\n" +
 			"         │               │   │   └─ Table\n" +
-			"         │               │   │       └─ name: E2I7U\n" +
+			"         │               │   │       ├─ name: E2I7U\n" +
+			"         │               │   │       └─ columns: [id tw55n]\n" +
 			"         │               │   └─ Filter\n" +
 			"         │               │       ├─ Eq\n" +
-			"         │               │       │   ├─ sn.NUMK2:6!null\n" +
+			"         │               │       │   ├─ sn.NUMK2:3!null\n" +
 			"         │               │       │   └─ 1 (tinyint)\n" +
 			"         │               │       └─ TableAlias(sn)\n" +
-			"         │               │           └─ IndexedTableAccess\n" +
+			"         │               │           └─ IndexedTableAccess(NOXN3)\n" +
 			"         │               │               ├─ index: [NOXN3.BRQP2]\n" +
-			"         │               │               └─ Table\n" +
-			"         │               │                   └─ name: NOXN3\n" +
+			"         │               │               └─ columns: [id brqp2 fftbj numk2]\n" +
 			"         │               └─ TableAlias(CGFRZ)\n" +
-			"         │                   └─ IndexedTableAccess\n" +
+			"         │                   └─ IndexedTableAccess(E2I7U)\n" +
 			"         │                       ├─ index: [E2I7U.id]\n" +
-			"         │                       └─ Table\n" +
-			"         │                           └─ name: E2I7U\n" +
+			"         │                       └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(rn)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(QYWQD)\n" +
 			"                 ├─ index: [QYWQD.HHVLX]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: QYWQD\n" +
+			"                 └─ columns: [wnunu hhvlx]\n" +
 			"",
 	},
 	{
@@ -8991,23 +8236,19 @@ WHERE
 			"     │               │               │   └─ S5KBM.FGG57:18!null\n" +
 			"     │               │               ├─ TableAlias(nd)\n" +
 			"     │               │               │   └─ Table\n" +
-			"     │               │               │       └─ name: E2I7U\n" +
+			"     │               │               │       ├─ name: E2I7U\n" +
+			"     │               │               │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │               │               └─ TableAlias(S5KBM)\n" +
-			"     │               │                   └─ IndexedTableAccess\n" +
+			"     │               │                   └─ IndexedTableAccess(TDRVG)\n" +
 			"     │               │                       ├─ index: [TDRVG.FGG57]\n" +
-			"     │               │                       └─ Table\n" +
-			"     │               │                           └─ name: TDRVG\n" +
+			"     │               │                       └─ columns: [id fgg57 sshpj sfj6l zh72s]\n" +
 			"     │               └─ TableAlias(applySubq0)\n" +
-			"     │                   └─ IndexedTableAccess\n" +
+			"     │                   └─ IndexedTableAccess(WE72E)\n" +
 			"     │                       ├─ index: [WE72E.SSHPJ]\n" +
-			"     │                       ├─ columns: [sshpj]\n" +
-			"     │                       └─ Table\n" +
-			"     │                           ├─ name: WE72E\n" +
-			"     │                           └─ projections: [2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │                       └─ columns: [sshpj]\n" +
+			"     └─ IndexedTableAccess(TDRVG)\n" +
 			"         ├─ index: [TDRVG.id]\n" +
-			"         └─ Table\n" +
-			"             └─ name: TDRVG\n" +
+			"         └─ columns: [id fgg57 sshpj sfj6l zh72s]\n" +
 			"",
 	},
 	{
@@ -9048,10 +8289,10 @@ WHERE
 	       CL3DT.R5CKX > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:7!null as UYOGN, PBMRX.ZH72S:11 as H4JEA]\n" +
+			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:5!null as UYOGN, PBMRX.ZH72S:6 as H4JEA]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ PBMRX.ZH72S:11\n" +
+			"     │   ├─ PBMRX.ZH72S:6\n" +
 			"     │   └─ CL3DT.ZH72S:0\n" +
 			"     ├─ SubqueryAlias\n" +
 			"     │   ├─ name: CL3DT\n" +
@@ -9099,18 +8340,16 @@ WHERE
 			"     │                               └─ Filter\n" +
 			"     │                                   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
 			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ Filter\n" +
-			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
 			"                 ├─ index: [E2I7U.ZH72S]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"                 └─ columns: [id tw55n zh72s]\n" +
 			"",
 	},
 	{
@@ -9151,24 +8390,20 @@ WHERE
 			"         │   │   │   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"         │   │   │   └─ TableAlias(nd)\n" +
 			"         │   │   │       └─ Table\n" +
-			"         │   │   │           └─ name: E2I7U\n" +
+			"         │   │   │           ├─ name: E2I7U\n" +
+			"         │   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │   │   └─ TableAlias(ufc)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(SISUT)\n" +
 			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: SISUT\n" +
+			"         │   │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
 			"         │   └─ TableAlias(cla)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(YK2GW)\n" +
 			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"         │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ TableAlias(applySubq0)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.KKGN5]\n" +
-			"                 ├─ columns: [kkgn5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: AMYXQ\n" +
-			"                     └─ projections: [7]\n" +
+			"                 └─ columns: [kkgn5]\n" +
 			"",
 	},
 	{
@@ -9209,24 +8444,20 @@ WHERE
 			"         │   │   │   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"         │   │   │   └─ TableAlias(nd)\n" +
 			"         │   │   │       └─ Table\n" +
-			"         │   │   │           └─ name: E2I7U\n" +
+			"         │   │   │           ├─ name: E2I7U\n" +
+			"         │   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │   │   └─ TableAlias(ufc)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(SISUT)\n" +
 			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: SISUT\n" +
+			"         │   │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
 			"         │   └─ TableAlias(cla)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(YK2GW)\n" +
 			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"         │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ TableAlias(applySubq0)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.KKGN5]\n" +
-			"                 ├─ columns: [kkgn5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: AMYXQ\n" +
-			"                     └─ projections: [7]\n" +
+			"                 └─ columns: [kkgn5]\n" +
 			"",
 	},
 	{
@@ -9254,19 +8485,16 @@ WHERE
 			"     │   │   └─ ums.T4IBQ:1\n" +
 			"     │   ├─ TableAlias(ums)\n" +
 			"     │   │   └─ Table\n" +
-			"     │   │       └─ name: FG26Y\n" +
+			"     │   │       ├─ name: FG26Y\n" +
+			"     │   │       └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"     │   └─ TableAlias(cla)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(YK2GW)\n" +
 			"     │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"     │           └─ Table\n" +
-			"     │               └─ name: YK2GW\n" +
+			"     │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(SZQWJ)\n" +
 			"             ├─ index: [SZQWJ.JOGI6]\n" +
-			"             ├─ columns: [jogi6]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: SZQWJ\n" +
-			"                 └─ projections: [4]\n" +
+			"             └─ columns: [jogi6]\n" +
 			"",
 	},
 	{
@@ -9344,14 +8572,15 @@ WHERE
 			"     │   │       │   ├─ Subquery\n" +
 			"     │   │       │   │   ├─ cacheable: false\n" +
 			"     │   │       │   │   └─ Project\n" +
-			"     │   │       │   │       ├─ columns: [TJ5D2.SWCQV:76!null]\n" +
+			"     │   │       │   │       ├─ columns: [TJ5D2.SWCQV:72!null]\n" +
 			"     │   │       │   │       └─ Filter\n" +
 			"     │   │       │   │           ├─ Eq\n" +
 			"     │   │       │   │           │   ├─ TJ5D2.id:71!null\n" +
 			"     │   │       │   │           │   └─ mf.QQV4M:32\n" +
 			"     │   │       │   │           └─ TableAlias(TJ5D2)\n" +
 			"     │   │       │   │               └─ Table\n" +
-			"     │   │       │   │                   └─ name: SZW6V\n" +
+			"     │   │       │   │                   ├─ name: SZW6V\n" +
+			"     │   │       │   │                   └─ columns: [id swcqv]\n" +
 			"     │   │       │   └─ 1 (tinyint)\n" +
 			"     │   │       └─ (NOT(Eq\n" +
 			"     │   │           ├─ Subquery\n" +
@@ -9364,17 +8593,19 @@ WHERE
 			"     │   │           │           │   └─ Subquery\n" +
 			"     │   │           │           │       ├─ cacheable: false\n" +
 			"     │   │           │           │       └─ Project\n" +
-			"     │   │           │           │           ├─ columns: [TJ5D2.H4DMT:92!null]\n" +
+			"     │   │           │           │           ├─ columns: [TJ5D2.H4DMT:89!null]\n" +
 			"     │   │           │           │           └─ Filter\n" +
 			"     │   │           │           │               ├─ Eq\n" +
 			"     │   │           │           │               │   ├─ TJ5D2.id:88!null\n" +
 			"     │   │           │           │               │   └─ mf.QQV4M:32\n" +
 			"     │   │           │           │               └─ TableAlias(TJ5D2)\n" +
 			"     │   │           │           │                   └─ Table\n" +
-			"     │   │           │           │                       └─ name: SZW6V\n" +
+			"     │   │           │           │                       ├─ name: SZW6V\n" +
+			"     │   │           │           │                       └─ columns: [id h4dmt]\n" +
 			"     │   │           │           └─ TableAlias(nd)\n" +
 			"     │   │           │               └─ Table\n" +
-			"     │   │           │                   └─ name: E2I7U\n" +
+			"     │   │           │                   ├─ name: E2I7U\n" +
+			"     │   │           │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │   │           └─ mf.LUEVY:19!null\n" +
 			"     │   │          ))\n" +
 			"     │   └─ AND\n" +
@@ -9392,13 +8623,10 @@ WHERE
 			"     │                       │       ├─ cacheable: true\n" +
 			"     │                       │       └─ Filter\n" +
 			"     │                       │           ├─ (NOT(HGMQ6.QQV4M:104 IS NULL))\n" +
-			"     │                       │           └─ IndexedTableAccess\n" +
+			"     │                       │           └─ IndexedTableAccess(HGMQ6)\n" +
 			"     │                       │               ├─ index: [HGMQ6.QQV4M]\n" +
 			"     │                       │               ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                       │               ├─ columns: [qqv4m]\n" +
-			"     │                       │               └─ Table\n" +
-			"     │                       │                   ├─ name: HGMQ6\n" +
-			"     │                       │                   └─ projections: [15]\n" +
+			"     │                       │               └─ columns: [qqv4m]\n" +
 			"     │                       │  ))\n" +
 			"     │                       └─ InnerJoin\n" +
 			"     │                           ├─ AND\n" +
@@ -9418,10 +8646,12 @@ WHERE
 			"     │                           │   │   └─ 0 (tinyint)\n" +
 			"     │                           │   └─ TableAlias(TJ5D2)\n" +
 			"     │                           │       └─ Table\n" +
-			"     │                           │           └─ name: SZW6V\n" +
+			"     │                           │           ├─ name: SZW6V\n" +
+			"     │                           │           └─ columns: [id t4ibq v7ufh sypkf h4dmt swcqv ykssu fhcyt]\n" +
 			"     │                           └─ TableAlias(umf)\n" +
 			"     │                               └─ Table\n" +
-			"     │                                   └─ name: NZKPM\n" +
+			"     │                                   ├─ name: NZKPM\n" +
+			"     │                                   └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ aac.id:68!null\n" +
@@ -9436,12 +8666,12 @@ WHERE
 			"         │   │   │   └─ mf.LUEVY:19!null\n" +
 			"         │   │   ├─ TableAlias(nd)\n" +
 			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: E2I7U\n" +
+			"         │   │   │       ├─ name: E2I7U\n" +
+			"         │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │   │   └─ TableAlias(mf)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"         │   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: HGMQ6\n" +
+			"         │   │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"         │   └─ HashLookup\n" +
 			"         │       ├─ source: TUPLE(mf.GXLUB:18!null)\n" +
 			"         │       ├─ target: TUPLE(bs.id:0!null)\n" +
@@ -9452,17 +8682,16 @@ WHERE
 			"         │               │   └─ bs.IXUXU:36\n" +
 			"         │               ├─ TableAlias(bs)\n" +
 			"         │               │   └─ Table\n" +
-			"         │               │       └─ name: THNTS\n" +
+			"         │               │       ├─ name: THNTS\n" +
+			"         │               │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"         │               └─ TableAlias(cla)\n" +
-			"         │                   └─ IndexedTableAccess\n" +
+			"         │                   └─ IndexedTableAccess(YK2GW)\n" +
 			"         │                       ├─ index: [YK2GW.id]\n" +
-			"         │                       └─ Table\n" +
-			"         │                           └─ name: YK2GW\n" +
+			"         │                       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ TableAlias(aac)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(TPXBU)\n" +
 			"                 ├─ index: [TPXBU.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: TPXBU\n" +
+			"                 └─ columns: [id btxc5 fhcyt]\n" +
 			"",
 	},
 	{
@@ -9502,31 +8731,27 @@ WHERE
 			"     │   │   │   └─ umf.T4IBQ:31\n" +
 			"     │   │   ├─ TableAlias(cla)\n" +
 			"     │   │   │   └─ Table\n" +
-			"     │   │   │       └─ name: YK2GW\n" +
+			"     │   │   │       ├─ name: YK2GW\n" +
+			"     │   │   │       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"     │   │   └─ Filter\n" +
 			"     │   │       ├─ (NOT(Eq\n" +
 			"     │   │       │   ├─ umf.ARN5P:7\n" +
 			"     │   │       │   └─ N/A (longtext)\n" +
 			"     │   │       │  ))\n" +
 			"     │   │       └─ TableAlias(umf)\n" +
-			"     │   │           └─ IndexedTableAccess\n" +
+			"     │   │           └─ IndexedTableAccess(NZKPM)\n" +
 			"     │   │               ├─ index: [NZKPM.T4IBQ]\n" +
-			"     │   │               └─ Table\n" +
-			"     │   │                   └─ name: NZKPM\n" +
+			"     │   │               └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ (NOT(nd.FGG57:6 IS NULL))\n" +
 			"     │       └─ TableAlias(nd)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(E2I7U)\n" +
 			"     │               ├─ index: [E2I7U.FGG57]\n" +
-			"     │               └─ Table\n" +
-			"     │                   └─ name: E2I7U\n" +
+			"     │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(HGMQ6)\n" +
 			"             ├─ index: [HGMQ6.TEUJA]\n" +
-			"             ├─ columns: [teuja]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: HGMQ6\n" +
-			"                 └─ projections: [14]\n" +
+			"             └─ columns: [teuja]\n" +
 			"",
 	},
 	{
@@ -9537,13 +8762,10 @@ WHERE
 	ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [QYWQD.HVHRZ:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id hvhrz]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: QYWQD\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [id hvhrz]\n" +
 			"",
 	},
 	{
@@ -9662,10 +8884,9 @@ WHERE
 			" │       │           │   ├─ aac.id:67!null\n" +
 			" │       │           │   └─ SL3S5.M22QN:53!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ IndexedTableAccess\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
 			" │       │                   ├─ index: [TPXBU.id]\n" +
-			" │       │                   └─ Table\n" +
-			" │       │                       └─ name: TPXBU\n" +
+			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, SL3S5.NO52D:55!null as NO52D, SL3S5.IDPK7:56!null as IDPK7]\n" +
 			" │       └─ HashJoin\n" +
 			" │           ├─ AND\n" +
@@ -9685,21 +8906,20 @@ WHERE
 			" │           │   │   │   └─ bs.IXUXU:2\n" +
 			" │           │   │   ├─ TableAlias(bs)\n" +
 			" │           │   │   │   └─ Table\n" +
-			" │           │   │   │       └─ name: THNTS\n" +
+			" │           │   │   │       ├─ name: THNTS\n" +
+			" │           │   │   │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			" │           │   │   └─ Filter\n" +
 			" │           │   │       ├─ HashIn\n" +
 			" │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			" │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │           │   │       └─ TableAlias(cla)\n" +
-			" │           │   │           └─ IndexedTableAccess\n" +
+			" │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
 			" │           │   │               ├─ index: [YK2GW.id]\n" +
-			" │           │   │               └─ Table\n" +
-			" │           │   │                   └─ name: YK2GW\n" +
+			" │           │   │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			" │           │   └─ TableAlias(mf)\n" +
-			" │           │       └─ IndexedTableAccess\n" +
+			" │           │       └─ IndexedTableAccess(HGMQ6)\n" +
 			" │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			" │           │           └─ Table\n" +
-			" │           │               └─ name: HGMQ6\n" +
+			" │           │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │           └─ HashLookup\n" +
 			" │               ├─ source: TUPLE(mf.LUEVY:36!null, mf.M22QN:37!null)\n" +
 			" │               ├─ target: TUPLE(sn.BRQP2:7!null, SL3S5.M22QN:2!null)\n" +
@@ -9713,49 +8933,46 @@ WHERE
 			" │                       │   ├─ outerVisibility: false\n" +
 			" │                       │   ├─ cacheable: true\n" +
 			" │                       │   └─ Project\n" +
-			" │                       │       ├─ columns: [KHJJO.BDNYB:24!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:8!null as M22QN, cec.ADURZ:21!null as ADURZ, cec.NO52D:18!null as NO52D, ct.S3Q3Y:14!null as IDPK7]\n" +
+			" │                       │       ├─ columns: [KHJJO.BDNYB:12!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:4!null as M22QN, cec.ADURZ:10!null as ADURZ, cec.NO52D:9!null as NO52D, ct.S3Q3Y:6!null as IDPK7]\n" +
 			" │                       │       └─ HashJoin\n" +
 			" │                       │           ├─ AND\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ ct.M22QN:8!null\n" +
-			" │                       │           │   │   └─ KHJJO.M22QN:23!null\n" +
+			" │                       │           │   │   ├─ ct.M22QN:4!null\n" +
+			" │                       │           │   │   └─ KHJJO.M22QN:11!null\n" +
 			" │                       │           │   └─ Eq\n" +
-			" │                       │           │       ├─ ct.LUEVY:7!null\n" +
-			" │                       │           │       └─ KHJJO.LUEVY:25!null\n" +
+			" │                       │           │       ├─ ct.LUEVY:3!null\n" +
+			" │                       │           │       └─ KHJJO.LUEVY:13!null\n" +
 			" │                       │           ├─ LookupJoin\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ cec.id:17!null\n" +
-			" │                       │           │   │   └─ ct.OVE3E:9!null\n" +
+			" │                       │           │   │   ├─ cec.id:8!null\n" +
+			" │                       │           │   │   └─ ct.OVE3E:5!null\n" +
 			" │                       │           │   ├─ LookupJoin\n" +
 			" │                       │           │   │   ├─ Eq\n" +
 			" │                       │           │   │   │   ├─ ci.id:0!null\n" +
-			" │                       │           │   │   │   └─ ct.FZ2R5:6!null\n" +
+			" │                       │           │   │   │   └─ ct.FZ2R5:2!null\n" +
 			" │                       │           │   │   ├─ Filter\n" +
 			" │                       │           │   │   │   ├─ HashIn\n" +
 			" │                       │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
 			" │                       │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │                       │           │   │   │   └─ TableAlias(ci)\n" +
-			" │                       │           │   │   │       └─ IndexedTableAccess\n" +
+			" │                       │           │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
 			" │                       │           │   │   │           ├─ index: [JDLNA.FTQLQ]\n" +
 			" │                       │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			" │                       │           │   │   │           └─ Table\n" +
-			" │                       │           │   │   │               └─ name: JDLNA\n" +
+			" │                       │           │   │   │           └─ columns: [id ftqlq]\n" +
 			" │                       │           │   │   └─ Filter\n" +
 			" │                       │           │   │       ├─ Eq\n" +
-			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
+			" │                       │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
 			" │                       │           │   │       │   └─ = (longtext)\n" +
 			" │                       │           │   │       └─ TableAlias(ct)\n" +
-			" │                       │           │   │           └─ IndexedTableAccess\n" +
+			" │                       │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			" │                       │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
-			" │                       │           │   │               └─ Table\n" +
-			" │                       │           │   │                   └─ name: FLQLP\n" +
+			" │                       │           │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
 			" │                       │           │   └─ TableAlias(cec)\n" +
-			" │                       │           │       └─ IndexedTableAccess\n" +
+			" │                       │           │       └─ IndexedTableAccess(SFEGG)\n" +
 			" │                       │           │           ├─ index: [SFEGG.id]\n" +
-			" │                       │           │           └─ Table\n" +
-			" │                       │           │               └─ name: SFEGG\n" +
+			" │                       │           │           └─ columns: [id no52d adurz]\n" +
 			" │                       │           └─ HashLookup\n" +
-			" │                       │               ├─ source: TUPLE(ct.M22QN:8!null, ct.LUEVY:7!null)\n" +
+			" │                       │               ├─ source: TUPLE(ct.M22QN:4!null, ct.LUEVY:3!null)\n" +
 			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
 			" │                       │               └─ CachedResults\n" +
 			" │                       │                   └─ SubqueryAlias\n" +
@@ -9771,17 +8988,16 @@ WHERE
 			" │                       │                                   │   └─ mf.LUEVY:12!null\n" +
 			" │                       │                                   ├─ TableAlias(sn)\n" +
 			" │                       │                                   │   └─ Table\n" +
-			" │                       │                                   │       └─ name: NOXN3\n" +
+			" │                       │                                   │       ├─ name: NOXN3\n" +
+			" │                       │                                   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" │                       │                                   └─ TableAlias(mf)\n" +
-			" │                       │                                       └─ IndexedTableAccess\n" +
+			" │                       │                                       └─ IndexedTableAccess(HGMQ6)\n" +
 			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │                       │                                           └─ Table\n" +
-			" │                       │                                               └─ name: HGMQ6\n" +
+			" │                       │                                           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │                       └─ TableAlias(sn)\n" +
-			" │                           └─ IndexedTableAccess\n" +
+			" │                           └─ IndexedTableAccess(NOXN3)\n" +
 			" │                               ├─ index: [NOXN3.id]\n" +
-			" │                               └─ Table\n" +
-			" │                                   └─ name: NOXN3\n" +
+			" │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [AOEV5.T4IBQ:0!null as T4IBQ, VUMUY.DL754:1!null, VUMUY.BDNYB:2!null, VUMUY.ADURZ:3!null, VUMUY.TPXBU:4, VUMUY.NO52D:5!null, VUMUY.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
@@ -9801,10 +9017,9 @@ WHERE
 			"             │       │           │   ├─ aac.id:16!null\n" +
 			"             │       │           │   └─ SL3S5.M22QN:2!null\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
 			"             │       │                   ├─ index: [TPXBU.id]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   as TPXBU, SL3S5.NO52D:4!null as NO52D, SL3S5.IDPK7:5!null as IDPK7]\n" +
 			"             │       └─ LookupJoin\n" +
 			"             │           ├─ Eq\n" +
@@ -9815,67 +9030,63 @@ WHERE
 			"             │           │   ├─ outerVisibility: false\n" +
 			"             │           │   ├─ cacheable: true\n" +
 			"             │           │   └─ Project\n" +
-			"             │           │       ├─ columns: [sn.id:23!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
+			"             │           │       ├─ columns: [sn.id:17!null as BDNYB, ci.FTQLQ:16!null as TOFPN, ct.M22QN:6!null as M22QN, cec.ADURZ:2!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:12!null as IDPK7]\n" +
 			"             │           │       └─ Filter\n" +
 			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ ct.M22QN:9!null\n" +
+			"             │           │           │   ├─ ct.M22QN:6!null\n" +
 			"             │           │           │   └─ Subquery\n" +
 			"             │           │           │       ├─ cacheable: true\n" +
 			"             │           │           │       └─ Project\n" +
-			"             │           │           │           ├─ columns: [aac.id:33!null]\n" +
+			"             │           │           │           ├─ columns: [aac.id:27!null]\n" +
 			"             │           │           │           └─ Filter\n" +
 			"             │           │           │               ├─ Eq\n" +
-			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
+			"             │           │           │               │   ├─ aac.BTXC5:28\n" +
 			"             │           │           │               │   └─ WT (longtext)\n" +
 			"             │           │           │               └─ TableAlias(aac)\n" +
-			"             │           │           │                   └─ IndexedTableAccess\n" +
+			"             │           │           │                   └─ IndexedTableAccess(TPXBU)\n" +
 			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
 			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
-			"             │           │           │                       └─ Table\n" +
-			"             │           │           │                           └─ name: TPXBU\n" +
+			"             │           │           │                       └─ columns: [id btxc5]\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
-			"             │           │               │   ├─ ct.LUEVY:8!null\n" +
-			"             │           │               │   └─ sn.BRQP2:24!null\n" +
+			"             │           │               │   ├─ ct.LUEVY:5!null\n" +
+			"             │           │               │   └─ sn.BRQP2:18!null\n" +
 			"             │           │               ├─ LookupJoin\n" +
 			"             │           │               │   ├─ Eq\n" +
-			"             │           │               │   │   ├─ ci.id:18!null\n" +
-			"             │           │               │   │   └─ ct.FZ2R5:7!null\n" +
+			"             │           │               │   │   ├─ ci.id:15!null\n" +
+			"             │           │               │   │   └─ ct.FZ2R5:4!null\n" +
 			"             │           │               │   ├─ LookupJoin\n" +
 			"             │           │               │   │   ├─ Eq\n" +
 			"             │           │               │   │   │   ├─ cec.id:0!null\n" +
-			"             │           │               │   │   │   └─ ct.OVE3E:10!null\n" +
+			"             │           │               │   │   │   └─ ct.OVE3E:7!null\n" +
 			"             │           │               │   │   ├─ TableAlias(cec)\n" +
 			"             │           │               │   │   │   └─ Table\n" +
-			"             │           │               │   │   │       └─ name: SFEGG\n" +
+			"             │           │               │   │   │       ├─ name: SFEGG\n" +
+			"             │           │               │   │   │       └─ columns: [id no52d adurz]\n" +
 			"             │           │               │   │   └─ Filter\n" +
 			"             │           │               │   │       ├─ Eq\n" +
 			"             │           │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
 			"             │           │               │   │       │   └─ = (longtext)\n" +
 			"             │           │               │   │       └─ TableAlias(ct)\n" +
-			"             │           │               │   │           └─ IndexedTableAccess\n" +
+			"             │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			"             │           │               │   │               ├─ index: [FLQLP.OVE3E]\n" +
-			"             │           │               │   │               └─ Table\n" +
-			"             │           │               │   │                   └─ name: FLQLP\n" +
+			"             │           │               │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"             │           │               │   └─ Filter\n" +
 			"             │           │               │       ├─ HashIn\n" +
 			"             │           │               │       │   ├─ ci.FTQLQ:1!null\n" +
 			"             │           │               │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │           │               │       └─ TableAlias(ci)\n" +
-			"             │           │               │           └─ IndexedTableAccess\n" +
+			"             │           │               │           └─ IndexedTableAccess(JDLNA)\n" +
 			"             │           │               │               ├─ index: [JDLNA.id]\n" +
-			"             │           │               │               └─ Table\n" +
-			"             │           │               │                   └─ name: JDLNA\n" +
+			"             │           │               │               └─ columns: [id ftqlq]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
+			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
 			"             │           │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: NOXN3\n" +
+			"             │           │                       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(sn)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(NOXN3)\n" +
 			"             │                   ├─ index: [NOXN3.id]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: NOXN3\n" +
+			"             │                   └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             └─ SubqueryAlias\n" +
 			"                 ├─ name: AOEV5\n" +
 			"                 ├─ outerVisibility: false\n" +
@@ -10009,10 +9220,9 @@ WHERE
 			" │       │           │   ├─ aac.id:67!null\n" +
 			" │       │           │   └─ SL3S5.M22QN:53!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ IndexedTableAccess\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
 			" │       │                   ├─ index: [TPXBU.id]\n" +
-			" │       │                   └─ Table\n" +
-			" │       │                       └─ name: TPXBU\n" +
+			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, SL3S5.NO52D:55!null as NO52D, SL3S5.IDPK7:56!null as IDPK7]\n" +
 			" │       └─ HashJoin\n" +
 			" │           ├─ AND\n" +
@@ -10032,21 +9242,20 @@ WHERE
 			" │           │   │   │   └─ bs.IXUXU:2\n" +
 			" │           │   │   ├─ TableAlias(bs)\n" +
 			" │           │   │   │   └─ Table\n" +
-			" │           │   │   │       └─ name: THNTS\n" +
+			" │           │   │   │       ├─ name: THNTS\n" +
+			" │           │   │   │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			" │           │   │   └─ Filter\n" +
 			" │           │   │       ├─ HashIn\n" +
 			" │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			" │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │           │   │       └─ TableAlias(cla)\n" +
-			" │           │   │           └─ IndexedTableAccess\n" +
+			" │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
 			" │           │   │               ├─ index: [YK2GW.id]\n" +
-			" │           │   │               └─ Table\n" +
-			" │           │   │                   └─ name: YK2GW\n" +
+			" │           │   │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			" │           │   └─ TableAlias(mf)\n" +
-			" │           │       └─ IndexedTableAccess\n" +
+			" │           │       └─ IndexedTableAccess(HGMQ6)\n" +
 			" │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			" │           │           └─ Table\n" +
-			" │           │               └─ name: HGMQ6\n" +
+			" │           │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │           └─ HashLookup\n" +
 			" │               ├─ source: TUPLE(mf.LUEVY:36!null, mf.M22QN:37!null)\n" +
 			" │               ├─ target: TUPLE(sn.BRQP2:7!null, SL3S5.M22QN:2!null)\n" +
@@ -10060,46 +9269,45 @@ WHERE
 			" │                       │   ├─ outerVisibility: false\n" +
 			" │                       │   ├─ cacheable: true\n" +
 			" │                       │   └─ Project\n" +
-			" │                       │       ├─ columns: [KHJJO.BDNYB:24!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
+			" │                       │       ├─ columns: [KHJJO.BDNYB:12!null as BDNYB, ci.FTQLQ:10!null as TOFPN, ct.M22QN:5!null as M22QN, cec.ADURZ:2!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:7!null as IDPK7]\n" +
 			" │                       │       └─ HashJoin\n" +
 			" │                       │           ├─ AND\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ ct.M22QN:9!null\n" +
-			" │                       │           │   │   └─ KHJJO.M22QN:23!null\n" +
+			" │                       │           │   │   ├─ ct.M22QN:5!null\n" +
+			" │                       │           │   │   └─ KHJJO.M22QN:11!null\n" +
 			" │                       │           │   └─ Eq\n" +
-			" │                       │           │       ├─ ct.LUEVY:8!null\n" +
-			" │                       │           │       └─ KHJJO.LUEVY:25!null\n" +
+			" │                       │           │       ├─ ct.LUEVY:4!null\n" +
+			" │                       │           │       └─ KHJJO.LUEVY:13!null\n" +
 			" │                       │           ├─ LookupJoin\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ ci.id:18!null\n" +
-			" │                       │           │   │   └─ ct.FZ2R5:7!null\n" +
+			" │                       │           │   │   ├─ ci.id:9!null\n" +
+			" │                       │           │   │   └─ ct.FZ2R5:3!null\n" +
 			" │                       │           │   ├─ LookupJoin\n" +
 			" │                       │           │   │   ├─ Eq\n" +
 			" │                       │           │   │   │   ├─ cec.id:0!null\n" +
-			" │                       │           │   │   │   └─ ct.OVE3E:10!null\n" +
+			" │                       │           │   │   │   └─ ct.OVE3E:6!null\n" +
 			" │                       │           │   │   ├─ TableAlias(cec)\n" +
 			" │                       │           │   │   │   └─ Table\n" +
-			" │                       │           │   │   │       └─ name: SFEGG\n" +
+			" │                       │           │   │   │       ├─ name: SFEGG\n" +
+			" │                       │           │   │   │       └─ columns: [id no52d adurz]\n" +
 			" │                       │           │   │   └─ Filter\n" +
 			" │                       │           │   │       ├─ Eq\n" +
-			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
+			" │                       │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
 			" │                       │           │   │       │   └─ = (longtext)\n" +
 			" │                       │           │   │       └─ TableAlias(ct)\n" +
-			" │                       │           │   │           └─ IndexedTableAccess\n" +
+			" │                       │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			" │                       │           │   │               ├─ index: [FLQLP.OVE3E]\n" +
-			" │                       │           │   │               └─ Table\n" +
-			" │                       │           │   │                   └─ name: FLQLP\n" +
+			" │                       │           │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
 			" │                       │           │   └─ Filter\n" +
 			" │                       │           │       ├─ HashIn\n" +
 			" │                       │           │       │   ├─ ci.FTQLQ:1!null\n" +
 			" │                       │           │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │                       │           │       └─ TableAlias(ci)\n" +
-			" │                       │           │           └─ IndexedTableAccess\n" +
+			" │                       │           │           └─ IndexedTableAccess(JDLNA)\n" +
 			" │                       │           │               ├─ index: [JDLNA.id]\n" +
-			" │                       │           │               └─ Table\n" +
-			" │                       │           │                   └─ name: JDLNA\n" +
+			" │                       │           │               └─ columns: [id ftqlq]\n" +
 			" │                       │           └─ HashLookup\n" +
-			" │                       │               ├─ source: TUPLE(ct.M22QN:9!null, ct.LUEVY:8!null)\n" +
+			" │                       │               ├─ source: TUPLE(ct.M22QN:5!null, ct.LUEVY:4!null)\n" +
 			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
 			" │                       │               └─ CachedResults\n" +
 			" │                       │                   └─ SubqueryAlias\n" +
@@ -10115,17 +9323,16 @@ WHERE
 			" │                       │                                   │   └─ mf.LUEVY:12!null\n" +
 			" │                       │                                   ├─ TableAlias(sn)\n" +
 			" │                       │                                   │   └─ Table\n" +
-			" │                       │                                   │       └─ name: NOXN3\n" +
+			" │                       │                                   │       ├─ name: NOXN3\n" +
+			" │                       │                                   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" │                       │                                   └─ TableAlias(mf)\n" +
-			" │                       │                                       └─ IndexedTableAccess\n" +
+			" │                       │                                       └─ IndexedTableAccess(HGMQ6)\n" +
 			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │                       │                                           └─ Table\n" +
-			" │                       │                                               └─ name: HGMQ6\n" +
+			" │                       │                                           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │                       └─ TableAlias(sn)\n" +
-			" │                           └─ IndexedTableAccess\n" +
+			" │                           └─ IndexedTableAccess(NOXN3)\n" +
 			" │                               ├─ index: [NOXN3.id]\n" +
-			" │                               └─ Table\n" +
-			" │                                   └─ name: NOXN3\n" +
+			" │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [AOEV5.T4IBQ:0!null as T4IBQ, VUMUY.DL754:1!null, VUMUY.BDNYB:2!null, VUMUY.ADURZ:3!null, VUMUY.TPXBU:4, VUMUY.NO52D:5!null, VUMUY.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
@@ -10145,10 +9352,9 @@ WHERE
 			"             │       │           │   ├─ aac.id:16!null\n" +
 			"             │       │           │   └─ SL3S5.M22QN:2!null\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
 			"             │       │                   ├─ index: [TPXBU.id]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   as TPXBU, SL3S5.NO52D:4!null as NO52D, SL3S5.IDPK7:5!null as IDPK7]\n" +
 			"             │       └─ LookupJoin\n" +
 			"             │           ├─ Eq\n" +
@@ -10159,67 +9365,63 @@ WHERE
 			"             │           │   ├─ outerVisibility: false\n" +
 			"             │           │   ├─ cacheable: true\n" +
 			"             │           │   └─ Project\n" +
-			"             │           │       ├─ columns: [sn.id:23!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
+			"             │           │       ├─ columns: [sn.id:17!null as BDNYB, ci.FTQLQ:16!null as TOFPN, ct.M22QN:6!null as M22QN, cec.ADURZ:2!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:12!null as IDPK7]\n" +
 			"             │           │       └─ Filter\n" +
 			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ ct.M22QN:9!null\n" +
+			"             │           │           │   ├─ ct.M22QN:6!null\n" +
 			"             │           │           │   └─ Subquery\n" +
 			"             │           │           │       ├─ cacheable: true\n" +
 			"             │           │           │       └─ Project\n" +
-			"             │           │           │           ├─ columns: [aac.id:33!null]\n" +
+			"             │           │           │           ├─ columns: [aac.id:27!null]\n" +
 			"             │           │           │           └─ Filter\n" +
 			"             │           │           │               ├─ Eq\n" +
-			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
+			"             │           │           │               │   ├─ aac.BTXC5:28\n" +
 			"             │           │           │               │   └─ WT (longtext)\n" +
 			"             │           │           │               └─ TableAlias(aac)\n" +
-			"             │           │           │                   └─ IndexedTableAccess\n" +
+			"             │           │           │                   └─ IndexedTableAccess(TPXBU)\n" +
 			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
 			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
-			"             │           │           │                       └─ Table\n" +
-			"             │           │           │                           └─ name: TPXBU\n" +
+			"             │           │           │                       └─ columns: [id btxc5]\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
-			"             │           │               │   ├─ ct.LUEVY:8!null\n" +
-			"             │           │               │   └─ sn.BRQP2:24!null\n" +
+			"             │           │               │   ├─ ct.LUEVY:5!null\n" +
+			"             │           │               │   └─ sn.BRQP2:18!null\n" +
 			"             │           │               ├─ LookupJoin\n" +
 			"             │           │               │   ├─ Eq\n" +
-			"             │           │               │   │   ├─ ci.id:18!null\n" +
-			"             │           │               │   │   └─ ct.FZ2R5:7!null\n" +
+			"             │           │               │   │   ├─ ci.id:15!null\n" +
+			"             │           │               │   │   └─ ct.FZ2R5:4!null\n" +
 			"             │           │               │   ├─ LookupJoin\n" +
 			"             │           │               │   │   ├─ Eq\n" +
 			"             │           │               │   │   │   ├─ cec.id:0!null\n" +
-			"             │           │               │   │   │   └─ ct.OVE3E:10!null\n" +
+			"             │           │               │   │   │   └─ ct.OVE3E:7!null\n" +
 			"             │           │               │   │   ├─ TableAlias(cec)\n" +
 			"             │           │               │   │   │   └─ Table\n" +
-			"             │           │               │   │   │       └─ name: SFEGG\n" +
+			"             │           │               │   │   │       ├─ name: SFEGG\n" +
+			"             │           │               │   │   │       └─ columns: [id no52d adurz]\n" +
 			"             │           │               │   │   └─ Filter\n" +
 			"             │           │               │   │       ├─ Eq\n" +
 			"             │           │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
 			"             │           │               │   │       │   └─ = (longtext)\n" +
 			"             │           │               │   │       └─ TableAlias(ct)\n" +
-			"             │           │               │   │           └─ IndexedTableAccess\n" +
+			"             │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			"             │           │               │   │               ├─ index: [FLQLP.OVE3E]\n" +
-			"             │           │               │   │               └─ Table\n" +
-			"             │           │               │   │                   └─ name: FLQLP\n" +
+			"             │           │               │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"             │           │               │   └─ Filter\n" +
 			"             │           │               │       ├─ HashIn\n" +
 			"             │           │               │       │   ├─ ci.FTQLQ:1!null\n" +
 			"             │           │               │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │           │               │       └─ TableAlias(ci)\n" +
-			"             │           │               │           └─ IndexedTableAccess\n" +
+			"             │           │               │           └─ IndexedTableAccess(JDLNA)\n" +
 			"             │           │               │               ├─ index: [JDLNA.id]\n" +
-			"             │           │               │               └─ Table\n" +
-			"             │           │               │                   └─ name: JDLNA\n" +
+			"             │           │               │               └─ columns: [id ftqlq]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
+			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
 			"             │           │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: NOXN3\n" +
+			"             │           │                       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(sn)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(NOXN3)\n" +
 			"             │                   ├─ index: [NOXN3.id]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: NOXN3\n" +
+			"             │                   └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             └─ SubqueryAlias\n" +
 			"                 ├─ name: AOEV5\n" +
 			"                 ├─ outerVisibility: false\n" +
@@ -10246,7 +9448,8 @@ WHERE
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
 			"     └─ Table\n" +
-			"         └─ name: NOXN3\n" +
+			"         ├─ name: NOXN3\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -10279,10 +9482,10 @@ WHERE
 	ORDER BY Y3IOU`,
 		ExpectedPlan: "Sort(Y3IOU:0!null ASC nullsFirst)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [NB6PJ.Y3IOU:0!null as Y3IOU, S7EGW.TW55N:26!null as FJVD7, TYMVL.TW55N:9!null as KBXXJ, NB6PJ.NUMK2:4!null as NUMK2, NB6PJ.LETOE:5!null as LETOE]\n" +
+			"     ├─ columns: [NB6PJ.Y3IOU:0!null as Y3IOU, S7EGW.TW55N:9!null as FJVD7, TYMVL.TW55N:7!null as KBXXJ, NB6PJ.NUMK2:4!null as NUMK2, NB6PJ.LETOE:5!null as LETOE]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ S7EGW.id:23!null\n" +
+			"         │   ├─ S7EGW.id:8!null\n" +
 			"         │   └─ NB6PJ.BRQP2:2!null\n" +
 			"         ├─ LookupJoin\n" +
 			"         │   ├─ Eq\n" +
@@ -10306,15 +9509,13 @@ WHERE
 			"         │   │                   ├─ name: NOXN3\n" +
 			"         │   │                   └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"         │   └─ TableAlias(TYMVL)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │           └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(S7EGW)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
 			"                 ├─ index: [E2I7U.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"                 └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -10340,7 +9541,7 @@ WHERE
 	ORDER BY TW55N, Y3IOU`,
 		ExpectedPlan: "Sort(TW55N:0!null ASC nullsFirst, Y3IOU:1!null ASC nullsFirst)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [nd.TW55N:9!null as TW55N, NB6PJ.Y3IOU:0!null as Y3IOU]\n" +
+			"     ├─ columns: [nd.TW55N:7!null as TW55N, NB6PJ.Y3IOU:0!null as Y3IOU]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ nd.id:6!null\n" +
@@ -10363,10 +9564,9 @@ WHERE
 			"         │                   ├─ name: NOXN3\n" +
 			"         │                   └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"         └─ TableAlias(nd)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
 			"                 ├─ index: [E2I7U.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"                 └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -10390,32 +9590,31 @@ WHERE
 			"     ├─ columns: [(row_number() over ( order by sn.id ASC):0!null - 1 (tinyint)) as M6T2N, FJVD7:1!null, KBXXJ:2!null, sn.NUMK2:3!null, sn.LETOE:4!null, XLFIA:5!null]\n" +
 			"     └─ Window\n" +
 			"         ├─ row_number() over ( order by sn.id ASC)\n" +
-			"         ├─ S7EGW.TW55N:30!null as FJVD7\n" +
-			"         ├─ TYMVL.TW55N:3!null as KBXXJ\n" +
-			"         ├─ sn.NUMK2:23!null\n" +
-			"         ├─ sn.LETOE:24!null\n" +
-			"         ├─ sn.id:17!null as XLFIA\n" +
+			"         ├─ S7EGW.TW55N:8!null as FJVD7\n" +
+			"         ├─ TYMVL.TW55N:1!null as KBXXJ\n" +
+			"         ├─ sn.NUMK2:5!null\n" +
+			"         ├─ sn.LETOE:6!null\n" +
+			"         ├─ sn.id:2!null as XLFIA\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ Eq\n" +
-			"             │   ├─ sn.BRQP2:18!null\n" +
-			"             │   └─ S7EGW.id:27!null\n" +
+			"             │   ├─ sn.BRQP2:3!null\n" +
+			"             │   └─ S7EGW.id:7!null\n" +
 			"             ├─ LookupJoin\n" +
 			"             │   ├─ Eq\n" +
-			"             │   │   ├─ sn.FFTBJ:19!null\n" +
+			"             │   │   ├─ sn.FFTBJ:4!null\n" +
 			"             │   │   └─ TYMVL.id:0!null\n" +
 			"             │   ├─ TableAlias(TYMVL)\n" +
 			"             │   │   └─ Table\n" +
-			"             │   │       └─ name: E2I7U\n" +
+			"             │   │       ├─ name: E2I7U\n" +
+			"             │   │       └─ columns: [id tw55n]\n" +
 			"             │   └─ TableAlias(sn)\n" +
-			"             │       └─ IndexedTableAccess\n" +
+			"             │       └─ IndexedTableAccess(NOXN3)\n" +
 			"             │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"             │           └─ Table\n" +
-			"             │               └─ name: NOXN3\n" +
+			"             │           └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"             └─ TableAlias(S7EGW)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
 			"                     ├─ index: [E2I7U.id]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: E2I7U\n" +
+			"                     └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -10428,7 +9627,8 @@ WHERE
 			"     ├─ row_number() over ( order by sn.id ASC)\n" +
 			"     └─ TableAlias(sn)\n" +
 			"         └─ Table\n" +
-			"             └─ name: NOXN3\n" +
+			"             ├─ name: NOXN3\n" +
+			"             └─ columns: [id]\n" +
 			"",
 	},
 	{
@@ -10449,14 +9649,14 @@ WHERE
 	ORDER BY nd.TW55N`,
 		ExpectedPlan: "Sort(nd.TW55N:0!null ASC nullsFirst)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [nd.TW55N:6!null, il.LIILR:22, il.KSFXH:23, il.KLMAU:24, il.ecm:25]\n" +
+			"     ├─ columns: [nd.TW55N:4!null, il.LIILR:6, il.KSFXH:7, il.KLMAU:8, il.ecm:9]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ il.LUEVY:21!null\n" +
-			"         │   └─ nd.id:3!null\n" +
+			"         │   ├─ il.LUEVY:5!null\n" +
+			"         │   └─ nd.id:2!null\n" +
 			"         ├─ LookupJoin\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ nd.DKCAJ:4!null\n" +
+			"         │   │   ├─ nd.DKCAJ:3!null\n" +
 			"         │   │   └─ nt.id:0!null\n" +
 			"         │   ├─ Filter\n" +
 			"         │   │   ├─ (NOT(Eq\n" +
@@ -10464,21 +9664,18 @@ WHERE
 			"         │   │   │   └─ SUZTA (longtext)\n" +
 			"         │   │   │  ))\n" +
 			"         │   │   └─ TableAlias(nt)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(F35MI)\n" +
 			"         │   │           ├─ index: [F35MI.DZLIM]\n" +
 			"         │   │           ├─ static: [{(SUZTA, ∞)}, {(NULL, SUZTA)}]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: F35MI\n" +
+			"         │   │           └─ columns: [id dzlim]\n" +
 			"         │   └─ TableAlias(nd)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │           ├─ index: [E2I7U.DKCAJ]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │           └─ columns: [id dkcaj tw55n]\n" +
 			"         └─ TableAlias(il)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(RLOHD)\n" +
 			"                 ├─ index: [RLOHD.LUEVY]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: RLOHD\n" +
+			"                 └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
 			"",
 	},
 	{
@@ -10491,13 +9688,10 @@ WHERE
 			" ├─ HashIn\n" +
 			" │   ├─ YK2GW.FTQLQ:0!null\n" +
 			" │   └─ TUPLE(SQ1 (longtext))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(YK2GW)\n" +
 			"     ├─ index: [YK2GW.FTQLQ]\n" +
 			"     ├─ static: [{[SQ1, SQ1]}]\n" +
-			"     ├─ columns: [ftqlq tpnj6]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: YK2GW\n" +
-			"         └─ projections: [1 5]\n" +
+			"     └─ columns: [ftqlq tpnj6]\n" +
 			"",
 	},
 	{
@@ -10548,7 +9742,7 @@ WHERE
 	   YYKXN
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [ATHCU.T4IBQ:1!null as T4IBQ, ATHCU.TW55N:3!null as TW55N, CASE  WHEN fc.OZTQF:11 IS NULL THEN 0 (tinyint) WHEN IN\n" +
+			" ├─ columns: [ATHCU.T4IBQ:1!null as T4IBQ, ATHCU.TW55N:3!null as TW55N, CASE  WHEN fc.OZTQF:8 IS NULL THEN 0 (tinyint) WHEN IN\n" +
 			" │   ├─ left: ATHCU.SJ5DU:5\n" +
 			" │   └─ right: TUPLE(log (longtext), com (longtext), ex (longtext))\n" +
 			" │   THEN 0 (tinyint) WHEN Eq\n" +
@@ -10557,18 +9751,18 @@ WHERE
 			" │   THEN 0 (tinyint) WHEN Eq\n" +
 			" │   ├─ ATHCU.SOWRY:4!null\n" +
 			" │   └─ z (longtext)\n" +
-			" │   THEN fc.OZTQF:11 WHEN Eq\n" +
+			" │   THEN fc.OZTQF:8 WHEN Eq\n" +
 			" │   ├─ ATHCU.SOWRY:4!null\n" +
 			" │   └─ o (longtext)\n" +
-			" │   THEN (fc.OZTQF:11 - 1 (tinyint)) END as OZTQF]\n" +
+			" │   THEN (fc.OZTQF:8 - 1 (tinyint)) END as OZTQF]\n" +
 			" └─ Sort(ATHCU.YYKXN:2!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ fc.LUEVY:8!null\n" +
+			"         │   │   ├─ fc.LUEVY:7!null\n" +
 			"         │   │   └─ ATHCU.YYKXN:2!null\n" +
 			"         │   └─ Eq\n" +
-			"         │       ├─ fc.GXLUB:7!null\n" +
+			"         │       ├─ fc.GXLUB:6!null\n" +
 			"         │       └─ ATHCU.B2TX3:0!null\n" +
 			"         ├─ SubqueryAlias\n" +
 			"         │   ├─ name: ATHCU\n" +
@@ -10584,10 +9778,9 @@ WHERE
 			"         │       │           │   ├─ nt.id:19!null\n" +
 			"         │       │           │   └─ nd.DKCAJ:3!null\n" +
 			"         │       │           └─ TableAlias(nt)\n" +
-			"         │       │               └─ IndexedTableAccess\n" +
+			"         │       │               └─ IndexedTableAccess(F35MI)\n" +
 			"         │       │                   ├─ index: [F35MI.id]\n" +
-			"         │       │                   └─ Table\n" +
-			"         │       │                       └─ name: F35MI\n" +
+			"         │       │                   └─ columns: [id dzlim]\n" +
 			"         │       │   as SJ5DU]\n" +
 			"         │       └─ CrossJoin\n" +
 			"         │           ├─ SubqueryAlias\n" +
@@ -10595,31 +9788,31 @@ WHERE
 			"         │           │   ├─ outerVisibility: false\n" +
 			"         │           │   ├─ cacheable: true\n" +
 			"         │           │   └─ Project\n" +
-			"         │           │       ├─ columns: [bs.id:0!null as B2TX3, cla.FTQLQ:5!null as T4IBQ]\n" +
+			"         │           │       ├─ columns: [bs.id:0!null as B2TX3, cla.FTQLQ:3!null as T4IBQ]\n" +
 			"         │           │       └─ LookupJoin\n" +
 			"         │           │           ├─ Eq\n" +
-			"         │           │           │   ├─ bs.IXUXU:2\n" +
-			"         │           │           │   └─ cla.id:4!null\n" +
+			"         │           │           │   ├─ bs.IXUXU:1\n" +
+			"         │           │           │   └─ cla.id:2!null\n" +
 			"         │           │           ├─ TableAlias(bs)\n" +
 			"         │           │           │   └─ Table\n" +
-			"         │           │           │       └─ name: THNTS\n" +
+			"         │           │           │       ├─ name: THNTS\n" +
+			"         │           │           │       └─ columns: [id ixuxu]\n" +
 			"         │           │           └─ Filter\n" +
 			"         │           │               ├─ HashIn\n" +
 			"         │           │               │   ├─ cla.FTQLQ:1!null\n" +
 			"         │           │               │   └─ TUPLE(SQ1 (longtext))\n" +
 			"         │           │               └─ TableAlias(cla)\n" +
-			"         │           │                   └─ IndexedTableAccess\n" +
+			"         │           │                   └─ IndexedTableAccess(YK2GW)\n" +
 			"         │           │                       ├─ index: [YK2GW.id]\n" +
-			"         │           │                       └─ Table\n" +
-			"         │           │                           └─ name: YK2GW\n" +
+			"         │           │                       └─ columns: [id ftqlq]\n" +
 			"         │           └─ TableAlias(nd)\n" +
 			"         │               └─ Table\n" +
-			"         │                   └─ name: E2I7U\n" +
+			"         │                   ├─ name: E2I7U\n" +
+			"         │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         └─ TableAlias(fc)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: AMYXQ\n" +
+			"                 └─ columns: [gxlub luevy oztqf]\n" +
 			"",
 	},
 	{
@@ -10772,34 +9965,34 @@ WHERE
 			"                                         ├─ outerVisibility: false\n" +
 			"                                         ├─ cacheable: true\n" +
 			"                                         └─ Project\n" +
-			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:15 as GSTQA, pog.B5OUF:13, fc.OZTQF:45, F26ZW.YHYLK:51, nd.TW55N:20 as TW55N]\n" +
+			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:12 as GSTQA, pog.B5OUF:10, fc.OZTQF:20, F26ZW.YHYLK:24, nd.TW55N:14 as TW55N]\n" +
 			"                                             └─ Filter\n" +
 			"                                                 ├─ Eq\n" +
-			"                                                 │   ├─ ms.D237E:8\n" +
+			"                                                 │   ├─ ms.D237E:6\n" +
 			"                                                 │   └─ %!s(bool=true) (tinyint)\n" +
 			"                                                 └─ LeftOuterLookupJoin\n" +
 			"                                                     ├─ Eq\n" +
-			"                                                     │   ├─ nd.HPCMS:29\n" +
-			"                                                     │   └─ nma.id:52!null\n" +
+			"                                                     │   ├─ nd.HPCMS:15\n" +
+			"                                                     │   └─ nma.id:25!null\n" +
 			"                                                     ├─ LeftOuterHashJoin\n" +
 			"                                                     │   ├─ AND\n" +
 			"                                                     │   │   ├─ Eq\n" +
-			"                                                     │   │   │   ├─ F26ZW.T4IBQ:48!null\n" +
+			"                                                     │   │   │   ├─ F26ZW.T4IBQ:21!null\n" +
 			"                                                     │   │   │   └─ bs.T4IBQ:1!null\n" +
 			"                                                     │   │   └─ Eq\n" +
-			"                                                     │   │       ├─ F26ZW.BRQP2:49!null\n" +
-			"                                                     │   │       └─ nd.id:17\n" +
+			"                                                     │   │       ├─ F26ZW.BRQP2:22!null\n" +
+			"                                                     │   │       └─ nd.id:13\n" +
 			"                                                     │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   ├─ AND\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
 			"                                                     │   │   │   │   ├─ bs.id:0!null\n" +
-			"                                                     │   │   │   │   └─ fc.GXLUB:41!null\n" +
+			"                                                     │   │   │   │   └─ fc.GXLUB:18!null\n" +
 			"                                                     │   │   │   └─ Eq\n" +
-			"                                                     │   │   │       ├─ nd.id:17\n" +
-			"                                                     │   │   │       └─ fc.LUEVY:42!null\n" +
+			"                                                     │   │   │       ├─ nd.id:13\n" +
+			"                                                     │   │   │       └─ fc.LUEVY:19!null\n" +
 			"                                                     │   │   ├─ LeftOuterHashJoin\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │   │   ├─ ms.GXLUB:6!null\n" +
+			"                                                     │   │   │   │   ├─ ms.GXLUB:4!null\n" +
 			"                                                     │   │   │   │   └─ bs.id:0!null\n" +
 			"                                                     │   │   │   ├─ SubqueryAlias\n" +
 			"                                                     │   │   │   │   ├─ name: bs\n" +
@@ -10818,73 +10011,67 @@ WHERE
 			"                                                     │   │   │   │               ├─ Table\n" +
 			"                                                     │   │   │   │               │   ├─ name: THNTS\n" +
 			"                                                     │   │   │   │               │   └─ columns: [id ixuxu]\n" +
-			"                                                     │   │   │   │               └─ IndexedTableAccess\n" +
+			"                                                     │   │   │   │               └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │   │   │   │                   ├─ index: [YK2GW.id]\n" +
-			"                                                     │   │   │   │                   ├─ columns: [id ftqlq]\n" +
-			"                                                     │   │   │   │                   └─ Table\n" +
-			"                                                     │   │   │   │                       ├─ name: YK2GW\n" +
-			"                                                     │   │   │   │                       └─ projections: [0 1]\n" +
+			"                                                     │   │   │   │                   └─ columns: [id ftqlq]\n" +
 			"                                                     │   │   │   └─ HashLookup\n" +
 			"                                                     │   │   │       ├─ source: TUPLE(bs.id:0!null)\n" +
-			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:4!null)\n" +
+			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:2!null)\n" +
 			"                                                     │   │   │       └─ CachedResults\n" +
 			"                                                     │   │   │           └─ HashJoin\n" +
 			"                                                     │   │   │               ├─ Eq\n" +
-			"                                                     │   │   │               │   ├─ pog.id:10\n" +
-			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:36!null\n" +
+			"                                                     │   │   │               │   ├─ pog.id:7\n" +
+			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:17!null\n" +
 			"                                                     │   │   │               ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   ├─ pog.XVSBH:12\n" +
-			"                                                     │   │   │               │   │   └─ pga.id:14!null\n" +
+			"                                                     │   │   │               │   │   ├─ pog.XVSBH:9\n" +
+			"                                                     │   │   │               │   │   └─ pga.id:11!null\n" +
 			"                                                     │   │   │               │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   │               │   │   ├─ Eq\n" +
 			"                                                     │   │   │               │   │   │   ├─ pa.id:2!null\n" +
-			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:11!null\n" +
+			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:8!null\n" +
 			"                                                     │   │   │               │   │   ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:7!null\n" +
+			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:5!null\n" +
 			"                                                     │   │   │               │   │   │   │   └─ pa.id:2!null\n" +
 			"                                                     │   │   │               │   │   │   ├─ TableAlias(pa)\n" +
 			"                                                     │   │   │               │   │   │   │   └─ Table\n" +
-			"                                                     │   │   │               │   │   │   │       └─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       ├─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               │   │   │   └─ TableAlias(ms)\n" +
-			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess\n" +
+			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess(SZQWJ)\n" +
 			"                                                     │   │   │               │   │   │           ├─ index: [SZQWJ.CH3FR]\n" +
-			"                                                     │   │   │               │   │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │   │               └─ name: SZQWJ\n" +
+			"                                                     │   │   │               │   │   │           └─ columns: [gxlub ch3fr d237e]\n" +
 			"                                                     │   │   │               │   │   └─ TableAlias(pog)\n" +
-			"                                                     │   │   │               │   │       └─ IndexedTableAccess\n" +
+			"                                                     │   │   │               │   │       └─ IndexedTableAccess(NPCYY)\n" +
 			"                                                     │   │   │               │   │           ├─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
-			"                                                     │   │   │               │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │               └─ name: NPCYY\n" +
+			"                                                     │   │   │               │   │           └─ columns: [id ch3fr xvsbh b5ouf]\n" +
 			"                                                     │   │   │               │   └─ TableAlias(pga)\n" +
-			"                                                     │   │   │               │       └─ IndexedTableAccess\n" +
+			"                                                     │   │   │               │       └─ IndexedTableAccess(PG27A)\n" +
 			"                                                     │   │   │               │           ├─ index: [PG27A.id]\n" +
-			"                                                     │   │   │               │           └─ Table\n" +
-			"                                                     │   │   │               │               └─ name: PG27A\n" +
+			"                                                     │   │   │               │           └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               └─ HashLookup\n" +
-			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:10)\n" +
-			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:19!null)\n" +
+			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:7)\n" +
+			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:4!null)\n" +
 			"                                                     │   │   │                   └─ CachedResults\n" +
 			"                                                     │   │   │                       └─ LookupJoin\n" +
 			"                                                     │   │   │                           ├─ Eq\n" +
-			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:35!null\n" +
-			"                                                     │   │   │                           │   └─ nd.id:17!null\n" +
+			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:16!null\n" +
+			"                                                     │   │   │                           │   └─ nd.id:13!null\n" +
 			"                                                     │   │   │                           ├─ TableAlias(nd)\n" +
 			"                                                     │   │   │                           │   └─ Table\n" +
-			"                                                     │   │   │                           │       └─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       ├─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       └─ columns: [id tw55n hpcms]\n" +
 			"                                                     │   │   │                           └─ TableAlias(GZ7Z4)\n" +
-			"                                                     │   │   │                               └─ IndexedTableAccess\n" +
+			"                                                     │   │   │                               └─ IndexedTableAccess(FEIOE)\n" +
 			"                                                     │   │   │                                   ├─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
-			"                                                     │   │   │                                   └─ Table\n" +
-			"                                                     │   │   │                                       └─ name: FEIOE\n" +
+			"                                                     │   │   │                                   └─ columns: [luevy gmsga]\n" +
 			"                                                     │   │   └─ TableAlias(fc)\n" +
-			"                                                     │   │       └─ IndexedTableAccess\n" +
+			"                                                     │   │       └─ IndexedTableAccess(AMYXQ)\n" +
 			"                                                     │   │           ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                                                     │   │           └─ Table\n" +
-			"                                                     │   │               └─ name: AMYXQ\n" +
+			"                                                     │   │           └─ columns: [gxlub luevy oztqf]\n" +
 			"                                                     │   └─ HashLookup\n" +
-			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:17)\n" +
+			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:13)\n" +
 			"                                                     │       ├─ target: TUPLE(F26ZW.T4IBQ:0!null, F26ZW.BRQP2:1!null)\n" +
 			"                                                     │       └─ CachedResults\n" +
 			"                                                     │           └─ SubqueryAlias\n" +
@@ -10898,7 +10085,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -10909,7 +10096,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -10920,7 +10107,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -10931,7 +10118,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -10943,7 +10130,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -10955,7 +10142,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -10964,90 +10151,83 @@ WHERE
 			"                                                     │                   │   THEN 0 (tinyint) ELSE NULL (null) END as YHYLK]\n" +
 			"                                                     │                   └─ LeftOuterLookupJoin\n" +
 			"                                                     │                       ├─ Eq\n" +
-			"                                                     │                       │   ├─ W2MAO.YH4XB:7\n" +
-			"                                                     │                       │   └─ vc.id:8!null\n" +
+			"                                                     │                       │   ├─ W2MAO.YH4XB:6\n" +
+			"                                                     │                       │   └─ vc.id:7!null\n" +
 			"                                                     │                       ├─ LeftOuterLookupJoin\n" +
 			"                                                     │                       │   ├─ Eq\n" +
 			"                                                     │                       │   │   ├─ iq.Z7CP5:2!null\n" +
-			"                                                     │                       │   │   └─ W2MAO.Z7CP5:6!null\n" +
+			"                                                     │                       │   │   └─ W2MAO.Z7CP5:5!null\n" +
 			"                                                     │                       │   ├─ SubqueryAlias\n" +
 			"                                                     │                       │   │   ├─ name: iq\n" +
 			"                                                     │                       │   │   ├─ outerVisibility: false\n" +
 			"                                                     │                       │   │   ├─ cacheable: true\n" +
 			"                                                     │                       │   │   └─ Project\n" +
-			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.BRQP2:72!null, mf.id:34!null as Z7CP5, mf.FSDY2:44!null, nma.DZLIM:69!null as IDWIO]\n" +
+			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.BRQP2:12!null, mf.id:4!null as Z7CP5, mf.FSDY2:7!null, nma.DZLIM:11!null as IDWIO]\n" +
 			"                                                     │                       │   │       └─ HashJoin\n" +
 			"                                                     │                       │   │           ├─ Eq\n" +
-			"                                                     │                       │   │           │   ├─ mf.LUEVY:36!null\n" +
-			"                                                     │                       │   │           │   └─ nd.id:51!null\n" +
+			"                                                     │                       │   │           │   ├─ mf.LUEVY:6!null\n" +
+			"                                                     │                       │   │           │   └─ nd.id:8!null\n" +
 			"                                                     │                       │   │           ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:35!null\n" +
-			"                                                     │                       │   │           │   │   └─ bs.id:30!null\n" +
+			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:5!null\n" +
+			"                                                     │                       │   │           │   │   └─ bs.id:2!null\n" +
 			"                                                     │                       │   │           │   ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:32\n" +
+			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:3\n" +
 			"                                                     │                       │   │           │   │   │   └─ cla.id:0!null\n" +
 			"                                                     │                       │   │           │   │   ├─ Filter\n" +
 			"                                                     │                       │   │           │   │   │   ├─ HashIn\n" +
 			"                                                     │                       │   │           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"                                                     │                       │   │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                                                     │                       │   │           │   │   │   └─ TableAlias(cla)\n" +
-			"                                                     │                       │   │           │   │   │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │                       │   │           │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
 			"                                                     │                       │   │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"                                                     │                       │   │           │   │   │           └─ Table\n" +
-			"                                                     │                       │   │           │   │   │               └─ name: YK2GW\n" +
+			"                                                     │                       │   │           │   │   │           └─ columns: [id ftqlq]\n" +
 			"                                                     │                       │   │           │   │   └─ TableAlias(bs)\n" +
-			"                                                     │                       │   │           │   │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │           │   │       └─ IndexedTableAccess(THNTS)\n" +
 			"                                                     │                       │   │           │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"                                                     │                       │   │           │   │           └─ Table\n" +
-			"                                                     │                       │   │           │   │               └─ name: THNTS\n" +
+			"                                                     │                       │   │           │   │           └─ columns: [id ixuxu]\n" +
 			"                                                     │                       │   │           │   └─ TableAlias(mf)\n" +
-			"                                                     │                       │   │           │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │           │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"                                                     │                       │   │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                                                     │                       │   │           │           └─ Table\n" +
-			"                                                     │                       │   │           │               └─ name: HGMQ6\n" +
+			"                                                     │                       │   │           │           └─ columns: [id gxlub luevy fsdy2]\n" +
 			"                                                     │                       │   │           └─ HashLookup\n" +
-			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
 			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:0!null)\n" +
 			"                                                     │                       │   │               └─ CachedResults\n" +
 			"                                                     │                       │   │                   └─ LookupJoin\n" +
 			"                                                     │                       │   │                       ├─ Eq\n" +
-			"                                                     │                       │   │                       │   ├─ sn.BRQP2:72!null\n" +
-			"                                                     │                       │   │                       │   └─ nd.id:51!null\n" +
+			"                                                     │                       │   │                       │   ├─ sn.BRQP2:12!null\n" +
+			"                                                     │                       │   │                       │   └─ nd.id:8!null\n" +
 			"                                                     │                       │   │                       ├─ LookupJoin\n" +
 			"                                                     │                       │   │                       │   ├─ Eq\n" +
-			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:63!null\n" +
-			"                                                     │                       │   │                       │   │   └─ nma.id:68!null\n" +
+			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:9!null\n" +
+			"                                                     │                       │   │                       │   │   └─ nma.id:10!null\n" +
 			"                                                     │                       │   │                       │   ├─ TableAlias(nd)\n" +
 			"                                                     │                       │   │                       │   │   └─ Table\n" +
-			"                                                     │                       │   │                       │   │       └─ name: E2I7U\n" +
+			"                                                     │                       │   │                       │   │       ├─ name: E2I7U\n" +
+			"                                                     │                       │   │                       │   │       └─ columns: [id hpcms]\n" +
 			"                                                     │                       │   │                       │   └─ TableAlias(nma)\n" +
-			"                                                     │                       │   │                       │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │                       │       └─ IndexedTableAccess(TNMXI)\n" +
 			"                                                     │                       │   │                       │           ├─ index: [TNMXI.id]\n" +
-			"                                                     │                       │   │                       │           └─ Table\n" +
-			"                                                     │                       │   │                       │               └─ name: TNMXI\n" +
+			"                                                     │                       │   │                       │           └─ columns: [id dzlim]\n" +
 			"                                                     │                       │   │                       └─ TableAlias(sn)\n" +
-			"                                                     │                       │   │                           └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │                           └─ IndexedTableAccess(NOXN3)\n" +
 			"                                                     │                       │   │                               ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                     │                       │   │                               └─ Table\n" +
-			"                                                     │                       │   │                                   └─ name: NOXN3\n" +
+			"                                                     │                       │   │                               └─ columns: [brqp2]\n" +
 			"                                                     │                       │   └─ TableAlias(W2MAO)\n" +
-			"                                                     │                       │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │       └─ IndexedTableAccess(SEQS3)\n" +
 			"                                                     │                       │           ├─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
-			"                                                     │                       │           └─ Table\n" +
-			"                                                     │                       │               └─ name: SEQS3\n" +
+			"                                                     │                       │           └─ columns: [z7cp5 yh4xb]\n" +
 			"                                                     │                       └─ TableAlias(vc)\n" +
-			"                                                     │                           └─ IndexedTableAccess\n" +
+			"                                                     │                           └─ IndexedTableAccess(D34QP)\n" +
 			"                                                     │                               ├─ index: [D34QP.id]\n" +
-			"                                                     │                               └─ Table\n" +
-			"                                                     │                                   └─ name: D34QP\n" +
+			"                                                     │                               └─ columns: [id znp4p]\n" +
 			"                                                     └─ TableAlias(nma)\n" +
-			"                                                         └─ IndexedTableAccess\n" +
+			"                                                         └─ IndexedTableAccess(TNMXI)\n" +
 			"                                                             ├─ index: [TNMXI.id]\n" +
-			"                                                             └─ Table\n" +
-			"                                                                 └─ name: TNMXI\n" +
+			"                                                             └─ columns: [id]\n" +
 			"",
 	},
 	{
@@ -11200,34 +10380,34 @@ WHERE
 			"                                         ├─ outerVisibility: false\n" +
 			"                                         ├─ cacheable: true\n" +
 			"                                         └─ Project\n" +
-			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:15 as GSTQA, pog.B5OUF:13, fc.OZTQF:45, F26ZW.YHYLK:51, nd.TW55N:20 as TW55N]\n" +
+			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:12 as GSTQA, pog.B5OUF:10, fc.OZTQF:20, F26ZW.YHYLK:24, nd.TW55N:14 as TW55N]\n" +
 			"                                             └─ Filter\n" +
 			"                                                 ├─ Eq\n" +
-			"                                                 │   ├─ ms.D237E:8\n" +
+			"                                                 │   ├─ ms.D237E:6\n" +
 			"                                                 │   └─ %!s(bool=true) (tinyint)\n" +
 			"                                                 └─ LeftOuterLookupJoin\n" +
 			"                                                     ├─ Eq\n" +
-			"                                                     │   ├─ nd.HPCMS:29\n" +
-			"                                                     │   └─ nma.id:52!null\n" +
+			"                                                     │   ├─ nd.HPCMS:15\n" +
+			"                                                     │   └─ nma.id:25!null\n" +
 			"                                                     ├─ LeftOuterHashJoin\n" +
 			"                                                     │   ├─ AND\n" +
 			"                                                     │   │   ├─ Eq\n" +
-			"                                                     │   │   │   ├─ F26ZW.T4IBQ:48!null\n" +
+			"                                                     │   │   │   ├─ F26ZW.T4IBQ:21!null\n" +
 			"                                                     │   │   │   └─ bs.T4IBQ:1!null\n" +
 			"                                                     │   │   └─ Eq\n" +
-			"                                                     │   │       ├─ F26ZW.BRQP2:49!null\n" +
-			"                                                     │   │       └─ nd.id:17\n" +
+			"                                                     │   │       ├─ F26ZW.BRQP2:22!null\n" +
+			"                                                     │   │       └─ nd.id:13\n" +
 			"                                                     │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   ├─ AND\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
 			"                                                     │   │   │   │   ├─ bs.id:0!null\n" +
-			"                                                     │   │   │   │   └─ fc.GXLUB:41!null\n" +
+			"                                                     │   │   │   │   └─ fc.GXLUB:18!null\n" +
 			"                                                     │   │   │   └─ Eq\n" +
-			"                                                     │   │   │       ├─ nd.id:17\n" +
-			"                                                     │   │   │       └─ fc.LUEVY:42!null\n" +
+			"                                                     │   │   │       ├─ nd.id:13\n" +
+			"                                                     │   │   │       └─ fc.LUEVY:19!null\n" +
 			"                                                     │   │   ├─ LeftOuterHashJoin\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │   │   ├─ ms.GXLUB:6!null\n" +
+			"                                                     │   │   │   │   ├─ ms.GXLUB:4!null\n" +
 			"                                                     │   │   │   │   └─ bs.id:0!null\n" +
 			"                                                     │   │   │   ├─ SubqueryAlias\n" +
 			"                                                     │   │   │   │   ├─ name: bs\n" +
@@ -11246,73 +10426,67 @@ WHERE
 			"                                                     │   │   │   │               ├─ Table\n" +
 			"                                                     │   │   │   │               │   ├─ name: THNTS\n" +
 			"                                                     │   │   │   │               │   └─ columns: [id ixuxu]\n" +
-			"                                                     │   │   │   │               └─ IndexedTableAccess\n" +
+			"                                                     │   │   │   │               └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │   │   │   │                   ├─ index: [YK2GW.id]\n" +
-			"                                                     │   │   │   │                   ├─ columns: [id ftqlq]\n" +
-			"                                                     │   │   │   │                   └─ Table\n" +
-			"                                                     │   │   │   │                       ├─ name: YK2GW\n" +
-			"                                                     │   │   │   │                       └─ projections: [0 1]\n" +
+			"                                                     │   │   │   │                   └─ columns: [id ftqlq]\n" +
 			"                                                     │   │   │   └─ HashLookup\n" +
 			"                                                     │   │   │       ├─ source: TUPLE(bs.id:0!null)\n" +
-			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:4!null)\n" +
+			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:2!null)\n" +
 			"                                                     │   │   │       └─ CachedResults\n" +
 			"                                                     │   │   │           └─ HashJoin\n" +
 			"                                                     │   │   │               ├─ Eq\n" +
-			"                                                     │   │   │               │   ├─ pog.id:10\n" +
-			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:36!null\n" +
+			"                                                     │   │   │               │   ├─ pog.id:7\n" +
+			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:17!null\n" +
 			"                                                     │   │   │               ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   ├─ pog.XVSBH:12\n" +
-			"                                                     │   │   │               │   │   └─ pga.id:14!null\n" +
+			"                                                     │   │   │               │   │   ├─ pog.XVSBH:9\n" +
+			"                                                     │   │   │               │   │   └─ pga.id:11!null\n" +
 			"                                                     │   │   │               │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   │               │   │   ├─ Eq\n" +
 			"                                                     │   │   │               │   │   │   ├─ pa.id:2!null\n" +
-			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:11!null\n" +
+			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:8!null\n" +
 			"                                                     │   │   │               │   │   ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:7!null\n" +
+			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:5!null\n" +
 			"                                                     │   │   │               │   │   │   │   └─ pa.id:2!null\n" +
 			"                                                     │   │   │               │   │   │   ├─ TableAlias(pa)\n" +
 			"                                                     │   │   │               │   │   │   │   └─ Table\n" +
-			"                                                     │   │   │               │   │   │   │       └─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       ├─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               │   │   │   └─ TableAlias(ms)\n" +
-			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess\n" +
+			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess(SZQWJ)\n" +
 			"                                                     │   │   │               │   │   │           ├─ index: [SZQWJ.CH3FR]\n" +
-			"                                                     │   │   │               │   │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │   │               └─ name: SZQWJ\n" +
+			"                                                     │   │   │               │   │   │           └─ columns: [gxlub ch3fr d237e]\n" +
 			"                                                     │   │   │               │   │   └─ TableAlias(pog)\n" +
-			"                                                     │   │   │               │   │       └─ IndexedTableAccess\n" +
+			"                                                     │   │   │               │   │       └─ IndexedTableAccess(NPCYY)\n" +
 			"                                                     │   │   │               │   │           ├─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
-			"                                                     │   │   │               │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │               └─ name: NPCYY\n" +
+			"                                                     │   │   │               │   │           └─ columns: [id ch3fr xvsbh b5ouf]\n" +
 			"                                                     │   │   │               │   └─ TableAlias(pga)\n" +
-			"                                                     │   │   │               │       └─ IndexedTableAccess\n" +
+			"                                                     │   │   │               │       └─ IndexedTableAccess(PG27A)\n" +
 			"                                                     │   │   │               │           ├─ index: [PG27A.id]\n" +
-			"                                                     │   │   │               │           └─ Table\n" +
-			"                                                     │   │   │               │               └─ name: PG27A\n" +
+			"                                                     │   │   │               │           └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               └─ HashLookup\n" +
-			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:10)\n" +
-			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:19!null)\n" +
+			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:7)\n" +
+			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:4!null)\n" +
 			"                                                     │   │   │                   └─ CachedResults\n" +
 			"                                                     │   │   │                       └─ LookupJoin\n" +
 			"                                                     │   │   │                           ├─ Eq\n" +
-			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:35!null\n" +
-			"                                                     │   │   │                           │   └─ nd.id:17!null\n" +
+			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:16!null\n" +
+			"                                                     │   │   │                           │   └─ nd.id:13!null\n" +
 			"                                                     │   │   │                           ├─ TableAlias(nd)\n" +
 			"                                                     │   │   │                           │   └─ Table\n" +
-			"                                                     │   │   │                           │       └─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       ├─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       └─ columns: [id tw55n hpcms]\n" +
 			"                                                     │   │   │                           └─ TableAlias(GZ7Z4)\n" +
-			"                                                     │   │   │                               └─ IndexedTableAccess\n" +
+			"                                                     │   │   │                               └─ IndexedTableAccess(FEIOE)\n" +
 			"                                                     │   │   │                                   ├─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
-			"                                                     │   │   │                                   └─ Table\n" +
-			"                                                     │   │   │                                       └─ name: FEIOE\n" +
+			"                                                     │   │   │                                   └─ columns: [luevy gmsga]\n" +
 			"                                                     │   │   └─ TableAlias(fc)\n" +
-			"                                                     │   │       └─ IndexedTableAccess\n" +
+			"                                                     │   │       └─ IndexedTableAccess(AMYXQ)\n" +
 			"                                                     │   │           ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                                                     │   │           └─ Table\n" +
-			"                                                     │   │               └─ name: AMYXQ\n" +
+			"                                                     │   │           └─ columns: [gxlub luevy oztqf]\n" +
 			"                                                     │   └─ HashLookup\n" +
-			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:17)\n" +
+			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:13)\n" +
 			"                                                     │       ├─ target: TUPLE(F26ZW.T4IBQ:0!null, F26ZW.BRQP2:1!null)\n" +
 			"                                                     │       └─ CachedResults\n" +
 			"                                                     │           └─ SubqueryAlias\n" +
@@ -11326,7 +10500,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -11337,7 +10511,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -11348,7 +10522,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -11359,7 +10533,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -11371,7 +10545,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -11383,7 +10557,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -11392,87 +10566,82 @@ WHERE
 			"                                                     │                   │   THEN 0 (tinyint) ELSE NULL (null) END as YHYLK]\n" +
 			"                                                     │                   └─ LeftOuterLookupJoin\n" +
 			"                                                     │                       ├─ Eq\n" +
-			"                                                     │                       │   ├─ W2MAO.YH4XB:7\n" +
-			"                                                     │                       │   └─ vc.id:8!null\n" +
+			"                                                     │                       │   ├─ W2MAO.YH4XB:6\n" +
+			"                                                     │                       │   └─ vc.id:7!null\n" +
 			"                                                     │                       ├─ LeftOuterLookupJoin\n" +
 			"                                                     │                       │   ├─ Eq\n" +
 			"                                                     │                       │   │   ├─ iq.Z7CP5:2!null\n" +
-			"                                                     │                       │   │   └─ W2MAO.Z7CP5:6!null\n" +
+			"                                                     │                       │   │   └─ W2MAO.Z7CP5:5!null\n" +
 			"                                                     │                       │   ├─ SubqueryAlias\n" +
 			"                                                     │                       │   │   ├─ name: iq\n" +
 			"                                                     │                       │   │   ├─ outerVisibility: false\n" +
 			"                                                     │                       │   │   ├─ cacheable: true\n" +
 			"                                                     │                       │   │   └─ Project\n" +
-			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.BRQP2:72!null, mf.id:34!null as Z7CP5, mf.FSDY2:44!null, nma.DZLIM:52!null as IDWIO]\n" +
+			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.BRQP2:12!null, mf.id:4!null as Z7CP5, mf.FSDY2:7!null, nma.DZLIM:9!null as IDWIO]\n" +
 			"                                                     │                       │   │       └─ HashJoin\n" +
 			"                                                     │                       │   │           ├─ Eq\n" +
-			"                                                     │                       │   │           │   ├─ mf.LUEVY:36!null\n" +
-			"                                                     │                       │   │           │   └─ nd.id:54!null\n" +
+			"                                                     │                       │   │           │   ├─ mf.LUEVY:6!null\n" +
+			"                                                     │                       │   │           │   └─ nd.id:10!null\n" +
 			"                                                     │                       │   │           ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:35!null\n" +
+			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:5!null\n" +
 			"                                                     │                       │   │           │   │   └─ bs.id:0!null\n" +
 			"                                                     │                       │   │           │   ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:2\n" +
-			"                                                     │                       │   │           │   │   │   └─ cla.id:4!null\n" +
+			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:1\n" +
+			"                                                     │                       │   │           │   │   │   └─ cla.id:2!null\n" +
 			"                                                     │                       │   │           │   │   ├─ TableAlias(bs)\n" +
 			"                                                     │                       │   │           │   │   │   └─ Table\n" +
-			"                                                     │                       │   │           │   │   │       └─ name: THNTS\n" +
+			"                                                     │                       │   │           │   │   │       ├─ name: THNTS\n" +
+			"                                                     │                       │   │           │   │   │       └─ columns: [id ixuxu]\n" +
 			"                                                     │                       │   │           │   │   └─ Filter\n" +
 			"                                                     │                       │   │           │   │       ├─ HashIn\n" +
 			"                                                     │                       │   │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                                                     │                       │   │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                                                     │                       │   │           │   │       └─ TableAlias(cla)\n" +
-			"                                                     │                       │   │           │   │           └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │                       │   │           │   │               ├─ index: [YK2GW.id]\n" +
-			"                                                     │                       │   │           │   │               └─ Table\n" +
-			"                                                     │                       │   │           │   │                   └─ name: YK2GW\n" +
+			"                                                     │                       │   │           │   │               └─ columns: [id ftqlq]\n" +
 			"                                                     │                       │   │           │   └─ TableAlias(mf)\n" +
-			"                                                     │                       │   │           │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │           │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"                                                     │                       │   │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                                                     │                       │   │           │           └─ Table\n" +
-			"                                                     │                       │   │           │               └─ name: HGMQ6\n" +
+			"                                                     │                       │   │           │           └─ columns: [id gxlub luevy fsdy2]\n" +
 			"                                                     │                       │   │           └─ HashLookup\n" +
-			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
-			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:3!null)\n" +
+			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
+			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:2!null)\n" +
 			"                                                     │                       │   │               └─ CachedResults\n" +
 			"                                                     │                       │   │                   └─ LookupJoin\n" +
 			"                                                     │                       │   │                       ├─ Eq\n" +
-			"                                                     │                       │   │                       │   ├─ sn.BRQP2:72!null\n" +
-			"                                                     │                       │   │                       │   └─ nd.id:54!null\n" +
+			"                                                     │                       │   │                       │   ├─ sn.BRQP2:12!null\n" +
+			"                                                     │                       │   │                       │   └─ nd.id:10!null\n" +
 			"                                                     │                       │   │                       ├─ LookupJoin\n" +
 			"                                                     │                       │   │                       │   ├─ Eq\n" +
-			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:66!null\n" +
-			"                                                     │                       │   │                       │   │   └─ nma.id:51!null\n" +
+			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:11!null\n" +
+			"                                                     │                       │   │                       │   │   └─ nma.id:8!null\n" +
 			"                                                     │                       │   │                       │   ├─ TableAlias(nma)\n" +
 			"                                                     │                       │   │                       │   │   └─ Table\n" +
-			"                                                     │                       │   │                       │   │       └─ name: TNMXI\n" +
+			"                                                     │                       │   │                       │   │       ├─ name: TNMXI\n" +
+			"                                                     │                       │   │                       │   │       └─ columns: [id dzlim]\n" +
 			"                                                     │                       │   │                       │   └─ TableAlias(nd)\n" +
-			"                                                     │                       │   │                       │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │                       │       └─ IndexedTableAccess(E2I7U)\n" +
 			"                                                     │                       │   │                       │           ├─ index: [E2I7U.HPCMS]\n" +
-			"                                                     │                       │   │                       │           └─ Table\n" +
-			"                                                     │                       │   │                       │               └─ name: E2I7U\n" +
+			"                                                     │                       │   │                       │           └─ columns: [id hpcms]\n" +
 			"                                                     │                       │   │                       └─ TableAlias(sn)\n" +
-			"                                                     │                       │   │                           └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │                           └─ IndexedTableAccess(NOXN3)\n" +
 			"                                                     │                       │   │                               ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                     │                       │   │                               └─ Table\n" +
-			"                                                     │                       │   │                                   └─ name: NOXN3\n" +
+			"                                                     │                       │   │                               └─ columns: [brqp2]\n" +
 			"                                                     │                       │   └─ TableAlias(W2MAO)\n" +
-			"                                                     │                       │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │       └─ IndexedTableAccess(SEQS3)\n" +
 			"                                                     │                       │           ├─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
-			"                                                     │                       │           └─ Table\n" +
-			"                                                     │                       │               └─ name: SEQS3\n" +
+			"                                                     │                       │           └─ columns: [z7cp5 yh4xb]\n" +
 			"                                                     │                       └─ TableAlias(vc)\n" +
-			"                                                     │                           └─ IndexedTableAccess\n" +
+			"                                                     │                           └─ IndexedTableAccess(D34QP)\n" +
 			"                                                     │                               ├─ index: [D34QP.id]\n" +
-			"                                                     │                               └─ Table\n" +
-			"                                                     │                                   └─ name: D34QP\n" +
+			"                                                     │                               └─ columns: [id znp4p]\n" +
 			"                                                     └─ TableAlias(nma)\n" +
-			"                                                         └─ IndexedTableAccess\n" +
+			"                                                         └─ IndexedTableAccess(TNMXI)\n" +
 			"                                                             ├─ index: [TNMXI.id]\n" +
-			"                                                             └─ Table\n" +
-			"                                                                 └─ name: TNMXI\n" +
+			"                                                             └─ columns: [id]\n" +
 			"",
 	},
 	{
@@ -11538,13 +10707,10 @@ WHERE
 	ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.ECXAJ:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id ecxaj]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 5]\n" +
+			"     └─ columns: [id ecxaj]\n" +
 			"",
 	},
 	{
@@ -11643,14 +10809,12 @@ WHERE
 			" │               │   ├─ E2I7U.id:17!null\n" +
 			" │               │   └─ applySubq0.LUEVY:34!null\n" +
 			" │               ├─ Table\n" +
-			" │               │   └─ name: E2I7U\n" +
+			" │               │   ├─ name: E2I7U\n" +
+			" │               │   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │               └─ TableAlias(applySubq0)\n" +
-			" │                   └─ IndexedTableAccess\n" +
+			" │                   └─ IndexedTableAccess(AMYXQ)\n" +
 			" │                       ├─ index: [AMYXQ.LUEVY]\n" +
-			" │                       ├─ columns: [luevy]\n" +
-			" │                       └─ Table\n" +
-			" │                           ├─ name: AMYXQ\n" +
-			" │                           └─ projections: [2]\n" +
+			" │                       └─ columns: [luevy]\n" +
 			" │   THEN 1 (tinyint) WHEN Eq\n" +
 			" │   ├─ E2I7U.FSK67:8!null\n" +
 			" │   └─ z (longtext)\n" +
@@ -11658,11 +10822,10 @@ WHERE
 			" │   ├─ E2I7U.FSK67:8!null\n" +
 			" │   └─ CRZ2X (longtext)\n" +
 			" │   THEN 0 (tinyint) ELSE 3 (tinyint) END as SZ6KK]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     └─ Table\n" +
-			"         └─ name: E2I7U\n" +
+			"     └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -11764,82 +10927,79 @@ WHERE
 			"             │               ├─ outerVisibility: false\n" +
 			"             │               ├─ cacheable: true\n" +
 			"             │               └─ Project\n" +
-			"             │                   ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:51!null as BDNYB, aac.BTXC5:62 as BTXC5, mf.id:34!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:45 IS NULL)) THEN mf.LT7K6:45 ELSE mf.SPPYD:46 END as vaf, CASE  WHEN (NOT(mf.QCGTS:47 IS NULL)) THEN mf.QCGTS:47 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
-			"             │                   │   ├─ vc.ZNP4P:72!null\n" +
+			"             │                   ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:12!null as BDNYB, aac.BTXC5:15 as BTXC5, mf.id:4!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:9 IS NULL)) THEN mf.LT7K6:9 ELSE mf.SPPYD:10 END as vaf, CASE  WHEN (NOT(mf.QCGTS:11 IS NULL)) THEN mf.QCGTS:11 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
+			"             │                   │   ├─ vc.ZNP4P:19!null\n" +
 			"             │                   │   └─ L5Q44 (longtext)\n" +
 			"             │                   │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
 			"             │                   └─ HashJoin\n" +
 			"             │                       ├─ Eq\n" +
-			"             │                       │   ├─ W2MAO.Z7CP5:65!null\n" +
-			"             │                       │   └─ mf.id:34!null\n" +
+			"             │                       │   ├─ W2MAO.Z7CP5:16!null\n" +
+			"             │                       │   └─ mf.id:4!null\n" +
 			"             │                       ├─ LookupJoin\n" +
 			"             │                       │   ├─ Eq\n" +
-			"             │                       │   │   ├─ aac.id:61!null\n" +
-			"             │                       │   │   └─ mf.M22QN:37!null\n" +
+			"             │                       │   │   ├─ aac.id:14!null\n" +
+			"             │                       │   │   └─ mf.M22QN:7!null\n" +
 			"             │                       │   ├─ HashJoin\n" +
 			"             │                       │   │   ├─ Eq\n" +
-			"             │                       │   │   │   ├─ sn.BRQP2:52!null\n" +
-			"             │                       │   │   │   └─ mf.LUEVY:36!null\n" +
+			"             │                       │   │   │   ├─ sn.BRQP2:13!null\n" +
+			"             │                       │   │   │   └─ mf.LUEVY:6!null\n" +
 			"             │                       │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   ├─ mf.GXLUB:35!null\n" +
-			"             │                       │   │   │   │   └─ bs.id:30!null\n" +
+			"             │                       │   │   │   │   ├─ mf.GXLUB:5!null\n" +
+			"             │                       │   │   │   │   └─ bs.id:2!null\n" +
 			"             │                       │   │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   │   ├─ bs.IXUXU:32\n" +
+			"             │                       │   │   │   │   │   ├─ bs.IXUXU:3\n" +
 			"             │                       │   │   │   │   │   └─ cla.id:0!null\n" +
 			"             │                       │   │   │   │   ├─ Filter\n" +
 			"             │                       │   │   │   │   │   ├─ HashIn\n" +
 			"             │                       │   │   │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"             │                       │   │   │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │                       │   │   │   │   │   └─ TableAlias(cla)\n" +
-			"             │                       │   │   │   │   │       └─ IndexedTableAccess\n" +
+			"             │                       │   │   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"             │                       │   │   │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
 			"             │                       │   │   │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"             │                       │   │   │   │   │           └─ Table\n" +
-			"             │                       │   │   │   │   │               └─ name: YK2GW\n" +
+			"             │                       │   │   │   │   │           └─ columns: [id ftqlq]\n" +
 			"             │                       │   │   │   │   └─ TableAlias(bs)\n" +
-			"             │                       │   │   │   │       └─ IndexedTableAccess\n" +
+			"             │                       │   │   │   │       └─ IndexedTableAccess(THNTS)\n" +
 			"             │                       │   │   │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"             │                       │   │   │   │           └─ Table\n" +
-			"             │                       │   │   │   │               └─ name: THNTS\n" +
+			"             │                       │   │   │   │           └─ columns: [id ixuxu]\n" +
 			"             │                       │   │   │   └─ Filter\n" +
 			"             │                       │   │   │       ├─ HashIn\n" +
-			"             │                       │   │   │       │   ├─ mf.FSDY2:10!null\n" +
+			"             │                       │   │   │       │   ├─ mf.FSDY2:4!null\n" +
 			"             │                       │   │   │       │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"             │                       │   │   │       └─ TableAlias(mf)\n" +
-			"             │                       │   │   │           └─ IndexedTableAccess\n" +
+			"             │                       │   │   │           └─ IndexedTableAccess(HGMQ6)\n" +
 			"             │                       │   │   │               ├─ index: [HGMQ6.GXLUB]\n" +
-			"             │                       │   │   │               └─ Table\n" +
-			"             │                       │   │   │                   └─ name: HGMQ6\n" +
+			"             │                       │   │   │               └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
 			"             │                       │   │   └─ HashLookup\n" +
-			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
 			"             │                       │   │       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"             │                       │   │       └─ CachedResults\n" +
 			"             │                       │   │           └─ TableAlias(sn)\n" +
 			"             │                       │   │               └─ Table\n" +
-			"             │                       │   │                   └─ name: NOXN3\n" +
+			"             │                       │   │                   ├─ name: NOXN3\n" +
+			"             │                       │   │                   └─ columns: [id brqp2]\n" +
 			"             │                       │   └─ TableAlias(aac)\n" +
-			"             │                       │       └─ IndexedTableAccess\n" +
+			"             │                       │       └─ IndexedTableAccess(TPXBU)\n" +
 			"             │                       │           ├─ index: [TPXBU.id]\n" +
-			"             │                       │           └─ Table\n" +
-			"             │                       │               └─ name: TPXBU\n" +
+			"             │                       │           └─ columns: [id btxc5]\n" +
 			"             │                       └─ HashLookup\n" +
-			"             │                           ├─ source: TUPLE(mf.id:34!null)\n" +
-			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:1!null)\n" +
+			"             │                           ├─ source: TUPLE(mf.id:4!null)\n" +
+			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:0!null)\n" +
 			"             │                           └─ CachedResults\n" +
 			"             │                               └─ LookupJoin\n" +
 			"             │                                   ├─ Eq\n" +
-			"             │                                   │   ├─ vc.id:67!null\n" +
-			"             │                                   │   └─ W2MAO.YH4XB:66!null\n" +
+			"             │                                   │   ├─ vc.id:18!null\n" +
+			"             │                                   │   └─ W2MAO.YH4XB:17!null\n" +
 			"             │                                   ├─ TableAlias(W2MAO)\n" +
 			"             │                                   │   └─ Table\n" +
-			"             │                                   │       └─ name: SEQS3\n" +
+			"             │                                   │       ├─ name: SEQS3\n" +
+			"             │                                   │       └─ columns: [z7cp5 yh4xb]\n" +
 			"             │                                   └─ TableAlias(vc)\n" +
-			"             │                                       └─ IndexedTableAccess\n" +
+			"             │                                       └─ IndexedTableAccess(D34QP)\n" +
 			"             │                                           ├─ index: [D34QP.id]\n" +
-			"             │                                           └─ Table\n" +
-			"             │                                               └─ name: D34QP\n" +
+			"             │                                           └─ columns: [id znp4p]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(OXXEI.BDNYB:3!null)\n" +
 			"                 ├─ target: TUPLE(E52AP.BDNYB:1!null)\n" +
@@ -11850,36 +11010,35 @@ WHERE
 			"                         ├─ cacheable: true\n" +
 			"                         └─ Sort(BDNYB:1!null ASC nullsFirst)\n" +
 			"                             └─ Project\n" +
-			"                                 ├─ columns: [nd.TW55N:13 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28 as YHVEZ, CASE  WHEN LessThan\n" +
-			"                                 │   ├─ nd.TCE7A:20\n" +
+			"                                 ├─ columns: [nd.TW55N:3 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:7 as YHVEZ, CASE  WHEN LessThan\n" +
+			"                                 │   ├─ nd.TCE7A:4\n" +
 			"                                 │   └─ 0.900000 (double)\n" +
 			"                                 │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
 			"                                 └─ Filter\n" +
 			"                                     ├─ (NOT(Eq\n" +
-			"                                     │   ├─ nma.DZLIM:28\n" +
+			"                                     │   ├─ nma.DZLIM:7\n" +
 			"                                     │   └─ Q5I4E (longtext)\n" +
 			"                                     │  ))\n" +
 			"                                     └─ LeftOuterLookupJoin\n" +
 			"                                         ├─ Eq\n" +
-			"                                         │   ├─ nd.HPCMS:22\n" +
-			"                                         │   └─ nma.id:27!null\n" +
+			"                                         │   ├─ nd.HPCMS:5\n" +
+			"                                         │   └─ nma.id:6!null\n" +
 			"                                         ├─ LeftOuterLookupJoin\n" +
 			"                                         │   ├─ Eq\n" +
 			"                                         │   │   ├─ sn.BRQP2:1!null\n" +
-			"                                         │   │   └─ nd.id:10!null\n" +
+			"                                         │   │   └─ nd.id:2!null\n" +
 			"                                         │   ├─ TableAlias(sn)\n" +
 			"                                         │   │   └─ Table\n" +
-			"                                         │   │       └─ name: NOXN3\n" +
+			"                                         │   │       ├─ name: NOXN3\n" +
+			"                                         │   │       └─ columns: [id brqp2]\n" +
 			"                                         │   └─ TableAlias(nd)\n" +
-			"                                         │       └─ IndexedTableAccess\n" +
+			"                                         │       └─ IndexedTableAccess(E2I7U)\n" +
 			"                                         │           ├─ index: [E2I7U.id]\n" +
-			"                                         │           └─ Table\n" +
-			"                                         │               └─ name: E2I7U\n" +
+			"                                         │           └─ columns: [id tw55n tce7a hpcms]\n" +
 			"                                         └─ TableAlias(nma)\n" +
-			"                                             └─ IndexedTableAccess\n" +
+			"                                             └─ IndexedTableAccess(TNMXI)\n" +
 			"                                                 ├─ index: [TNMXI.id]\n" +
-			"                                                 └─ Table\n" +
-			"                                                     └─ name: TNMXI\n" +
+			"                                                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -11981,79 +11140,78 @@ WHERE
 			"             │               ├─ outerVisibility: false\n" +
 			"             │               ├─ cacheable: true\n" +
 			"             │               └─ Project\n" +
-			"             │                   ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.id:51!null as BDNYB, aac.BTXC5:62 as BTXC5, mf.id:34!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:45 IS NULL)) THEN mf.LT7K6:45 ELSE mf.SPPYD:46 END as vaf, CASE  WHEN (NOT(mf.QCGTS:47 IS NULL)) THEN mf.QCGTS:47 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
-			"             │                   │   ├─ vc.ZNP4P:69!null\n" +
+			"             │                   ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.id:12!null as BDNYB, aac.BTXC5:15 as BTXC5, mf.id:4!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:9 IS NULL)) THEN mf.LT7K6:9 ELSE mf.SPPYD:10 END as vaf, CASE  WHEN (NOT(mf.QCGTS:11 IS NULL)) THEN mf.QCGTS:11 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
+			"             │                   │   ├─ vc.ZNP4P:17!null\n" +
 			"             │                   │   └─ L5Q44 (longtext)\n" +
 			"             │                   │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
 			"             │                   └─ HashJoin\n" +
 			"             │                       ├─ Eq\n" +
-			"             │                       │   ├─ W2MAO.Z7CP5:71!null\n" +
-			"             │                       │   └─ mf.id:34!null\n" +
+			"             │                       │   ├─ W2MAO.Z7CP5:18!null\n" +
+			"             │                       │   └─ mf.id:4!null\n" +
 			"             │                       ├─ LookupJoin\n" +
 			"             │                       │   ├─ Eq\n" +
-			"             │                       │   │   ├─ aac.id:61!null\n" +
-			"             │                       │   │   └─ mf.M22QN:37!null\n" +
+			"             │                       │   │   ├─ aac.id:14!null\n" +
+			"             │                       │   │   └─ mf.M22QN:7!null\n" +
 			"             │                       │   ├─ HashJoin\n" +
 			"             │                       │   │   ├─ Eq\n" +
-			"             │                       │   │   │   ├─ sn.BRQP2:52!null\n" +
-			"             │                       │   │   │   └─ mf.LUEVY:36!null\n" +
+			"             │                       │   │   │   ├─ sn.BRQP2:13!null\n" +
+			"             │                       │   │   │   └─ mf.LUEVY:6!null\n" +
 			"             │                       │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   ├─ mf.GXLUB:35!null\n" +
+			"             │                       │   │   │   │   ├─ mf.GXLUB:5!null\n" +
 			"             │                       │   │   │   │   └─ bs.id:0!null\n" +
 			"             │                       │   │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   │   ├─ bs.IXUXU:2\n" +
-			"             │                       │   │   │   │   │   └─ cla.id:4!null\n" +
+			"             │                       │   │   │   │   │   ├─ bs.IXUXU:1\n" +
+			"             │                       │   │   │   │   │   └─ cla.id:2!null\n" +
 			"             │                       │   │   │   │   ├─ TableAlias(bs)\n" +
 			"             │                       │   │   │   │   │   └─ Table\n" +
-			"             │                       │   │   │   │   │       └─ name: THNTS\n" +
+			"             │                       │   │   │   │   │       ├─ name: THNTS\n" +
+			"             │                       │   │   │   │   │       └─ columns: [id ixuxu]\n" +
 			"             │                       │   │   │   │   └─ Filter\n" +
 			"             │                       │   │   │   │       ├─ HashIn\n" +
 			"             │                       │   │   │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"             │                       │   │   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │                       │   │   │   │       └─ TableAlias(cla)\n" +
-			"             │                       │   │   │   │           └─ IndexedTableAccess\n" +
+			"             │                       │   │   │   │           └─ IndexedTableAccess(YK2GW)\n" +
 			"             │                       │   │   │   │               ├─ index: [YK2GW.id]\n" +
-			"             │                       │   │   │   │               └─ Table\n" +
-			"             │                       │   │   │   │                   └─ name: YK2GW\n" +
+			"             │                       │   │   │   │               └─ columns: [id ftqlq]\n" +
 			"             │                       │   │   │   └─ Filter\n" +
 			"             │                       │   │   │       ├─ HashIn\n" +
-			"             │                       │   │   │       │   ├─ mf.FSDY2:10!null\n" +
+			"             │                       │   │   │       │   ├─ mf.FSDY2:4!null\n" +
 			"             │                       │   │   │       │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"             │                       │   │   │       └─ TableAlias(mf)\n" +
-			"             │                       │   │   │           └─ IndexedTableAccess\n" +
+			"             │                       │   │   │           └─ IndexedTableAccess(HGMQ6)\n" +
 			"             │                       │   │   │               ├─ index: [HGMQ6.GXLUB]\n" +
-			"             │                       │   │   │               └─ Table\n" +
-			"             │                       │   │   │                   └─ name: HGMQ6\n" +
+			"             │                       │   │   │               └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
 			"             │                       │   │   └─ HashLookup\n" +
-			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
 			"             │                       │   │       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"             │                       │   │       └─ CachedResults\n" +
 			"             │                       │   │           └─ TableAlias(sn)\n" +
 			"             │                       │   │               └─ Table\n" +
-			"             │                       │   │                   └─ name: NOXN3\n" +
+			"             │                       │   │                   ├─ name: NOXN3\n" +
+			"             │                       │   │                   └─ columns: [id brqp2]\n" +
 			"             │                       │   └─ TableAlias(aac)\n" +
-			"             │                       │       └─ IndexedTableAccess\n" +
+			"             │                       │       └─ IndexedTableAccess(TPXBU)\n" +
 			"             │                       │           ├─ index: [TPXBU.id]\n" +
-			"             │                       │           └─ Table\n" +
-			"             │                       │               └─ name: TPXBU\n" +
+			"             │                       │           └─ columns: [id btxc5]\n" +
 			"             │                       └─ HashLookup\n" +
-			"             │                           ├─ source: TUPLE(mf.id:34!null)\n" +
-			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:7!null)\n" +
+			"             │                           ├─ source: TUPLE(mf.id:4!null)\n" +
+			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:2!null)\n" +
 			"             │                           └─ CachedResults\n" +
 			"             │                               └─ LookupJoin\n" +
 			"             │                                   ├─ Eq\n" +
-			"             │                                   │   ├─ vc.id:64!null\n" +
-			"             │                                   │   └─ W2MAO.YH4XB:72!null\n" +
+			"             │                                   │   ├─ vc.id:16!null\n" +
+			"             │                                   │   └─ W2MAO.YH4XB:19!null\n" +
 			"             │                                   ├─ TableAlias(vc)\n" +
 			"             │                                   │   └─ Table\n" +
-			"             │                                   │       └─ name: D34QP\n" +
+			"             │                                   │       ├─ name: D34QP\n" +
+			"             │                                   │       └─ columns: [id znp4p]\n" +
 			"             │                                   └─ TableAlias(W2MAO)\n" +
-			"             │                                       └─ IndexedTableAccess\n" +
+			"             │                                       └─ IndexedTableAccess(SEQS3)\n" +
 			"             │                                           ├─ index: [SEQS3.YH4XB]\n" +
-			"             │                                           └─ Table\n" +
-			"             │                                               └─ name: SEQS3\n" +
+			"             │                                           └─ columns: [z7cp5 yh4xb]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(OXXEI.BDNYB:3!null)\n" +
 			"                 ├─ target: TUPLE(E52AP.BDNYB:1!null)\n" +
@@ -12064,36 +11222,35 @@ WHERE
 			"                         ├─ cacheable: true\n" +
 			"                         └─ Sort(BDNYB:1!null ASC nullsFirst)\n" +
 			"                             └─ Project\n" +
-			"                                 ├─ columns: [nd.TW55N:13 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28 as YHVEZ, CASE  WHEN LessThan\n" +
-			"                                 │   ├─ nd.TCE7A:20\n" +
+			"                                 ├─ columns: [nd.TW55N:3 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:7 as YHVEZ, CASE  WHEN LessThan\n" +
+			"                                 │   ├─ nd.TCE7A:4\n" +
 			"                                 │   └─ 0.900000 (double)\n" +
 			"                                 │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
 			"                                 └─ Filter\n" +
 			"                                     ├─ (NOT(Eq\n" +
-			"                                     │   ├─ nma.DZLIM:28\n" +
+			"                                     │   ├─ nma.DZLIM:7\n" +
 			"                                     │   └─ Q5I4E (longtext)\n" +
 			"                                     │  ))\n" +
 			"                                     └─ LeftOuterLookupJoin\n" +
 			"                                         ├─ Eq\n" +
-			"                                         │   ├─ nd.HPCMS:22\n" +
-			"                                         │   └─ nma.id:27!null\n" +
+			"                                         │   ├─ nd.HPCMS:5\n" +
+			"                                         │   └─ nma.id:6!null\n" +
 			"                                         ├─ LeftOuterLookupJoin\n" +
 			"                                         │   ├─ Eq\n" +
 			"                                         │   │   ├─ sn.BRQP2:1!null\n" +
-			"                                         │   │   └─ nd.id:10!null\n" +
+			"                                         │   │   └─ nd.id:2!null\n" +
 			"                                         │   ├─ TableAlias(sn)\n" +
 			"                                         │   │   └─ Table\n" +
-			"                                         │   │       └─ name: NOXN3\n" +
+			"                                         │   │       ├─ name: NOXN3\n" +
+			"                                         │   │       └─ columns: [id brqp2]\n" +
 			"                                         │   └─ TableAlias(nd)\n" +
-			"                                         │       └─ IndexedTableAccess\n" +
+			"                                         │       └─ IndexedTableAccess(E2I7U)\n" +
 			"                                         │           ├─ index: [E2I7U.id]\n" +
-			"                                         │           └─ Table\n" +
-			"                                         │               └─ name: E2I7U\n" +
+			"                                         │           └─ columns: [id tw55n tce7a hpcms]\n" +
 			"                                         └─ TableAlias(nma)\n" +
-			"                                             └─ IndexedTableAccess\n" +
+			"                                             └─ IndexedTableAccess(TNMXI)\n" +
 			"                                                 ├─ index: [TNMXI.id]\n" +
-			"                                                 └─ Table\n" +
-			"                                                     └─ name: TNMXI\n" +
+			"                                                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -12347,7 +11504,8 @@ WHERE
 			"     │   │   │   │   │                       │   └─ MJR3D.BJUF2:1\n" +
 			"     │   │   │   │   │                       └─ TableAlias(JTEHG)\n" +
 			"     │   │   │   │   │                           └─ Table\n" +
-			"     │   │   │   │   │                               └─ name: NOXN3\n" +
+			"     │   │   │   │   │                               ├─ name: NOXN3\n" +
+			"     │   │   │   │   │                               └─ columns: [id brqp2]\n" +
 			"     │   │   │   │   └─ AND\n" +
 			"     │   │   │   │       ├─ AND\n" +
 			"     │   │   │   │       │   ├─ (NOT(MJR3D.TDEIU:10 IS NULL))\n" +
@@ -12364,7 +11522,8 @@ WHERE
 			"     │   │   │   │                       │   └─ MJR3D.FJDP5:0!null\n" +
 			"     │   │   │   │                       └─ TableAlias(XMAFZ)\n" +
 			"     │   │   │   │                           └─ Table\n" +
-			"     │   │   │   │                               └─ name: NOXN3\n" +
+			"     │   │   │   │                               ├─ name: NOXN3\n" +
+			"     │   │   │   │                               └─ columns: [id brqp2]\n" +
 			"     │   │   │   └─ AND\n" +
 			"     │   │   │       ├─ AND\n" +
 			"     │   │   │       │   ├─ (NOT(MJR3D.TDEIU:10 IS NULL))\n" +
@@ -12381,7 +11540,8 @@ WHERE
 			"     │   │   │                       │   └─ MJR3D.BJUF2:1\n" +
 			"     │   │   │                       └─ TableAlias(XMAFZ)\n" +
 			"     │   │   │                           └─ Table\n" +
-			"     │   │   │                               └─ name: NOXN3\n" +
+			"     │   │   │                               ├─ name: NOXN3\n" +
+			"     │   │   │                               └─ columns: [id brqp2]\n" +
 			"     │   │   ├─ SubqueryAlias\n" +
 			"     │   │   │   ├─ name: MJR3D\n" +
 			"     │   │   │   ├─ outerVisibility: false\n" +
@@ -12411,74 +11571,80 @@ WHERE
 			"     │   │   │       │       │           │       ├─ QNI57:9 IS NULL\n" +
 			"     │   │   │       │       │           │       └─ (NOT(TDEIU:10 IS NULL))\n" +
 			"     │   │   │       │       │           └─ Project\n" +
-			"     │   │   │       │       │               ├─ columns: [ism.FV24E:1!null as FJDP5, CPMFE.id:27 as BJUF2, CPMFE.TW55N:30 as PSMU6, ism.M22QN:3!null as M22QN, G3YXS.GE5EL:12, G3YXS.F7A4Q:13, G3YXS.ESFVY:10!null, CASE  WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               ├─ columns: [ism.FV24E:0!null as FJDP5, CPMFE.id:12 as BJUF2, CPMFE.TW55N:13 as PSMU6, ism.M22QN:2!null as M22QN, G3YXS.GE5EL:8, G3YXS.F7A4Q:9, G3YXS.ESFVY:6!null, CASE  WHEN IN\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"     │   │   │       │       │               │   THEN 0 (tinyint) WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
 			"     │   │   │       │       │               │   THEN 1 (tinyint) WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
 			"     │   │   │       │       │               │   THEN 2 (tinyint) WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"     │   │   │       │       │               │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:11!null as SL76B, YQIF4.id:44 as QNI57, YVHJZ.id:54 as TDEIU]\n" +
+			"     │   │   │       │       │               │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:7!null as SL76B, YQIF4.id:15 as QNI57, YVHJZ.id:18 as TDEIU]\n" +
 			"     │   │   │       │       │               └─ Filter\n" +
 			"     │   │   │       │       │                   ├─ Or\n" +
-			"     │   │   │       │       │                   │   ├─ (NOT(YQIF4.id:44 IS NULL))\n" +
-			"     │   │   │       │       │                   │   └─ (NOT(YVHJZ.id:54 IS NULL))\n" +
+			"     │   │   │       │       │                   │   ├─ (NOT(YQIF4.id:15 IS NULL))\n" +
+			"     │   │   │       │       │                   │   └─ (NOT(YVHJZ.id:18 IS NULL))\n" +
 			"     │   │   │       │       │                   └─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       ├─ AND\n" +
 			"     │   │   │       │       │                       │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   ├─ YVHJZ.BRQP2:55!null\n" +
-			"     │   │   │       │       │                       │   │   └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │       │                       │   │   ├─ YVHJZ.BRQP2:19!null\n" +
+			"     │   │   │       │       │                       │   │   └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │       │                       │   └─ Eq\n" +
-			"     │   │   │       │       │                       │       ├─ YVHJZ.FFTBJ:56!null\n" +
-			"     │   │   │       │       │                       │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │       │                       │       ├─ YVHJZ.FFTBJ:20!null\n" +
+			"     │   │   │       │       │                       │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │       │                       ├─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       │   ├─ AND\n" +
 			"     │   │   │       │       │                       │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   ├─ YQIF4.BRQP2:45!null\n" +
-			"     │   │   │       │       │                       │   │   │   └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │       │                       │   │   │   ├─ YQIF4.BRQP2:16!null\n" +
+			"     │   │   │       │       │                       │   │   │   └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │       │                       │   │   └─ Eq\n" +
-			"     │   │   │       │       │                       │   │       ├─ YQIF4.FFTBJ:46!null\n" +
-			"     │   │   │       │       │                       │   │       └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │       │                       │   │       ├─ YQIF4.FFTBJ:17!null\n" +
+			"     │   │   │       │       │                       │   │       └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │       │                       │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       │   │   ├─ AND\n" +
 			"     │   │   │       │       │                       │   │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   │   ├─ CPMFE.ZH72S:34\n" +
-			"     │   │   │       │       │                       │   │   │   │   └─ NHMXW.NOHHR:18\n" +
+			"     │   │   │       │       │                       │   │   │   │   ├─ CPMFE.ZH72S:14\n" +
+			"     │   │   │       │       │                       │   │   │   │   └─ NHMXW.NOHHR:11\n" +
 			"     │   │   │       │       │                       │   │   │   └─ (NOT(Eq\n" +
-			"     │   │   │       │       │                       │   │   │       ├─ CPMFE.id:27!null\n" +
-			"     │   │   │       │       │                       │   │   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │       │                       │   │   │       ├─ CPMFE.id:12!null\n" +
+			"     │   │   │       │       │                       │   │   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │       │                       │   │   │      ))\n" +
 			"     │   │   │       │       │                       │   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       │   │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   │   ├─ NHMXW.id:17!null\n" +
-			"     │   │   │       │       │                       │   │   │   │   └─ ism.PRUV2:6\n" +
+			"     │   │   │       │       │                       │   │   │   │   ├─ NHMXW.id:10!null\n" +
+			"     │   │   │       │       │                       │   │   │   │   └─ ism.PRUV2:4\n" +
 			"     │   │   │       │       │                       │   │   │   ├─ InnerJoin\n" +
 			"     │   │   │       │       │                       │   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   │   │   ├─ G3YXS.id:9!null\n" +
-			"     │   │   │       │       │                       │   │   │   │   │   └─ ism.NZ4MQ:4!null\n" +
+			"     │   │   │       │       │                       │   │   │   │   │   ├─ G3YXS.id:5!null\n" +
+			"     │   │   │       │       │                       │   │   │   │   │   └─ ism.NZ4MQ:3!null\n" +
 			"     │   │   │       │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
 			"     │   │   │       │       │                       │   │   │   │   │   └─ Table\n" +
-			"     │   │   │       │       │                       │   │   │   │   │       └─ name: HDDVB\n" +
+			"     │   │   │       │       │                       │   │   │   │   │       ├─ name: HDDVB\n" +
+			"     │   │   │       │       │                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
 			"     │   │   │       │       │                       │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │   │   │       │       │                       │   │   │   │       └─ Table\n" +
-			"     │   │   │       │       │                       │   │   │   │           └─ name: YYBCX\n" +
+			"     │   │   │       │       │                       │   │   │   │           ├─ name: YYBCX\n" +
+			"     │   │   │       │       │                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
 			"     │   │   │       │       │                       │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │   │   │       │       │                       │   │   │       └─ Table\n" +
-			"     │   │   │       │       │                       │   │   │           └─ name: WGSDC\n" +
+			"     │   │   │       │       │                       │   │   │           ├─ name: WGSDC\n" +
+			"     │   │   │       │       │                       │   │   │           └─ columns: [id nohhr]\n" +
 			"     │   │   │       │       │                       │   │   └─ TableAlias(CPMFE)\n" +
 			"     │   │   │       │       │                       │   │       └─ Table\n" +
-			"     │   │   │       │       │                       │   │           └─ name: E2I7U\n" +
+			"     │   │   │       │       │                       │   │           ├─ name: E2I7U\n" +
+			"     │   │   │       │       │                       │   │           └─ columns: [id tw55n zh72s]\n" +
 			"     │   │   │       │       │                       │   └─ TableAlias(YQIF4)\n" +
 			"     │   │   │       │       │                       │       └─ Table\n" +
-			"     │   │   │       │       │                       │           └─ name: NOXN3\n" +
+			"     │   │   │       │       │                       │           ├─ name: NOXN3\n" +
+			"     │   │   │       │       │                       │           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       │       │                       └─ TableAlias(YVHJZ)\n" +
 			"     │   │   │       │       │                           └─ Table\n" +
-			"     │   │   │       │       │                               └─ name: NOXN3\n" +
+			"     │   │   │       │       │                               ├─ name: NOXN3\n" +
+			"     │   │   │       │       │                               └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       │       └─ Project\n" +
 			"     │   │   │       │           ├─ columns: [JCHIR.FJDP5:0!null, JCHIR.BJUF2:1, JCHIR.PSMU6:2, JCHIR.M22QN:3!null, JCHIR.GE5EL:4, JCHIR.F7A4Q:5, JCHIR.ESFVY:6!null, JCHIR.CC4AX:7, JCHIR.SL76B:8!null, JCHIR.QNI57:9, convert\n" +
 			"     │   │   │       │           │   ├─ type: char\n" +
@@ -12495,74 +11661,80 @@ WHERE
 			"     │   │   │       │                       │   ├─ (NOT(QNI57:9 IS NULL))\n" +
 			"     │   │   │       │                       │   └─ (NOT(TDEIU:10 IS NULL))\n" +
 			"     │   │   │       │                       └─ Project\n" +
-			"     │   │   │       │                           ├─ columns: [ism.FV24E:1!null as FJDP5, CPMFE.id:27 as BJUF2, CPMFE.TW55N:30 as PSMU6, ism.M22QN:3!null as M22QN, G3YXS.GE5EL:12, G3YXS.F7A4Q:13, G3YXS.ESFVY:10!null, CASE  WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           ├─ columns: [ism.FV24E:0!null as FJDP5, CPMFE.id:12 as BJUF2, CPMFE.TW55N:13 as PSMU6, ism.M22QN:2!null as M22QN, G3YXS.GE5EL:8, G3YXS.F7A4Q:9, G3YXS.ESFVY:6!null, CASE  WHEN IN\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"     │   │   │       │                           │   THEN 0 (tinyint) WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
 			"     │   │   │       │                           │   THEN 1 (tinyint) WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
 			"     │   │   │       │                           │   THEN 2 (tinyint) WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"     │   │   │       │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:11!null as SL76B, YQIF4.id:44 as QNI57, YVHJZ.id:54 as TDEIU]\n" +
+			"     │   │   │       │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:7!null as SL76B, YQIF4.id:15 as QNI57, YVHJZ.id:18 as TDEIU]\n" +
 			"     │   │   │       │                           └─ Filter\n" +
 			"     │   │   │       │                               ├─ Or\n" +
-			"     │   │   │       │                               │   ├─ (NOT(YQIF4.id:44 IS NULL))\n" +
-			"     │   │   │       │                               │   └─ (NOT(YVHJZ.id:54 IS NULL))\n" +
+			"     │   │   │       │                               │   ├─ (NOT(YQIF4.id:15 IS NULL))\n" +
+			"     │   │   │       │                               │   └─ (NOT(YVHJZ.id:18 IS NULL))\n" +
 			"     │   │   │       │                               └─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   ├─ AND\n" +
 			"     │   │   │       │                                   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   ├─ YVHJZ.BRQP2:55!null\n" +
-			"     │   │   │       │                                   │   │   └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │                                   │   │   ├─ YVHJZ.BRQP2:19!null\n" +
+			"     │   │   │       │                                   │   │   └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │                                   │   └─ Eq\n" +
-			"     │   │   │       │                                   │       ├─ YVHJZ.FFTBJ:56!null\n" +
-			"     │   │   │       │                                   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │                                   │       ├─ YVHJZ.FFTBJ:20!null\n" +
+			"     │   │   │       │                                   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │                                   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   │   ├─ AND\n" +
 			"     │   │   │       │                                   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   ├─ YQIF4.BRQP2:45!null\n" +
-			"     │   │   │       │                                   │   │   │   └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │                                   │   │   │   ├─ YQIF4.BRQP2:16!null\n" +
+			"     │   │   │       │                                   │   │   │   └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │                                   │   │   └─ Eq\n" +
-			"     │   │   │       │                                   │   │       ├─ YQIF4.FFTBJ:46!null\n" +
-			"     │   │   │       │                                   │   │       └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │                                   │   │       ├─ YQIF4.FFTBJ:17!null\n" +
+			"     │   │   │       │                                   │   │       └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │                                   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   │   │   ├─ AND\n" +
 			"     │   │   │       │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   │   ├─ CPMFE.ZH72S:34\n" +
-			"     │   │   │       │                                   │   │   │   │   └─ NHMXW.NOHHR:18\n" +
+			"     │   │   │       │                                   │   │   │   │   ├─ CPMFE.ZH72S:14\n" +
+			"     │   │   │       │                                   │   │   │   │   └─ NHMXW.NOHHR:11\n" +
 			"     │   │   │       │                                   │   │   │   └─ (NOT(Eq\n" +
-			"     │   │   │       │                                   │   │   │       ├─ CPMFE.id:27!null\n" +
-			"     │   │   │       │                                   │   │   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │                                   │   │   │       ├─ CPMFE.id:12!null\n" +
+			"     │   │   │       │                                   │   │   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │                                   │   │   │      ))\n" +
 			"     │   │   │       │                                   │   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   │   ├─ NHMXW.id:17!null\n" +
-			"     │   │   │       │                                   │   │   │   │   └─ ism.PRUV2:6\n" +
+			"     │   │   │       │                                   │   │   │   │   ├─ NHMXW.id:10!null\n" +
+			"     │   │   │       │                                   │   │   │   │   └─ ism.PRUV2:4\n" +
 			"     │   │   │       │                                   │   │   │   ├─ InnerJoin\n" +
 			"     │   │   │       │                                   │   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   │   │   ├─ G3YXS.id:9!null\n" +
-			"     │   │   │       │                                   │   │   │   │   │   └─ ism.NZ4MQ:4!null\n" +
+			"     │   │   │       │                                   │   │   │   │   │   ├─ G3YXS.id:5!null\n" +
+			"     │   │   │       │                                   │   │   │   │   │   └─ ism.NZ4MQ:3!null\n" +
 			"     │   │   │       │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
 			"     │   │   │       │                                   │   │   │   │   │   └─ Table\n" +
-			"     │   │   │       │                                   │   │   │   │   │       └─ name: HDDVB\n" +
+			"     │   │   │       │                                   │   │   │   │   │       ├─ name: HDDVB\n" +
+			"     │   │   │       │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
 			"     │   │   │       │                                   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │   │   │       │                                   │   │   │   │       └─ Table\n" +
-			"     │   │   │       │                                   │   │   │   │           └─ name: YYBCX\n" +
+			"     │   │   │       │                                   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │   │   │       │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
 			"     │   │   │       │                                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │   │   │       │                                   │   │   │       └─ Table\n" +
-			"     │   │   │       │                                   │   │   │           └─ name: WGSDC\n" +
+			"     │   │   │       │                                   │   │   │           ├─ name: WGSDC\n" +
+			"     │   │   │       │                                   │   │   │           └─ columns: [id nohhr]\n" +
 			"     │   │   │       │                                   │   │   └─ TableAlias(CPMFE)\n" +
 			"     │   │   │       │                                   │   │       └─ Table\n" +
-			"     │   │   │       │                                   │   │           └─ name: E2I7U\n" +
+			"     │   │   │       │                                   │   │           ├─ name: E2I7U\n" +
+			"     │   │   │       │                                   │   │           └─ columns: [id tw55n zh72s]\n" +
 			"     │   │   │       │                                   │   └─ TableAlias(YQIF4)\n" +
 			"     │   │   │       │                                   │       └─ Table\n" +
-			"     │   │   │       │                                   │           └─ name: NOXN3\n" +
+			"     │   │   │       │                                   │           ├─ name: NOXN3\n" +
+			"     │   │   │       │                                   │           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       │                                   └─ TableAlias(YVHJZ)\n" +
 			"     │   │   │       │                                       └─ Table\n" +
-			"     │   │   │       │                                           └─ name: NOXN3\n" +
+			"     │   │   │       │                                           ├─ name: NOXN3\n" +
+			"     │   │   │       │                                           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       └─ Project\n" +
 			"     │   │   │           ├─ columns: [JCHIR.FJDP5:0!null, JCHIR.BJUF2:1, JCHIR.PSMU6:2, JCHIR.M22QN:3!null, JCHIR.GE5EL:4, JCHIR.F7A4Q:5, JCHIR.ESFVY:6!null, JCHIR.CC4AX:7, JCHIR.SL76B:8!null, convert\n" +
 			"     │   │   │           │   ├─ type: char\n" +
@@ -12582,77 +11754,84 @@ WHERE
 			"     │   │   │                       │   ├─ (NOT(QNI57:9 IS NULL))\n" +
 			"     │   │   │                       │   └─ (NOT(TDEIU:10 IS NULL))\n" +
 			"     │   │   │                       └─ Project\n" +
-			"     │   │   │                           ├─ columns: [ism.FV24E:1!null as FJDP5, CPMFE.id:27 as BJUF2, CPMFE.TW55N:30 as PSMU6, ism.M22QN:3!null as M22QN, G3YXS.GE5EL:12, G3YXS.F7A4Q:13, G3YXS.ESFVY:10!null, CASE  WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           ├─ columns: [ism.FV24E:0!null as FJDP5, CPMFE.id:12 as BJUF2, CPMFE.TW55N:13 as PSMU6, ism.M22QN:2!null as M22QN, G3YXS.GE5EL:8, G3YXS.F7A4Q:9, G3YXS.ESFVY:6!null, CASE  WHEN IN\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"     │   │   │                           │   THEN 0 (tinyint) WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
 			"     │   │   │                           │   THEN 1 (tinyint) WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
 			"     │   │   │                           │   THEN 2 (tinyint) WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"     │   │   │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:11!null as SL76B, YQIF4.id:44 as QNI57, YVHJZ.id:54 as TDEIU]\n" +
+			"     │   │   │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:7!null as SL76B, YQIF4.id:15 as QNI57, YVHJZ.id:18 as TDEIU]\n" +
 			"     │   │   │                           └─ Filter\n" +
 			"     │   │   │                               ├─ Or\n" +
-			"     │   │   │                               │   ├─ (NOT(YQIF4.id:44 IS NULL))\n" +
-			"     │   │   │                               │   └─ (NOT(YVHJZ.id:54 IS NULL))\n" +
+			"     │   │   │                               │   ├─ (NOT(YQIF4.id:15 IS NULL))\n" +
+			"     │   │   │                               │   └─ (NOT(YVHJZ.id:18 IS NULL))\n" +
 			"     │   │   │                               └─ LeftOuterJoin\n" +
 			"     │   │   │                                   ├─ AND\n" +
 			"     │   │   │                                   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   ├─ YVHJZ.BRQP2:55!null\n" +
-			"     │   │   │                                   │   │   └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │                                   │   │   ├─ YVHJZ.BRQP2:19!null\n" +
+			"     │   │   │                                   │   │   └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │                                   │   └─ Eq\n" +
-			"     │   │   │                                   │       ├─ YVHJZ.FFTBJ:56!null\n" +
-			"     │   │   │                                   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │                                   │       ├─ YVHJZ.FFTBJ:20!null\n" +
+			"     │   │   │                                   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │                                   ├─ LeftOuterJoin\n" +
 			"     │   │   │                                   │   ├─ AND\n" +
 			"     │   │   │                                   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   ├─ YQIF4.BRQP2:45!null\n" +
-			"     │   │   │                                   │   │   │   └─ ism.FV24E:1!null\n" +
+			"     │   │   │                                   │   │   │   ├─ YQIF4.BRQP2:16!null\n" +
+			"     │   │   │                                   │   │   │   └─ ism.FV24E:0!null\n" +
 			"     │   │   │                                   │   │   └─ Eq\n" +
-			"     │   │   │                                   │   │       ├─ YQIF4.FFTBJ:46!null\n" +
-			"     │   │   │                                   │   │       └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │                                   │   │       ├─ YQIF4.FFTBJ:17!null\n" +
+			"     │   │   │                                   │   │       └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │                                   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │                                   │   │   ├─ AND\n" +
 			"     │   │   │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   │   ├─ CPMFE.ZH72S:34\n" +
-			"     │   │   │                                   │   │   │   │   └─ NHMXW.NOHHR:18\n" +
+			"     │   │   │                                   │   │   │   │   ├─ CPMFE.ZH72S:14\n" +
+			"     │   │   │                                   │   │   │   │   └─ NHMXW.NOHHR:11\n" +
 			"     │   │   │                                   │   │   │   └─ (NOT(Eq\n" +
-			"     │   │   │                                   │   │   │       ├─ CPMFE.id:27!null\n" +
-			"     │   │   │                                   │   │   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │                                   │   │   │       ├─ CPMFE.id:12!null\n" +
+			"     │   │   │                                   │   │   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │                                   │   │   │      ))\n" +
 			"     │   │   │                                   │   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   │   ├─ NHMXW.id:17!null\n" +
-			"     │   │   │                                   │   │   │   │   └─ ism.PRUV2:6\n" +
+			"     │   │   │                                   │   │   │   │   ├─ NHMXW.id:10!null\n" +
+			"     │   │   │                                   │   │   │   │   └─ ism.PRUV2:4\n" +
 			"     │   │   │                                   │   │   │   ├─ InnerJoin\n" +
 			"     │   │   │                                   │   │   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   │   │   ├─ G3YXS.id:9!null\n" +
-			"     │   │   │                                   │   │   │   │   │   └─ ism.NZ4MQ:4!null\n" +
+			"     │   │   │                                   │   │   │   │   │   ├─ G3YXS.id:5!null\n" +
+			"     │   │   │                                   │   │   │   │   │   └─ ism.NZ4MQ:3!null\n" +
 			"     │   │   │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
 			"     │   │   │                                   │   │   │   │   │   └─ Table\n" +
-			"     │   │   │                                   │   │   │   │   │       └─ name: HDDVB\n" +
+			"     │   │   │                                   │   │   │   │   │       ├─ name: HDDVB\n" +
+			"     │   │   │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
 			"     │   │   │                                   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │   │   │                                   │   │   │   │       └─ Table\n" +
-			"     │   │   │                                   │   │   │   │           └─ name: YYBCX\n" +
+			"     │   │   │                                   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │   │   │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
 			"     │   │   │                                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │   │   │                                   │   │   │       └─ Table\n" +
-			"     │   │   │                                   │   │   │           └─ name: WGSDC\n" +
+			"     │   │   │                                   │   │   │           ├─ name: WGSDC\n" +
+			"     │   │   │                                   │   │   │           └─ columns: [id nohhr]\n" +
 			"     │   │   │                                   │   │   └─ TableAlias(CPMFE)\n" +
 			"     │   │   │                                   │   │       └─ Table\n" +
-			"     │   │   │                                   │   │           └─ name: E2I7U\n" +
+			"     │   │   │                                   │   │           ├─ name: E2I7U\n" +
+			"     │   │   │                                   │   │           └─ columns: [id tw55n zh72s]\n" +
 			"     │   │   │                                   │   └─ TableAlias(YQIF4)\n" +
 			"     │   │   │                                   │       └─ Table\n" +
-			"     │   │   │                                   │           └─ name: NOXN3\n" +
+			"     │   │   │                                   │           ├─ name: NOXN3\n" +
+			"     │   │   │                                   │           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │                                   └─ TableAlias(YVHJZ)\n" +
 			"     │   │   │                                       └─ Table\n" +
-			"     │   │   │                                           └─ name: NOXN3\n" +
+			"     │   │   │                                           ├─ name: NOXN3\n" +
+			"     │   │   │                                           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   └─ TableAlias(sn)\n" +
 			"     │   │       └─ Table\n" +
-			"     │   │           └─ name: NOXN3\n" +
+			"     │   │           ├─ name: NOXN3\n" +
+			"     │   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │   └─ HashLookup\n" +
 			"     │       ├─ source: TUPLE(MJR3D.M22QN:3!null)\n" +
 			"     │       ├─ target: TUPLE(aac.id:0!null)\n" +
@@ -12673,32 +11852,31 @@ WHERE
 			"                 ├─ outerVisibility: false\n" +
 			"                 ├─ cacheable: true\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [cla.FTQLQ:5!null, mf.LUEVY:36!null, mf.M22QN:37!null]\n" +
+			"                     ├─ columns: [cla.FTQLQ:3!null, mf.LUEVY:5!null, mf.M22QN:6!null]\n" +
 			"                     └─ LookupJoin\n" +
 			"                         ├─ Eq\n" +
 			"                         │   ├─ bs.id:0!null\n" +
-			"                         │   └─ mf.GXLUB:35!null\n" +
+			"                         │   └─ mf.GXLUB:4!null\n" +
 			"                         ├─ LookupJoin\n" +
 			"                         │   ├─ Eq\n" +
-			"                         │   │   ├─ cla.id:4!null\n" +
-			"                         │   │   └─ bs.IXUXU:2\n" +
+			"                         │   │   ├─ cla.id:2!null\n" +
+			"                         │   │   └─ bs.IXUXU:1\n" +
 			"                         │   ├─ TableAlias(bs)\n" +
 			"                         │   │   └─ Table\n" +
-			"                         │   │       └─ name: THNTS\n" +
+			"                         │   │       ├─ name: THNTS\n" +
+			"                         │   │       └─ columns: [id ixuxu]\n" +
 			"                         │   └─ Filter\n" +
 			"                         │       ├─ HashIn\n" +
 			"                         │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                         │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                         │       └─ TableAlias(cla)\n" +
-			"                         │           └─ IndexedTableAccess\n" +
+			"                         │           └─ IndexedTableAccess(YK2GW)\n" +
 			"                         │               ├─ index: [YK2GW.id]\n" +
-			"                         │               └─ Table\n" +
-			"                         │                   └─ name: YK2GW\n" +
+			"                         │               └─ columns: [id ftqlq]\n" +
 			"                         └─ TableAlias(mf)\n" +
-			"                             └─ IndexedTableAccess\n" +
+			"                             └─ IndexedTableAccess(HGMQ6)\n" +
 			"                                 ├─ index: [HGMQ6.GXLUB]\n" +
-			"                                 └─ Table\n" +
-			"                                     └─ name: HGMQ6\n" +
+			"                                 └─ columns: [gxlub luevy m22qn]\n" +
 			"",
 	},
 	{
@@ -12946,7 +12124,8 @@ WHERE
 			"     │           │                       │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"     │           │                       │   │   │       │                       └─ Table\n" +
-			"     │           │                       │   │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       │   │   └─ AND\n" +
 			"     │           │                       │   │       ├─ AND\n" +
@@ -12963,7 +12142,8 @@ WHERE
 			"     │           │                       │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"     │           │                       │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │   │       │                       └─ Table\n" +
-			"     │           │                       │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"     │           │                       │   └─ AND\n" +
 			"     │           │                       │       ├─ AND\n" +
@@ -12980,7 +12160,8 @@ WHERE
 			"     │           │                       │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │       │                       └─ Table\n" +
-			"     │           │                       │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       ├─ LookupJoin\n" +
 			"     │           │                       │   ├─ Eq\n" +
@@ -13034,40 +12215,36 @@ WHERE
 			"     │           │                       │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"     │           │                       │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │           │                       │   │                   │   │   │   │   │       └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
 			"     │           │                       │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"     │           │                       │   │                   │   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"     │           │                       │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
 			"     │           │                       │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"     │           │                       │   │                   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │               └─ name: WGSDC\n" +
+			"     │           │                       │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"     │           │                       │   │                   │   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │           │                       │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │           │                       │   │                   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │               └─ name: E2I7U\n" +
+			"     │           │                       │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │           │                       │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"     │           │                       │   │                   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"     │           │                       │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                   │           └─ Table\n" +
-			"     │           │                       │   │                   │               └─ name: NOXN3\n" +
+			"     │           │                       │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   │                   └─ TableAlias(YVHJZ)\n" +
-			"     │           │                       │   │                       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                       └─ IndexedTableAccess(NOXN3)\n" +
 			"     │           │                       │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                           └─ Table\n" +
-			"     │           │                       │   │                               └─ name: NOXN3\n" +
+			"     │           │                       │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   └─ TableAlias(aac)\n" +
-			"     │           │                       │       └─ IndexedTableAccess\n" +
+			"     │           │                       │       └─ IndexedTableAccess(TPXBU)\n" +
 			"     │           │                       │           ├─ index: [TPXBU.id]\n" +
-			"     │           │                       │           └─ Table\n" +
-			"     │           │                       │               └─ name: TPXBU\n" +
+			"     │           │                       │           └─ columns: [id btxc5 fhcyt]\n" +
 			"     │           │                       └─ TableAlias(sn)\n" +
 			"     │           │                           └─ Table\n" +
-			"     │           │                               └─ name: NOXN3\n" +
+			"     │           │                               ├─ name: NOXN3\n" +
+			"     │           │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: RSA3Y\n" +
 			"     │               ├─ outerVisibility: false\n" +
@@ -13080,46 +12257,44 @@ WHERE
 			"     │                           ├─ outerVisibility: false\n" +
 			"     │                           ├─ cacheable: true\n" +
 			"     │                           └─ Project\n" +
-			"     │                               ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"     │                               ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"     │                               └─ HashJoin\n" +
 			"     │                                   ├─ Eq\n" +
-			"     │                                   │   ├─ sn.BRQP2:52!null\n" +
-			"     │                                   │   └─ mf.LUEVY:36!null\n" +
+			"     │                                   │   ├─ sn.BRQP2:8!null\n" +
+			"     │                                   │   └─ mf.LUEVY:5!null\n" +
 			"     │                                   ├─ LookupJoin\n" +
 			"     │                                   │   ├─ Eq\n" +
-			"     │                                   │   │   ├─ bs.id:30!null\n" +
-			"     │                                   │   │   └─ mf.GXLUB:35!null\n" +
+			"     │                                   │   │   ├─ bs.id:2!null\n" +
+			"     │                                   │   │   └─ mf.GXLUB:4!null\n" +
 			"     │                                   │   ├─ LookupJoin\n" +
 			"     │                                   │   │   ├─ Eq\n" +
 			"     │                                   │   │   │   ├─ cla.id:0!null\n" +
-			"     │                                   │   │   │   └─ bs.IXUXU:32\n" +
+			"     │                                   │   │   │   └─ bs.IXUXU:3\n" +
 			"     │                                   │   │   ├─ Filter\n" +
 			"     │                                   │   │   │   ├─ HashIn\n" +
 			"     │                                   │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"     │                                   │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"     │                                   │   │   │   └─ TableAlias(cla)\n" +
-			"     │                                   │   │   │       └─ IndexedTableAccess\n" +
+			"     │                                   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"     │                                   │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
 			"     │                                   │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"     │                                   │   │   │           └─ Table\n" +
-			"     │                                   │   │   │               └─ name: YK2GW\n" +
+			"     │                                   │   │   │           └─ columns: [id ftqlq]\n" +
 			"     │                                   │   │   └─ TableAlias(bs)\n" +
-			"     │                                   │   │       └─ IndexedTableAccess\n" +
+			"     │                                   │   │       └─ IndexedTableAccess(THNTS)\n" +
 			"     │                                   │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"     │                                   │   │           └─ Table\n" +
-			"     │                                   │   │               └─ name: THNTS\n" +
+			"     │                                   │   │           └─ columns: [id ixuxu]\n" +
 			"     │                                   │   └─ TableAlias(mf)\n" +
-			"     │                                   │       └─ IndexedTableAccess\n" +
+			"     │                                   │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"     │                                   │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"     │                                   │           └─ Table\n" +
-			"     │                                   │               └─ name: HGMQ6\n" +
+			"     │                                   │           └─ columns: [gxlub luevy m22qn]\n" +
 			"     │                                   └─ HashLookup\n" +
-			"     │                                       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"     │                                       ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"     │                                       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"     │                                       └─ CachedResults\n" +
 			"     │                                           └─ TableAlias(sn)\n" +
 			"     │                                               └─ Table\n" +
-			"     │                                                   └─ name: NOXN3\n" +
+			"     │                                                   ├─ name: NOXN3\n" +
+			"     │                                                   └─ columns: [id brqp2]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -13146,46 +12321,44 @@ WHERE
 			"                             │   ├─ outerVisibility: false\n" +
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
-			"                             │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"                             │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"                             │       └─ HashJoin\n" +
 			"                             │           ├─ Eq\n" +
-			"                             │           │   ├─ sn.BRQP2:52!null\n" +
-			"                             │           │   └─ mf.LUEVY:36!null\n" +
+			"                             │           │   ├─ sn.BRQP2:8!null\n" +
+			"                             │           │   └─ mf.LUEVY:5!null\n" +
 			"                             │           ├─ LookupJoin\n" +
 			"                             │           │   ├─ Eq\n" +
-			"                             │           │   │   ├─ bs.id:30!null\n" +
-			"                             │           │   │   └─ mf.GXLUB:35!null\n" +
+			"                             │           │   │   ├─ bs.id:2!null\n" +
+			"                             │           │   │   └─ mf.GXLUB:4!null\n" +
 			"                             │           │   ├─ LookupJoin\n" +
 			"                             │           │   │   ├─ Eq\n" +
 			"                             │           │   │   │   ├─ cla.id:0!null\n" +
-			"                             │           │   │   │   └─ bs.IXUXU:32\n" +
+			"                             │           │   │   │   └─ bs.IXUXU:3\n" +
 			"                             │           │   │   ├─ Filter\n" +
 			"                             │           │   │   │   ├─ HashIn\n" +
 			"                             │           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"                             │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                             │           │   │   │   └─ TableAlias(cla)\n" +
-			"                             │           │   │   │       └─ IndexedTableAccess\n" +
+			"                             │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"                             │           │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
 			"                             │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"                             │           │   │   │           └─ Table\n" +
-			"                             │           │   │   │               └─ name: YK2GW\n" +
+			"                             │           │   │   │           └─ columns: [id ftqlq]\n" +
 			"                             │           │   │   └─ TableAlias(bs)\n" +
-			"                             │           │   │       └─ IndexedTableAccess\n" +
+			"                             │           │   │       └─ IndexedTableAccess(THNTS)\n" +
 			"                             │           │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"                             │           │   │           └─ Table\n" +
-			"                             │           │   │               └─ name: THNTS\n" +
+			"                             │           │   │           └─ columns: [id ixuxu]\n" +
 			"                             │           │   └─ TableAlias(mf)\n" +
-			"                             │           │       └─ IndexedTableAccess\n" +
+			"                             │           │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"                             │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                             │           │           └─ Table\n" +
-			"                             │           │               └─ name: HGMQ6\n" +
+			"                             │           │           └─ columns: [gxlub luevy m22qn]\n" +
 			"                             │           └─ HashLookup\n" +
-			"                             │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"                             │               ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"                             │               ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"                             │               └─ CachedResults\n" +
 			"                             │                   └─ TableAlias(sn)\n" +
 			"                             │                       └─ Table\n" +
-			"                             │                           └─ name: NOXN3\n" +
+			"                             │                           ├─ name: NOXN3\n" +
+			"                             │                           └─ columns: [id brqp2]\n" +
 			"                             └─ HashLookup\n" +
 			"                                 ├─ source: TUPLE(cld.BDNYB:1!null, cld.M22QN:2!null)\n" +
 			"                                 ├─ target: TUPLE(P4PJZ.LWQ6O:3, P4PJZ.NTOFG:2!null)\n" +
@@ -13262,7 +12435,8 @@ WHERE
 			"                                                 │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 │   │   └─ AND\n" +
 			"                                                 │   │       ├─ AND\n" +
@@ -13279,7 +12453,8 @@ WHERE
 			"                                                 │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"                                                 │   └─ AND\n" +
 			"                                                 │       ├─ AND\n" +
@@ -13296,7 +12471,8 @@ WHERE
 			"                                                 │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           └─ name: NOXN3\n" +
+			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 ├─ LookupJoin\n" +
 			"                                                 │   ├─ Eq\n" +
@@ -13350,40 +12526,36 @@ WHERE
 			"                                                 │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"                                                 │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"                                                 │   │                   │   │   │   │   │       └─ Table\n" +
-			"                                                 │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
 			"                                                 │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"                                                 │   │                   │   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"                                                 │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"                                                 │   │                   │   │   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
 			"                                                 │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"                                                 │   │                   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │               └─ name: WGSDC\n" +
+			"                                                 │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"                                                 │   │                   │   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"                                                 │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"                                                 │   │                   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │               └─ name: E2I7U\n" +
+			"                                                 │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"                                                 │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"                                                 │   │                   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"                                                 │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                   │           └─ Table\n" +
-			"                                                 │   │                   │               └─ name: NOXN3\n" +
+			"                                                 │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   │                   └─ TableAlias(YVHJZ)\n" +
-			"                                                 │   │                       └─ IndexedTableAccess\n" +
+			"                                                 │   │                       └─ IndexedTableAccess(NOXN3)\n" +
 			"                                                 │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                           └─ Table\n" +
-			"                                                 │   │                               └─ name: NOXN3\n" +
+			"                                                 │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   └─ TableAlias(aac)\n" +
-			"                                                 │       └─ IndexedTableAccess\n" +
+			"                                                 │       └─ IndexedTableAccess(TPXBU)\n" +
 			"                                                 │           ├─ index: [TPXBU.id]\n" +
-			"                                                 │           └─ Table\n" +
-			"                                                 │               └─ name: TPXBU\n" +
+			"                                                 │           └─ columns: [id btxc5 fhcyt]\n" +
 			"                                                 └─ TableAlias(sn)\n" +
 			"                                                     └─ Table\n" +
-			"                                                         └─ name: NOXN3\n" +
+			"                                                         ├─ name: NOXN3\n" +
+			"                                                         └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -13632,7 +12804,8 @@ WHERE
 			"     │           │                       │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"     │           │                       │   │   │       │                       └─ Table\n" +
-			"     │           │                       │   │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       │   │   └─ AND\n" +
 			"     │           │                       │   │       ├─ AND\n" +
@@ -13649,7 +12822,8 @@ WHERE
 			"     │           │                       │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"     │           │                       │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │   │       │                       └─ Table\n" +
-			"     │           │                       │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"     │           │                       │   └─ AND\n" +
 			"     │           │                       │       ├─ AND\n" +
@@ -13666,7 +12840,8 @@ WHERE
 			"     │           │                       │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │       │                       └─ Table\n" +
-			"     │           │                       │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       ├─ LookupJoin\n" +
 			"     │           │                       │   ├─ Eq\n" +
@@ -13720,40 +12895,36 @@ WHERE
 			"     │           │                       │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"     │           │                       │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │           │                       │   │                   │   │   │   │   │       └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
 			"     │           │                       │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"     │           │                       │   │                   │   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"     │           │                       │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
 			"     │           │                       │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"     │           │                       │   │                   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │               └─ name: WGSDC\n" +
+			"     │           │                       │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"     │           │                       │   │                   │   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │           │                       │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │           │                       │   │                   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │               └─ name: E2I7U\n" +
+			"     │           │                       │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │           │                       │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"     │           │                       │   │                   │       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"     │           │                       │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                   │           └─ Table\n" +
-			"     │           │                       │   │                   │               └─ name: NOXN3\n" +
+			"     │           │                       │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   │                   └─ TableAlias(YVHJZ)\n" +
-			"     │           │                       │   │                       └─ IndexedTableAccess\n" +
+			"     │           │                       │   │                       └─ IndexedTableAccess(NOXN3)\n" +
 			"     │           │                       │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                           └─ Table\n" +
-			"     │           │                       │   │                               └─ name: NOXN3\n" +
+			"     │           │                       │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   └─ TableAlias(aac)\n" +
-			"     │           │                       │       └─ IndexedTableAccess\n" +
+			"     │           │                       │       └─ IndexedTableAccess(TPXBU)\n" +
 			"     │           │                       │           ├─ index: [TPXBU.id]\n" +
-			"     │           │                       │           └─ Table\n" +
-			"     │           │                       │               └─ name: TPXBU\n" +
+			"     │           │                       │           └─ columns: [id btxc5 fhcyt]\n" +
 			"     │           │                       └─ TableAlias(sn)\n" +
 			"     │           │                           └─ Table\n" +
-			"     │           │                               └─ name: NOXN3\n" +
+			"     │           │                               ├─ name: NOXN3\n" +
+			"     │           │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: RSA3Y\n" +
 			"     │               ├─ outerVisibility: false\n" +
@@ -13766,43 +12937,43 @@ WHERE
 			"     │                           ├─ outerVisibility: false\n" +
 			"     │                           ├─ cacheable: true\n" +
 			"     │                           └─ Project\n" +
-			"     │                               ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"     │                               ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"     │                               └─ HashJoin\n" +
 			"     │                                   ├─ Eq\n" +
-			"     │                                   │   ├─ sn.BRQP2:52!null\n" +
-			"     │                                   │   └─ mf.LUEVY:36!null\n" +
+			"     │                                   │   ├─ sn.BRQP2:8!null\n" +
+			"     │                                   │   └─ mf.LUEVY:5!null\n" +
 			"     │                                   ├─ LookupJoin\n" +
 			"     │                                   │   ├─ Eq\n" +
 			"     │                                   │   │   ├─ bs.id:0!null\n" +
-			"     │                                   │   │   └─ mf.GXLUB:35!null\n" +
+			"     │                                   │   │   └─ mf.GXLUB:4!null\n" +
 			"     │                                   │   ├─ LookupJoin\n" +
 			"     │                                   │   │   ├─ Eq\n" +
-			"     │                                   │   │   │   ├─ cla.id:4!null\n" +
-			"     │                                   │   │   │   └─ bs.IXUXU:2\n" +
+			"     │                                   │   │   │   ├─ cla.id:2!null\n" +
+			"     │                                   │   │   │   └─ bs.IXUXU:1\n" +
 			"     │                                   │   │   ├─ TableAlias(bs)\n" +
 			"     │                                   │   │   │   └─ Table\n" +
-			"     │                                   │   │   │       └─ name: THNTS\n" +
+			"     │                                   │   │   │       ├─ name: THNTS\n" +
+			"     │                                   │   │   │       └─ columns: [id ixuxu]\n" +
 			"     │                                   │   │   └─ Filter\n" +
 			"     │                                   │   │       ├─ HashIn\n" +
 			"     │                                   │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"     │                                   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"     │                                   │   │       └─ TableAlias(cla)\n" +
-			"     │                                   │   │           └─ IndexedTableAccess\n" +
+			"     │                                   │   │           └─ IndexedTableAccess(YK2GW)\n" +
 			"     │                                   │   │               ├─ index: [YK2GW.id]\n" +
-			"     │                                   │   │               └─ Table\n" +
-			"     │                                   │   │                   └─ name: YK2GW\n" +
+			"     │                                   │   │               └─ columns: [id ftqlq]\n" +
 			"     │                                   │   └─ TableAlias(mf)\n" +
-			"     │                                   │       └─ IndexedTableAccess\n" +
+			"     │                                   │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"     │                                   │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"     │                                   │           └─ Table\n" +
-			"     │                                   │               └─ name: HGMQ6\n" +
+			"     │                                   │           └─ columns: [gxlub luevy m22qn]\n" +
 			"     │                                   └─ HashLookup\n" +
-			"     │                                       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"     │                                       ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"     │                                       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"     │                                       └─ CachedResults\n" +
 			"     │                                           └─ TableAlias(sn)\n" +
 			"     │                                               └─ Table\n" +
-			"     │                                                   └─ name: NOXN3\n" +
+			"     │                                                   ├─ name: NOXN3\n" +
+			"     │                                                   └─ columns: [id brqp2]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -13829,43 +13000,43 @@ WHERE
 			"                             │   ├─ outerVisibility: false\n" +
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
-			"                             │       ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"                             │       ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"                             │       └─ HashJoin\n" +
 			"                             │           ├─ Eq\n" +
-			"                             │           │   ├─ sn.BRQP2:52!null\n" +
-			"                             │           │   └─ mf.LUEVY:36!null\n" +
+			"                             │           │   ├─ sn.BRQP2:8!null\n" +
+			"                             │           │   └─ mf.LUEVY:5!null\n" +
 			"                             │           ├─ LookupJoin\n" +
 			"                             │           │   ├─ Eq\n" +
 			"                             │           │   │   ├─ bs.id:0!null\n" +
-			"                             │           │   │   └─ mf.GXLUB:35!null\n" +
+			"                             │           │   │   └─ mf.GXLUB:4!null\n" +
 			"                             │           │   ├─ LookupJoin\n" +
 			"                             │           │   │   ├─ Eq\n" +
-			"                             │           │   │   │   ├─ cla.id:4!null\n" +
-			"                             │           │   │   │   └─ bs.IXUXU:2\n" +
+			"                             │           │   │   │   ├─ cla.id:2!null\n" +
+			"                             │           │   │   │   └─ bs.IXUXU:1\n" +
 			"                             │           │   │   ├─ TableAlias(bs)\n" +
 			"                             │           │   │   │   └─ Table\n" +
-			"                             │           │   │   │       └─ name: THNTS\n" +
+			"                             │           │   │   │       ├─ name: THNTS\n" +
+			"                             │           │   │   │       └─ columns: [id ixuxu]\n" +
 			"                             │           │   │   └─ Filter\n" +
 			"                             │           │   │       ├─ HashIn\n" +
 			"                             │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                             │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                             │           │   │       └─ TableAlias(cla)\n" +
-			"                             │           │   │           └─ IndexedTableAccess\n" +
+			"                             │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
 			"                             │           │   │               ├─ index: [YK2GW.id]\n" +
-			"                             │           │   │               └─ Table\n" +
-			"                             │           │   │                   └─ name: YK2GW\n" +
+			"                             │           │   │               └─ columns: [id ftqlq]\n" +
 			"                             │           │   └─ TableAlias(mf)\n" +
-			"                             │           │       └─ IndexedTableAccess\n" +
+			"                             │           │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"                             │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                             │           │           └─ Table\n" +
-			"                             │           │               └─ name: HGMQ6\n" +
+			"                             │           │           └─ columns: [gxlub luevy m22qn]\n" +
 			"                             │           └─ HashLookup\n" +
-			"                             │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"                             │               ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"                             │               ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"                             │               └─ CachedResults\n" +
 			"                             │                   └─ TableAlias(sn)\n" +
 			"                             │                       └─ Table\n" +
-			"                             │                           └─ name: NOXN3\n" +
+			"                             │                           ├─ name: NOXN3\n" +
+			"                             │                           └─ columns: [id brqp2]\n" +
 			"                             └─ HashLookup\n" +
 			"                                 ├─ source: TUPLE(cld.BDNYB:1!null, cld.M22QN:2!null)\n" +
 			"                                 ├─ target: TUPLE(P4PJZ.LWQ6O:3, P4PJZ.NTOFG:2!null)\n" +
@@ -13942,7 +13113,8 @@ WHERE
 			"                                                 │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 │   │   └─ AND\n" +
 			"                                                 │   │       ├─ AND\n" +
@@ -13959,7 +13131,8 @@ WHERE
 			"                                                 │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"                                                 │   └─ AND\n" +
 			"                                                 │       ├─ AND\n" +
@@ -13976,7 +13149,8 @@ WHERE
 			"                                                 │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           └─ name: NOXN3\n" +
+			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 ├─ LookupJoin\n" +
 			"                                                 │   ├─ Eq\n" +
@@ -14030,40 +13204,36 @@ WHERE
 			"                                                 │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"                                                 │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"                                                 │   │                   │   │   │   │   │       └─ Table\n" +
-			"                                                 │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
 			"                                                 │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"                                                 │   │                   │   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"                                                 │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"                                                 │   │                   │   │   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
 			"                                                 │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"                                                 │   │                   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │               └─ name: WGSDC\n" +
+			"                                                 │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"                                                 │   │                   │   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"                                                 │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"                                                 │   │                   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │               └─ name: E2I7U\n" +
+			"                                                 │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"                                                 │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"                                                 │   │                   │       └─ IndexedTableAccess\n" +
+			"                                                 │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"                                                 │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                   │           └─ Table\n" +
-			"                                                 │   │                   │               └─ name: NOXN3\n" +
+			"                                                 │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   │                   └─ TableAlias(YVHJZ)\n" +
-			"                                                 │   │                       └─ IndexedTableAccess\n" +
+			"                                                 │   │                       └─ IndexedTableAccess(NOXN3)\n" +
 			"                                                 │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                           └─ Table\n" +
-			"                                                 │   │                               └─ name: NOXN3\n" +
+			"                                                 │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   └─ TableAlias(aac)\n" +
-			"                                                 │       └─ IndexedTableAccess\n" +
+			"                                                 │       └─ IndexedTableAccess(TPXBU)\n" +
 			"                                                 │           ├─ index: [TPXBU.id]\n" +
-			"                                                 │           └─ Table\n" +
-			"                                                 │               └─ name: TPXBU\n" +
+			"                                                 │           └─ columns: [id btxc5 fhcyt]\n" +
 			"                                                 └─ TableAlias(sn)\n" +
 			"                                                     └─ Table\n" +
-			"                                                         └─ name: NOXN3\n" +
+			"                                                         ├─ name: NOXN3\n" +
+			"                                                         └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -14075,13 +13245,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.TW55N:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id tw55n]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -14093,13 +13260,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.TW55N:1!null, E2I7U.FGG57:2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id tw55n fgg57]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 3 6]\n" +
+			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 	},
 	{
@@ -14111,7 +13275,8 @@ SELECT COUNT(*) FROM E2I7U`,
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
 			"     └─ Table\n" +
-			"         └─ name: E2I7U\n" +
+			"         ├─ name: E2I7U\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -14231,13 +13396,10 @@ ORDER BY sn.XLFIA ASC`,
 			"         │   ├─ cacheable: true\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [NOXN3.id:0!null as XLFIA, NOXN3.BRQP2:1!null]\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
 			"         │           ├─ static: [{[NULL, ∞)}]\n" +
-			"         │           ├─ columns: [id brqp2]\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: NOXN3\n" +
-			"         │               └─ projections: [0 1]\n" +
+			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ source: TUPLE(sn.BRQP2:1!null)\n" +
 			"             ├─ target: TUPLE(I2GJ5.LUEVY:0!null)\n" +
@@ -14373,12 +13535,12 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │       │               └─ columns: [gxlub]\n" +
 			"             │       └─ TableAlias(applySubq0)\n" +
 			"             │           └─ Table\n" +
-			"             │               └─ name: THNTS\n" +
+			"             │               ├─ name: THNTS\n" +
+			"             │               └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"             └─ TableAlias(cla)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(YK2GW)\n" +
 			"                     ├─ index: [YK2GW.id]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: YK2GW\n" +
+			"                     └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -14405,17 +13567,16 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │   │   └─ cla.id:4!null\n" +
 			"             │   ├─ TableAlias(bs)\n" +
 			"             │   │   └─ Table\n" +
-			"             │   │       └─ name: THNTS\n" +
+			"             │   │       ├─ name: THNTS\n" +
+			"             │   │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"             │   └─ TableAlias(cla)\n" +
-			"             │       └─ IndexedTableAccess\n" +
+			"             │       └─ IndexedTableAccess(YK2GW)\n" +
 			"             │           ├─ index: [YK2GW.id]\n" +
-			"             │           └─ Table\n" +
-			"             │               └─ name: YK2GW\n" +
+			"             │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             └─ TableAlias(mf)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(HGMQ6)\n" +
 			"                     ├─ index: [HGMQ6.GXLUB]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: HGMQ6\n" +
+			"                     └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"",
 	},
 	{
@@ -14437,21 +13598,20 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │   └─ applySubq0.IXUXU:32\n" +
 			"             ├─ TableAlias(cla)\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: YK2GW\n" +
+			"             │       ├─ name: YK2GW\n" +
+			"             │       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             └─ SemiLookupJoin\n" +
 			"                 ├─ Eq\n" +
 			"                 │   ├─ applySubq0.id:30!null\n" +
 			"                 │   └─ applySubq1.GXLUB:34!null\n" +
 			"                 ├─ TableAlias(applySubq0)\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: THNTS\n" +
+			"                 │       ├─ name: THNTS\n" +
+			"                 │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"                 └─ TableAlias(applySubq1)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(AMYXQ)\n" +
 			"                         ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                         ├─ columns: [gxlub]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: AMYXQ\n" +
-			"                             └─ projections: [1]\n" +
+			"                         └─ columns: [gxlub]\n" +
 			"",
 	},
 	{
@@ -14472,12 +13632,12 @@ ORDER BY ci.FTQLQ`,
 			"             │   └─ ci.id:0!null\n" +
 			"             ├─ TableAlias(ci)\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: JDLNA\n" +
+			"             │       ├─ name: JDLNA\n" +
+			"             │       └─ columns: [id ftqlq fwwiq o3qxw fhcyt]\n" +
 			"             └─ TableAlias(ct)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(FLQLP)\n" +
 			"                     ├─ index: [FLQLP.FZ2R5]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: FLQLP\n" +
+			"                     └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -14576,17 +13736,16 @@ ORDER BY LUEVY`,
 			"         │           │   └─ nd.HPCMS:12!null\n" +
 			"         │           ├─ TableAlias(nd)\n" +
 			"         │           │   └─ Table\n" +
-			"         │           │       └─ name: E2I7U\n" +
+			"         │           │       ├─ name: E2I7U\n" +
+			"         │           │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │           └─ TableAlias(nma)\n" +
-			"         │               └─ IndexedTableAccess\n" +
+			"         │               └─ IndexedTableAccess(TNMXI)\n" +
 			"         │                   ├─ index: [TNMXI.id]\n" +
-			"         │                   └─ Table\n" +
-			"         │                       └─ name: TNMXI\n" +
+			"         │                   └─ columns: [id dzlim f3yue]\n" +
 			"         └─ TableAlias(YBBG5)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(XGSJM)\n" +
 			"                 ├─ index: [XGSJM.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: XGSJM\n" +
+			"                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -14651,38 +13810,36 @@ LEFT JOIN
     ON sn.A7XO2 = it.id
 ORDER BY sn.id ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [TVQG4.TW55N:13 as FJVD7, LSM32.TW55N:30 as KBXXJ, sn.NUMK2:6!null as NUMK2, CASE  WHEN it.DZLIM:45 IS NULL THEN N/A (longtext) ELSE it.DZLIM:45 END as TP6BK, sn.ECDKM:5 as ECDKM, sn.KBO7R:4!null as KBO7R, CASE  WHEN sn.YKSSU:8 IS NULL THEN N/A (longtext) ELSE sn.YKSSU:8 END as RQI4M, CASE  WHEN sn.FHCYT:9 IS NULL THEN N/A (longtext) ELSE sn.FHCYT:9 END as RNVLS, sn.LETOE:7!null as LETOE]\n" +
+			" ├─ columns: [TVQG4.TW55N:11 as FJVD7, LSM32.TW55N:13 as KBXXJ, sn.NUMK2:6!null as NUMK2, CASE  WHEN it.DZLIM:15 IS NULL THEN N/A (longtext) ELSE it.DZLIM:15 END as TP6BK, sn.ECDKM:5 as ECDKM, sn.KBO7R:4!null as KBO7R, CASE  WHEN sn.YKSSU:8 IS NULL THEN N/A (longtext) ELSE sn.YKSSU:8 END as RQI4M, CASE  WHEN sn.FHCYT:9 IS NULL THEN N/A (longtext) ELSE sn.FHCYT:9 END as RNVLS, sn.LETOE:7!null as LETOE]\n" +
 			" └─ Sort(sn.id:0!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ sn.A7XO2:3\n" +
-			"         │   └─ it.id:44!null\n" +
+			"         │   └─ it.id:14!null\n" +
 			"         ├─ LeftOuterLookupJoin\n" +
 			"         │   ├─ Eq\n" +
 			"         │   │   ├─ sn.FFTBJ:2!null\n" +
-			"         │   │   └─ LSM32.id:27!null\n" +
+			"         │   │   └─ LSM32.id:12!null\n" +
 			"         │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
 			"         │   │   │   ├─ sn.BRQP2:1!null\n" +
 			"         │   │   │   └─ TVQG4.id:10!null\n" +
 			"         │   │   ├─ TableAlias(sn)\n" +
 			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: NOXN3\n" +
+			"         │   │   │       ├─ name: NOXN3\n" +
+			"         │   │   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"         │   │   └─ TableAlias(TVQG4)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ TableAlias(LSM32)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │           └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(it)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(FEVH4)\n" +
 			"                 ├─ index: [FEVH4.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: FEVH4\n" +
+			"                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -14694,13 +13851,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [NOXN3.KBO7R:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id kbo7r]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: NOXN3\n" +
-			"         └─ projections: [0 4]\n" +
+			"     └─ columns: [id kbo7r]\n" +
 			"",
 	},
 	{
@@ -14751,56 +13905,52 @@ LEFT JOIN
     ON AYFCD.FFTBJ = FA75Y.id
 ORDER BY rn.id ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [SDLLR.TW55N:29 as FZX4Y, JGT2H.LETOE:13 as QWTOI, RIIW6.TW55N:46 as PDX5Y, AYFCD.NUMK2:22 as V45YB, AYFCD.LETOE:23 as DAGQN, FA75Y.TW55N:63 as SFQTS, rn.HVHRZ:3!null as HVHRZ, CASE  WHEN rn.YKSSU:4 IS NULL THEN N/A (longtext) ELSE rn.YKSSU:4 END as RQI4M, CASE  WHEN rn.FHCYT:5 IS NULL THEN N/A (longtext) ELSE rn.FHCYT:5 END as RNVLS]\n" +
+			" ├─ columns: [SDLLR.TW55N:15 as FZX4Y, JGT2H.LETOE:9 as QWTOI, RIIW6.TW55N:17 as PDX5Y, AYFCD.NUMK2:12 as V45YB, AYFCD.LETOE:13 as DAGQN, FA75Y.TW55N:19 as SFQTS, rn.HVHRZ:3!null as HVHRZ, CASE  WHEN rn.YKSSU:4 IS NULL THEN N/A (longtext) ELSE rn.YKSSU:4 END as RQI4M, CASE  WHEN rn.FHCYT:5 IS NULL THEN N/A (longtext) ELSE rn.FHCYT:5 END as RNVLS]\n" +
 			" └─ Sort(rn.id:0!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ AYFCD.FFTBJ:18\n" +
-			"         │   └─ FA75Y.id:60!null\n" +
+			"         │   ├─ AYFCD.FFTBJ:11\n" +
+			"         │   └─ FA75Y.id:18!null\n" +
 			"         ├─ LeftOuterLookupJoin\n" +
 			"         │   ├─ Eq\n" +
 			"         │   │   ├─ JGT2H.FFTBJ:8\n" +
-			"         │   │   └─ RIIW6.id:43!null\n" +
+			"         │   │   └─ RIIW6.id:16!null\n" +
 			"         │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
 			"         │   │   │   ├─ JGT2H.BRQP2:7\n" +
-			"         │   │   │   └─ SDLLR.id:26!null\n" +
+			"         │   │   │   └─ SDLLR.id:14!null\n" +
 			"         │   │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ rn.HHVLX:2!null\n" +
-			"         │   │   │   │   └─ AYFCD.id:16!null\n" +
+			"         │   │   │   │   └─ AYFCD.id:10!null\n" +
 			"         │   │   │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   ├─ rn.WNUNU:1!null\n" +
 			"         │   │   │   │   │   └─ JGT2H.id:6!null\n" +
 			"         │   │   │   │   ├─ TableAlias(rn)\n" +
 			"         │   │   │   │   │   └─ Table\n" +
-			"         │   │   │   │   │       └─ name: QYWQD\n" +
+			"         │   │   │   │   │       ├─ name: QYWQD\n" +
+			"         │   │   │   │   │       └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"         │   │   │   │   └─ TableAlias(JGT2H)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess\n" +
+			"         │   │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │   │   │   │           ├─ index: [NOXN3.id]\n" +
-			"         │   │   │   │           └─ Table\n" +
-			"         │   │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │   │           └─ columns: [id brqp2 fftbj letoe]\n" +
 			"         │   │   │   └─ TableAlias(AYFCD)\n" +
-			"         │   │   │       └─ IndexedTableAccess\n" +
+			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │   │   │           ├─ index: [NOXN3.id]\n" +
-			"         │   │   │           └─ Table\n" +
-			"         │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │           └─ columns: [id fftbj numk2 letoe]\n" +
 			"         │   │   └─ TableAlias(SDLLR)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ TableAlias(RIIW6)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
 			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │           └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(FA75Y)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
 			"                 ├─ index: [E2I7U.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"                 └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -14812,13 +13962,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.QRQXW:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id qrqxw]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 4]\n" +
+			"     └─ columns: [id qrqxw]\n" +
 			"",
 	},
 	{
@@ -14866,13 +14013,10 @@ FROM NOXN3
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [NOXN3.id:0!null, NOXN3.NUMK2:2!null, NOXN3.ECDKM:1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id ecdkm numk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: NOXN3\n" +
-			"         └─ projections: [0 5 6]\n" +
+			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
 	{
@@ -14889,13 +14033,10 @@ SELECT
 			" │   ├─ NOXN3.NUMK2:2!null\n" +
 			" │   └─ 2 (tinyint)\n" +
 			" │   THEN NOXN3.ECDKM:1 ELSE 0 (tinyint) END as RGXLL]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id ecdkm numk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: NOXN3\n" +
-			"         └─ projections: [0 5 6]\n" +
+			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
 	{
@@ -14909,28 +14050,27 @@ INNER JOIN E2I7U nd
 INNER JOIN XOAOP pa
     ON QNRBH.CH3FR = pa.id`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [pa.DZLIM:4!null as ECUWU, nd.TW55N:9!null]\n" +
+			" ├─ columns: [pa.DZLIM:3!null as ECUWU, nd.TW55N:5!null]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ QNRBH.LUEVY:2!null\n" +
-			"     │   └─ nd.id:6!null\n" +
+			"     │   ├─ QNRBH.LUEVY:1!null\n" +
+			"     │   └─ nd.id:4!null\n" +
 			"     ├─ LookupJoin\n" +
 			"     │   ├─ Eq\n" +
-			"     │   │   ├─ QNRBH.CH3FR:1!null\n" +
-			"     │   │   └─ pa.id:3!null\n" +
+			"     │   │   ├─ QNRBH.CH3FR:0!null\n" +
+			"     │   │   └─ pa.id:2!null\n" +
 			"     │   ├─ TableAlias(QNRBH)\n" +
 			"     │   │   └─ Table\n" +
-			"     │   │       └─ name: JJGQT\n" +
+			"     │   │       ├─ name: JJGQT\n" +
+			"     │   │       └─ columns: [ch3fr luevy]\n" +
 			"     │   └─ TableAlias(pa)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(XOAOP)\n" +
 			"     │           ├─ index: [XOAOP.id]\n" +
-			"     │           └─ Table\n" +
-			"     │               └─ name: XOAOP\n" +
+			"     │           └─ columns: [id dzlim]\n" +
 			"     └─ TableAlias(nd)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.id]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: E2I7U\n" +
+			"             └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -14943,11 +14083,10 @@ WHERE id IN ('1','2','3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ QYWQD.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(QYWQD)\n" +
 			"             ├─ index: [QYWQD.id]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: QYWQD\n" +
+			"             └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -14967,7 +14106,8 @@ WHERE
 			"         │       ├─ HDDVB.UJ6XY:2!null\n" +
 			"         │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ Table\n" +
-			"             └─ name: HDDVB\n" +
+			"             ├─ name: HDDVB\n" +
+			"             └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -14980,11 +14120,10 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ QYWQD.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(QYWQD)\n" +
 			"             ├─ index: [QYWQD.id]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: QYWQD\n" +
+			"             └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -14997,11 +14136,10 @@ WHERE LUEVY IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ AMYXQ.LUEVY:2!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(AMYXQ)\n" +
 			"             ├─ index: [AMYXQ.LUEVY]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: AMYXQ\n" +
+			"             └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
 			"",
 	},
 	{
@@ -15014,11 +14152,10 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ HGMQ6.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(HGMQ6)\n" +
 			"             ├─ index: [HGMQ6.id]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: HGMQ6\n" +
+			"             └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"",
 	},
 	{
@@ -15031,11 +14168,10 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ HDDVB.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(HDDVB)\n" +
 			"             ├─ index: [HDDVB.id]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: HDDVB\n" +
+			"             └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -15048,11 +14184,10 @@ WHERE LUEVY IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ FLQLP.LUEVY:2!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.LUEVY]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: FLQLP\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -15065,11 +14200,10 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ FLQLP.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.id]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: FLQLP\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -15082,11 +14216,10 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ FLQLP.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.id]\n" +
 			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: FLQLP\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -15103,31 +14236,30 @@ WHERE nd.FGG57 IS NOT NULL AND nd.KNG7T IS NULL`,
 			"             ├─ columns: [gn.id:17!null]\n" +
 			"             └─ Filter\n" +
 			"                 ├─ Eq\n" +
-			"                 │   ├─ ltnm.FGG57:22!null\n" +
+			"                 │   ├─ ltnm.FGG57:19!null\n" +
 			"                 │   └─ nd.FGG57:6\n" +
 			"                 └─ LookupJoin\n" +
 			"                     ├─ Eq\n" +
-			"                     │   ├─ ltnm.SSHPJ:23!null\n" +
-			"                     │   └─ gn.SSHPJ:19!null\n" +
+			"                     │   ├─ ltnm.SSHPJ:20!null\n" +
+			"                     │   └─ gn.SSHPJ:18!null\n" +
 			"                     ├─ TableAlias(gn)\n" +
 			"                     │   └─ Table\n" +
-			"                     │       └─ name: WE72E\n" +
+			"                     │       ├─ name: WE72E\n" +
+			"                     │       └─ columns: [id sshpj]\n" +
 			"                     └─ TableAlias(ltnm)\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(TDRVG)\n" +
 			"                             ├─ index: [TDRVG.SSHPJ]\n" +
-			"                             └─ Table\n" +
-			"                                 └─ name: TDRVG\n" +
+			"                             └─ columns: [fgg57 sshpj]\n" +
 			"        )\n" +
 			"         └─ Filter\n" +
 			"             ├─ AND\n" +
 			"             │   ├─ (NOT(nd.FGG57:6 IS NULL))\n" +
 			"             │   └─ nd.KNG7T:2 IS NULL\n" +
 			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
 			"                     ├─ index: [E2I7U.FGG57]\n" +
 			"                     ├─ static: [{(NULL, ∞)}]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: E2I7U\n" +
+			"                     └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -15155,7 +14287,8 @@ UPDATE S3FQX SET ADWYM = 0, FPUYA = 0`,
 			"            END//)\n" +
 			"             ├─ UpdateSource(SET S3FQX.ADWYM:1!null = 0 (tinyint),SET S3FQX.FPUYA:2!null = 0 (tinyint))\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: S3FQX\n" +
+			"             │       ├─ name: S3FQX\n" +
+			"             │       └─ columns: [id adwym fpuya]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -15192,7 +14325,8 @@ WHERE
 			"     └─ Insert(id, NFRYN, IXUXU, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: THNTS\n" +
+			"         │       ├─ name: THNTS\n" +
+			"         │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER THNTS_on_insert BEFORE INSERT ON THNTS\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15213,23 +14347,19 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ JMRQL.DZLIM:31!null\n" +
 			"             │       │           │   └─ T4IBQ (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(JMRQL)\n" +
 			"             │       │               ├─ index: [JMRQL.DZLIM]\n" +
 			"             │       │               ├─ static: [{[T4IBQ, T4IBQ]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: JMRQL\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as NFRYN, YK2GW.id:0!null as IXUXU, NULL (null) as FHCYT]\n" +
 			"             │       └─ Filter\n" +
 			"             │           ├─ HashIn\n" +
 			"             │           │   ├─ YK2GW.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │           └─ IndexedTableAccess\n" +
+			"             │           └─ IndexedTableAccess(YK2GW)\n" +
 			"             │               ├─ index: [YK2GW.id]\n" +
 			"             │               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │               └─ Table\n" +
-			"             │                   └─ name: YK2GW\n" +
+			"             │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(new.IXUXU:2 IS NULL)\n" +
@@ -15276,7 +14406,8 @@ FROM
 			"     └─ Insert(id, WNUNU, HHVLX, HVHRZ, YKSSU, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: QYWQD\n" +
+			"         │       ├─ name: QYWQD\n" +
+			"         │       └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER QYWQD_on_insert BEFORE INSERT ON QYWQD\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15297,40 +14428,39 @@ FROM
 			"             │           ├─ outerVisibility: false\n" +
 			"             │           ├─ cacheable: true\n" +
 			"             │           └─ Project\n" +
-			"             │               ├─ columns: [sn.id:10!null as DRIWM, SKPM6.id:0!null as JIEVY, sn.ECDKM:15 as HVHRZ]\n" +
+			"             │               ├─ columns: [sn.id:2!null as DRIWM, SKPM6.id:0!null as JIEVY, sn.ECDKM:4 as HVHRZ]\n" +
 			"             │               └─ Filter\n" +
 			"             │                   ├─ AND\n" +
-			"             │                   │   ├─ rn.WNUNU:21 IS NULL\n" +
-			"             │                   │   └─ rn.HHVLX:22 IS NULL\n" +
+			"             │                   │   ├─ rn.WNUNU:6 IS NULL\n" +
+			"             │                   │   └─ rn.HHVLX:7 IS NULL\n" +
 			"             │                   └─ LeftOuterLookupJoin\n" +
 			"             │                       ├─ AND\n" +
 			"             │                       │   ├─ Eq\n" +
-			"             │                       │   │   ├─ rn.WNUNU:21!null\n" +
-			"             │                       │   │   └─ sn.id:10!null\n" +
+			"             │                       │   │   ├─ rn.WNUNU:6!null\n" +
+			"             │                       │   │   └─ sn.id:2!null\n" +
 			"             │                       │   └─ Eq\n" +
-			"             │                       │       ├─ rn.HHVLX:22!null\n" +
+			"             │                       │       ├─ rn.HHVLX:7!null\n" +
 			"             │                       │       └─ SKPM6.id:0!null\n" +
 			"             │                       ├─ LookupJoin\n" +
 			"             │                       │   ├─ Eq\n" +
 			"             │                       │   │   ├─ SKPM6.BRQP2:1!null\n" +
-			"             │                       │   │   └─ sn.FFTBJ:12!null\n" +
+			"             │                       │   │   └─ sn.FFTBJ:3!null\n" +
 			"             │                       │   ├─ TableAlias(SKPM6)\n" +
 			"             │                       │   │   └─ Table\n" +
-			"             │                       │   │       └─ name: NOXN3\n" +
+			"             │                       │   │       ├─ name: NOXN3\n" +
+			"             │                       │   │       └─ columns: [id brqp2]\n" +
 			"             │                       │   └─ Filter\n" +
 			"             │                       │       ├─ Eq\n" +
-			"             │                       │       │   ├─ sn.NUMK2:6!null\n" +
+			"             │                       │       │   ├─ sn.NUMK2:3!null\n" +
 			"             │                       │       │   └─ 1 (tinyint)\n" +
 			"             │                       │       └─ TableAlias(sn)\n" +
-			"             │                       │           └─ IndexedTableAccess\n" +
+			"             │                       │           └─ IndexedTableAccess(NOXN3)\n" +
 			"             │                       │               ├─ index: [NOXN3.FFTBJ]\n" +
-			"             │                       │               └─ Table\n" +
-			"             │                       │                   └─ name: NOXN3\n" +
+			"             │                       │               └─ columns: [id fftbj ecdkm numk2]\n" +
 			"             │                       └─ TableAlias(rn)\n" +
-			"             │                           └─ IndexedTableAccess\n" +
+			"             │                           └─ IndexedTableAccess(QYWQD)\n" +
 			"             │                               ├─ index: [QYWQD.HHVLX]\n" +
-			"             │                               └─ Table\n" +
-			"             │                                   └─ name: QYWQD\n" +
+			"             │                               └─ columns: [wnunu hhvlx]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF((NOT(Eq\n" +
@@ -15379,7 +14509,8 @@ WHERE
 			"     └─ Insert(id, QZ7E7, SSHPJ, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: WE72E\n" +
+			"         │       ├─ name: WE72E\n" +
+			"         │       └─ columns: [id qz7e7 sshpj fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER WE72E_on_insert BEFORE INSERT ON WE72E\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15401,13 +14532,10 @@ WHERE
 			"             │           ├─ HashIn\n" +
 			"             │           │   ├─ TDRVG.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │           └─ IndexedTableAccess\n" +
+			"             │           └─ IndexedTableAccess(TDRVG)\n" +
 			"             │               ├─ index: [TDRVG.id]\n" +
 			"             │               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │               ├─ columns: [id sshpj sfj6l]\n" +
-			"             │               └─ Table\n" +
-			"             │                   ├─ name: TDRVG\n" +
-			"             │                   └─ projections: [0 2 3]\n" +
+			"             │               └─ columns: [id sshpj sfj6l]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(Or\n" +
@@ -15477,7 +14605,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, LUEVY, XQDYT, AMYXQ, OZTQF, Z35GY, KKGN5)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: AMYXQ\n" +
+			"         │       ├─ name: AMYXQ\n" +
+			"         │       └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
 			"         └─ Trigger(CREATE TRIGGER AMYXQ_on_insert BEFORE INSERT ON AMYXQ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15502,7 +14631,7 @@ WHERE
 			"             │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   └─ Project\n" +
-			"             │       │       ├─ columns: [bs.id:61!null]\n" +
+			"             │       │       ├─ columns: [bs.id:33!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ cla.FTQLQ:32!null\n" +
@@ -15510,17 +14639,15 @@ WHERE
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
 			"             │       │               │   ├─ cla.id:31!null\n" +
-			"             │       │               │   └─ bs.IXUXU:63\n" +
+			"             │       │               │   └─ bs.IXUXU:34\n" +
 			"             │       │               ├─ TableAlias(cla)\n" +
-			"             │       │               │   └─ IndexedTableAccess\n" +
+			"             │       │               │   └─ IndexedTableAccess(YK2GW)\n" +
 			"             │       │               │       ├─ index: [YK2GW.FTQLQ]\n" +
-			"             │       │               │       └─ Table\n" +
-			"             │       │               │           └─ name: YK2GW\n" +
+			"             │       │               │       └─ columns: [id ftqlq]\n" +
 			"             │       │               └─ TableAlias(bs)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
+			"             │       │                   └─ IndexedTableAccess(THNTS)\n" +
 			"             │       │                       ├─ index: [THNTS.IXUXU]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: THNTS\n" +
+			"             │       │                       └─ columns: [id ixuxu]\n" +
 			"             │       │   as GXLUB, nd.id:11!null as LUEVY, nd.XQDYT:20!null as XQDYT, (ufc.AMYXQ:3 + 0 (decimal(2,1))) as AMYXQ, CASE  WHEN Eq\n" +
 			"             │       │   ├─ YBBG5.DZLIM:29!null\n" +
 			"             │       │   └─ KTNZ2 (longtext)\n" +
@@ -15546,11 +14673,10 @@ WHERE
 			"             │           │   │   ├─ ufc.id:0!null\n" +
 			"             │           │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           │   └─ TableAlias(ufc)\n" +
-			"             │           │       └─ IndexedTableAccess\n" +
+			"             │           │       └─ IndexedTableAccess(SISUT)\n" +
 			"             │           │           ├─ index: [SISUT.id]\n" +
 			"             │           │           ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │           │           └─ Table\n" +
-			"             │           │               └─ name: SISUT\n" +
+			"             │           │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
 			"             │           └─ HashLookup\n" +
 			"             │               ├─ source: TUPLE(ufc.ZH72S:2)\n" +
 			"             │               ├─ target: TUPLE(nd.ZH72S:7)\n" +
@@ -15561,12 +14687,12 @@ WHERE
 			"             │                       │   └─ nd.XQDYT:20!null\n" +
 			"             │                       ├─ TableAlias(nd)\n" +
 			"             │                       │   └─ Table\n" +
-			"             │                       │       └─ name: E2I7U\n" +
+			"             │                       │       ├─ name: E2I7U\n" +
+			"             │                       │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                       └─ TableAlias(YBBG5)\n" +
-			"             │                           └─ IndexedTableAccess\n" +
+			"             │                           └─ IndexedTableAccess(XGSJM)\n" +
 			"             │                               ├─ index: [XGSJM.id]\n" +
-			"             │                               └─ Table\n" +
-			"             │                                   └─ name: XGSJM\n" +
+			"             │                               └─ columns: [id dzlim f3yue]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Subquery\n" +
@@ -15623,7 +14749,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15651,20 +14778,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
 			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -15673,13 +14800,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ NER (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[NER, NER]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.ner:2\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -15692,11 +14816,10 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
 			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -15747,7 +14870,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15775,20 +14899,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
 			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -15797,13 +14921,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ BER (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[BER, BER]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.ber:3\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -15816,11 +14937,10 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
 			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -15871,7 +14991,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15899,20 +15020,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
 			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -15921,13 +15042,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ HR (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[HR, HR]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.hr:4\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -15940,11 +15058,10 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
 			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -15995,7 +15112,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -16023,20 +15141,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
 			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -16045,13 +15163,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ MMR (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[MMR, MMR]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.mmr:5\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -16064,11 +15179,10 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
 			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -16124,7 +15238,8 @@ WHERE
 			"     └─ Insert(id, BTXC5, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: TPXBU\n" +
+			"         │       ├─ name: TPXBU\n" +
+			"         │       └─ columns: [id btxc5 fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER TPXBU_on_insert BEFORE INSERT ON TPXBU\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -16157,13 +15272,10 @@ WHERE
 			"             │                       │   │   │   │       ├─ cacheable: true\n" +
 			"             │                       │   │   │   │       └─ Filter\n" +
 			"             │                       │   │   │   │           ├─ (NOT(TPXBU.BTXC5:25 IS NULL))\n" +
-			"             │                       │   │   │   │           └─ IndexedTableAccess\n" +
+			"             │                       │   │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
 			"             │                       │   │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
 			"             │                       │   │   │   │               ├─ static: [{(NULL, ∞)}]\n" +
-			"             │                       │   │   │   │               ├─ columns: [btxc5]\n" +
-			"             │                       │   │   │   │               └─ Table\n" +
-			"             │                       │   │   │   │                   ├─ name: TPXBU\n" +
-			"             │                       │   │   │   │                   └─ projections: [1]\n" +
+			"             │                       │   │   │   │               └─ columns: [btxc5]\n" +
 			"             │                       │   │   │   │  ))\n" +
 			"             │                       │   │   │   └─ (NOT(umf.SYPKF:8 IS NULL))\n" +
 			"             │                       │   │   └─ (NOT(Eq\n" +
@@ -16174,11 +15286,10 @@ WHERE
 			"             │                       │       ├─ umf.id:0!null\n" +
 			"             │                       │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                       └─ TableAlias(umf)\n" +
-			"             │                           └─ IndexedTableAccess\n" +
+			"             │                           └─ IndexedTableAccess(NZKPM)\n" +
 			"             │                               ├─ index: [NZKPM.id]\n" +
 			"             │                               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                               └─ Table\n" +
-			"             │                                   └─ name: NZKPM\n" +
+			"             │                               └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(InSubquery\n" +
@@ -16267,7 +15378,8 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     └─ Insert(id, GXLUB, LUEVY, M22QN, TJPT7, ARN5P, XOSD4, IDE43, HMW4H, ZBT6R, FSDY2, LT7K6, SPPYD, QCGTS, TEUJA, QQV4M, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: HGMQ6\n" +
+			"         │       ├─ name: HGMQ6\n" +
+			"         │       └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER HGMQ6_on_insert BEFORE INSERT ON HGMQ6\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -16315,29 +15427,27 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │       ├─ columns: [nd_for_id_overridden.id:67!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ nd_for_id_overridden.TW55N:70!null\n" +
+			"             │       │           │   ├─ nd_for_id_overridden.TW55N:68!null\n" +
 			"             │       │           │   └─ TJ5D2.H4DMT:63\n" +
 			"             │       │           └─ TableAlias(nd_for_id_overridden)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
+			"             │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"             │       │                   ├─ index: [E2I7U.TW55N]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: E2I7U\n" +
+			"             │       │                   └─ columns: [id tw55n]\n" +
 			"             │       │   ELSE Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   └─ Project\n" +
 			"             │       │       ├─ columns: [nd_for_id.id:67!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ AND\n" +
-			"             │       │           │   ├─ (NOT(nd_for_id.FGG57:73 IS NULL))\n" +
+			"             │       │           │   ├─ (NOT(nd_for_id.FGG57:68 IS NULL))\n" +
 			"             │       │           │   └─ Eq\n" +
-			"             │       │           │       ├─ nd_for_id.FGG57:73\n" +
+			"             │       │           │       ├─ nd_for_id.FGG57:68\n" +
 			"             │       │           │       └─ umf.FGG57:2\n" +
 			"             │       │           └─ TableAlias(nd_for_id)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
+			"             │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"             │       │                   ├─ index: [E2I7U.FGG57]\n" +
 			"             │       │                   ├─ static: [{(NULL, ∞)}]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: E2I7U\n" +
+			"             │       │                   └─ columns: [id fgg57]\n" +
 			"             │       │   END as LUEVY, CASE  WHEN Eq\n" +
 			"             │       │   ├─ umf.SYPKF:8\n" +
 			"             │       │   └─ N/A (longtext)\n" +
@@ -16347,13 +15457,10 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │       ├─ columns: [TPXBU.id:67!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ TPXBU.BTXC5:68 IS NULL\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(TPXBU)\n" +
 			"             │       │               ├─ index: [TPXBU.BTXC5]\n" +
 			"             │       │               ├─ static: [{[NULL, NULL]}]\n" +
-			"             │       │               ├─ columns: [id btxc5]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: TPXBU\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id btxc5]\n" +
 			"             │       │   ELSE Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   └─ Project\n" +
@@ -16363,10 +15470,9 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │           │   ├─ aac.BTXC5:68\n" +
 			"             │       │           │   └─ umf.SYPKF:8\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
 			"             │       │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   END as M22QN, umf.TJPT7:6 as TJPT7, umf.ARN5P:7 as ARN5P, umf.XOSD4:13 as XOSD4, umf.IDE43:10 as IDE43, CASE  WHEN (NOT(Eq\n" +
 			"             │       │   ├─ umf.HMW4H:14\n" +
 			"             │       │   └─ N/A (longtext)\n" +
@@ -16434,18 +15540,14 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │           │   │       │           ├─ cacheable: true\n" +
 			"             │           │   │       │           └─ Filter\n" +
 			"             │           │   │       │               ├─ (NOT(E2I7U.FGG57:25 IS NULL))\n" +
-			"             │           │   │       │               └─ IndexedTableAccess\n" +
+			"             │           │   │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"             │           │   │       │                   ├─ index: [E2I7U.FGG57]\n" +
 			"             │           │   │       │                   ├─ static: [{(NULL, ∞)}]\n" +
-			"             │           │   │       │                   ├─ columns: [fgg57]\n" +
-			"             │           │   │       │                   └─ Table\n" +
-			"             │           │   │       │                       ├─ name: E2I7U\n" +
-			"             │           │   │       │                       └─ projections: [6]\n" +
-			"             │           │   │       └─ IndexedTableAccess\n" +
+			"             │           │   │       │                   └─ columns: [fgg57]\n" +
+			"             │           │   │       └─ IndexedTableAccess(NZKPM)\n" +
 			"             │           │   │           ├─ index: [NZKPM.id]\n" +
 			"             │           │   │           ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │           │   │           └─ Table\n" +
-			"             │           │   │               └─ name: NZKPM\n" +
+			"             │           │   │           └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"             │           │   └─ HashLookup\n" +
 			"             │           │       ├─ source: TUPLE(umf.T4IBQ:1)\n" +
 			"             │           │       ├─ target: TUPLE(cla.FTQLQ:5!null)\n" +
@@ -16456,15 +15558,16 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │           │               │   └─ bs.IXUXU:27\n" +
 			"             │           │               ├─ TableAlias(bs)\n" +
 			"             │           │               │   └─ Table\n" +
-			"             │           │               │       └─ name: THNTS\n" +
+			"             │           │               │       ├─ name: THNTS\n" +
+			"             │           │               │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"             │           │               └─ TableAlias(cla)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
+			"             │           │                   └─ IndexedTableAccess(YK2GW)\n" +
 			"             │           │                       ├─ index: [YK2GW.id]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: YK2GW\n" +
+			"             │           │                       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(TJ5D2)\n" +
 			"             │               └─ Table\n" +
-			"             │                   └─ name: SZW6V\n" +
+			"             │                   ├─ name: SZW6V\n" +
+			"             │                   └─ columns: [id t4ibq v7ufh sypkf h4dmt swcqv ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -16560,7 +15663,8 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			" └─ Insert(id, Z7CP5, YH4XB)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: SEQS3\n" +
+			"     │       ├─ name: SEQS3\n" +
+			"     │       └─ columns: [id z7cp5 yh4xb]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [id:0!null, Z7CP5:1!null, YH4XB:2!null]\n" +
 			"         └─ Project\n" +
@@ -16572,26 +15676,27 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			"                 │   ├─ outerVisibility: false\n" +
 			"                 │   ├─ cacheable: true\n" +
 			"                 │   └─ Project\n" +
-			"                 │       ├─ columns: [mf.id:0!null as id, umf.AZ6SP:28 as AZ6SP]\n" +
+			"                 │       ├─ columns: [mf.id:0!null as id, umf.AZ6SP:3 as AZ6SP]\n" +
 			"                 │       └─ LookupJoin\n" +
 			"                 │           ├─ Eq\n" +
-			"                 │           │   ├─ umf.id:17!null\n" +
-			"                 │           │   └─ mf.TEUJA:14\n" +
+			"                 │           │   ├─ umf.id:2!null\n" +
+			"                 │           │   └─ mf.TEUJA:1\n" +
 			"                 │           ├─ TableAlias(mf)\n" +
 			"                 │           │   └─ Table\n" +
-			"                 │           │       └─ name: HGMQ6\n" +
+			"                 │           │       ├─ name: HGMQ6\n" +
+			"                 │           │       └─ columns: [id teuja]\n" +
 			"                 │           └─ Filter\n" +
 			"                 │               ├─ HashIn\n" +
 			"                 │               │   ├─ umf.id:0!null\n" +
 			"                 │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"                 │               └─ TableAlias(umf)\n" +
-			"                 │                   └─ IndexedTableAccess\n" +
+			"                 │                   └─ IndexedTableAccess(NZKPM)\n" +
 			"                 │                       ├─ index: [NZKPM.id]\n" +
-			"                 │                       └─ Table\n" +
-			"                 │                           └─ name: NZKPM\n" +
+			"                 │                       └─ columns: [id az6sp]\n" +
 			"                 └─ TableAlias(vc)\n" +
 			"                     └─ Table\n" +
-			"                         └─ name: D34QP\n" +
+			"                         ├─ name: D34QP\n" +
+			"                         └─ columns: [id twmsr]\n" +
 			"",
 	},
 	{
@@ -16705,7 +15810,8 @@ FROM
 			" └─ Insert(id, FV24E, UJ6XY, M22QN, NZ4MQ, ETPQV, PRUV2, YKSSU, FHCYT)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: HDDVB\n" +
+			"     │       ├─ name: HDDVB\n" +
+			"     │       └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [id:0!null, FV24E:1!null, UJ6XY:2!null, M22QN:3!null, NZ4MQ:4!null, ETPQV:5, PRUV2:6, YKSSU:7, FHCYT:8]\n" +
 			"         └─ Union distinct\n" +
@@ -16738,7 +15844,8 @@ FROM
 			"             │                   │           │   └─ TIZHK.IDUT2:21\n" +
 			"             │                   │           └─ TableAlias(G3YXS)\n" +
 			"             │                   │               └─ Table\n" +
-			"             │                   │                   └─ name: YYBCX\n" +
+			"             │                   │                   ├─ name: YYBCX\n" +
+			"             │                   │                   └─ columns: [id esfvy sl76b]\n" +
 			"             │                   │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU]\n" +
 			"             │                   └─ Filter\n" +
 			"             │                       ├─ AND\n" +
@@ -16784,40 +15891,40 @@ FROM
 			"             │                           │   │   │   │   │   └─ TIZHK.ZHITY:19\n" +
 			"             │                           │   │   │   │   ├─ TableAlias(RHUZN)\n" +
 			"             │                           │   │   │   │   │   └─ Table\n" +
-			"             │                           │   │   │   │   │       └─ name: E2I7U\n" +
+			"             │                           │   │   │   │   │       ├─ name: E2I7U\n" +
+			"             │                           │   │   │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                           │   │   │   │   └─ Filter\n" +
 			"             │                           │   │   │   │       ├─ HashIn\n" +
 			"             │                           │   │   │   │       │   ├─ TIZHK.id:0!null\n" +
 			"             │                           │   │   │   │       │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                           │   │   │   │       └─ TableAlias(TIZHK)\n" +
-			"             │                           │   │   │   │           └─ IndexedTableAccess\n" +
+			"             │                           │   │   │   │           └─ IndexedTableAccess(WRZVO)\n" +
 			"             │                           │   │   │   │               ├─ index: [WRZVO.ZHITY]\n" +
-			"             │                           │   │   │   │               └─ Table\n" +
-			"             │                           │   │   │   │                   └─ name: WRZVO\n" +
+			"             │                           │   │   │   │               └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			"             │                           │   │   │   └─ HashLookup\n" +
 			"             │                           │   │   │       ├─ source: TUPLE(0 (tinyint), TIZHK.TVNW2:18, TIZHK.ZHITY:19, TIZHK.SYPKF:20, TIZHK.IDUT2:21)\n" +
 			"             │                           │   │   │       ├─ target: TUPLE(NHMXW.SWCQV:7!null, NHMXW.NOHHR:1!null, NHMXW.AVPYF:2!null, NHMXW.SYPKF:3!null, NHMXW.IDUT2:4!null)\n" +
 			"             │                           │   │   │       └─ CachedResults\n" +
 			"             │                           │   │   │           └─ TableAlias(NHMXW)\n" +
 			"             │                           │   │   │               └─ Table\n" +
-			"             │                           │   │   │                   └─ name: WGSDC\n" +
+			"             │                           │   │   │                   ├─ name: WGSDC\n" +
+			"             │                           │   │   │                   └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"             │                           │   │   └─ HashLookup\n" +
 			"             │                           │   │       ├─ source: TUPLE(TIZHK.TVNW2:18)\n" +
 			"             │                           │   │       ├─ target: TUPLE(J4JYP.ZH72S:7)\n" +
 			"             │                           │   │       └─ CachedResults\n" +
 			"             │                           │   │           └─ TableAlias(J4JYP)\n" +
 			"             │                           │   │               └─ Table\n" +
-			"             │                           │   │                   └─ name: E2I7U\n" +
+			"             │                           │   │                   ├─ name: E2I7U\n" +
+			"             │                           │   │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                           │   └─ TableAlias(mf)\n" +
-			"             │                           │       └─ IndexedTableAccess\n" +
+			"             │                           │       └─ IndexedTableAccess(HGMQ6)\n" +
 			"             │                           │           ├─ index: [HGMQ6.LUEVY]\n" +
-			"             │                           │           └─ Table\n" +
-			"             │                           │               └─ name: HGMQ6\n" +
+			"             │                           │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"             │                           └─ TableAlias(aac)\n" +
-			"             │                               └─ IndexedTableAccess\n" +
+			"             │                               └─ IndexedTableAccess(TPXBU)\n" +
 			"             │                                   ├─ index: [TPXBU.id]\n" +
-			"             │                                   └─ Table\n" +
-			"             │                                       └─ name: TPXBU\n" +
+			"             │                                   └─ columns: [id btxc5 fhcyt]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [id:0!null, FV24E:1 as FV24E, UJ6XY:2 as UJ6XY, M22QN:3, NZ4MQ:4, ETPQV:5!null, convert\n" +
 			"                 │   ├─ type: char\n" +
@@ -16833,10 +15940,9 @@ FROM
 			"                     │           │   ├─ aac.BTXC5:9\n" +
 			"                     │           │   └─ BPNW2.SYPKF:3\n" +
 			"                     │           └─ TableAlias(aac)\n" +
-			"                     │               └─ IndexedTableAccess\n" +
+			"                     │               └─ IndexedTableAccess(TPXBU)\n" +
 			"                     │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"                     │                   └─ Table\n" +
-			"                     │                       └─ name: TPXBU\n" +
+			"                     │                   └─ columns: [id btxc5]\n" +
 			"                     │   as M22QN, BPNW2.NZ4MQ:4 as NZ4MQ, BPNW2.MU3KG:0!null as ETPQV, BPNW2.I4NDZ:7 as PRUV2, BPNW2.YKSSU:6 as YKSSU, BPNW2.FHCYT:5 as FHCYT]\n" +
 			"                     └─ SubqueryAlias\n" +
 			"                         ├─ name: BPNW2\n" +
@@ -16850,24 +15956,24 @@ FROM
 			"                                 │       ├─ columns: [overridden_nd_mutant.id:54!null]\n" +
 			"                                 │       └─ Filter\n" +
 			"                                 │           ├─ Eq\n" +
-			"                                 │           │   ├─ overridden_nd_mutant.TW55N:57!null\n" +
+			"                                 │           │   ├─ overridden_nd_mutant.TW55N:55!null\n" +
 			"                                 │           │   └─ NHMXW.FZXV5:15\n" +
 			"                                 │           └─ TableAlias(overridden_nd_mutant)\n" +
-			"                                 │               └─ IndexedTableAccess\n" +
+			"                                 │               └─ IndexedTableAccess(E2I7U)\n" +
 			"                                 │                   ├─ index: [E2I7U.TW55N]\n" +
-			"                                 │                   └─ Table\n" +
-			"                                 │                       └─ name: E2I7U\n" +
+			"                                 │                   └─ columns: [id tw55n]\n" +
 			"                                 │   ELSE J4JYP.id:20 END as FV24E, CASE  WHEN (NOT(NHMXW.DQYGV:16 IS NULL)) THEN Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
 			"                                 │   └─ Project\n" +
 			"                                 │       ├─ columns: [overridden_QI2IEner.id:54!null]\n" +
 			"                                 │       └─ Filter\n" +
 			"                                 │           ├─ Eq\n" +
-			"                                 │           │   ├─ overridden_QI2IEner.TW55N:57!null\n" +
+			"                                 │           │   ├─ overridden_QI2IEner.TW55N:55!null\n" +
 			"                                 │           │   └─ NHMXW.DQYGV:16\n" +
 			"                                 │           └─ TableAlias(overridden_QI2IEner)\n" +
 			"                                 │               └─ Table\n" +
-			"                                 │                   └─ name: E2I7U\n" +
+			"                                 │                   ├─ name: E2I7U\n" +
+			"                                 │                   └─ columns: [id tw55n]\n" +
 			"                                 │   ELSE RHUZN.id:37 END as UJ6XY, TIZHK.SYPKF:3 as SYPKF, Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
 			"                                 │   └─ Project\n" +
@@ -16878,7 +15984,8 @@ FROM
 			"                                 │           │   └─ TIZHK.IDUT2:4\n" +
 			"                                 │           └─ TableAlias(G3YXS)\n" +
 			"                                 │               └─ Table\n" +
-			"                                 │                   └─ name: YYBCX\n" +
+			"                                 │                   ├─ name: YYBCX\n" +
+			"                                 │                   └─ columns: [id esfvy sl76b]\n" +
 			"                                 │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU, NHMXW.id:10 as I4NDZ]\n" +
 			"                                 └─ Filter\n" +
 			"                                     ├─ (NOT(NHMXW.id:10 IS NULL))\n" +
@@ -16914,31 +16021,31 @@ FROM
 			"                                         │   │   │   │   ├─ TIZHK.id:0!null\n" +
 			"                                         │   │   │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"                                         │   │   │   └─ TableAlias(TIZHK)\n" +
-			"                                         │   │   │       └─ IndexedTableAccess\n" +
+			"                                         │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
 			"                                         │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
 			"                                         │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                         │   │   │           └─ Table\n" +
-			"                                         │   │   │               └─ name: WRZVO\n" +
+			"                                         │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			"                                         │   │   └─ TableAlias(NHMXW)\n" +
-			"                                         │   │       └─ IndexedTableAccess\n" +
+			"                                         │   │       └─ IndexedTableAccess(WGSDC)\n" +
 			"                                         │   │           ├─ index: [WGSDC.NOHHR]\n" +
 			"                                         │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                         │   │           └─ Table\n" +
-			"                                         │   │               └─ name: WGSDC\n" +
+			"                                         │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"                                         │   └─ HashLookup\n" +
 			"                                         │       ├─ source: TUPLE(TIZHK.TVNW2:1)\n" +
 			"                                         │       ├─ target: TUPLE(J4JYP.ZH72S:7)\n" +
 			"                                         │       └─ CachedResults\n" +
 			"                                         │           └─ TableAlias(J4JYP)\n" +
 			"                                         │               └─ Table\n" +
-			"                                         │                   └─ name: E2I7U\n" +
+			"                                         │                   ├─ name: E2I7U\n" +
+			"                                         │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"                                         └─ HashLookup\n" +
 			"                                             ├─ source: TUPLE(TIZHK.ZHITY:2)\n" +
 			"                                             ├─ target: TUPLE(RHUZN.ZH72S:7)\n" +
 			"                                             └─ CachedResults\n" +
 			"                                                 └─ TableAlias(RHUZN)\n" +
 			"                                                     └─ Table\n" +
-			"                                                         └─ name: E2I7U\n" +
+			"                                                         ├─ name: E2I7U\n" +
+			"                                                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -17028,7 +16135,8 @@ WHERE
 			"     └─ Insert(id, NO52D, VYO5E, DKCAJ, ADURZ, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SFEGG\n" +
+			"         │       ├─ name: SFEGG\n" +
+			"         │       └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER SFEGG_on_insert BEFORE INSERT ON SFEGG\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -17106,7 +16214,8 @@ WHERE
 			"             │           │   │                   └─ Filter\n" +
 			"             │           │   │                       ├─ (NOT(SFEGG.VYO5E:6 IS NULL))\n" +
 			"             │           │   │                       └─ Table\n" +
-			"             │           │   │                           └─ name: SFEGG\n" +
+			"             │           │   │                           ├─ name: SFEGG\n" +
+			"             │           │   │                           └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │   │      ))\n" +
 			"             │           │   └─ AND\n" +
 			"             │           │       ├─ rs.VYO5E:1 IS NULL\n" +
@@ -17120,7 +16229,8 @@ WHERE
 			"             │           │                       └─ Filter\n" +
 			"             │           │                           ├─ SFEGG.VYO5E:6 IS NULL\n" +
 			"             │           │                           └─ Table\n" +
-			"             │           │                               └─ name: SFEGG\n" +
+			"             │           │                               ├─ name: SFEGG\n" +
+			"             │           │                               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │          ))\n" +
 			"             │           └─ SubqueryAlias\n" +
 			"             │               ├─ name: rs\n" +
@@ -17171,29 +16281,27 @@ WHERE
 			"             │                           │               │   │   ├─ uct.id:0!null\n" +
 			"             │                           │               │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                           │               │   └─ TableAlias(uct)\n" +
-			"             │                           │               │       └─ IndexedTableAccess\n" +
+			"             │                           │               │       └─ IndexedTableAccess(OUBDL)\n" +
 			"             │                           │               │           ├─ index: [OUBDL.FTQLQ]\n" +
 			"             │                           │               │           ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                           │               │           └─ Table\n" +
-			"             │                           │               │               └─ name: OUBDL\n" +
+			"             │                           │               │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"             │                           │               └─ TableAlias(I7HCR)\n" +
-			"             │                           │                   └─ IndexedTableAccess\n" +
+			"             │                           │                   └─ IndexedTableAccess(EPZU6)\n" +
 			"             │                           │                       ├─ index: [EPZU6.TOFPN]\n" +
 			"             │                           │                       ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                           │                       └─ Table\n" +
-			"             │                           │                           └─ name: EPZU6\n" +
+			"             │                           │                       └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"             │                           └─ LookupJoin\n" +
 			"             │                               ├─ Eq\n" +
 			"             │                               │   ├─ nt.id:4!null\n" +
 			"             │                               │   └─ nd.DKCAJ:8!null\n" +
 			"             │                               ├─ TableAlias(nt)\n" +
 			"             │                               │   └─ Table\n" +
-			"             │                               │       └─ name: F35MI\n" +
+			"             │                               │       ├─ name: F35MI\n" +
+			"             │                               │       └─ columns: [id dzlim f3yue]\n" +
 			"             │                               └─ TableAlias(nd)\n" +
-			"             │                                   └─ IndexedTableAccess\n" +
+			"             │                                   └─ IndexedTableAccess(E2I7U)\n" +
 			"             │                                       ├─ index: [E2I7U.DKCAJ]\n" +
-			"             │                                       └─ Table\n" +
-			"             │                                           └─ name: E2I7U\n" +
+			"             │                                       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -17312,7 +16420,8 @@ WHERE
 			"     └─ Insert(id, FZ2R5, LUEVY, M22QN, OVE3E, NRURT, OCA7E, XMM6Q, V5DPX, S3Q3Y, ZRV3B, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: FLQLP\n" +
+			"         │       ├─ name: FLQLP\n" +
+			"         │       └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER FLQLP_on_insert BEFORE INSERT ON FLQLP\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -17343,10 +16452,9 @@ WHERE
 			"             │       │           │   ├─ aac.BTXC5:30\n" +
 			"             │       │           │   └─ PQSXB.BTXC5:10\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
 			"             │       │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   as M22QN, PQSXB.OVE3E:1 as OVE3E, PQSXB.NRURT:2!null as NRURT, PQSXB.OCA7E:3 as OCA7E, PQSXB.XMM6Q:4 as XMM6Q, PQSXB.V5DPX:5 as V5DPX, PQSXB.S3Q3Y:6 as S3Q3Y, PQSXB.ZRV3B:7 as ZRV3B, PQSXB.FHCYT:8 as FHCYT]\n" +
 			"             │       └─ InnerJoin\n" +
 			"             │           ├─ Or\n" +
@@ -17412,34 +16520,34 @@ WHERE
 			"             │           │           │           │               │   ├─ cacheable: false\n" +
 			"             │           │           │           │               │   └─ Limit(1)\n" +
 			"             │           │           │           │               │       └─ Project\n" +
-			"             │           │           │           │               │           ├─ columns: [nd.DKCAJ:29!null]\n" +
+			"             │           │           │           │               │           ├─ columns: [nd.DKCAJ:28!null]\n" +
 			"             │           │           │           │               │           └─ Filter\n" +
 			"             │           │           │           │               │               ├─ Eq\n" +
-			"             │           │           │           │               │               │   ├─ nd.ZH72S:35\n" +
+			"             │           │           │           │               │               │   ├─ nd.ZH72S:29\n" +
 			"             │           │           │           │               │               │   └─ uct.ZH72S:2\n" +
 			"             │           │           │           │               │               └─ TableAlias(nd)\n" +
-			"             │           │           │           │               │                   └─ IndexedTableAccess\n" +
+			"             │           │           │           │               │                   └─ IndexedTableAccess(E2I7U)\n" +
 			"             │           │           │           │               │                       ├─ index: [E2I7U.ZH72S]\n" +
-			"             │           │           │           │               │                       └─ Table\n" +
-			"             │           │           │           │               │                           └─ name: E2I7U\n" +
+			"             │           │           │           │               │                       └─ columns: [dkcaj zh72s]\n" +
 			"             │           │           │           │               │   ELSE Subquery\n" +
 			"             │           │           │           │               │   ├─ cacheable: false\n" +
 			"             │           │           │           │               │   └─ Project\n" +
-			"             │           │           │           │               │       ├─ columns: [nd.DKCAJ:29!null]\n" +
+			"             │           │           │           │               │       ├─ columns: [nd.DKCAJ:28!null]\n" +
 			"             │           │           │           │               │       └─ Filter\n" +
 			"             │           │           │           │               │           ├─ Eq\n" +
-			"             │           │           │           │               │           │   ├─ nd.TW55N:31!null\n" +
+			"             │           │           │           │               │           │   ├─ nd.TW55N:29!null\n" +
 			"             │           │           │           │               │           │   └─ I7HCR.FVUCX:17\n" +
 			"             │           │           │           │               │           └─ TableAlias(nd)\n" +
-			"             │           │           │           │               │               └─ IndexedTableAccess\n" +
+			"             │           │           │           │               │               └─ IndexedTableAccess(E2I7U)\n" +
 			"             │           │           │           │               │                   ├─ index: [E2I7U.TW55N]\n" +
-			"             │           │           │           │               │                   └─ Table\n" +
-			"             │           │           │           │               │                       └─ name: E2I7U\n" +
+			"             │           │           │           │               │                   └─ columns: [dkcaj tw55n]\n" +
 			"             │           │           │           │               │   END]\n" +
 			"             │           │           │           │               └─ Table\n" +
-			"             │           │           │           │                   └─ name: \n" +
+			"             │           │           │           │                   ├─ name: \n" +
+			"             │           │           │           │                   └─ columns: []\n" +
 			"             │           │           │           └─ Table\n" +
-			"             │           │           │               └─ name: SFEGG\n" +
+			"             │           │           │               ├─ name: SFEGG\n" +
+			"             │           │           │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │           │   as OVE3E, uct.id:0!null as NRURT, I7HCR.id:13 as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN (NOT(Eq\n" +
 			"             │           │           │   ├─ uct.FHCYT:11\n" +
 			"             │           │           │   └─ N/A (longtext)\n" +
@@ -17464,20 +16572,19 @@ WHERE
 			"             │           │               │   │   ├─ uct.id:0!null\n" +
 			"             │           │               │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           │               │   └─ TableAlias(uct)\n" +
-			"             │           │               │       └─ IndexedTableAccess\n" +
+			"             │           │               │       └─ IndexedTableAccess(OUBDL)\n" +
 			"             │           │               │           ├─ index: [OUBDL.FTQLQ]\n" +
 			"             │           │               │           ├─ static: [{[NULL, ∞)}]\n" +
-			"             │           │               │           └─ Table\n" +
-			"             │           │               │               └─ name: OUBDL\n" +
+			"             │           │               │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"             │           │               └─ TableAlias(I7HCR)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
+			"             │           │                   └─ IndexedTableAccess(EPZU6)\n" +
 			"             │           │                       ├─ index: [EPZU6.TOFPN]\n" +
 			"             │           │                       ├─ static: [{[NULL, ∞)}]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: EPZU6\n" +
+			"             │           │                       └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(nd)\n" +
 			"             │               └─ Table\n" +
-			"             │                   └─ name: E2I7U\n" +
+			"             │                   ├─ name: E2I7U\n" +
+			"             │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(InSubquery\n" +
@@ -17553,7 +16660,8 @@ WHERE
 			"     └─ Insert(id, NO52D, VYO5E, DKCAJ, ADURZ, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SFEGG\n" +
+			"         │       ├─ name: SFEGG\n" +
+			"         │       └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER SFEGG_on_insert BEFORE INSERT ON SFEGG\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -17631,7 +16739,8 @@ WHERE
 			"             │           │   │                   └─ Filter\n" +
 			"             │           │   │                       ├─ (NOT(SFEGG.VYO5E:6 IS NULL))\n" +
 			"             │           │   │                       └─ Table\n" +
-			"             │           │   │                           └─ name: SFEGG\n" +
+			"             │           │   │                           ├─ name: SFEGG\n" +
+			"             │           │   │                           └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │   │      ))\n" +
 			"             │           │   └─ AND\n" +
 			"             │           │       ├─ rs.VYO5E:1 IS NULL\n" +
@@ -17645,7 +16754,8 @@ WHERE
 			"             │           │                       └─ Filter\n" +
 			"             │           │                           ├─ SFEGG.VYO5E:6 IS NULL\n" +
 			"             │           │                           └─ Table\n" +
-			"             │           │                               └─ name: SFEGG\n" +
+			"             │           │                               ├─ name: SFEGG\n" +
+			"             │           │                               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │          ))\n" +
 			"             │           └─ SubqueryAlias\n" +
 			"             │               ├─ name: rs\n" +
@@ -17664,12 +16774,12 @@ WHERE
 			"             │                           │   │   └─ nd.DKCAJ:4!null\n" +
 			"             │                           │   ├─ TableAlias(nt)\n" +
 			"             │                           │   │   └─ Table\n" +
-			"             │                           │   │       └─ name: F35MI\n" +
+			"             │                           │   │       ├─ name: F35MI\n" +
+			"             │                           │   │       └─ columns: [id dzlim f3yue]\n" +
 			"             │                           │   └─ TableAlias(nd)\n" +
-			"             │                           │       └─ IndexedTableAccess\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
 			"             │                           │           ├─ index: [E2I7U.DKCAJ]\n" +
-			"             │                           │           └─ Table\n" +
-			"             │                           │               └─ name: E2I7U\n" +
+			"             │                           │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                           └─ HashLookup\n" +
 			"             │                               ├─ source: TUPLE(nd.TW55N:6!null)\n" +
 			"             │                               ├─ target: TUPLE(TVTJS.I3VTA:2!null)\n" +
@@ -17679,11 +16789,10 @@ WHERE
 			"             │                                       │   ├─ TVTJS.id:0!null\n" +
 			"             │                                       │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                                       └─ TableAlias(TVTJS)\n" +
-			"             │                                           └─ IndexedTableAccess\n" +
+			"             │                                           └─ IndexedTableAccess(HU5A5)\n" +
 			"             │                                               ├─ index: [HU5A5.id]\n" +
 			"             │                                               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                                               └─ Table\n" +
-			"             │                                                   └─ name: HU5A5\n" +
+			"             │                                               └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -17748,7 +16857,8 @@ WHERE
 			"     └─ Insert(id, FZ2R5, LUEVY, M22QN, OVE3E, NRURT, OCA7E, XMM6Q, V5DPX, S3Q3Y, ZRV3B, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: FLQLP\n" +
+			"         │       ├─ name: FLQLP\n" +
+			"         │       └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER FLQLP_on_insert BEFORE INSERT ON FLQLP\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -17833,29 +16943,28 @@ WHERE
 			"             │       │           │       └─ Subquery\n" +
 			"             │       │           │           ├─ cacheable: false\n" +
 			"             │       │           │           └─ Project\n" +
-			"             │       │           │               ├─ columns: [nd.DKCAJ:20!null]\n" +
+			"             │       │           │               ├─ columns: [nd.DKCAJ:19!null]\n" +
 			"             │       │           │               └─ Filter\n" +
 			"             │       │           │                   ├─ Eq\n" +
-			"             │       │           │                   │   ├─ nd.TW55N:22!null\n" +
+			"             │       │           │                   │   ├─ nd.TW55N:20!null\n" +
 			"             │       │           │                   │   └─ TVTJS.I3VTA:2!null\n" +
 			"             │       │           │                   └─ TableAlias(nd)\n" +
-			"             │       │           │                       └─ IndexedTableAccess\n" +
+			"             │       │           │                       └─ IndexedTableAccess(E2I7U)\n" +
 			"             │       │           │                           ├─ index: [E2I7U.TW55N]\n" +
-			"             │       │           │                           └─ Table\n" +
-			"             │       │           │                               └─ name: E2I7U\n" +
+			"             │       │           │                           └─ columns: [dkcaj tw55n]\n" +
 			"             │       │           └─ Table\n" +
-			"             │       │               └─ name: SFEGG\n" +
+			"             │       │               ├─ name: SFEGG\n" +
+			"             │       │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │       │   as OVE3E, NULL (null) as NRURT, NULL (null) as OCA7E, TVTJS.id:0!null as XMM6Q, TVTJS.V5DPX:4!null as V5DPX, (TVTJS.IDPK7:6!null + 0 (decimal(2,1))) as S3Q3Y, TVTJS.ZRV3B:8!null as ZRV3B, TVTJS.FHCYT:12 as FHCYT]\n" +
 			"             │       └─ Filter\n" +
 			"             │           ├─ HashIn\n" +
 			"             │           │   ├─ TVTJS.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(TVTJS)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(HU5A5)\n" +
 			"             │                   ├─ index: [HU5A5.id]\n" +
 			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: HU5A5\n" +
+			"             │                   └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(InSubquery\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -3194,20 +3194,33 @@ inner join pq on true
 			"",
 	},
 	{
+		Query: "select a.S, b.S from mytable A, mytable B",
+		ExpectedPlan: "CrossJoin\n" +
+			" ├─ TableAlias(a)\n" +
+			" │   └─ Table\n" +
+			" │       ├─ name: mytable\n" +
+			" │       └─ columns: [s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: [s]\n" +
+			"",
+	},
+	{
 		Query: `SELECT t1.timestamp FROM reservedWordsTable t1 JOIN reservedWordsTable t2 ON t1.TIMESTAMP = t2.tImEstamp`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [t1.Timestamp:0!null]\n" +
-			" └─ InnerJoin\n" +
-			"     ├─ Eq\n" +
-			"     │   ├─ t1.Timestamp:0!null\n" +
-			"     │   └─ t2.Timestamp:4!null\n" +
-			"     ├─ TableAlias(t1)\n" +
-			"     │   └─ Table\n" +
-			"     │       └─ name: reservedWordsTable\n" +
-			"     └─ TableAlias(t2)\n" +
-			"         └─ Table\n" +
-			"             └─ name: reservedWordsTable\n" +
-			"",
+				" ├─ columns: [t1.Timestamp:0!null]\n" +
+				" └─ InnerJoin\n" +
+				"     ├─ Eq\n" +
+				"     │   ├─ t1.Timestamp:0!null\n" +
+				"     │   └─ t2.Timestamp:4!null\n" +
+				"     ├─ TableAlias(t1)\n" +
+				"     │   └─ Table\n" +
+				"     │       └─ name: reservedWordsTable\n" +
+				"     └─ TableAlias(t2)\n" +
+				"         └─ Table\n" +
+				"             └─ name: reservedWordsTable\n" +
+				"",
 	},
 	{
 		Query: `SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2`,

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -46,12 +46,9 @@ var PlanTests = []QueryPlanTest{
 			"     │       │       ├─ Eq\n" +
 			"     │       │       │   ├─ uv.u:1!null\n" +
 			"     │       │       │   └─ sq.p:0!null\n" +
-			"     │       │       └─ IndexedTableAccess\n" +
+			"     │       │       └─ IndexedTableAccess(uv)\n" +
 			"     │       │           ├─ index: [uv.u]\n" +
-			"     │       │           ├─ columns: [u]\n" +
-			"     │       │           └─ Table\n" +
-			"     │       │               ├─ name: uv\n" +
-			"     │       │               └─ projections: [0]\n" +
+			"     │       │           └─ columns: [u]\n" +
 			"     │       │   as (select u from uv where u = sq.p)]\n" +
 			"     │       └─ SubqueryAlias\n" +
 			"     │           ├─ name: sq\n" +
@@ -60,10 +57,8 @@ var PlanTests = []QueryPlanTest{
 			"     │           └─ Table\n" +
 			"     │               ├─ name: pq\n" +
 			"     │               └─ columns: [p]\n" +
-			"     └─ IndexedTableAccess\n" +
-			"         ├─ index: [xy.x]\n" +
-			"         └─ Table\n" +
-			"             └─ name: xy\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
+			"         └─ index: [xy.x]\n" +
 			"",
 	},
 	{
@@ -84,10 +79,8 @@ var PlanTests = []QueryPlanTest{
 			"     │               └─ Table\n" +
 			"     │                   ├─ name: othertable\n" +
 			"     │                   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
-			"         ├─ index: [mytable.i]\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
+			"         └─ index: [mytable.i]\n" +
 			"",
 	},
 	{
@@ -103,10 +96,8 @@ var PlanTests = []QueryPlanTest{
 			"         │   └─ Table\n" +
 			"         │       ├─ name: othertable\n" +
 			"         │       └─ columns: [i2]\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [mytable.i]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: mytable\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             └─ index: [mytable.i]\n" +
 			"",
 	},
 	{
@@ -116,20 +107,14 @@ var PlanTests = []QueryPlanTest{
 			"     ├─ cmp: Eq\n" +
 			"     │   ├─ rs.s:1\n" +
 			"     │   └─ xy.y:3\n" +
-			"     ├─ IndexedTableAccess\n" +
+			"     ├─ IndexedTableAccess(rs)\n" +
 			"     │   ├─ index: [rs.s]\n" +
 			"     │   ├─ static: [{[NULL, ∞)}]\n" +
-			"     │   ├─ columns: [r s]\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: rs\n" +
-			"     │       └─ projections: [0 1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   └─ columns: [r s]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.y]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
-			"         ├─ columns: [x y]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: xy\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -148,26 +133,17 @@ var PlanTests = []QueryPlanTest{
 			"     │       ├─ cmp: Eq\n" +
 			"     │       │   ├─ ab.a:0!null\n" +
 			"     │       │   └─ xy.y:3\n" +
-			"     │       ├─ IndexedTableAccess\n" +
+			"     │       ├─ IndexedTableAccess(ab)\n" +
 			"     │       │   ├─ index: [ab.a]\n" +
 			"     │       │   ├─ static: [{[NULL, ∞)}]\n" +
-			"     │       │   ├─ columns: [a b]\n" +
-			"     │       │   └─ Table\n" +
-			"     │       │       ├─ name: ab\n" +
-			"     │       │       └─ projections: [0 1]\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       │   └─ columns: [a b]\n" +
+			"     │       └─ IndexedTableAccess(xy)\n" +
 			"     │           ├─ index: [xy.y]\n" +
 			"     │           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           ├─ columns: [x y]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: xy\n" +
-			"     │               └─ projections: [0 1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │           └─ columns: [x y]\n" +
+			"     └─ IndexedTableAccess(uv)\n" +
 			"         ├─ index: [uv.u]\n" +
-			"         ├─ columns: [u v]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: uv\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [u v]\n" +
 			"",
 	},
 	{
@@ -176,20 +152,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ cmp: Eq\n" +
 			" │   ├─ ab.a:0!null\n" +
 			" │   └─ xy.y:3\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(ab)\n" +
 			" │   ├─ index: [ab.a]\n" +
 			" │   ├─ static: [{[NULL, ∞)}]\n" +
-			" │   ├─ columns: [a b]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: ab\n" +
-			" │       └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [a b]\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.y]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -199,20 +169,14 @@ var PlanTests = []QueryPlanTest{
 			"     ├─ cmp: Eq\n" +
 			"     │   ├─ rs.s:1\n" +
 			"     │   └─ xy.y:3\n" +
-			"     ├─ IndexedTableAccess\n" +
+			"     ├─ IndexedTableAccess(rs)\n" +
 			"     │   ├─ index: [rs.s]\n" +
 			"     │   ├─ static: [{[NULL, ∞)}]\n" +
-			"     │   ├─ columns: [r s]\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: rs\n" +
-			"     │       └─ projections: [0 1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   └─ columns: [r s]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.y]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
-			"         ├─ columns: [x y]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: xy\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -221,20 +185,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ cmp: Eq\n" +
 			" │   ├─ rs.s:1\n" +
 			" │   └─ xy.y:3\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(rs)\n" +
 			" │   ├─ index: [rs.s]\n" +
 			" │   ├─ static: [{[NULL, ∞)}]\n" +
-			" │   ├─ columns: [r s]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: rs\n" +
-			" │       └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [r s]\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.y]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -243,20 +201,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ cmp: Eq\n" +
 			" │   ├─ rs.s:1\n" +
 			" │   └─ (xy.y:3 + 10 (tinyint))\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(rs)\n" +
 			" │   ├─ index: [rs.s]\n" +
 			" │   ├─ static: [{[NULL, ∞)}]\n" +
-			" │   ├─ columns: [r s]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: rs\n" +
-			" │       └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [r s]\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.y]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -291,12 +243,9 @@ var PlanTests = []QueryPlanTest{
 			" │               │           ├─ Eq\n" +
 			" │               │           │   ├─ uv.u:4!null\n" +
 			" │               │           │   └─ ab.a:0!null\n" +
-			" │               │           └─ IndexedTableAccess\n" +
+			" │               │           └─ IndexedTableAccess(uv)\n" +
 			" │               │               ├─ index: [uv.u]\n" +
-			" │               │               ├─ columns: [u]\n" +
-			" │               │               └─ Table\n" +
-			" │               │                   ├─ name: uv\n" +
-			" │               │                   └─ projections: [0]\n" +
+			" │               │               └─ columns: [u]\n" +
 			" │               └─ Table\n" +
 			" │                   └─ name: xy\n" +
 			" └─ Table\n" +
@@ -389,10 +338,8 @@ var PlanTests = []QueryPlanTest{
 			"             │   └─ pq.p:0!null\n" +
 			"             ├─ Table\n" +
 			"             │   └─ name: pq\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [ab.a]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: ab\n" +
+			"             └─ IndexedTableAccess(ab)\n" +
+			"                 └─ index: [ab.a]\n" +
 			"",
 	},
 	{
@@ -411,12 +358,9 @@ var PlanTests = []QueryPlanTest{
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ uv.u:4!null\n" +
 			"     │           │       └─ xy.x:2!null\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(uv)\n" +
 			"     │               ├─ index: [uv.u]\n" +
-			"     │               ├─ columns: [u]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: uv\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [u]\n" +
 			"     │   as is_one]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
@@ -424,10 +368,8 @@ var PlanTests = []QueryPlanTest{
 			"         │   └─ uv.v:1\n" +
 			"         ├─ Table\n" +
 			"         │   └─ name: uv\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [xy.x]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: xy\n" +
+			"         └─ IndexedTableAccess(xy)\n" +
+			"             └─ index: [xy.x]\n" +
 			"",
 	},
 	{
@@ -455,10 +397,8 @@ var PlanTests = []QueryPlanTest{
 			"             │   └─ uv.v:1\n" +
 			"             ├─ Table\n" +
 			"             │   └─ name: uv\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [xy.x]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: xy\n" +
+			"             └─ IndexedTableAccess(xy)\n" +
+			"                 └─ index: [xy.x]\n" +
 			"",
 	},
 	{
@@ -481,10 +421,8 @@ var PlanTests = []QueryPlanTest{
 			"     │   └─ uv.v:1\n" +
 			"     ├─ Table\n" +
 			"     │   └─ name: uv\n" +
-			"     └─ IndexedTableAccess\n" +
-			"         ├─ index: [xy.x]\n" +
-			"         └─ Table\n" +
-			"             └─ name: xy\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
+			"         └─ index: [xy.x]\n" +
 			"",
 	},
 	{
@@ -523,13 +461,10 @@ var PlanTests = []QueryPlanTest{
 			"             │       ├─ Eq\n" +
 			"             │       │   ├─ bus_routes.origin:0!null\n" +
 			"             │       │   └─ New York (longtext)\n" +
-			"             │       └─ IndexedTableAccess\n" +
+			"             │       └─ IndexedTableAccess(bus_routes)\n" +
 			"             │           ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
 			"             │           ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
-			"             │           ├─ columns: [origin]\n" +
-			"             │           └─ Table\n" +
-			"             │               ├─ name: bus_routes\n" +
-			"             │               └─ projections: [0]\n" +
+			"             │           └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst:2!null]\n" +
 			"                 └─ HashJoin\n" +
@@ -595,12 +530,9 @@ var PlanTests = []QueryPlanTest{
 			"                                                 ├─ HashIn\n" +
 			"                                                 │   ├─ uv.u:0!null\n" +
 			"                                                 │   └─ TUPLE(2 (tinyint), 3 (tinyint))\n" +
-			"                                                 └─ IndexedTableAccess\n" +
+			"                                                 └─ IndexedTableAccess(uv)\n" +
 			"                                                     ├─ index: [uv.u]\n" +
-			"                                                     ├─ columns: [u v]\n" +
-			"                                                     └─ Table\n" +
-			"                                                         ├─ name: uv\n" +
-			"                                                         └─ projections: [0 1]\n" +
+			"                                                     └─ columns: [u v]\n" +
 			"",
 	},
 	{
@@ -653,19 +585,13 @@ var PlanTests = []QueryPlanTest{
 			"                 │   ├─ Eq\n" +
 			"                 │   │   ├─ uv.u:0!null\n" +
 			"                 │   │   └─ -1 (tinyint)\n" +
-			"                 │   └─ IndexedTableAccess\n" +
+			"                 │   └─ IndexedTableAccess(uv)\n" +
 			"                 │       ├─ index: [uv.u]\n" +
 			"                 │       ├─ static: [{[-1, -1]}]\n" +
-			"                 │       ├─ columns: [u v]\n" +
-			"                 │       └─ Table\n" +
-			"                 │           ├─ name: uv\n" +
-			"                 │           └─ projections: [0 1]\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 │       └─ columns: [u v]\n" +
+			"                 └─ IndexedTableAccess(xy)\n" +
 			"                     ├─ index: [xy.y]\n" +
-			"                     ├─ columns: [x y]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: xy\n" +
-			"                         └─ projections: [0 1]\n" +
+			"                     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -689,12 +615,9 @@ var PlanTests = []QueryPlanTest{
 			"     │           ├─ Table\n" +
 			"     │           │   ├─ name: pq\n" +
 			"     │           │   └─ columns: [p q]\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(xy)\n" +
 			"     │               ├─ index: [xy.x]\n" +
-			"     │               ├─ columns: [x]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: xy\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [x]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(xq.x:0!null)\n" +
 			"         ├─ target: TUPLE(av.v:1)\n" +
@@ -712,12 +635,9 @@ var PlanTests = []QueryPlanTest{
 			"                         ├─ Table\n" +
 			"                         │   ├─ name: uv\n" +
 			"                         │   └─ columns: [u v]\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(ab)\n" +
 			"                             ├─ index: [ab.a]\n" +
-			"                             ├─ columns: [a]\n" +
-			"                             └─ Table\n" +
-			"                                 ├─ name: ab\n" +
-			"                                 └─ projections: [0]\n" +
+			"                             └─ columns: [a]\n" +
 			"",
 	},
 	{
@@ -770,25 +690,16 @@ var PlanTests = []QueryPlanTest{
 			"     │   ├─ name: ab\n" +
 			"     │   └─ columns: [a]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(xy)\n" +
 			"         │   ├─ index: [xy.x]\n" +
-			"         │   ├─ columns: [x]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: xy\n" +
-			"         │       └─ projections: [0]\n" +
+			"         │   └─ columns: [x]\n" +
 			"         └─ Concat\n" +
-			"             ├─ IndexedTableAccess\n" +
+			"             ├─ IndexedTableAccess(xy)\n" +
 			"             │   ├─ index: [xy.x]\n" +
-			"             │   ├─ columns: [x]\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: xy\n" +
-			"             │       └─ projections: [0]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   └─ columns: [x]\n" +
+			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ columns: [x]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: xy\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [x]\n" +
 			"",
 	},
 	{
@@ -807,10 +718,8 @@ var PlanTests = []QueryPlanTest{
 			" │               ├─ Table\n" +
 			" │               │   ├─ name: uv\n" +
 			" │               │   └─ columns: [u v]\n" +
-			" │               └─ IndexedTableAccess\n" +
-			" │                   ├─ index: [ab.a]\n" +
-			" │                   └─ Table\n" +
-			" │                       └─ name: ab\n" +
+			" │               └─ IndexedTableAccess(ab)\n" +
+			" │                   └─ index: [ab.a]\n" +
 			" │   as s]\n" +
 			" └─ Table\n" +
 			"     └─ name: xy\n" +
@@ -879,12 +788,9 @@ var PlanTests = []QueryPlanTest{
 			" │   └─ ab.a:2!null\n" +
 			" ├─ Table\n" +
 			" │   └─ name: uv\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(ab)\n" +
 			"     ├─ index: [ab.a]\n" +
-			"     ├─ columns: [a]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: ab\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [a]\n" +
 			"",
 	},
 	{
@@ -901,10 +807,8 @@ var PlanTests = []QueryPlanTest{
 			"         ├─ Table\n" +
 			"         │   ├─ name: xy\n" +
 			"         │   └─ columns: [x y]\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [ab.a]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: ab\n" +
+			"         └─ IndexedTableAccess(ab)\n" +
+			"             └─ index: [ab.a]\n" +
 			"",
 	},
 	{
@@ -920,10 +824,8 @@ var PlanTests = []QueryPlanTest{
 			" │   └─ Table\n" +
 			" │       ├─ name: ab\n" +
 			" │       └─ columns: [a b]\n" +
-			" └─ IndexedTableAccess\n" +
-			"     ├─ index: [xy.x]\n" +
-			"     └─ Table\n" +
-			"         └─ name: xy\n" +
+			" └─ IndexedTableAccess(xy)\n" +
+			"     └─ index: [xy.x]\n" +
 			"",
 	},
 	{
@@ -935,12 +837,9 @@ var PlanTests = []QueryPlanTest{
 			"     │   └─ xy.x:0!null\n" +
 			"     ├─ Table\n" +
 			"     │   └─ name: xy\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(ab)\n" +
 			"         ├─ index: [ab.a]\n" +
-			"         ├─ columns: [a b]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: ab\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -953,12 +852,9 @@ var PlanTests = []QueryPlanTest{
 			"         │   └─ xy.x:0!null\n" +
 			"         ├─ Table\n" +
 			"         │   └─ name: xy\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(ab)\n" +
 			"             ├─ index: [ab.a]\n" +
-			"             ├─ columns: [a b]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: ab\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -988,19 +884,14 @@ inner join xy on a = x;`,
 			" │       │   │   └─ uv.u:2!null\n" +
 			" │       │   ├─ Table\n" +
 			" │       │   │   └─ name: ab\n" +
-			" │       │   └─ IndexedTableAccess\n" +
-			" │       │       ├─ index: [uv.u]\n" +
-			" │       │       └─ Table\n" +
-			" │       │           └─ name: uv\n" +
+			" │       │   └─ IndexedTableAccess(uv)\n" +
+			" │       │       └─ index: [uv.u]\n" +
 			" │       └─ Table\n" +
 			" │           ├─ name: pq\n" +
 			" │           └─ columns: [p q]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(xy)\n" +
 			"     ├─ index: [xy.x]\n" +
-			"     ├─ columns: [x y]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: xy\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -1023,16 +914,11 @@ where exists
 			" │   ├─ Table\n" +
 			" │   │   ├─ name: uv\n" +
 			" │   │   └─ columns: [u v]\n" +
-			" │   └─ IndexedTableAccess\n" +
+			" │   └─ IndexedTableAccess(pq)\n" +
 			" │       ├─ index: [pq.p]\n" +
-			" │       ├─ columns: [p q]\n" +
-			" │       └─ Table\n" +
-			" │           ├─ name: pq\n" +
-			" │           └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
-			"     ├─ index: [ab.a]\n" +
-			"     └─ Table\n" +
-			"         └─ name: ab\n" +
+			" │       └─ columns: [p q]\n" +
+			" └─ IndexedTableAccess(ab)\n" +
+			"     └─ index: [ab.a]\n" +
 			"",
 	},
 	{
@@ -1058,18 +944,12 @@ where exists (select * from pq where a = p)
 			" │       │   └─ uv.u:2!null\n" +
 			" │       ├─ Table\n" +
 			" │       │   └─ name: ab\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(uv)\n" +
 			" │           ├─ index: [uv.u]\n" +
-			" │           ├─ columns: [u v]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: uv\n" +
-			" │               └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │           └─ columns: [u v]\n" +
+			" └─ IndexedTableAccess(pq)\n" +
 			"     ├─ index: [pq.p]\n" +
-			"     ├─ columns: [p q]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pq\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [p q]\n" +
 			"",
 	},
 	{
@@ -1091,12 +971,9 @@ full join pq on a = p
 			"     │   ├─ Table\n" +
 			"     │   │   ├─ name: uv\n" +
 			"     │   │   └─ columns: [u v]\n" +
-			"     │   └─ IndexedTableAccess\n" +
+			"     │   └─ IndexedTableAccess(ab)\n" +
 			"     │       ├─ index: [ab.a]\n" +
-			"     │       ├─ columns: [a b]\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: ab\n" +
-			"     │           └─ projections: [0 1]\n" +
+			"     │       └─ columns: [a b]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: pq\n" +
 			"         └─ columns: [p q]\n" +
@@ -1161,16 +1038,11 @@ inner join pq on true
 			" │   │       │   └─ xy.x:2!null\n" +
 			" │   │       ├─ Table\n" +
 			" │   │       │   └─ name: ab\n" +
-			" │   │       └─ IndexedTableAccess\n" +
+			" │   │       └─ IndexedTableAccess(xy)\n" +
 			" │   │           ├─ index: [xy.x]\n" +
-			" │   │           ├─ columns: [x y]\n" +
-			" │   │           └─ Table\n" +
-			" │   │               ├─ name: xy\n" +
-			" │   │               └─ projections: [0 1]\n" +
-			" │   └─ IndexedTableAccess\n" +
-			" │       ├─ index: [pq.p]\n" +
-			" │       └─ Table\n" +
-			" │           └─ name: pq\n" +
+			" │   │           └─ columns: [x y]\n" +
+			" │   └─ IndexedTableAccess(pq)\n" +
+			" │       └─ index: [pq.p]\n" +
 			" └─ Table\n" +
 			"     ├─ name: uv\n" +
 			"     └─ columns: [u v]\n" +
@@ -1189,10 +1061,8 @@ inner join pq on true
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [mytable.i]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: mytable\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             └─ index: [mytable.i]\n" +
 			"",
 	},
 	{
@@ -1207,12 +1077,9 @@ inner join pq on true
 			"     │   └─ Table\n" +
 			"     │       └─ name: mytable\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1247,78 +1114,57 @@ inner join pq on true
 			"         │   ├─ Table\n" +
 			"         │   │   ├─ name: othertable\n" +
 			"         │   │   └─ columns: [i2]\n" +
-			"         │   └─ IndexedTableAccess\n" +
+			"         │   └─ IndexedTableAccess(mytable)\n" +
 			"         │       ├─ index: [mytable.i]\n" +
-			"         │       ├─ columns: [i]\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: mytable\n" +
-			"         │           └─ projections: [0]\n" +
+			"         │       └─ columns: [i]\n" +
 			"         └─ TableAlias(T4)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.i2]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk ORDER BY pk`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
 			" ├─ static: [{[NULL, ∞)}]\n" +
-			" ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: one_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5]\n" +
+			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM two_pk ORDER BY pk1, pk2`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: two_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5 6]\n" +
+			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM two_pk ORDER BY pk1`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: two_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5 6]\n" +
+			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
 		Query: `SELECT pk1 AS one, pk2 AS two FROM two_pk ORDER BY pk1, pk2`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT pk1 AS one, pk2 AS two FROM two_pk ORDER BY one, two`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -1334,24 +1180,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1370,25 +1210,19 @@ inner join pq on true
 			"             ├─ Table\n" +
 			"             │   ├─ name: othertable\n" +
 			"             │   └─ columns: [i2]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk_two_idx WHERE v1 < 2 AND v2 IS NOT NULL`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (NOT(one_pk_two_idx.v2:2 IS NULL))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
 			"     ├─ static: [{(NULL, 2), (NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_two_idx\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1397,24 +1231,18 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ one_pk_two_idx.v1:1\n" +
 			" │   └─ TUPLE(1 (tinyint), 2 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
 			"     ├─ static: [{[2, 2], (NULL, 2]}, {[1, 1], (NULL, 2]}]\n" +
-			"     ├─ columns: [pk v1 v2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_two_idx\n" +
-			"         └─ projections: [0 1 2]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk_three_idx WHERE v1 > 2 AND v2 = 3`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(one_pk_three_idx)\n" +
 			" ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			" ├─ static: [{(2, ∞), [3, 3], [NULL, ∞)}]\n" +
-			" ├─ columns: [pk v1 v2 v3]\n" +
-			" └─ Table\n" +
-			"     ├─ name: one_pk_three_idx\n" +
-			"     └─ projections: [0 1 2 3]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -1423,13 +1251,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ one_pk_three_idx.v3:3\n" +
 			" │   └─ 3 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			"     ├─ static: [{(2, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_three_idx\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -1454,12 +1279,9 @@ inner join pq on true
 			"                 ├─ Eq\n" +
 			"                 │   ├─ mytable.i:0!null\n" +
 			"                 │   └─ 2 (tinyint)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(mytable)\n" +
 			"                     ├─ index: [mytable.i]\n" +
-			"                     ├─ columns: [i]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: mytable\n" +
-			"                         └─ projections: [0]\n" +
+			"                     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1482,24 +1304,18 @@ inner join pq on true
 			"                 │   │   ├─ t2.i:0!null\n" +
 			"                 │   │   └─ 1 (tinyint)\n" +
 			"                 │   └─ TableAlias(t2)\n" +
-			"                 │       └─ IndexedTableAccess\n" +
+			"                 │       └─ IndexedTableAccess(mytable)\n" +
 			"                 │           ├─ index: [mytable.i]\n" +
 			"                 │           ├─ static: [{[1, 1]}]\n" +
-			"                 │           ├─ columns: [i]\n" +
-			"                 │           └─ Table\n" +
-			"                 │               ├─ name: mytable\n" +
-			"                 │               └─ projections: [0]\n" +
+			"                 │           └─ columns: [i]\n" +
 			"                 └─ Filter\n" +
 			"                     ├─ Eq\n" +
 			"                     │   ├─ t1.i:0!null\n" +
 			"                     │   └─ 2 (tinyint)\n" +
 			"                     └─ TableAlias(t1)\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(mytable)\n" +
 			"                             ├─ index: [mytable.i]\n" +
-			"                             ├─ columns: [i]\n" +
-			"                             └─ Table\n" +
-			"                                 ├─ name: mytable\n" +
-			"                                 └─ projections: [0]\n" +
+			"                             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1515,25 +1331,19 @@ inner join pq on true
 			"     │   │   ├─ t1.i:0!null\n" +
 			"     │   │   └─ 2 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t2.i:0!null\n" +
 			"         │   └─ 1 (tinyint)\n" +
 			"         └─ TableAlias(t2)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
 			"                 ├─ static: [{[NULL, ∞)}]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1549,24 +1359,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1582,24 +1386,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1615,24 +1413,18 @@ inner join pq on true
 			"     │   │   ├─ t2.i:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t2)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [i]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t1.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(t1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1646,12 +1438,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1670,18 +1459,12 @@ inner join pq on true
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(mytable)\n" +
 			"         │   ├─ index: [mytable.s,mytable.i]\n" +
-			"         │   ├─ columns: [i s]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: mytable\n" +
-			"         │       └─ projections: [0 1]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   └─ columns: [i s]\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -1701,18 +1484,12 @@ inner join pq on true
 			"     │       ├─ name: othertable\n" +
 			"     │       └─ columns: [s2 i2]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(mytable)\n" +
 			"         │   ├─ index: [mytable.s,mytable.i]\n" +
-			"         │   ├─ columns: [i s]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: mytable\n" +
-			"         │       └─ projections: [0 1]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   └─ columns: [i s]\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -1731,18 +1508,12 @@ inner join pq on true
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i s]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(othertable)\n" +
 			"         │   ├─ index: [othertable.s2]\n" +
-			"         │   ├─ columns: [s2 i2]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: othertable\n" +
-			"         │       └─ projections: [0 1]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         │   └─ columns: [s2 i2]\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1765,25 +1536,16 @@ inner join pq on true
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i s]\n" +
 			"     └─ Concat\n" +
-			"         ├─ IndexedTableAccess\n" +
+			"         ├─ IndexedTableAccess(othertable)\n" +
 			"         │   ├─ index: [othertable.s2]\n" +
-			"         │   ├─ columns: [s2 i2]\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: othertable\n" +
-			"         │       └─ projections: [0 1]\n" +
+			"         │   └─ columns: [s2 i2]\n" +
 			"         └─ Concat\n" +
-			"             ├─ IndexedTableAccess\n" +
+			"             ├─ IndexedTableAccess(othertable)\n" +
 			"             │   ├─ index: [othertable.s2]\n" +
-			"             │   ├─ columns: [s2 i2]\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: othertable\n" +
-			"             │       └─ projections: [0 1]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   └─ columns: [s2 i2]\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.i2]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1798,12 +1560,9 @@ inner join pq on true
 			" │       ├─ Table\n" +
 			" │       │   ├─ name: othertable\n" +
 			" │       │   └─ columns: [s2 i2]\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(mytable)\n" +
 			" │           ├─ index: [mytable.i]\n" +
-			" │           ├─ columns: [i]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: mytable\n" +
-			" │               └─ projections: [0]\n" +
+			" │           └─ columns: [i]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [mytable.i:2!null, othertable.i2:1!null, othertable.s2:0!null]\n" +
 			"     └─ LookupJoin\n" +
@@ -1813,12 +1572,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: othertable\n" +
 			"         │   └─ columns: [s2 i2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1842,19 +1598,13 @@ inner join pq on true
 			"     │           ├─ Table\n" +
 			"     │           │   ├─ name: othertable\n" +
 			"     │           │   └─ columns: [s2 i2]\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ TableAlias(ot)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1878,19 +1628,13 @@ inner join pq on true
 			"     │           ├─ Table\n" +
 			"     │           │   ├─ name: othertable\n" +
 			"     │           │   └─ columns: [s2 i2]\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ TableAlias(ot)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -1906,13 +1650,10 @@ inner join pq on true
 			"     │   │   ├─ ot.i2:1!null\n" +
 			"     │   │   └─ 0 (tinyint)\n" +
 			"     │   └─ TableAlias(ot)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(othertable)\n" +
 			"     │           ├─ index: [othertable.i2]\n" +
 			"     │           ├─ static: [{(0, ∞)}]\n" +
-			"     │           ├─ columns: [s2 i2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: othertable\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [s2 i2]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(ot.i2:1!null)\n" +
 			"         ├─ target: TUPLE(sub.i:0!null)\n" +
@@ -1937,12 +1678,9 @@ inner join pq on true
 			"                         │   └─ Table\n" +
 			"                         │       ├─ name: othertable\n" +
 			"                         │       └─ columns: [s2 i2]\n" +
-			"                         └─ IndexedTableAccess\n" +
+			"                         └─ IndexedTableAccess(mytable)\n" +
 			"                             ├─ index: [mytable.i]\n" +
-			"                             ├─ columns: [i]\n" +
-			"                             └─ Table\n" +
-			"                                 ├─ name: mytable\n" +
-			"                                 └─ projections: [0]\n" +
+			"                             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -1960,12 +1698,9 @@ inner join pq on true
 			" │   │       ├─ name: one_pk\n" +
 			" │   │       └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" │   └─ TableAlias(k)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(one_pk)\n" +
 			" │           ├─ index: [one_pk.pk]\n" +
-			" │           ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: one_pk\n" +
-			" │               └─ projections: [0 1 2 3 4 5]\n" +
+			" │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" └─ HashLookup\n" +
 			"     ├─ source: TUPLE(i.pk:0!null)\n" +
 			"     ├─ target: TUPLE(j.pk:0!null)\n" +
@@ -1996,12 +1731,9 @@ inner join pq on true
 			" │   │       ├─ name: one_pk\n" +
 			" │   │       └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" │   └─ TableAlias(k)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(one_pk)\n" +
 			" │           ├─ index: [one_pk.pk]\n" +
-			" │           ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: one_pk\n" +
-			" │               └─ projections: [0 1 2 3 4 5]\n" +
+			" │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			" └─ HashLookup\n" +
 			"     ├─ source: TUPLE(i.pk:0!null)\n" +
 			"     ├─ target: TUPLE(j.pk:0!null)\n" +
@@ -2045,19 +1777,13 @@ inner join pq on true
 			"                 │           ├─ Table\n" +
 			"                 │           │   ├─ name: othertable\n" +
 			"                 │           │   └─ columns: [s2 i2]\n" +
-			"                 │           └─ IndexedTableAccess\n" +
+			"                 │           └─ IndexedTableAccess(mytable)\n" +
 			"                 │               ├─ index: [mytable.i]\n" +
-			"                 │               ├─ columns: [i]\n" +
-			"                 │               └─ Table\n" +
-			"                 │                   ├─ name: mytable\n" +
-			"                 │                   └─ projections: [0]\n" +
+			"                 │               └─ columns: [i]\n" +
 			"                 └─ TableAlias(ot)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(othertable)\n" +
 			"                         ├─ index: [othertable.i2]\n" +
-			"                         ├─ columns: [s2 i2]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: othertable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2075,10 +1801,8 @@ inner join pq on true
 			"     │   ├─ TableAlias(selfjoin)\n" +
 			"     │   │   └─ Table\n" +
 			"     │   │       └─ name: mytable\n" +
-			"     │   └─ IndexedTableAccess\n" +
-			"     │       ├─ index: [mytable.i]\n" +
-			"     │       └─ Table\n" +
-			"     │           └─ name: mytable\n" +
+			"     │   └─ IndexedTableAccess(mytable)\n" +
+			"     │       └─ index: [mytable.i]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -2098,12 +1822,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: othertable\n" +
 			" │   └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2117,12 +1838,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.i2]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2136,12 +1854,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.i2]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2155,12 +1870,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: mytable\n" +
 			"     │   └─ columns: [i]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.i2]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2175,12 +1887,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: mytable\n" +
 			"         │   └─ columns: [i]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -2194,12 +1903,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2211,12 +1917,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: othertable\n" +
 			" │   └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2232,12 +1935,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2256,12 +1956,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2277,12 +1974,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2300,12 +1994,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2324,12 +2015,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2413,13 +2101,10 @@ inner join pq on true
 		ExpectedPlan: "Filter\n" +
 			" ├─ (NOT(a.s:1!null IS NULL))\n" +
 			" └─ TableAlias(a)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.s]\n" +
 			"         ├─ static: [{(NULL, ∞)}]\n" +
-			"         ├─ columns: [i s]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2437,12 +2122,9 @@ inner join pq on true
 			"     └─ Filter\n" +
 			"         ├─ (NOT(a.s:1!null IS NULL))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2460,12 +2142,9 @@ inner join pq on true
 			"     └─ Filter\n" +
 			"         ├─ (NOT(a.s:1!null IS NULL))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2486,12 +2165,9 @@ inner join pq on true
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext), 4 (longtext))\n" +
 			"         │  ))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2511,12 +2187,9 @@ inner join pq on true
 			"         │   ├─ a.i:0!null\n" +
 			"         │   └─ TUPLE(1 (tinyint), 2 (tinyint), 3 (tinyint), 4 (tinyint))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2525,13 +2198,10 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(1 (tinyint), 2 (tinyint), 3 (tinyint), 4 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
 			"     ├─ static: [{[2, 2]}, {[3, 3]}, {[4, 4]}, {[1, 1]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2540,24 +2210,18 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(NULL (bigint), 2 (tinyint), 3 (tinyint), 4 (tinyint))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
 			"     ├─ static: [{[3, 3]}, {[4, 4]}, {[2, 2]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM mytable WHERE i in (1+2)`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(mytable)\n" +
 			" ├─ index: [mytable.i]\n" +
 			" ├─ static: [{[3, 3]}]\n" +
-			" ├─ columns: [i s]\n" +
-			" └─ Table\n" +
-			"     ├─ name: mytable\n" +
-			"     └─ projections: [0 1]\n" +
+			" └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2697,13 +2361,10 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.s:1!null\n" +
 			" │   └─ TUPLE(first row (longtext))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s]\n" +
 			"     ├─ static: [{[first row, first row]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2712,13 +2373,10 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ mytable.s:1!null\n" +
 			" │   └─ TUPLE(second row (longtext), FIRST ROW (longtext))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s]\n" +
 			"     ├─ static: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
-			"     ├─ columns: [i s]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2748,12 +2406,9 @@ inner join pq on true
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2867,13 +2522,10 @@ inner join pq on true
 			"     │   │   ├─ a.i:0!null\n" +
 			"     │   │   └─ TUPLE(2 (tinyint), 432 (smallint), 7 (tinyint))\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
 			"     │           ├─ static: [{[432, 432]}, {[7, 7]}, {[2, 2]}]\n" +
-			"     │           ├─ columns: [i s]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ Table\n" +
 			"             └─ name: mytable\n" +
@@ -2900,12 +2552,9 @@ inner join pq on true
 			"     │       │   ├─ c.i:0!null\n" +
 			"     │       │   └─ 2 (tinyint)\n" +
 			"     │       └─ TableAlias(c)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(c.i:1!null)\n" +
 			"         ├─ target: TUPLE(b.i:0!null)\n" +
@@ -2919,12 +2568,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2964,12 +2610,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -2990,19 +2633,13 @@ inner join pq on true
 			"     │   │   │       ├─ name: mytable\n" +
 			"     │   │   │       └─ columns: [i]\n" +
 			"     │   │   └─ TableAlias(b)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
-			"     │   │           ├─ columns: [i]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [i]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
-			"     │           ├─ columns: [i s]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
 			"         └─ Table\n" +
 			"             └─ name: mytable\n" +
@@ -3021,12 +2658,9 @@ inner join pq on true
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3047,18 +2681,12 @@ inner join pq on true
 			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ Concat\n" +
-			"             ├─ IndexedTableAccess\n" +
+			"             ├─ IndexedTableAccess(mytable)\n" +
 			"             │   ├─ index: [mytable.i]\n" +
-			"             │   ├─ columns: [i s]\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: mytable\n" +
-			"             │       └─ projections: [0 1]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             │   └─ columns: [i s]\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3161,12 +2789,9 @@ inner join pq on true
 			"     │       │   ├─ c.i:0!null\n" +
 			"     │       │   └─ 2 (tinyint)\n" +
 			"     │       └─ TableAlias(c)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(mytable)\n" +
 			"     │               ├─ index: [mytable.i]\n" +
-			"     │               ├─ columns: [i]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: mytable\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [i]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(c.i:1!null)\n" +
 			"         ├─ target: TUPLE(b.i:0!null)\n" +
@@ -3180,12 +2805,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3225,12 +2847,9 @@ inner join pq on true
 			"                 │       ├─ name: mytable\n" +
 			"                 │       └─ columns: [i]\n" +
 			"                 └─ TableAlias(a)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(mytable)\n" +
 			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ columns: [i s]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: mytable\n" +
-			"                             └─ projections: [0 1]\n" +
+			"                         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3251,19 +2870,13 @@ inner join pq on true
 			"     │   │   │       ├─ name: mytable\n" +
 			"     │   │   │       └─ columns: [s]\n" +
 			"     │   │   └─ TableAlias(b)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.s]\n" +
-			"     │   │           ├─ columns: [i s]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0 1]\n" +
+			"     │   │           └─ columns: [i s]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
 			"     │           ├─ index: [mytable.i]\n" +
-			"     │           ├─ columns: [i s]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
 			"         └─ Table\n" +
 			"             └─ name: mytable\n" +
@@ -3284,12 +2897,9 @@ inner join pq on true
 			"     └─ Filter\n" +
 			"         ├─ (a.i:0!null BETWEEN 10 (tinyint) AND 20 (tinyint))\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3342,12 +2952,9 @@ inner join pq on true
 			" │   └─ Table\n" +
 			" │       ├─ name: othertable\n" +
 			" │       └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3363,12 +2970,9 @@ inner join pq on true
 			" │   └─ Table\n" +
 			" │       ├─ name: othertable\n" +
 			" │       └─ columns: [s2 i2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3381,13 +2985,10 @@ inner join pq on true
 			"     ├─ Eq\n" +
 			"     │   ├─ othertable.s2:0!null\n" +
 			"     │   └─ a (longtext)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(othertable)\n" +
 			"         ├─ index: [othertable.s2]\n" +
 			"         ├─ static: [{[a, a]}]\n" +
-			"         ├─ columns: [s2 i2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3408,13 +3009,10 @@ inner join pq on true
 			"             ├─ Eq\n" +
 			"             │   ├─ othertable.s2:0!null\n" +
 			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.s2]\n" +
 			"                 ├─ static: [{[a, a]}]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3431,19 +3029,13 @@ inner join pq on true
 			" │       ├─ GreaterThan\n" +
 			" │       │   ├─ othertable.s2:0!null\n" +
 			" │       │   └─ a (longtext)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(othertable)\n" +
 			" │           ├─ index: [othertable.s2]\n" +
 			" │           ├─ static: [{(a, ∞)}]\n" +
-			" │           ├─ columns: [s2 i2]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: othertable\n" +
-			" │               └─ projections: [0 1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │           └─ columns: [s2 i2]\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ columns: [i]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ projections: [0]\n" +
+			"     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3461,10 +3053,8 @@ inner join pq on true
 			" │           └─ Table\n" +
 			" │               ├─ name: othertable\n" +
 			" │               └─ columns: [i2]\n" +
-			" └─ IndexedTableAccess\n" +
-			"     ├─ index: [mytable.i]\n" +
-			"     └─ Table\n" +
-			"         └─ name: mytable\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
+			"     └─ index: [mytable.i]\n" +
 			"",
 	},
 	{
@@ -3477,10 +3067,8 @@ inner join pq on true
 			" │   └─ Table\n" +
 			" │       ├─ name: othertable\n" +
 			" │       └─ columns: [i2]\n" +
-			" └─ IndexedTableAccess\n" +
-			"     ├─ index: [mytable.i]\n" +
-			"     └─ Table\n" +
-			"         └─ name: mytable\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
+			"     └─ index: [mytable.i]\n" +
 			"",
 	},
 	{
@@ -3494,12 +3082,9 @@ inner join pq on true
 			" │           ├─ Eq\n" +
 			" │           │   ├─ mytable.i:0!null\n" +
 			" │           │   └─ othertable.i2:2!null\n" +
-			" │           └─ IndexedTableAccess\n" +
+			" │           └─ IndexedTableAccess(othertable)\n" +
 			" │               ├─ index: [othertable.i2]\n" +
-			" │               ├─ columns: [i2]\n" +
-			" │               └─ Table\n" +
-			" │                   ├─ name: othertable\n" +
-			" │                   └─ projections: [1]\n" +
+			" │               └─ columns: [i2]\n" +
 			" └─ Table\n" +
 			"     └─ name: mytable\n" +
 			"",
@@ -3521,12 +3106,9 @@ inner join pq on true
 			"         │   ├─ mt.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(mt)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3544,12 +3126,9 @@ inner join pq on true
 			" │       ├─ name: mytable\n" +
 			" │       └─ columns: [i s]\n" +
 			" └─ TableAlias(o)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0 1 2 3 4 5]\n" +
+			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -3563,12 +3142,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: othertable\n" +
 			"     │   └─ columns: [s2 i2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ columns: [i]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3588,12 +3164,9 @@ inner join pq on true
 			"         │       ├─ name: othertable\n" +
 			"         │       └─ columns: [s2 i2]\n" +
 			"         └─ TableAlias(mt)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3625,12 +3198,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3672,12 +3242,9 @@ inner join pq on true
 			" │       ├─ name: one_pk\n" +
 			" │       └─ columns: [pk]\n" +
 			" └─ TableAlias(tpk)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3693,12 +3260,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3712,12 +3276,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3731,12 +3292,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3748,12 +3306,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -3771,12 +3326,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: two_pk\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -3785,13 +3337,10 @@ inner join pq on true
 			" ├─ name: othertable_alias\n" +
 			" ├─ outerVisibility: false\n" +
 			" ├─ cacheable: true\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
 			"     ├─ index: [othertable.i2]\n" +
 			"     ├─ static: [{[1, 1]}]\n" +
-			"     ├─ columns: [s2 i2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: othertable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3800,13 +3349,10 @@ inner join pq on true
 			" ├─ name: othertable_alias\n" +
 			" ├─ outerVisibility: false\n" +
 			" ├─ cacheable: true\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
 			"     ├─ index: [othertable.i2]\n" +
 			"     ├─ static: [{[1, 1]}]\n" +
-			"     ├─ columns: [s2 i2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: othertable\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -3842,13 +3388,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ datetime_table.date_col:1\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.date_col]\n" +
 			"     ├─ static: [{[2020-01-01, 2020-01-01]}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3857,13 +3400,10 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ datetime_table.date_col:1\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.date_col]\n" +
 			"     ├─ static: [{(2020-01-01, ∞)}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3872,13 +3412,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ datetime_table.datetime_col:2\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.datetime_col]\n" +
 			"     ├─ static: [{[2020-01-01, 2020-01-01]}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3887,13 +3424,10 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ datetime_table.datetime_col:2\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.datetime_col]\n" +
 			"     ├─ static: [{(2020-01-01, ∞)}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3902,13 +3436,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ datetime_table.timestamp_col:3\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.timestamp_col]\n" +
 			"     ├─ static: [{[2020-01-01, 2020-01-01]}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3917,13 +3448,10 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ datetime_table.timestamp_col:3\n" +
 			" │   └─ 2020-01-01 (longtext)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(datetime_table)\n" +
 			"     ├─ index: [datetime_table.timestamp_col]\n" +
 			"     ├─ static: [{(2020-01-01, ∞)}]\n" +
-			"     ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: datetime_table\n" +
-			"         └─ projections: [0 1 2 3 4]\n" +
+			"     └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3939,12 +3467,9 @@ inner join pq on true
 			"     │       ├─ name: datetime_table\n" +
 			"     │       └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"     └─ TableAlias(dt1)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(datetime_table)\n" +
 			"             ├─ index: [datetime_table.timestamp_col]\n" +
-			"             ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: datetime_table\n" +
-			"                 └─ projections: [0 1 2 3 4]\n" +
+			"             └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3960,12 +3485,9 @@ inner join pq on true
 			"     │       ├─ name: datetime_table\n" +
 			"     │       └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"     └─ TableAlias(dt1)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(datetime_table)\n" +
 			"             ├─ index: [datetime_table.date_col]\n" +
-			"             ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: datetime_table\n" +
-			"                 └─ projections: [0 1 2 3 4]\n" +
+			"             └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -3981,12 +3503,9 @@ inner join pq on true
 			"     │       ├─ name: datetime_table\n" +
 			"     │       └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"     └─ TableAlias(dt1)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(datetime_table)\n" +
 			"             ├─ index: [datetime_table.datetime_col]\n" +
-			"             ├─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: datetime_table\n" +
-			"                 └─ projections: [0 1 2 3 4]\n" +
+			"             └─ columns: [i date_col datetime_col timestamp_col time_col]\n" +
 			"",
 	},
 	{
@@ -4005,12 +3524,9 @@ inner join pq on true
 			"         │       ├─ name: datetime_table\n" +
 			"         │       └─ columns: [timestamp_col]\n" +
 			"         └─ TableAlias(dt1)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(datetime_table)\n" +
 			"                 ├─ index: [datetime_table.date_col]\n" +
-			"                 ├─ columns: [i date_col]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: datetime_table\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i date_col]\n" +
 			"",
 	},
 	{
@@ -4051,12 +3567,9 @@ inner join pq on true
 			"             │       ├─ name: datetime_table\n" +
 			"             │       └─ columns: [timestamp_col]\n" +
 			"             └─ TableAlias(dt1)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(datetime_table)\n" +
 			"                     ├─ index: [datetime_table.date_col]\n" +
-			"                     ├─ columns: [i date_col]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: datetime_table\n" +
-			"                         └─ projections: [0 1]\n" +
+			"                     └─ columns: [i date_col]\n" +
 			"",
 	},
 	{
@@ -4085,19 +3598,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4127,19 +3634,13 @@ inner join pq on true
 			"     │   │   └─ Table\n" +
 			"     │   │       ├─ name: two_pk\n" +
 			"     │   │       └─ columns: [pk1 pk2]\n" +
-			"     │   └─ IndexedTableAccess\n" +
+			"     │   └─ IndexedTableAccess(one_pk)\n" +
 			"     │       ├─ index: [one_pk.pk]\n" +
-			"     │       ├─ columns: [pk]\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: one_pk\n" +
-			"     │           └─ projections: [0]\n" +
+			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4169,19 +3670,13 @@ inner join pq on true
 			"     │   │   └─ Table\n" +
 			"     │   │       ├─ name: two_pk\n" +
 			"     │   │       └─ columns: [pk1 pk2]\n" +
-			"     │   └─ IndexedTableAccess\n" +
+			"     │   └─ IndexedTableAccess(one_pk)\n" +
 			"     │       ├─ index: [one_pk.pk]\n" +
-			"     │       ├─ columns: [pk]\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: one_pk\n" +
-			"     │           └─ projections: [0]\n" +
+			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4212,19 +3707,13 @@ inner join pq on true
 			"         │   │   ├─ name: one_pk\n" +
 			"         │   │   └─ columns: [pk]\n" +
 			"         │   └─ TableAlias(tpk2)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(two_pk)\n" +
 			"         │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │           ├─ columns: [pk1 pk2]\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: two_pk\n" +
-			"         │               └─ projections: [0 1]\n" +
+			"         │           └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(tpk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4253,19 +3742,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4294,19 +3777,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4335,19 +3812,13 @@ inner join pq on true
 			"     │   │   ├─ name: one_pk\n" +
 			"     │   │   └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(tpk)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(two_pk)\n" +
 			"     │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │           ├─ columns: [pk1 pk2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: two_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(tpk2)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4384,12 +3855,9 @@ inner join pq on true
 			"                 │   └─ Table\n" +
 			"                 │       ├─ name: two_pk\n" +
 			"                 │       └─ columns: [pk1 pk2]\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(one_pk)\n" +
 			"                     ├─ index: [one_pk.pk]\n" +
-			"                     ├─ columns: [pk]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: one_pk\n" +
-			"                         └─ projections: [0]\n" +
+			"                     └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4405,12 +3873,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: mytable\n" +
 			" │   └─ columns: [i]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4422,12 +3887,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ columns: [pk1 pk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: two_pk\n" +
-			"         └─ projections: [0 1]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4439,12 +3901,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i]\n" +
-			"     ├─ columns: [i f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4458,12 +3917,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: niltable\n" +
 			"     │   └─ columns: [i f]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4492,12 +3948,9 @@ inner join pq on true
 			"                 │   └─ Table\n" +
 			"                 │       ├─ name: niltable\n" +
 			"                 │       └─ columns: [i]\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(one_pk)\n" +
 			"                     ├─ index: [one_pk.pk]\n" +
-			"                     ├─ columns: [pk]\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: one_pk\n" +
-			"                         └─ projections: [0]\n" +
+			"                     └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4511,12 +3964,9 @@ inner join pq on true
 			" ├─ Table\n" +
 			" │   ├─ name: one_pk\n" +
 			" │   └─ columns: [pk]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i]\n" +
-			"     ├─ columns: [i f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4534,12 +3984,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: niltable\n" +
 			"     │   └─ columns: [i f]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4553,12 +4000,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4576,12 +4020,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: one_pk\n" +
 			"         │   └─ columns: [pk]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 3]\n" +
+			"             └─ columns: [i i2 f]\n" +
 			"",
 	},
 	{
@@ -4597,12 +4038,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4620,12 +4058,9 @@ inner join pq on true
 			"     │   └─ Table\n" +
 			"     │       ├─ name: one_pk\n" +
 			"     │       └─ columns: [pk c1]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4641,12 +4076,9 @@ inner join pq on true
 			"     │   └─ Table\n" +
 			"     │       ├─ name: niltable\n" +
 			"     │       └─ columns: [i f]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4655,19 +4087,13 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ one_pk.pk:0!null\n" +
 			" │   └─ niltable.i:1!null\n" +
-			" ├─ IndexedTableAccess\n" +
+			" ├─ IndexedTableAccess(one_pk)\n" +
 			" │   ├─ index: [one_pk.pk]\n" +
 			" │   ├─ static: [{(1, ∞)}]\n" +
-			" │   ├─ columns: [pk]\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: one_pk\n" +
-			" │       └─ projections: [0]\n" +
-			" └─ IndexedTableAccess\n" +
+			" │   └─ columns: [pk]\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i]\n" +
-			"     ├─ columns: [i f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -4682,12 +4108,9 @@ inner join pq on true
 			"         │       ├─ name: niltable\n" +
 			"         │       └─ columns: [i2]\n" +
 			"         └─ TableAlias(l)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(niltable)\n" +
 			"                 ├─ index: [niltable.i2]\n" +
-			"                 ├─ columns: [i i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: niltable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i i2]\n" +
 			"",
 	},
 	{
@@ -4705,12 +4128,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: niltable\n" +
 			"         │   └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4724,12 +4144,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: two_pk\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4743,12 +4160,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: two_pk\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ columns: [pk]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: one_pk\n" +
-			"             └─ projections: [0]\n" +
+			"         └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -4769,12 +4183,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4795,12 +4206,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4821,12 +4229,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4845,12 +4250,9 @@ inner join pq on true
 			"     │       ├─ name: two_pk\n" +
 			"     │       └─ columns: [pk1 pk2]\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4871,12 +4273,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4897,12 +4296,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -4917,12 +4313,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: two_pk\n" +
 			"         │   └─ columns: [pk1 pk2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk c5]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0 5]\n" +
+			"             └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -4939,12 +4332,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(opk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk c5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0 5]\n" +
+			"                 └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -4961,12 +4351,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(opk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk c5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0 5]\n" +
+			"                 └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -4983,12 +4370,9 @@ inner join pq on true
 			"         │       ├─ name: two_pk\n" +
 			"         │       └─ columns: [pk1 pk2]\n" +
 			"         └─ TableAlias(opk)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk c5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0 5]\n" +
+			"                 └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -5003,12 +4387,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: two_pk\n" +
 			"         │   └─ columns: [pk1 pk2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk c5]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0 5]\n" +
+			"             └─ columns: [pk c5]\n" +
 			"",
 	},
 	{
@@ -5017,13 +4398,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ niltable.i2:1\n" +
 			" │   └─ NULL (null)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{(∞, ∞)}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -5033,13 +4411,10 @@ inner join pq on true
 			" │   ├─ niltable.i2:1\n" +
 			" │   └─ NULL (null)\n" +
 			" │  ))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{(∞, ∞)}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -5048,26 +4423,20 @@ inner join pq on true
 			" ├─ GreaterThan\n" +
 			" │   ├─ niltable.i2:1\n" +
 			" │   └─ NULL (null)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{(∞, ∞)}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM niltable WHERE i2 <=> NULL`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ (niltable.i2:1 <=> NULL (null))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(niltable)\n" +
 			"     ├─ index: [niltable.i2]\n" +
 			"     ├─ static: [{[NULL, NULL]}]\n" +
-			"     ├─ columns: [i i2 b f]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: niltable\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -5080,12 +4449,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -5100,12 +4466,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: one_pk\n" +
 			"         │   └─ columns: [pk]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 3]\n" +
+			"             └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -5115,19 +4478,13 @@ inner join pq on true
 			"     ├─ Eq\n" +
 			"     │   ├─ one_pk.pk:0!null\n" +
 			"     │   └─ niltable.i:1!null\n" +
-			"     ├─ IndexedTableAccess\n" +
+			"     ├─ IndexedTableAccess(one_pk)\n" +
 			"     │   ├─ index: [one_pk.pk]\n" +
 			"     │   ├─ static: [{(1, ∞)}]\n" +
-			"     │   ├─ columns: [pk]\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: one_pk\n" +
-			"     │       └─ projections: [0]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     │   └─ columns: [pk]\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 3]\n" +
+			"         └─ columns: [i f]\n" +
 			"",
 	},
 	{
@@ -5142,12 +4499,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: niltable\n" +
 			"         │   └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5164,12 +4518,9 @@ inner join pq on true
 			"         │   └─ Table\n" +
 			"         │       ├─ name: niltable\n" +
 			"         │       └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5188,12 +4539,9 @@ inner join pq on true
 			"             ├─ Table\n" +
 			"             │   ├─ name: niltable\n" +
 			"             │   └─ columns: [i f]\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
-			"                 ├─ columns: [pk]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: one_pk\n" +
-			"                     └─ projections: [0]\n" +
+			"                 └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5212,12 +4560,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: niltable\n" +
 			"         │   └─ columns: [i f]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5234,12 +4579,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5286,12 +4628,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5304,12 +4643,9 @@ inner join pq on true
 			"     ├─ Table\n" +
 			"     │   ├─ name: one_pk\n" +
 			"     │   └─ columns: [pk]\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ columns: [pk1 pk2]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ projections: [0 1]\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5328,12 +4664,9 @@ inner join pq on true
 			"         ├─ Table\n" +
 			"         │   ├─ name: two_pk\n" +
 			"         │   └─ columns: [pk1 pk2]\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -5352,12 +4685,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk\n" +
 			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5376,12 +4706,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk\n" +
 			"     │       └─ columns: [pk]\n" +
 			"     └─ TableAlias(tpk)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ columns: [pk1 pk2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: two_pk\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5459,13 +4786,10 @@ inner join pq on true
 			"     │   │   ├─ t1.pk:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ t2.pk2:0!null\n" +
@@ -5485,13 +4809,10 @@ inner join pq on true
 			"     │   │   ├─ t1.pk:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ Filter\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
@@ -5501,13 +4822,10 @@ inner join pq on true
 			"         │       ├─ t2.pk1:0!null\n" +
 			"         │       └─ 1 (tinyint)\n" +
 			"         └─ TableAlias(t2)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"                 ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -5524,13 +4842,10 @@ inner join pq on true
 			"     │   │       ├─ Eq\n" +
 			"     │   │       │   ├─ mytable.i:2!null\n" +
 			"     │   │       │   └─ mt.i:0!null\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
 			"     │   │           ├─ static: [{(2, ∞)}]\n" +
-			"     │   │           ├─ columns: [i]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [i]\n" +
 			"     │   │   IS NULL))\n" +
 			"     │   └─ (NOT(Subquery\n" +
 			"     │       ├─ cacheable: false\n" +
@@ -5538,12 +4853,9 @@ inner join pq on true
 			"     │           ├─ Eq\n" +
 			"     │           │   ├─ othertable.i2:2!null\n" +
 			"     │           │   └─ mt.i:0!null\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(othertable)\n" +
 			"     │               ├─ index: [othertable.i2]\n" +
-			"     │               ├─ columns: [i2]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: othertable\n" +
-			"     │                   └─ projections: [1]\n" +
+			"     │               └─ columns: [i2]\n" +
 			"     │       IS NULL))\n" +
 			"     └─ TableAlias(mt)\n" +
 			"         └─ Table\n" +
@@ -5564,12 +4876,9 @@ inner join pq on true
 			"     │   │       ├─ Eq\n" +
 			"     │   │       │   ├─ mytable.i:2!null\n" +
 			"     │   │       │   └─ mt.i:0!null\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
-			"     │   │           ├─ columns: [i]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [i]\n" +
 			"     │   │   IS NULL))\n" +
 			"     │   └─ (NOT(Subquery\n" +
 			"     │       ├─ cacheable: false\n" +
@@ -5581,12 +4890,9 @@ inner join pq on true
 			"     │           │   └─ GreaterThan\n" +
 			"     │           │       ├─ mt.i:0!null\n" +
 			"     │           │       └─ 2 (tinyint)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(othertable)\n" +
 			"     │               ├─ index: [othertable.i2]\n" +
-			"     │               ├─ columns: [i2]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: othertable\n" +
-			"     │                   └─ projections: [1]\n" +
+			"     │               └─ columns: [i2]\n" +
 			"     │       IS NULL))\n" +
 			"     └─ TableAlias(mt)\n" +
 			"         └─ Table\n" +
@@ -5600,13 +4906,10 @@ inner join pq on true
 			"     ├─ columns: [t1.pk:0!null, t2.pk2:7!null, Subquery\n" +
 			"     │   ├─ cacheable: true\n" +
 			"     │   └─ Limit(1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     │   as (SELECT pk from one_pk where pk = 1 limit 1)]\n" +
 			"     └─ CrossJoin\n" +
 			"         ├─ Filter\n" +
@@ -5614,11 +4917,9 @@ inner join pq on true
 			"         │   │   ├─ t1.pk:0!null\n" +
 			"         │   │   └─ 1 (tinyint)\n" +
 			"         │   └─ TableAlias(t1)\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(one_pk)\n" +
 			"         │           ├─ index: [one_pk.pk]\n" +
-			"         │           ├─ static: [{[1, 1]}]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: one_pk\n" +
+			"         │           └─ static: [{[1, 1]}]\n" +
 			"         └─ Filter\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ t2.pk2:1!null\n" +
@@ -5642,13 +4943,10 @@ inner join pq on true
 			"             │   ├─ othertable.s2:0!null\n" +
 			"             │   └─ second (longtext)\n" +
 			"             │  ))\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
 			"                 ├─ index: [othertable.s2]\n" +
 			"                 ├─ static: [{(second, ∞)}, {(NULL, second)}]\n" +
-			"                 ├─ columns: [s2 i2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -5683,13 +4981,10 @@ inner join pq on true
 			"         ├─ row_number() over ( order by othertable.s2 ASC)\n" +
 			"         ├─ othertable.i2:1!null\n" +
 			"         ├─ othertable.s2:0!null\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
 			"             ├─ static: [{(NULL, 2)}, {(2, ∞)}]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -5771,11 +5066,9 @@ inner join pq on true
 		Query: `DELETE FROM two_pk WHERE pk1 = 1 AND pk2 = 2`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[1, 1], [2, 2]}]\n" +
-			"         └─ Table\n" +
-			"             └─ name: two_pk\n" +
+			"         └─ static: [{[1, 1], [2, 2]}]\n" +
 			"",
 	},
 	{
@@ -5796,11 +5089,9 @@ inner join pq on true
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET two_pk.c1:2!null = 1 (tinyint))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             ├─ static: [{[1, 1], [2, 2]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: two_pk\n" +
+			"             └─ static: [{[1, 1], [2, 2]}]\n" +
 			"",
 	},
 	{
@@ -5853,12 +5144,9 @@ inner join pq on true
 			"     │       ├─ name: invert_pk\n" +
 			"     │       └─ columns: [z]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ columns: [x y z]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: invert_pk\n" +
-			"                 └─ projections: [0 1 2]\n" +
+			"             └─ columns: [x y z]\n" +
 			"",
 	},
 	{
@@ -5878,56 +5166,41 @@ inner join pq on true
 			"         │   ├─ a.z:2!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(invert_pk)\n" +
 			"                 ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"                 ├─ columns: [x y z]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: invert_pk\n" +
-			"                     └─ projections: [0 1 2]\n" +
+			"                 └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM invert_pk WHERE y = 0`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
 			" ├─ static: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [x y z]\n" +
-			" └─ Table\n" +
-			"     ├─ name: invert_pk\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM invert_pk WHERE y >= 0`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
 			" ├─ static: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ columns: [x y z]\n" +
-			" └─ Table\n" +
-			"     ├─ name: invert_pk\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM invert_pk WHERE y >= 0 AND z < 1`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
 			" ├─ static: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
-			" ├─ columns: [x y z]\n" +
-			" └─ Table\n" +
-			"     ├─ name: invert_pk\n" +
-			"     └─ projections: [0 1 2]\n" +
+			" └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM one_pk WHERE pk IN (1)`,
-		ExpectedPlan: "IndexedTableAccess\n" +
+		ExpectedPlan: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
 			" ├─ static: [{[1, 1]}]\n" +
-			" ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			" └─ Table\n" +
-			"     ├─ name: one_pk\n" +
-			"     └─ projections: [0 1 2 3 4 5]\n" +
+			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5952,12 +5225,9 @@ inner join pq on true
 			"     │           ├─ name: one_pk\n" +
 			"     │           └─ columns: [pk]\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6008,19 +5278,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk\n" +
 			"     │   │       └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1 c2 c3 c4 c5]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1 2 3 4 5]\n" +
+			"     │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"     └─ TableAlias(c)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6045,19 +5309,13 @@ inner join pq on true
 			"     │   │           ├─ name: one_pk\n" +
 			"     │   │           └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(c)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ TableAlias(d)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk)\n" +
 			"             ├─ index: [one_pk.pk]\n" +
-			"             ├─ columns: [pk]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk\n" +
-			"                 └─ projections: [0]\n" +
+			"             └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6106,12 +5364,9 @@ inner join pq on true
 			"     │           ├─ name: mytable\n" +
 			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(ot)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [s2 i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -6171,13 +5426,10 @@ inner join pq on true
 			"     │       │   ├─ b.pk:0!null\n" +
 			"     │       │   └─ 0 (tinyint)\n" +
 			"     │       └─ TableAlias(b)\n" +
-			"     │           └─ IndexedTableAccess\n" +
+			"     │           └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     │               ├─ index: [one_pk_three_idx.pk]\n" +
 			"     │               ├─ static: [{[0, 0]}]\n" +
-			"     │               ├─ columns: [pk]\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: one_pk_three_idx\n" +
-			"     │                   └─ projections: [0]\n" +
+			"     │               └─ columns: [pk]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(b.pk:2!null)\n" +
 			"         ├─ target: TUPLE(c.v1:0)\n" +
@@ -6249,12 +5501,9 @@ inner join pq on true
 			"                 │   │       ├─ name: mytable\n" +
 			"                 │   │       └─ columns: [i]\n" +
 			"                 │   └─ TableAlias(a)\n" +
-			"                 │       └─ IndexedTableAccess\n" +
+			"                 │       └─ IndexedTableAccess(mytable)\n" +
 			"                 │           ├─ index: [mytable.i]\n" +
-			"                 │           ├─ columns: [i s]\n" +
-			"                 │           └─ Table\n" +
-			"                 │               ├─ name: mytable\n" +
-			"                 │               └─ projections: [0 1]\n" +
+			"                 │           └─ columns: [i s]\n" +
 			"                 └─ HashLookup\n" +
 			"                     ├─ source: TUPLE(a.i:2)\n" +
 			"                     ├─ target: TUPLE((c.i:0!null - 1 (tinyint)))\n" +
@@ -6286,12 +5535,9 @@ inner join pq on true
 			"     │   │   │       ├─ name: othertable\n" +
 			"     │   │   │       └─ columns: [s2 i2]\n" +
 			"     │   │   └─ TableAlias(a)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(mytable)\n" +
 			"     │   │           ├─ index: [mytable.i]\n" +
-			"     │   │           ├─ columns: [i s]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: mytable\n" +
-			"     │   │               └─ projections: [0 1]\n" +
+			"     │   │           └─ columns: [i s]\n" +
 			"     │   └─ HashLookup\n" +
 			"     │       ├─ source: TUPLE(a.i:2)\n" +
 			"     │       ├─ target: TUPLE((c.i:0!null - 1 (tinyint)))\n" +
@@ -6301,12 +5547,9 @@ inner join pq on true
 			"     │                   ├─ name: mytable\n" +
 			"     │                   └─ columns: [i]\n" +
 			"     └─ TableAlias(d)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [1]\n" +
+			"             └─ columns: [i2]\n" +
 			"",
 	},
 	{
@@ -6338,19 +5581,13 @@ inner join pq on true
 			"     │               │       ├─ name: othertable\n" +
 			"     │               │       └─ columns: [s2 i2]\n" +
 			"     │               └─ TableAlias(a)\n" +
-			"     │                   └─ IndexedTableAccess\n" +
+			"     │                   └─ IndexedTableAccess(mytable)\n" +
 			"     │                       ├─ index: [mytable.i]\n" +
-			"     │                       ├─ columns: [i s]\n" +
-			"     │                       └─ Table\n" +
-			"     │                           ├─ name: mytable\n" +
-			"     │                           └─ projections: [0 1]\n" +
+			"     │                       └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
 			"             ├─ index: [othertable.i2]\n" +
-			"             ├─ columns: [i2]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: othertable\n" +
-			"                 └─ projections: [1]\n" +
+			"             └─ columns: [i2]\n" +
 			"",
 	},
 	{
@@ -6366,12 +5603,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk_two_idx\n" +
 			"     │       └─ columns: [pk v1]\n" +
 			"     └─ TableAlias(j)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"             ├─ index: [one_pk_three_idx.pk]\n" +
-			"             ├─ columns: [pk v3]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_three_idx\n" +
-			"                 └─ projections: [0 3]\n" +
+			"             └─ columns: [pk v3]\n" +
 			"",
 	},
 	{
@@ -6391,19 +5625,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk_three_idx\n" +
 			"     │   │       └─ columns: [pk v3]\n" +
 			"     │   └─ TableAlias(k)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk c1]\n" +
 			"     └─ TableAlias(i)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"             ├─ index: [one_pk_two_idx.v1]\n" +
-			"             ├─ columns: [pk v1]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_two_idx\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk v1]\n" +
 			"",
 	},
 	{
@@ -6419,12 +5647,9 @@ inner join pq on true
 			"     │       ├─ name: one_pk_two_idx\n" +
 			"     │       └─ columns: [pk v1]\n" +
 			"     └─ TableAlias(j)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"             ├─ index: [one_pk_three_idx.pk]\n" +
-			"             ├─ columns: [pk v3]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_three_idx\n" +
-			"                 └─ projections: [0 3]\n" +
+			"             └─ columns: [pk v3]\n" +
 			"",
 	},
 	{
@@ -6444,19 +5669,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk_three_idx\n" +
 			"     │   │       └─ columns: [pk v3]\n" +
 			"     │   └─ TableAlias(k)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk c1]\n" +
 			"     └─ TableAlias(i)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"             ├─ index: [one_pk_two_idx.v1]\n" +
-			"             ├─ columns: [pk v1]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_two_idx\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk v1]\n" +
 			"",
 	},
 	{
@@ -6476,19 +5695,13 @@ inner join pq on true
 			"     │   │       ├─ name: one_pk_three_idx\n" +
 			"     │   │       └─ columns: [pk v3]\n" +
 			"     │   └─ TableAlias(k)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
-			"     │           ├─ columns: [pk c1]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0 1]\n" +
+			"     │           └─ columns: [pk c1]\n" +
 			"     └─ TableAlias(i)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"             ├─ index: [one_pk_two_idx.v1]\n" +
-			"             ├─ columns: [pk v1]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_two_idx\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [pk v1]\n" +
 			"",
 	},
 	{
@@ -6512,19 +5725,13 @@ inner join pq on true
 			"     │   │   │       ├─ name: one_pk_two_idx\n" +
 			"     │   │   │       └─ columns: [v1]\n" +
 			"     │   │   └─ TableAlias(j)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
+			"     │   │       └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     │   │           ├─ index: [one_pk_three_idx.pk]\n" +
-			"     │   │           ├─ columns: [pk]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: one_pk_three_idx\n" +
-			"     │   │               └─ projections: [0]\n" +
+			"     │   │           └─ columns: [pk]\n" +
 			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"     │           ├─ index: [one_pk_two_idx.pk]\n" +
-			"     │           ├─ columns: [pk v1 v2]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk_two_idx\n" +
-			"     │               └─ projections: [0 1 2]\n" +
+			"     │           └─ columns: [pk v1 v2]\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ source: TUPLE(a.pk:2)\n" +
 			"         ├─ target: TUPLE(l.v2:2)\n" +
@@ -6538,12 +5745,9 @@ inner join pq on true
 			"                 │       ├─ name: one_pk_two_idx\n" +
 			"                 │       └─ columns: [v1]\n" +
 			"                 └─ TableAlias(l)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"                         ├─ index: [one_pk_three_idx.pk]\n" +
-			"                         ├─ columns: [pk v2]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: one_pk_three_idx\n" +
-			"                             └─ projections: [0 2]\n" +
+			"                         └─ columns: [pk v2]\n" +
 			"",
 	},
 	{
@@ -6595,12 +5799,9 @@ inner join pq on true
 			"                             │       ├─ name: one_pk_three_idx\n" +
 			"                             │       └─ columns: [v3]\n" +
 			"                             └─ TableAlias(i)\n" +
-			"                                 └─ IndexedTableAccess\n" +
+			"                                 └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"                                     ├─ index: [one_pk_two_idx.pk]\n" +
-			"                                     ├─ columns: [pk]\n" +
-			"                                     └─ Table\n" +
-			"                                         ├─ name: one_pk_two_idx\n" +
-			"                                         └─ projections: [0]\n" +
+			"                                     └─ columns: [pk]\n" +
 			"",
 	},
 	{
@@ -6620,12 +5821,9 @@ inner join pq on true
 			"         │   ├─ a.i:0!null\n" +
 			"         │   └─ 2 (tinyint)\n" +
 			"         └─ TableAlias(a)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: mytable\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -6641,12 +5839,9 @@ inner join pq on true
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ columns: [i s]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ projections: [0 1]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -6655,13 +5850,10 @@ inner join pq on true
 			" ├─ LessThan\n" +
 			" │   ├─ one_pk_three_idx.pk:0!null\n" +
 			" │   └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_three_idx\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6670,13 +5862,10 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ one_pk_three_idx.pk:0!null\n" +
 			" │   └─ 1 (tinyint)\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
 			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
-			"     ├─ columns: [pk v1 v2 v3]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: one_pk_three_idx\n" +
-			"         └─ projections: [0 1 2 3]\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6692,12 +5881,9 @@ inner join pq on true
 			" └─ Filter\n" +
 			"     ├─ (b.b:2 <=> NULL (null))\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 b f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 2 3]\n" +
+			"             └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6713,12 +5899,9 @@ inner join pq on true
 			" └─ Filter\n" +
 			"     ├─ (NOT(b.b:2 IS NULL))\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 b f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 2 3]\n" +
+			"             └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6737,12 +5920,9 @@ inner join pq on true
 			"     │   └─ 0 (tinyint)\n" +
 			"     │  ))\n" +
 			"     └─ TableAlias(b)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(niltable)\n" +
 			"             ├─ index: [niltable.i]\n" +
-			"             ├─ columns: [i i2 b f]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: niltable\n" +
-			"                 └─ projections: [0 1 2 3]\n" +
+			"             └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6754,20 +5934,14 @@ inner join pq on true
 			" ├─ Filter\n" +
 			" │   ├─ (NOT(a.s:1!null IS NULL))\n" +
 			" │   └─ TableAlias(a)\n" +
-			" │       └─ IndexedTableAccess\n" +
+			" │       └─ IndexedTableAccess(mytable)\n" +
 			" │           ├─ index: [mytable.s]\n" +
 			" │           ├─ static: [{(NULL, ∞)}]\n" +
-			" │           ├─ columns: [i s]\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: mytable\n" +
-			" │               └─ projections: [0 1]\n" +
+			" │           └─ columns: [i s]\n" +
 			" └─ TableAlias(b)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(niltable)\n" +
 			"         ├─ index: [niltable.i]\n" +
-			"         ├─ columns: [i i2 b f]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: niltable\n" +
-			"             └─ projections: [0 1 2 3]\n" +
+			"         └─ columns: [i i2 b f]\n" +
 			"",
 	},
 	{
@@ -6848,13 +6022,10 @@ inner join pq on true
 			"     │   │   ├─ t1.pk:0!null\n" +
 			"     │   │   └─ 1 (tinyint)\n" +
 			"     │   └─ TableAlias(t1)\n" +
-			"     │       └─ IndexedTableAccess\n" +
+			"     │       └─ IndexedTableAccess(one_pk)\n" +
 			"     │           ├─ index: [one_pk.pk]\n" +
 			"     │           ├─ static: [{[1, 1]}]\n" +
-			"     │           ├─ columns: [pk]\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk\n" +
-			"     │               └─ projections: [0]\n" +
+			"     │           └─ columns: [pk]\n" +
 			"     └─ Filter\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
@@ -6864,13 +6035,10 @@ inner join pq on true
 			"         │       ├─ t2.pk1:0!null\n" +
 			"         │       └─ 1 (tinyint)\n" +
 			"         └─ TableAlias(t2)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(two_pk)\n" +
 			"                 ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"                 ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
-			"                 ├─ columns: [pk1 pk2]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: two_pk\n" +
-			"                     └─ projections: [0 1]\n" +
+			"                 └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{
@@ -7603,20 +6771,14 @@ With c as (
 			"             │   │       │   ├─ t2.i:0!null\n" +
 			"             │   │       │   └─ TUPLE(1 (tinyint), 2 (tinyint))\n" +
 			"             │   │       └─ TableAlias(t2)\n" +
-			"             │   │           └─ IndexedTableAccess\n" +
+			"             │   │           └─ IndexedTableAccess(mytable)\n" +
 			"             │   │               ├─ index: [mytable.i]\n" +
 			"             │   │               ├─ static: [{[2, 2]}, {[1, 1]}]\n" +
-			"             │   │               ├─ columns: [i s]\n" +
-			"             │   │               └─ Table\n" +
-			"             │   │                   ├─ name: mytable\n" +
-			"             │   │                   └─ projections: [0 1]\n" +
+			"             │   │               └─ columns: [i s]\n" +
 			"             │   └─ TableAlias(a)\n" +
-			"             │       └─ IndexedTableAccess\n" +
+			"             │       └─ IndexedTableAccess(mytable)\n" +
 			"             │           ├─ index: [mytable.i]\n" +
-			"             │           ├─ columns: [i s]\n" +
-			"             │           └─ Table\n" +
-			"             │               ├─ name: mytable\n" +
-			"             │               └─ projections: [0 1]\n" +
+			"             │           └─ columns: [i s]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(b.i:0!null)\n" +
 			"                 ├─ target: TUPLE(e.i:0!null)\n" +
@@ -7630,13 +6792,10 @@ With c as (
 			"                             │   ├─ t1.i:0!null\n" +
 			"                             │   └─ TUPLE(2 (tinyint), 3 (tinyint))\n" +
 			"                             └─ TableAlias(t1)\n" +
-			"                                 └─ IndexedTableAccess\n" +
+			"                                 └─ IndexedTableAccess(mytable)\n" +
 			"                                     ├─ index: [mytable.i]\n" +
 			"                                     ├─ static: [{[3, 3]}, {[2, 2]}]\n" +
-			"                                     ├─ columns: [i s]\n" +
-			"                                     └─ Table\n" +
-			"                                         ├─ name: mytable\n" +
-			"                                         └─ projections: [0 1]\n" +
+			"                                     └─ columns: [i s]\n" +
 			"",
 	},
 }
@@ -7680,12 +6839,9 @@ WHERE
 			"     ├─ Table\n" +
 			"     │   └─ name: YK2GW\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(THNTS)\n" +
 			"             ├─ index: [THNTS.IXUXU]\n" +
-			"             ├─ columns: [ixuxu]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: THNTS\n" +
-			"                 └─ projections: [2]\n" +
+			"             └─ columns: [ixuxu]\n" +
 			"",
 	},
 	{
@@ -7777,18 +6933,14 @@ WHERE
 			"     │                               └─ Filter\n" +
 			"     │                                   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
 			"     └─ Filter\n" +
 			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [E2I7U.ZH72S]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 └─ index: [E2I7U.ZH72S]\n" +
 			"",
 	},
 	{
@@ -7938,13 +7090,10 @@ WHERE
 			" │                       │       ├─ cacheable: true\n" +
 			" │                       │       └─ Filter\n" +
 			" │                       │           ├─ (NOT(HDDVB.PRUV2:29 IS NULL))\n" +
-			" │                       │           └─ IndexedTableAccess\n" +
+			" │                       │           └─ IndexedTableAccess(HDDVB)\n" +
 			" │                       │               ├─ index: [HDDVB.PRUV2]\n" +
 			" │                       │               ├─ static: [{(NULL, ∞)}]\n" +
-			" │                       │               ├─ columns: [pruv2]\n" +
-			" │                       │               └─ Table\n" +
-			" │                       │                   ├─ name: HDDVB\n" +
-			" │                       │                   └─ projections: [6]\n" +
+			" │                       │               └─ columns: [pruv2]\n" +
 			" │                       │  ))\n" +
 			" │                       └─ LookupJoin\n" +
 			" │                           ├─ AND\n" +
@@ -7970,10 +7119,8 @@ WHERE
 			" │                           │       └─ Table\n" +
 			" │                           │           └─ name: WGSDC\n" +
 			" │                           └─ TableAlias(TIZHK)\n" +
-			" │                               └─ IndexedTableAccess\n" +
-			" │                                   ├─ index: [WRZVO.TVNW2]\n" +
-			" │                                   └─ Table\n" +
-			" │                                       └─ name: WRZVO\n" +
+			" │                               └─ IndexedTableAccess(WRZVO)\n" +
+			" │                                   └─ index: [WRZVO.TVNW2]\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ Table\n" +
 			"         └─ name: HDDVB\n" +
@@ -8048,37 +7195,24 @@ WHERE
 			" │   │                   │   │   │   │   └─ Table\n" +
 			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
 			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
-			" │   │                   │   │   │           └─ Table\n" +
-			" │   │                   │   │   │               └─ name: WRZVO\n" +
+			" │   │                   │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
+			" │   │                   │   │   │           └─ index: [WRZVO.TVNW2]\n" +
 			" │   │                   │   │   └─ TableAlias(RHUZN)\n" +
-			" │   │                   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                   │   │           └─ Table\n" +
-			" │   │                   │   │               └─ name: E2I7U\n" +
+			" │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			" │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
 			" │   │                   │   └─ TableAlias(mf)\n" +
-			" │   │                   │       └─ IndexedTableAccess\n" +
-			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                   │           └─ Table\n" +
-			" │   │                   │               └─ name: HGMQ6\n" +
+			" │   │                   │       └─ IndexedTableAccess(HGMQ6)\n" +
+			" │   │                   │           └─ index: [HGMQ6.LUEVY]\n" +
 			" │   │                   └─ TableAlias(aac)\n" +
-			" │   │                       └─ IndexedTableAccess\n" +
-			" │   │                           ├─ index: [TPXBU.id]\n" +
-			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: TPXBU\n" +
+			" │   │                       └─ IndexedTableAccess(TPXBU)\n" +
+			" │   │                           └─ index: [TPXBU.id]\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
-			" │       └─ IndexedTableAccess\n" +
-			" │           ├─ index: [WRZVO.id]\n" +
-			" │           └─ Table\n" +
-			" │               └─ name: WRZVO\n" +
+			" │       └─ IndexedTableAccess(WRZVO)\n" +
+			" │           └─ index: [WRZVO.id]\n" +
 			" └─ TableAlias(applySubq1)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(HDDVB)\n" +
 			"         ├─ index: [HDDVB.ETPQV]\n" +
-			"         ├─ columns: [etpqv]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: HDDVB\n" +
-			"             └─ projections: [5]\n" +
+			"         └─ columns: [etpqv]\n" +
 			"",
 	},
 	{
@@ -8150,37 +7284,24 @@ WHERE
 			" │   │                   │   │   │   │   └─ Table\n" +
 			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
 			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │   │           ├─ index: [WRZVO.ZHITY]\n" +
-			" │   │                   │   │   │           └─ Table\n" +
-			" │   │                   │   │   │               └─ name: WRZVO\n" +
+			" │   │                   │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
+			" │   │                   │   │   │           └─ index: [WRZVO.ZHITY]\n" +
 			" │   │                   │   │   └─ TableAlias(J4JYP)\n" +
-			" │   │                   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                   │   │           └─ Table\n" +
-			" │   │                   │   │               └─ name: E2I7U\n" +
+			" │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			" │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
 			" │   │                   │   └─ TableAlias(mf)\n" +
-			" │   │                   │       └─ IndexedTableAccess\n" +
-			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                   │           └─ Table\n" +
-			" │   │                   │               └─ name: HGMQ6\n" +
+			" │   │                   │       └─ IndexedTableAccess(HGMQ6)\n" +
+			" │   │                   │           └─ index: [HGMQ6.LUEVY]\n" +
 			" │   │                   └─ TableAlias(aac)\n" +
-			" │   │                       └─ IndexedTableAccess\n" +
-			" │   │                           ├─ index: [TPXBU.id]\n" +
-			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: TPXBU\n" +
+			" │   │                       └─ IndexedTableAccess(TPXBU)\n" +
+			" │   │                           └─ index: [TPXBU.id]\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
-			" │       └─ IndexedTableAccess\n" +
-			" │           ├─ index: [WRZVO.id]\n" +
-			" │           └─ Table\n" +
-			" │               └─ name: WRZVO\n" +
+			" │       └─ IndexedTableAccess(WRZVO)\n" +
+			" │           └─ index: [WRZVO.id]\n" +
 			" └─ TableAlias(applySubq1)\n" +
-			"     └─ IndexedTableAccess\n" +
+			"     └─ IndexedTableAccess(HDDVB)\n" +
 			"         ├─ index: [HDDVB.ETPQV]\n" +
-			"         ├─ columns: [etpqv]\n" +
-			"         └─ Table\n" +
-			"             ├─ name: HDDVB\n" +
-			"             └─ projections: [5]\n" +
+			"         └─ columns: [etpqv]\n" +
 			"",
 	},
 	{
@@ -8272,18 +7393,14 @@ WHERE
 			"     │                               └─ Filter\n" +
 			"     │                                   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
 			"     └─ Filter\n" +
 			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [E2I7U.ZH72S]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 └─ index: [E2I7U.ZH72S]\n" +
 			"",
 	},
 	{
@@ -8407,13 +7524,10 @@ WHERE
 			"     │                       │       ├─ cacheable: true\n" +
 			"     │                       │       └─ Filter\n" +
 			"     │                       │           ├─ (NOT(FLQLP.OCA7E:58 IS NULL))\n" +
-			"     │                       │           └─ IndexedTableAccess\n" +
+			"     │                       │           └─ IndexedTableAccess(FLQLP)\n" +
 			"     │                       │               ├─ index: [FLQLP.OCA7E]\n" +
 			"     │                       │               ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                       │               ├─ columns: [oca7e]\n" +
-			"     │                       │               └─ Table\n" +
-			"     │                       │                   ├─ name: FLQLP\n" +
-			"     │                       │                   └─ projections: [6]\n" +
+			"     │                       │               └─ columns: [oca7e]\n" +
 			"     │                       │  ))\n" +
 			"     │                       └─ LookupJoin\n" +
 			"     │                           ├─ AND\n" +
@@ -8435,10 +7549,8 @@ WHERE
 			"     │                           │       └─ Table\n" +
 			"     │                           │           └─ name: EPZU6\n" +
 			"     │                           └─ TableAlias(uct)\n" +
-			"     │                               └─ IndexedTableAccess\n" +
-			"     │                                   ├─ index: [OUBDL.ZH72S]\n" +
-			"     │                                   └─ Table\n" +
-			"     │                                       └─ name: OUBDL\n" +
+			"     │                               └─ IndexedTableAccess(OUBDL)\n" +
+			"     │                                   └─ index: [OUBDL.ZH72S]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ aac.id:34!null\n" +
@@ -8455,20 +7567,14 @@ WHERE
 			"         │   │   │   └─ Table\n" +
 			"         │   │   │       └─ name: JDLNA\n" +
 			"         │   │   └─ TableAlias(ct)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [FLQLP.FZ2R5]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: FLQLP\n" +
+			"         │   │       └─ IndexedTableAccess(FLQLP)\n" +
+			"         │   │           └─ index: [FLQLP.FZ2R5]\n" +
 			"         │   └─ TableAlias(nd)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           └─ index: [E2I7U.id]\n" +
 			"         └─ TableAlias(aac)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [TPXBU.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: TPXBU\n" +
+			"             └─ IndexedTableAccess(TPXBU)\n" +
+			"                 └─ index: [TPXBU.id]\n" +
 			"",
 	},
 	{
@@ -8538,36 +7644,24 @@ WHERE
 			"     │               │   │   │   └─ Filter\n" +
 			"     │               │   │   │       ├─ (NOT(YLKSY.LJLUM LIKE '%|%'))\n" +
 			"     │               │   │   │       └─ TableAlias(YLKSY)\n" +
-			"     │               │   │   │           └─ IndexedTableAccess\n" +
-			"     │               │   │   │               ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │               │   │   │               └─ Table\n" +
-			"     │               │   │   │                   └─ name: OUBDL\n" +
+			"     │               │   │   │           └─ IndexedTableAccess(OUBDL)\n" +
+			"     │               │   │   │               └─ index: [OUBDL.FTQLQ]\n" +
 			"     │               │   │   └─ TableAlias(nd)\n" +
-			"     │               │   │       └─ IndexedTableAccess\n" +
-			"     │               │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │               │   │           └─ Table\n" +
-			"     │               │   │               └─ name: E2I7U\n" +
+			"     │               │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │               │   │           └─ index: [E2I7U.ZH72S]\n" +
 			"     │               │   └─ Filter\n" +
 			"     │               │       ├─ (NOT(applySubq0.NRURT:0 IS NULL))\n" +
 			"     │               │       └─ TableAlias(applySubq0)\n" +
-			"     │               │           └─ IndexedTableAccess\n" +
+			"     │               │           └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │               ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │               ├─ columns: [nrurt]\n" +
-			"     │               │               └─ Table\n" +
-			"     │               │                   ├─ name: FLQLP\n" +
-			"     │               │                   └─ projections: [5]\n" +
+			"     │               │               └─ columns: [nrurt]\n" +
 			"     │               └─ TableAlias(aac)\n" +
-			"     │                   └─ IndexedTableAccess\n" +
-			"     │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"     │                       └─ Table\n" +
-			"     │                           └─ name: TPXBU\n" +
+			"     │                   └─ IndexedTableAccess(TPXBU)\n" +
+			"     │                       └─ index: [TPXBU.BTXC5]\n" +
 			"     └─ TableAlias(uct)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(OUBDL)\n" +
 			"             ├─ index: [OUBDL.id]\n" +
-			"             ├─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: OUBDL\n" +
-			"                 └─ projections: [0 1 2 3 4 5 6 7 8 9 10 11 12]\n" +
+			"             └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"",
 	},
 	{
@@ -8627,25 +7721,17 @@ WHERE
 			"     │   │   │   │       └─ Table\n" +
 			"     │   │   │   │           └─ name: HU5A5\n" +
 			"     │   │   │   └─ TableAlias(ct)\n" +
-			"     │   │   │       └─ IndexedTableAccess\n" +
-			"     │   │   │           ├─ index: [FLQLP.XMM6Q]\n" +
-			"     │   │   │           └─ Table\n" +
-			"     │   │   │               └─ name: FLQLP\n" +
+			"     │   │   │       └─ IndexedTableAccess(FLQLP)\n" +
+			"     │   │   │           └─ index: [FLQLP.XMM6Q]\n" +
 			"     │   │   └─ TableAlias(ci)\n" +
-			"     │   │       └─ IndexedTableAccess\n" +
-			"     │   │           ├─ index: [JDLNA.id]\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               └─ name: JDLNA\n" +
+			"     │   │       └─ IndexedTableAccess(JDLNA)\n" +
+			"     │   │           └─ index: [JDLNA.id]\n" +
 			"     │   └─ TableAlias(nd)\n" +
-			"     │       └─ IndexedTableAccess\n" +
-			"     │           ├─ index: [E2I7U.id]\n" +
-			"     │           └─ Table\n" +
-			"     │               └─ name: E2I7U\n" +
+			"     │       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │           └─ index: [E2I7U.id]\n" +
 			"     └─ TableAlias(aac)\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [TPXBU.id]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: TPXBU\n" +
+			"         └─ IndexedTableAccess(TPXBU)\n" +
+			"             └─ index: [TPXBU.id]\n" +
 			"",
 	},
 	{
@@ -8679,12 +7765,9 @@ WHERE
 			" └─ Filter\n" +
 			"     ├─ (NOT(applySubq0.XMM6Q:0 IS NULL))\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.XMM6Q]\n" +
-			"             ├─ columns: [xmm6q]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: FLQLP\n" +
-			"                 └─ projections: [7]\n" +
+			"             └─ columns: [xmm6q]\n" +
 			"",
 	},
 	{
@@ -8757,20 +7840,14 @@ WHERE
 			"         │   │   │   │   └─ Table\n" +
 			"         │   │   │   │       └─ name: E2I7U\n" +
 			"         │   │   │   └─ TableAlias(PV6R5)\n" +
-			"         │   │   │       └─ IndexedTableAccess\n" +
-			"         │   │   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │   │           └─ Table\n" +
-			"         │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │           └─ index: [NOXN3.BRQP2]\n" +
 			"         │   │   └─ TableAlias(LQNCX)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │   │           └─ index: [E2I7U.id]\n" +
 			"         │   └─ TableAlias(rn)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [QYWQD.WNUNU]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: QYWQD\n" +
+			"         │       └─ IndexedTableAccess(QYWQD)\n" +
+			"         │           └─ index: [QYWQD.WNUNU]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ source: TUPLE(rn.HHVLX:46!null)\n" +
 			"             ├─ target: TUPLE(ZYUTC.id:17!null)\n" +
@@ -8787,15 +7864,11 @@ WHERE
 			"                     │   │   └─ Table\n" +
 			"                     │   │       └─ name: E2I7U\n" +
 			"                     │   └─ TableAlias(ZYUTC)\n" +
-			"                     │       └─ IndexedTableAccess\n" +
-			"                     │           ├─ index: [NOXN3.BRQP2]\n" +
-			"                     │           └─ Table\n" +
-			"                     │               └─ name: NOXN3\n" +
+			"                     │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                     │           └─ index: [NOXN3.BRQP2]\n" +
 			"                     └─ TableAlias(AFJMD)\n" +
-			"                         └─ IndexedTableAccess\n" +
-			"                             ├─ index: [E2I7U.id]\n" +
-			"                             └─ Table\n" +
-			"                                 └─ name: E2I7U\n" +
+			"                         └─ IndexedTableAccess(E2I7U)\n" +
+			"                             └─ index: [E2I7U.id]\n" +
 			"",
 	},
 	{
@@ -8869,15 +7942,11 @@ WHERE
 			"         │   │   │   │   └─ Table\n" +
 			"         │   │   │   │       └─ name: E2I7U\n" +
 			"         │   │   │   └─ TableAlias(SKPM6)\n" +
-			"         │   │   │       └─ IndexedTableAccess\n" +
-			"         │   │   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │   │           └─ Table\n" +
-			"         │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │           └─ index: [NOXN3.BRQP2]\n" +
 			"         │   │   └─ TableAlias(FQTHF)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │   │           └─ index: [E2I7U.id]\n" +
 			"         │   └─ HashLookup\n" +
 			"         │       ├─ source: TUPLE(SKPM6.BRQP2:18!null)\n" +
 			"         │       ├─ target: TUPLE(sn.FFTBJ:19!null)\n" +
@@ -8898,20 +7967,14 @@ WHERE
 			"         │               │       │   ├─ sn.NUMK2:6!null\n" +
 			"         │               │       │   └─ 1 (tinyint)\n" +
 			"         │               │       └─ TableAlias(sn)\n" +
-			"         │               │           └─ IndexedTableAccess\n" +
-			"         │               │               ├─ index: [NOXN3.BRQP2]\n" +
-			"         │               │               └─ Table\n" +
-			"         │               │                   └─ name: NOXN3\n" +
+			"         │               │           └─ IndexedTableAccess(NOXN3)\n" +
+			"         │               │               └─ index: [NOXN3.BRQP2]\n" +
 			"         │               └─ TableAlias(CGFRZ)\n" +
-			"         │                   └─ IndexedTableAccess\n" +
-			"         │                       ├─ index: [E2I7U.id]\n" +
-			"         │                       └─ Table\n" +
-			"         │                           └─ name: E2I7U\n" +
+			"         │                   └─ IndexedTableAccess(E2I7U)\n" +
+			"         │                       └─ index: [E2I7U.id]\n" +
 			"         └─ TableAlias(rn)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [QYWQD.HHVLX]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: QYWQD\n" +
+			"             └─ IndexedTableAccess(QYWQD)\n" +
+			"                 └─ index: [QYWQD.HHVLX]\n" +
 			"",
 	},
 	{
@@ -8982,21 +8045,14 @@ WHERE
 			"     │           │               │   └─ Table\n" +
 			"     │           │               │       └─ name: E2I7U\n" +
 			"     │           │               └─ TableAlias(S5KBM)\n" +
-			"     │           │                   └─ IndexedTableAccess\n" +
-			"     │           │                       ├─ index: [TDRVG.FGG57]\n" +
-			"     │           │                       └─ Table\n" +
-			"     │           │                           └─ name: TDRVG\n" +
+			"     │           │                   └─ IndexedTableAccess(TDRVG)\n" +
+			"     │           │                       └─ index: [TDRVG.FGG57]\n" +
 			"     │           └─ TableAlias(applySubq0)\n" +
-			"     │               └─ IndexedTableAccess\n" +
+			"     │               └─ IndexedTableAccess(WE72E)\n" +
 			"     │                   ├─ index: [WE72E.SSHPJ]\n" +
-			"     │                   ├─ columns: [sshpj]\n" +
-			"     │                   └─ Table\n" +
-			"     │                       ├─ name: WE72E\n" +
-			"     │                       └─ projections: [2]\n" +
-			"     └─ IndexedTableAccess\n" +
-			"         ├─ index: [TDRVG.id]\n" +
-			"         └─ Table\n" +
-			"             └─ name: TDRVG\n" +
+			"     │                   └─ columns: [sshpj]\n" +
+			"     └─ IndexedTableAccess(TDRVG)\n" +
+			"         └─ index: [TDRVG.id]\n" +
 			"",
 	},
 	{
@@ -9088,18 +8144,14 @@ WHERE
 			"     │                               └─ Filter\n" +
 			"     │                                   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
 			"     └─ Filter\n" +
 			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [E2I7U.ZH72S]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 └─ index: [E2I7U.ZH72S]\n" +
 			"",
 	},
 	{
@@ -9142,22 +8194,15 @@ WHERE
 			"         │   │   │       └─ Table\n" +
 			"         │   │   │           └─ name: E2I7U\n" +
 			"         │   │   └─ TableAlias(ufc)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: SISUT\n" +
+			"         │   │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           └─ index: [SISUT.ZH72S]\n" +
 			"         │   └─ TableAlias(cla)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"         │       └─ IndexedTableAccess(YK2GW)\n" +
+			"         │           └─ index: [YK2GW.FTQLQ]\n" +
 			"         └─ TableAlias(applySubq0)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.KKGN5]\n" +
-			"                 ├─ columns: [kkgn5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: AMYXQ\n" +
-			"                     └─ projections: [7]\n" +
+			"                 └─ columns: [kkgn5]\n" +
 			"",
 	},
 	{
@@ -9200,22 +8245,15 @@ WHERE
 			"         │   │   │       └─ Table\n" +
 			"         │   │   │           └─ name: E2I7U\n" +
 			"         │   │   └─ TableAlias(ufc)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: SISUT\n" +
+			"         │   │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           └─ index: [SISUT.ZH72S]\n" +
 			"         │   └─ TableAlias(cla)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"         │       └─ IndexedTableAccess(YK2GW)\n" +
+			"         │           └─ index: [YK2GW.FTQLQ]\n" +
 			"         └─ TableAlias(applySubq0)\n" +
-			"             └─ IndexedTableAccess\n" +
+			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.KKGN5]\n" +
-			"                 ├─ columns: [kkgn5]\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: AMYXQ\n" +
-			"                     └─ projections: [7]\n" +
+			"                 └─ columns: [kkgn5]\n" +
 			"",
 	},
 	{
@@ -9245,17 +8283,12 @@ WHERE
 			"     │   │   └─ Table\n" +
 			"     │   │       └─ name: FG26Y\n" +
 			"     │   └─ TableAlias(cla)\n" +
-			"     │       └─ IndexedTableAccess\n" +
-			"     │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"     │           └─ Table\n" +
-			"     │               └─ name: YK2GW\n" +
+			"     │       └─ IndexedTableAccess(YK2GW)\n" +
+			"     │           └─ index: [YK2GW.FTQLQ]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(SZQWJ)\n" +
 			"             ├─ index: [SZQWJ.JOGI6]\n" +
-			"             ├─ columns: [jogi6]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: SZQWJ\n" +
-			"                 └─ projections: [4]\n" +
+			"             └─ columns: [jogi6]\n" +
 			"",
 	},
 	{
@@ -9381,13 +8414,10 @@ WHERE
 			"     │                       │       ├─ cacheable: true\n" +
 			"     │                       │       └─ Filter\n" +
 			"     │                       │           ├─ (NOT(HGMQ6.QQV4M:104 IS NULL))\n" +
-			"     │                       │           └─ IndexedTableAccess\n" +
+			"     │                       │           └─ IndexedTableAccess(HGMQ6)\n" +
 			"     │                       │               ├─ index: [HGMQ6.QQV4M]\n" +
 			"     │                       │               ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                       │               ├─ columns: [qqv4m]\n" +
-			"     │                       │               └─ Table\n" +
-			"     │                       │                   ├─ name: HGMQ6\n" +
-			"     │                       │                   └─ projections: [15]\n" +
+			"     │                       │               └─ columns: [qqv4m]\n" +
 			"     │                       │  ))\n" +
 			"     │                       └─ InnerJoin\n" +
 			"     │                           ├─ AND\n" +
@@ -9427,10 +8457,8 @@ WHERE
 			"         │   │   │   └─ Table\n" +
 			"         │   │   │       └─ name: E2I7U\n" +
 			"         │   │   └─ TableAlias(mf)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: HGMQ6\n" +
+			"         │   │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"         │   │           └─ index: [HGMQ6.LUEVY]\n" +
 			"         │   └─ HashLookup\n" +
 			"         │       ├─ source: TUPLE(mf.GXLUB:18!null)\n" +
 			"         │       ├─ target: TUPLE(bs.id:0!null)\n" +
@@ -9443,15 +8471,11 @@ WHERE
 			"         │               │   └─ Table\n" +
 			"         │               │       └─ name: THNTS\n" +
 			"         │               └─ TableAlias(cla)\n" +
-			"         │                   └─ IndexedTableAccess\n" +
-			"         │                       ├─ index: [YK2GW.id]\n" +
-			"         │                       └─ Table\n" +
-			"         │                           └─ name: YK2GW\n" +
+			"         │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"         │                       └─ index: [YK2GW.id]\n" +
 			"         └─ TableAlias(aac)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [TPXBU.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: TPXBU\n" +
+			"             └─ IndexedTableAccess(TPXBU)\n" +
+			"                 └─ index: [TPXBU.id]\n" +
 			"",
 	},
 	{
@@ -9498,24 +8522,17 @@ WHERE
 			"     │   │       │   └─ N/A (longtext)\n" +
 			"     │   │       │  ))\n" +
 			"     │   │       └─ TableAlias(umf)\n" +
-			"     │   │           └─ IndexedTableAccess\n" +
-			"     │   │               ├─ index: [NZKPM.T4IBQ]\n" +
-			"     │   │               └─ Table\n" +
-			"     │   │                   └─ name: NZKPM\n" +
+			"     │   │           └─ IndexedTableAccess(NZKPM)\n" +
+			"     │   │               └─ index: [NZKPM.T4IBQ]\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ (NOT(nd.FGG57:6 IS NULL))\n" +
 			"     │       └─ TableAlias(nd)\n" +
-			"     │           └─ IndexedTableAccess\n" +
-			"     │               ├─ index: [E2I7U.FGG57]\n" +
-			"     │               └─ Table\n" +
-			"     │                   └─ name: E2I7U\n" +
+			"     │           └─ IndexedTableAccess(E2I7U)\n" +
+			"     │               └─ index: [E2I7U.FGG57]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(HGMQ6)\n" +
 			"             ├─ index: [HGMQ6.TEUJA]\n" +
-			"             ├─ columns: [teuja]\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: HGMQ6\n" +
-			"                 └─ projections: [14]\n" +
+			"             └─ columns: [teuja]\n" +
 			"",
 	},
 	{
@@ -9526,13 +8543,10 @@ WHERE
 	ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [QYWQD.HVHRZ:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id hvhrz]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: QYWQD\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [id hvhrz]\n" +
 			"",
 	},
 	{
@@ -9651,10 +8665,8 @@ WHERE
 			" │       │           │   ├─ aac.id:67!null\n" +
 			" │       │           │   └─ SL3S5.M22QN:53!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ IndexedTableAccess\n" +
-			" │       │                   ├─ index: [TPXBU.id]\n" +
-			" │       │                   └─ Table\n" +
-			" │       │                       └─ name: TPXBU\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │       │                   └─ index: [TPXBU.id]\n" +
 			" │       │   as TPXBU, SL3S5.NO52D:55!null as NO52D, SL3S5.IDPK7:56!null as IDPK7]\n" +
 			" │       └─ HashJoin\n" +
 			" │           ├─ AND\n" +
@@ -9680,15 +8692,11 @@ WHERE
 			" │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			" │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │           │   │       └─ TableAlias(cla)\n" +
-			" │           │   │           └─ IndexedTableAccess\n" +
-			" │           │   │               ├─ index: [YK2GW.id]\n" +
-			" │           │   │               └─ Table\n" +
-			" │           │   │                   └─ name: YK2GW\n" +
+			" │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
+			" │           │   │               └─ index: [YK2GW.id]\n" +
 			" │           │   └─ TableAlias(mf)\n" +
-			" │           │       └─ IndexedTableAccess\n" +
-			" │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			" │           │           └─ Table\n" +
-			" │           │               └─ name: HGMQ6\n" +
+			" │           │       └─ IndexedTableAccess(HGMQ6)\n" +
+			" │           │           └─ index: [HGMQ6.GXLUB]\n" +
 			" │           └─ HashLookup\n" +
 			" │               ├─ source: TUPLE(mf.LUEVY:36!null, mf.M22QN:37!null)\n" +
 			" │               ├─ target: TUPLE(sn.BRQP2:7!null, SL3S5.M22QN:2!null)\n" +
@@ -9724,25 +8732,19 @@ WHERE
 			" │                       │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
 			" │                       │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │                       │           │   │   │   └─ TableAlias(ci)\n" +
-			" │                       │           │   │   │       └─ IndexedTableAccess\n" +
+			" │                       │           │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
 			" │                       │           │   │   │           ├─ index: [JDLNA.FTQLQ]\n" +
-			" │                       │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			" │                       │           │   │   │           └─ Table\n" +
-			" │                       │           │   │   │               └─ name: JDLNA\n" +
+			" │                       │           │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
 			" │                       │           │   │   └─ Filter\n" +
 			" │                       │           │   │       ├─ Eq\n" +
 			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
 			" │                       │           │   │       │   └─ = (longtext)\n" +
 			" │                       │           │   │       └─ TableAlias(ct)\n" +
-			" │                       │           │   │           └─ IndexedTableAccess\n" +
-			" │                       │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
-			" │                       │           │   │               └─ Table\n" +
-			" │                       │           │   │                   └─ name: FLQLP\n" +
+			" │                       │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			" │                       │           │   │               └─ index: [FLQLP.FZ2R5]\n" +
 			" │                       │           │   └─ TableAlias(cec)\n" +
-			" │                       │           │       └─ IndexedTableAccess\n" +
-			" │                       │           │           ├─ index: [SFEGG.id]\n" +
-			" │                       │           │           └─ Table\n" +
-			" │                       │           │               └─ name: SFEGG\n" +
+			" │                       │           │       └─ IndexedTableAccess(SFEGG)\n" +
+			" │                       │           │           └─ index: [SFEGG.id]\n" +
 			" │                       │           └─ HashLookup\n" +
 			" │                       │               ├─ source: TUPLE(ct.M22QN:8!null, ct.LUEVY:7!null)\n" +
 			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
@@ -9762,15 +8764,11 @@ WHERE
 			" │                       │                                   │   └─ Table\n" +
 			" │                       │                                   │       └─ name: NOXN3\n" +
 			" │                       │                                   └─ TableAlias(mf)\n" +
-			" │                       │                                       └─ IndexedTableAccess\n" +
-			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │                       │                                           └─ Table\n" +
-			" │                       │                                               └─ name: HGMQ6\n" +
+			" │                       │                                       └─ IndexedTableAccess(HGMQ6)\n" +
+			" │                       │                                           └─ index: [HGMQ6.LUEVY]\n" +
 			" │                       └─ TableAlias(sn)\n" +
-			" │                           └─ IndexedTableAccess\n" +
-			" │                               ├─ index: [NOXN3.id]\n" +
-			" │                               └─ Table\n" +
-			" │                                   └─ name: NOXN3\n" +
+			" │                           └─ IndexedTableAccess(NOXN3)\n" +
+			" │                               └─ index: [NOXN3.id]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [AOEV5.T4IBQ:0!null as T4IBQ, VUMUY.DL754:1!null, VUMUY.BDNYB:2!null, VUMUY.ADURZ:3!null, VUMUY.TPXBU:4, VUMUY.NO52D:5!null, VUMUY.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
@@ -9790,10 +8788,8 @@ WHERE
 			"             │       │           │   ├─ aac.id:16!null\n" +
 			"             │       │           │   └─ SL3S5.M22QN:2!null\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
-			"             │       │                   ├─ index: [TPXBU.id]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			"             │       │                   └─ index: [TPXBU.id]\n" +
 			"             │       │   as TPXBU, SL3S5.NO52D:4!null as NO52D, SL3S5.IDPK7:5!null as IDPK7]\n" +
 			"             │       └─ LookupJoin\n" +
 			"             │           ├─ Eq\n" +
@@ -9817,11 +8813,9 @@ WHERE
 			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
 			"             │           │           │               │   └─ WT (longtext)\n" +
 			"             │           │           │               └─ TableAlias(aac)\n" +
-			"             │           │           │                   └─ IndexedTableAccess\n" +
+			"             │           │           │                   └─ IndexedTableAccess(TPXBU)\n" +
 			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
-			"             │           │           │                       └─ Table\n" +
-			"             │           │           │                           └─ name: TPXBU\n" +
+			"             │           │           │                       └─ static: [{[WT, WT]}]\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
 			"             │           │               │   ├─ ct.LUEVY:8!null\n" +
@@ -9842,29 +8836,21 @@ WHERE
 			"             │           │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
 			"             │           │               │   │       │   └─ = (longtext)\n" +
 			"             │           │               │   │       └─ TableAlias(ct)\n" +
-			"             │           │               │   │           └─ IndexedTableAccess\n" +
-			"             │           │               │   │               ├─ index: [FLQLP.OVE3E]\n" +
-			"             │           │               │   │               └─ Table\n" +
-			"             │           │               │   │                   └─ name: FLQLP\n" +
+			"             │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			"             │           │               │   │               └─ index: [FLQLP.OVE3E]\n" +
 			"             │           │               │   └─ Filter\n" +
 			"             │           │               │       ├─ HashIn\n" +
 			"             │           │               │       │   ├─ ci.FTQLQ:1!null\n" +
 			"             │           │               │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │           │               │       └─ TableAlias(ci)\n" +
-			"             │           │               │           └─ IndexedTableAccess\n" +
-			"             │           │               │               ├─ index: [JDLNA.id]\n" +
-			"             │           │               │               └─ Table\n" +
-			"             │           │               │                   └─ name: JDLNA\n" +
+			"             │           │               │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │           │               │               └─ index: [JDLNA.id]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
-			"             │           │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: NOXN3\n" +
+			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │           │                       └─ index: [NOXN3.BRQP2]\n" +
 			"             │           └─ TableAlias(sn)\n" +
-			"             │               └─ IndexedTableAccess\n" +
-			"             │                   ├─ index: [NOXN3.id]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: NOXN3\n" +
+			"             │               └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                   └─ index: [NOXN3.id]\n" +
 			"             └─ SubqueryAlias\n" +
 			"                 ├─ name: AOEV5\n" +
 			"                 ├─ outerVisibility: false\n" +
@@ -9998,10 +8984,8 @@ WHERE
 			" │       │           │   ├─ aac.id:67!null\n" +
 			" │       │           │   └─ SL3S5.M22QN:53!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ IndexedTableAccess\n" +
-			" │       │                   ├─ index: [TPXBU.id]\n" +
-			" │       │                   └─ Table\n" +
-			" │       │                       └─ name: TPXBU\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │       │                   └─ index: [TPXBU.id]\n" +
 			" │       │   as TPXBU, SL3S5.NO52D:55!null as NO52D, SL3S5.IDPK7:56!null as IDPK7]\n" +
 			" │       └─ HashJoin\n" +
 			" │           ├─ AND\n" +
@@ -10027,15 +9011,11 @@ WHERE
 			" │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			" │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │           │   │       └─ TableAlias(cla)\n" +
-			" │           │   │           └─ IndexedTableAccess\n" +
-			" │           │   │               ├─ index: [YK2GW.id]\n" +
-			" │           │   │               └─ Table\n" +
-			" │           │   │                   └─ name: YK2GW\n" +
+			" │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
+			" │           │   │               └─ index: [YK2GW.id]\n" +
 			" │           │   └─ TableAlias(mf)\n" +
-			" │           │       └─ IndexedTableAccess\n" +
-			" │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			" │           │           └─ Table\n" +
-			" │           │               └─ name: HGMQ6\n" +
+			" │           │       └─ IndexedTableAccess(HGMQ6)\n" +
+			" │           │           └─ index: [HGMQ6.GXLUB]\n" +
 			" │           └─ HashLookup\n" +
 			" │               ├─ source: TUPLE(mf.LUEVY:36!null, mf.M22QN:37!null)\n" +
 			" │               ├─ target: TUPLE(sn.BRQP2:7!null, SL3S5.M22QN:2!null)\n" +
@@ -10074,19 +9054,15 @@ WHERE
 			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
 			" │                       │           │   │       │   └─ = (longtext)\n" +
 			" │                       │           │   │       └─ TableAlias(ct)\n" +
-			" │                       │           │   │           └─ IndexedTableAccess\n" +
-			" │                       │           │   │               ├─ index: [FLQLP.OVE3E]\n" +
-			" │                       │           │   │               └─ Table\n" +
-			" │                       │           │   │                   └─ name: FLQLP\n" +
+			" │                       │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			" │                       │           │   │               └─ index: [FLQLP.OVE3E]\n" +
 			" │                       │           │   └─ Filter\n" +
 			" │                       │           │       ├─ HashIn\n" +
 			" │                       │           │       │   ├─ ci.FTQLQ:1!null\n" +
 			" │                       │           │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │                       │           │       └─ TableAlias(ci)\n" +
-			" │                       │           │           └─ IndexedTableAccess\n" +
-			" │                       │           │               ├─ index: [JDLNA.id]\n" +
-			" │                       │           │               └─ Table\n" +
-			" │                       │           │                   └─ name: JDLNA\n" +
+			" │                       │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			" │                       │           │               └─ index: [JDLNA.id]\n" +
 			" │                       │           └─ HashLookup\n" +
 			" │                       │               ├─ source: TUPLE(ct.M22QN:9!null, ct.LUEVY:8!null)\n" +
 			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
@@ -10106,15 +9082,11 @@ WHERE
 			" │                       │                                   │   └─ Table\n" +
 			" │                       │                                   │       └─ name: NOXN3\n" +
 			" │                       │                                   └─ TableAlias(mf)\n" +
-			" │                       │                                       └─ IndexedTableAccess\n" +
-			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │                       │                                           └─ Table\n" +
-			" │                       │                                               └─ name: HGMQ6\n" +
+			" │                       │                                       └─ IndexedTableAccess(HGMQ6)\n" +
+			" │                       │                                           └─ index: [HGMQ6.LUEVY]\n" +
 			" │                       └─ TableAlias(sn)\n" +
-			" │                           └─ IndexedTableAccess\n" +
-			" │                               ├─ index: [NOXN3.id]\n" +
-			" │                               └─ Table\n" +
-			" │                                   └─ name: NOXN3\n" +
+			" │                           └─ IndexedTableAccess(NOXN3)\n" +
+			" │                               └─ index: [NOXN3.id]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [AOEV5.T4IBQ:0!null as T4IBQ, VUMUY.DL754:1!null, VUMUY.BDNYB:2!null, VUMUY.ADURZ:3!null, VUMUY.TPXBU:4, VUMUY.NO52D:5!null, VUMUY.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
@@ -10134,10 +9106,8 @@ WHERE
 			"             │       │           │   ├─ aac.id:16!null\n" +
 			"             │       │           │   └─ SL3S5.M22QN:2!null\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
-			"             │       │                   ├─ index: [TPXBU.id]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			"             │       │                   └─ index: [TPXBU.id]\n" +
 			"             │       │   as TPXBU, SL3S5.NO52D:4!null as NO52D, SL3S5.IDPK7:5!null as IDPK7]\n" +
 			"             │       └─ LookupJoin\n" +
 			"             │           ├─ Eq\n" +
@@ -10161,11 +9131,9 @@ WHERE
 			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
 			"             │           │           │               │   └─ WT (longtext)\n" +
 			"             │           │           │               └─ TableAlias(aac)\n" +
-			"             │           │           │                   └─ IndexedTableAccess\n" +
+			"             │           │           │                   └─ IndexedTableAccess(TPXBU)\n" +
 			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
-			"             │           │           │                       └─ Table\n" +
-			"             │           │           │                           └─ name: TPXBU\n" +
+			"             │           │           │                       └─ static: [{[WT, WT]}]\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
 			"             │           │               │   ├─ ct.LUEVY:8!null\n" +
@@ -10186,29 +9154,21 @@ WHERE
 			"             │           │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
 			"             │           │               │   │       │   └─ = (longtext)\n" +
 			"             │           │               │   │       └─ TableAlias(ct)\n" +
-			"             │           │               │   │           └─ IndexedTableAccess\n" +
-			"             │           │               │   │               ├─ index: [FLQLP.OVE3E]\n" +
-			"             │           │               │   │               └─ Table\n" +
-			"             │           │               │   │                   └─ name: FLQLP\n" +
+			"             │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			"             │           │               │   │               └─ index: [FLQLP.OVE3E]\n" +
 			"             │           │               │   └─ Filter\n" +
 			"             │           │               │       ├─ HashIn\n" +
 			"             │           │               │       │   ├─ ci.FTQLQ:1!null\n" +
 			"             │           │               │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │           │               │       └─ TableAlias(ci)\n" +
-			"             │           │               │           └─ IndexedTableAccess\n" +
-			"             │           │               │               ├─ index: [JDLNA.id]\n" +
-			"             │           │               │               └─ Table\n" +
-			"             │           │               │                   └─ name: JDLNA\n" +
+			"             │           │               │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │           │               │               └─ index: [JDLNA.id]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
-			"             │           │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: NOXN3\n" +
+			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │           │                       └─ index: [NOXN3.BRQP2]\n" +
 			"             │           └─ TableAlias(sn)\n" +
-			"             │               └─ IndexedTableAccess\n" +
-			"             │                   ├─ index: [NOXN3.id]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: NOXN3\n" +
+			"             │               └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                   └─ index: [NOXN3.id]\n" +
 			"             └─ SubqueryAlias\n" +
 			"                 ├─ name: AOEV5\n" +
 			"                 ├─ outerVisibility: false\n" +
@@ -10295,15 +9255,11 @@ WHERE
 			"         │   │                   ├─ name: NOXN3\n" +
 			"         │   │                   └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"         │   └─ TableAlias(TYMVL)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           └─ index: [E2I7U.id]\n" +
 			"         └─ TableAlias(S7EGW)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [E2I7U.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 └─ index: [E2I7U.id]\n" +
 			"",
 	},
 	{
@@ -10352,10 +9308,8 @@ WHERE
 			"         │                   ├─ name: NOXN3\n" +
 			"         │                   └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"         └─ TableAlias(nd)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [E2I7U.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 └─ index: [E2I7U.id]\n" +
 			"",
 	},
 	{
@@ -10396,15 +9350,11 @@ WHERE
 			"             │   │   └─ Table\n" +
 			"             │   │       └─ name: E2I7U\n" +
 			"             │   └─ TableAlias(sn)\n" +
-			"             │       └─ IndexedTableAccess\n" +
-			"             │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"             │           └─ Table\n" +
-			"             │               └─ name: NOXN3\n" +
+			"             │       └─ IndexedTableAccess(NOXN3)\n" +
+			"             │           └─ index: [NOXN3.FFTBJ]\n" +
 			"             └─ TableAlias(S7EGW)\n" +
-			"                 └─ IndexedTableAccess\n" +
-			"                     ├─ index: [E2I7U.id]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: E2I7U\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     └─ index: [E2I7U.id]\n" +
 			"",
 	},
 	{
@@ -10453,21 +9403,15 @@ WHERE
 			"         │   │   │   └─ SUZTA (longtext)\n" +
 			"         │   │   │  ))\n" +
 			"         │   │   └─ TableAlias(nt)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
+			"         │   │       └─ IndexedTableAccess(F35MI)\n" +
 			"         │   │           ├─ index: [F35MI.DZLIM]\n" +
-			"         │   │           ├─ static: [{(SUZTA, ∞)}, {(NULL, SUZTA)}]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: F35MI\n" +
+			"         │   │           └─ static: [{(SUZTA, ∞)}, {(NULL, SUZTA)}]\n" +
 			"         │   └─ TableAlias(nd)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [E2I7U.DKCAJ]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           └─ index: [E2I7U.DKCAJ]\n" +
 			"         └─ TableAlias(il)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [RLOHD.LUEVY]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: RLOHD\n" +
+			"             └─ IndexedTableAccess(RLOHD)\n" +
+			"                 └─ index: [RLOHD.LUEVY]\n" +
 			"",
 	},
 	{
@@ -10480,13 +9424,10 @@ WHERE
 			" ├─ HashIn\n" +
 			" │   ├─ YK2GW.FTQLQ:0!null\n" +
 			" │   └─ TUPLE(SQ1 (longtext))\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(YK2GW)\n" +
 			"     ├─ index: [YK2GW.FTQLQ]\n" +
 			"     ├─ static: [{[SQ1, SQ1]}]\n" +
-			"     ├─ columns: [ftqlq tpnj6]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: YK2GW\n" +
-			"         └─ projections: [1 5]\n" +
+			"     └─ columns: [ftqlq tpnj6]\n" +
 			"",
 	},
 	{
@@ -10573,10 +9514,8 @@ WHERE
 			"         │       │           │   ├─ nt.id:19!null\n" +
 			"         │       │           │   └─ nd.DKCAJ:3!null\n" +
 			"         │       │           └─ TableAlias(nt)\n" +
-			"         │       │               └─ IndexedTableAccess\n" +
-			"         │       │                   ├─ index: [F35MI.id]\n" +
-			"         │       │                   └─ Table\n" +
-			"         │       │                       └─ name: F35MI\n" +
+			"         │       │               └─ IndexedTableAccess(F35MI)\n" +
+			"         │       │                   └─ index: [F35MI.id]\n" +
 			"         │       │   as SJ5DU]\n" +
 			"         │       └─ CrossJoin\n" +
 			"         │           ├─ SubqueryAlias\n" +
@@ -10597,18 +9536,14 @@ WHERE
 			"         │           │               │   ├─ cla.FTQLQ:1!null\n" +
 			"         │           │               │   └─ TUPLE(SQ1 (longtext))\n" +
 			"         │           │               └─ TableAlias(cla)\n" +
-			"         │           │                   └─ IndexedTableAccess\n" +
-			"         │           │                       ├─ index: [YK2GW.id]\n" +
-			"         │           │                       └─ Table\n" +
-			"         │           │                           └─ name: YK2GW\n" +
+			"         │           │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"         │           │                       └─ index: [YK2GW.id]\n" +
 			"         │           └─ TableAlias(nd)\n" +
 			"         │               └─ Table\n" +
 			"         │                   └─ name: E2I7U\n" +
 			"         └─ TableAlias(fc)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: AMYXQ\n" +
+			"             └─ IndexedTableAccess(AMYXQ)\n" +
+			"                 └─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
 			"",
 	},
 	{
@@ -10807,12 +9742,9 @@ WHERE
 			"                                                     │   │   │   │               ├─ Table\n" +
 			"                                                     │   │   │   │               │   ├─ name: THNTS\n" +
 			"                                                     │   │   │   │               │   └─ columns: [id ixuxu]\n" +
-			"                                                     │   │   │   │               └─ IndexedTableAccess\n" +
+			"                                                     │   │   │   │               └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │   │   │   │                   ├─ index: [YK2GW.id]\n" +
-			"                                                     │   │   │   │                   ├─ columns: [id ftqlq]\n" +
-			"                                                     │   │   │   │                   └─ Table\n" +
-			"                                                     │   │   │   │                       ├─ name: YK2GW\n" +
-			"                                                     │   │   │   │                       └─ projections: [0 1]\n" +
+			"                                                     │   │   │   │                   └─ columns: [id ftqlq]\n" +
 			"                                                     │   │   │   └─ HashLookup\n" +
 			"                                                     │   │   │       ├─ source: TUPLE(bs.id:0!null)\n" +
 			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:4!null)\n" +
@@ -10837,20 +9769,14 @@ WHERE
 			"                                                     │   │   │               │   │   │   │   └─ Table\n" +
 			"                                                     │   │   │               │   │   │   │       └─ name: XOAOP\n" +
 			"                                                     │   │   │               │   │   │   └─ TableAlias(ms)\n" +
-			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess\n" +
-			"                                                     │   │   │               │   │   │           ├─ index: [SZQWJ.CH3FR]\n" +
-			"                                                     │   │   │               │   │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │   │               └─ name: SZQWJ\n" +
+			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess(SZQWJ)\n" +
+			"                                                     │   │   │               │   │   │           └─ index: [SZQWJ.CH3FR]\n" +
 			"                                                     │   │   │               │   │   └─ TableAlias(pog)\n" +
-			"                                                     │   │   │               │   │       └─ IndexedTableAccess\n" +
-			"                                                     │   │   │               │   │           ├─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
-			"                                                     │   │   │               │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │               └─ name: NPCYY\n" +
+			"                                                     │   │   │               │   │       └─ IndexedTableAccess(NPCYY)\n" +
+			"                                                     │   │   │               │   │           └─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
 			"                                                     │   │   │               │   └─ TableAlias(pga)\n" +
-			"                                                     │   │   │               │       └─ IndexedTableAccess\n" +
-			"                                                     │   │   │               │           ├─ index: [PG27A.id]\n" +
-			"                                                     │   │   │               │           └─ Table\n" +
-			"                                                     │   │   │               │               └─ name: PG27A\n" +
+			"                                                     │   │   │               │       └─ IndexedTableAccess(PG27A)\n" +
+			"                                                     │   │   │               │           └─ index: [PG27A.id]\n" +
 			"                                                     │   │   │               └─ HashLookup\n" +
 			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:10)\n" +
 			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:19!null)\n" +
@@ -10863,15 +9789,11 @@ WHERE
 			"                                                     │   │   │                           │   └─ Table\n" +
 			"                                                     │   │   │                           │       └─ name: E2I7U\n" +
 			"                                                     │   │   │                           └─ TableAlias(GZ7Z4)\n" +
-			"                                                     │   │   │                               └─ IndexedTableAccess\n" +
-			"                                                     │   │   │                                   ├─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
-			"                                                     │   │   │                                   └─ Table\n" +
-			"                                                     │   │   │                                       └─ name: FEIOE\n" +
+			"                                                     │   │   │                               └─ IndexedTableAccess(FEIOE)\n" +
+			"                                                     │   │   │                                   └─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
 			"                                                     │   │   └─ TableAlias(fc)\n" +
-			"                                                     │   │       └─ IndexedTableAccess\n" +
-			"                                                     │   │           ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                                                     │   │           └─ Table\n" +
-			"                                                     │   │               └─ name: AMYXQ\n" +
+			"                                                     │   │       └─ IndexedTableAccess(AMYXQ)\n" +
+			"                                                     │   │           └─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
 			"                                                     │   └─ HashLookup\n" +
 			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:17)\n" +
 			"                                                     │       ├─ target: TUPLE(F26ZW.T4IBQ:0!null, F26ZW.BRQP2:1!null)\n" +
@@ -10982,21 +9904,15 @@ WHERE
 			"                                                     │                       │   │           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"                                                     │                       │   │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                                                     │                       │   │           │   │   │   └─ TableAlias(cla)\n" +
-			"                                                     │                       │   │           │   │   │       └─ IndexedTableAccess\n" +
+			"                                                     │                       │   │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │                       │   │           │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"                                                     │                       │   │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"                                                     │                       │   │           │   │   │           └─ Table\n" +
-			"                                                     │                       │   │           │   │   │               └─ name: YK2GW\n" +
+			"                                                     │                       │   │           │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
 			"                                                     │                       │   │           │   │   └─ TableAlias(bs)\n" +
-			"                                                     │                       │   │           │   │       └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │           │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"                                                     │                       │   │           │   │           └─ Table\n" +
-			"                                                     │                       │   │           │   │               └─ name: THNTS\n" +
+			"                                                     │                       │   │           │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"                                                     │                       │   │           │   │           └─ index: [THNTS.IXUXU]\n" +
 			"                                                     │                       │   │           │   └─ TableAlias(mf)\n" +
-			"                                                     │                       │   │           │       └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                                                     │                       │   │           │           └─ Table\n" +
-			"                                                     │                       │   │           │               └─ name: HGMQ6\n" +
+			"                                                     │                       │   │           │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"                                                     │                       │   │           │           └─ index: [HGMQ6.GXLUB]\n" +
 			"                                                     │                       │   │           └─ HashLookup\n" +
 			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:0!null)\n" +
@@ -11013,30 +9929,20 @@ WHERE
 			"                                                     │                       │   │                       │   │   └─ Table\n" +
 			"                                                     │                       │   │                       │   │       └─ name: E2I7U\n" +
 			"                                                     │                       │   │                       │   └─ TableAlias(nma)\n" +
-			"                                                     │                       │   │                       │       └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │                       │           ├─ index: [TNMXI.id]\n" +
-			"                                                     │                       │   │                       │           └─ Table\n" +
-			"                                                     │                       │   │                       │               └─ name: TNMXI\n" +
+			"                                                     │                       │   │                       │       └─ IndexedTableAccess(TNMXI)\n" +
+			"                                                     │                       │   │                       │           └─ index: [TNMXI.id]\n" +
 			"                                                     │                       │   │                       └─ TableAlias(sn)\n" +
-			"                                                     │                       │   │                           └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │                               ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                     │                       │   │                               └─ Table\n" +
-			"                                                     │                       │   │                                   └─ name: NOXN3\n" +
+			"                                                     │                       │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                     │                       │   │                               └─ index: [NOXN3.BRQP2]\n" +
 			"                                                     │                       │   └─ TableAlias(W2MAO)\n" +
-			"                                                     │                       │       └─ IndexedTableAccess\n" +
-			"                                                     │                       │           ├─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
-			"                                                     │                       │           └─ Table\n" +
-			"                                                     │                       │               └─ name: SEQS3\n" +
+			"                                                     │                       │       └─ IndexedTableAccess(SEQS3)\n" +
+			"                                                     │                       │           └─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
 			"                                                     │                       └─ TableAlias(vc)\n" +
-			"                                                     │                           └─ IndexedTableAccess\n" +
-			"                                                     │                               ├─ index: [D34QP.id]\n" +
-			"                                                     │                               └─ Table\n" +
-			"                                                     │                                   └─ name: D34QP\n" +
+			"                                                     │                           └─ IndexedTableAccess(D34QP)\n" +
+			"                                                     │                               └─ index: [D34QP.id]\n" +
 			"                                                     └─ TableAlias(nma)\n" +
-			"                                                         └─ IndexedTableAccess\n" +
-			"                                                             ├─ index: [TNMXI.id]\n" +
-			"                                                             └─ Table\n" +
-			"                                                                 └─ name: TNMXI\n" +
+			"                                                         └─ IndexedTableAccess(TNMXI)\n" +
+			"                                                             └─ index: [TNMXI.id]\n" +
 			"",
 	},
 	{
@@ -11235,12 +10141,9 @@ WHERE
 			"                                                     │   │   │   │               ├─ Table\n" +
 			"                                                     │   │   │   │               │   ├─ name: THNTS\n" +
 			"                                                     │   │   │   │               │   └─ columns: [id ixuxu]\n" +
-			"                                                     │   │   │   │               └─ IndexedTableAccess\n" +
+			"                                                     │   │   │   │               └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │   │   │   │                   ├─ index: [YK2GW.id]\n" +
-			"                                                     │   │   │   │                   ├─ columns: [id ftqlq]\n" +
-			"                                                     │   │   │   │                   └─ Table\n" +
-			"                                                     │   │   │   │                       ├─ name: YK2GW\n" +
-			"                                                     │   │   │   │                       └─ projections: [0 1]\n" +
+			"                                                     │   │   │   │                   └─ columns: [id ftqlq]\n" +
 			"                                                     │   │   │   └─ HashLookup\n" +
 			"                                                     │   │   │       ├─ source: TUPLE(bs.id:0!null)\n" +
 			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:4!null)\n" +
@@ -11265,20 +10168,14 @@ WHERE
 			"                                                     │   │   │               │   │   │   │   └─ Table\n" +
 			"                                                     │   │   │               │   │   │   │       └─ name: XOAOP\n" +
 			"                                                     │   │   │               │   │   │   └─ TableAlias(ms)\n" +
-			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess\n" +
-			"                                                     │   │   │               │   │   │           ├─ index: [SZQWJ.CH3FR]\n" +
-			"                                                     │   │   │               │   │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │   │               └─ name: SZQWJ\n" +
+			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess(SZQWJ)\n" +
+			"                                                     │   │   │               │   │   │           └─ index: [SZQWJ.CH3FR]\n" +
 			"                                                     │   │   │               │   │   └─ TableAlias(pog)\n" +
-			"                                                     │   │   │               │   │       └─ IndexedTableAccess\n" +
-			"                                                     │   │   │               │   │           ├─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
-			"                                                     │   │   │               │   │           └─ Table\n" +
-			"                                                     │   │   │               │   │               └─ name: NPCYY\n" +
+			"                                                     │   │   │               │   │       └─ IndexedTableAccess(NPCYY)\n" +
+			"                                                     │   │   │               │   │           └─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
 			"                                                     │   │   │               │   └─ TableAlias(pga)\n" +
-			"                                                     │   │   │               │       └─ IndexedTableAccess\n" +
-			"                                                     │   │   │               │           ├─ index: [PG27A.id]\n" +
-			"                                                     │   │   │               │           └─ Table\n" +
-			"                                                     │   │   │               │               └─ name: PG27A\n" +
+			"                                                     │   │   │               │       └─ IndexedTableAccess(PG27A)\n" +
+			"                                                     │   │   │               │           └─ index: [PG27A.id]\n" +
 			"                                                     │   │   │               └─ HashLookup\n" +
 			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:10)\n" +
 			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:19!null)\n" +
@@ -11291,15 +10188,11 @@ WHERE
 			"                                                     │   │   │                           │   └─ Table\n" +
 			"                                                     │   │   │                           │       └─ name: E2I7U\n" +
 			"                                                     │   │   │                           └─ TableAlias(GZ7Z4)\n" +
-			"                                                     │   │   │                               └─ IndexedTableAccess\n" +
-			"                                                     │   │   │                                   ├─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
-			"                                                     │   │   │                                   └─ Table\n" +
-			"                                                     │   │   │                                       └─ name: FEIOE\n" +
+			"                                                     │   │   │                               └─ IndexedTableAccess(FEIOE)\n" +
+			"                                                     │   │   │                                   └─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
 			"                                                     │   │   └─ TableAlias(fc)\n" +
-			"                                                     │   │       └─ IndexedTableAccess\n" +
-			"                                                     │   │           ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                                                     │   │           └─ Table\n" +
-			"                                                     │   │               └─ name: AMYXQ\n" +
+			"                                                     │   │       └─ IndexedTableAccess(AMYXQ)\n" +
+			"                                                     │   │           └─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
 			"                                                     │   └─ HashLookup\n" +
 			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:17)\n" +
 			"                                                     │       ├─ target: TUPLE(F26ZW.T4IBQ:0!null, F26ZW.BRQP2:1!null)\n" +
@@ -11413,15 +10306,11 @@ WHERE
 			"                                                     │                       │   │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                                                     │                       │   │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                                                     │                       │   │           │   │       └─ TableAlias(cla)\n" +
-			"                                                     │                       │   │           │   │           └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │           │   │               ├─ index: [YK2GW.id]\n" +
-			"                                                     │                       │   │           │   │               └─ Table\n" +
-			"                                                     │                       │   │           │   │                   └─ name: YK2GW\n" +
+			"                                                     │                       │   │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
+			"                                                     │                       │   │           │   │               └─ index: [YK2GW.id]\n" +
 			"                                                     │                       │   │           │   └─ TableAlias(mf)\n" +
-			"                                                     │                       │   │           │       └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                                                     │                       │   │           │           └─ Table\n" +
-			"                                                     │                       │   │           │               └─ name: HGMQ6\n" +
+			"                                                     │                       │   │           │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"                                                     │                       │   │           │           └─ index: [HGMQ6.GXLUB]\n" +
 			"                                                     │                       │   │           └─ HashLookup\n" +
 			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:3!null)\n" +
@@ -11438,30 +10327,20 @@ WHERE
 			"                                                     │                       │   │                       │   │   └─ Table\n" +
 			"                                                     │                       │   │                       │   │       └─ name: TNMXI\n" +
 			"                                                     │                       │   │                       │   └─ TableAlias(nd)\n" +
-			"                                                     │                       │   │                       │       └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │                       │           ├─ index: [E2I7U.HPCMS]\n" +
-			"                                                     │                       │   │                       │           └─ Table\n" +
-			"                                                     │                       │   │                       │               └─ name: E2I7U\n" +
+			"                                                     │                       │   │                       │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                                                     │                       │   │                       │           └─ index: [E2I7U.HPCMS]\n" +
 			"                                                     │                       │   │                       └─ TableAlias(sn)\n" +
-			"                                                     │                       │   │                           └─ IndexedTableAccess\n" +
-			"                                                     │                       │   │                               ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                     │                       │   │                               └─ Table\n" +
-			"                                                     │                       │   │                                   └─ name: NOXN3\n" +
+			"                                                     │                       │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                     │                       │   │                               └─ index: [NOXN3.BRQP2]\n" +
 			"                                                     │                       │   └─ TableAlias(W2MAO)\n" +
-			"                                                     │                       │       └─ IndexedTableAccess\n" +
-			"                                                     │                       │           ├─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
-			"                                                     │                       │           └─ Table\n" +
-			"                                                     │                       │               └─ name: SEQS3\n" +
+			"                                                     │                       │       └─ IndexedTableAccess(SEQS3)\n" +
+			"                                                     │                       │           └─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
 			"                                                     │                       └─ TableAlias(vc)\n" +
-			"                                                     │                           └─ IndexedTableAccess\n" +
-			"                                                     │                               ├─ index: [D34QP.id]\n" +
-			"                                                     │                               └─ Table\n" +
-			"                                                     │                                   └─ name: D34QP\n" +
+			"                                                     │                           └─ IndexedTableAccess(D34QP)\n" +
+			"                                                     │                               └─ index: [D34QP.id]\n" +
 			"                                                     └─ TableAlias(nma)\n" +
-			"                                                         └─ IndexedTableAccess\n" +
-			"                                                             ├─ index: [TNMXI.id]\n" +
-			"                                                             └─ Table\n" +
-			"                                                                 └─ name: TNMXI\n" +
+			"                                                         └─ IndexedTableAccess(TNMXI)\n" +
+			"                                                             └─ index: [TNMXI.id]\n" +
 			"",
 	},
 	{
@@ -11527,13 +10406,10 @@ WHERE
 	ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.ECXAJ:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id ecxaj]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 5]\n" +
+			"     └─ columns: [id ecxaj]\n" +
 			"",
 	},
 	{
@@ -11634,12 +10510,9 @@ WHERE
 			" │               ├─ Table\n" +
 			" │               │   └─ name: E2I7U\n" +
 			" │               └─ TableAlias(applySubq0)\n" +
-			" │                   └─ IndexedTableAccess\n" +
+			" │                   └─ IndexedTableAccess(AMYXQ)\n" +
 			" │                       ├─ index: [AMYXQ.LUEVY]\n" +
-			" │                       ├─ columns: [luevy]\n" +
-			" │                       └─ Table\n" +
-			" │                           ├─ name: AMYXQ\n" +
-			" │                           └─ projections: [2]\n" +
+			" │                       └─ columns: [luevy]\n" +
 			" │   THEN 1 (tinyint) WHEN Eq\n" +
 			" │   ├─ E2I7U.FSK67:8!null\n" +
 			" │   └─ z (longtext)\n" +
@@ -11647,11 +10520,9 @@ WHERE
 			" │   ├─ E2I7U.FSK67:8!null\n" +
 			" │   └─ CRZ2X (longtext)\n" +
 			" │   THEN 0 (tinyint) ELSE 3 (tinyint) END as SZ6KK]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     └─ Table\n" +
-			"         └─ name: E2I7U\n" +
+			"     └─ static: [{[NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -11782,25 +10653,19 @@ WHERE
 			"             │                       │   │   │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"             │                       │   │   │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │                       │   │   │   │   │   └─ TableAlias(cla)\n" +
-			"             │                       │   │   │   │   │       └─ IndexedTableAccess\n" +
+			"             │                       │   │   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"             │                       │   │   │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"             │                       │   │   │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"             │                       │   │   │   │   │           └─ Table\n" +
-			"             │                       │   │   │   │   │               └─ name: YK2GW\n" +
+			"             │                       │   │   │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
 			"             │                       │   │   │   │   └─ TableAlias(bs)\n" +
-			"             │                       │   │   │   │       └─ IndexedTableAccess\n" +
-			"             │                       │   │   │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"             │                       │   │   │   │           └─ Table\n" +
-			"             │                       │   │   │   │               └─ name: THNTS\n" +
+			"             │                       │   │   │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"             │                       │   │   │   │           └─ index: [THNTS.IXUXU]\n" +
 			"             │                       │   │   │   └─ Filter\n" +
 			"             │                       │   │   │       ├─ HashIn\n" +
 			"             │                       │   │   │       │   ├─ mf.FSDY2:10!null\n" +
 			"             │                       │   │   │       │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"             │                       │   │   │       └─ TableAlias(mf)\n" +
-			"             │                       │   │   │           └─ IndexedTableAccess\n" +
-			"             │                       │   │   │               ├─ index: [HGMQ6.GXLUB]\n" +
-			"             │                       │   │   │               └─ Table\n" +
-			"             │                       │   │   │                   └─ name: HGMQ6\n" +
+			"             │                       │   │   │           └─ IndexedTableAccess(HGMQ6)\n" +
+			"             │                       │   │   │               └─ index: [HGMQ6.GXLUB]\n" +
 			"             │                       │   │   └─ HashLookup\n" +
 			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"             │                       │   │       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
@@ -11809,10 +10674,8 @@ WHERE
 			"             │                       │   │               └─ Table\n" +
 			"             │                       │   │                   └─ name: NOXN3\n" +
 			"             │                       │   └─ TableAlias(aac)\n" +
-			"             │                       │       └─ IndexedTableAccess\n" +
-			"             │                       │           ├─ index: [TPXBU.id]\n" +
-			"             │                       │           └─ Table\n" +
-			"             │                       │               └─ name: TPXBU\n" +
+			"             │                       │       └─ IndexedTableAccess(TPXBU)\n" +
+			"             │                       │           └─ index: [TPXBU.id]\n" +
 			"             │                       └─ HashLookup\n" +
 			"             │                           ├─ source: TUPLE(mf.id:34!null)\n" +
 			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:1!null)\n" +
@@ -11825,10 +10688,8 @@ WHERE
 			"             │                                   │   └─ Table\n" +
 			"             │                                   │       └─ name: SEQS3\n" +
 			"             │                                   └─ TableAlias(vc)\n" +
-			"             │                                       └─ IndexedTableAccess\n" +
-			"             │                                           ├─ index: [D34QP.id]\n" +
-			"             │                                           └─ Table\n" +
-			"             │                                               └─ name: D34QP\n" +
+			"             │                                       └─ IndexedTableAccess(D34QP)\n" +
+			"             │                                           └─ index: [D34QP.id]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(OXXEI.BDNYB:3!null)\n" +
 			"                 ├─ target: TUPLE(E52AP.BDNYB:1!null)\n" +
@@ -11860,15 +10721,11 @@ WHERE
 			"                                         │   │   └─ Table\n" +
 			"                                         │   │       └─ name: NOXN3\n" +
 			"                                         │   └─ TableAlias(nd)\n" +
-			"                                         │       └─ IndexedTableAccess\n" +
-			"                                         │           ├─ index: [E2I7U.id]\n" +
-			"                                         │           └─ Table\n" +
-			"                                         │               └─ name: E2I7U\n" +
+			"                                         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                                         │           └─ index: [E2I7U.id]\n" +
 			"                                         └─ TableAlias(nma)\n" +
-			"                                             └─ IndexedTableAccess\n" +
-			"                                                 ├─ index: [TNMXI.id]\n" +
-			"                                                 └─ Table\n" +
-			"                                                     └─ name: TNMXI\n" +
+			"                                             └─ IndexedTableAccess(TNMXI)\n" +
+			"                                                 └─ index: [TNMXI.id]\n" +
 			"",
 	},
 	{
@@ -12002,19 +10859,15 @@ WHERE
 			"             │                       │   │   │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"             │                       │   │   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │                       │   │   │   │       └─ TableAlias(cla)\n" +
-			"             │                       │   │   │   │           └─ IndexedTableAccess\n" +
-			"             │                       │   │   │   │               ├─ index: [YK2GW.id]\n" +
-			"             │                       │   │   │   │               └─ Table\n" +
-			"             │                       │   │   │   │                   └─ name: YK2GW\n" +
+			"             │                       │   │   │   │           └─ IndexedTableAccess(YK2GW)\n" +
+			"             │                       │   │   │   │               └─ index: [YK2GW.id]\n" +
 			"             │                       │   │   │   └─ Filter\n" +
 			"             │                       │   │   │       ├─ HashIn\n" +
 			"             │                       │   │   │       │   ├─ mf.FSDY2:10!null\n" +
 			"             │                       │   │   │       │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"             │                       │   │   │       └─ TableAlias(mf)\n" +
-			"             │                       │   │   │           └─ IndexedTableAccess\n" +
-			"             │                       │   │   │               ├─ index: [HGMQ6.GXLUB]\n" +
-			"             │                       │   │   │               └─ Table\n" +
-			"             │                       │   │   │                   └─ name: HGMQ6\n" +
+			"             │                       │   │   │           └─ IndexedTableAccess(HGMQ6)\n" +
+			"             │                       │   │   │               └─ index: [HGMQ6.GXLUB]\n" +
 			"             │                       │   │   └─ HashLookup\n" +
 			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"             │                       │   │       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
@@ -12023,10 +10876,8 @@ WHERE
 			"             │                       │   │               └─ Table\n" +
 			"             │                       │   │                   └─ name: NOXN3\n" +
 			"             │                       │   └─ TableAlias(aac)\n" +
-			"             │                       │       └─ IndexedTableAccess\n" +
-			"             │                       │           ├─ index: [TPXBU.id]\n" +
-			"             │                       │           └─ Table\n" +
-			"             │                       │               └─ name: TPXBU\n" +
+			"             │                       │       └─ IndexedTableAccess(TPXBU)\n" +
+			"             │                       │           └─ index: [TPXBU.id]\n" +
 			"             │                       └─ HashLookup\n" +
 			"             │                           ├─ source: TUPLE(mf.id:34!null)\n" +
 			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:7!null)\n" +
@@ -12039,10 +10890,8 @@ WHERE
 			"             │                                   │   └─ Table\n" +
 			"             │                                   │       └─ name: D34QP\n" +
 			"             │                                   └─ TableAlias(W2MAO)\n" +
-			"             │                                       └─ IndexedTableAccess\n" +
-			"             │                                           ├─ index: [SEQS3.YH4XB]\n" +
-			"             │                                           └─ Table\n" +
-			"             │                                               └─ name: SEQS3\n" +
+			"             │                                       └─ IndexedTableAccess(SEQS3)\n" +
+			"             │                                           └─ index: [SEQS3.YH4XB]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(OXXEI.BDNYB:3!null)\n" +
 			"                 ├─ target: TUPLE(E52AP.BDNYB:1!null)\n" +
@@ -12074,15 +10923,11 @@ WHERE
 			"                                         │   │   └─ Table\n" +
 			"                                         │   │       └─ name: NOXN3\n" +
 			"                                         │   └─ TableAlias(nd)\n" +
-			"                                         │       └─ IndexedTableAccess\n" +
-			"                                         │           ├─ index: [E2I7U.id]\n" +
-			"                                         │           └─ Table\n" +
-			"                                         │               └─ name: E2I7U\n" +
+			"                                         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                                         │           └─ index: [E2I7U.id]\n" +
 			"                                         └─ TableAlias(nma)\n" +
-			"                                             └─ IndexedTableAccess\n" +
-			"                                                 ├─ index: [TNMXI.id]\n" +
-			"                                                 └─ Table\n" +
-			"                                                     └─ name: TNMXI\n" +
+			"                                             └─ IndexedTableAccess(TNMXI)\n" +
+			"                                                 └─ index: [TNMXI.id]\n" +
 			"",
 	},
 	{
@@ -12679,15 +11524,11 @@ WHERE
 			"                         │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                         │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                         │       └─ TableAlias(cla)\n" +
-			"                         │           └─ IndexedTableAccess\n" +
-			"                         │               ├─ index: [YK2GW.id]\n" +
-			"                         │               └─ Table\n" +
-			"                         │                   └─ name: YK2GW\n" +
+			"                         │           └─ IndexedTableAccess(YK2GW)\n" +
+			"                         │               └─ index: [YK2GW.id]\n" +
 			"                         └─ TableAlias(mf)\n" +
-			"                             └─ IndexedTableAccess\n" +
-			"                                 ├─ index: [HGMQ6.GXLUB]\n" +
-			"                                 └─ Table\n" +
-			"                                     └─ name: HGMQ6\n" +
+			"                             └─ IndexedTableAccess(HGMQ6)\n" +
+			"                                 └─ index: [HGMQ6.GXLUB]\n" +
 			"",
 	},
 	{
@@ -13025,35 +11866,23 @@ WHERE
 			"     │           │                       │   │                   │   │   │   │   │       └─ Table\n" +
 			"     │           │                       │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
 			"     │           │                       │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"     │           │                       │   │                   │   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
+			"     │           │                       │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
 			"     │           │                       │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"     │           │                       │   │                   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │               └─ name: WGSDC\n" +
+			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
+			"     │           │                       │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
 			"     │           │                       │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"     │           │                       │   │                   │   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │           │                       │   │                   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │               └─ name: E2I7U\n" +
+			"     │           │                       │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │           │                       │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
 			"     │           │                       │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"     │           │                       │   │                   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                   │           └─ Table\n" +
-			"     │           │                       │   │                   │               └─ name: NOXN3\n" +
+			"     │           │                       │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │           │                       │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
 			"     │           │                       │   │                   └─ TableAlias(YVHJZ)\n" +
-			"     │           │                       │   │                       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                           └─ Table\n" +
-			"     │           │                       │   │                               └─ name: NOXN3\n" +
+			"     │           │                       │   │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │           │                       │   │                           └─ index: [NOXN3.BRQP2]\n" +
 			"     │           │                       │   └─ TableAlias(aac)\n" +
-			"     │           │                       │       └─ IndexedTableAccess\n" +
-			"     │           │                       │           ├─ index: [TPXBU.id]\n" +
-			"     │           │                       │           └─ Table\n" +
-			"     │           │                       │               └─ name: TPXBU\n" +
+			"     │           │                       │       └─ IndexedTableAccess(TPXBU)\n" +
+			"     │           │                       │           └─ index: [TPXBU.id]\n" +
 			"     │           │                       └─ TableAlias(sn)\n" +
 			"     │           │                           └─ Table\n" +
 			"     │           │                               └─ name: NOXN3\n" +
@@ -13087,21 +11916,15 @@ WHERE
 			"     │                                   │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"     │                                   │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"     │                                   │   │   │   └─ TableAlias(cla)\n" +
-			"     │                                   │   │   │       └─ IndexedTableAccess\n" +
+			"     │                                   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"     │                                   │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"     │                                   │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"     │                                   │   │   │           └─ Table\n" +
-			"     │                                   │   │   │               └─ name: YK2GW\n" +
+			"     │                                   │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
 			"     │                                   │   │   └─ TableAlias(bs)\n" +
-			"     │                                   │   │       └─ IndexedTableAccess\n" +
-			"     │                                   │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"     │                                   │   │           └─ Table\n" +
-			"     │                                   │   │               └─ name: THNTS\n" +
+			"     │                                   │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"     │                                   │   │           └─ index: [THNTS.IXUXU]\n" +
 			"     │                                   │   └─ TableAlias(mf)\n" +
-			"     │                                   │       └─ IndexedTableAccess\n" +
-			"     │                                   │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"     │                                   │           └─ Table\n" +
-			"     │                                   │               └─ name: HGMQ6\n" +
+			"     │                                   │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"     │                                   │           └─ index: [HGMQ6.GXLUB]\n" +
 			"     │                                   └─ HashLookup\n" +
 			"     │                                       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"     │                                       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
@@ -13153,21 +11976,15 @@ WHERE
 			"                             │           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
 			"                             │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                             │           │   │   │   └─ TableAlias(cla)\n" +
-			"                             │           │   │   │       └─ IndexedTableAccess\n" +
+			"                             │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"                             │           │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"                             │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			"                             │           │   │   │           └─ Table\n" +
-			"                             │           │   │   │               └─ name: YK2GW\n" +
+			"                             │           │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
 			"                             │           │   │   └─ TableAlias(bs)\n" +
-			"                             │           │   │       └─ IndexedTableAccess\n" +
-			"                             │           │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"                             │           │   │           └─ Table\n" +
-			"                             │           │   │               └─ name: THNTS\n" +
+			"                             │           │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"                             │           │   │           └─ index: [THNTS.IXUXU]\n" +
 			"                             │           │   └─ TableAlias(mf)\n" +
-			"                             │           │       └─ IndexedTableAccess\n" +
-			"                             │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                             │           │           └─ Table\n" +
-			"                             │           │               └─ name: HGMQ6\n" +
+			"                             │           │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"                             │           │           └─ index: [HGMQ6.GXLUB]\n" +
 			"                             │           └─ HashLookup\n" +
 			"                             │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"                             │               ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
@@ -13341,35 +12158,23 @@ WHERE
 			"                                                 │   │                   │   │   │   │   │       └─ Table\n" +
 			"                                                 │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
 			"                                                 │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"                                                 │   │                   │   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
+			"                                                 │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
 			"                                                 │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"                                                 │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"                                                 │   │                   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │               └─ name: WGSDC\n" +
+			"                                                 │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
+			"                                                 │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
 			"                                                 │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"                                                 │   │                   │   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"                                                 │   │                   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │               └─ name: E2I7U\n" +
+			"                                                 │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                                                 │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
 			"                                                 │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"                                                 │   │                   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                   │           └─ Table\n" +
-			"                                                 │   │                   │               └─ name: NOXN3\n" +
+			"                                                 │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │                   └─ TableAlias(YVHJZ)\n" +
-			"                                                 │   │                       └─ IndexedTableAccess\n" +
-			"                                                 │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                           └─ Table\n" +
-			"                                                 │   │                               └─ name: NOXN3\n" +
+			"                                                 │   │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │                           └─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   └─ TableAlias(aac)\n" +
-			"                                                 │       └─ IndexedTableAccess\n" +
-			"                                                 │           ├─ index: [TPXBU.id]\n" +
-			"                                                 │           └─ Table\n" +
-			"                                                 │               └─ name: TPXBU\n" +
+			"                                                 │       └─ IndexedTableAccess(TPXBU)\n" +
+			"                                                 │           └─ index: [TPXBU.id]\n" +
 			"                                                 └─ TableAlias(sn)\n" +
 			"                                                     └─ Table\n" +
 			"                                                         └─ name: NOXN3\n" +
@@ -13711,35 +12516,23 @@ WHERE
 			"     │           │                       │   │                   │   │   │   │   │       └─ Table\n" +
 			"     │           │                       │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
 			"     │           │                       │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"     │           │                       │   │                   │   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
+			"     │           │                       │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
 			"     │           │                       │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"     │           │                       │   │                   │   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │   │               └─ name: WGSDC\n" +
+			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
+			"     │           │                       │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
 			"     │           │                       │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"     │           │                       │   │                   │   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │           │                       │   │                   │   │           └─ Table\n" +
-			"     │           │                       │   │                   │   │               └─ name: E2I7U\n" +
+			"     │           │                       │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │           │                       │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
 			"     │           │                       │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"     │           │                       │   │                   │       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                   │           └─ Table\n" +
-			"     │           │                       │   │                   │               └─ name: NOXN3\n" +
+			"     │           │                       │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │           │                       │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
 			"     │           │                       │   │                   └─ TableAlias(YVHJZ)\n" +
-			"     │           │                       │   │                       └─ IndexedTableAccess\n" +
-			"     │           │                       │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"     │           │                       │   │                           └─ Table\n" +
-			"     │           │                       │   │                               └─ name: NOXN3\n" +
+			"     │           │                       │   │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │           │                       │   │                           └─ index: [NOXN3.BRQP2]\n" +
 			"     │           │                       │   └─ TableAlias(aac)\n" +
-			"     │           │                       │       └─ IndexedTableAccess\n" +
-			"     │           │                       │           ├─ index: [TPXBU.id]\n" +
-			"     │           │                       │           └─ Table\n" +
-			"     │           │                       │               └─ name: TPXBU\n" +
+			"     │           │                       │       └─ IndexedTableAccess(TPXBU)\n" +
+			"     │           │                       │           └─ index: [TPXBU.id]\n" +
 			"     │           │                       └─ TableAlias(sn)\n" +
 			"     │           │                           └─ Table\n" +
 			"     │           │                               └─ name: NOXN3\n" +
@@ -13776,15 +12569,11 @@ WHERE
 			"     │                                   │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"     │                                   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"     │                                   │   │       └─ TableAlias(cla)\n" +
-			"     │                                   │   │           └─ IndexedTableAccess\n" +
-			"     │                                   │   │               ├─ index: [YK2GW.id]\n" +
-			"     │                                   │   │               └─ Table\n" +
-			"     │                                   │   │                   └─ name: YK2GW\n" +
+			"     │                                   │   │           └─ IndexedTableAccess(YK2GW)\n" +
+			"     │                                   │   │               └─ index: [YK2GW.id]\n" +
 			"     │                                   │   └─ TableAlias(mf)\n" +
-			"     │                                   │       └─ IndexedTableAccess\n" +
-			"     │                                   │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"     │                                   │           └─ Table\n" +
-			"     │                                   │               └─ name: HGMQ6\n" +
+			"     │                                   │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"     │                                   │           └─ index: [HGMQ6.GXLUB]\n" +
 			"     │                                   └─ HashLookup\n" +
 			"     │                                       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"     │                                       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
@@ -13839,15 +12628,11 @@ WHERE
 			"                             │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                             │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                             │           │   │       └─ TableAlias(cla)\n" +
-			"                             │           │   │           └─ IndexedTableAccess\n" +
-			"                             │           │   │               ├─ index: [YK2GW.id]\n" +
-			"                             │           │   │               └─ Table\n" +
-			"                             │           │   │                   └─ name: YK2GW\n" +
+			"                             │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
+			"                             │           │   │               └─ index: [YK2GW.id]\n" +
 			"                             │           │   └─ TableAlias(mf)\n" +
-			"                             │           │       └─ IndexedTableAccess\n" +
-			"                             │           │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                             │           │           └─ Table\n" +
-			"                             │           │               └─ name: HGMQ6\n" +
+			"                             │           │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"                             │           │           └─ index: [HGMQ6.GXLUB]\n" +
 			"                             │           └─ HashLookup\n" +
 			"                             │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
 			"                             │               ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
@@ -14021,35 +12806,23 @@ WHERE
 			"                                                 │   │                   │   │   │   │   │       └─ Table\n" +
 			"                                                 │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
 			"                                                 │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
-			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
-			"                                                 │   │                   │   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │   │               └─ name: HDDVB\n" +
+			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
+			"                                                 │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
 			"                                                 │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
-			"                                                 │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
-			"                                                 │   │                   │   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │   │               └─ name: WGSDC\n" +
+			"                                                 │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
+			"                                                 │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
 			"                                                 │   │                   │   │   └─ TableAlias(CPMFE)\n" +
-			"                                                 │   │                   │   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"                                                 │   │                   │   │           └─ Table\n" +
-			"                                                 │   │                   │   │               └─ name: E2I7U\n" +
+			"                                                 │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                                                 │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
 			"                                                 │   │                   │   └─ TableAlias(YQIF4)\n" +
-			"                                                 │   │                   │       └─ IndexedTableAccess\n" +
-			"                                                 │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                   │           └─ Table\n" +
-			"                                                 │   │                   │               └─ name: NOXN3\n" +
+			"                                                 │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │                   └─ TableAlias(YVHJZ)\n" +
-			"                                                 │   │                       └─ IndexedTableAccess\n" +
-			"                                                 │   │                           ├─ index: [NOXN3.BRQP2]\n" +
-			"                                                 │   │                           └─ Table\n" +
-			"                                                 │   │                               └─ name: NOXN3\n" +
+			"                                                 │   │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │                           └─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   └─ TableAlias(aac)\n" +
-			"                                                 │       └─ IndexedTableAccess\n" +
-			"                                                 │           ├─ index: [TPXBU.id]\n" +
-			"                                                 │           └─ Table\n" +
-			"                                                 │               └─ name: TPXBU\n" +
+			"                                                 │       └─ IndexedTableAccess(TPXBU)\n" +
+			"                                                 │           └─ index: [TPXBU.id]\n" +
 			"                                                 └─ TableAlias(sn)\n" +
 			"                                                     └─ Table\n" +
 			"                                                         └─ name: NOXN3\n" +
@@ -14064,13 +12837,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.TW55N:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id tw55n]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 3]\n" +
+			"     └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -14082,13 +12852,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.TW55N:1!null, E2I7U.FGG57:2]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id tw55n fgg57]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 3 6]\n" +
+			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 	},
 	{
@@ -14220,13 +12987,10 @@ ORDER BY sn.XLFIA ASC`,
 			"         │   ├─ cacheable: true\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [NOXN3.id:0!null as XLFIA, NOXN3.BRQP2:1!null]\n" +
-			"         │       └─ IndexedTableAccess\n" +
+			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
 			"         │           ├─ static: [{[NULL, ∞)}]\n" +
-			"         │           ├─ columns: [id brqp2]\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: NOXN3\n" +
-			"         │               └─ projections: [0 1]\n" +
+			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ source: TUPLE(sn.BRQP2:1!null)\n" +
 			"             ├─ target: TUPLE(I2GJ5.LUEVY:0!null)\n" +
@@ -14363,10 +13127,8 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │       └─ Table\n" +
 			"             │           └─ name: THNTS\n" +
 			"             └─ TableAlias(cla)\n" +
-			"                 └─ IndexedTableAccess\n" +
-			"                     ├─ index: [YK2GW.id]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: YK2GW\n" +
+			"                 └─ IndexedTableAccess(YK2GW)\n" +
+			"                     └─ index: [YK2GW.id]\n" +
 			"",
 	},
 	{
@@ -14395,15 +13157,11 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │   │   └─ Table\n" +
 			"             │   │       └─ name: THNTS\n" +
 			"             │   └─ TableAlias(cla)\n" +
-			"             │       └─ IndexedTableAccess\n" +
-			"             │           ├─ index: [YK2GW.id]\n" +
-			"             │           └─ Table\n" +
-			"             │               └─ name: YK2GW\n" +
+			"             │       └─ IndexedTableAccess(YK2GW)\n" +
+			"             │           └─ index: [YK2GW.id]\n" +
 			"             └─ TableAlias(mf)\n" +
-			"                 └─ IndexedTableAccess\n" +
-			"                     ├─ index: [HGMQ6.GXLUB]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: HGMQ6\n" +
+			"                 └─ IndexedTableAccess(HGMQ6)\n" +
+			"                     └─ index: [HGMQ6.GXLUB]\n" +
 			"",
 	},
 	{
@@ -14434,12 +13192,9 @@ ORDER BY cla.FTQLQ ASC`,
 			"                 │   └─ Table\n" +
 			"                 │       └─ name: THNTS\n" +
 			"                 └─ TableAlias(applySubq1)\n" +
-			"                     └─ IndexedTableAccess\n" +
+			"                     └─ IndexedTableAccess(AMYXQ)\n" +
 			"                         ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
-			"                         ├─ columns: [gxlub]\n" +
-			"                         └─ Table\n" +
-			"                             ├─ name: AMYXQ\n" +
-			"                             └─ projections: [1]\n" +
+			"                         └─ columns: [gxlub]\n" +
 			"",
 	},
 	{
@@ -14462,10 +13217,8 @@ ORDER BY ci.FTQLQ`,
 			"             │   └─ Table\n" +
 			"             │       └─ name: JDLNA\n" +
 			"             └─ TableAlias(ct)\n" +
-			"                 └─ IndexedTableAccess\n" +
-			"                     ├─ index: [FLQLP.FZ2R5]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: FLQLP\n" +
+			"                 └─ IndexedTableAccess(FLQLP)\n" +
+			"                     └─ index: [FLQLP.FZ2R5]\n" +
 			"",
 	},
 	{
@@ -14566,15 +13319,11 @@ ORDER BY LUEVY`,
 			"         │           │   └─ Table\n" +
 			"         │           │       └─ name: E2I7U\n" +
 			"         │           └─ TableAlias(nma)\n" +
-			"         │               └─ IndexedTableAccess\n" +
-			"         │                   ├─ index: [TNMXI.id]\n" +
-			"         │                   └─ Table\n" +
-			"         │                       └─ name: TNMXI\n" +
+			"         │               └─ IndexedTableAccess(TNMXI)\n" +
+			"         │                   └─ index: [TNMXI.id]\n" +
 			"         └─ TableAlias(YBBG5)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [XGSJM.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: XGSJM\n" +
+			"             └─ IndexedTableAccess(XGSJM)\n" +
+			"                 └─ index: [XGSJM.id]\n" +
 			"",
 	},
 	{
@@ -14657,20 +13406,14 @@ ORDER BY sn.id ASC`,
 			"         │   │   │   └─ Table\n" +
 			"         │   │   │       └─ name: NOXN3\n" +
 			"         │   │   └─ TableAlias(TVQG4)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │   │           └─ index: [E2I7U.id]\n" +
 			"         │   └─ TableAlias(LSM32)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           └─ index: [E2I7U.id]\n" +
 			"         └─ TableAlias(it)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [FEVH4.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: FEVH4\n" +
+			"             └─ IndexedTableAccess(FEVH4)\n" +
+			"                 └─ index: [FEVH4.id]\n" +
 			"",
 	},
 	{
@@ -14682,13 +13425,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [NOXN3.KBO7R:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id kbo7r]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: NOXN3\n" +
-			"         └─ projections: [0 4]\n" +
+			"     └─ columns: [id kbo7r]\n" +
 			"",
 	},
 	{
@@ -14765,30 +13505,20 @@ ORDER BY rn.id ASC`,
 			"         │   │   │   │   │   └─ Table\n" +
 			"         │   │   │   │   │       └─ name: QYWQD\n" +
 			"         │   │   │   │   └─ TableAlias(JGT2H)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess\n" +
-			"         │   │   │   │           ├─ index: [NOXN3.id]\n" +
-			"         │   │   │   │           └─ Table\n" +
-			"         │   │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │   │           └─ index: [NOXN3.id]\n" +
 			"         │   │   │   └─ TableAlias(AYFCD)\n" +
-			"         │   │   │       └─ IndexedTableAccess\n" +
-			"         │   │   │           ├─ index: [NOXN3.id]\n" +
-			"         │   │   │           └─ Table\n" +
-			"         │   │   │               └─ name: NOXN3\n" +
+			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │           └─ index: [NOXN3.id]\n" +
 			"         │   │   └─ TableAlias(SDLLR)\n" +
-			"         │   │       └─ IndexedTableAccess\n" +
-			"         │   │           ├─ index: [E2I7U.id]\n" +
-			"         │   │           └─ Table\n" +
-			"         │   │               └─ name: E2I7U\n" +
+			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │   │           └─ index: [E2I7U.id]\n" +
 			"         │   └─ TableAlias(RIIW6)\n" +
-			"         │       └─ IndexedTableAccess\n" +
-			"         │           ├─ index: [E2I7U.id]\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: E2I7U\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           └─ index: [E2I7U.id]\n" +
 			"         └─ TableAlias(FA75Y)\n" +
-			"             └─ IndexedTableAccess\n" +
-			"                 ├─ index: [E2I7U.id]\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 └─ index: [E2I7U.id]\n" +
 			"",
 	},
 	{
@@ -14800,13 +13530,10 @@ FROM
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [E2I7U.QRQXW:1!null]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id qrqxw]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: E2I7U\n" +
-			"         └─ projections: [0 4]\n" +
+			"     └─ columns: [id qrqxw]\n" +
 			"",
 	},
 	{
@@ -14854,13 +13581,10 @@ FROM NOXN3
 ORDER BY id ASC`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [NOXN3.id:0!null, NOXN3.NUMK2:2!null, NOXN3.ECDKM:1]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id ecdkm numk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: NOXN3\n" +
-			"         └─ projections: [0 5 6]\n" +
+			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
 	{
@@ -14877,13 +13601,10 @@ SELECT
 			" │   ├─ NOXN3.NUMK2:2!null\n" +
 			" │   └─ 2 (tinyint)\n" +
 			" │   THEN NOXN3.ECDKM:1 ELSE 0 (tinyint) END as RGXLL]\n" +
-			" └─ IndexedTableAccess\n" +
+			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
-			"     ├─ columns: [id ecdkm numk2]\n" +
-			"     └─ Table\n" +
-			"         ├─ name: NOXN3\n" +
-			"         └─ projections: [0 5 6]\n" +
+			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
 	{
@@ -14910,15 +13631,11 @@ INNER JOIN XOAOP pa
 			"     │   │   └─ Table\n" +
 			"     │   │       └─ name: JJGQT\n" +
 			"     │   └─ TableAlias(pa)\n" +
-			"     │       └─ IndexedTableAccess\n" +
-			"     │           ├─ index: [XOAOP.id]\n" +
-			"     │           └─ Table\n" +
-			"     │               └─ name: XOAOP\n" +
+			"     │       └─ IndexedTableAccess(XOAOP)\n" +
+			"     │           └─ index: [XOAOP.id]\n" +
 			"     └─ TableAlias(nd)\n" +
-			"         └─ IndexedTableAccess\n" +
-			"             ├─ index: [E2I7U.id]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: E2I7U\n" +
+			"         └─ IndexedTableAccess(E2I7U)\n" +
+			"             └─ index: [E2I7U.id]\n" +
 			"",
 	},
 	{
@@ -14931,11 +13648,9 @@ WHERE id IN ('1','2','3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ QYWQD.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(QYWQD)\n" +
 			"             ├─ index: [QYWQD.id]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: QYWQD\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -14968,11 +13683,9 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ QYWQD.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(QYWQD)\n" +
 			"             ├─ index: [QYWQD.id]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: QYWQD\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -14985,11 +13698,9 @@ WHERE LUEVY IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ AMYXQ.LUEVY:2!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(AMYXQ)\n" +
 			"             ├─ index: [AMYXQ.LUEVY]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: AMYXQ\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -15002,11 +13713,9 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ HGMQ6.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(HGMQ6)\n" +
 			"             ├─ index: [HGMQ6.id]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: HGMQ6\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -15019,11 +13728,9 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ HDDVB.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(HDDVB)\n" +
 			"             ├─ index: [HDDVB.id]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: HDDVB\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -15036,11 +13743,9 @@ WHERE LUEVY IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ FLQLP.LUEVY:2!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.LUEVY]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: FLQLP\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -15053,11 +13758,9 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ FLQLP.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.id]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: FLQLP\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -15070,11 +13773,9 @@ WHERE id IN ('1', '2', '3')`,
 			"         ├─ HashIn\n" +
 			"         │   ├─ FLQLP.id:0!null\n" +
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess\n" +
+			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.id]\n" +
-			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             └─ Table\n" +
-			"                 └─ name: FLQLP\n" +
+			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"",
 	},
 	{
@@ -15101,21 +13802,17 @@ WHERE nd.FGG57 IS NOT NULL AND nd.KNG7T IS NULL`,
 			"                     │   └─ Table\n" +
 			"                     │       └─ name: WE72E\n" +
 			"                     └─ TableAlias(ltnm)\n" +
-			"                         └─ IndexedTableAccess\n" +
-			"                             ├─ index: [TDRVG.SSHPJ]\n" +
-			"                             └─ Table\n" +
-			"                                 └─ name: TDRVG\n" +
+			"                         └─ IndexedTableAccess(TDRVG)\n" +
+			"                             └─ index: [TDRVG.SSHPJ]\n" +
 			"        )\n" +
 			"         └─ Filter\n" +
 			"             ├─ AND\n" +
 			"             │   ├─ (NOT(nd.FGG57:6 IS NULL))\n" +
 			"             │   └─ nd.KNG7T:2 IS NULL\n" +
 			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
 			"                     ├─ index: [E2I7U.FGG57]\n" +
-			"                     ├─ static: [{(NULL, ∞)}]\n" +
-			"                     └─ Table\n" +
-			"                         └─ name: E2I7U\n" +
+			"                     └─ static: [{(NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -15201,23 +13898,18 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ JMRQL.DZLIM:31!null\n" +
 			"             │       │           │   └─ T4IBQ (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(JMRQL)\n" +
 			"             │       │               ├─ index: [JMRQL.DZLIM]\n" +
 			"             │       │               ├─ static: [{[T4IBQ, T4IBQ]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: JMRQL\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as NFRYN, YK2GW.id:0!null as IXUXU, NULL (null) as FHCYT]\n" +
 			"             │       └─ Filter\n" +
 			"             │           ├─ HashIn\n" +
 			"             │           │   ├─ YK2GW.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │           └─ IndexedTableAccess\n" +
+			"             │           └─ IndexedTableAccess(YK2GW)\n" +
 			"             │               ├─ index: [YK2GW.id]\n" +
-			"             │               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │               └─ Table\n" +
-			"             │                   └─ name: YK2GW\n" +
+			"             │               └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(new.IXUXU:2 IS NULL)\n" +
@@ -15310,15 +14002,11 @@ FROM
 			"             │                       │       │   ├─ sn.NUMK2:6!null\n" +
 			"             │                       │       │   └─ 1 (tinyint)\n" +
 			"             │                       │       └─ TableAlias(sn)\n" +
-			"             │                       │           └─ IndexedTableAccess\n" +
-			"             │                       │               ├─ index: [NOXN3.FFTBJ]\n" +
-			"             │                       │               └─ Table\n" +
-			"             │                       │                   └─ name: NOXN3\n" +
+			"             │                       │           └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                       │               └─ index: [NOXN3.FFTBJ]\n" +
 			"             │                       └─ TableAlias(rn)\n" +
-			"             │                           └─ IndexedTableAccess\n" +
-			"             │                               ├─ index: [QYWQD.HHVLX]\n" +
-			"             │                               └─ Table\n" +
-			"             │                                   └─ name: QYWQD\n" +
+			"             │                           └─ IndexedTableAccess(QYWQD)\n" +
+			"             │                               └─ index: [QYWQD.HHVLX]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF((NOT(Eq\n" +
@@ -15389,13 +14077,10 @@ WHERE
 			"             │           ├─ HashIn\n" +
 			"             │           │   ├─ TDRVG.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │           └─ IndexedTableAccess\n" +
+			"             │           └─ IndexedTableAccess(TDRVG)\n" +
 			"             │               ├─ index: [TDRVG.id]\n" +
 			"             │               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │               ├─ columns: [id sshpj sfj6l]\n" +
-			"             │               └─ Table\n" +
-			"             │                   ├─ name: TDRVG\n" +
-			"             │                   └─ projections: [0 2 3]\n" +
+			"             │               └─ columns: [id sshpj sfj6l]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(Or\n" +
@@ -15500,15 +14185,11 @@ WHERE
 			"             │       │               │   ├─ cla.id:31!null\n" +
 			"             │       │               │   └─ bs.IXUXU:63\n" +
 			"             │       │               ├─ TableAlias(cla)\n" +
-			"             │       │               │   └─ IndexedTableAccess\n" +
-			"             │       │               │       ├─ index: [YK2GW.FTQLQ]\n" +
-			"             │       │               │       └─ Table\n" +
-			"             │       │               │           └─ name: YK2GW\n" +
+			"             │       │               │   └─ IndexedTableAccess(YK2GW)\n" +
+			"             │       │               │       └─ index: [YK2GW.FTQLQ]\n" +
 			"             │       │               └─ TableAlias(bs)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
-			"             │       │                       ├─ index: [THNTS.IXUXU]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: THNTS\n" +
+			"             │       │                   └─ IndexedTableAccess(THNTS)\n" +
+			"             │       │                       └─ index: [THNTS.IXUXU]\n" +
 			"             │       │   as GXLUB, nd.id:11!null as LUEVY, nd.XQDYT:20!null as XQDYT, (ufc.AMYXQ:3 + 0 (decimal(2,1))) as AMYXQ, CASE  WHEN Eq\n" +
 			"             │       │   ├─ YBBG5.DZLIM:29!null\n" +
 			"             │       │   └─ KTNZ2 (longtext)\n" +
@@ -15534,11 +14215,9 @@ WHERE
 			"             │           │   │   ├─ ufc.id:0!null\n" +
 			"             │           │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           │   └─ TableAlias(ufc)\n" +
-			"             │           │       └─ IndexedTableAccess\n" +
+			"             │           │       └─ IndexedTableAccess(SISUT)\n" +
 			"             │           │           ├─ index: [SISUT.id]\n" +
-			"             │           │           ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │           │           └─ Table\n" +
-			"             │           │               └─ name: SISUT\n" +
+			"             │           │           └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             │           └─ HashLookup\n" +
 			"             │               ├─ source: TUPLE(ufc.ZH72S:2)\n" +
 			"             │               ├─ target: TUPLE(nd.ZH72S:7)\n" +
@@ -15551,10 +14230,8 @@ WHERE
 			"             │                       │   └─ Table\n" +
 			"             │                       │       └─ name: E2I7U\n" +
 			"             │                       └─ TableAlias(YBBG5)\n" +
-			"             │                           └─ IndexedTableAccess\n" +
-			"             │                               ├─ index: [XGSJM.id]\n" +
-			"             │                               └─ Table\n" +
-			"             │                                   └─ name: XGSJM\n" +
+			"             │                           └─ IndexedTableAccess(XGSJM)\n" +
+			"             │                               └─ index: [XGSJM.id]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Subquery\n" +
@@ -15649,10 +14326,8 @@ WHERE
 			"             │       │               │   └─ Table\n" +
 			"             │       │               │       └─ name: THNTS\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
-			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"             │       │                       └─ index: [YK2GW.id]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -15661,13 +14336,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ NER (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[NER, NER]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.ner:2\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -15680,11 +14352,9 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -15773,10 +14443,8 @@ WHERE
 			"             │       │               │   └─ Table\n" +
 			"             │       │               │       └─ name: THNTS\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
-			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"             │       │                       └─ index: [YK2GW.id]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -15785,13 +14453,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ BER (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[BER, BER]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.ber:3\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -15804,11 +14469,9 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -15897,10 +14560,8 @@ WHERE
 			"             │       │               │   └─ Table\n" +
 			"             │       │               │       └─ name: THNTS\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
-			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"             │       │                       └─ index: [YK2GW.id]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -15909,13 +14570,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ HR (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[HR, HR]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.hr:4\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -15928,11 +14586,9 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -16021,10 +14677,8 @@ WHERE
 			"             │       │               │   └─ Table\n" +
 			"             │       │               │       └─ name: THNTS\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
-			"             │       │                   └─ IndexedTableAccess\n" +
-			"             │       │                       ├─ index: [YK2GW.id]\n" +
-			"             │       │                       └─ Table\n" +
-			"             │       │                           └─ name: YK2GW\n" +
+			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"             │       │                       └─ index: [YK2GW.id]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -16033,13 +14687,10 @@ WHERE
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ XOAOP.DZLIM:8!null\n" +
 			"             │       │           │   └─ MMR (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
 			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
 			"             │       │               ├─ static: [{[MMR, MMR]}]\n" +
-			"             │       │               ├─ columns: [id dzlim]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.mmr:5\n" +
 			"             │       │   └─ 0.500000 (double)\n" +
@@ -16052,11 +14703,9 @@ WHERE
 			"             │           │   ├─ ums.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(ums)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: FG26Y\n" +
+			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -16145,13 +14794,10 @@ WHERE
 			"             │                       │   │   │   │       ├─ cacheable: true\n" +
 			"             │                       │   │   │   │       └─ Filter\n" +
 			"             │                       │   │   │   │           ├─ (NOT(TPXBU.BTXC5:25 IS NULL))\n" +
-			"             │                       │   │   │   │           └─ IndexedTableAccess\n" +
+			"             │                       │   │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
 			"             │                       │   │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
 			"             │                       │   │   │   │               ├─ static: [{(NULL, ∞)}]\n" +
-			"             │                       │   │   │   │               ├─ columns: [btxc5]\n" +
-			"             │                       │   │   │   │               └─ Table\n" +
-			"             │                       │   │   │   │                   ├─ name: TPXBU\n" +
-			"             │                       │   │   │   │                   └─ projections: [1]\n" +
+			"             │                       │   │   │   │               └─ columns: [btxc5]\n" +
 			"             │                       │   │   │   │  ))\n" +
 			"             │                       │   │   │   └─ (NOT(umf.SYPKF:8 IS NULL))\n" +
 			"             │                       │   │   └─ (NOT(Eq\n" +
@@ -16162,11 +14808,9 @@ WHERE
 			"             │                       │       ├─ umf.id:0!null\n" +
 			"             │                       │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                       └─ TableAlias(umf)\n" +
-			"             │                           └─ IndexedTableAccess\n" +
+			"             │                           └─ IndexedTableAccess(NZKPM)\n" +
 			"             │                               ├─ index: [NZKPM.id]\n" +
-			"             │                               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                               └─ Table\n" +
-			"             │                                   └─ name: NZKPM\n" +
+			"             │                               └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(InSubquery\n" +
@@ -16306,10 +14950,8 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │           │   ├─ nd_for_id_overridden.TW55N:70!null\n" +
 			"             │       │           │   └─ TJ5D2.H4DMT:63\n" +
 			"             │       │           └─ TableAlias(nd_for_id_overridden)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
-			"             │       │                   ├─ index: [E2I7U.TW55N]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: E2I7U\n" +
+			"             │       │               └─ IndexedTableAccess(E2I7U)\n" +
+			"             │       │                   └─ index: [E2I7U.TW55N]\n" +
 			"             │       │   ELSE Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   └─ Project\n" +
@@ -16321,11 +14963,9 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │           │       ├─ nd_for_id.FGG57:73\n" +
 			"             │       │           │       └─ umf.FGG57:2\n" +
 			"             │       │           └─ TableAlias(nd_for_id)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
+			"             │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"             │       │                   ├─ index: [E2I7U.FGG57]\n" +
-			"             │       │                   ├─ static: [{(NULL, ∞)}]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: E2I7U\n" +
+			"             │       │                   └─ static: [{(NULL, ∞)}]\n" +
 			"             │       │   END as LUEVY, CASE  WHEN Eq\n" +
 			"             │       │   ├─ umf.SYPKF:8\n" +
 			"             │       │   └─ N/A (longtext)\n" +
@@ -16335,13 +14975,10 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │       ├─ columns: [TPXBU.id:67!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ TPXBU.BTXC5:68 IS NULL\n" +
-			"             │       │           └─ IndexedTableAccess\n" +
+			"             │       │           └─ IndexedTableAccess(TPXBU)\n" +
 			"             │       │               ├─ index: [TPXBU.BTXC5]\n" +
 			"             │       │               ├─ static: [{[NULL, NULL]}]\n" +
-			"             │       │               ├─ columns: [id btxc5]\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: TPXBU\n" +
-			"             │       │                   └─ projections: [0 1]\n" +
+			"             │       │               └─ columns: [id btxc5]\n" +
 			"             │       │   ELSE Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   └─ Project\n" +
@@ -16351,10 +14988,8 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │           │   ├─ aac.BTXC5:68\n" +
 			"             │       │           │   └─ umf.SYPKF:8\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
-			"             │       │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			"             │       │                   └─ index: [TPXBU.BTXC5]\n" +
 			"             │       │   END as M22QN, umf.TJPT7:6 as TJPT7, umf.ARN5P:7 as ARN5P, umf.XOSD4:13 as XOSD4, umf.IDE43:10 as IDE43, CASE  WHEN (NOT(Eq\n" +
 			"             │       │   ├─ umf.HMW4H:14\n" +
 			"             │       │   └─ N/A (longtext)\n" +
@@ -16422,18 +15057,13 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │           │   │       │           ├─ cacheable: true\n" +
 			"             │           │   │       │           └─ Filter\n" +
 			"             │           │   │       │               ├─ (NOT(E2I7U.FGG57:25 IS NULL))\n" +
-			"             │           │   │       │               └─ IndexedTableAccess\n" +
+			"             │           │   │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"             │           │   │       │                   ├─ index: [E2I7U.FGG57]\n" +
 			"             │           │   │       │                   ├─ static: [{(NULL, ∞)}]\n" +
-			"             │           │   │       │                   ├─ columns: [fgg57]\n" +
-			"             │           │   │       │                   └─ Table\n" +
-			"             │           │   │       │                       ├─ name: E2I7U\n" +
-			"             │           │   │       │                       └─ projections: [6]\n" +
-			"             │           │   │       └─ IndexedTableAccess\n" +
+			"             │           │   │       │                   └─ columns: [fgg57]\n" +
+			"             │           │   │       └─ IndexedTableAccess(NZKPM)\n" +
 			"             │           │   │           ├─ index: [NZKPM.id]\n" +
-			"             │           │   │           ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │           │   │           └─ Table\n" +
-			"             │           │   │               └─ name: NZKPM\n" +
+			"             │           │   │           └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             │           │   └─ HashLookup\n" +
 			"             │           │       ├─ source: TUPLE(umf.T4IBQ:1)\n" +
 			"             │           │       ├─ target: TUPLE(cla.FTQLQ:5!null)\n" +
@@ -16446,10 +15076,8 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │           │               │   └─ Table\n" +
 			"             │           │               │       └─ name: THNTS\n" +
 			"             │           │               └─ TableAlias(cla)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
-			"             │           │                       ├─ index: [YK2GW.id]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: YK2GW\n" +
+			"             │           │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"             │           │                       └─ index: [YK2GW.id]\n" +
 			"             │           └─ TableAlias(TJ5D2)\n" +
 			"             │               └─ Table\n" +
 			"             │                   └─ name: SZW6V\n" +
@@ -16573,10 +15201,8 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			"                 │               │   ├─ umf.id:0!null\n" +
 			"                 │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"                 │               └─ TableAlias(umf)\n" +
-			"                 │                   └─ IndexedTableAccess\n" +
-			"                 │                       ├─ index: [NZKPM.id]\n" +
-			"                 │                       └─ Table\n" +
-			"                 │                           └─ name: NZKPM\n" +
+			"                 │                   └─ IndexedTableAccess(NZKPM)\n" +
+			"                 │                       └─ index: [NZKPM.id]\n" +
 			"                 └─ TableAlias(vc)\n" +
 			"                     └─ Table\n" +
 			"                         └─ name: D34QP\n" +
@@ -16778,10 +15404,8 @@ FROM
 			"             │                           │   │   │   │       │   ├─ TIZHK.id:0!null\n" +
 			"             │                           │   │   │   │       │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                           │   │   │   │       └─ TableAlias(TIZHK)\n" +
-			"             │                           │   │   │   │           └─ IndexedTableAccess\n" +
-			"             │                           │   │   │   │               ├─ index: [WRZVO.ZHITY]\n" +
-			"             │                           │   │   │   │               └─ Table\n" +
-			"             │                           │   │   │   │                   └─ name: WRZVO\n" +
+			"             │                           │   │   │   │           └─ IndexedTableAccess(WRZVO)\n" +
+			"             │                           │   │   │   │               └─ index: [WRZVO.ZHITY]\n" +
 			"             │                           │   │   │   └─ HashLookup\n" +
 			"             │                           │   │   │       ├─ source: TUPLE(0 (tinyint), TIZHK.TVNW2:18, TIZHK.ZHITY:19, TIZHK.SYPKF:20, TIZHK.IDUT2:21)\n" +
 			"             │                           │   │   │       ├─ target: TUPLE(NHMXW.SWCQV:7!null, NHMXW.NOHHR:1!null, NHMXW.AVPYF:2!null, NHMXW.SYPKF:3!null, NHMXW.IDUT2:4!null)\n" +
@@ -16797,15 +15421,11 @@ FROM
 			"             │                           │   │               └─ Table\n" +
 			"             │                           │   │                   └─ name: E2I7U\n" +
 			"             │                           │   └─ TableAlias(mf)\n" +
-			"             │                           │       └─ IndexedTableAccess\n" +
-			"             │                           │           ├─ index: [HGMQ6.LUEVY]\n" +
-			"             │                           │           └─ Table\n" +
-			"             │                           │               └─ name: HGMQ6\n" +
+			"             │                           │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"             │                           │           └─ index: [HGMQ6.LUEVY]\n" +
 			"             │                           └─ TableAlias(aac)\n" +
-			"             │                               └─ IndexedTableAccess\n" +
-			"             │                                   ├─ index: [TPXBU.id]\n" +
-			"             │                                   └─ Table\n" +
-			"             │                                       └─ name: TPXBU\n" +
+			"             │                               └─ IndexedTableAccess(TPXBU)\n" +
+			"             │                                   └─ index: [TPXBU.id]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [id:0!null, FV24E:1 as FV24E, UJ6XY:2 as UJ6XY, M22QN:3, NZ4MQ:4, ETPQV:5!null, convert\n" +
 			"                 │   ├─ type: char\n" +
@@ -16821,10 +15441,8 @@ FROM
 			"                     │           │   ├─ aac.BTXC5:9\n" +
 			"                     │           │   └─ BPNW2.SYPKF:3\n" +
 			"                     │           └─ TableAlias(aac)\n" +
-			"                     │               └─ IndexedTableAccess\n" +
-			"                     │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"                     │                   └─ Table\n" +
-			"                     │                       └─ name: TPXBU\n" +
+			"                     │               └─ IndexedTableAccess(TPXBU)\n" +
+			"                     │                   └─ index: [TPXBU.BTXC5]\n" +
 			"                     │   as M22QN, BPNW2.NZ4MQ:4 as NZ4MQ, BPNW2.MU3KG:0!null as ETPQV, BPNW2.I4NDZ:7 as PRUV2, BPNW2.YKSSU:6 as YKSSU, BPNW2.FHCYT:5 as FHCYT]\n" +
 			"                     └─ SubqueryAlias\n" +
 			"                         ├─ name: BPNW2\n" +
@@ -16841,10 +15459,8 @@ FROM
 			"                                 │           │   ├─ overridden_nd_mutant.TW55N:57!null\n" +
 			"                                 │           │   └─ NHMXW.FZXV5:15\n" +
 			"                                 │           └─ TableAlias(overridden_nd_mutant)\n" +
-			"                                 │               └─ IndexedTableAccess\n" +
-			"                                 │                   ├─ index: [E2I7U.TW55N]\n" +
-			"                                 │                   └─ Table\n" +
-			"                                 │                       └─ name: E2I7U\n" +
+			"                                 │               └─ IndexedTableAccess(E2I7U)\n" +
+			"                                 │                   └─ index: [E2I7U.TW55N]\n" +
 			"                                 │   ELSE J4JYP.id:20 END as FV24E, CASE  WHEN (NOT(NHMXW.DQYGV:16 IS NULL)) THEN Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
 			"                                 │   └─ Project\n" +
@@ -16902,17 +15518,13 @@ FROM
 			"                                         │   │   │   │   ├─ TIZHK.id:0!null\n" +
 			"                                         │   │   │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"                                         │   │   │   └─ TableAlias(TIZHK)\n" +
-			"                                         │   │   │       └─ IndexedTableAccess\n" +
+			"                                         │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
 			"                                         │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
-			"                                         │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                         │   │   │           └─ Table\n" +
-			"                                         │   │   │               └─ name: WRZVO\n" +
+			"                                         │   │   │           └─ static: [{[NULL, ∞)}]\n" +
 			"                                         │   │   └─ TableAlias(NHMXW)\n" +
-			"                                         │   │       └─ IndexedTableAccess\n" +
+			"                                         │   │       └─ IndexedTableAccess(WGSDC)\n" +
 			"                                         │   │           ├─ index: [WGSDC.NOHHR]\n" +
-			"                                         │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                         │   │           └─ Table\n" +
-			"                                         │   │               └─ name: WGSDC\n" +
+			"                                         │   │           └─ static: [{[NULL, ∞)}]\n" +
 			"                                         │   └─ HashLookup\n" +
 			"                                         │       ├─ source: TUPLE(TIZHK.TVNW2:1)\n" +
 			"                                         │       ├─ target: TUPLE(J4JYP.ZH72S:7)\n" +
@@ -17159,17 +15771,13 @@ WHERE
 			"             │                           │               │   │   ├─ uct.id:0!null\n" +
 			"             │                           │               │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                           │               │   └─ TableAlias(uct)\n" +
-			"             │                           │               │       └─ IndexedTableAccess\n" +
+			"             │                           │               │       └─ IndexedTableAccess(OUBDL)\n" +
 			"             │                           │               │           ├─ index: [OUBDL.FTQLQ]\n" +
-			"             │                           │               │           ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                           │               │           └─ Table\n" +
-			"             │                           │               │               └─ name: OUBDL\n" +
+			"             │                           │               │           └─ static: [{[NULL, ∞)}]\n" +
 			"             │                           │               └─ TableAlias(I7HCR)\n" +
-			"             │                           │                   └─ IndexedTableAccess\n" +
+			"             │                           │                   └─ IndexedTableAccess(EPZU6)\n" +
 			"             │                           │                       ├─ index: [EPZU6.TOFPN]\n" +
-			"             │                           │                       ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                           │                       └─ Table\n" +
-			"             │                           │                           └─ name: EPZU6\n" +
+			"             │                           │                       └─ static: [{[NULL, ∞)}]\n" +
 			"             │                           └─ LookupJoin\n" +
 			"             │                               ├─ Eq\n" +
 			"             │                               │   ├─ nt.id:4!null\n" +
@@ -17178,10 +15786,8 @@ WHERE
 			"             │                               │   └─ Table\n" +
 			"             │                               │       └─ name: F35MI\n" +
 			"             │                               └─ TableAlias(nd)\n" +
-			"             │                                   └─ IndexedTableAccess\n" +
-			"             │                                       ├─ index: [E2I7U.DKCAJ]\n" +
-			"             │                                       └─ Table\n" +
-			"             │                                           └─ name: E2I7U\n" +
+			"             │                                   └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                                       └─ index: [E2I7U.DKCAJ]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -17331,10 +15937,8 @@ WHERE
 			"             │       │           │   ├─ aac.BTXC5:30\n" +
 			"             │       │           │   └─ PQSXB.BTXC5:10\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
-			"             │       │               └─ IndexedTableAccess\n" +
-			"             │       │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │       │                   └─ Table\n" +
-			"             │       │                       └─ name: TPXBU\n" +
+			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			"             │       │                   └─ index: [TPXBU.BTXC5]\n" +
 			"             │       │   as M22QN, PQSXB.OVE3E:1 as OVE3E, PQSXB.NRURT:2!null as NRURT, PQSXB.OCA7E:3 as OCA7E, PQSXB.XMM6Q:4 as XMM6Q, PQSXB.V5DPX:5 as V5DPX, PQSXB.S3Q3Y:6 as S3Q3Y, PQSXB.ZRV3B:7 as ZRV3B, PQSXB.FHCYT:8 as FHCYT]\n" +
 			"             │       └─ InnerJoin\n" +
 			"             │           ├─ Or\n" +
@@ -17406,10 +16010,8 @@ WHERE
 			"             │           │           │           │               │               │   ├─ nd.ZH72S:35\n" +
 			"             │           │           │           │               │               │   └─ uct.ZH72S:2\n" +
 			"             │           │           │           │               │               └─ TableAlias(nd)\n" +
-			"             │           │           │           │               │                   └─ IndexedTableAccess\n" +
-			"             │           │           │           │               │                       ├─ index: [E2I7U.ZH72S]\n" +
-			"             │           │           │           │               │                       └─ Table\n" +
-			"             │           │           │           │               │                           └─ name: E2I7U\n" +
+			"             │           │           │           │               │                   └─ IndexedTableAccess(E2I7U)\n" +
+			"             │           │           │           │               │                       └─ index: [E2I7U.ZH72S]\n" +
 			"             │           │           │           │               │   ELSE Subquery\n" +
 			"             │           │           │           │               │   ├─ cacheable: false\n" +
 			"             │           │           │           │               │   └─ Project\n" +
@@ -17419,10 +16021,8 @@ WHERE
 			"             │           │           │           │               │           │   ├─ nd.TW55N:31!null\n" +
 			"             │           │           │           │               │           │   └─ I7HCR.FVUCX:17\n" +
 			"             │           │           │           │               │           └─ TableAlias(nd)\n" +
-			"             │           │           │           │               │               └─ IndexedTableAccess\n" +
-			"             │           │           │           │               │                   ├─ index: [E2I7U.TW55N]\n" +
-			"             │           │           │           │               │                   └─ Table\n" +
-			"             │           │           │           │               │                       └─ name: E2I7U\n" +
+			"             │           │           │           │               │               └─ IndexedTableAccess(E2I7U)\n" +
+			"             │           │           │           │               │                   └─ index: [E2I7U.TW55N]\n" +
 			"             │           │           │           │               │   END]\n" +
 			"             │           │           │           │               └─ Table\n" +
 			"             │           │           │           │                   └─ name: \n" +
@@ -17452,17 +16052,13 @@ WHERE
 			"             │           │               │   │   ├─ uct.id:0!null\n" +
 			"             │           │               │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           │               │   └─ TableAlias(uct)\n" +
-			"             │           │               │       └─ IndexedTableAccess\n" +
+			"             │           │               │       └─ IndexedTableAccess(OUBDL)\n" +
 			"             │           │               │           ├─ index: [OUBDL.FTQLQ]\n" +
-			"             │           │               │           ├─ static: [{[NULL, ∞)}]\n" +
-			"             │           │               │           └─ Table\n" +
-			"             │           │               │               └─ name: OUBDL\n" +
+			"             │           │               │           └─ static: [{[NULL, ∞)}]\n" +
 			"             │           │               └─ TableAlias(I7HCR)\n" +
-			"             │           │                   └─ IndexedTableAccess\n" +
+			"             │           │                   └─ IndexedTableAccess(EPZU6)\n" +
 			"             │           │                       ├─ index: [EPZU6.TOFPN]\n" +
-			"             │           │                       ├─ static: [{[NULL, ∞)}]\n" +
-			"             │           │                       └─ Table\n" +
-			"             │           │                           └─ name: EPZU6\n" +
+			"             │           │                       └─ static: [{[NULL, ∞)}]\n" +
 			"             │           └─ TableAlias(nd)\n" +
 			"             │               └─ Table\n" +
 			"             │                   └─ name: E2I7U\n" +
@@ -17654,10 +16250,8 @@ WHERE
 			"             │                           │   │   └─ Table\n" +
 			"             │                           │   │       └─ name: F35MI\n" +
 			"             │                           │   └─ TableAlias(nd)\n" +
-			"             │                           │       └─ IndexedTableAccess\n" +
-			"             │                           │           ├─ index: [E2I7U.DKCAJ]\n" +
-			"             │                           │           └─ Table\n" +
-			"             │                           │               └─ name: E2I7U\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │           └─ index: [E2I7U.DKCAJ]\n" +
 			"             │                           └─ HashLookup\n" +
 			"             │                               ├─ source: TUPLE(nd.TW55N:6!null)\n" +
 			"             │                               ├─ target: TUPLE(TVTJS.I3VTA:2!null)\n" +
@@ -17667,11 +16261,9 @@ WHERE
 			"             │                                       │   ├─ TVTJS.id:0!null\n" +
 			"             │                                       │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                                       └─ TableAlias(TVTJS)\n" +
-			"             │                                           └─ IndexedTableAccess\n" +
+			"             │                                           └─ IndexedTableAccess(HU5A5)\n" +
 			"             │                                               ├─ index: [HU5A5.id]\n" +
-			"             │                                               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                                               └─ Table\n" +
-			"             │                                                   └─ name: HU5A5\n" +
+			"             │                                               └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -17827,10 +16419,8 @@ WHERE
 			"             │       │           │                   │   ├─ nd.TW55N:22!null\n" +
 			"             │       │           │                   │   └─ TVTJS.I3VTA:2!null\n" +
 			"             │       │           │                   └─ TableAlias(nd)\n" +
-			"             │       │           │                       └─ IndexedTableAccess\n" +
-			"             │       │           │                           ├─ index: [E2I7U.TW55N]\n" +
-			"             │       │           │                           └─ Table\n" +
-			"             │       │           │                               └─ name: E2I7U\n" +
+			"             │       │           │                       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │       │           │                           └─ index: [E2I7U.TW55N]\n" +
 			"             │       │           └─ Table\n" +
 			"             │       │               └─ name: SFEGG\n" +
 			"             │       │   as OVE3E, NULL (null) as NRURT, NULL (null) as OCA7E, TVTJS.id:0!null as XMM6Q, TVTJS.V5DPX:4!null as V5DPX, (TVTJS.IDPK7:6!null + 0 (decimal(2,1))) as S3Q3Y, TVTJS.ZRV3B:8!null as ZRV3B, TVTJS.FHCYT:12 as FHCYT]\n" +
@@ -17839,11 +16429,9 @@ WHERE
 			"             │           │   ├─ TVTJS.id:0!null\n" +
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ TableAlias(TVTJS)\n" +
-			"             │               └─ IndexedTableAccess\n" +
+			"             │               └─ IndexedTableAccess(HU5A5)\n" +
 			"             │                   ├─ index: [HU5A5.id]\n" +
-			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
-			"             │                   └─ Table\n" +
-			"             │                       └─ name: HU5A5\n" +
+			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(InSubquery\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -58,7 +58,8 @@ var PlanTests = []QueryPlanTest{
 			"     │               ├─ name: pq\n" +
 			"     │               └─ columns: [p]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
-			"         └─ index: [xy.x]\n" +
+			"         ├─ index: [xy.x]\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -80,7 +81,8 @@ var PlanTests = []QueryPlanTest{
 			"     │                   ├─ name: othertable\n" +
 			"     │                   └─ columns: [s2 i2]\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
-			"         └─ index: [mytable.i]\n" +
+			"         ├─ index: [mytable.i]\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -97,7 +99,8 @@ var PlanTests = []QueryPlanTest{
 			"         │       ├─ name: othertable\n" +
 			"         │       └─ columns: [i2]\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
-			"             └─ index: [mytable.i]\n" +
+			"             ├─ index: [mytable.i]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -247,9 +250,11 @@ var PlanTests = []QueryPlanTest{
 			" │               │               ├─ index: [uv.u]\n" +
 			" │               │               └─ columns: [u]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: xy\n" +
+			" │                   ├─ name: xy\n" +
+			" │                   └─ columns: [x y]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -274,9 +279,11 @@ var PlanTests = []QueryPlanTest{
 			" │               │               ├─ name: uv\n" +
 			" │               │               └─ columns: [v]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: xy\n" +
+			" │                   ├─ name: xy\n" +
+			" │                   └─ columns: [x y]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -301,9 +308,11 @@ var PlanTests = []QueryPlanTest{
 			" │               │               ├─ name: uv\n" +
 			" │               │               └─ columns: [v]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: xy\n" +
+			" │                   ├─ name: xy\n" +
+			" │                   └─ columns: [x y]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -331,15 +340,18 @@ var PlanTests = []QueryPlanTest{
 			"         │               │               ├─ name: uv\n" +
 			"         │               │               └─ columns: [v]\n" +
 			"         │               └─ Table\n" +
-			"         │                   └─ name: xy\n" +
+			"         │                   ├─ name: xy\n" +
+			"         │                   └─ columns: [x y]\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ ab.a:2!null\n" +
 			"             │   └─ pq.p:0!null\n" +
 			"             ├─ Table\n" +
-			"             │   └─ name: pq\n" +
+			"             │   ├─ name: pq\n" +
+			"             │   └─ columns: [p q]\n" +
 			"             └─ IndexedTableAccess(ab)\n" +
-			"                 └─ index: [ab.a]\n" +
+			"                 ├─ index: [ab.a]\n" +
+			"                 └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -367,9 +379,11 @@ var PlanTests = []QueryPlanTest{
 			"         │   ├─ xy.x:2!null\n" +
 			"         │   └─ uv.v:1\n" +
 			"         ├─ Table\n" +
-			"         │   └─ name: uv\n" +
+			"         │   ├─ name: uv\n" +
+			"         │   └─ columns: [u v]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
-			"             └─ index: [xy.x]\n" +
+			"             ├─ index: [xy.x]\n" +
+			"             └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -389,16 +403,19 @@ var PlanTests = []QueryPlanTest{
 			"         │           │   ├─ xy.y:3\n" +
 			"         │           │   └─ 1 (tinyint)\n" +
 			"         │           └─ Table\n" +
-			"         │               └─ name: \n" +
+			"         │               ├─ name: \n" +
+			"         │               └─ columns: []\n" +
 			"         │   as is_one]\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ xy.x:2!null\n" +
 			"             │   └─ uv.v:1\n" +
 			"             ├─ Table\n" +
-			"             │   └─ name: uv\n" +
+			"             │   ├─ name: uv\n" +
+			"             │   └─ columns: [u v]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
-			"                 └─ index: [xy.x]\n" +
+			"                 ├─ index: [xy.x]\n" +
+			"                 └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -413,16 +430,19 @@ var PlanTests = []QueryPlanTest{
 			" │           │   ├─ xy.y:3\n" +
 			" │           │   └─ 1 (tinyint)\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" │   as is_one]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ xy.x:2!null\n" +
 			"     │   └─ uv.v:1\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: uv\n" +
+			"     │   ├─ name: uv\n" +
+			"     │   └─ columns: [u v]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
-			"         └─ index: [xy.x]\n" +
+			"         ├─ index: [xy.x]\n" +
+			"         └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -489,7 +509,8 @@ var PlanTests = []QueryPlanTest{
 			"     │   ├─ xy.x:0!null\n" +
 			"     │   └─ applySubq0.u:2!null\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: xy\n" +
+			"     │   ├─ name: xy\n" +
+			"     │   └─ columns: [x y]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -719,10 +740,12 @@ var PlanTests = []QueryPlanTest{
 			" │               │   ├─ name: uv\n" +
 			" │               │   └─ columns: [u v]\n" +
 			" │               └─ IndexedTableAccess(ab)\n" +
-			" │                   └─ index: [ab.a]\n" +
+			" │                   ├─ index: [ab.a]\n" +
+			" │                   └─ columns: [a b]\n" +
 			" │   as s]\n" +
 			" └─ Table\n" +
-			"     └─ name: xy\n" +
+			"     ├─ name: xy\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -743,7 +766,8 @@ var PlanTests = []QueryPlanTest{
 			" │   ├─ ab.a:0!null\n" +
 			" │   └─ 1 (tinyint)\n" +
 			" ├─ Table\n" +
-			" │   └─ name: ab\n" +
+			" │   ├─ name: ab\n" +
+			" │   └─ columns: [a b]\n" +
 			" └─ Table\n" +
 			"     ├─ name: uv\n" +
 			"     └─ columns: [u v]\n" +
@@ -759,7 +783,8 @@ var PlanTests = []QueryPlanTest{
 			" │       ├─ filters: [{[1, 1]}]\n" +
 			" │       └─ columns: [a b]\n" +
 			" └─ Table\n" +
-			"     └─ name: ab\n" +
+			"     ├─ name: ab\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -774,7 +799,8 @@ var PlanTests = []QueryPlanTest{
 			" │       └─ 1 (tinyint)\n" +
 			" ├─ TableAlias(s)\n" +
 			" │   └─ Table\n" +
-			" │       └─ name: ab\n" +
+			" │       ├─ name: ab\n" +
+			" │       └─ columns: [a b]\n" +
 			" └─ Table\n" +
 			"     ├─ name: ab\n" +
 			"     └─ columns: [a b]\n" +
@@ -787,7 +813,8 @@ var PlanTests = []QueryPlanTest{
 			" │   ├─ uv.u:0!null\n" +
 			" │   └─ ab.a:2!null\n" +
 			" ├─ Table\n" +
-			" │   └─ name: uv\n" +
+			" │   ├─ name: uv\n" +
+			" │   └─ columns: [u v]\n" +
 			" └─ IndexedTableAccess(ab)\n" +
 			"     ├─ index: [ab.a]\n" +
 			"     └─ columns: [a]\n" +
@@ -808,7 +835,8 @@ var PlanTests = []QueryPlanTest{
 			"         │   ├─ name: xy\n" +
 			"         │   └─ columns: [x y]\n" +
 			"         └─ IndexedTableAccess(ab)\n" +
-			"             └─ index: [ab.a]\n" +
+			"             ├─ index: [ab.a]\n" +
+			"             └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -825,7 +853,8 @@ var PlanTests = []QueryPlanTest{
 			" │       ├─ name: ab\n" +
 			" │       └─ columns: [a b]\n" +
 			" └─ IndexedTableAccess(xy)\n" +
-			"     └─ index: [xy.x]\n" +
+			"     ├─ index: [xy.x]\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{
@@ -836,7 +865,8 @@ var PlanTests = []QueryPlanTest{
 			"     │   ├─ ab.a:2!null\n" +
 			"     │   └─ xy.x:0!null\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: xy\n" +
+			"     │   ├─ name: xy\n" +
+			"     │   └─ columns: [x y]\n" +
 			"     └─ IndexedTableAccess(ab)\n" +
 			"         ├─ index: [ab.a]\n" +
 			"         └─ columns: [a b]\n" +
@@ -851,7 +881,8 @@ var PlanTests = []QueryPlanTest{
 			"         │   ├─ ab.a:2!null\n" +
 			"         │   └─ xy.x:0!null\n" +
 			"         ├─ Table\n" +
-			"         │   └─ name: xy\n" +
+			"         │   ├─ name: xy\n" +
+			"         │   └─ columns: [x y]\n" +
 			"         └─ IndexedTableAccess(ab)\n" +
 			"             ├─ index: [ab.a]\n" +
 			"             └─ columns: [a b]\n" +
@@ -883,9 +914,11 @@ inner join xy on a = x;`,
 			" │       │   │   ├─ ab.a:0!null\n" +
 			" │       │   │   └─ uv.u:2!null\n" +
 			" │       │   ├─ Table\n" +
-			" │       │   │   └─ name: ab\n" +
+			" │       │   │   ├─ name: ab\n" +
+			" │       │   │   └─ columns: [a b]\n" +
 			" │       │   └─ IndexedTableAccess(uv)\n" +
-			" │       │       └─ index: [uv.u]\n" +
+			" │       │       ├─ index: [uv.u]\n" +
+			" │       │       └─ columns: [u v]\n" +
 			" │       └─ Table\n" +
 			" │           ├─ name: pq\n" +
 			" │           └─ columns: [p q]\n" +
@@ -918,7 +951,8 @@ where exists
 			" │       ├─ index: [pq.p]\n" +
 			" │       └─ columns: [p q]\n" +
 			" └─ IndexedTableAccess(ab)\n" +
-			"     └─ index: [ab.a]\n" +
+			"     ├─ index: [ab.a]\n" +
+			"     └─ columns: [a b]\n" +
 			"",
 	},
 	{
@@ -943,7 +977,8 @@ where exists (select * from pq where a = p)
 			" │       │   ├─ ab.a:0!null\n" +
 			" │       │   └─ uv.u:2!null\n" +
 			" │       ├─ Table\n" +
-			" │       │   └─ name: ab\n" +
+			" │       │   ├─ name: ab\n" +
+			" │       │   └─ columns: [a b]\n" +
 			" │       └─ IndexedTableAccess(uv)\n" +
 			" │           ├─ index: [uv.u]\n" +
 			" │           └─ columns: [u v]\n" +
@@ -1037,12 +1072,14 @@ inner join pq on true
 			" │   │       │   ├─ ab.a:0!null\n" +
 			" │   │       │   └─ xy.x:2!null\n" +
 			" │   │       ├─ Table\n" +
-			" │   │       │   └─ name: ab\n" +
+			" │   │       │   ├─ name: ab\n" +
+			" │   │       │   └─ columns: [a b]\n" +
 			" │   │       └─ IndexedTableAccess(xy)\n" +
 			" │   │           ├─ index: [xy.x]\n" +
 			" │   │           └─ columns: [x y]\n" +
 			" │   └─ IndexedTableAccess(pq)\n" +
-			" │       └─ index: [pq.p]\n" +
+			" │       ├─ index: [pq.p]\n" +
+			" │       └─ columns: [p q]\n" +
 			" └─ Table\n" +
 			"     ├─ name: uv\n" +
 			"     └─ columns: [u v]\n" +
@@ -1062,7 +1099,8 @@ inner join pq on true
 			"     │       └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
-			"             └─ index: [mytable.i]\n" +
+			"             ├─ index: [mytable.i]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -1075,7 +1113,8 @@ inner join pq on true
 			"     │   └─ b.i:2!null\n" +
 			"     ├─ TableAlias(a)\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: mytable\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
@@ -1290,7 +1329,8 @@ inner join pq on true
 			" └─ Insert(i, s)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: mytable\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [i:0!null, s:1!null]\n" +
 			"         └─ Project\n" +
@@ -1755,7 +1795,8 @@ inner join pq on true
 			" └─ Insert(i, s)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: mytable\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [i:0!null, s:1!null]\n" +
 			"         └─ Project\n" +
@@ -1800,9 +1841,11 @@ inner join pq on true
 			"     │   │   └─ selfjoin.i:0!null\n" +
 			"     │   ├─ TableAlias(selfjoin)\n" +
 			"     │   │   └─ Table\n" +
-			"     │   │       └─ name: mytable\n" +
+			"     │   │       ├─ name: mytable\n" +
+			"     │   │       └─ columns: [i s]\n" +
 			"     │   └─ IndexedTableAccess(mytable)\n" +
-			"     │       └─ index: [mytable.i]\n" +
+			"     │       ├─ index: [mytable.i]\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -1810,7 +1853,8 @@ inner join pq on true
 			"         └─ Project\n" +
 			"             ├─ columns: [1 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -3075,7 +3119,8 @@ inner join pq on true
 			" │               ├─ name: othertable\n" +
 			" │               └─ columns: [i2]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
-			"     └─ index: [mytable.i]\n" +
+			"     ├─ index: [mytable.i]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3089,7 +3134,8 @@ inner join pq on true
 			" │       ├─ name: othertable\n" +
 			" │       └─ columns: [i2]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
-			"     └─ index: [mytable.i]\n" +
+			"     ├─ index: [mytable.i]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -3107,7 +3153,8 @@ inner join pq on true
 			" │               ├─ index: [othertable.i2]\n" +
 			" │               └─ columns: [i2]\n" +
 			" └─ Table\n" +
-			"     └─ name: mytable\n" +
+			"     ├─ name: mytable\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -4895,7 +4942,8 @@ inner join pq on true
 			"     │       IS NULL))\n" +
 			"     └─ TableAlias(mt)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -4932,7 +4980,8 @@ inner join pq on true
 			"     │       IS NULL))\n" +
 			"     └─ TableAlias(mt)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -4955,14 +5004,16 @@ inner join pq on true
 			"         │   └─ TableAlias(t1)\n" +
 			"         │       └─ IndexedTableAccess(one_pk)\n" +
 			"         │           ├─ index: [one_pk.pk]\n" +
-			"         │           └─ static: [{[1, 1]}]\n" +
+			"         │           ├─ static: [{[1, 1]}]\n" +
+			"         │           └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"         └─ Filter\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ t2.pk2:1!null\n" +
 			"             │   └─ 1 (tinyint)\n" +
 			"             └─ TableAlias(t2)\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: two_pk\n" +
+			"                     ├─ name: two_pk\n" +
+			"                     └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5095,7 +5146,8 @@ inner join pq on true
 			"         │   ├─ two_pk.c1:2!null\n" +
 			"         │   └─ 1 (tinyint)\n" +
 			"         └─ Table\n" +
-			"             └─ name: two_pk\n" +
+			"             ├─ name: two_pk\n" +
+			"             └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5104,7 +5156,8 @@ inner join pq on true
 			" └─ Delete\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         └─ static: [{[1, 1], [2, 2]}]\n" +
+			"         ├─ static: [{[1, 1], [2, 2]}]\n" +
+			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5117,7 +5170,8 @@ inner join pq on true
 			"             │   ├─ two_pk.c1:2!null\n" +
 			"             │   └─ 1 (tinyint)\n" +
 			"             └─ Table\n" +
-			"                 └─ name: two_pk\n" +
+			"                 ├─ name: two_pk\n" +
+			"                 └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -5127,7 +5181,8 @@ inner join pq on true
 			"     └─ UpdateSource(SET two_pk.c1:2!null = 1 (tinyint))\n" +
 			"         └─ IndexedTableAccess(two_pk)\n" +
 			"             ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"             └─ static: [{[1, 1], [2, 2]}]\n" +
+			"             ├─ static: [{[1, 1], [2, 2]}]\n" +
+			"             └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -6039,13 +6094,16 @@ inner join pq on true
 			"         │               ├─ Project\n" +
 			"         │               │   ├─ columns: [1 (tinyint)]\n" +
 			"         │               │   └─ Table\n" +
-			"         │               │       └─ name: \n" +
+			"         │               │       ├─ name: \n" +
+			"         │               │       └─ columns: []\n" +
 			"         │               └─ Project\n" +
 			"         │                   ├─ columns: [2 (tinyint)]\n" +
 			"         │                   └─ Table\n" +
-			"         │                       └─ name: \n" +
+			"         │                       ├─ name: \n" +
+			"         │                       └─ columns: []\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6088,11 +6146,13 @@ inner join pq on true
 			" │       ├─ Project\n" +
 			" │       │   ├─ columns: [1 (tinyint)]\n" +
 			" │       │   └─ Table\n" +
-			" │       │       └─ name: \n" +
+			" │       │       ├─ name: \n" +
+			" │       │       └─ columns: []\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6101,11 +6161,13 @@ inner join pq on true
 			"         ├─ Project\n" +
 			"         │   ├─ columns: [1 (tinyint)]\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: \n" +
+			"         │       ├─ name: \n" +
+			"         │       └─ columns: []\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [2 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6123,11 +6185,13 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [1 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [2 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ Having\n" +
 			"     ├─ GreaterThan\n" +
 			"     │   ├─ a.x:0!null\n" +
@@ -6140,11 +6204,13 @@ inner join pq on true
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1 (tinyint)]\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: \n" +
+			"             │       ├─ name: \n" +
+			"             │       └─ columns: []\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [2 (tinyint)]\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: \n" +
+			"                     ├─ name: \n" +
+			"                     └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6162,11 +6228,13 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [1 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [2 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6179,11 +6247,13 @@ inner join pq on true
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1 (tinyint)]\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: \n" +
+			"             │       ├─ name: \n" +
+			"             │       └─ columns: []\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [2 (tinyint)]\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: \n" +
+			"                     ├─ name: \n" +
+			"                     └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6197,11 +6267,13 @@ inner join pq on true
 			" │       ├─ Project\n" +
 			" │       │   ├─ columns: [1 (tinyint)]\n" +
 			" │       │   └─ Table\n" +
-			" │       │       └─ name: \n" +
+			" │       │       ├─ name: \n" +
+			" │       │       └─ columns: []\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: a.x:0!null\n" +
 			"     ├─ group: a.x:0!null\n" +
@@ -6213,11 +6285,13 @@ inner join pq on true
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1 (tinyint)]\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: \n" +
+			"             │       ├─ name: \n" +
+			"             │       └─ columns: []\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [2 (tinyint)]\n" +
 			"                 └─ Table\n" +
-			"                     └─ name: \n" +
+			"                     ├─ name: \n" +
+			"                     └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6232,11 +6306,13 @@ inner join pq on true
 			" │       ├─ Project\n" +
 			" │       │   ├─ columns: [1 (tinyint)]\n" +
 			" │       │   └─ Table\n" +
-			" │       │       └─ name: \n" +
+			" │       │       ├─ name: \n" +
+			" │       │       └─ columns: []\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6245,11 +6321,13 @@ inner join pq on true
 			"         ├─ Project\n" +
 			"         │   ├─ columns: [1 (tinyint)]\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: \n" +
+			"         │       ├─ name: \n" +
+			"         │       └─ columns: []\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [2 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6269,7 +6347,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i:0!null + 1 (tinyint))]\n" +
 			"                     └─ Filter\n" +
@@ -6295,7 +6374,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i + 1):0!null]\n" +
 			"                     └─ Having\n" +
@@ -6326,7 +6406,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i + 1):0!null]\n" +
 			"                     └─ Having\n" +
@@ -6360,7 +6441,8 @@ inner join pq on true
 			"                 ├─ Project\n" +
 			"                 │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: \n" +
+			"                 │       ├─ name: \n" +
+			"                 │       └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(n.i:0!null + 1 (tinyint))]\n" +
 			"                     └─ Filter\n" +
@@ -6391,13 +6473,16 @@ inner join pq on true
 			"         │               ├─ Project\n" +
 			"         │               │   ├─ columns: [1 (tinyint)]\n" +
 			"         │               │   └─ Table\n" +
-			"         │               │       └─ name: \n" +
+			"         │               │       ├─ name: \n" +
+			"         │               │       └─ columns: []\n" +
 			"         │               └─ Project\n" +
 			"         │                   ├─ columns: [2 (tinyint)]\n" +
 			"         │                   └─ Table\n" +
-			"         │                       └─ name: \n" +
+			"         │                       ├─ name: \n" +
+			"         │                       └─ columns: []\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6407,7 +6492,8 @@ inner join pq on true
 			" │   ├─ Project\n" +
 			" │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │   └─ Table\n" +
-			" │   │       └─ name: \n" +
+			" │   │       ├─ name: \n" +
+			" │   │       └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: a\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -6416,15 +6502,18 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [2 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [3 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [4 (tinyint)]\n" +
 			"     └─ Table\n" +
-			"         └─ name: \n" +
+			"         ├─ name: \n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6434,7 +6523,8 @@ inner join pq on true
 			" │   ├─ Project\n" +
 			" │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │   └─ Table\n" +
-			" │   │       └─ name: \n" +
+			" │   │       ├─ name: \n" +
+			" │   │       └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: a\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -6443,15 +6533,18 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [2 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [3 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [4 (tinyint)]\n" +
 			"     └─ Table\n" +
-			"         └─ name: \n" +
+			"         ├─ name: \n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6472,11 +6565,13 @@ inner join pq on true
 			"                 │   │   ├─ Project\n" +
 			"                 │   │   │   ├─ columns: [1 (tinyint)]\n" +
 			"                 │   │   │   └─ Table\n" +
-			"                 │   │   │       └─ name: \n" +
+			"                 │   │   │       ├─ name: \n" +
+			"                 │   │   │       └─ columns: []\n" +
 			"                 │   │   └─ Project\n" +
 			"                 │   │       ├─ columns: [4 (tinyint)]\n" +
 			"                 │   │       └─ Table\n" +
-			"                 │   │           └─ name: \n" +
+			"                 │   │           ├─ name: \n" +
+			"                 │   │           └─ columns: []\n" +
 			"                 │   └─ SubqueryAlias\n" +
 			"                 │       ├─ name: b\n" +
 			"                 │       ├─ outerVisibility: false\n" +
@@ -6485,11 +6580,13 @@ inner join pq on true
 			"                 │           ├─ Project\n" +
 			"                 │           │   ├─ columns: [2 (tinyint)]\n" +
 			"                 │           │   └─ Table\n" +
-			"                 │           │       └─ name: \n" +
+			"                 │           │       ├─ name: \n" +
+			"                 │           │       └─ columns: []\n" +
 			"                 │           └─ Project\n" +
 			"                 │               ├─ columns: [3 (tinyint)]\n" +
 			"                 │               └─ Table\n" +
-			"                 │                   └─ name: \n" +
+			"                 │                   ├─ name: \n" +
+			"                 │                   └─ columns: []\n" +
 			"                 └─ Project\n" +
 			"                     ├─ columns: [(a.x:0!null + 1 (tinyint))]\n" +
 			"                     └─ Filter\n" +
@@ -6510,7 +6607,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ Sort(b.i:0!null DESC nullsFirst)\n" +
 			" │       └─ SubqueryAlias\n" +
 			" │           ├─ name: b\n" +
@@ -6519,7 +6617,8 @@ inner join pq on true
 			" │           └─ Project\n" +
 			" │               ├─ columns: [2 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6527,7 +6626,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6549,7 +6649,8 @@ inner join pq on true
 			" │   │       │   └─ Project\n" +
 			" │   │       │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       │       └─ Table\n" +
-			" │   │       │           └─ name: \n" +
+			" │   │       │           ├─ name: \n" +
+			" │   │       │           └─ columns: []\n" +
 			" │   │       └─ HashLookup\n" +
 			" │   │           ├─ source: TUPLE(t2.j:0!null)\n" +
 			" │   │           ├─ target: TUPLE(t1.j:0!null)\n" +
@@ -6561,7 +6662,8 @@ inner join pq on true
 			" │   │                   └─ Project\n" +
 			" │   │                       ├─ columns: [1 (tinyint)]\n" +
 			" │   │                       └─ Table\n" +
-			" │   │                           └─ name: \n" +
+			" │   │                           ├─ name: \n" +
+			" │   │                           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -6569,7 +6671,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6577,7 +6680,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6601,15 +6705,18 @@ inner join pq on true
 			" │   │       │       │   ├─ Project\n" +
 			" │   │       │       │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │       │       │   │   └─ Table\n" +
-			" │   │       │       │   │       └─ name: \n" +
+			" │   │       │       │   │       ├─ name: \n" +
+			" │   │       │       │   │       └─ columns: []\n" +
 			" │   │       │       │   └─ Project\n" +
 			" │   │       │       │       ├─ columns: [2 (tinyint)]\n" +
 			" │   │       │       │       └─ Table\n" +
-			" │   │       │       │           └─ name: \n" +
+			" │   │       │       │           ├─ name: \n" +
+			" │   │       │       │           └─ columns: []\n" +
 			" │   │       │       └─ Project\n" +
 			" │   │       │           ├─ columns: [3 (tinyint)]\n" +
 			" │   │       │           └─ Table\n" +
-			" │   │       │               └─ name: \n" +
+			" │   │       │               ├─ name: \n" +
+			" │   │       │               └─ columns: []\n" +
 			" │   │       └─ HashLookup\n" +
 			" │   │           ├─ source: TUPLE(t2.j:0!null)\n" +
 			" │   │           ├─ target: TUPLE(t1.j:0!null)\n" +
@@ -6623,15 +6730,18 @@ inner join pq on true
 			" │   │                       │   ├─ Project\n" +
 			" │   │                       │   │   ├─ columns: [1 (tinyint)]\n" +
 			" │   │                       │   │   └─ Table\n" +
-			" │   │                       │   │       └─ name: \n" +
+			" │   │                       │   │       ├─ name: \n" +
+			" │   │                       │   │       └─ columns: []\n" +
 			" │   │                       │   └─ Project\n" +
 			" │   │                       │       ├─ columns: [2 (tinyint)]\n" +
 			" │   │                       │       └─ Table\n" +
-			" │   │                       │           └─ name: \n" +
+			" │   │                       │           ├─ name: \n" +
+			" │   │                       │           └─ columns: []\n" +
 			" │   │                       └─ Project\n" +
 			" │   │                           ├─ columns: [3 (tinyint)]\n" +
 			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: \n" +
+			" │   │                               ├─ name: \n" +
+			" │   │                               └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -6640,11 +6750,13 @@ inner join pq on true
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [2 (tinyint)]\n" +
 			" │           │   └─ Table\n" +
-			" │           │       └─ name: \n" +
+			" │           │       ├─ name: \n" +
+			" │           │       └─ columns: []\n" +
 			" │           └─ Project\n" +
 			" │               ├─ columns: [3 (tinyint)]\n" +
 			" │               └─ Table\n" +
-			" │                   └─ name: \n" +
+			" │                   ├─ name: \n" +
+			" │                   └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6654,15 +6766,18 @@ inner join pq on true
 			"         │   ├─ Project\n" +
 			"         │   │   ├─ columns: [1 (tinyint)]\n" +
 			"         │   │   └─ Table\n" +
-			"         │   │       └─ name: \n" +
+			"         │   │       ├─ name: \n" +
+			"         │   │       └─ columns: []\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [2 (tinyint)]\n" +
 			"         │       └─ Table\n" +
-			"         │           └─ name: \n" +
+			"         │           ├─ name: \n" +
+			"         │           └─ columns: []\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [3 (tinyint)]\n" +
 			"             └─ Table\n" +
-			"                 └─ name: \n" +
+			"                 ├─ name: \n" +
+			"                 └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6678,7 +6793,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -6686,7 +6802,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6694,7 +6811,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6710,7 +6828,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -6718,7 +6837,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [2 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6726,7 +6846,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6740,7 +6861,8 @@ inner join pq on true
 			" │   │   └─ Project\n" +
 			" │   │       ├─ columns: [1 (tinyint)]\n" +
 			" │   │       └─ Table\n" +
-			" │   │           └─ name: \n" +
+			" │   │           ├─ name: \n" +
+			" │   │           └─ columns: []\n" +
 			" │   └─ SubqueryAlias\n" +
 			" │       ├─ name: b\n" +
 			" │       ├─ outerVisibility: false\n" +
@@ -6748,7 +6870,8 @@ inner join pq on true
 			" │       └─ Project\n" +
 			" │           ├─ columns: [1 (tinyint)]\n" +
 			" │           └─ Table\n" +
-			" │               └─ name: \n" +
+			" │               ├─ name: \n" +
+			" │               └─ columns: []\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: a\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -6756,7 +6879,8 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [1 (tinyint)]\n" +
 			"         └─ Table\n" +
-			"             └─ name: \n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6872,7 +6996,8 @@ WHERE
 			"     │   ├─ YK2GW.id:0!null\n" +
 			"     │   └─ applySubq0.IXUXU:30\n" +
 			"     ├─ Table\n" +
-			"     │   └─ name: YK2GW\n" +
+			"     │   ├─ name: YK2GW\n" +
+			"     │   └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
 			"         └─ IndexedTableAccess(THNTS)\n" +
 			"             ├─ index: [THNTS.IXUXU]\n" +
@@ -6970,7 +7095,8 @@ WHERE
 			"     │                                   └─ TableAlias(nd)\n" +
 			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ Filter\n" +
 			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
@@ -7084,7 +7210,8 @@ WHERE
 			" │   │           │       │           │                       └─ columns: [id fzxv5]\n" +
 			" │   │           │       │           └─ TableAlias(nd)\n" +
 			" │   │           │       │               └─ Table\n" +
-			" │   │           │       │                   └─ name: E2I7U\n" +
+			" │   │           │       │                   ├─ name: E2I7U\n" +
+			" │   │           │       │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │           │       └─ ism.FV24E:1!null\n" +
 			" │   │           │      ))\n" +
 			" │   │           └─ AND\n" +
@@ -7111,7 +7238,8 @@ WHERE
 			" │   │                   │           │                       └─ columns: [id dqygv]\n" +
 			" │   │                   │           └─ TableAlias(nd)\n" +
 			" │   │                   │               └─ Table\n" +
-			" │   │                   │                   └─ name: E2I7U\n" +
+			" │   │                   │                   ├─ name: E2I7U\n" +
+			" │   │                   │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                   └─ ism.UJ6XY:2!null\n" +
 			" │   │                  ))\n" +
 			" │   └─ AND\n" +
@@ -7156,13 +7284,16 @@ WHERE
 			" │                           │   │   └─ 0 (tinyint)\n" +
 			" │                           │   └─ TableAlias(NHMXW)\n" +
 			" │                           │       └─ Table\n" +
-			" │                           │           └─ name: WGSDC\n" +
+			" │                           │           ├─ name: WGSDC\n" +
+			" │                           │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			" │                           └─ TableAlias(TIZHK)\n" +
 			" │                               └─ IndexedTableAccess(WRZVO)\n" +
-			" │                                   └─ index: [WRZVO.TVNW2]\n" +
+			" │                                   ├─ index: [WRZVO.TVNW2]\n" +
+			" │                                   └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ Table\n" +
-			"         └─ name: HDDVB\n" +
+			"         ├─ name: HDDVB\n" +
+			"         └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -7232,22 +7363,28 @@ WHERE
 			" │   │                   │   │   │   │   └─ TIZHK.TVNW2:18\n" +
 			" │   │                   │   │   │   ├─ TableAlias(J4JYP)\n" +
 			" │   │                   │   │   │   │   └─ Table\n" +
-			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                   │   │   │   │       ├─ name: E2I7U\n" +
+			" │   │                   │   │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
 			" │   │                   │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
-			" │   │                   │   │   │           └─ index: [WRZVO.TVNW2]\n" +
+			" │   │                   │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
+			" │   │                   │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" │   │                   │   │   └─ TableAlias(RHUZN)\n" +
 			" │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			" │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
+			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			" │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                   │   └─ TableAlias(mf)\n" +
 			" │   │                   │       └─ IndexedTableAccess(HGMQ6)\n" +
-			" │   │                   │           └─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                   │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │   │                   └─ TableAlias(aac)\n" +
 			" │   │                       └─ IndexedTableAccess(TPXBU)\n" +
-			" │   │                           └─ index: [TPXBU.id]\n" +
+			" │   │                           ├─ index: [TPXBU.id]\n" +
+			" │   │                           └─ columns: [id btxc5 fhcyt]\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
 			" │       └─ IndexedTableAccess(WRZVO)\n" +
-			" │           └─ index: [WRZVO.id]\n" +
+			" │           ├─ index: [WRZVO.id]\n" +
+			" │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" └─ TableAlias(applySubq1)\n" +
 			"     └─ IndexedTableAccess(HDDVB)\n" +
 			"         ├─ index: [HDDVB.ETPQV]\n" +
@@ -7321,22 +7458,28 @@ WHERE
 			" │   │                   │   │   │   │   └─ TIZHK.ZHITY:19\n" +
 			" │   │                   │   │   │   ├─ TableAlias(RHUZN)\n" +
 			" │   │                   │   │   │   │   └─ Table\n" +
-			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                   │   │   │   │       ├─ name: E2I7U\n" +
+			" │   │                   │   │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
 			" │   │                   │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
-			" │   │                   │   │   │           └─ index: [WRZVO.ZHITY]\n" +
+			" │   │                   │   │   │           ├─ index: [WRZVO.ZHITY]\n" +
+			" │   │                   │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" │   │                   │   │   └─ TableAlias(J4JYP)\n" +
 			" │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			" │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
+			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			" │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │   │                   │   └─ TableAlias(mf)\n" +
 			" │   │                   │       └─ IndexedTableAccess(HGMQ6)\n" +
-			" │   │                   │           └─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                   │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │   │                   └─ TableAlias(aac)\n" +
 			" │   │                       └─ IndexedTableAccess(TPXBU)\n" +
-			" │   │                           └─ index: [TPXBU.id]\n" +
+			" │   │                           ├─ index: [TPXBU.id]\n" +
+			" │   │                           └─ columns: [id btxc5 fhcyt]\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
 			" │       └─ IndexedTableAccess(WRZVO)\n" +
-			" │           └─ index: [WRZVO.id]\n" +
+			" │           ├─ index: [WRZVO.id]\n" +
+			" │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" └─ TableAlias(applySubq1)\n" +
 			"     └─ IndexedTableAccess(HDDVB)\n" +
 			"         ├─ index: [HDDVB.ETPQV]\n" +
@@ -7434,7 +7577,8 @@ WHERE
 			"     │                                   └─ TableAlias(nd)\n" +
 			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ Filter\n" +
 			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
@@ -7548,7 +7692,8 @@ WHERE
 			"     │   │           │           │                       └─ columns: [id fvucx]\n" +
 			"     │   │           │           └─ TableAlias(nd)\n" +
 			"     │   │           │               └─ Table\n" +
-			"     │   │           │                   └─ name: E2I7U\n" +
+			"     │   │           │                   ├─ name: E2I7U\n" +
+			"     │   │           │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │   │           └─ ct.LUEVY:7!null\n" +
 			"     │   │          ))\n" +
 			"     │   └─ AND\n" +
@@ -7589,10 +7734,12 @@ WHERE
 			"     │                           │   │   └─ 0 (tinyint)\n" +
 			"     │                           │   └─ TableAlias(I7HCR)\n" +
 			"     │                           │       └─ Table\n" +
-			"     │                           │           └─ name: EPZU6\n" +
+			"     │                           │           ├─ name: EPZU6\n" +
+			"     │                           │           └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"     │                           └─ TableAlias(uct)\n" +
 			"     │                               └─ IndexedTableAccess(OUBDL)\n" +
-			"     │                                   └─ index: [OUBDL.ZH72S]\n" +
+			"     │                                   ├─ index: [OUBDL.ZH72S]\n" +
+			"     │                                   └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ aac.id:34!null\n" +
@@ -7607,16 +7754,20 @@ WHERE
 			"         │   │   │   └─ ct.FZ2R5:6!null\n" +
 			"         │   │   ├─ TableAlias(ci)\n" +
 			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: JDLNA\n" +
+			"         │   │   │       ├─ name: JDLNA\n" +
+			"         │   │   │       └─ columns: [id ftqlq fwwiq o3qxw fhcyt]\n" +
 			"         │   │   └─ TableAlias(ct)\n" +
 			"         │   │       └─ IndexedTableAccess(FLQLP)\n" +
-			"         │   │           └─ index: [FLQLP.FZ2R5]\n" +
+			"         │   │           ├─ index: [FLQLP.FZ2R5]\n" +
+			"         │   │           └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"         │   └─ TableAlias(nd)\n" +
 			"         │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │           └─ index: [E2I7U.id]\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         └─ TableAlias(aac)\n" +
 			"             └─ IndexedTableAccess(TPXBU)\n" +
-			"                 └─ index: [TPXBU.id]\n" +
+			"                 ├─ index: [TPXBU.id]\n" +
+			"                 └─ columns: [id btxc5 fhcyt]\n" +
 			"",
 	},
 	{
@@ -7682,15 +7833,18 @@ WHERE
 			"     │               │   │   │   │   └─ YLKSY.FTQLQ:6\n" +
 			"     │               │   │   │   ├─ TableAlias(ci)\n" +
 			"     │               │   │   │   │   └─ Table\n" +
-			"     │               │   │   │   │       └─ name: JDLNA\n" +
+			"     │               │   │   │   │       ├─ name: JDLNA\n" +
+			"     │               │   │   │   │       └─ columns: [id ftqlq fwwiq o3qxw fhcyt]\n" +
 			"     │               │   │   │   └─ Filter\n" +
 			"     │               │   │   │       ├─ (NOT(YLKSY.LJLUM LIKE '%|%'))\n" +
 			"     │               │   │   │       └─ TableAlias(YLKSY)\n" +
 			"     │               │   │   │           └─ IndexedTableAccess(OUBDL)\n" +
-			"     │               │   │   │               └─ index: [OUBDL.FTQLQ]\n" +
+			"     │               │   │   │               ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │               │   │   │               └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"     │               │   │   └─ TableAlias(nd)\n" +
 			"     │               │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │               │   │           └─ index: [E2I7U.ZH72S]\n" +
+			"     │               │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │               │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │               │   └─ Filter\n" +
 			"     │               │       ├─ (NOT(applySubq0.NRURT:0 IS NULL))\n" +
 			"     │               │       └─ TableAlias(applySubq0)\n" +
@@ -7699,7 +7853,8 @@ WHERE
 			"     │               │               └─ columns: [nrurt]\n" +
 			"     │               └─ TableAlias(aac)\n" +
 			"     │                   └─ IndexedTableAccess(TPXBU)\n" +
-			"     │                       └─ index: [TPXBU.BTXC5]\n" +
+			"     │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"     │                       └─ columns: [id btxc5 fhcyt]\n" +
 			"     └─ TableAlias(uct)\n" +
 			"         └─ IndexedTableAccess(OUBDL)\n" +
 			"             ├─ index: [OUBDL.id]\n" +
@@ -7808,7 +7963,8 @@ WHERE
 			" │   │   ├─ HU5A5.SWCQV:10!null\n" +
 			" │   │   └─ 0 (tinyint)\n" +
 			" │   └─ Table\n" +
-			" │       └─ name: HU5A5\n" +
+			" │       ├─ name: HU5A5\n" +
+			" │       └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			" └─ Filter\n" +
 			"     ├─ (NOT(applySubq0.XMM6Q:0 IS NULL))\n" +
 			"     └─ TableAlias(applySubq0)\n" +
@@ -8104,16 +8260,19 @@ WHERE
 			"     │           │               │   └─ S5KBM.FGG57:18!null\n" +
 			"     │           │               ├─ TableAlias(nd)\n" +
 			"     │           │               │   └─ Table\n" +
-			"     │           │               │       └─ name: E2I7U\n" +
+			"     │           │               │       ├─ name: E2I7U\n" +
+			"     │           │               │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │           │               └─ TableAlias(S5KBM)\n" +
 			"     │           │                   └─ IndexedTableAccess(TDRVG)\n" +
-			"     │           │                       └─ index: [TDRVG.FGG57]\n" +
+			"     │           │                       ├─ index: [TDRVG.FGG57]\n" +
+			"     │           │                       └─ columns: [id fgg57 sshpj sfj6l zh72s]\n" +
 			"     │           └─ TableAlias(applySubq0)\n" +
 			"     │               └─ IndexedTableAccess(WE72E)\n" +
 			"     │                   ├─ index: [WE72E.SSHPJ]\n" +
 			"     │                   └─ columns: [sshpj]\n" +
 			"     └─ IndexedTableAccess(TDRVG)\n" +
-			"         └─ index: [TDRVG.id]\n" +
+			"         ├─ index: [TDRVG.id]\n" +
+			"         └─ columns: [id fgg57 sshpj sfj6l zh72s]\n" +
 			"",
 	},
 	{
@@ -8207,7 +8366,8 @@ WHERE
 			"     │                                   └─ TableAlias(nd)\n" +
 			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ Filter\n" +
 			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
@@ -8254,13 +8414,16 @@ WHERE
 			"         │   │   │   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"         │   │   │   └─ TableAlias(nd)\n" +
 			"         │   │   │       └─ Table\n" +
-			"         │   │   │           └─ name: E2I7U\n" +
+			"         │   │   │           ├─ name: E2I7U\n" +
+			"         │   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │   │   └─ TableAlias(ufc)\n" +
 			"         │   │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           └─ index: [SISUT.ZH72S]\n" +
+			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │   │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
 			"         │   └─ TableAlias(cla)\n" +
 			"         │       └─ IndexedTableAccess(YK2GW)\n" +
-			"         │           └─ index: [YK2GW.FTQLQ]\n" +
+			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
+			"         │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ TableAlias(applySubq0)\n" +
 			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.KKGN5]\n" +
@@ -8305,13 +8468,16 @@ WHERE
 			"         │   │   │   ├─ (NOT(nd.ZH72S:7 IS NULL))\n" +
 			"         │   │   │   └─ TableAlias(nd)\n" +
 			"         │   │   │       └─ Table\n" +
-			"         │   │   │           └─ name: E2I7U\n" +
+			"         │   │   │           ├─ name: E2I7U\n" +
+			"         │   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │   │   └─ TableAlias(ufc)\n" +
 			"         │   │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           └─ index: [SISUT.ZH72S]\n" +
+			"         │   │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │   │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
 			"         │   └─ TableAlias(cla)\n" +
 			"         │       └─ IndexedTableAccess(YK2GW)\n" +
-			"         │           └─ index: [YK2GW.FTQLQ]\n" +
+			"         │           ├─ index: [YK2GW.FTQLQ]\n" +
+			"         │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ TableAlias(applySubq0)\n" +
 			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.KKGN5]\n" +
@@ -8343,10 +8509,12 @@ WHERE
 			"     │   │   └─ ums.T4IBQ:1\n" +
 			"     │   ├─ TableAlias(ums)\n" +
 			"     │   │   └─ Table\n" +
-			"     │   │       └─ name: FG26Y\n" +
+			"     │   │       ├─ name: FG26Y\n" +
+			"     │   │       └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"     │   └─ TableAlias(cla)\n" +
 			"     │       └─ IndexedTableAccess(YK2GW)\n" +
-			"     │           └─ index: [YK2GW.FTQLQ]\n" +
+			"     │           ├─ index: [YK2GW.FTQLQ]\n" +
+			"     │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
 			"         └─ IndexedTableAccess(SZQWJ)\n" +
 			"             ├─ index: [SZQWJ.JOGI6]\n" +
@@ -8460,7 +8628,8 @@ WHERE
 			"     │   │           │           │                       └─ columns: [id h4dmt]\n" +
 			"     │   │           │           └─ TableAlias(nd)\n" +
 			"     │   │           │               └─ Table\n" +
-			"     │   │           │                   └─ name: E2I7U\n" +
+			"     │   │           │                   ├─ name: E2I7U\n" +
+			"     │   │           │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │   │           └─ mf.LUEVY:19!null\n" +
 			"     │   │          ))\n" +
 			"     │   └─ AND\n" +
@@ -8501,10 +8670,12 @@ WHERE
 			"     │                           │   │   └─ 0 (tinyint)\n" +
 			"     │                           │   └─ TableAlias(TJ5D2)\n" +
 			"     │                           │       └─ Table\n" +
-			"     │                           │           └─ name: SZW6V\n" +
+			"     │                           │           ├─ name: SZW6V\n" +
+			"     │                           │           └─ columns: [id t4ibq v7ufh sypkf h4dmt swcqv ykssu fhcyt]\n" +
 			"     │                           └─ TableAlias(umf)\n" +
 			"     │                               └─ Table\n" +
-			"     │                                   └─ name: NZKPM\n" +
+			"     │                                   ├─ name: NZKPM\n" +
+			"     │                                   └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ aac.id:68!null\n" +
@@ -8519,10 +8690,12 @@ WHERE
 			"         │   │   │   └─ mf.LUEVY:19!null\n" +
 			"         │   │   ├─ TableAlias(nd)\n" +
 			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: E2I7U\n" +
+			"         │   │   │       ├─ name: E2I7U\n" +
+			"         │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │   │   └─ TableAlias(mf)\n" +
 			"         │   │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"         │   │           └─ index: [HGMQ6.LUEVY]\n" +
+			"         │   │           ├─ index: [HGMQ6.LUEVY]\n" +
+			"         │   │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"         │   └─ HashLookup\n" +
 			"         │       ├─ source: TUPLE(mf.GXLUB:18!null)\n" +
 			"         │       ├─ target: TUPLE(bs.id:0!null)\n" +
@@ -8533,13 +8706,16 @@ WHERE
 			"         │               │   └─ bs.IXUXU:36\n" +
 			"         │               ├─ TableAlias(bs)\n" +
 			"         │               │   └─ Table\n" +
-			"         │               │       └─ name: THNTS\n" +
+			"         │               │       ├─ name: THNTS\n" +
+			"         │               │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"         │               └─ TableAlias(cla)\n" +
 			"         │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"         │                       └─ index: [YK2GW.id]\n" +
+			"         │                       ├─ index: [YK2GW.id]\n" +
+			"         │                       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ TableAlias(aac)\n" +
 			"             └─ IndexedTableAccess(TPXBU)\n" +
-			"                 └─ index: [TPXBU.id]\n" +
+			"                 ├─ index: [TPXBU.id]\n" +
+			"                 └─ columns: [id btxc5 fhcyt]\n" +
 			"",
 	},
 	{
@@ -8579,7 +8755,8 @@ WHERE
 			"     │   │   │   └─ umf.T4IBQ:31\n" +
 			"     │   │   ├─ TableAlias(cla)\n" +
 			"     │   │   │   └─ Table\n" +
-			"     │   │   │       └─ name: YK2GW\n" +
+			"     │   │   │       ├─ name: YK2GW\n" +
+			"     │   │   │       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"     │   │   └─ Filter\n" +
 			"     │   │       ├─ (NOT(Eq\n" +
 			"     │   │       │   ├─ umf.ARN5P:7\n" +
@@ -8587,12 +8764,14 @@ WHERE
 			"     │   │       │  ))\n" +
 			"     │   │       └─ TableAlias(umf)\n" +
 			"     │   │           └─ IndexedTableAccess(NZKPM)\n" +
-			"     │   │               └─ index: [NZKPM.T4IBQ]\n" +
+			"     │   │               ├─ index: [NZKPM.T4IBQ]\n" +
+			"     │   │               └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ (NOT(nd.FGG57:6 IS NULL))\n" +
 			"     │       └─ TableAlias(nd)\n" +
 			"     │           └─ IndexedTableAccess(E2I7U)\n" +
-			"     │               └─ index: [E2I7U.FGG57]\n" +
+			"     │               ├─ index: [E2I7U.FGG57]\n" +
+			"     │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ TableAlias(applySubq0)\n" +
 			"         └─ IndexedTableAccess(HGMQ6)\n" +
 			"             ├─ index: [HGMQ6.TEUJA]\n" +
@@ -8751,17 +8930,20 @@ WHERE
 			" │           │   │   │   └─ bs.IXUXU:2\n" +
 			" │           │   │   ├─ TableAlias(bs)\n" +
 			" │           │   │   │   └─ Table\n" +
-			" │           │   │   │       └─ name: THNTS\n" +
+			" │           │   │   │       ├─ name: THNTS\n" +
+			" │           │   │   │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			" │           │   │   └─ Filter\n" +
 			" │           │   │       ├─ HashIn\n" +
 			" │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			" │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │           │   │       └─ TableAlias(cla)\n" +
 			" │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
-			" │           │   │               └─ index: [YK2GW.id]\n" +
+			" │           │   │               ├─ index: [YK2GW.id]\n" +
+			" │           │   │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			" │           │   └─ TableAlias(mf)\n" +
 			" │           │       └─ IndexedTableAccess(HGMQ6)\n" +
-			" │           │           └─ index: [HGMQ6.GXLUB]\n" +
+			" │           │           ├─ index: [HGMQ6.GXLUB]\n" +
+			" │           │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │           └─ HashLookup\n" +
 			" │               ├─ source: TUPLE(mf.LUEVY:36!null, mf.M22QN:37!null)\n" +
 			" │               ├─ target: TUPLE(sn.BRQP2:7!null, SL3S5.M22QN:2!null)\n" +
@@ -8830,13 +9012,16 @@ WHERE
 			" │                       │                                   │   └─ mf.LUEVY:12!null\n" +
 			" │                       │                                   ├─ TableAlias(sn)\n" +
 			" │                       │                                   │   └─ Table\n" +
-			" │                       │                                   │       └─ name: NOXN3\n" +
+			" │                       │                                   │       ├─ name: NOXN3\n" +
+			" │                       │                                   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" │                       │                                   └─ TableAlias(mf)\n" +
 			" │                       │                                       └─ IndexedTableAccess(HGMQ6)\n" +
-			" │                       │                                           └─ index: [HGMQ6.LUEVY]\n" +
+			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │                       │                                           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │                       └─ TableAlias(sn)\n" +
 			" │                           └─ IndexedTableAccess(NOXN3)\n" +
-			" │                               └─ index: [NOXN3.id]\n" +
+			" │                               ├─ index: [NOXN3.id]\n" +
+			" │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [AOEV5.T4IBQ:0!null as T4IBQ, VUMUY.DL754:1!null, VUMUY.BDNYB:2!null, VUMUY.ADURZ:3!null, VUMUY.TPXBU:4, VUMUY.NO52D:5!null, VUMUY.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
@@ -8908,7 +9093,8 @@ WHERE
 			"             │           │               │   │       │   └─ = (longtext)\n" +
 			"             │           │               │   │       └─ TableAlias(ct)\n" +
 			"             │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			"             │           │               │   │               └─ index: [FLQLP.OVE3E]\n" +
+			"             │           │               │   │               ├─ index: [FLQLP.OVE3E]\n" +
+			"             │           │               │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"             │           │               │   └─ Filter\n" +
 			"             │           │               │       ├─ HashIn\n" +
 			"             │           │               │       │   ├─ ci.FTQLQ:1!null\n" +
@@ -8919,10 +9105,12 @@ WHERE
 			"             │           │               │               └─ columns: [id ftqlq]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
 			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │           │                       └─ index: [NOXN3.BRQP2]\n" +
+			"             │           │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │           │                       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(sn)\n" +
 			"             │               └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                   └─ index: [NOXN3.id]\n" +
+			"             │                   ├─ index: [NOXN3.id]\n" +
+			"             │                   └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             └─ SubqueryAlias\n" +
 			"                 ├─ name: AOEV5\n" +
 			"                 ├─ outerVisibility: false\n" +
@@ -9078,17 +9266,20 @@ WHERE
 			" │           │   │   │   └─ bs.IXUXU:2\n" +
 			" │           │   │   ├─ TableAlias(bs)\n" +
 			" │           │   │   │   └─ Table\n" +
-			" │           │   │   │       └─ name: THNTS\n" +
+			" │           │   │   │       ├─ name: THNTS\n" +
+			" │           │   │   │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			" │           │   │   └─ Filter\n" +
 			" │           │   │       ├─ HashIn\n" +
 			" │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			" │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │           │   │       └─ TableAlias(cla)\n" +
 			" │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
-			" │           │   │               └─ index: [YK2GW.id]\n" +
+			" │           │   │               ├─ index: [YK2GW.id]\n" +
+			" │           │   │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			" │           │   └─ TableAlias(mf)\n" +
 			" │           │       └─ IndexedTableAccess(HGMQ6)\n" +
-			" │           │           └─ index: [HGMQ6.GXLUB]\n" +
+			" │           │           ├─ index: [HGMQ6.GXLUB]\n" +
+			" │           │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │           └─ HashLookup\n" +
 			" │               ├─ source: TUPLE(mf.LUEVY:36!null, mf.M22QN:37!null)\n" +
 			" │               ├─ target: TUPLE(sn.BRQP2:7!null, SL3S5.M22QN:2!null)\n" +
@@ -9156,13 +9347,16 @@ WHERE
 			" │                       │                                   │   └─ mf.LUEVY:12!null\n" +
 			" │                       │                                   ├─ TableAlias(sn)\n" +
 			" │                       │                                   │   └─ Table\n" +
-			" │                       │                                   │       └─ name: NOXN3\n" +
+			" │                       │                                   │       ├─ name: NOXN3\n" +
+			" │                       │                                   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" │                       │                                   └─ TableAlias(mf)\n" +
 			" │                       │                                       └─ IndexedTableAccess(HGMQ6)\n" +
-			" │                       │                                           └─ index: [HGMQ6.LUEVY]\n" +
+			" │                       │                                           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │                       │                                           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			" │                       └─ TableAlias(sn)\n" +
 			" │                           └─ IndexedTableAccess(NOXN3)\n" +
-			" │                               └─ index: [NOXN3.id]\n" +
+			" │                               ├─ index: [NOXN3.id]\n" +
+			" │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [AOEV5.T4IBQ:0!null as T4IBQ, VUMUY.DL754:1!null, VUMUY.BDNYB:2!null, VUMUY.ADURZ:3!null, VUMUY.TPXBU:4, VUMUY.NO52D:5!null, VUMUY.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
@@ -9234,7 +9428,8 @@ WHERE
 			"             │           │               │   │       │   └─ = (longtext)\n" +
 			"             │           │               │   │       └─ TableAlias(ct)\n" +
 			"             │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			"             │           │               │   │               └─ index: [FLQLP.OVE3E]\n" +
+			"             │           │               │   │               ├─ index: [FLQLP.OVE3E]\n" +
+			"             │           │               │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"             │           │               │   └─ Filter\n" +
 			"             │           │               │       ├─ HashIn\n" +
 			"             │           │               │       │   ├─ ci.FTQLQ:1!null\n" +
@@ -9245,10 +9440,12 @@ WHERE
 			"             │           │               │               └─ columns: [id ftqlq]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
 			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │           │                       └─ index: [NOXN3.BRQP2]\n" +
+			"             │           │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │           │                       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(sn)\n" +
 			"             │               └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                   └─ index: [NOXN3.id]\n" +
+			"             │                   ├─ index: [NOXN3.id]\n" +
+			"             │                   └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"             └─ SubqueryAlias\n" +
 			"                 ├─ name: AOEV5\n" +
 			"                 ├─ outerVisibility: false\n" +
@@ -9634,7 +9831,8 @@ WHERE
 			"         │           │                       └─ columns: [id ftqlq]\n" +
 			"         │           └─ TableAlias(nd)\n" +
 			"         │               └─ Table\n" +
-			"         │                   └─ name: E2I7U\n" +
+			"         │                   ├─ name: E2I7U\n" +
+			"         │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         └─ TableAlias(fc)\n" +
 			"             └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
@@ -10635,7 +10833,8 @@ WHERE
 			" │               │   ├─ E2I7U.id:17!null\n" +
 			" │               │   └─ applySubq0.LUEVY:34!null\n" +
 			" │               ├─ Table\n" +
-			" │               │   └─ name: E2I7U\n" +
+			" │               │   ├─ name: E2I7U\n" +
+			" │               │   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			" │               └─ TableAlias(applySubq0)\n" +
 			" │                   └─ IndexedTableAccess(AMYXQ)\n" +
 			" │                       ├─ index: [AMYXQ.LUEVY]\n" +
@@ -10649,7 +10848,8 @@ WHERE
 			" │   THEN 0 (tinyint) ELSE 3 (tinyint) END as SZ6KK]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     └─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -11654,7 +11854,8 @@ WHERE
 			"     │   │   │                                           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   └─ TableAlias(sn)\n" +
 			"     │   │       └─ Table\n" +
-			"     │   │           └─ name: NOXN3\n" +
+			"     │   │           ├─ name: NOXN3\n" +
+			"     │   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │   └─ HashLookup\n" +
 			"     │       ├─ source: TUPLE(MJR3D.M22QN:3!null)\n" +
 			"     │       ├─ target: TUPLE(aac.id:0!null)\n" +
@@ -12038,28 +12239,36 @@ WHERE
 			"     │           │                       │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"     │           │                       │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │           │                       │   │                   │   │   │   │   │       └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
 			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
-			"     │           │                       │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
+			"     │           │                       │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
+			"     │           │                       │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
-			"     │           │                       │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
+			"     │           │                       │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
+			"     │           │                       │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   └─ TableAlias(CPMFE)\n" +
 			"     │           │                       │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │           │                       │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
+			"     │           │                       │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │           │                       │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │           │                       │   │                   │   └─ TableAlias(YQIF4)\n" +
 			"     │           │                       │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │           │                       │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   │                   └─ TableAlias(YVHJZ)\n" +
 			"     │           │                       │   │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │           │                       │   │                           └─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   └─ TableAlias(aac)\n" +
 			"     │           │                       │       └─ IndexedTableAccess(TPXBU)\n" +
-			"     │           │                       │           └─ index: [TPXBU.id]\n" +
+			"     │           │                       │           ├─ index: [TPXBU.id]\n" +
+			"     │           │                       │           └─ columns: [id btxc5 fhcyt]\n" +
 			"     │           │                       └─ TableAlias(sn)\n" +
 			"     │           │                           └─ Table\n" +
-			"     │           │                               └─ name: NOXN3\n" +
+			"     │           │                               ├─ name: NOXN3\n" +
+			"     │           │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: RSA3Y\n" +
 			"     │               ├─ outerVisibility: false\n" +
@@ -12341,28 +12550,36 @@ WHERE
 			"                                                 │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"                                                 │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"                                                 │   │                   │   │   │   │   │       └─ Table\n" +
-			"                                                 │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
 			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
-			"                                                 │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
+			"                                                 │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                                                 │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"                                                 │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
-			"                                                 │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
+			"                                                 │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
+			"                                                 │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   └─ TableAlias(CPMFE)\n" +
 			"                                                 │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"                                                 │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
+			"                                                 │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                                                 │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"                                                 │   │                   │   └─ TableAlias(YQIF4)\n" +
 			"                                                 │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   │                   └─ TableAlias(YVHJZ)\n" +
 			"                                                 │   │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │                           └─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   └─ TableAlias(aac)\n" +
 			"                                                 │       └─ IndexedTableAccess(TPXBU)\n" +
-			"                                                 │           └─ index: [TPXBU.id]\n" +
+			"                                                 │           ├─ index: [TPXBU.id]\n" +
+			"                                                 │           └─ columns: [id btxc5 fhcyt]\n" +
 			"                                                 └─ TableAlias(sn)\n" +
 			"                                                     └─ Table\n" +
-			"                                                         └─ name: NOXN3\n" +
+			"                                                         ├─ name: NOXN3\n" +
+			"                                                         └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -12702,28 +12919,36 @@ WHERE
 			"     │           │                       │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"     │           │                       │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │           │                       │   │                   │   │   │   │   │       └─ Table\n" +
-			"     │           │                       │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │           │                       │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
 			"     │           │                       │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
-			"     │           │                       │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
+			"     │           │                       │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
+			"     │           │                       │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │           │                       │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
-			"     │           │                       │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
+			"     │           │                       │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
+			"     │           │                       │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"     │           │                       │   │                   │   │   └─ TableAlias(CPMFE)\n" +
 			"     │           │                       │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │           │                       │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
+			"     │           │                       │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │           │                       │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     │           │                       │   │                   │   └─ TableAlias(YQIF4)\n" +
 			"     │           │                       │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │           │                       │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   │                   └─ TableAlias(YVHJZ)\n" +
 			"     │           │                       │   │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │           │                       │   │                           └─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │           │                       │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           │                       │   └─ TableAlias(aac)\n" +
 			"     │           │                       │       └─ IndexedTableAccess(TPXBU)\n" +
-			"     │           │                       │           └─ index: [TPXBU.id]\n" +
+			"     │           │                       │           ├─ index: [TPXBU.id]\n" +
+			"     │           │                       │           └─ columns: [id btxc5 fhcyt]\n" +
 			"     │           │                       └─ TableAlias(sn)\n" +
 			"     │           │                           └─ Table\n" +
-			"     │           │                               └─ name: NOXN3\n" +
+			"     │           │                               ├─ name: NOXN3\n" +
+			"     │           │                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: RSA3Y\n" +
 			"     │               ├─ outerVisibility: false\n" +
@@ -13003,28 +13228,36 @@ WHERE
 			"                                                 │   │                   │   │   │   │   │   ├─ (NOT(G3YXS.TUV25:5 IS NULL))\n" +
 			"                                                 │   │                   │   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"                                                 │   │                   │   │   │   │   │       └─ Table\n" +
-			"                                                 │   │                   │   │   │   │   │           └─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           ├─ name: YYBCX\n" +
+			"                                                 │   │                   │   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q tuv25 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   │   └─ TableAlias(ism)\n" +
 			"                                                 │   │                   │   │   │   │       └─ IndexedTableAccess(HDDVB)\n" +
-			"                                                 │   │                   │   │   │   │           └─ index: [HDDVB.NZ4MQ]\n" +
+			"                                                 │   │                   │   │   │   │           ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                                                 │   │                   │   │   │   │           └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"                                                 │   │                   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
-			"                                                 │   │                   │   │   │           └─ index: [WGSDC.id]\n" +
+			"                                                 │   │                   │   │   │           ├─ index: [WGSDC.id]\n" +
+			"                                                 │   │                   │   │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"                                                 │   │                   │   │   └─ TableAlias(CPMFE)\n" +
 			"                                                 │   │                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"                                                 │   │                   │   │           └─ index: [E2I7U.ZH72S]\n" +
+			"                                                 │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                                                 │   │                   │   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"                                                 │   │                   │   └─ TableAlias(YQIF4)\n" +
 			"                                                 │   │                   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │                   │           └─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                   │           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   │                   └─ TableAlias(YVHJZ)\n" +
 			"                                                 │   │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │                           └─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                                                 │   └─ TableAlias(aac)\n" +
 			"                                                 │       └─ IndexedTableAccess(TPXBU)\n" +
-			"                                                 │           └─ index: [TPXBU.id]\n" +
+			"                                                 │           ├─ index: [TPXBU.id]\n" +
+			"                                                 │           └─ columns: [id btxc5 fhcyt]\n" +
 			"                                                 └─ TableAlias(sn)\n" +
 			"                                                     └─ Table\n" +
-			"                                                         └─ name: NOXN3\n" +
+			"                                                         ├─ name: NOXN3\n" +
+			"                                                         └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -13325,10 +13558,12 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │   │               └─ columns: [gxlub]\n" +
 			"             │   └─ TableAlias(applySubq0)\n" +
 			"             │       └─ Table\n" +
-			"             │           └─ name: THNTS\n" +
+			"             │           ├─ name: THNTS\n" +
+			"             │           └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"             └─ TableAlias(cla)\n" +
 			"                 └─ IndexedTableAccess(YK2GW)\n" +
-			"                     └─ index: [YK2GW.id]\n" +
+			"                     ├─ index: [YK2GW.id]\n" +
+			"                     └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -13355,13 +13590,16 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │   │   └─ cla.id:4!null\n" +
 			"             │   ├─ TableAlias(bs)\n" +
 			"             │   │   └─ Table\n" +
-			"             │   │       └─ name: THNTS\n" +
+			"             │   │       ├─ name: THNTS\n" +
+			"             │   │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"             │   └─ TableAlias(cla)\n" +
 			"             │       └─ IndexedTableAccess(YK2GW)\n" +
-			"             │           └─ index: [YK2GW.id]\n" +
+			"             │           ├─ index: [YK2GW.id]\n" +
+			"             │           └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             └─ TableAlias(mf)\n" +
 			"                 └─ IndexedTableAccess(HGMQ6)\n" +
-			"                     └─ index: [HGMQ6.GXLUB]\n" +
+			"                     ├─ index: [HGMQ6.GXLUB]\n" +
+			"                     └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"",
 	},
 	{
@@ -13383,14 +13621,16 @@ ORDER BY cla.FTQLQ ASC`,
 			"             │   └─ applySubq0.IXUXU:32\n" +
 			"             ├─ TableAlias(cla)\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: YK2GW\n" +
+			"             │       ├─ name: YK2GW\n" +
+			"             │       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             └─ SemiLookupJoin\n" +
 			"                 ├─ Eq\n" +
 			"                 │   ├─ applySubq0.id:30!null\n" +
 			"                 │   └─ applySubq1.GXLUB:34!null\n" +
 			"                 ├─ TableAlias(applySubq0)\n" +
 			"                 │   └─ Table\n" +
-			"                 │       └─ name: THNTS\n" +
+			"                 │       ├─ name: THNTS\n" +
+			"                 │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"                 └─ TableAlias(applySubq1)\n" +
 			"                     └─ IndexedTableAccess(AMYXQ)\n" +
 			"                         ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
@@ -13415,10 +13655,12 @@ ORDER BY ci.FTQLQ`,
 			"             │   └─ ci.id:0!null\n" +
 			"             ├─ TableAlias(ci)\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: JDLNA\n" +
+			"             │       ├─ name: JDLNA\n" +
+			"             │       └─ columns: [id ftqlq fwwiq o3qxw fhcyt]\n" +
 			"             └─ TableAlias(ct)\n" +
 			"                 └─ IndexedTableAccess(FLQLP)\n" +
-			"                     └─ index: [FLQLP.FZ2R5]\n" +
+			"                     ├─ index: [FLQLP.FZ2R5]\n" +
+			"                     └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -13517,10 +13759,12 @@ ORDER BY LUEVY`,
 			"         │           │   └─ nd.HPCMS:12!null\n" +
 			"         │           ├─ TableAlias(nd)\n" +
 			"         │           │   └─ Table\n" +
-			"         │           │       └─ name: E2I7U\n" +
+			"         │           │       ├─ name: E2I7U\n" +
+			"         │           │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         │           └─ TableAlias(nma)\n" +
 			"         │               └─ IndexedTableAccess(TNMXI)\n" +
-			"         │                   └─ index: [TNMXI.id]\n" +
+			"         │                   ├─ index: [TNMXI.id]\n" +
+			"         │                   └─ columns: [id dzlim f3yue]\n" +
 			"         └─ TableAlias(YBBG5)\n" +
 			"             └─ IndexedTableAccess(XGSJM)\n" +
 			"                 ├─ index: [XGSJM.id]\n" +
@@ -13864,7 +14108,8 @@ WHERE id IN ('1','2','3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(QYWQD)\n" +
 			"             ├─ index: [QYWQD.id]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -13884,7 +14129,8 @@ WHERE
 			"         │       ├─ HDDVB.UJ6XY:2!null\n" +
 			"         │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ Table\n" +
-			"             └─ name: HDDVB\n" +
+			"             ├─ name: HDDVB\n" +
+			"             └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -13899,7 +14145,8 @@ WHERE id IN ('1', '2', '3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(QYWQD)\n" +
 			"             ├─ index: [QYWQD.id]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -13914,7 +14161,8 @@ WHERE LUEVY IN ('1', '2', '3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(AMYXQ)\n" +
 			"             ├─ index: [AMYXQ.LUEVY]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
 			"",
 	},
 	{
@@ -13929,7 +14177,8 @@ WHERE id IN ('1', '2', '3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(HGMQ6)\n" +
 			"             ├─ index: [HGMQ6.id]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"",
 	},
 	{
@@ -13944,7 +14193,8 @@ WHERE id IN ('1', '2', '3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(HDDVB)\n" +
 			"             ├─ index: [HDDVB.id]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -13959,7 +14209,8 @@ WHERE LUEVY IN ('1', '2', '3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.LUEVY]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -13974,7 +14225,8 @@ WHERE id IN ('1', '2', '3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.id]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -13989,7 +14241,8 @@ WHERE id IN ('1', '2', '3')`,
 			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"         └─ IndexedTableAccess(FLQLP)\n" +
 			"             ├─ index: [FLQLP.id]\n" +
-			"             └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -14028,7 +14281,8 @@ WHERE nd.FGG57 IS NOT NULL AND nd.KNG7T IS NULL`,
 			"             └─ TableAlias(nd)\n" +
 			"                 └─ IndexedTableAccess(E2I7U)\n" +
 			"                     ├─ index: [E2I7U.FGG57]\n" +
-			"                     └─ static: [{(NULL, ∞)}]\n" +
+			"                     ├─ static: [{(NULL, ∞)}]\n" +
+			"                     └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -14056,7 +14310,8 @@ UPDATE S3FQX SET ADWYM = 0, FPUYA = 0`,
 			"            END//)\n" +
 			"             ├─ UpdateSource(SET S3FQX.ADWYM:1!null = 0 (tinyint),SET S3FQX.FPUYA:2!null = 0 (tinyint))\n" +
 			"             │   └─ Table\n" +
-			"             │       └─ name: S3FQX\n" +
+			"             │       ├─ name: S3FQX\n" +
+			"             │       └─ columns: [id adwym fpuya]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -14093,7 +14348,8 @@ WHERE
 			"     └─ Insert(id, NFRYN, IXUXU, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: THNTS\n" +
+			"         │       ├─ name: THNTS\n" +
+			"         │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER THNTS_on_insert BEFORE INSERT ON THNTS\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14125,7 +14381,8 @@ WHERE
 			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │           └─ IndexedTableAccess(YK2GW)\n" +
 			"             │               ├─ index: [YK2GW.id]\n" +
-			"             │               └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(new.IXUXU:2 IS NULL)\n" +
@@ -14172,7 +14429,8 @@ FROM
 			"     └─ Insert(id, WNUNU, HHVLX, HVHRZ, YKSSU, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: QYWQD\n" +
+			"         │       ├─ name: QYWQD\n" +
+			"         │       └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER QYWQD_on_insert BEFORE INSERT ON QYWQD\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14274,7 +14532,8 @@ WHERE
 			"     └─ Insert(id, QZ7E7, SSHPJ, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: WE72E\n" +
+			"         │       ├─ name: WE72E\n" +
+			"         │       └─ columns: [id qz7e7 sshpj fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER WE72E_on_insert BEFORE INSERT ON WE72E\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14369,7 +14628,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, LUEVY, XQDYT, AMYXQ, OZTQF, Z35GY, KKGN5)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: AMYXQ\n" +
+			"         │       ├─ name: AMYXQ\n" +
+			"         │       └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
 			"         └─ Trigger(CREATE TRIGGER AMYXQ_on_insert BEFORE INSERT ON AMYXQ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14438,7 +14698,8 @@ WHERE
 			"             │           │   └─ TableAlias(ufc)\n" +
 			"             │           │       └─ IndexedTableAccess(SISUT)\n" +
 			"             │           │           ├─ index: [SISUT.id]\n" +
-			"             │           │           └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │           │           ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │           │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
 			"             │           └─ HashLookup\n" +
 			"             │               ├─ source: TUPLE(ufc.ZH72S:2)\n" +
 			"             │               ├─ target: TUPLE(nd.ZH72S:7)\n" +
@@ -14449,10 +14710,12 @@ WHERE
 			"             │                       │   └─ nd.XQDYT:20!null\n" +
 			"             │                       ├─ TableAlias(nd)\n" +
 			"             │                       │   └─ Table\n" +
-			"             │                       │       └─ name: E2I7U\n" +
+			"             │                       │       ├─ name: E2I7U\n" +
+			"             │                       │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                       └─ TableAlias(YBBG5)\n" +
 			"             │                           └─ IndexedTableAccess(XGSJM)\n" +
-			"             │                               └─ index: [XGSJM.id]\n" +
+			"             │                               ├─ index: [XGSJM.id]\n" +
+			"             │                               └─ columns: [id dzlim f3yue]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Subquery\n" +
@@ -14509,7 +14772,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14577,7 +14841,8 @@ WHERE
 			"             │           └─ TableAlias(ums)\n" +
 			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -14628,7 +14893,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14696,7 +14962,8 @@ WHERE
 			"             │           └─ TableAlias(ums)\n" +
 			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -14747,7 +15014,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14815,7 +15083,8 @@ WHERE
 			"             │           └─ TableAlias(ums)\n" +
 			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -14866,7 +15135,8 @@ WHERE
 			"     └─ Insert(id, GXLUB, CH3FR, D237E, JOGI6)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SZQWJ\n" +
+			"         │       ├─ name: SZQWJ\n" +
+			"         │       └─ columns: [id gxlub ch3fr d237e jogi6]\n" +
 			"         └─ Trigger(CREATE TRIGGER SZQWJ_on_insert BEFORE INSERT ON SZQWJ\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -14934,7 +15204,8 @@ WHERE
 			"             │           └─ TableAlias(ums)\n" +
 			"             │               └─ IndexedTableAccess(FG26Y)\n" +
 			"             │                   ├─ index: [FG26Y.id]\n" +
-			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF((NOT(IN\n" +
@@ -14990,7 +15261,8 @@ WHERE
 			"     └─ Insert(id, BTXC5, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: TPXBU\n" +
+			"         │       ├─ name: TPXBU\n" +
+			"         │       └─ columns: [id btxc5 fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER TPXBU_on_insert BEFORE INSERT ON TPXBU\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15039,7 +15311,8 @@ WHERE
 			"             │                       └─ TableAlias(umf)\n" +
 			"             │                           └─ IndexedTableAccess(NZKPM)\n" +
 			"             │                               ├─ index: [NZKPM.id]\n" +
-			"             │                               └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                               └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(InSubquery\n" +
@@ -15128,7 +15401,8 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     └─ Insert(id, GXLUB, LUEVY, M22QN, TJPT7, ARN5P, XOSD4, IDE43, HMW4H, ZBT6R, FSDY2, LT7K6, SPPYD, QCGTS, TEUJA, QQV4M, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: HGMQ6\n" +
+			"         │       ├─ name: HGMQ6\n" +
+			"         │       └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER HGMQ6_on_insert BEFORE INSERT ON HGMQ6\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15295,7 +15569,8 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │           │   │       │                   └─ columns: [fgg57]\n" +
 			"             │           │   │       └─ IndexedTableAccess(NZKPM)\n" +
 			"             │           │   │           ├─ index: [NZKPM.id]\n" +
-			"             │           │   │           └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │           │   │           ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │           │   │           └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"             │           │   └─ HashLookup\n" +
 			"             │           │       ├─ source: TUPLE(umf.T4IBQ:1)\n" +
 			"             │           │       ├─ target: TUPLE(cla.FTQLQ:5!null)\n" +
@@ -15306,13 +15581,16 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │           │               │   └─ bs.IXUXU:27\n" +
 			"             │           │               ├─ TableAlias(bs)\n" +
 			"             │           │               │   └─ Table\n" +
-			"             │           │               │       └─ name: THNTS\n" +
+			"             │           │               │       ├─ name: THNTS\n" +
+			"             │           │               │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
 			"             │           │               └─ TableAlias(cla)\n" +
 			"             │           │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"             │           │                       └─ index: [YK2GW.id]\n" +
+			"             │           │                       ├─ index: [YK2GW.id]\n" +
+			"             │           │                       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(TJ5D2)\n" +
 			"             │               └─ Table\n" +
-			"             │                   └─ name: SZW6V\n" +
+			"             │                   ├─ name: SZW6V\n" +
+			"             │                   └─ columns: [id t4ibq v7ufh sypkf h4dmt swcqv ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -15408,7 +15686,8 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			" └─ Insert(id, Z7CP5, YH4XB)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: SEQS3\n" +
+			"     │       ├─ name: SEQS3\n" +
+			"     │       └─ columns: [id z7cp5 yh4xb]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [id:0!null, Z7CP5:1!null, YH4XB:2!null]\n" +
 			"         └─ Project\n" +
@@ -15554,7 +15833,8 @@ FROM
 			" └─ Insert(id, FV24E, UJ6XY, M22QN, NZ4MQ, ETPQV, PRUV2, YKSSU, FHCYT)\n" +
 			"     ├─ InsertDestination\n" +
 			"     │   └─ Table\n" +
-			"     │       └─ name: HDDVB\n" +
+			"     │       ├─ name: HDDVB\n" +
+			"     │       └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [id:0!null, FV24E:1!null, UJ6XY:2!null, M22QN:3!null, NZ4MQ:4!null, ETPQV:5, PRUV2:6, YKSSU:7, FHCYT:8]\n" +
 			"         └─ Union distinct\n" +
@@ -15634,34 +15914,40 @@ FROM
 			"             │                           │   │   │   │   │   └─ TIZHK.ZHITY:19\n" +
 			"             │                           │   │   │   │   ├─ TableAlias(RHUZN)\n" +
 			"             │                           │   │   │   │   │   └─ Table\n" +
-			"             │                           │   │   │   │   │       └─ name: E2I7U\n" +
+			"             │                           │   │   │   │   │       ├─ name: E2I7U\n" +
+			"             │                           │   │   │   │   │       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                           │   │   │   │   └─ Filter\n" +
 			"             │                           │   │   │   │       ├─ HashIn\n" +
 			"             │                           │   │   │   │       │   ├─ TIZHK.id:0!null\n" +
 			"             │                           │   │   │   │       │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"             │                           │   │   │   │       └─ TableAlias(TIZHK)\n" +
 			"             │                           │   │   │   │           └─ IndexedTableAccess(WRZVO)\n" +
-			"             │                           │   │   │   │               └─ index: [WRZVO.ZHITY]\n" +
+			"             │                           │   │   │   │               ├─ index: [WRZVO.ZHITY]\n" +
+			"             │                           │   │   │   │               └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			"             │                           │   │   │   └─ HashLookup\n" +
 			"             │                           │   │   │       ├─ source: TUPLE(0 (tinyint), TIZHK.TVNW2:18, TIZHK.ZHITY:19, TIZHK.SYPKF:20, TIZHK.IDUT2:21)\n" +
 			"             │                           │   │   │       ├─ target: TUPLE(NHMXW.SWCQV:7!null, NHMXW.NOHHR:1!null, NHMXW.AVPYF:2!null, NHMXW.SYPKF:3!null, NHMXW.IDUT2:4!null)\n" +
 			"             │                           │   │   │       └─ CachedResults\n" +
 			"             │                           │   │   │           └─ TableAlias(NHMXW)\n" +
 			"             │                           │   │   │               └─ Table\n" +
-			"             │                           │   │   │                   └─ name: WGSDC\n" +
+			"             │                           │   │   │                   ├─ name: WGSDC\n" +
+			"             │                           │   │   │                   └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"             │                           │   │   └─ HashLookup\n" +
 			"             │                           │   │       ├─ source: TUPLE(TIZHK.TVNW2:18)\n" +
 			"             │                           │   │       ├─ target: TUPLE(J4JYP.ZH72S:7)\n" +
 			"             │                           │   │       └─ CachedResults\n" +
 			"             │                           │   │           └─ TableAlias(J4JYP)\n" +
 			"             │                           │   │               └─ Table\n" +
-			"             │                           │   │                   └─ name: E2I7U\n" +
+			"             │                           │   │                   ├─ name: E2I7U\n" +
+			"             │                           │   │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                           │   └─ TableAlias(mf)\n" +
 			"             │                           │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"             │                           │           └─ index: [HGMQ6.LUEVY]\n" +
+			"             │                           │           ├─ index: [HGMQ6.LUEVY]\n" +
+			"             │                           │           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"             │                           └─ TableAlias(aac)\n" +
 			"             │                               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │                                   └─ index: [TPXBU.id]\n" +
+			"             │                                   ├─ index: [TPXBU.id]\n" +
+			"             │                                   └─ columns: [id btxc5 fhcyt]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [id:0!null, FV24E:1 as FV24E, UJ6XY:2 as UJ6XY, M22QN:3, NZ4MQ:4, ETPQV:5!null, convert\n" +
 			"                 │   ├─ type: char\n" +
@@ -15760,25 +16046,29 @@ FROM
 			"                                         │   │   │   └─ TableAlias(TIZHK)\n" +
 			"                                         │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
 			"                                         │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
-			"                                         │   │   │           └─ static: [{[NULL, ∞)}]\n" +
+			"                                         │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                                         │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			"                                         │   │   └─ TableAlias(NHMXW)\n" +
 			"                                         │   │       └─ IndexedTableAccess(WGSDC)\n" +
 			"                                         │   │           ├─ index: [WGSDC.NOHHR]\n" +
-			"                                         │   │           └─ static: [{[NULL, ∞)}]\n" +
+			"                                         │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                                         │   │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"                                         │   └─ HashLookup\n" +
 			"                                         │       ├─ source: TUPLE(TIZHK.TVNW2:1)\n" +
 			"                                         │       ├─ target: TUPLE(J4JYP.ZH72S:7)\n" +
 			"                                         │       └─ CachedResults\n" +
 			"                                         │           └─ TableAlias(J4JYP)\n" +
 			"                                         │               └─ Table\n" +
-			"                                         │                   └─ name: E2I7U\n" +
+			"                                         │                   ├─ name: E2I7U\n" +
+			"                                         │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"                                         └─ HashLookup\n" +
 			"                                             ├─ source: TUPLE(TIZHK.ZHITY:2)\n" +
 			"                                             ├─ target: TUPLE(RHUZN.ZH72S:7)\n" +
 			"                                             └─ CachedResults\n" +
 			"                                                 └─ TableAlias(RHUZN)\n" +
 			"                                                     └─ Table\n" +
-			"                                                         └─ name: E2I7U\n" +
+			"                                                         ├─ name: E2I7U\n" +
+			"                                                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -15868,7 +16158,8 @@ WHERE
 			"     └─ Insert(id, NO52D, VYO5E, DKCAJ, ADURZ, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SFEGG\n" +
+			"         │       ├─ name: SFEGG\n" +
+			"         │       └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER SFEGG_on_insert BEFORE INSERT ON SFEGG\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -15946,7 +16237,8 @@ WHERE
 			"             │           │   │                   └─ Filter\n" +
 			"             │           │   │                       ├─ (NOT(SFEGG.VYO5E:6 IS NULL))\n" +
 			"             │           │   │                       └─ Table\n" +
-			"             │           │   │                           └─ name: SFEGG\n" +
+			"             │           │   │                           ├─ name: SFEGG\n" +
+			"             │           │   │                           └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │   │      ))\n" +
 			"             │           │   └─ AND\n" +
 			"             │           │       ├─ rs.VYO5E:1 IS NULL\n" +
@@ -15960,7 +16252,8 @@ WHERE
 			"             │           │                       └─ Filter\n" +
 			"             │           │                           ├─ SFEGG.VYO5E:6 IS NULL\n" +
 			"             │           │                           └─ Table\n" +
-			"             │           │                               └─ name: SFEGG\n" +
+			"             │           │                               ├─ name: SFEGG\n" +
+			"             │           │                               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │          ))\n" +
 			"             │           └─ SubqueryAlias\n" +
 			"             │               ├─ name: rs\n" +
@@ -16013,21 +16306,25 @@ WHERE
 			"             │                           │               │   └─ TableAlias(uct)\n" +
 			"             │                           │               │       └─ IndexedTableAccess(OUBDL)\n" +
 			"             │                           │               │           ├─ index: [OUBDL.FTQLQ]\n" +
-			"             │                           │               │           └─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │               │           ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │               │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"             │                           │               └─ TableAlias(I7HCR)\n" +
 			"             │                           │                   └─ IndexedTableAccess(EPZU6)\n" +
 			"             │                           │                       ├─ index: [EPZU6.TOFPN]\n" +
-			"             │                           │                       └─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │                       ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │                       └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"             │                           └─ LookupJoin\n" +
 			"             │                               ├─ Eq\n" +
 			"             │                               │   ├─ nt.id:4!null\n" +
 			"             │                               │   └─ nd.DKCAJ:8!null\n" +
 			"             │                               ├─ TableAlias(nt)\n" +
 			"             │                               │   └─ Table\n" +
-			"             │                               │       └─ name: F35MI\n" +
+			"             │                               │       ├─ name: F35MI\n" +
+			"             │                               │       └─ columns: [id dzlim f3yue]\n" +
 			"             │                               └─ TableAlias(nd)\n" +
 			"             │                                   └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                                       └─ index: [E2I7U.DKCAJ]\n" +
+			"             │                                       ├─ index: [E2I7U.DKCAJ]\n" +
+			"             │                                       └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -16146,7 +16443,8 @@ WHERE
 			"     └─ Insert(id, FZ2R5, LUEVY, M22QN, OVE3E, NRURT, OCA7E, XMM6Q, V5DPX, S3Q3Y, ZRV3B, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: FLQLP\n" +
+			"         │       ├─ name: FLQLP\n" +
+			"         │       └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER FLQLP_on_insert BEFORE INSERT ON FLQLP\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -16268,9 +16566,11 @@ WHERE
 			"             │           │           │           │               │                   └─ columns: [dkcaj tw55n]\n" +
 			"             │           │           │           │               │   END]\n" +
 			"             │           │           │           │               └─ Table\n" +
-			"             │           │           │           │                   └─ name: \n" +
+			"             │           │           │           │                   ├─ name: \n" +
+			"             │           │           │           │                   └─ columns: []\n" +
 			"             │           │           │           └─ Table\n" +
-			"             │           │           │               └─ name: SFEGG\n" +
+			"             │           │           │               ├─ name: SFEGG\n" +
+			"             │           │           │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │           │   as OVE3E, uct.id:0!null as NRURT, I7HCR.id:13 as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN (NOT(Eq\n" +
 			"             │           │           │   ├─ uct.FHCYT:11\n" +
 			"             │           │           │   └─ N/A (longtext)\n" +
@@ -16297,14 +16597,17 @@ WHERE
 			"             │           │               │   └─ TableAlias(uct)\n" +
 			"             │           │               │       └─ IndexedTableAccess(OUBDL)\n" +
 			"             │           │               │           ├─ index: [OUBDL.FTQLQ]\n" +
-			"             │           │               │           └─ static: [{[NULL, ∞)}]\n" +
+			"             │           │               │           ├─ static: [{[NULL, ∞)}]\n" +
+			"             │           │               │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"             │           │               └─ TableAlias(I7HCR)\n" +
 			"             │           │                   └─ IndexedTableAccess(EPZU6)\n" +
 			"             │           │                       ├─ index: [EPZU6.TOFPN]\n" +
-			"             │           │                       └─ static: [{[NULL, ∞)}]\n" +
+			"             │           │                       ├─ static: [{[NULL, ∞)}]\n" +
+			"             │           │                       └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"             │           └─ TableAlias(nd)\n" +
 			"             │               └─ Table\n" +
-			"             │                   └─ name: E2I7U\n" +
+			"             │                   ├─ name: E2I7U\n" +
+			"             │                   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(InSubquery\n" +
@@ -16380,7 +16683,8 @@ WHERE
 			"     └─ Insert(id, NO52D, VYO5E, DKCAJ, ADURZ, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: SFEGG\n" +
+			"         │       ├─ name: SFEGG\n" +
+			"         │       └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER SFEGG_on_insert BEFORE INSERT ON SFEGG\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -16458,7 +16762,8 @@ WHERE
 			"             │           │   │                   └─ Filter\n" +
 			"             │           │   │                       ├─ (NOT(SFEGG.VYO5E:6 IS NULL))\n" +
 			"             │           │   │                       └─ Table\n" +
-			"             │           │   │                           └─ name: SFEGG\n" +
+			"             │           │   │                           ├─ name: SFEGG\n" +
+			"             │           │   │                           └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │   │      ))\n" +
 			"             │           │   └─ AND\n" +
 			"             │           │       ├─ rs.VYO5E:1 IS NULL\n" +
@@ -16472,7 +16777,8 @@ WHERE
 			"             │           │                       └─ Filter\n" +
 			"             │           │                           ├─ SFEGG.VYO5E:6 IS NULL\n" +
 			"             │           │                           └─ Table\n" +
-			"             │           │                               └─ name: SFEGG\n" +
+			"             │           │                               ├─ name: SFEGG\n" +
+			"             │           │                               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │          ))\n" +
 			"             │           └─ SubqueryAlias\n" +
 			"             │               ├─ name: rs\n" +
@@ -16491,10 +16797,12 @@ WHERE
 			"             │                           │   │   └─ nd.DKCAJ:4!null\n" +
 			"             │                           │   ├─ TableAlias(nt)\n" +
 			"             │                           │   │   └─ Table\n" +
-			"             │                           │   │       └─ name: F35MI\n" +
+			"             │                           │   │       ├─ name: F35MI\n" +
+			"             │                           │   │       └─ columns: [id dzlim f3yue]\n" +
 			"             │                           │   └─ TableAlias(nd)\n" +
 			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                           │           └─ index: [E2I7U.DKCAJ]\n" +
+			"             │                           │           ├─ index: [E2I7U.DKCAJ]\n" +
+			"             │                           │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             │                           └─ HashLookup\n" +
 			"             │                               ├─ source: TUPLE(nd.TW55N:6!null)\n" +
 			"             │                               ├─ target: TUPLE(TVTJS.I3VTA:2!null)\n" +
@@ -16506,7 +16814,8 @@ WHERE
 			"             │                                       └─ TableAlias(TVTJS)\n" +
 			"             │                                           └─ IndexedTableAccess(HU5A5)\n" +
 			"             │                                               ├─ index: [HU5A5.id]\n" +
-			"             │                                               └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                                               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                                               └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Or\n" +
@@ -16571,7 +16880,8 @@ WHERE
 			"     └─ Insert(id, FZ2R5, LUEVY, M22QN, OVE3E, NRURT, OCA7E, XMM6Q, V5DPX, S3Q3Y, ZRV3B, FHCYT)\n" +
 			"         ├─ InsertDestination\n" +
 			"         │   └─ Table\n" +
-			"         │       └─ name: FLQLP\n" +
+			"         │       ├─ name: FLQLP\n" +
+			"         │       └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"         └─ Trigger(CREATE TRIGGER FLQLP_on_insert BEFORE INSERT ON FLQLP\n" +
 			"            FOR EACH ROW\n" +
 			"            BEGIN\n" +
@@ -16666,7 +16976,8 @@ WHERE
 			"             │       │           │                           ├─ index: [E2I7U.TW55N]\n" +
 			"             │       │           │                           └─ columns: [dkcaj tw55n]\n" +
 			"             │       │           └─ Table\n" +
-			"             │       │               └─ name: SFEGG\n" +
+			"             │       │               ├─ name: SFEGG\n" +
+			"             │       │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │       │   as OVE3E, NULL (null) as NRURT, NULL (null) as OCA7E, TVTJS.id:0!null as XMM6Q, TVTJS.V5DPX:4!null as V5DPX, (TVTJS.IDPK7:6!null + 0 (decimal(2,1))) as S3Q3Y, TVTJS.ZRV3B:8!null as ZRV3B, TVTJS.FHCYT:12 as FHCYT]\n" +
 			"             │       └─ Filter\n" +
 			"             │           ├─ HashIn\n" +
@@ -16675,7 +16986,8 @@ WHERE
 			"             │           └─ TableAlias(TVTJS)\n" +
 			"             │               └─ IndexedTableAccess(HU5A5)\n" +
 			"             │                   ├─ index: [HU5A5.id]\n" +
-			"             │                   └─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                   └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(InSubquery\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -2108,6 +2108,30 @@ inner join pq on true
 			"",
 	},
 	{
+		Query: `SELECT 1 FROM mytable a WHERE a.s is not null`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [1 (tinyint)]\n" +
+			" └─ Filter\n" +
+			"     ├─ (NOT(a.s:0!null IS NULL))\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.s]\n" +
+			"             ├─ static: [{(NULL, ∞)}]\n" +
+			"             └─ columns: [s]\n",
+	},
+	{
+		Query: `SELECT 1 FROM mytable`,
+		ExpectedPlan: "Project\n" +
+				" ├─ columns: [1 (tinyint)]\n" +
+				" └─ Filter\n" +
+				"     ├─ (NOT(a.s:0!null IS NULL))\n" +
+				"     └─ TableAlias(a)\n" +
+				"         └─ IndexedTableAccess(mytable)\n" +
+				"             ├─ index: [mytable.s]\n" +
+				"             ├─ static: [{(NULL, ∞)}]\n" +
+				"             └─ columns: [s]\n",
+	},
+	{
 		Query: `SELECT a.* FROM mytable a inner join mytable b on (a.i = b.s) WHERE a.s is not null`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [a.i:1!null, a.s:2!null]\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -2117,19 +2117,17 @@ inner join pq on true
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s]\n" +
 			"             ├─ static: [{(NULL, ∞)}]\n" +
-			"             └─ columns: [s]\n",
+			"             └─ columns: [s]\n" +
+			"",
 	},
 	{
 		Query: `SELECT 1 FROM mytable`,
 		ExpectedPlan: "Project\n" +
-				" ├─ columns: [1 (tinyint)]\n" +
-				" └─ Filter\n" +
-				"     ├─ (NOT(a.s:0!null IS NULL))\n" +
-				"     └─ TableAlias(a)\n" +
-				"         └─ IndexedTableAccess(mytable)\n" +
-				"             ├─ index: [mytable.s]\n" +
-				"             ├─ static: [{(NULL, ∞)}]\n" +
-				"             └─ columns: [s]\n",
+			" ├─ columns: [1 (tinyint)]\n" +
+			" └─ Table\n" +
+			"     ├─ name: mytable\n" +
+			"     └─ columns: []\n" +
+			"",
 	},
 	{
 		Query: `SELECT a.* FROM mytable a inner join mytable b on (a.i = b.s) WHERE a.s is not null`,
@@ -2520,39 +2518,37 @@ inner join pq on true
 	},
 	{
 		Query: `SELECT a.* FROM mytable a, mytable b where a.i = a.s`,
-		ExpectedPlan: "Project\n" +
-			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ CrossJoin\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ Eq\n" +
-			"     │   │   ├─ a.i:0!null\n" +
-			"     │   │   └─ a.s:1!null\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: mytable\n" +
-			"     │           └─ columns: [i s]\n" +
-			"     └─ TableAlias(b)\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+		ExpectedPlan: "CrossJoin\n" +
+			" ├─ Filter\n" +
+			" │   ├─ Eq\n" +
+			" │   │   ├─ a.i:0!null\n" +
+			" │   │   └─ a.s:1!null\n" +
+			" │   └─ TableAlias(a)\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: mytable\n" +
+			" │           └─ columns: [i s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
 		Query: `SELECT a.* FROM mytable a, mytable b where a.i in (2, 432, 7)`,
-		ExpectedPlan: "Project\n" +
-			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ CrossJoin\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ HashIn\n" +
-			"     │   │   ├─ a.i:0!null\n" +
-			"     │   │   └─ TUPLE(2 (tinyint), 432 (smallint), 7 (tinyint))\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess(mytable)\n" +
-			"     │           ├─ index: [mytable.i]\n" +
-			"     │           ├─ static: [{[432, 432]}, {[7, 7]}, {[2, 2]}]\n" +
-			"     │           └─ columns: [i s]\n" +
-			"     └─ TableAlias(b)\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+		ExpectedPlan: "CrossJoin\n" +
+			" ├─ Filter\n" +
+			" │   ├─ HashIn\n" +
+			" │   │   ├─ a.i:0!null\n" +
+			" │   │   └─ TUPLE(2 (tinyint), 432 (smallint), 7 (tinyint))\n" +
+			" │   └─ TableAlias(a)\n" +
+			" │       └─ IndexedTableAccess(mytable)\n" +
+			" │           ├─ index: [mytable.i]\n" +
+			" │           ├─ static: [{[432, 432]}, {[7, 7]}, {[2, 2]}]\n" +
+			" │           └─ columns: [i s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -2666,7 +2662,8 @@ inner join pq on true
 			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -2776,20 +2773,19 @@ inner join pq on true
 	},
 	{
 		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = a.i`,
-		ExpectedPlan: "Project\n" +
-			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ CrossJoin\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ Eq\n" +
-			"     │   │   ├─ a.i:0!null\n" +
-			"     │   │   └─ a.i:0!null\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: mytable\n" +
-			"     │           └─ columns: [i s]\n" +
-			"     └─ TableAlias(b)\n" +
-			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+		ExpectedPlan: "CrossJoin\n" +
+			" ├─ Filter\n" +
+			" │   ├─ Eq\n" +
+			" │   │   ├─ a.i:0!null\n" +
+			" │   │   └─ a.i:0!null\n" +
+			" │   └─ TableAlias(a)\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: mytable\n" +
+			" │           └─ columns: [i s]\n" +
+			" └─ TableAlias(b)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -2903,7 +2899,8 @@ inner join pq on true
 			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(d)\n" +
 			"         └─ Table\n" +
-			"             └─ name: mytable\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -3194,13 +3191,13 @@ inner join pq on true
 			"",
 	},
 	{
-		Query: "select a.S, b.S from mytable A, mytable B",
+		Query: `select a.S, b.S from mytable A, mytable B`,
 		ExpectedPlan: "CrossJoin\n" +
-			" ├─ TableAlias(a)\n" +
+			" ├─ TableAlias(A)\n" +
 			" │   └─ Table\n" +
 			" │       ├─ name: mytable\n" +
 			" │       └─ columns: [s]\n" +
-			" └─ TableAlias(b)\n" +
+			" └─ TableAlias(B)\n" +
 			"     └─ Table\n" +
 			"         ├─ name: mytable\n" +
 			"         └─ columns: [s]\n" +
@@ -3209,18 +3206,20 @@ inner join pq on true
 	{
 		Query: `SELECT t1.timestamp FROM reservedWordsTable t1 JOIN reservedWordsTable t2 ON t1.TIMESTAMP = t2.tImEstamp`,
 		ExpectedPlan: "Project\n" +
-				" ├─ columns: [t1.Timestamp:0!null]\n" +
-				" └─ InnerJoin\n" +
-				"     ├─ Eq\n" +
-				"     │   ├─ t1.Timestamp:0!null\n" +
-				"     │   └─ t2.Timestamp:4!null\n" +
-				"     ├─ TableAlias(t1)\n" +
-				"     │   └─ Table\n" +
-				"     │       └─ name: reservedWordsTable\n" +
-				"     └─ TableAlias(t2)\n" +
-				"         └─ Table\n" +
-				"             └─ name: reservedWordsTable\n" +
-				"",
+			" ├─ columns: [t1.Timestamp:0!null]\n" +
+			" └─ InnerJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ t1.Timestamp:0!null\n" +
+			"     │   └─ t2.Timestamp:1!null\n" +
+			"     ├─ TableAlias(t1)\n" +
+			"     │   └─ Table\n" +
+			"     │       ├─ name: reservedWordsTable\n" +
+			"     │       └─ columns: [timestamp]\n" +
+			"     └─ TableAlias(t2)\n" +
+			"         └─ Table\n" +
+			"             ├─ name: reservedWordsTable\n" +
+			"             └─ columns: [timestamp]\n" +
+			"",
 	},
 	{
 		Query: `SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2`,
@@ -5497,16 +5496,15 @@ inner join pq on true
 			"                 ├─ name: a\n" +
 			"                 ├─ outerVisibility: false\n" +
 			"                 ├─ cacheable: true\n" +
-			"                 └─ Project\n" +
-			"                     ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			"                     └─ CrossJoin\n" +
-			"                         ├─ TableAlias(a)\n" +
-			"                         │   └─ Table\n" +
-			"                         │       ├─ name: mytable\n" +
-			"                         │       └─ columns: [i s]\n" +
-			"                         └─ TableAlias(b)\n" +
-			"                             └─ Table\n" +
-			"                                 └─ name: mytable\n" +
+			"                 └─ CrossJoin\n" +
+			"                     ├─ TableAlias(a)\n" +
+			"                     │   └─ Table\n" +
+			"                     │       ├─ name: mytable\n" +
+			"                     │       └─ columns: [i s]\n" +
+			"                     └─ TableAlias(b)\n" +
+			"                         └─ Table\n" +
+			"                             ├─ name: mytable\n" +
+			"                             └─ columns: []\n" +
 			"",
 	},
 	{
@@ -6919,10 +6917,10 @@ WHERE
 	       CL3DT.FBSRS > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:7!null as TEYBZ, PBMRX.ZH72S:11 as FB6N7]\n" +
+			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:5!null as TEYBZ, PBMRX.ZH72S:6 as FB6N7]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ PBMRX.ZH72S:11\n" +
+			"     │   ├─ PBMRX.ZH72S:6\n" +
 			"     │   └─ CL3DT.ZH72S:0\n" +
 			"     ├─ SubqueryAlias\n" +
 			"     │   ├─ name: CL3DT\n" +
@@ -6974,10 +6972,11 @@ WHERE
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
 			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
 			"     └─ Filter\n" +
-			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
 			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 └─ index: [E2I7U.ZH72S]\n" +
+			"                 ├─ index: [E2I7U.ZH72S]\n" +
+			"                 └─ columns: [id tw55n zh72s]\n" +
 			"",
 	},
 	{
@@ -7050,14 +7049,15 @@ WHERE
 			" │   │       │   ├─ Subquery\n" +
 			" │   │       │   │   ├─ cacheable: false\n" +
 			" │   │       │   │   └─ Project\n" +
-			" │   │       │   │       ├─ columns: [NHMXW.SWCQV:16!null]\n" +
+			" │   │       │   │       ├─ columns: [NHMXW.SWCQV:10!null]\n" +
 			" │   │       │   │       └─ Filter\n" +
 			" │   │       │   │           ├─ Eq\n" +
 			" │   │       │   │           │   ├─ NHMXW.id:9!null\n" +
 			" │   │       │   │           │   └─ ism.PRUV2:6\n" +
 			" │   │       │   │           └─ TableAlias(NHMXW)\n" +
 			" │   │       │   │               └─ Table\n" +
-			" │   │       │   │                   └─ name: WGSDC\n" +
+			" │   │       │   │                   ├─ name: WGSDC\n" +
+			" │   │       │   │                   └─ columns: [id swcqv]\n" +
 			" │   │       │   └─ 1 (tinyint)\n" +
 			" │   │       └─ Or\n" +
 			" │   │           ├─ AND\n" +
@@ -7073,14 +7073,15 @@ WHERE
 			" │   │           │       │           │   └─ Subquery\n" +
 			" │   │           │       │           │       ├─ cacheable: false\n" +
 			" │   │           │       │           │       └─ Project\n" +
-			" │   │           │       │           │           ├─ columns: [NHMXW.FZXV5:31]\n" +
+			" │   │           │       │           │           ├─ columns: [NHMXW.FZXV5:27]\n" +
 			" │   │           │       │           │           └─ Filter\n" +
 			" │   │           │       │           │               ├─ Eq\n" +
 			" │   │           │       │           │               │   ├─ NHMXW.id:26!null\n" +
 			" │   │           │       │           │               │   └─ ism.PRUV2:6\n" +
 			" │   │           │       │           │               └─ TableAlias(NHMXW)\n" +
 			" │   │           │       │           │                   └─ Table\n" +
-			" │   │           │       │           │                       └─ name: WGSDC\n" +
+			" │   │           │       │           │                       ├─ name: WGSDC\n" +
+			" │   │           │       │           │                       └─ columns: [id fzxv5]\n" +
 			" │   │           │       │           └─ TableAlias(nd)\n" +
 			" │   │           │       │               └─ Table\n" +
 			" │   │           │       │                   └─ name: E2I7U\n" +
@@ -7099,14 +7100,15 @@ WHERE
 			" │   │                   │           │   └─ Subquery\n" +
 			" │   │                   │           │       ├─ cacheable: false\n" +
 			" │   │                   │           │       └─ Project\n" +
-			" │   │                   │           │           ├─ columns: [NHMXW.DQYGV:32]\n" +
+			" │   │                   │           │           ├─ columns: [NHMXW.DQYGV:27]\n" +
 			" │   │                   │           │           └─ Filter\n" +
 			" │   │                   │           │               ├─ Eq\n" +
 			" │   │                   │           │               │   ├─ NHMXW.id:26!null\n" +
 			" │   │                   │           │               │   └─ ism.PRUV2:6\n" +
 			" │   │                   │           │               └─ TableAlias(NHMXW)\n" +
 			" │   │                   │           │                   └─ Table\n" +
-			" │   │                   │           │                       └─ name: WGSDC\n" +
+			" │   │                   │           │                       ├─ name: WGSDC\n" +
+			" │   │                   │           │                       └─ columns: [id dqygv]\n" +
 			" │   │                   │           └─ TableAlias(nd)\n" +
 			" │   │                   │               └─ Table\n" +
 			" │   │                   │                   └─ name: E2I7U\n" +
@@ -7379,10 +7381,10 @@ WHERE
 	       CL3DT.FLHXH > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:7!null as TEYBZ, PBMRX.ZH72S:11 as FB6N7]\n" +
+			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:5!null as TEYBZ, PBMRX.ZH72S:6 as FB6N7]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ PBMRX.ZH72S:11\n" +
+			"     │   ├─ PBMRX.ZH72S:6\n" +
 			"     │   └─ CL3DT.ZH72S:0\n" +
 			"     ├─ SubqueryAlias\n" +
 			"     │   ├─ name: CL3DT\n" +
@@ -7434,10 +7436,11 @@ WHERE
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
 			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
 			"     └─ Filter\n" +
-			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
 			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 └─ index: [E2I7U.ZH72S]\n" +
+			"                 ├─ index: [E2I7U.ZH72S]\n" +
+			"                 └─ columns: [id tw55n zh72s]\n" +
 			"",
 	},
 	{
@@ -7513,14 +7516,15 @@ WHERE
 			"     │   │       │   ├─ Subquery\n" +
 			"     │   │       │   │   ├─ cacheable: false\n" +
 			"     │   │       │   │   └─ Project\n" +
-			"     │   │       │   │       ├─ columns: [I7HCR.SWCQV:42!null]\n" +
+			"     │   │       │   │       ├─ columns: [I7HCR.SWCQV:38!null]\n" +
 			"     │   │       │   │       └─ Filter\n" +
 			"     │   │       │   │           ├─ Eq\n" +
 			"     │   │       │   │           │   ├─ I7HCR.id:37!null\n" +
 			"     │   │       │   │           │   └─ ct.OCA7E:11\n" +
 			"     │   │       │   │           └─ TableAlias(I7HCR)\n" +
 			"     │   │       │   │               └─ Table\n" +
-			"     │   │       │   │                   └─ name: EPZU6\n" +
+			"     │   │       │   │                   ├─ name: EPZU6\n" +
+			"     │   │       │   │                   └─ columns: [id swcqv]\n" +
 			"     │   │       │   └─ 1 (tinyint)\n" +
 			"     │   │       └─ (NOT(Eq\n" +
 			"     │   │           ├─ Subquery\n" +
@@ -7533,14 +7537,15 @@ WHERE
 			"     │   │           │           │   └─ Subquery\n" +
 			"     │   │           │           │       ├─ cacheable: false\n" +
 			"     │   │           │           │       └─ Project\n" +
-			"     │   │           │           │           ├─ columns: [I7HCR.FVUCX:58!null]\n" +
+			"     │   │           │           │           ├─ columns: [I7HCR.FVUCX:55!null]\n" +
 			"     │   │           │           │           └─ Filter\n" +
 			"     │   │           │           │               ├─ Eq\n" +
 			"     │   │           │           │               │   ├─ I7HCR.id:54!null\n" +
 			"     │   │           │           │               │   └─ ct.OCA7E:11\n" +
 			"     │   │           │           │               └─ TableAlias(I7HCR)\n" +
 			"     │   │           │           │                   └─ Table\n" +
-			"     │   │           │           │                       └─ name: EPZU6\n" +
+			"     │   │           │           │                       ├─ name: EPZU6\n" +
+			"     │   │           │           │                       └─ columns: [id fvucx]\n" +
 			"     │   │           │           └─ TableAlias(nd)\n" +
 			"     │   │           │               └─ Table\n" +
 			"     │   │           │                   └─ name: E2I7U\n" +
@@ -7733,42 +7738,47 @@ WHERE
 	   TVTJS.SWCQV = 1
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [ct.id:13!null as id, ci.FTQLQ:26!null as VCGT3, nd.TW55N:33!null as UWBAI, aac.BTXC5:48 as TPXBU, ct.V5DPX:21!null as V5DPX, ct.S3Q3Y:22!null as S3Q3Y, ct.ZRV3B:23!null as ZRV3B]\n" +
+			" ├─ columns: [ct.id:2!null as id, ci.FTQLQ:11!null as VCGT3, nd.TW55N:13!null as UWBAI, aac.BTXC5:15 as TPXBU, ct.V5DPX:7!null as V5DPX, ct.S3Q3Y:8!null as S3Q3Y, ct.ZRV3B:9!null as ZRV3B]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ aac.id:47!null\n" +
-			"     │   └─ ct.M22QN:16!null\n" +
+			"     │   ├─ aac.id:14!null\n" +
+			"     │   └─ ct.M22QN:5!null\n" +
 			"     ├─ LookupJoin\n" +
 			"     │   ├─ Eq\n" +
-			"     │   │   ├─ nd.id:30!null\n" +
-			"     │   │   └─ ct.LUEVY:15!null\n" +
+			"     │   │   ├─ nd.id:12!null\n" +
+			"     │   │   └─ ct.LUEVY:4!null\n" +
 			"     │   ├─ LookupJoin\n" +
 			"     │   │   ├─ Eq\n" +
-			"     │   │   │   ├─ ci.id:25!null\n" +
-			"     │   │   │   └─ ct.FZ2R5:14!null\n" +
+			"     │   │   │   ├─ ci.id:10!null\n" +
+			"     │   │   │   └─ ct.FZ2R5:3!null\n" +
 			"     │   │   ├─ LookupJoin\n" +
 			"     │   │   │   ├─ Eq\n" +
 			"     │   │   │   │   ├─ TVTJS.id:0!null\n" +
-			"     │   │   │   │   └─ ct.XMM6Q:20\n" +
+			"     │   │   │   │   └─ ct.XMM6Q:6\n" +
 			"     │   │   │   ├─ Filter\n" +
 			"     │   │   │   │   ├─ Eq\n" +
-			"     │   │   │   │   │   ├─ TVTJS.SWCQV:10!null\n" +
+			"     │   │   │   │   │   ├─ TVTJS.SWCQV:1!null\n" +
 			"     │   │   │   │   │   └─ 1 (tinyint)\n" +
 			"     │   │   │   │   └─ TableAlias(TVTJS)\n" +
 			"     │   │   │   │       └─ Table\n" +
-			"     │   │   │   │           └─ name: HU5A5\n" +
+			"     │   │   │   │           ├─ name: HU5A5\n" +
+			"     │   │   │   │           └─ columns: [id swcqv]\n" +
 			"     │   │   │   └─ TableAlias(ct)\n" +
 			"     │   │   │       └─ IndexedTableAccess(FLQLP)\n" +
-			"     │   │   │           └─ index: [FLQLP.XMM6Q]\n" +
+			"     │   │   │           ├─ index: [FLQLP.XMM6Q]\n" +
+			"     │   │   │           └─ columns: [id fz2r5 luevy m22qn xmm6q v5dpx s3q3y zrv3b]\n" +
 			"     │   │   └─ TableAlias(ci)\n" +
 			"     │   │       └─ IndexedTableAccess(JDLNA)\n" +
-			"     │   │           └─ index: [JDLNA.id]\n" +
+			"     │   │           ├─ index: [JDLNA.id]\n" +
+			"     │   │           └─ columns: [id ftqlq]\n" +
 			"     │   └─ TableAlias(nd)\n" +
 			"     │       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │           └─ index: [E2I7U.id]\n" +
+			"     │           ├─ index: [E2I7U.id]\n" +
+			"     │           └─ columns: [id tw55n]\n" +
 			"     └─ TableAlias(aac)\n" +
 			"         └─ IndexedTableAccess(TPXBU)\n" +
-			"             └─ index: [TPXBU.id]\n" +
+			"             ├─ index: [TPXBU.id]\n" +
+			"             └─ columns: [id btxc5]\n" +
 			"",
 	},
 	{
@@ -7846,66 +7856,73 @@ WHERE
 	       PV6R5.NUMK2 <> 1
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [rn.id:44!null as id, concat(NSPLT.TW55N:3!null,FDNCN (longtext),LQNCX.TW55N:30!null) as X37NA, concat(XLZA5.TW55N:53!null,FDNCN (longtext),AFJMD.TW55N:80!null) as THWCS, rn.HVHRZ:47!null as HVHRZ]\n" +
+			" ├─ columns: [rn.id:8!null as id, concat(NSPLT.TW55N:1!null,FDNCN (longtext),LQNCX.TW55N:7!null) as X37NA, concat(XLZA5.TW55N:13!null,FDNCN (longtext),AFJMD.TW55N:18!null) as THWCS, rn.HVHRZ:11!null as HVHRZ]\n" +
 			" └─ Filter\n" +
 			"     ├─ Or\n" +
 			"     │   ├─ (NOT(Eq\n" +
-			"     │   │   ├─ PV6R5.FFTBJ:19!null\n" +
-			"     │   │   └─ ZYUTC.BRQP2:68!null\n" +
+			"     │   │   ├─ PV6R5.FFTBJ:4!null\n" +
+			"     │   │   └─ ZYUTC.BRQP2:15!null\n" +
 			"     │   │  ))\n" +
 			"     │   └─ (NOT(Eq\n" +
-			"     │       ├─ PV6R5.NUMK2:23!null\n" +
+			"     │       ├─ PV6R5.NUMK2:5!null\n" +
 			"     │       └─ 1 (tinyint)\n" +
 			"     │      ))\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ rn.HHVLX:46!null\n" +
-			"         │   └─ ZYUTC.id:67!null\n" +
+			"         │   ├─ rn.HHVLX:10!null\n" +
+			"         │   └─ ZYUTC.id:14!null\n" +
 			"         ├─ LookupJoin\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ rn.WNUNU:45!null\n" +
-			"         │   │   └─ PV6R5.id:17!null\n" +
+			"         │   │   ├─ rn.WNUNU:9!null\n" +
+			"         │   │   └─ PV6R5.id:2!null\n" +
 			"         │   ├─ LookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ LQNCX.id:27!null\n" +
-			"         │   │   │   └─ PV6R5.FFTBJ:19!null\n" +
+			"         │   │   │   ├─ LQNCX.id:6!null\n" +
+			"         │   │   │   └─ PV6R5.FFTBJ:4!null\n" +
 			"         │   │   ├─ LookupJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ NSPLT.id:0!null\n" +
-			"         │   │   │   │   └─ PV6R5.BRQP2:18!null\n" +
+			"         │   │   │   │   └─ PV6R5.BRQP2:3!null\n" +
 			"         │   │   │   ├─ TableAlias(NSPLT)\n" +
 			"         │   │   │   │   └─ Table\n" +
-			"         │   │   │   │       └─ name: E2I7U\n" +
+			"         │   │   │   │       ├─ name: E2I7U\n" +
+			"         │   │   │   │       └─ columns: [id tw55n]\n" +
 			"         │   │   │   └─ TableAlias(PV6R5)\n" +
 			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │           └─ index: [NOXN3.BRQP2]\n" +
+			"         │   │   │           ├─ index: [NOXN3.BRQP2]\n" +
+			"         │   │   │           └─ columns: [id brqp2 fftbj numk2]\n" +
 			"         │   │   └─ TableAlias(LQNCX)\n" +
 			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │           └─ index: [E2I7U.id]\n" +
+			"         │   │           ├─ index: [E2I7U.id]\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ TableAlias(rn)\n" +
 			"         │       └─ IndexedTableAccess(QYWQD)\n" +
-			"         │           └─ index: [QYWQD.WNUNU]\n" +
+			"         │           ├─ index: [QYWQD.WNUNU]\n" +
+			"         │           └─ columns: [id wnunu hhvlx hvhrz]\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ source: TUPLE(rn.HHVLX:46!null)\n" +
-			"             ├─ target: TUPLE(ZYUTC.id:17!null)\n" +
+			"             ├─ source: TUPLE(rn.HHVLX:10!null)\n" +
+			"             ├─ target: TUPLE(ZYUTC.id:2!null)\n" +
 			"             └─ CachedResults\n" +
 			"                 └─ LookupJoin\n" +
 			"                     ├─ Eq\n" +
-			"                     │   ├─ AFJMD.id:77!null\n" +
-			"                     │   └─ ZYUTC.FFTBJ:69!null\n" +
+			"                     │   ├─ AFJMD.id:17!null\n" +
+			"                     │   └─ ZYUTC.FFTBJ:16!null\n" +
 			"                     ├─ LookupJoin\n" +
 			"                     │   ├─ Eq\n" +
-			"                     │   │   ├─ XLZA5.id:50!null\n" +
-			"                     │   │   └─ ZYUTC.BRQP2:68!null\n" +
+			"                     │   │   ├─ XLZA5.id:12!null\n" +
+			"                     │   │   └─ ZYUTC.BRQP2:15!null\n" +
 			"                     │   ├─ TableAlias(XLZA5)\n" +
 			"                     │   │   └─ Table\n" +
-			"                     │   │       └─ name: E2I7U\n" +
+			"                     │   │       ├─ name: E2I7U\n" +
+			"                     │   │       └─ columns: [id tw55n]\n" +
 			"                     │   └─ TableAlias(ZYUTC)\n" +
 			"                     │       └─ IndexedTableAccess(NOXN3)\n" +
-			"                     │           └─ index: [NOXN3.BRQP2]\n" +
+			"                     │           ├─ index: [NOXN3.BRQP2]\n" +
+			"                     │           └─ columns: [id brqp2 fftbj]\n" +
 			"                     └─ TableAlias(AFJMD)\n" +
 			"                         └─ IndexedTableAccess(E2I7U)\n" +
-			"                             └─ index: [E2I7U.id]\n" +
+			"                             ├─ index: [E2I7U.id]\n" +
+			"                             └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -7950,68 +7967,75 @@ WHERE
 	       rn.WNUNU IS NULL AND rn.HHVLX IS NULL
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sn.id:61!null as DRIWM, concat(OE56M.TW55N:47!null,FDNCN (longtext),CGFRZ.TW55N:74!null) as GRVSE, SKPM6.id:17!null as JIEVY, concat(V5SAY.TW55N:3!null,FDNCN (longtext),FQTHF.TW55N:30!null) as ENCM3, 1 (decimal(2,1)) as OHD3R]\n" +
+			" ├─ columns: [sn.id:9!null as DRIWM, concat(OE56M.TW55N:8!null,FDNCN (longtext),CGFRZ.TW55N:14!null) as GRVSE, SKPM6.id:2!null as JIEVY, concat(V5SAY.TW55N:1!null,FDNCN (longtext),FQTHF.TW55N:6!null) as ENCM3, 1 (decimal(2,1)) as OHD3R]\n" +
 			" └─ Filter\n" +
 			"     ├─ AND\n" +
-			"     │   ├─ rn.WNUNU:89 IS NULL\n" +
-			"     │   └─ rn.HHVLX:90 IS NULL\n" +
+			"     │   ├─ rn.WNUNU:15 IS NULL\n" +
+			"     │   └─ rn.HHVLX:16 IS NULL\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ rn.WNUNU:89!null\n" +
-			"         │   │   └─ sn.id:61!null\n" +
+			"         │   │   ├─ rn.WNUNU:15!null\n" +
+			"         │   │   └─ sn.id:9!null\n" +
 			"         │   └─ Eq\n" +
-			"         │       ├─ rn.HHVLX:90!null\n" +
-			"         │       └─ SKPM6.id:17!null\n" +
+			"         │       ├─ rn.HHVLX:16!null\n" +
+			"         │       └─ SKPM6.id:2!null\n" +
 			"         ├─ HashJoin\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ SKPM6.BRQP2:18!null\n" +
-			"         │   │   └─ sn.FFTBJ:63!null\n" +
+			"         │   │   ├─ SKPM6.BRQP2:3!null\n" +
+			"         │   │   └─ sn.FFTBJ:11!null\n" +
 			"         │   ├─ LookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ FQTHF.id:27!null\n" +
-			"         │   │   │   └─ SKPM6.FFTBJ:19!null\n" +
+			"         │   │   │   ├─ FQTHF.id:5!null\n" +
+			"         │   │   │   └─ SKPM6.FFTBJ:4!null\n" +
 			"         │   │   ├─ LookupJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ V5SAY.id:0!null\n" +
-			"         │   │   │   │   └─ SKPM6.BRQP2:18!null\n" +
+			"         │   │   │   │   └─ SKPM6.BRQP2:3!null\n" +
 			"         │   │   │   ├─ TableAlias(V5SAY)\n" +
 			"         │   │   │   │   └─ Table\n" +
-			"         │   │   │   │       └─ name: E2I7U\n" +
+			"         │   │   │   │       ├─ name: E2I7U\n" +
+			"         │   │   │   │       └─ columns: [id tw55n]\n" +
 			"         │   │   │   └─ TableAlias(SKPM6)\n" +
 			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │           └─ index: [NOXN3.BRQP2]\n" +
+			"         │   │   │           ├─ index: [NOXN3.BRQP2]\n" +
+			"         │   │   │           └─ columns: [id brqp2 fftbj]\n" +
 			"         │   │   └─ TableAlias(FQTHF)\n" +
 			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │           └─ index: [E2I7U.id]\n" +
+			"         │   │           ├─ index: [E2I7U.id]\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ HashLookup\n" +
-			"         │       ├─ source: TUPLE(SKPM6.BRQP2:18!null)\n" +
-			"         │       ├─ target: TUPLE(sn.FFTBJ:19!null)\n" +
+			"         │       ├─ source: TUPLE(SKPM6.BRQP2:3!null)\n" +
+			"         │       ├─ target: TUPLE(sn.FFTBJ:4!null)\n" +
 			"         │       └─ CachedResults\n" +
 			"         │           └─ LookupJoin\n" +
 			"         │               ├─ Eq\n" +
-			"         │               │   ├─ CGFRZ.id:71!null\n" +
-			"         │               │   └─ sn.FFTBJ:63!null\n" +
+			"         │               │   ├─ CGFRZ.id:13!null\n" +
+			"         │               │   └─ sn.FFTBJ:11!null\n" +
 			"         │               ├─ LookupJoin\n" +
 			"         │               │   ├─ Eq\n" +
-			"         │               │   │   ├─ OE56M.id:44!null\n" +
-			"         │               │   │   └─ sn.BRQP2:62!null\n" +
+			"         │               │   │   ├─ OE56M.id:7!null\n" +
+			"         │               │   │   └─ sn.BRQP2:10!null\n" +
 			"         │               │   ├─ TableAlias(OE56M)\n" +
 			"         │               │   │   └─ Table\n" +
-			"         │               │   │       └─ name: E2I7U\n" +
+			"         │               │   │       ├─ name: E2I7U\n" +
+			"         │               │   │       └─ columns: [id tw55n]\n" +
 			"         │               │   └─ Filter\n" +
 			"         │               │       ├─ Eq\n" +
-			"         │               │       │   ├─ sn.NUMK2:6!null\n" +
+			"         │               │       │   ├─ sn.NUMK2:3!null\n" +
 			"         │               │       │   └─ 1 (tinyint)\n" +
 			"         │               │       └─ TableAlias(sn)\n" +
 			"         │               │           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │               │               └─ index: [NOXN3.BRQP2]\n" +
+			"         │               │               ├─ index: [NOXN3.BRQP2]\n" +
+			"         │               │               └─ columns: [id brqp2 fftbj numk2]\n" +
 			"         │               └─ TableAlias(CGFRZ)\n" +
 			"         │                   └─ IndexedTableAccess(E2I7U)\n" +
-			"         │                       └─ index: [E2I7U.id]\n" +
+			"         │                       ├─ index: [E2I7U.id]\n" +
+			"         │                       └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(rn)\n" +
 			"             └─ IndexedTableAccess(QYWQD)\n" +
-			"                 └─ index: [QYWQD.HHVLX]\n" +
+			"                 ├─ index: [QYWQD.HHVLX]\n" +
+			"                 └─ columns: [wnunu hhvlx]\n" +
 			"",
 	},
 	{
@@ -8130,10 +8154,10 @@ WHERE
 	       CL3DT.R5CKX > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:7!null as UYOGN, PBMRX.ZH72S:11 as H4JEA]\n" +
+			" ├─ columns: [PBMRX.id:4!null as id, PBMRX.TW55N:5!null as UYOGN, PBMRX.ZH72S:6 as H4JEA]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ PBMRX.ZH72S:11\n" +
+			"     │   ├─ PBMRX.ZH72S:6\n" +
 			"     │   └─ CL3DT.ZH72S:0\n" +
 			"     ├─ SubqueryAlias\n" +
 			"     │   ├─ name: CL3DT\n" +
@@ -8185,10 +8209,11 @@ WHERE
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
 			"     │                                           └─ static: [{(NULL, ∞)}]\n" +
 			"     └─ Filter\n" +
-			"         ├─ (NOT(PBMRX.ZH72S:7 IS NULL))\n" +
+			"         ├─ (NOT(PBMRX.ZH72S:2 IS NULL))\n" +
 			"         └─ TableAlias(PBMRX)\n" +
 			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 └─ index: [E2I7U.ZH72S]\n" +
+			"                 ├─ index: [E2I7U.ZH72S]\n" +
+			"                 └─ columns: [id tw55n zh72s]\n" +
 			"",
 	},
 	{
@@ -8403,14 +8428,15 @@ WHERE
 			"     │   │       │   ├─ Subquery\n" +
 			"     │   │       │   │   ├─ cacheable: false\n" +
 			"     │   │       │   │   └─ Project\n" +
-			"     │   │       │   │       ├─ columns: [TJ5D2.SWCQV:76!null]\n" +
+			"     │   │       │   │       ├─ columns: [TJ5D2.SWCQV:72!null]\n" +
 			"     │   │       │   │       └─ Filter\n" +
 			"     │   │       │   │           ├─ Eq\n" +
 			"     │   │       │   │           │   ├─ TJ5D2.id:71!null\n" +
 			"     │   │       │   │           │   └─ mf.QQV4M:32\n" +
 			"     │   │       │   │           └─ TableAlias(TJ5D2)\n" +
 			"     │   │       │   │               └─ Table\n" +
-			"     │   │       │   │                   └─ name: SZW6V\n" +
+			"     │   │       │   │                   ├─ name: SZW6V\n" +
+			"     │   │       │   │                   └─ columns: [id swcqv]\n" +
 			"     │   │       │   └─ 1 (tinyint)\n" +
 			"     │   │       └─ (NOT(Eq\n" +
 			"     │   │           ├─ Subquery\n" +
@@ -8423,14 +8449,15 @@ WHERE
 			"     │   │           │           │   └─ Subquery\n" +
 			"     │   │           │           │       ├─ cacheable: false\n" +
 			"     │   │           │           │       └─ Project\n" +
-			"     │   │           │           │           ├─ columns: [TJ5D2.H4DMT:92!null]\n" +
+			"     │   │           │           │           ├─ columns: [TJ5D2.H4DMT:89!null]\n" +
 			"     │   │           │           │           └─ Filter\n" +
 			"     │   │           │           │               ├─ Eq\n" +
 			"     │   │           │           │               │   ├─ TJ5D2.id:88!null\n" +
 			"     │   │           │           │               │   └─ mf.QQV4M:32\n" +
 			"     │   │           │           │               └─ TableAlias(TJ5D2)\n" +
 			"     │   │           │           │                   └─ Table\n" +
-			"     │   │           │           │                       └─ name: SZW6V\n" +
+			"     │   │           │           │                       ├─ name: SZW6V\n" +
+			"     │   │           │           │                       └─ columns: [id h4dmt]\n" +
 			"     │   │           │           └─ TableAlias(nd)\n" +
 			"     │   │           │               └─ Table\n" +
 			"     │   │           │                   └─ name: E2I7U\n" +
@@ -8703,7 +8730,8 @@ WHERE
 			" │       │           │   └─ SL3S5.M22QN:53!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
 			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			" │       │                   └─ index: [TPXBU.id]\n" +
+			" │       │                   ├─ index: [TPXBU.id]\n" +
+			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, SL3S5.NO52D:55!null as NO52D, SL3S5.IDPK7:56!null as IDPK7]\n" +
 			" │       └─ HashJoin\n" +
 			" │           ├─ AND\n" +
@@ -8747,23 +8775,23 @@ WHERE
 			" │                       │   ├─ outerVisibility: false\n" +
 			" │                       │   ├─ cacheable: true\n" +
 			" │                       │   └─ Project\n" +
-			" │                       │       ├─ columns: [KHJJO.BDNYB:24!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:8!null as M22QN, cec.ADURZ:21!null as ADURZ, cec.NO52D:18!null as NO52D, ct.S3Q3Y:14!null as IDPK7]\n" +
+			" │                       │       ├─ columns: [KHJJO.BDNYB:12!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:4!null as M22QN, cec.ADURZ:10!null as ADURZ, cec.NO52D:9!null as NO52D, ct.S3Q3Y:6!null as IDPK7]\n" +
 			" │                       │       └─ HashJoin\n" +
 			" │                       │           ├─ AND\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ ct.M22QN:8!null\n" +
-			" │                       │           │   │   └─ KHJJO.M22QN:23!null\n" +
+			" │                       │           │   │   ├─ ct.M22QN:4!null\n" +
+			" │                       │           │   │   └─ KHJJO.M22QN:11!null\n" +
 			" │                       │           │   └─ Eq\n" +
-			" │                       │           │       ├─ ct.LUEVY:7!null\n" +
-			" │                       │           │       └─ KHJJO.LUEVY:25!null\n" +
+			" │                       │           │       ├─ ct.LUEVY:3!null\n" +
+			" │                       │           │       └─ KHJJO.LUEVY:13!null\n" +
 			" │                       │           ├─ LookupJoin\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ cec.id:17!null\n" +
-			" │                       │           │   │   └─ ct.OVE3E:9!null\n" +
+			" │                       │           │   │   ├─ cec.id:8!null\n" +
+			" │                       │           │   │   └─ ct.OVE3E:5!null\n" +
 			" │                       │           │   ├─ LookupJoin\n" +
 			" │                       │           │   │   ├─ Eq\n" +
 			" │                       │           │   │   │   ├─ ci.id:0!null\n" +
-			" │                       │           │   │   │   └─ ct.FZ2R5:6!null\n" +
+			" │                       │           │   │   │   └─ ct.FZ2R5:2!null\n" +
 			" │                       │           │   │   ├─ Filter\n" +
 			" │                       │           │   │   │   ├─ HashIn\n" +
 			" │                       │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
@@ -8771,19 +8799,22 @@ WHERE
 			" │                       │           │   │   │   └─ TableAlias(ci)\n" +
 			" │                       │           │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
 			" │                       │           │   │   │           ├─ index: [JDLNA.FTQLQ]\n" +
-			" │                       │           │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
+			" │                       │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
+			" │                       │           │   │   │           └─ columns: [id ftqlq]\n" +
 			" │                       │           │   │   └─ Filter\n" +
 			" │                       │           │   │       ├─ Eq\n" +
-			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
+			" │                       │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
 			" │                       │           │   │       │   └─ = (longtext)\n" +
 			" │                       │           │   │       └─ TableAlias(ct)\n" +
 			" │                       │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			" │                       │           │   │               └─ index: [FLQLP.FZ2R5]\n" +
+			" │                       │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
+			" │                       │           │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
 			" │                       │           │   └─ TableAlias(cec)\n" +
 			" │                       │           │       └─ IndexedTableAccess(SFEGG)\n" +
-			" │                       │           │           └─ index: [SFEGG.id]\n" +
+			" │                       │           │           ├─ index: [SFEGG.id]\n" +
+			" │                       │           │           └─ columns: [id no52d adurz]\n" +
 			" │                       │           └─ HashLookup\n" +
-			" │                       │               ├─ source: TUPLE(ct.M22QN:8!null, ct.LUEVY:7!null)\n" +
+			" │                       │               ├─ source: TUPLE(ct.M22QN:4!null, ct.LUEVY:3!null)\n" +
 			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
 			" │                       │               └─ CachedResults\n" +
 			" │                       │                   └─ SubqueryAlias\n" +
@@ -8826,7 +8857,8 @@ WHERE
 			"             │       │           │   └─ SL3S5.M22QN:2!null\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
 			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │       │                   └─ index: [TPXBU.id]\n" +
+			"             │       │                   ├─ index: [TPXBU.id]\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   as TPXBU, SL3S5.NO52D:4!null as NO52D, SL3S5.IDPK7:5!null as IDPK7]\n" +
 			"             │       └─ LookupJoin\n" +
 			"             │           ├─ Eq\n" +
@@ -8837,37 +8869,39 @@ WHERE
 			"             │           │   ├─ outerVisibility: false\n" +
 			"             │           │   ├─ cacheable: true\n" +
 			"             │           │   └─ Project\n" +
-			"             │           │       ├─ columns: [sn.id:23!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
+			"             │           │       ├─ columns: [sn.id:17!null as BDNYB, ci.FTQLQ:16!null as TOFPN, ct.M22QN:6!null as M22QN, cec.ADURZ:2!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:12!null as IDPK7]\n" +
 			"             │           │       └─ Filter\n" +
 			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ ct.M22QN:9!null\n" +
+			"             │           │           │   ├─ ct.M22QN:6!null\n" +
 			"             │           │           │   └─ Subquery\n" +
 			"             │           │           │       ├─ cacheable: true\n" +
 			"             │           │           │       └─ Project\n" +
-			"             │           │           │           ├─ columns: [aac.id:33!null]\n" +
+			"             │           │           │           ├─ columns: [aac.id:27!null]\n" +
 			"             │           │           │           └─ Filter\n" +
 			"             │           │           │               ├─ Eq\n" +
-			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
+			"             │           │           │               │   ├─ aac.BTXC5:28\n" +
 			"             │           │           │               │   └─ WT (longtext)\n" +
 			"             │           │           │               └─ TableAlias(aac)\n" +
 			"             │           │           │                   └─ IndexedTableAccess(TPXBU)\n" +
 			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"             │           │           │                       └─ static: [{[WT, WT]}]\n" +
+			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
+			"             │           │           │                       └─ columns: [id btxc5]\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
-			"             │           │               │   ├─ ct.LUEVY:8!null\n" +
-			"             │           │               │   └─ sn.BRQP2:24!null\n" +
+			"             │           │               │   ├─ ct.LUEVY:5!null\n" +
+			"             │           │               │   └─ sn.BRQP2:18!null\n" +
 			"             │           │               ├─ LookupJoin\n" +
 			"             │           │               │   ├─ Eq\n" +
-			"             │           │               │   │   ├─ ci.id:18!null\n" +
-			"             │           │               │   │   └─ ct.FZ2R5:7!null\n" +
+			"             │           │               │   │   ├─ ci.id:15!null\n" +
+			"             │           │               │   │   └─ ct.FZ2R5:4!null\n" +
 			"             │           │               │   ├─ LookupJoin\n" +
 			"             │           │               │   │   ├─ Eq\n" +
 			"             │           │               │   │   │   ├─ cec.id:0!null\n" +
-			"             │           │               │   │   │   └─ ct.OVE3E:10!null\n" +
+			"             │           │               │   │   │   └─ ct.OVE3E:7!null\n" +
 			"             │           │               │   │   ├─ TableAlias(cec)\n" +
 			"             │           │               │   │   │   └─ Table\n" +
-			"             │           │               │   │   │       └─ name: SFEGG\n" +
+			"             │           │               │   │   │       ├─ name: SFEGG\n" +
+			"             │           │               │   │   │       └─ columns: [id no52d adurz]\n" +
 			"             │           │               │   │   └─ Filter\n" +
 			"             │           │               │   │       ├─ Eq\n" +
 			"             │           │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
@@ -8881,7 +8915,8 @@ WHERE
 			"             │           │               │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │           │               │       └─ TableAlias(ci)\n" +
 			"             │           │               │           └─ IndexedTableAccess(JDLNA)\n" +
-			"             │           │               │               └─ index: [JDLNA.id]\n" +
+			"             │           │               │               ├─ index: [JDLNA.id]\n" +
+			"             │           │               │               └─ columns: [id ftqlq]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
 			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
 			"             │           │                       └─ index: [NOXN3.BRQP2]\n" +
@@ -9022,7 +9057,8 @@ WHERE
 			" │       │           │   └─ SL3S5.M22QN:53!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
 			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			" │       │                   └─ index: [TPXBU.id]\n" +
+			" │       │                   ├─ index: [TPXBU.id]\n" +
+			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, SL3S5.NO52D:55!null as NO52D, SL3S5.IDPK7:56!null as IDPK7]\n" +
 			" │       └─ HashJoin\n" +
 			" │           ├─ AND\n" +
@@ -9066,42 +9102,45 @@ WHERE
 			" │                       │   ├─ outerVisibility: false\n" +
 			" │                       │   ├─ cacheable: true\n" +
 			" │                       │   └─ Project\n" +
-			" │                       │       ├─ columns: [KHJJO.BDNYB:24!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
+			" │                       │       ├─ columns: [KHJJO.BDNYB:12!null as BDNYB, ci.FTQLQ:10!null as TOFPN, ct.M22QN:5!null as M22QN, cec.ADURZ:2!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:7!null as IDPK7]\n" +
 			" │                       │       └─ HashJoin\n" +
 			" │                       │           ├─ AND\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ ct.M22QN:9!null\n" +
-			" │                       │           │   │   └─ KHJJO.M22QN:23!null\n" +
+			" │                       │           │   │   ├─ ct.M22QN:5!null\n" +
+			" │                       │           │   │   └─ KHJJO.M22QN:11!null\n" +
 			" │                       │           │   └─ Eq\n" +
-			" │                       │           │       ├─ ct.LUEVY:8!null\n" +
-			" │                       │           │       └─ KHJJO.LUEVY:25!null\n" +
+			" │                       │           │       ├─ ct.LUEVY:4!null\n" +
+			" │                       │           │       └─ KHJJO.LUEVY:13!null\n" +
 			" │                       │           ├─ LookupJoin\n" +
 			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ ci.id:18!null\n" +
-			" │                       │           │   │   └─ ct.FZ2R5:7!null\n" +
+			" │                       │           │   │   ├─ ci.id:9!null\n" +
+			" │                       │           │   │   └─ ct.FZ2R5:3!null\n" +
 			" │                       │           │   ├─ LookupJoin\n" +
 			" │                       │           │   │   ├─ Eq\n" +
 			" │                       │           │   │   │   ├─ cec.id:0!null\n" +
-			" │                       │           │   │   │   └─ ct.OVE3E:10!null\n" +
+			" │                       │           │   │   │   └─ ct.OVE3E:6!null\n" +
 			" │                       │           │   │   ├─ TableAlias(cec)\n" +
 			" │                       │           │   │   │   └─ Table\n" +
-			" │                       │           │   │   │       └─ name: SFEGG\n" +
+			" │                       │           │   │   │       ├─ name: SFEGG\n" +
+			" │                       │           │   │   │       └─ columns: [id no52d adurz]\n" +
 			" │                       │           │   │   └─ Filter\n" +
 			" │                       │           │   │       ├─ Eq\n" +
-			" │                       │           │   │       │   ├─ ct.ZRV3B:10!null\n" +
+			" │                       │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
 			" │                       │           │   │       │   └─ = (longtext)\n" +
 			" │                       │           │   │       └─ TableAlias(ct)\n" +
 			" │                       │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			" │                       │           │   │               └─ index: [FLQLP.OVE3E]\n" +
+			" │                       │           │   │               ├─ index: [FLQLP.OVE3E]\n" +
+			" │                       │           │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
 			" │                       │           │   └─ Filter\n" +
 			" │                       │           │       ├─ HashIn\n" +
 			" │                       │           │       │   ├─ ci.FTQLQ:1!null\n" +
 			" │                       │           │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			" │                       │           │       └─ TableAlias(ci)\n" +
 			" │                       │           │           └─ IndexedTableAccess(JDLNA)\n" +
-			" │                       │           │               └─ index: [JDLNA.id]\n" +
+			" │                       │           │               ├─ index: [JDLNA.id]\n" +
+			" │                       │           │               └─ columns: [id ftqlq]\n" +
 			" │                       │           └─ HashLookup\n" +
-			" │                       │               ├─ source: TUPLE(ct.M22QN:9!null, ct.LUEVY:8!null)\n" +
+			" │                       │               ├─ source: TUPLE(ct.M22QN:5!null, ct.LUEVY:4!null)\n" +
 			" │                       │               ├─ target: TUPLE(KHJJO.M22QN:0!null, KHJJO.LUEVY:2!null)\n" +
 			" │                       │               └─ CachedResults\n" +
 			" │                       │                   └─ SubqueryAlias\n" +
@@ -9144,7 +9183,8 @@ WHERE
 			"             │       │           │   └─ SL3S5.M22QN:2!null\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
 			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │       │                   └─ index: [TPXBU.id]\n" +
+			"             │       │                   ├─ index: [TPXBU.id]\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   as TPXBU, SL3S5.NO52D:4!null as NO52D, SL3S5.IDPK7:5!null as IDPK7]\n" +
 			"             │       └─ LookupJoin\n" +
 			"             │           ├─ Eq\n" +
@@ -9155,37 +9195,39 @@ WHERE
 			"             │           │   ├─ outerVisibility: false\n" +
 			"             │           │   ├─ cacheable: true\n" +
 			"             │           │   └─ Project\n" +
-			"             │           │       ├─ columns: [sn.id:23!null as BDNYB, ci.FTQLQ:19!null as TOFPN, ct.M22QN:9!null as M22QN, cec.ADURZ:4!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:15!null as IDPK7]\n" +
+			"             │           │       ├─ columns: [sn.id:17!null as BDNYB, ci.FTQLQ:16!null as TOFPN, ct.M22QN:6!null as M22QN, cec.ADURZ:2!null as ADURZ, cec.NO52D:1!null as NO52D, ct.S3Q3Y:12!null as IDPK7]\n" +
 			"             │           │       └─ Filter\n" +
 			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ ct.M22QN:9!null\n" +
+			"             │           │           │   ├─ ct.M22QN:6!null\n" +
 			"             │           │           │   └─ Subquery\n" +
 			"             │           │           │       ├─ cacheable: true\n" +
 			"             │           │           │       └─ Project\n" +
-			"             │           │           │           ├─ columns: [aac.id:33!null]\n" +
+			"             │           │           │           ├─ columns: [aac.id:27!null]\n" +
 			"             │           │           │           └─ Filter\n" +
 			"             │           │           │               ├─ Eq\n" +
-			"             │           │           │               │   ├─ aac.BTXC5:34\n" +
+			"             │           │           │               │   ├─ aac.BTXC5:28\n" +
 			"             │           │           │               │   └─ WT (longtext)\n" +
 			"             │           │           │               └─ TableAlias(aac)\n" +
 			"             │           │           │                   └─ IndexedTableAccess(TPXBU)\n" +
 			"             │           │           │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"             │           │           │                       └─ static: [{[WT, WT]}]\n" +
+			"             │           │           │                       ├─ static: [{[WT, WT]}]\n" +
+			"             │           │           │                       └─ columns: [id btxc5]\n" +
 			"             │           │           └─ LookupJoin\n" +
 			"             │           │               ├─ Eq\n" +
-			"             │           │               │   ├─ ct.LUEVY:8!null\n" +
-			"             │           │               │   └─ sn.BRQP2:24!null\n" +
+			"             │           │               │   ├─ ct.LUEVY:5!null\n" +
+			"             │           │               │   └─ sn.BRQP2:18!null\n" +
 			"             │           │               ├─ LookupJoin\n" +
 			"             │           │               │   ├─ Eq\n" +
-			"             │           │               │   │   ├─ ci.id:18!null\n" +
-			"             │           │               │   │   └─ ct.FZ2R5:7!null\n" +
+			"             │           │               │   │   ├─ ci.id:15!null\n" +
+			"             │           │               │   │   └─ ct.FZ2R5:4!null\n" +
 			"             │           │               │   ├─ LookupJoin\n" +
 			"             │           │               │   │   ├─ Eq\n" +
 			"             │           │               │   │   │   ├─ cec.id:0!null\n" +
-			"             │           │               │   │   │   └─ ct.OVE3E:10!null\n" +
+			"             │           │               │   │   │   └─ ct.OVE3E:7!null\n" +
 			"             │           │               │   │   ├─ TableAlias(cec)\n" +
 			"             │           │               │   │   │   └─ Table\n" +
-			"             │           │               │   │   │       └─ name: SFEGG\n" +
+			"             │           │               │   │   │       ├─ name: SFEGG\n" +
+			"             │           │               │   │   │       └─ columns: [id no52d adurz]\n" +
 			"             │           │               │   │   └─ Filter\n" +
 			"             │           │               │   │       ├─ Eq\n" +
 			"             │           │               │   │       │   ├─ ct.ZRV3B:10!null\n" +
@@ -9199,7 +9241,8 @@ WHERE
 			"             │           │               │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │           │               │       └─ TableAlias(ci)\n" +
 			"             │           │               │           └─ IndexedTableAccess(JDLNA)\n" +
-			"             │           │               │               └─ index: [JDLNA.id]\n" +
+			"             │           │               │               ├─ index: [JDLNA.id]\n" +
+			"             │           │               │               └─ columns: [id ftqlq]\n" +
 			"             │           │               └─ TableAlias(sn)\n" +
 			"             │           │                   └─ IndexedTableAccess(NOXN3)\n" +
 			"             │           │                       └─ index: [NOXN3.BRQP2]\n" +
@@ -9232,7 +9275,8 @@ WHERE
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
 			"     └─ Table\n" +
-			"         └─ name: NOXN3\n" +
+			"         ├─ name: NOXN3\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -9265,10 +9309,10 @@ WHERE
 	ORDER BY Y3IOU`,
 		ExpectedPlan: "Sort(Y3IOU:0!null ASC nullsFirst)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [NB6PJ.Y3IOU:0!null as Y3IOU, S7EGW.TW55N:26!null as FJVD7, TYMVL.TW55N:9!null as KBXXJ, NB6PJ.NUMK2:4!null as NUMK2, NB6PJ.LETOE:5!null as LETOE]\n" +
+			"     ├─ columns: [NB6PJ.Y3IOU:0!null as Y3IOU, S7EGW.TW55N:9!null as FJVD7, TYMVL.TW55N:7!null as KBXXJ, NB6PJ.NUMK2:4!null as NUMK2, NB6PJ.LETOE:5!null as LETOE]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ S7EGW.id:23!null\n" +
+			"         │   ├─ S7EGW.id:8!null\n" +
 			"         │   └─ NB6PJ.BRQP2:2!null\n" +
 			"         ├─ LookupJoin\n" +
 			"         │   ├─ Eq\n" +
@@ -9293,10 +9337,12 @@ WHERE
 			"         │   │                   └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"         │   └─ TableAlias(TYMVL)\n" +
 			"         │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │           └─ index: [E2I7U.id]\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(S7EGW)\n" +
 			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 └─ index: [E2I7U.id]\n" +
+			"                 ├─ index: [E2I7U.id]\n" +
+			"                 └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -9322,7 +9368,7 @@ WHERE
 	ORDER BY TW55N, Y3IOU`,
 		ExpectedPlan: "Sort(TW55N:0!null ASC nullsFirst, Y3IOU:1!null ASC nullsFirst)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [nd.TW55N:9!null as TW55N, NB6PJ.Y3IOU:0!null as Y3IOU]\n" +
+			"     ├─ columns: [nd.TW55N:7!null as TW55N, NB6PJ.Y3IOU:0!null as Y3IOU]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ nd.id:6!null\n" +
@@ -9346,7 +9392,8 @@ WHERE
 			"         │                   └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"         └─ TableAlias(nd)\n" +
 			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 └─ index: [E2I7U.id]\n" +
+			"                 ├─ index: [E2I7U.id]\n" +
+			"                 └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -9370,28 +9417,31 @@ WHERE
 			"     ├─ columns: [(row_number() over ( order by sn.id ASC):0!null - 1 (tinyint)) as M6T2N, FJVD7:1!null, KBXXJ:2!null, sn.NUMK2:3!null, sn.LETOE:4!null, XLFIA:5!null]\n" +
 			"     └─ Window\n" +
 			"         ├─ row_number() over ( order by sn.id ASC)\n" +
-			"         ├─ S7EGW.TW55N:30!null as FJVD7\n" +
-			"         ├─ TYMVL.TW55N:3!null as KBXXJ\n" +
-			"         ├─ sn.NUMK2:23!null\n" +
-			"         ├─ sn.LETOE:24!null\n" +
-			"         ├─ sn.id:17!null as XLFIA\n" +
+			"         ├─ S7EGW.TW55N:8!null as FJVD7\n" +
+			"         ├─ TYMVL.TW55N:1!null as KBXXJ\n" +
+			"         ├─ sn.NUMK2:5!null\n" +
+			"         ├─ sn.LETOE:6!null\n" +
+			"         ├─ sn.id:2!null as XLFIA\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ Eq\n" +
-			"             │   ├─ sn.BRQP2:18!null\n" +
-			"             │   └─ S7EGW.id:27!null\n" +
+			"             │   ├─ sn.BRQP2:3!null\n" +
+			"             │   └─ S7EGW.id:7!null\n" +
 			"             ├─ LookupJoin\n" +
 			"             │   ├─ Eq\n" +
-			"             │   │   ├─ sn.FFTBJ:19!null\n" +
+			"             │   │   ├─ sn.FFTBJ:4!null\n" +
 			"             │   │   └─ TYMVL.id:0!null\n" +
 			"             │   ├─ TableAlias(TYMVL)\n" +
 			"             │   │   └─ Table\n" +
-			"             │   │       └─ name: E2I7U\n" +
+			"             │   │       ├─ name: E2I7U\n" +
+			"             │   │       └─ columns: [id tw55n]\n" +
 			"             │   └─ TableAlias(sn)\n" +
 			"             │       └─ IndexedTableAccess(NOXN3)\n" +
-			"             │           └─ index: [NOXN3.FFTBJ]\n" +
+			"             │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"             │           └─ columns: [id brqp2 fftbj numk2 letoe]\n" +
 			"             └─ TableAlias(S7EGW)\n" +
 			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     └─ index: [E2I7U.id]\n" +
+			"                     ├─ index: [E2I7U.id]\n" +
+			"                     └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -9404,7 +9454,8 @@ WHERE
 			"     ├─ row_number() over ( order by sn.id ASC)\n" +
 			"     └─ TableAlias(sn)\n" +
 			"         └─ Table\n" +
-			"             └─ name: NOXN3\n" +
+			"             ├─ name: NOXN3\n" +
+			"             └─ columns: [id]\n" +
 			"",
 	},
 	{
@@ -9425,14 +9476,14 @@ WHERE
 	ORDER BY nd.TW55N`,
 		ExpectedPlan: "Sort(nd.TW55N:0!null ASC nullsFirst)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [nd.TW55N:6!null, il.LIILR:22, il.KSFXH:23, il.KLMAU:24, il.ecm:25]\n" +
+			"     ├─ columns: [nd.TW55N:4!null, il.LIILR:6, il.KSFXH:7, il.KLMAU:8, il.ecm:9]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ il.LUEVY:21!null\n" +
-			"         │   └─ nd.id:3!null\n" +
+			"         │   ├─ il.LUEVY:5!null\n" +
+			"         │   └─ nd.id:2!null\n" +
 			"         ├─ LookupJoin\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ nd.DKCAJ:4!null\n" +
+			"         │   │   ├─ nd.DKCAJ:3!null\n" +
 			"         │   │   └─ nt.id:0!null\n" +
 			"         │   ├─ Filter\n" +
 			"         │   │   ├─ (NOT(Eq\n" +
@@ -9442,13 +9493,16 @@ WHERE
 			"         │   │   └─ TableAlias(nt)\n" +
 			"         │   │       └─ IndexedTableAccess(F35MI)\n" +
 			"         │   │           ├─ index: [F35MI.DZLIM]\n" +
-			"         │   │           └─ static: [{(SUZTA, ∞)}, {(NULL, SUZTA)}]\n" +
+			"         │   │           ├─ static: [{(SUZTA, ∞)}, {(NULL, SUZTA)}]\n" +
+			"         │   │           └─ columns: [id dzlim]\n" +
 			"         │   └─ TableAlias(nd)\n" +
 			"         │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │           └─ index: [E2I7U.DKCAJ]\n" +
+			"         │           ├─ index: [E2I7U.DKCAJ]\n" +
+			"         │           └─ columns: [id dkcaj tw55n]\n" +
 			"         └─ TableAlias(il)\n" +
 			"             └─ IndexedTableAccess(RLOHD)\n" +
-			"                 └─ index: [RLOHD.LUEVY]\n" +
+			"                 ├─ index: [RLOHD.LUEVY]\n" +
+			"                 └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
 			"",
 	},
 	{
@@ -9515,7 +9569,7 @@ WHERE
 	   YYKXN
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [ATHCU.T4IBQ:1!null as T4IBQ, ATHCU.TW55N:3!null as TW55N, CASE  WHEN fc.OZTQF:11 IS NULL THEN 0 (tinyint) WHEN IN\n" +
+			" ├─ columns: [ATHCU.T4IBQ:1!null as T4IBQ, ATHCU.TW55N:3!null as TW55N, CASE  WHEN fc.OZTQF:8 IS NULL THEN 0 (tinyint) WHEN IN\n" +
 			" │   ├─ left: ATHCU.SJ5DU:5\n" +
 			" │   └─ right: TUPLE(log (longtext), com (longtext), ex (longtext))\n" +
 			" │   THEN 0 (tinyint) WHEN Eq\n" +
@@ -9524,18 +9578,18 @@ WHERE
 			" │   THEN 0 (tinyint) WHEN Eq\n" +
 			" │   ├─ ATHCU.SOWRY:4!null\n" +
 			" │   └─ z (longtext)\n" +
-			" │   THEN fc.OZTQF:11 WHEN Eq\n" +
+			" │   THEN fc.OZTQF:8 WHEN Eq\n" +
 			" │   ├─ ATHCU.SOWRY:4!null\n" +
 			" │   └─ o (longtext)\n" +
-			" │   THEN (fc.OZTQF:11 - 1 (tinyint)) END as OZTQF]\n" +
+			" │   THEN (fc.OZTQF:8 - 1 (tinyint)) END as OZTQF]\n" +
 			" └─ Sort(ATHCU.YYKXN:2!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ AND\n" +
 			"         │   ├─ Eq\n" +
-			"         │   │   ├─ fc.LUEVY:8!null\n" +
+			"         │   │   ├─ fc.LUEVY:7!null\n" +
 			"         │   │   └─ ATHCU.YYKXN:2!null\n" +
 			"         │   └─ Eq\n" +
-			"         │       ├─ fc.GXLUB:7!null\n" +
+			"         │       ├─ fc.GXLUB:6!null\n" +
 			"         │       └─ ATHCU.B2TX3:0!null\n" +
 			"         ├─ SubqueryAlias\n" +
 			"         │   ├─ name: ATHCU\n" +
@@ -9552,7 +9606,8 @@ WHERE
 			"         │       │           │   └─ nd.DKCAJ:3!null\n" +
 			"         │       │           └─ TableAlias(nt)\n" +
 			"         │       │               └─ IndexedTableAccess(F35MI)\n" +
-			"         │       │                   └─ index: [F35MI.id]\n" +
+			"         │       │                   ├─ index: [F35MI.id]\n" +
+			"         │       │                   └─ columns: [id dzlim]\n" +
 			"         │       │   as SJ5DU]\n" +
 			"         │       └─ CrossJoin\n" +
 			"         │           ├─ SubqueryAlias\n" +
@@ -9560,27 +9615,30 @@ WHERE
 			"         │           │   ├─ outerVisibility: false\n" +
 			"         │           │   ├─ cacheable: true\n" +
 			"         │           │   └─ Project\n" +
-			"         │           │       ├─ columns: [bs.id:0!null as B2TX3, cla.FTQLQ:5!null as T4IBQ]\n" +
+			"         │           │       ├─ columns: [bs.id:0!null as B2TX3, cla.FTQLQ:3!null as T4IBQ]\n" +
 			"         │           │       └─ LookupJoin\n" +
 			"         │           │           ├─ Eq\n" +
-			"         │           │           │   ├─ bs.IXUXU:2\n" +
-			"         │           │           │   └─ cla.id:4!null\n" +
+			"         │           │           │   ├─ bs.IXUXU:1\n" +
+			"         │           │           │   └─ cla.id:2!null\n" +
 			"         │           │           ├─ TableAlias(bs)\n" +
 			"         │           │           │   └─ Table\n" +
-			"         │           │           │       └─ name: THNTS\n" +
+			"         │           │           │       ├─ name: THNTS\n" +
+			"         │           │           │       └─ columns: [id ixuxu]\n" +
 			"         │           │           └─ Filter\n" +
 			"         │           │               ├─ HashIn\n" +
 			"         │           │               │   ├─ cla.FTQLQ:1!null\n" +
 			"         │           │               │   └─ TUPLE(SQ1 (longtext))\n" +
 			"         │           │               └─ TableAlias(cla)\n" +
 			"         │           │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"         │           │                       └─ index: [YK2GW.id]\n" +
+			"         │           │                       ├─ index: [YK2GW.id]\n" +
+			"         │           │                       └─ columns: [id ftqlq]\n" +
 			"         │           └─ TableAlias(nd)\n" +
 			"         │               └─ Table\n" +
 			"         │                   └─ name: E2I7U\n" +
 			"         └─ TableAlias(fc)\n" +
 			"             └─ IndexedTableAccess(AMYXQ)\n" +
-			"                 └─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
+			"                 ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
+			"                 └─ columns: [gxlub luevy oztqf]\n" +
 			"",
 	},
 	{
@@ -9733,34 +9791,34 @@ WHERE
 			"                                         ├─ outerVisibility: false\n" +
 			"                                         ├─ cacheable: true\n" +
 			"                                         └─ Project\n" +
-			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:15 as GSTQA, pog.B5OUF:13, fc.OZTQF:45, F26ZW.YHYLK:51, nd.TW55N:20 as TW55N]\n" +
+			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:12 as GSTQA, pog.B5OUF:10, fc.OZTQF:20, F26ZW.YHYLK:24, nd.TW55N:14 as TW55N]\n" +
 			"                                             └─ Filter\n" +
 			"                                                 ├─ Eq\n" +
-			"                                                 │   ├─ ms.D237E:8\n" +
+			"                                                 │   ├─ ms.D237E:6\n" +
 			"                                                 │   └─ %!s(bool=true) (tinyint)\n" +
 			"                                                 └─ LeftOuterLookupJoin\n" +
 			"                                                     ├─ Eq\n" +
-			"                                                     │   ├─ nd.HPCMS:29\n" +
-			"                                                     │   └─ nma.id:52!null\n" +
+			"                                                     │   ├─ nd.HPCMS:15\n" +
+			"                                                     │   └─ nma.id:25!null\n" +
 			"                                                     ├─ LeftOuterHashJoin\n" +
 			"                                                     │   ├─ AND\n" +
 			"                                                     │   │   ├─ Eq\n" +
-			"                                                     │   │   │   ├─ F26ZW.T4IBQ:48!null\n" +
+			"                                                     │   │   │   ├─ F26ZW.T4IBQ:21!null\n" +
 			"                                                     │   │   │   └─ bs.T4IBQ:1!null\n" +
 			"                                                     │   │   └─ Eq\n" +
-			"                                                     │   │       ├─ F26ZW.BRQP2:49!null\n" +
-			"                                                     │   │       └─ nd.id:17\n" +
+			"                                                     │   │       ├─ F26ZW.BRQP2:22!null\n" +
+			"                                                     │   │       └─ nd.id:13\n" +
 			"                                                     │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   ├─ AND\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
 			"                                                     │   │   │   │   ├─ bs.id:0!null\n" +
-			"                                                     │   │   │   │   └─ fc.GXLUB:41!null\n" +
+			"                                                     │   │   │   │   └─ fc.GXLUB:18!null\n" +
 			"                                                     │   │   │   └─ Eq\n" +
-			"                                                     │   │   │       ├─ nd.id:17\n" +
-			"                                                     │   │   │       └─ fc.LUEVY:42!null\n" +
+			"                                                     │   │   │       ├─ nd.id:13\n" +
+			"                                                     │   │   │       └─ fc.LUEVY:19!null\n" +
 			"                                                     │   │   ├─ LeftOuterHashJoin\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │   │   ├─ ms.GXLUB:6!null\n" +
+			"                                                     │   │   │   │   ├─ ms.GXLUB:4!null\n" +
 			"                                                     │   │   │   │   └─ bs.id:0!null\n" +
 			"                                                     │   │   │   ├─ SubqueryAlias\n" +
 			"                                                     │   │   │   │   ├─ name: bs\n" +
@@ -9784,55 +9842,62 @@ WHERE
 			"                                                     │   │   │   │                   └─ columns: [id ftqlq]\n" +
 			"                                                     │   │   │   └─ HashLookup\n" +
 			"                                                     │   │   │       ├─ source: TUPLE(bs.id:0!null)\n" +
-			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:4!null)\n" +
+			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:2!null)\n" +
 			"                                                     │   │   │       └─ CachedResults\n" +
 			"                                                     │   │   │           └─ HashJoin\n" +
 			"                                                     │   │   │               ├─ Eq\n" +
-			"                                                     │   │   │               │   ├─ pog.id:10\n" +
-			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:36!null\n" +
+			"                                                     │   │   │               │   ├─ pog.id:7\n" +
+			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:17!null\n" +
 			"                                                     │   │   │               ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   ├─ pog.XVSBH:12\n" +
-			"                                                     │   │   │               │   │   └─ pga.id:14!null\n" +
+			"                                                     │   │   │               │   │   ├─ pog.XVSBH:9\n" +
+			"                                                     │   │   │               │   │   └─ pga.id:11!null\n" +
 			"                                                     │   │   │               │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   │               │   │   ├─ Eq\n" +
 			"                                                     │   │   │               │   │   │   ├─ pa.id:2!null\n" +
-			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:11!null\n" +
+			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:8!null\n" +
 			"                                                     │   │   │               │   │   ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:7!null\n" +
+			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:5!null\n" +
 			"                                                     │   │   │               │   │   │   │   └─ pa.id:2!null\n" +
 			"                                                     │   │   │               │   │   │   ├─ TableAlias(pa)\n" +
 			"                                                     │   │   │               │   │   │   │   └─ Table\n" +
-			"                                                     │   │   │               │   │   │   │       └─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       ├─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               │   │   │   └─ TableAlias(ms)\n" +
 			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess(SZQWJ)\n" +
-			"                                                     │   │   │               │   │   │           └─ index: [SZQWJ.CH3FR]\n" +
+			"                                                     │   │   │               │   │   │           ├─ index: [SZQWJ.CH3FR]\n" +
+			"                                                     │   │   │               │   │   │           └─ columns: [gxlub ch3fr d237e]\n" +
 			"                                                     │   │   │               │   │   └─ TableAlias(pog)\n" +
 			"                                                     │   │   │               │   │       └─ IndexedTableAccess(NPCYY)\n" +
-			"                                                     │   │   │               │   │           └─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
+			"                                                     │   │   │               │   │           ├─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
+			"                                                     │   │   │               │   │           └─ columns: [id ch3fr xvsbh b5ouf]\n" +
 			"                                                     │   │   │               │   └─ TableAlias(pga)\n" +
 			"                                                     │   │   │               │       └─ IndexedTableAccess(PG27A)\n" +
-			"                                                     │   │   │               │           └─ index: [PG27A.id]\n" +
+			"                                                     │   │   │               │           ├─ index: [PG27A.id]\n" +
+			"                                                     │   │   │               │           └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               └─ HashLookup\n" +
-			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:10)\n" +
-			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:19!null)\n" +
+			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:7)\n" +
+			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:4!null)\n" +
 			"                                                     │   │   │                   └─ CachedResults\n" +
 			"                                                     │   │   │                       └─ LookupJoin\n" +
 			"                                                     │   │   │                           ├─ Eq\n" +
-			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:35!null\n" +
-			"                                                     │   │   │                           │   └─ nd.id:17!null\n" +
+			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:16!null\n" +
+			"                                                     │   │   │                           │   └─ nd.id:13!null\n" +
 			"                                                     │   │   │                           ├─ TableAlias(nd)\n" +
 			"                                                     │   │   │                           │   └─ Table\n" +
-			"                                                     │   │   │                           │       └─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       ├─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       └─ columns: [id tw55n hpcms]\n" +
 			"                                                     │   │   │                           └─ TableAlias(GZ7Z4)\n" +
 			"                                                     │   │   │                               └─ IndexedTableAccess(FEIOE)\n" +
-			"                                                     │   │   │                                   └─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
+			"                                                     │   │   │                                   ├─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
+			"                                                     │   │   │                                   └─ columns: [luevy gmsga]\n" +
 			"                                                     │   │   └─ TableAlias(fc)\n" +
 			"                                                     │   │       └─ IndexedTableAccess(AMYXQ)\n" +
-			"                                                     │   │           └─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
+			"                                                     │   │           ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
+			"                                                     │   │           └─ columns: [gxlub luevy oztqf]\n" +
 			"                                                     │   └─ HashLookup\n" +
-			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:17)\n" +
+			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:13)\n" +
 			"                                                     │       ├─ target: TUPLE(F26ZW.T4IBQ:0!null, F26ZW.BRQP2:1!null)\n" +
 			"                                                     │       └─ CachedResults\n" +
 			"                                                     │           └─ SubqueryAlias\n" +
@@ -9846,7 +9911,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -9857,7 +9922,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -9868,7 +9933,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -9879,7 +9944,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -9891,7 +9956,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -9903,7 +9968,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -9912,29 +9977,29 @@ WHERE
 			"                                                     │                   │   THEN 0 (tinyint) ELSE NULL (null) END as YHYLK]\n" +
 			"                                                     │                   └─ LeftOuterLookupJoin\n" +
 			"                                                     │                       ├─ Eq\n" +
-			"                                                     │                       │   ├─ W2MAO.YH4XB:7\n" +
-			"                                                     │                       │   └─ vc.id:8!null\n" +
+			"                                                     │                       │   ├─ W2MAO.YH4XB:6\n" +
+			"                                                     │                       │   └─ vc.id:7!null\n" +
 			"                                                     │                       ├─ LeftOuterLookupJoin\n" +
 			"                                                     │                       │   ├─ Eq\n" +
 			"                                                     │                       │   │   ├─ iq.Z7CP5:2!null\n" +
-			"                                                     │                       │   │   └─ W2MAO.Z7CP5:6!null\n" +
+			"                                                     │                       │   │   └─ W2MAO.Z7CP5:5!null\n" +
 			"                                                     │                       │   ├─ SubqueryAlias\n" +
 			"                                                     │                       │   │   ├─ name: iq\n" +
 			"                                                     │                       │   │   ├─ outerVisibility: false\n" +
 			"                                                     │                       │   │   ├─ cacheable: true\n" +
 			"                                                     │                       │   │   └─ Project\n" +
-			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.BRQP2:72!null, mf.id:34!null as Z7CP5, mf.FSDY2:44!null, nma.DZLIM:69!null as IDWIO]\n" +
+			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.BRQP2:12!null, mf.id:4!null as Z7CP5, mf.FSDY2:7!null, nma.DZLIM:11!null as IDWIO]\n" +
 			"                                                     │                       │   │       └─ HashJoin\n" +
 			"                                                     │                       │   │           ├─ Eq\n" +
-			"                                                     │                       │   │           │   ├─ mf.LUEVY:36!null\n" +
-			"                                                     │                       │   │           │   └─ nd.id:51!null\n" +
+			"                                                     │                       │   │           │   ├─ mf.LUEVY:6!null\n" +
+			"                                                     │                       │   │           │   └─ nd.id:8!null\n" +
 			"                                                     │                       │   │           ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:35!null\n" +
-			"                                                     │                       │   │           │   │   └─ bs.id:30!null\n" +
+			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:5!null\n" +
+			"                                                     │                       │   │           │   │   └─ bs.id:2!null\n" +
 			"                                                     │                       │   │           │   ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:32\n" +
+			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:3\n" +
 			"                                                     │                       │   │           │   │   │   └─ cla.id:0!null\n" +
 			"                                                     │                       │   │           │   │   ├─ Filter\n" +
 			"                                                     │                       │   │           │   │   │   ├─ HashIn\n" +
@@ -9943,43 +10008,52 @@ WHERE
 			"                                                     │                       │   │           │   │   │   └─ TableAlias(cla)\n" +
 			"                                                     │                       │   │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"                                                     │                       │   │           │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"                                                     │                       │   │           │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
+			"                                                     │                       │   │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
+			"                                                     │                       │   │           │   │   │           └─ columns: [id ftqlq]\n" +
 			"                                                     │                       │   │           │   │   └─ TableAlias(bs)\n" +
 			"                                                     │                       │   │           │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"                                                     │                       │   │           │   │           └─ index: [THNTS.IXUXU]\n" +
+			"                                                     │                       │   │           │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"                                                     │                       │   │           │   │           └─ columns: [id ixuxu]\n" +
 			"                                                     │                       │   │           │   └─ TableAlias(mf)\n" +
 			"                                                     │                       │   │           │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"                                                     │                       │   │           │           └─ index: [HGMQ6.GXLUB]\n" +
+			"                                                     │                       │   │           │           ├─ index: [HGMQ6.GXLUB]\n" +
+			"                                                     │                       │   │           │           └─ columns: [id gxlub luevy fsdy2]\n" +
 			"                                                     │                       │   │           └─ HashLookup\n" +
-			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
 			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:0!null)\n" +
 			"                                                     │                       │   │               └─ CachedResults\n" +
 			"                                                     │                       │   │                   └─ LookupJoin\n" +
 			"                                                     │                       │   │                       ├─ Eq\n" +
-			"                                                     │                       │   │                       │   ├─ sn.BRQP2:72!null\n" +
-			"                                                     │                       │   │                       │   └─ nd.id:51!null\n" +
+			"                                                     │                       │   │                       │   ├─ sn.BRQP2:12!null\n" +
+			"                                                     │                       │   │                       │   └─ nd.id:8!null\n" +
 			"                                                     │                       │   │                       ├─ LookupJoin\n" +
 			"                                                     │                       │   │                       │   ├─ Eq\n" +
-			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:63!null\n" +
-			"                                                     │                       │   │                       │   │   └─ nma.id:68!null\n" +
+			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:9!null\n" +
+			"                                                     │                       │   │                       │   │   └─ nma.id:10!null\n" +
 			"                                                     │                       │   │                       │   ├─ TableAlias(nd)\n" +
 			"                                                     │                       │   │                       │   │   └─ Table\n" +
-			"                                                     │                       │   │                       │   │       └─ name: E2I7U\n" +
+			"                                                     │                       │   │                       │   │       ├─ name: E2I7U\n" +
+			"                                                     │                       │   │                       │   │       └─ columns: [id hpcms]\n" +
 			"                                                     │                       │   │                       │   └─ TableAlias(nma)\n" +
 			"                                                     │                       │   │                       │       └─ IndexedTableAccess(TNMXI)\n" +
-			"                                                     │                       │   │                       │           └─ index: [TNMXI.id]\n" +
+			"                                                     │                       │   │                       │           ├─ index: [TNMXI.id]\n" +
+			"                                                     │                       │   │                       │           └─ columns: [id dzlim]\n" +
 			"                                                     │                       │   │                       └─ TableAlias(sn)\n" +
 			"                                                     │                       │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                     │                       │   │                               └─ index: [NOXN3.BRQP2]\n" +
+			"                                                     │                       │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                     │                       │   │                               └─ columns: [brqp2]\n" +
 			"                                                     │                       │   └─ TableAlias(W2MAO)\n" +
 			"                                                     │                       │       └─ IndexedTableAccess(SEQS3)\n" +
-			"                                                     │                       │           └─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
+			"                                                     │                       │           ├─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
+			"                                                     │                       │           └─ columns: [z7cp5 yh4xb]\n" +
 			"                                                     │                       └─ TableAlias(vc)\n" +
 			"                                                     │                           └─ IndexedTableAccess(D34QP)\n" +
-			"                                                     │                               └─ index: [D34QP.id]\n" +
+			"                                                     │                               ├─ index: [D34QP.id]\n" +
+			"                                                     │                               └─ columns: [id znp4p]\n" +
 			"                                                     └─ TableAlias(nma)\n" +
 			"                                                         └─ IndexedTableAccess(TNMXI)\n" +
-			"                                                             └─ index: [TNMXI.id]\n" +
+			"                                                             ├─ index: [TNMXI.id]\n" +
+			"                                                             └─ columns: [id]\n" +
 			"",
 	},
 	{
@@ -10132,34 +10206,34 @@ WHERE
 			"                                         ├─ outerVisibility: false\n" +
 			"                                         ├─ cacheable: true\n" +
 			"                                         └─ Project\n" +
-			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:15 as GSTQA, pog.B5OUF:13, fc.OZTQF:45, F26ZW.YHYLK:51, nd.TW55N:20 as TW55N]\n" +
+			"                                             ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:3 as ECUWU, pga.DZLIM:12 as GSTQA, pog.B5OUF:10, fc.OZTQF:20, F26ZW.YHYLK:24, nd.TW55N:14 as TW55N]\n" +
 			"                                             └─ Filter\n" +
 			"                                                 ├─ Eq\n" +
-			"                                                 │   ├─ ms.D237E:8\n" +
+			"                                                 │   ├─ ms.D237E:6\n" +
 			"                                                 │   └─ %!s(bool=true) (tinyint)\n" +
 			"                                                 └─ LeftOuterLookupJoin\n" +
 			"                                                     ├─ Eq\n" +
-			"                                                     │   ├─ nd.HPCMS:29\n" +
-			"                                                     │   └─ nma.id:52!null\n" +
+			"                                                     │   ├─ nd.HPCMS:15\n" +
+			"                                                     │   └─ nma.id:25!null\n" +
 			"                                                     ├─ LeftOuterHashJoin\n" +
 			"                                                     │   ├─ AND\n" +
 			"                                                     │   │   ├─ Eq\n" +
-			"                                                     │   │   │   ├─ F26ZW.T4IBQ:48!null\n" +
+			"                                                     │   │   │   ├─ F26ZW.T4IBQ:21!null\n" +
 			"                                                     │   │   │   └─ bs.T4IBQ:1!null\n" +
 			"                                                     │   │   └─ Eq\n" +
-			"                                                     │   │       ├─ F26ZW.BRQP2:49!null\n" +
-			"                                                     │   │       └─ nd.id:17\n" +
+			"                                                     │   │       ├─ F26ZW.BRQP2:22!null\n" +
+			"                                                     │   │       └─ nd.id:13\n" +
 			"                                                     │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   ├─ AND\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
 			"                                                     │   │   │   │   ├─ bs.id:0!null\n" +
-			"                                                     │   │   │   │   └─ fc.GXLUB:41!null\n" +
+			"                                                     │   │   │   │   └─ fc.GXLUB:18!null\n" +
 			"                                                     │   │   │   └─ Eq\n" +
-			"                                                     │   │   │       ├─ nd.id:17\n" +
-			"                                                     │   │   │       └─ fc.LUEVY:42!null\n" +
+			"                                                     │   │   │       ├─ nd.id:13\n" +
+			"                                                     │   │   │       └─ fc.LUEVY:19!null\n" +
 			"                                                     │   │   ├─ LeftOuterHashJoin\n" +
 			"                                                     │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │   │   ├─ ms.GXLUB:6!null\n" +
+			"                                                     │   │   │   │   ├─ ms.GXLUB:4!null\n" +
 			"                                                     │   │   │   │   └─ bs.id:0!null\n" +
 			"                                                     │   │   │   ├─ SubqueryAlias\n" +
 			"                                                     │   │   │   │   ├─ name: bs\n" +
@@ -10183,55 +10257,62 @@ WHERE
 			"                                                     │   │   │   │                   └─ columns: [id ftqlq]\n" +
 			"                                                     │   │   │   └─ HashLookup\n" +
 			"                                                     │   │   │       ├─ source: TUPLE(bs.id:0!null)\n" +
-			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:4!null)\n" +
+			"                                                     │   │   │       ├─ target: TUPLE(ms.GXLUB:2!null)\n" +
 			"                                                     │   │   │       └─ CachedResults\n" +
 			"                                                     │   │   │           └─ HashJoin\n" +
 			"                                                     │   │   │               ├─ Eq\n" +
-			"                                                     │   │   │               │   ├─ pog.id:10\n" +
-			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:36!null\n" +
+			"                                                     │   │   │               │   ├─ pog.id:7\n" +
+			"                                                     │   │   │               │   └─ GZ7Z4.GMSGA:17!null\n" +
 			"                                                     │   │   │               ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   ├─ pog.XVSBH:12\n" +
-			"                                                     │   │   │               │   │   └─ pga.id:14!null\n" +
+			"                                                     │   │   │               │   │   ├─ pog.XVSBH:9\n" +
+			"                                                     │   │   │               │   │   └─ pga.id:11!null\n" +
 			"                                                     │   │   │               │   ├─ LeftOuterLookupJoin\n" +
 			"                                                     │   │   │               │   │   ├─ Eq\n" +
 			"                                                     │   │   │               │   │   │   ├─ pa.id:2!null\n" +
-			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:11!null\n" +
+			"                                                     │   │   │               │   │   │   └─ pog.CH3FR:8!null\n" +
 			"                                                     │   │   │               │   │   ├─ LookupJoin\n" +
 			"                                                     │   │   │               │   │   │   ├─ Eq\n" +
-			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:7!null\n" +
+			"                                                     │   │   │               │   │   │   │   ├─ ms.CH3FR:5!null\n" +
 			"                                                     │   │   │               │   │   │   │   └─ pa.id:2!null\n" +
 			"                                                     │   │   │               │   │   │   ├─ TableAlias(pa)\n" +
 			"                                                     │   │   │               │   │   │   │   └─ Table\n" +
-			"                                                     │   │   │               │   │   │   │       └─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       ├─ name: XOAOP\n" +
+			"                                                     │   │   │               │   │   │   │       └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               │   │   │   └─ TableAlias(ms)\n" +
 			"                                                     │   │   │               │   │   │       └─ IndexedTableAccess(SZQWJ)\n" +
-			"                                                     │   │   │               │   │   │           └─ index: [SZQWJ.CH3FR]\n" +
+			"                                                     │   │   │               │   │   │           ├─ index: [SZQWJ.CH3FR]\n" +
+			"                                                     │   │   │               │   │   │           └─ columns: [gxlub ch3fr d237e]\n" +
 			"                                                     │   │   │               │   │   └─ TableAlias(pog)\n" +
 			"                                                     │   │   │               │   │       └─ IndexedTableAccess(NPCYY)\n" +
-			"                                                     │   │   │               │   │           └─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
+			"                                                     │   │   │               │   │           ├─ index: [NPCYY.CH3FR,NPCYY.XVSBH]\n" +
+			"                                                     │   │   │               │   │           └─ columns: [id ch3fr xvsbh b5ouf]\n" +
 			"                                                     │   │   │               │   └─ TableAlias(pga)\n" +
 			"                                                     │   │   │               │       └─ IndexedTableAccess(PG27A)\n" +
-			"                                                     │   │   │               │           └─ index: [PG27A.id]\n" +
+			"                                                     │   │   │               │           ├─ index: [PG27A.id]\n" +
+			"                                                     │   │   │               │           └─ columns: [id dzlim]\n" +
 			"                                                     │   │   │               └─ HashLookup\n" +
-			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:10)\n" +
-			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:19!null)\n" +
+			"                                                     │   │   │                   ├─ source: TUPLE(pog.id:7)\n" +
+			"                                                     │   │   │                   ├─ target: TUPLE(GZ7Z4.GMSGA:4!null)\n" +
 			"                                                     │   │   │                   └─ CachedResults\n" +
 			"                                                     │   │   │                       └─ LookupJoin\n" +
 			"                                                     │   │   │                           ├─ Eq\n" +
-			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:35!null\n" +
-			"                                                     │   │   │                           │   └─ nd.id:17!null\n" +
+			"                                                     │   │   │                           │   ├─ GZ7Z4.LUEVY:16!null\n" +
+			"                                                     │   │   │                           │   └─ nd.id:13!null\n" +
 			"                                                     │   │   │                           ├─ TableAlias(nd)\n" +
 			"                                                     │   │   │                           │   └─ Table\n" +
-			"                                                     │   │   │                           │       └─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       ├─ name: E2I7U\n" +
+			"                                                     │   │   │                           │       └─ columns: [id tw55n hpcms]\n" +
 			"                                                     │   │   │                           └─ TableAlias(GZ7Z4)\n" +
 			"                                                     │   │   │                               └─ IndexedTableAccess(FEIOE)\n" +
-			"                                                     │   │   │                                   └─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
+			"                                                     │   │   │                                   ├─ index: [FEIOE.LUEVY,FEIOE.GMSGA]\n" +
+			"                                                     │   │   │                                   └─ columns: [luevy gmsga]\n" +
 			"                                                     │   │   └─ TableAlias(fc)\n" +
 			"                                                     │   │       └─ IndexedTableAccess(AMYXQ)\n" +
-			"                                                     │   │           └─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
+			"                                                     │   │           ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
+			"                                                     │   │           └─ columns: [gxlub luevy oztqf]\n" +
 			"                                                     │   └─ HashLookup\n" +
-			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:17)\n" +
+			"                                                     │       ├─ source: TUPLE(bs.T4IBQ:1!null, nd.id:13)\n" +
 			"                                                     │       ├─ target: TUPLE(F26ZW.T4IBQ:0!null, F26ZW.BRQP2:1!null)\n" +
 			"                                                     │       └─ CachedResults\n" +
 			"                                                     │           └─ SubqueryAlias\n" +
@@ -10245,7 +10326,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -10256,7 +10337,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -10267,7 +10348,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   └─ Eq\n" +
 			"                                                     │                   │       ├─ iq.IDWIO:4!null\n" +
@@ -10278,7 +10359,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -10290,7 +10371,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -10302,7 +10383,7 @@ WHERE
 			"                                                     │                   │   │   │   ├─ left: iq.FSDY2:3!null\n" +
 			"                                                     │                   │   │   │   └─ right: TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"                                                     │                   │   │   └─ (NOT(Eq\n" +
-			"                                                     │                   │   │       ├─ vc.ZNP4P:13\n" +
+			"                                                     │                   │   │       ├─ vc.ZNP4P:8\n" +
 			"                                                     │                   │   │       └─ L5Q44 (longtext)\n" +
 			"                                                     │                   │   │      ))\n" +
 			"                                                     │                   │   └─ Eq\n" +
@@ -10311,73 +10392,82 @@ WHERE
 			"                                                     │                   │   THEN 0 (tinyint) ELSE NULL (null) END as YHYLK]\n" +
 			"                                                     │                   └─ LeftOuterLookupJoin\n" +
 			"                                                     │                       ├─ Eq\n" +
-			"                                                     │                       │   ├─ W2MAO.YH4XB:7\n" +
-			"                                                     │                       │   └─ vc.id:8!null\n" +
+			"                                                     │                       │   ├─ W2MAO.YH4XB:6\n" +
+			"                                                     │                       │   └─ vc.id:7!null\n" +
 			"                                                     │                       ├─ LeftOuterLookupJoin\n" +
 			"                                                     │                       │   ├─ Eq\n" +
 			"                                                     │                       │   │   ├─ iq.Z7CP5:2!null\n" +
-			"                                                     │                       │   │   └─ W2MAO.Z7CP5:6!null\n" +
+			"                                                     │                       │   │   └─ W2MAO.Z7CP5:5!null\n" +
 			"                                                     │                       │   ├─ SubqueryAlias\n" +
 			"                                                     │                       │   │   ├─ name: iq\n" +
 			"                                                     │                       │   │   ├─ outerVisibility: false\n" +
 			"                                                     │                       │   │   ├─ cacheable: true\n" +
 			"                                                     │                       │   │   └─ Project\n" +
-			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.BRQP2:72!null, mf.id:34!null as Z7CP5, mf.FSDY2:44!null, nma.DZLIM:52!null as IDWIO]\n" +
+			"                                                     │                       │   │       ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.BRQP2:12!null, mf.id:4!null as Z7CP5, mf.FSDY2:7!null, nma.DZLIM:9!null as IDWIO]\n" +
 			"                                                     │                       │   │       └─ HashJoin\n" +
 			"                                                     │                       │   │           ├─ Eq\n" +
-			"                                                     │                       │   │           │   ├─ mf.LUEVY:36!null\n" +
-			"                                                     │                       │   │           │   └─ nd.id:54!null\n" +
+			"                                                     │                       │   │           │   ├─ mf.LUEVY:6!null\n" +
+			"                                                     │                       │   │           │   └─ nd.id:10!null\n" +
 			"                                                     │                       │   │           ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:35!null\n" +
+			"                                                     │                       │   │           │   │   ├─ mf.GXLUB:5!null\n" +
 			"                                                     │                       │   │           │   │   └─ bs.id:0!null\n" +
 			"                                                     │                       │   │           │   ├─ LookupJoin\n" +
 			"                                                     │                       │   │           │   │   ├─ Eq\n" +
-			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:2\n" +
-			"                                                     │                       │   │           │   │   │   └─ cla.id:4!null\n" +
+			"                                                     │                       │   │           │   │   │   ├─ bs.IXUXU:1\n" +
+			"                                                     │                       │   │           │   │   │   └─ cla.id:2!null\n" +
 			"                                                     │                       │   │           │   │   ├─ TableAlias(bs)\n" +
 			"                                                     │                       │   │           │   │   │   └─ Table\n" +
-			"                                                     │                       │   │           │   │   │       └─ name: THNTS\n" +
+			"                                                     │                       │   │           │   │   │       ├─ name: THNTS\n" +
+			"                                                     │                       │   │           │   │   │       └─ columns: [id ixuxu]\n" +
 			"                                                     │                       │   │           │   │   └─ Filter\n" +
 			"                                                     │                       │   │           │   │       ├─ HashIn\n" +
 			"                                                     │                       │   │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                                                     │                       │   │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                                                     │                       │   │           │   │       └─ TableAlias(cla)\n" +
 			"                                                     │                       │   │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
-			"                                                     │                       │   │           │   │               └─ index: [YK2GW.id]\n" +
+			"                                                     │                       │   │           │   │               ├─ index: [YK2GW.id]\n" +
+			"                                                     │                       │   │           │   │               └─ columns: [id ftqlq]\n" +
 			"                                                     │                       │   │           │   └─ TableAlias(mf)\n" +
 			"                                                     │                       │   │           │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"                                                     │                       │   │           │           └─ index: [HGMQ6.GXLUB]\n" +
+			"                                                     │                       │   │           │           ├─ index: [HGMQ6.GXLUB]\n" +
+			"                                                     │                       │   │           │           └─ columns: [id gxlub luevy fsdy2]\n" +
 			"                                                     │                       │   │           └─ HashLookup\n" +
-			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
-			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:3!null)\n" +
+			"                                                     │                       │   │               ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
+			"                                                     │                       │   │               ├─ target: TUPLE(nd.id:2!null)\n" +
 			"                                                     │                       │   │               └─ CachedResults\n" +
 			"                                                     │                       │   │                   └─ LookupJoin\n" +
 			"                                                     │                       │   │                       ├─ Eq\n" +
-			"                                                     │                       │   │                       │   ├─ sn.BRQP2:72!null\n" +
-			"                                                     │                       │   │                       │   └─ nd.id:54!null\n" +
+			"                                                     │                       │   │                       │   ├─ sn.BRQP2:12!null\n" +
+			"                                                     │                       │   │                       │   └─ nd.id:10!null\n" +
 			"                                                     │                       │   │                       ├─ LookupJoin\n" +
 			"                                                     │                       │   │                       │   ├─ Eq\n" +
-			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:66!null\n" +
-			"                                                     │                       │   │                       │   │   └─ nma.id:51!null\n" +
+			"                                                     │                       │   │                       │   │   ├─ nd.HPCMS:11!null\n" +
+			"                                                     │                       │   │                       │   │   └─ nma.id:8!null\n" +
 			"                                                     │                       │   │                       │   ├─ TableAlias(nma)\n" +
 			"                                                     │                       │   │                       │   │   └─ Table\n" +
-			"                                                     │                       │   │                       │   │       └─ name: TNMXI\n" +
+			"                                                     │                       │   │                       │   │       ├─ name: TNMXI\n" +
+			"                                                     │                       │   │                       │   │       └─ columns: [id dzlim]\n" +
 			"                                                     │                       │   │                       │   └─ TableAlias(nd)\n" +
 			"                                                     │                       │   │                       │       └─ IndexedTableAccess(E2I7U)\n" +
-			"                                                     │                       │   │                       │           └─ index: [E2I7U.HPCMS]\n" +
+			"                                                     │                       │   │                       │           ├─ index: [E2I7U.HPCMS]\n" +
+			"                                                     │                       │   │                       │           └─ columns: [id hpcms]\n" +
 			"                                                     │                       │   │                       └─ TableAlias(sn)\n" +
 			"                                                     │                       │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                     │                       │   │                               └─ index: [NOXN3.BRQP2]\n" +
+			"                                                     │                       │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                     │                       │   │                               └─ columns: [brqp2]\n" +
 			"                                                     │                       │   └─ TableAlias(W2MAO)\n" +
 			"                                                     │                       │       └─ IndexedTableAccess(SEQS3)\n" +
-			"                                                     │                       │           └─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
+			"                                                     │                       │           ├─ index: [SEQS3.Z7CP5,SEQS3.YH4XB]\n" +
+			"                                                     │                       │           └─ columns: [z7cp5 yh4xb]\n" +
 			"                                                     │                       └─ TableAlias(vc)\n" +
 			"                                                     │                           └─ IndexedTableAccess(D34QP)\n" +
-			"                                                     │                               └─ index: [D34QP.id]\n" +
+			"                                                     │                               ├─ index: [D34QP.id]\n" +
+			"                                                     │                               └─ columns: [id znp4p]\n" +
 			"                                                     └─ TableAlias(nma)\n" +
 			"                                                         └─ IndexedTableAccess(TNMXI)\n" +
-			"                                                             └─ index: [TNMXI.id]\n" +
+			"                                                             ├─ index: [TNMXI.id]\n" +
+			"                                                             └─ columns: [id]\n" +
 			"",
 	},
 	{
@@ -10661,29 +10751,29 @@ WHERE
 			"             │               ├─ outerVisibility: false\n" +
 			"             │               ├─ cacheable: true\n" +
 			"             │               └─ Project\n" +
-			"             │                   ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:51!null as BDNYB, aac.BTXC5:62 as BTXC5, mf.id:34!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:45 IS NULL)) THEN mf.LT7K6:45 ELSE mf.SPPYD:46 END as vaf, CASE  WHEN (NOT(mf.QCGTS:47 IS NULL)) THEN mf.QCGTS:47 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
-			"             │                   │   ├─ vc.ZNP4P:72!null\n" +
+			"             │                   ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:12!null as BDNYB, aac.BTXC5:15 as BTXC5, mf.id:4!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:9 IS NULL)) THEN mf.LT7K6:9 ELSE mf.SPPYD:10 END as vaf, CASE  WHEN (NOT(mf.QCGTS:11 IS NULL)) THEN mf.QCGTS:11 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
+			"             │                   │   ├─ vc.ZNP4P:19!null\n" +
 			"             │                   │   └─ L5Q44 (longtext)\n" +
 			"             │                   │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
 			"             │                   └─ HashJoin\n" +
 			"             │                       ├─ Eq\n" +
-			"             │                       │   ├─ W2MAO.Z7CP5:65!null\n" +
-			"             │                       │   └─ mf.id:34!null\n" +
+			"             │                       │   ├─ W2MAO.Z7CP5:16!null\n" +
+			"             │                       │   └─ mf.id:4!null\n" +
 			"             │                       ├─ LookupJoin\n" +
 			"             │                       │   ├─ Eq\n" +
-			"             │                       │   │   ├─ aac.id:61!null\n" +
-			"             │                       │   │   └─ mf.M22QN:37!null\n" +
+			"             │                       │   │   ├─ aac.id:14!null\n" +
+			"             │                       │   │   └─ mf.M22QN:7!null\n" +
 			"             │                       │   ├─ HashJoin\n" +
 			"             │                       │   │   ├─ Eq\n" +
-			"             │                       │   │   │   ├─ sn.BRQP2:52!null\n" +
-			"             │                       │   │   │   └─ mf.LUEVY:36!null\n" +
+			"             │                       │   │   │   ├─ sn.BRQP2:13!null\n" +
+			"             │                       │   │   │   └─ mf.LUEVY:6!null\n" +
 			"             │                       │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   ├─ mf.GXLUB:35!null\n" +
-			"             │                       │   │   │   │   └─ bs.id:30!null\n" +
+			"             │                       │   │   │   │   ├─ mf.GXLUB:5!null\n" +
+			"             │                       │   │   │   │   └─ bs.id:2!null\n" +
 			"             │                       │   │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   │   ├─ bs.IXUXU:32\n" +
+			"             │                       │   │   │   │   │   ├─ bs.IXUXU:3\n" +
 			"             │                       │   │   │   │   │   └─ cla.id:0!null\n" +
 			"             │                       │   │   │   │   ├─ Filter\n" +
 			"             │                       │   │   │   │   │   ├─ HashIn\n" +
@@ -10692,41 +10782,48 @@ WHERE
 			"             │                       │   │   │   │   │   └─ TableAlias(cla)\n" +
 			"             │                       │   │   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"             │                       │   │   │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"             │                       │   │   │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
+			"             │                       │   │   │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
+			"             │                       │   │   │   │   │           └─ columns: [id ftqlq]\n" +
 			"             │                       │   │   │   │   └─ TableAlias(bs)\n" +
 			"             │                       │   │   │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"             │                       │   │   │   │           └─ index: [THNTS.IXUXU]\n" +
+			"             │                       │   │   │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"             │                       │   │   │   │           └─ columns: [id ixuxu]\n" +
 			"             │                       │   │   │   └─ Filter\n" +
 			"             │                       │   │   │       ├─ HashIn\n" +
-			"             │                       │   │   │       │   ├─ mf.FSDY2:10!null\n" +
+			"             │                       │   │   │       │   ├─ mf.FSDY2:4!null\n" +
 			"             │                       │   │   │       │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"             │                       │   │   │       └─ TableAlias(mf)\n" +
 			"             │                       │   │   │           └─ IndexedTableAccess(HGMQ6)\n" +
-			"             │                       │   │   │               └─ index: [HGMQ6.GXLUB]\n" +
+			"             │                       │   │   │               ├─ index: [HGMQ6.GXLUB]\n" +
+			"             │                       │   │   │               └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
 			"             │                       │   │   └─ HashLookup\n" +
-			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
 			"             │                       │   │       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"             │                       │   │       └─ CachedResults\n" +
 			"             │                       │   │           └─ TableAlias(sn)\n" +
 			"             │                       │   │               └─ Table\n" +
-			"             │                       │   │                   └─ name: NOXN3\n" +
+			"             │                       │   │                   ├─ name: NOXN3\n" +
+			"             │                       │   │                   └─ columns: [id brqp2]\n" +
 			"             │                       │   └─ TableAlias(aac)\n" +
 			"             │                       │       └─ IndexedTableAccess(TPXBU)\n" +
-			"             │                       │           └─ index: [TPXBU.id]\n" +
+			"             │                       │           ├─ index: [TPXBU.id]\n" +
+			"             │                       │           └─ columns: [id btxc5]\n" +
 			"             │                       └─ HashLookup\n" +
-			"             │                           ├─ source: TUPLE(mf.id:34!null)\n" +
-			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:1!null)\n" +
+			"             │                           ├─ source: TUPLE(mf.id:4!null)\n" +
+			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:0!null)\n" +
 			"             │                           └─ CachedResults\n" +
 			"             │                               └─ LookupJoin\n" +
 			"             │                                   ├─ Eq\n" +
-			"             │                                   │   ├─ vc.id:67!null\n" +
-			"             │                                   │   └─ W2MAO.YH4XB:66!null\n" +
+			"             │                                   │   ├─ vc.id:18!null\n" +
+			"             │                                   │   └─ W2MAO.YH4XB:17!null\n" +
 			"             │                                   ├─ TableAlias(W2MAO)\n" +
 			"             │                                   │   └─ Table\n" +
-			"             │                                   │       └─ name: SEQS3\n" +
+			"             │                                   │       ├─ name: SEQS3\n" +
+			"             │                                   │       └─ columns: [z7cp5 yh4xb]\n" +
 			"             │                                   └─ TableAlias(vc)\n" +
 			"             │                                       └─ IndexedTableAccess(D34QP)\n" +
-			"             │                                           └─ index: [D34QP.id]\n" +
+			"             │                                           ├─ index: [D34QP.id]\n" +
+			"             │                                           └─ columns: [id znp4p]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(OXXEI.BDNYB:3!null)\n" +
 			"                 ├─ target: TUPLE(E52AP.BDNYB:1!null)\n" +
@@ -10737,32 +10834,35 @@ WHERE
 			"                         ├─ cacheable: true\n" +
 			"                         └─ Sort(BDNYB:1!null ASC nullsFirst)\n" +
 			"                             └─ Project\n" +
-			"                                 ├─ columns: [nd.TW55N:13 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28 as YHVEZ, CASE  WHEN LessThan\n" +
-			"                                 │   ├─ nd.TCE7A:20\n" +
+			"                                 ├─ columns: [nd.TW55N:3 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:7 as YHVEZ, CASE  WHEN LessThan\n" +
+			"                                 │   ├─ nd.TCE7A:4\n" +
 			"                                 │   └─ 0.900000 (double)\n" +
 			"                                 │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
 			"                                 └─ Filter\n" +
 			"                                     ├─ (NOT(Eq\n" +
-			"                                     │   ├─ nma.DZLIM:28\n" +
+			"                                     │   ├─ nma.DZLIM:7\n" +
 			"                                     │   └─ Q5I4E (longtext)\n" +
 			"                                     │  ))\n" +
 			"                                     └─ LeftOuterLookupJoin\n" +
 			"                                         ├─ Eq\n" +
-			"                                         │   ├─ nd.HPCMS:22\n" +
-			"                                         │   └─ nma.id:27!null\n" +
+			"                                         │   ├─ nd.HPCMS:5\n" +
+			"                                         │   └─ nma.id:6!null\n" +
 			"                                         ├─ LeftOuterLookupJoin\n" +
 			"                                         │   ├─ Eq\n" +
 			"                                         │   │   ├─ sn.BRQP2:1!null\n" +
-			"                                         │   │   └─ nd.id:10!null\n" +
+			"                                         │   │   └─ nd.id:2!null\n" +
 			"                                         │   ├─ TableAlias(sn)\n" +
 			"                                         │   │   └─ Table\n" +
-			"                                         │   │       └─ name: NOXN3\n" +
+			"                                         │   │       ├─ name: NOXN3\n" +
+			"                                         │   │       └─ columns: [id brqp2]\n" +
 			"                                         │   └─ TableAlias(nd)\n" +
 			"                                         │       └─ IndexedTableAccess(E2I7U)\n" +
-			"                                         │           └─ index: [E2I7U.id]\n" +
+			"                                         │           ├─ index: [E2I7U.id]\n" +
+			"                                         │           └─ columns: [id tw55n tce7a hpcms]\n" +
 			"                                         └─ TableAlias(nma)\n" +
 			"                                             └─ IndexedTableAccess(TNMXI)\n" +
-			"                                                 └─ index: [TNMXI.id]\n" +
+			"                                                 ├─ index: [TNMXI.id]\n" +
+			"                                                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -10864,71 +10964,78 @@ WHERE
 			"             │               ├─ outerVisibility: false\n" +
 			"             │               ├─ cacheable: true\n" +
 			"             │               └─ Project\n" +
-			"             │                   ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.id:51!null as BDNYB, aac.BTXC5:62 as BTXC5, mf.id:34!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:45 IS NULL)) THEN mf.LT7K6:45 ELSE mf.SPPYD:46 END as vaf, CASE  WHEN (NOT(mf.QCGTS:47 IS NULL)) THEN mf.QCGTS:47 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
-			"             │                   │   ├─ vc.ZNP4P:69!null\n" +
+			"             │                   ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.id:12!null as BDNYB, aac.BTXC5:15 as BTXC5, mf.id:4!null as Z7CP5, CASE  WHEN (NOT(mf.LT7K6:9 IS NULL)) THEN mf.LT7K6:9 ELSE mf.SPPYD:10 END as vaf, CASE  WHEN (NOT(mf.QCGTS:11 IS NULL)) THEN mf.QCGTS:11 ELSE 0.500000 (double) END as QCGTS, CASE  WHEN Eq\n" +
+			"             │                   │   ├─ vc.ZNP4P:17!null\n" +
 			"             │                   │   └─ L5Q44 (longtext)\n" +
 			"             │                   │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
 			"             │                   └─ HashJoin\n" +
 			"             │                       ├─ Eq\n" +
-			"             │                       │   ├─ W2MAO.Z7CP5:71!null\n" +
-			"             │                       │   └─ mf.id:34!null\n" +
+			"             │                       │   ├─ W2MAO.Z7CP5:18!null\n" +
+			"             │                       │   └─ mf.id:4!null\n" +
 			"             │                       ├─ LookupJoin\n" +
 			"             │                       │   ├─ Eq\n" +
-			"             │                       │   │   ├─ aac.id:61!null\n" +
-			"             │                       │   │   └─ mf.M22QN:37!null\n" +
+			"             │                       │   │   ├─ aac.id:14!null\n" +
+			"             │                       │   │   └─ mf.M22QN:7!null\n" +
 			"             │                       │   ├─ HashJoin\n" +
 			"             │                       │   │   ├─ Eq\n" +
-			"             │                       │   │   │   ├─ sn.BRQP2:52!null\n" +
-			"             │                       │   │   │   └─ mf.LUEVY:36!null\n" +
+			"             │                       │   │   │   ├─ sn.BRQP2:13!null\n" +
+			"             │                       │   │   │   └─ mf.LUEVY:6!null\n" +
 			"             │                       │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   ├─ mf.GXLUB:35!null\n" +
+			"             │                       │   │   │   │   ├─ mf.GXLUB:5!null\n" +
 			"             │                       │   │   │   │   └─ bs.id:0!null\n" +
 			"             │                       │   │   │   ├─ LookupJoin\n" +
 			"             │                       │   │   │   │   ├─ Eq\n" +
-			"             │                       │   │   │   │   │   ├─ bs.IXUXU:2\n" +
-			"             │                       │   │   │   │   │   └─ cla.id:4!null\n" +
+			"             │                       │   │   │   │   │   ├─ bs.IXUXU:1\n" +
+			"             │                       │   │   │   │   │   └─ cla.id:2!null\n" +
 			"             │                       │   │   │   │   ├─ TableAlias(bs)\n" +
 			"             │                       │   │   │   │   │   └─ Table\n" +
-			"             │                       │   │   │   │   │       └─ name: THNTS\n" +
+			"             │                       │   │   │   │   │       ├─ name: THNTS\n" +
+			"             │                       │   │   │   │   │       └─ columns: [id ixuxu]\n" +
 			"             │                       │   │   │   │   └─ Filter\n" +
 			"             │                       │   │   │   │       ├─ HashIn\n" +
 			"             │                       │   │   │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"             │                       │   │   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"             │                       │   │   │   │       └─ TableAlias(cla)\n" +
 			"             │                       │   │   │   │           └─ IndexedTableAccess(YK2GW)\n" +
-			"             │                       │   │   │   │               └─ index: [YK2GW.id]\n" +
+			"             │                       │   │   │   │               ├─ index: [YK2GW.id]\n" +
+			"             │                       │   │   │   │               └─ columns: [id ftqlq]\n" +
 			"             │                       │   │   │   └─ Filter\n" +
 			"             │                       │   │   │       ├─ HashIn\n" +
-			"             │                       │   │   │       │   ├─ mf.FSDY2:10!null\n" +
+			"             │                       │   │   │       │   ├─ mf.FSDY2:4!null\n" +
 			"             │                       │   │   │       │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
 			"             │                       │   │   │       └─ TableAlias(mf)\n" +
 			"             │                       │   │   │           └─ IndexedTableAccess(HGMQ6)\n" +
-			"             │                       │   │   │               └─ index: [HGMQ6.GXLUB]\n" +
+			"             │                       │   │   │               ├─ index: [HGMQ6.GXLUB]\n" +
+			"             │                       │   │   │               └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
 			"             │                       │   │   └─ HashLookup\n" +
-			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"             │                       │   │       ├─ source: TUPLE(mf.LUEVY:6!null)\n" +
 			"             │                       │   │       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"             │                       │   │       └─ CachedResults\n" +
 			"             │                       │   │           └─ TableAlias(sn)\n" +
 			"             │                       │   │               └─ Table\n" +
-			"             │                       │   │                   └─ name: NOXN3\n" +
+			"             │                       │   │                   ├─ name: NOXN3\n" +
+			"             │                       │   │                   └─ columns: [id brqp2]\n" +
 			"             │                       │   └─ TableAlias(aac)\n" +
 			"             │                       │       └─ IndexedTableAccess(TPXBU)\n" +
-			"             │                       │           └─ index: [TPXBU.id]\n" +
+			"             │                       │           ├─ index: [TPXBU.id]\n" +
+			"             │                       │           └─ columns: [id btxc5]\n" +
 			"             │                       └─ HashLookup\n" +
-			"             │                           ├─ source: TUPLE(mf.id:34!null)\n" +
-			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:7!null)\n" +
+			"             │                           ├─ source: TUPLE(mf.id:4!null)\n" +
+			"             │                           ├─ target: TUPLE(W2MAO.Z7CP5:2!null)\n" +
 			"             │                           └─ CachedResults\n" +
 			"             │                               └─ LookupJoin\n" +
 			"             │                                   ├─ Eq\n" +
-			"             │                                   │   ├─ vc.id:64!null\n" +
-			"             │                                   │   └─ W2MAO.YH4XB:72!null\n" +
+			"             │                                   │   ├─ vc.id:16!null\n" +
+			"             │                                   │   └─ W2MAO.YH4XB:19!null\n" +
 			"             │                                   ├─ TableAlias(vc)\n" +
 			"             │                                   │   └─ Table\n" +
-			"             │                                   │       └─ name: D34QP\n" +
+			"             │                                   │       ├─ name: D34QP\n" +
+			"             │                                   │       └─ columns: [id znp4p]\n" +
 			"             │                                   └─ TableAlias(W2MAO)\n" +
 			"             │                                       └─ IndexedTableAccess(SEQS3)\n" +
-			"             │                                           └─ index: [SEQS3.YH4XB]\n" +
+			"             │                                           ├─ index: [SEQS3.YH4XB]\n" +
+			"             │                                           └─ columns: [z7cp5 yh4xb]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ source: TUPLE(OXXEI.BDNYB:3!null)\n" +
 			"                 ├─ target: TUPLE(E52AP.BDNYB:1!null)\n" +
@@ -10939,32 +11046,35 @@ WHERE
 			"                         ├─ cacheable: true\n" +
 			"                         └─ Sort(BDNYB:1!null ASC nullsFirst)\n" +
 			"                             └─ Project\n" +
-			"                                 ├─ columns: [nd.TW55N:13 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28 as YHVEZ, CASE  WHEN LessThan\n" +
-			"                                 │   ├─ nd.TCE7A:20\n" +
+			"                                 ├─ columns: [nd.TW55N:3 as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:7 as YHVEZ, CASE  WHEN LessThan\n" +
+			"                                 │   ├─ nd.TCE7A:4\n" +
 			"                                 │   └─ 0.900000 (double)\n" +
 			"                                 │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
 			"                                 └─ Filter\n" +
 			"                                     ├─ (NOT(Eq\n" +
-			"                                     │   ├─ nma.DZLIM:28\n" +
+			"                                     │   ├─ nma.DZLIM:7\n" +
 			"                                     │   └─ Q5I4E (longtext)\n" +
 			"                                     │  ))\n" +
 			"                                     └─ LeftOuterLookupJoin\n" +
 			"                                         ├─ Eq\n" +
-			"                                         │   ├─ nd.HPCMS:22\n" +
-			"                                         │   └─ nma.id:27!null\n" +
+			"                                         │   ├─ nd.HPCMS:5\n" +
+			"                                         │   └─ nma.id:6!null\n" +
 			"                                         ├─ LeftOuterLookupJoin\n" +
 			"                                         │   ├─ Eq\n" +
 			"                                         │   │   ├─ sn.BRQP2:1!null\n" +
-			"                                         │   │   └─ nd.id:10!null\n" +
+			"                                         │   │   └─ nd.id:2!null\n" +
 			"                                         │   ├─ TableAlias(sn)\n" +
 			"                                         │   │   └─ Table\n" +
-			"                                         │   │       └─ name: NOXN3\n" +
+			"                                         │   │       ├─ name: NOXN3\n" +
+			"                                         │   │       └─ columns: [id brqp2]\n" +
 			"                                         │   └─ TableAlias(nd)\n" +
 			"                                         │       └─ IndexedTableAccess(E2I7U)\n" +
-			"                                         │           └─ index: [E2I7U.id]\n" +
+			"                                         │           ├─ index: [E2I7U.id]\n" +
+			"                                         │           └─ columns: [id tw55n tce7a hpcms]\n" +
 			"                                         └─ TableAlias(nma)\n" +
 			"                                             └─ IndexedTableAccess(TNMXI)\n" +
-			"                                                 └─ index: [TNMXI.id]\n" +
+			"                                                 ├─ index: [TNMXI.id]\n" +
+			"                                                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -11218,7 +11328,8 @@ WHERE
 			"     │   │   │   │   │                       │   └─ MJR3D.BJUF2:1\n" +
 			"     │   │   │   │   │                       └─ TableAlias(JTEHG)\n" +
 			"     │   │   │   │   │                           └─ Table\n" +
-			"     │   │   │   │   │                               └─ name: NOXN3\n" +
+			"     │   │   │   │   │                               ├─ name: NOXN3\n" +
+			"     │   │   │   │   │                               └─ columns: [id brqp2]\n" +
 			"     │   │   │   │   └─ AND\n" +
 			"     │   │   │   │       ├─ AND\n" +
 			"     │   │   │   │       │   ├─ (NOT(MJR3D.TDEIU:10 IS NULL))\n" +
@@ -11235,7 +11346,8 @@ WHERE
 			"     │   │   │   │                       │   └─ MJR3D.FJDP5:0!null\n" +
 			"     │   │   │   │                       └─ TableAlias(XMAFZ)\n" +
 			"     │   │   │   │                           └─ Table\n" +
-			"     │   │   │   │                               └─ name: NOXN3\n" +
+			"     │   │   │   │                               ├─ name: NOXN3\n" +
+			"     │   │   │   │                               └─ columns: [id brqp2]\n" +
 			"     │   │   │   └─ AND\n" +
 			"     │   │   │       ├─ AND\n" +
 			"     │   │   │       │   ├─ (NOT(MJR3D.TDEIU:10 IS NULL))\n" +
@@ -11252,7 +11364,8 @@ WHERE
 			"     │   │   │                       │   └─ MJR3D.BJUF2:1\n" +
 			"     │   │   │                       └─ TableAlias(XMAFZ)\n" +
 			"     │   │   │                           └─ Table\n" +
-			"     │   │   │                               └─ name: NOXN3\n" +
+			"     │   │   │                               ├─ name: NOXN3\n" +
+			"     │   │   │                               └─ columns: [id brqp2]\n" +
 			"     │   │   ├─ SubqueryAlias\n" +
 			"     │   │   │   ├─ name: MJR3D\n" +
 			"     │   │   │   ├─ outerVisibility: false\n" +
@@ -11282,74 +11395,80 @@ WHERE
 			"     │   │   │       │       │           │       ├─ QNI57:9 IS NULL\n" +
 			"     │   │   │       │       │           │       └─ (NOT(TDEIU:10 IS NULL))\n" +
 			"     │   │   │       │       │           └─ Project\n" +
-			"     │   │   │       │       │               ├─ columns: [ism.FV24E:1!null as FJDP5, CPMFE.id:27 as BJUF2, CPMFE.TW55N:30 as PSMU6, ism.M22QN:3!null as M22QN, G3YXS.GE5EL:12, G3YXS.F7A4Q:13, G3YXS.ESFVY:10!null, CASE  WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               ├─ columns: [ism.FV24E:0!null as FJDP5, CPMFE.id:12 as BJUF2, CPMFE.TW55N:13 as PSMU6, ism.M22QN:2!null as M22QN, G3YXS.GE5EL:8, G3YXS.F7A4Q:9, G3YXS.ESFVY:6!null, CASE  WHEN IN\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"     │   │   │       │       │               │   THEN 0 (tinyint) WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
 			"     │   │   │       │       │               │   THEN 1 (tinyint) WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
 			"     │   │   │       │       │               │   THEN 2 (tinyint) WHEN IN\n" +
-			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │       │               │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │       │               │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"     │   │   │       │       │               │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:11!null as SL76B, YQIF4.id:44 as QNI57, YVHJZ.id:54 as TDEIU]\n" +
+			"     │   │   │       │       │               │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:7!null as SL76B, YQIF4.id:15 as QNI57, YVHJZ.id:18 as TDEIU]\n" +
 			"     │   │   │       │       │               └─ Filter\n" +
 			"     │   │   │       │       │                   ├─ Or\n" +
-			"     │   │   │       │       │                   │   ├─ (NOT(YQIF4.id:44 IS NULL))\n" +
-			"     │   │   │       │       │                   │   └─ (NOT(YVHJZ.id:54 IS NULL))\n" +
+			"     │   │   │       │       │                   │   ├─ (NOT(YQIF4.id:15 IS NULL))\n" +
+			"     │   │   │       │       │                   │   └─ (NOT(YVHJZ.id:18 IS NULL))\n" +
 			"     │   │   │       │       │                   └─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       ├─ AND\n" +
 			"     │   │   │       │       │                       │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   ├─ YVHJZ.BRQP2:55!null\n" +
-			"     │   │   │       │       │                       │   │   └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │       │                       │   │   ├─ YVHJZ.BRQP2:19!null\n" +
+			"     │   │   │       │       │                       │   │   └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │       │                       │   └─ Eq\n" +
-			"     │   │   │       │       │                       │       ├─ YVHJZ.FFTBJ:56!null\n" +
-			"     │   │   │       │       │                       │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │       │                       │       ├─ YVHJZ.FFTBJ:20!null\n" +
+			"     │   │   │       │       │                       │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │       │                       ├─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       │   ├─ AND\n" +
 			"     │   │   │       │       │                       │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   ├─ YQIF4.BRQP2:45!null\n" +
-			"     │   │   │       │       │                       │   │   │   └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │       │                       │   │   │   ├─ YQIF4.BRQP2:16!null\n" +
+			"     │   │   │       │       │                       │   │   │   └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │       │                       │   │   └─ Eq\n" +
-			"     │   │   │       │       │                       │   │       ├─ YQIF4.FFTBJ:46!null\n" +
-			"     │   │   │       │       │                       │   │       └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │       │                       │   │       ├─ YQIF4.FFTBJ:17!null\n" +
+			"     │   │   │       │       │                       │   │       └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │       │                       │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       │   │   ├─ AND\n" +
 			"     │   │   │       │       │                       │   │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   │   ├─ CPMFE.ZH72S:34\n" +
-			"     │   │   │       │       │                       │   │   │   │   └─ NHMXW.NOHHR:18\n" +
+			"     │   │   │       │       │                       │   │   │   │   ├─ CPMFE.ZH72S:14\n" +
+			"     │   │   │       │       │                       │   │   │   │   └─ NHMXW.NOHHR:11\n" +
 			"     │   │   │       │       │                       │   │   │   └─ (NOT(Eq\n" +
-			"     │   │   │       │       │                       │   │   │       ├─ CPMFE.id:27!null\n" +
-			"     │   │   │       │       │                       │   │   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │       │                       │   │   │       ├─ CPMFE.id:12!null\n" +
+			"     │   │   │       │       │                       │   │   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │       │                       │   │   │      ))\n" +
 			"     │   │   │       │       │                       │   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │       │                       │   │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   │   ├─ NHMXW.id:17!null\n" +
-			"     │   │   │       │       │                       │   │   │   │   └─ ism.PRUV2:6\n" +
+			"     │   │   │       │       │                       │   │   │   │   ├─ NHMXW.id:10!null\n" +
+			"     │   │   │       │       │                       │   │   │   │   └─ ism.PRUV2:4\n" +
 			"     │   │   │       │       │                       │   │   │   ├─ InnerJoin\n" +
 			"     │   │   │       │       │                       │   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │       │                       │   │   │   │   │   ├─ G3YXS.id:9!null\n" +
-			"     │   │   │       │       │                       │   │   │   │   │   └─ ism.NZ4MQ:4!null\n" +
+			"     │   │   │       │       │                       │   │   │   │   │   ├─ G3YXS.id:5!null\n" +
+			"     │   │   │       │       │                       │   │   │   │   │   └─ ism.NZ4MQ:3!null\n" +
 			"     │   │   │       │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
 			"     │   │   │       │       │                       │   │   │   │   │   └─ Table\n" +
-			"     │   │   │       │       │                       │   │   │   │   │       └─ name: HDDVB\n" +
+			"     │   │   │       │       │                       │   │   │   │   │       ├─ name: HDDVB\n" +
+			"     │   │   │       │       │                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
 			"     │   │   │       │       │                       │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │   │   │       │       │                       │   │   │   │       └─ Table\n" +
-			"     │   │   │       │       │                       │   │   │   │           └─ name: YYBCX\n" +
+			"     │   │   │       │       │                       │   │   │   │           ├─ name: YYBCX\n" +
+			"     │   │   │       │       │                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
 			"     │   │   │       │       │                       │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │   │   │       │       │                       │   │   │       └─ Table\n" +
-			"     │   │   │       │       │                       │   │   │           └─ name: WGSDC\n" +
+			"     │   │   │       │       │                       │   │   │           ├─ name: WGSDC\n" +
+			"     │   │   │       │       │                       │   │   │           └─ columns: [id nohhr]\n" +
 			"     │   │   │       │       │                       │   │   └─ TableAlias(CPMFE)\n" +
 			"     │   │   │       │       │                       │   │       └─ Table\n" +
-			"     │   │   │       │       │                       │   │           └─ name: E2I7U\n" +
+			"     │   │   │       │       │                       │   │           ├─ name: E2I7U\n" +
+			"     │   │   │       │       │                       │   │           └─ columns: [id tw55n zh72s]\n" +
 			"     │   │   │       │       │                       │   └─ TableAlias(YQIF4)\n" +
 			"     │   │   │       │       │                       │       └─ Table\n" +
-			"     │   │   │       │       │                       │           └─ name: NOXN3\n" +
+			"     │   │   │       │       │                       │           ├─ name: NOXN3\n" +
+			"     │   │   │       │       │                       │           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       │       │                       └─ TableAlias(YVHJZ)\n" +
 			"     │   │   │       │       │                           └─ Table\n" +
-			"     │   │   │       │       │                               └─ name: NOXN3\n" +
+			"     │   │   │       │       │                               ├─ name: NOXN3\n" +
+			"     │   │   │       │       │                               └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       │       └─ Project\n" +
 			"     │   │   │       │           ├─ columns: [JCHIR.FJDP5:0!null, JCHIR.BJUF2:1, JCHIR.PSMU6:2, JCHIR.M22QN:3!null, JCHIR.GE5EL:4, JCHIR.F7A4Q:5, JCHIR.ESFVY:6!null, JCHIR.CC4AX:7, JCHIR.SL76B:8!null, JCHIR.QNI57:9, convert\n" +
 			"     │   │   │       │           │   ├─ type: char\n" +
@@ -11366,74 +11485,80 @@ WHERE
 			"     │   │   │       │                       │   ├─ (NOT(QNI57:9 IS NULL))\n" +
 			"     │   │   │       │                       │   └─ (NOT(TDEIU:10 IS NULL))\n" +
 			"     │   │   │       │                       └─ Project\n" +
-			"     │   │   │       │                           ├─ columns: [ism.FV24E:1!null as FJDP5, CPMFE.id:27 as BJUF2, CPMFE.TW55N:30 as PSMU6, ism.M22QN:3!null as M22QN, G3YXS.GE5EL:12, G3YXS.F7A4Q:13, G3YXS.ESFVY:10!null, CASE  WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           ├─ columns: [ism.FV24E:0!null as FJDP5, CPMFE.id:12 as BJUF2, CPMFE.TW55N:13 as PSMU6, ism.M22QN:2!null as M22QN, G3YXS.GE5EL:8, G3YXS.F7A4Q:9, G3YXS.ESFVY:6!null, CASE  WHEN IN\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"     │   │   │       │                           │   THEN 0 (tinyint) WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
 			"     │   │   │       │                           │   THEN 1 (tinyint) WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
 			"     │   │   │       │                           │   THEN 2 (tinyint) WHEN IN\n" +
-			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │       │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │       │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"     │   │   │       │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:11!null as SL76B, YQIF4.id:44 as QNI57, YVHJZ.id:54 as TDEIU]\n" +
+			"     │   │   │       │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:7!null as SL76B, YQIF4.id:15 as QNI57, YVHJZ.id:18 as TDEIU]\n" +
 			"     │   │   │       │                           └─ Filter\n" +
 			"     │   │   │       │                               ├─ Or\n" +
-			"     │   │   │       │                               │   ├─ (NOT(YQIF4.id:44 IS NULL))\n" +
-			"     │   │   │       │                               │   └─ (NOT(YVHJZ.id:54 IS NULL))\n" +
+			"     │   │   │       │                               │   ├─ (NOT(YQIF4.id:15 IS NULL))\n" +
+			"     │   │   │       │                               │   └─ (NOT(YVHJZ.id:18 IS NULL))\n" +
 			"     │   │   │       │                               └─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   ├─ AND\n" +
 			"     │   │   │       │                                   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   ├─ YVHJZ.BRQP2:55!null\n" +
-			"     │   │   │       │                                   │   │   └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │                                   │   │   ├─ YVHJZ.BRQP2:19!null\n" +
+			"     │   │   │       │                                   │   │   └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │                                   │   └─ Eq\n" +
-			"     │   │   │       │                                   │       ├─ YVHJZ.FFTBJ:56!null\n" +
-			"     │   │   │       │                                   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │                                   │       ├─ YVHJZ.FFTBJ:20!null\n" +
+			"     │   │   │       │                                   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │                                   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   │   ├─ AND\n" +
 			"     │   │   │       │                                   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   ├─ YQIF4.BRQP2:45!null\n" +
-			"     │   │   │       │                                   │   │   │   └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │                                   │   │   │   ├─ YQIF4.BRQP2:16!null\n" +
+			"     │   │   │       │                                   │   │   │   └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │                                   │   │   └─ Eq\n" +
-			"     │   │   │       │                                   │   │       ├─ YQIF4.FFTBJ:46!null\n" +
-			"     │   │   │       │                                   │   │       └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │       │                                   │   │       ├─ YQIF4.FFTBJ:17!null\n" +
+			"     │   │   │       │                                   │   │       └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │       │                                   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   │   │   ├─ AND\n" +
 			"     │   │   │       │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   │   ├─ CPMFE.ZH72S:34\n" +
-			"     │   │   │       │                                   │   │   │   │   └─ NHMXW.NOHHR:18\n" +
+			"     │   │   │       │                                   │   │   │   │   ├─ CPMFE.ZH72S:14\n" +
+			"     │   │   │       │                                   │   │   │   │   └─ NHMXW.NOHHR:11\n" +
 			"     │   │   │       │                                   │   │   │   └─ (NOT(Eq\n" +
-			"     │   │   │       │                                   │   │   │       ├─ CPMFE.id:27!null\n" +
-			"     │   │   │       │                                   │   │   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │       │                                   │   │   │       ├─ CPMFE.id:12!null\n" +
+			"     │   │   │       │                                   │   │   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │       │                                   │   │   │      ))\n" +
 			"     │   │   │       │                                   │   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │       │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   │   ├─ NHMXW.id:17!null\n" +
-			"     │   │   │       │                                   │   │   │   │   └─ ism.PRUV2:6\n" +
+			"     │   │   │       │                                   │   │   │   │   ├─ NHMXW.id:10!null\n" +
+			"     │   │   │       │                                   │   │   │   │   └─ ism.PRUV2:4\n" +
 			"     │   │   │       │                                   │   │   │   ├─ InnerJoin\n" +
 			"     │   │   │       │                                   │   │   │   │   ├─ Eq\n" +
-			"     │   │   │       │                                   │   │   │   │   │   ├─ G3YXS.id:9!null\n" +
-			"     │   │   │       │                                   │   │   │   │   │   └─ ism.NZ4MQ:4!null\n" +
+			"     │   │   │       │                                   │   │   │   │   │   ├─ G3YXS.id:5!null\n" +
+			"     │   │   │       │                                   │   │   │   │   │   └─ ism.NZ4MQ:3!null\n" +
 			"     │   │   │       │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
 			"     │   │   │       │                                   │   │   │   │   │   └─ Table\n" +
-			"     │   │   │       │                                   │   │   │   │   │       └─ name: HDDVB\n" +
+			"     │   │   │       │                                   │   │   │   │   │       ├─ name: HDDVB\n" +
+			"     │   │   │       │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
 			"     │   │   │       │                                   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │   │   │       │                                   │   │   │   │       └─ Table\n" +
-			"     │   │   │       │                                   │   │   │   │           └─ name: YYBCX\n" +
+			"     │   │   │       │                                   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │   │   │       │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
 			"     │   │   │       │                                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │   │   │       │                                   │   │   │       └─ Table\n" +
-			"     │   │   │       │                                   │   │   │           └─ name: WGSDC\n" +
+			"     │   │   │       │                                   │   │   │           ├─ name: WGSDC\n" +
+			"     │   │   │       │                                   │   │   │           └─ columns: [id nohhr]\n" +
 			"     │   │   │       │                                   │   │   └─ TableAlias(CPMFE)\n" +
 			"     │   │   │       │                                   │   │       └─ Table\n" +
-			"     │   │   │       │                                   │   │           └─ name: E2I7U\n" +
+			"     │   │   │       │                                   │   │           ├─ name: E2I7U\n" +
+			"     │   │   │       │                                   │   │           └─ columns: [id tw55n zh72s]\n" +
 			"     │   │   │       │                                   │   └─ TableAlias(YQIF4)\n" +
 			"     │   │   │       │                                   │       └─ Table\n" +
-			"     │   │   │       │                                   │           └─ name: NOXN3\n" +
+			"     │   │   │       │                                   │           ├─ name: NOXN3\n" +
+			"     │   │   │       │                                   │           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       │                                   └─ TableAlias(YVHJZ)\n" +
 			"     │   │   │       │                                       └─ Table\n" +
-			"     │   │   │       │                                           └─ name: NOXN3\n" +
+			"     │   │   │       │                                           ├─ name: NOXN3\n" +
+			"     │   │   │       │                                           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │       └─ Project\n" +
 			"     │   │   │           ├─ columns: [JCHIR.FJDP5:0!null, JCHIR.BJUF2:1, JCHIR.PSMU6:2, JCHIR.M22QN:3!null, JCHIR.GE5EL:4, JCHIR.F7A4Q:5, JCHIR.ESFVY:6!null, JCHIR.CC4AX:7, JCHIR.SL76B:8!null, convert\n" +
 			"     │   │   │           │   ├─ type: char\n" +
@@ -11453,74 +11578,80 @@ WHERE
 			"     │   │   │                       │   ├─ (NOT(QNI57:9 IS NULL))\n" +
 			"     │   │   │                       │   └─ (NOT(TDEIU:10 IS NULL))\n" +
 			"     │   │   │                       └─ Project\n" +
-			"     │   │   │                           ├─ columns: [ism.FV24E:1!null as FJDP5, CPMFE.id:27 as BJUF2, CPMFE.TW55N:30 as PSMU6, ism.M22QN:3!null as M22QN, G3YXS.GE5EL:12, G3YXS.F7A4Q:13, G3YXS.ESFVY:10!null, CASE  WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           ├─ columns: [ism.FV24E:0!null as FJDP5, CPMFE.id:12 as BJUF2, CPMFE.TW55N:13 as PSMU6, ism.M22QN:2!null as M22QN, G3YXS.GE5EL:8, G3YXS.F7A4Q:9, G3YXS.ESFVY:6!null, CASE  WHEN IN\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"     │   │   │                           │   THEN 0 (tinyint) WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
 			"     │   │   │                           │   THEN 1 (tinyint) WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
 			"     │   │   │                           │   THEN 2 (tinyint) WHEN IN\n" +
-			"     │   │   │                           │   ├─ left: G3YXS.SL76B:11!null\n" +
+			"     │   │   │                           │   ├─ left: G3YXS.SL76B:7!null\n" +
 			"     │   │   │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"     │   │   │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:11!null as SL76B, YQIF4.id:44 as QNI57, YVHJZ.id:54 as TDEIU]\n" +
+			"     │   │   │                           │   THEN 3 (tinyint) END as CC4AX, G3YXS.SL76B:7!null as SL76B, YQIF4.id:15 as QNI57, YVHJZ.id:18 as TDEIU]\n" +
 			"     │   │   │                           └─ Filter\n" +
 			"     │   │   │                               ├─ Or\n" +
-			"     │   │   │                               │   ├─ (NOT(YQIF4.id:44 IS NULL))\n" +
-			"     │   │   │                               │   └─ (NOT(YVHJZ.id:54 IS NULL))\n" +
+			"     │   │   │                               │   ├─ (NOT(YQIF4.id:15 IS NULL))\n" +
+			"     │   │   │                               │   └─ (NOT(YVHJZ.id:18 IS NULL))\n" +
 			"     │   │   │                               └─ LeftOuterJoin\n" +
 			"     │   │   │                                   ├─ AND\n" +
 			"     │   │   │                                   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   ├─ YVHJZ.BRQP2:55!null\n" +
-			"     │   │   │                                   │   │   └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │                                   │   │   ├─ YVHJZ.BRQP2:19!null\n" +
+			"     │   │   │                                   │   │   └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │                                   │   └─ Eq\n" +
-			"     │   │   │                                   │       ├─ YVHJZ.FFTBJ:56!null\n" +
-			"     │   │   │                                   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │                                   │       ├─ YVHJZ.FFTBJ:20!null\n" +
+			"     │   │   │                                   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │                                   ├─ LeftOuterJoin\n" +
 			"     │   │   │                                   │   ├─ AND\n" +
 			"     │   │   │                                   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   ├─ YQIF4.BRQP2:45!null\n" +
-			"     │   │   │                                   │   │   │   └─ ism.FV24E:1!null\n" +
+			"     │   │   │                                   │   │   │   ├─ YQIF4.BRQP2:16!null\n" +
+			"     │   │   │                                   │   │   │   └─ ism.FV24E:0!null\n" +
 			"     │   │   │                                   │   │   └─ Eq\n" +
-			"     │   │   │                                   │   │       ├─ YQIF4.FFTBJ:46!null\n" +
-			"     │   │   │                                   │   │       └─ ism.UJ6XY:2!null\n" +
+			"     │   │   │                                   │   │       ├─ YQIF4.FFTBJ:17!null\n" +
+			"     │   │   │                                   │   │       └─ ism.UJ6XY:1!null\n" +
 			"     │   │   │                                   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │                                   │   │   ├─ AND\n" +
 			"     │   │   │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   │   ├─ CPMFE.ZH72S:34\n" +
-			"     │   │   │                                   │   │   │   │   └─ NHMXW.NOHHR:18\n" +
+			"     │   │   │                                   │   │   │   │   ├─ CPMFE.ZH72S:14\n" +
+			"     │   │   │                                   │   │   │   │   └─ NHMXW.NOHHR:11\n" +
 			"     │   │   │                                   │   │   │   └─ (NOT(Eq\n" +
-			"     │   │   │                                   │   │   │       ├─ CPMFE.id:27!null\n" +
-			"     │   │   │                                   │   │   │       └─ ism.FV24E:1!null\n" +
+			"     │   │   │                                   │   │   │       ├─ CPMFE.id:12!null\n" +
+			"     │   │   │                                   │   │   │       └─ ism.FV24E:0!null\n" +
 			"     │   │   │                                   │   │   │      ))\n" +
 			"     │   │   │                                   │   │   ├─ LeftOuterJoin\n" +
 			"     │   │   │                                   │   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   │   ├─ NHMXW.id:17!null\n" +
-			"     │   │   │                                   │   │   │   │   └─ ism.PRUV2:6\n" +
+			"     │   │   │                                   │   │   │   │   ├─ NHMXW.id:10!null\n" +
+			"     │   │   │                                   │   │   │   │   └─ ism.PRUV2:4\n" +
 			"     │   │   │                                   │   │   │   ├─ InnerJoin\n" +
 			"     │   │   │                                   │   │   │   │   ├─ Eq\n" +
-			"     │   │   │                                   │   │   │   │   │   ├─ G3YXS.id:9!null\n" +
-			"     │   │   │                                   │   │   │   │   │   └─ ism.NZ4MQ:4!null\n" +
+			"     │   │   │                                   │   │   │   │   │   ├─ G3YXS.id:5!null\n" +
+			"     │   │   │                                   │   │   │   │   │   └─ ism.NZ4MQ:3!null\n" +
 			"     │   │   │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
 			"     │   │   │                                   │   │   │   │   │   └─ Table\n" +
-			"     │   │   │                                   │   │   │   │   │       └─ name: HDDVB\n" +
+			"     │   │   │                                   │   │   │   │   │       ├─ name: HDDVB\n" +
+			"     │   │   │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
 			"     │   │   │                                   │   │   │   │   └─ TableAlias(G3YXS)\n" +
 			"     │   │   │                                   │   │   │   │       └─ Table\n" +
-			"     │   │   │                                   │   │   │   │           └─ name: YYBCX\n" +
+			"     │   │   │                                   │   │   │   │           ├─ name: YYBCX\n" +
+			"     │   │   │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
 			"     │   │   │                                   │   │   │   └─ TableAlias(NHMXW)\n" +
 			"     │   │   │                                   │   │   │       └─ Table\n" +
-			"     │   │   │                                   │   │   │           └─ name: WGSDC\n" +
+			"     │   │   │                                   │   │   │           ├─ name: WGSDC\n" +
+			"     │   │   │                                   │   │   │           └─ columns: [id nohhr]\n" +
 			"     │   │   │                                   │   │   └─ TableAlias(CPMFE)\n" +
 			"     │   │   │                                   │   │       └─ Table\n" +
-			"     │   │   │                                   │   │           └─ name: E2I7U\n" +
+			"     │   │   │                                   │   │           ├─ name: E2I7U\n" +
+			"     │   │   │                                   │   │           └─ columns: [id tw55n zh72s]\n" +
 			"     │   │   │                                   │   └─ TableAlias(YQIF4)\n" +
 			"     │   │   │                                   │       └─ Table\n" +
-			"     │   │   │                                   │           └─ name: NOXN3\n" +
+			"     │   │   │                                   │           ├─ name: NOXN3\n" +
+			"     │   │   │                                   │           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   │                                   └─ TableAlias(YVHJZ)\n" +
 			"     │   │   │                                       └─ Table\n" +
-			"     │   │   │                                           └─ name: NOXN3\n" +
+			"     │   │   │                                           ├─ name: NOXN3\n" +
+			"     │   │   │                                           └─ columns: [id brqp2 fftbj]\n" +
 			"     │   │   └─ TableAlias(sn)\n" +
 			"     │   │       └─ Table\n" +
 			"     │   │           └─ name: NOXN3\n" +
@@ -11544,28 +11675,31 @@ WHERE
 			"                 ├─ outerVisibility: false\n" +
 			"                 ├─ cacheable: true\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [cla.FTQLQ:5!null, mf.LUEVY:36!null, mf.M22QN:37!null]\n" +
+			"                     ├─ columns: [cla.FTQLQ:3!null, mf.LUEVY:5!null, mf.M22QN:6!null]\n" +
 			"                     └─ LookupJoin\n" +
 			"                         ├─ Eq\n" +
 			"                         │   ├─ bs.id:0!null\n" +
-			"                         │   └─ mf.GXLUB:35!null\n" +
+			"                         │   └─ mf.GXLUB:4!null\n" +
 			"                         ├─ LookupJoin\n" +
 			"                         │   ├─ Eq\n" +
-			"                         │   │   ├─ cla.id:4!null\n" +
-			"                         │   │   └─ bs.IXUXU:2\n" +
+			"                         │   │   ├─ cla.id:2!null\n" +
+			"                         │   │   └─ bs.IXUXU:1\n" +
 			"                         │   ├─ TableAlias(bs)\n" +
 			"                         │   │   └─ Table\n" +
-			"                         │   │       └─ name: THNTS\n" +
+			"                         │   │       ├─ name: THNTS\n" +
+			"                         │   │       └─ columns: [id ixuxu]\n" +
 			"                         │   └─ Filter\n" +
 			"                         │       ├─ HashIn\n" +
 			"                         │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                         │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                         │       └─ TableAlias(cla)\n" +
 			"                         │           └─ IndexedTableAccess(YK2GW)\n" +
-			"                         │               └─ index: [YK2GW.id]\n" +
+			"                         │               ├─ index: [YK2GW.id]\n" +
+			"                         │               └─ columns: [id ftqlq]\n" +
 			"                         └─ TableAlias(mf)\n" +
 			"                             └─ IndexedTableAccess(HGMQ6)\n" +
-			"                                 └─ index: [HGMQ6.GXLUB]\n" +
+			"                                 ├─ index: [HGMQ6.GXLUB]\n" +
+			"                                 └─ columns: [gxlub luevy m22qn]\n" +
 			"",
 	},
 	{
@@ -11813,7 +11947,8 @@ WHERE
 			"     │           │                       │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"     │           │                       │   │   │       │                       └─ Table\n" +
-			"     │           │                       │   │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       │   │   └─ AND\n" +
 			"     │           │                       │   │       ├─ AND\n" +
@@ -11830,7 +11965,8 @@ WHERE
 			"     │           │                       │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"     │           │                       │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │   │       │                       └─ Table\n" +
-			"     │           │                       │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"     │           │                       │   └─ AND\n" +
 			"     │           │                       │       ├─ AND\n" +
@@ -11847,7 +11983,8 @@ WHERE
 			"     │           │                       │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │       │                       └─ Table\n" +
-			"     │           │                       │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       ├─ LookupJoin\n" +
 			"     │           │                       │   ├─ Eq\n" +
@@ -11935,19 +12072,19 @@ WHERE
 			"     │                           ├─ outerVisibility: false\n" +
 			"     │                           ├─ cacheable: true\n" +
 			"     │                           └─ Project\n" +
-			"     │                               ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"     │                               ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"     │                               └─ HashJoin\n" +
 			"     │                                   ├─ Eq\n" +
-			"     │                                   │   ├─ sn.BRQP2:52!null\n" +
-			"     │                                   │   └─ mf.LUEVY:36!null\n" +
+			"     │                                   │   ├─ sn.BRQP2:8!null\n" +
+			"     │                                   │   └─ mf.LUEVY:5!null\n" +
 			"     │                                   ├─ LookupJoin\n" +
 			"     │                                   │   ├─ Eq\n" +
-			"     │                                   │   │   ├─ bs.id:30!null\n" +
-			"     │                                   │   │   └─ mf.GXLUB:35!null\n" +
+			"     │                                   │   │   ├─ bs.id:2!null\n" +
+			"     │                                   │   │   └─ mf.GXLUB:4!null\n" +
 			"     │                                   │   ├─ LookupJoin\n" +
 			"     │                                   │   │   ├─ Eq\n" +
 			"     │                                   │   │   │   ├─ cla.id:0!null\n" +
-			"     │                                   │   │   │   └─ bs.IXUXU:32\n" +
+			"     │                                   │   │   │   └─ bs.IXUXU:3\n" +
 			"     │                                   │   │   ├─ Filter\n" +
 			"     │                                   │   │   │   ├─ HashIn\n" +
 			"     │                                   │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
@@ -11955,20 +12092,24 @@ WHERE
 			"     │                                   │   │   │   └─ TableAlias(cla)\n" +
 			"     │                                   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"     │                                   │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"     │                                   │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
+			"     │                                   │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
+			"     │                                   │   │   │           └─ columns: [id ftqlq]\n" +
 			"     │                                   │   │   └─ TableAlias(bs)\n" +
 			"     │                                   │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"     │                                   │   │           └─ index: [THNTS.IXUXU]\n" +
+			"     │                                   │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"     │                                   │   │           └─ columns: [id ixuxu]\n" +
 			"     │                                   │   └─ TableAlias(mf)\n" +
 			"     │                                   │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"     │                                   │           └─ index: [HGMQ6.GXLUB]\n" +
+			"     │                                   │           ├─ index: [HGMQ6.GXLUB]\n" +
+			"     │                                   │           └─ columns: [gxlub luevy m22qn]\n" +
 			"     │                                   └─ HashLookup\n" +
-			"     │                                       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"     │                                       ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"     │                                       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"     │                                       └─ CachedResults\n" +
 			"     │                                           └─ TableAlias(sn)\n" +
 			"     │                                               └─ Table\n" +
-			"     │                                                   └─ name: NOXN3\n" +
+			"     │                                                   ├─ name: NOXN3\n" +
+			"     │                                                   └─ columns: [id brqp2]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -11995,19 +12136,19 @@ WHERE
 			"                             │   ├─ outerVisibility: false\n" +
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
-			"                             │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"                             │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"                             │       └─ HashJoin\n" +
 			"                             │           ├─ Eq\n" +
-			"                             │           │   ├─ sn.BRQP2:52!null\n" +
-			"                             │           │   └─ mf.LUEVY:36!null\n" +
+			"                             │           │   ├─ sn.BRQP2:8!null\n" +
+			"                             │           │   └─ mf.LUEVY:5!null\n" +
 			"                             │           ├─ LookupJoin\n" +
 			"                             │           │   ├─ Eq\n" +
-			"                             │           │   │   ├─ bs.id:30!null\n" +
-			"                             │           │   │   └─ mf.GXLUB:35!null\n" +
+			"                             │           │   │   ├─ bs.id:2!null\n" +
+			"                             │           │   │   └─ mf.GXLUB:4!null\n" +
 			"                             │           │   ├─ LookupJoin\n" +
 			"                             │           │   │   ├─ Eq\n" +
 			"                             │           │   │   │   ├─ cla.id:0!null\n" +
-			"                             │           │   │   │   └─ bs.IXUXU:32\n" +
+			"                             │           │   │   │   └─ bs.IXUXU:3\n" +
 			"                             │           │   │   ├─ Filter\n" +
 			"                             │           │   │   │   ├─ HashIn\n" +
 			"                             │           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
@@ -12015,20 +12156,24 @@ WHERE
 			"                             │           │   │   │   └─ TableAlias(cla)\n" +
 			"                             │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
 			"                             │           │   │   │           ├─ index: [YK2GW.FTQLQ]\n" +
-			"                             │           │   │   │           └─ static: [{[SQ1, SQ1]}]\n" +
+			"                             │           │   │   │           ├─ static: [{[SQ1, SQ1]}]\n" +
+			"                             │           │   │   │           └─ columns: [id ftqlq]\n" +
 			"                             │           │   │   └─ TableAlias(bs)\n" +
 			"                             │           │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"                             │           │   │           └─ index: [THNTS.IXUXU]\n" +
+			"                             │           │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"                             │           │   │           └─ columns: [id ixuxu]\n" +
 			"                             │           │   └─ TableAlias(mf)\n" +
 			"                             │           │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"                             │           │           └─ index: [HGMQ6.GXLUB]\n" +
+			"                             │           │           ├─ index: [HGMQ6.GXLUB]\n" +
+			"                             │           │           └─ columns: [gxlub luevy m22qn]\n" +
 			"                             │           └─ HashLookup\n" +
-			"                             │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"                             │               ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"                             │               ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"                             │               └─ CachedResults\n" +
 			"                             │                   └─ TableAlias(sn)\n" +
 			"                             │                       └─ Table\n" +
-			"                             │                           └─ name: NOXN3\n" +
+			"                             │                           ├─ name: NOXN3\n" +
+			"                             │                           └─ columns: [id brqp2]\n" +
 			"                             └─ HashLookup\n" +
 			"                                 ├─ source: TUPLE(cld.BDNYB:1!null, cld.M22QN:2!null)\n" +
 			"                                 ├─ target: TUPLE(P4PJZ.LWQ6O:3, P4PJZ.NTOFG:2!null)\n" +
@@ -12105,7 +12250,8 @@ WHERE
 			"                                                 │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 │   │   └─ AND\n" +
 			"                                                 │   │       ├─ AND\n" +
@@ -12122,7 +12268,8 @@ WHERE
 			"                                                 │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"                                                 │   └─ AND\n" +
 			"                                                 │       ├─ AND\n" +
@@ -12139,7 +12286,8 @@ WHERE
 			"                                                 │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           └─ name: NOXN3\n" +
+			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 ├─ LookupJoin\n" +
 			"                                                 │   ├─ Eq\n" +
@@ -12463,7 +12611,8 @@ WHERE
 			"     │           │                       │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"     │           │                       │   │   │       │                       └─ Table\n" +
-			"     │           │                       │   │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       │   │   └─ AND\n" +
 			"     │           │                       │   │       ├─ AND\n" +
@@ -12480,7 +12629,8 @@ WHERE
 			"     │           │                       │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"     │           │                       │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │   │       │                       └─ Table\n" +
-			"     │           │                       │   │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"     │           │                       │   └─ AND\n" +
 			"     │           │                       │       ├─ AND\n" +
@@ -12497,7 +12647,8 @@ WHERE
 			"     │           │                       │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"     │           │                       │       │                   └─ TableAlias(XMAFZ)\n" +
 			"     │           │                       │       │                       └─ Table\n" +
-			"     │           │                       │       │                           └─ name: NOXN3\n" +
+			"     │           │                       │       │                           ├─ name: NOXN3\n" +
+			"     │           │                       │       │                           └─ columns: [id brqp2]\n" +
 			"     │           │                       │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"     │           │                       ├─ LookupJoin\n" +
 			"     │           │                       │   ├─ Eq\n" +
@@ -12585,39 +12736,43 @@ WHERE
 			"     │                           ├─ outerVisibility: false\n" +
 			"     │                           ├─ cacheable: true\n" +
 			"     │                           └─ Project\n" +
-			"     │                               ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"     │                               ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"     │                               └─ HashJoin\n" +
 			"     │                                   ├─ Eq\n" +
-			"     │                                   │   ├─ sn.BRQP2:52!null\n" +
-			"     │                                   │   └─ mf.LUEVY:36!null\n" +
+			"     │                                   │   ├─ sn.BRQP2:8!null\n" +
+			"     │                                   │   └─ mf.LUEVY:5!null\n" +
 			"     │                                   ├─ LookupJoin\n" +
 			"     │                                   │   ├─ Eq\n" +
 			"     │                                   │   │   ├─ bs.id:0!null\n" +
-			"     │                                   │   │   └─ mf.GXLUB:35!null\n" +
+			"     │                                   │   │   └─ mf.GXLUB:4!null\n" +
 			"     │                                   │   ├─ LookupJoin\n" +
 			"     │                                   │   │   ├─ Eq\n" +
-			"     │                                   │   │   │   ├─ cla.id:4!null\n" +
-			"     │                                   │   │   │   └─ bs.IXUXU:2\n" +
+			"     │                                   │   │   │   ├─ cla.id:2!null\n" +
+			"     │                                   │   │   │   └─ bs.IXUXU:1\n" +
 			"     │                                   │   │   ├─ TableAlias(bs)\n" +
 			"     │                                   │   │   │   └─ Table\n" +
-			"     │                                   │   │   │       └─ name: THNTS\n" +
+			"     │                                   │   │   │       ├─ name: THNTS\n" +
+			"     │                                   │   │   │       └─ columns: [id ixuxu]\n" +
 			"     │                                   │   │   └─ Filter\n" +
 			"     │                                   │   │       ├─ HashIn\n" +
 			"     │                                   │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"     │                                   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"     │                                   │   │       └─ TableAlias(cla)\n" +
 			"     │                                   │   │           └─ IndexedTableAccess(YK2GW)\n" +
-			"     │                                   │   │               └─ index: [YK2GW.id]\n" +
+			"     │                                   │   │               ├─ index: [YK2GW.id]\n" +
+			"     │                                   │   │               └─ columns: [id ftqlq]\n" +
 			"     │                                   │   └─ TableAlias(mf)\n" +
 			"     │                                   │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"     │                                   │           └─ index: [HGMQ6.GXLUB]\n" +
+			"     │                                   │           ├─ index: [HGMQ6.GXLUB]\n" +
+			"     │                                   │           └─ columns: [gxlub luevy m22qn]\n" +
 			"     │                                   └─ HashLookup\n" +
-			"     │                                       ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"     │                                       ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"     │                                       ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"     │                                       └─ CachedResults\n" +
 			"     │                                           └─ TableAlias(sn)\n" +
 			"     │                                               └─ Table\n" +
-			"     │                                                   └─ name: NOXN3\n" +
+			"     │                                                   ├─ name: NOXN3\n" +
+			"     │                                                   └─ columns: [id brqp2]\n" +
 			"     └─ SubqueryAlias\n" +
 			"         ├─ name: applySubq0\n" +
 			"         ├─ outerVisibility: false\n" +
@@ -12644,39 +12799,43 @@ WHERE
 			"                             │   ├─ outerVisibility: false\n" +
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
-			"                             │       ├─ columns: [cla.FTQLQ:5!null as T4IBQ, sn.id:51!null as BDNYB, mf.M22QN:37!null as M22QN]\n" +
+			"                             │       ├─ columns: [cla.FTQLQ:3!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
 			"                             │       └─ HashJoin\n" +
 			"                             │           ├─ Eq\n" +
-			"                             │           │   ├─ sn.BRQP2:52!null\n" +
-			"                             │           │   └─ mf.LUEVY:36!null\n" +
+			"                             │           │   ├─ sn.BRQP2:8!null\n" +
+			"                             │           │   └─ mf.LUEVY:5!null\n" +
 			"                             │           ├─ LookupJoin\n" +
 			"                             │           │   ├─ Eq\n" +
 			"                             │           │   │   ├─ bs.id:0!null\n" +
-			"                             │           │   │   └─ mf.GXLUB:35!null\n" +
+			"                             │           │   │   └─ mf.GXLUB:4!null\n" +
 			"                             │           │   ├─ LookupJoin\n" +
 			"                             │           │   │   ├─ Eq\n" +
-			"                             │           │   │   │   ├─ cla.id:4!null\n" +
-			"                             │           │   │   │   └─ bs.IXUXU:2\n" +
+			"                             │           │   │   │   ├─ cla.id:2!null\n" +
+			"                             │           │   │   │   └─ bs.IXUXU:1\n" +
 			"                             │           │   │   ├─ TableAlias(bs)\n" +
 			"                             │           │   │   │   └─ Table\n" +
-			"                             │           │   │   │       └─ name: THNTS\n" +
+			"                             │           │   │   │       ├─ name: THNTS\n" +
+			"                             │           │   │   │       └─ columns: [id ixuxu]\n" +
 			"                             │           │   │   └─ Filter\n" +
 			"                             │           │   │       ├─ HashIn\n" +
 			"                             │           │   │       │   ├─ cla.FTQLQ:1!null\n" +
 			"                             │           │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                             │           │   │       └─ TableAlias(cla)\n" +
 			"                             │           │   │           └─ IndexedTableAccess(YK2GW)\n" +
-			"                             │           │   │               └─ index: [YK2GW.id]\n" +
+			"                             │           │   │               ├─ index: [YK2GW.id]\n" +
+			"                             │           │   │               └─ columns: [id ftqlq]\n" +
 			"                             │           │   └─ TableAlias(mf)\n" +
 			"                             │           │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"                             │           │           └─ index: [HGMQ6.GXLUB]\n" +
+			"                             │           │           ├─ index: [HGMQ6.GXLUB]\n" +
+			"                             │           │           └─ columns: [gxlub luevy m22qn]\n" +
 			"                             │           └─ HashLookup\n" +
-			"                             │               ├─ source: TUPLE(mf.LUEVY:36!null)\n" +
+			"                             │               ├─ source: TUPLE(mf.LUEVY:5!null)\n" +
 			"                             │               ├─ target: TUPLE(sn.BRQP2:1!null)\n" +
 			"                             │               └─ CachedResults\n" +
 			"                             │                   └─ TableAlias(sn)\n" +
 			"                             │                       └─ Table\n" +
-			"                             │                           └─ name: NOXN3\n" +
+			"                             │                           ├─ name: NOXN3\n" +
+			"                             │                           └─ columns: [id brqp2]\n" +
 			"                             └─ HashLookup\n" +
 			"                                 ├─ source: TUPLE(cld.BDNYB:1!null, cld.M22QN:2!null)\n" +
 			"                                 ├─ target: TUPLE(P4PJZ.LWQ6O:3, P4PJZ.NTOFG:2!null)\n" +
@@ -12753,7 +12912,8 @@ WHERE
 			"                                                 │   │   │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(JTEHG)\n" +
 			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 │   │   └─ AND\n" +
 			"                                                 │   │       ├─ AND\n" +
@@ -12770,7 +12930,8 @@ WHERE
 			"                                                 │   │       │                   │   └─ MJR3D.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           └─ name: NOXN3\n" +
+			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ MJR3D.BJUF2:1 IS NULL\n" +
 			"                                                 │   └─ AND\n" +
 			"                                                 │       ├─ AND\n" +
@@ -12787,7 +12948,8 @@ WHERE
 			"                                                 │       │                   │   └─ MJR3D.BJUF2:1\n" +
 			"                                                 │       │                   └─ TableAlias(XMAFZ)\n" +
 			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           └─ name: NOXN3\n" +
+			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ (NOT(MJR3D.BJUF2:1 IS NULL))\n" +
 			"                                                 ├─ LookupJoin\n" +
 			"                                                 │   ├─ Eq\n" +
@@ -12904,7 +13066,8 @@ SELECT COUNT(*) FROM E2I7U`,
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
 			"     └─ Table\n" +
-			"         └─ name: E2I7U\n" +
+			"         ├─ name: E2I7U\n" +
+			"         └─ columns: []\n" +
 			"",
 	},
 	{
@@ -13360,7 +13523,8 @@ ORDER BY LUEVY`,
 			"         │                   └─ index: [TNMXI.id]\n" +
 			"         └─ TableAlias(YBBG5)\n" +
 			"             └─ IndexedTableAccess(XGSJM)\n" +
-			"                 └─ index: [XGSJM.id]\n" +
+			"                 ├─ index: [XGSJM.id]\n" +
+			"                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -13425,32 +13589,36 @@ LEFT JOIN
     ON sn.A7XO2 = it.id
 ORDER BY sn.id ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [TVQG4.TW55N:13 as FJVD7, LSM32.TW55N:30 as KBXXJ, sn.NUMK2:6!null as NUMK2, CASE  WHEN it.DZLIM:45 IS NULL THEN N/A (longtext) ELSE it.DZLIM:45 END as TP6BK, sn.ECDKM:5 as ECDKM, sn.KBO7R:4!null as KBO7R, CASE  WHEN sn.YKSSU:8 IS NULL THEN N/A (longtext) ELSE sn.YKSSU:8 END as RQI4M, CASE  WHEN sn.FHCYT:9 IS NULL THEN N/A (longtext) ELSE sn.FHCYT:9 END as RNVLS, sn.LETOE:7!null as LETOE]\n" +
+			" ├─ columns: [TVQG4.TW55N:11 as FJVD7, LSM32.TW55N:13 as KBXXJ, sn.NUMK2:6!null as NUMK2, CASE  WHEN it.DZLIM:15 IS NULL THEN N/A (longtext) ELSE it.DZLIM:15 END as TP6BK, sn.ECDKM:5 as ECDKM, sn.KBO7R:4!null as KBO7R, CASE  WHEN sn.YKSSU:8 IS NULL THEN N/A (longtext) ELSE sn.YKSSU:8 END as RQI4M, CASE  WHEN sn.FHCYT:9 IS NULL THEN N/A (longtext) ELSE sn.FHCYT:9 END as RNVLS, sn.LETOE:7!null as LETOE]\n" +
 			" └─ Sort(sn.id:0!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ sn.A7XO2:3\n" +
-			"         │   └─ it.id:44!null\n" +
+			"         │   └─ it.id:14!null\n" +
 			"         ├─ LeftOuterLookupJoin\n" +
 			"         │   ├─ Eq\n" +
 			"         │   │   ├─ sn.FFTBJ:2!null\n" +
-			"         │   │   └─ LSM32.id:27!null\n" +
+			"         │   │   └─ LSM32.id:12!null\n" +
 			"         │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
 			"         │   │   │   ├─ sn.BRQP2:1!null\n" +
 			"         │   │   │   └─ TVQG4.id:10!null\n" +
 			"         │   │   ├─ TableAlias(sn)\n" +
 			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: NOXN3\n" +
+			"         │   │   │       ├─ name: NOXN3\n" +
+			"         │   │   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"         │   │   └─ TableAlias(TVQG4)\n" +
 			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │           └─ index: [E2I7U.id]\n" +
+			"         │   │           ├─ index: [E2I7U.id]\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ TableAlias(LSM32)\n" +
 			"         │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │           └─ index: [E2I7U.id]\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(it)\n" +
 			"             └─ IndexedTableAccess(FEVH4)\n" +
-			"                 └─ index: [FEVH4.id]\n" +
+			"                 ├─ index: [FEVH4.id]\n" +
+			"                 └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -13516,46 +13684,52 @@ LEFT JOIN
     ON AYFCD.FFTBJ = FA75Y.id
 ORDER BY rn.id ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [SDLLR.TW55N:29 as FZX4Y, JGT2H.LETOE:13 as QWTOI, RIIW6.TW55N:46 as PDX5Y, AYFCD.NUMK2:22 as V45YB, AYFCD.LETOE:23 as DAGQN, FA75Y.TW55N:63 as SFQTS, rn.HVHRZ:3!null as HVHRZ, CASE  WHEN rn.YKSSU:4 IS NULL THEN N/A (longtext) ELSE rn.YKSSU:4 END as RQI4M, CASE  WHEN rn.FHCYT:5 IS NULL THEN N/A (longtext) ELSE rn.FHCYT:5 END as RNVLS]\n" +
+			" ├─ columns: [SDLLR.TW55N:15 as FZX4Y, JGT2H.LETOE:9 as QWTOI, RIIW6.TW55N:17 as PDX5Y, AYFCD.NUMK2:12 as V45YB, AYFCD.LETOE:13 as DAGQN, FA75Y.TW55N:19 as SFQTS, rn.HVHRZ:3!null as HVHRZ, CASE  WHEN rn.YKSSU:4 IS NULL THEN N/A (longtext) ELSE rn.YKSSU:4 END as RQI4M, CASE  WHEN rn.FHCYT:5 IS NULL THEN N/A (longtext) ELSE rn.FHCYT:5 END as RNVLS]\n" +
 			" └─ Sort(rn.id:0!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ AYFCD.FFTBJ:18\n" +
-			"         │   └─ FA75Y.id:60!null\n" +
+			"         │   ├─ AYFCD.FFTBJ:11\n" +
+			"         │   └─ FA75Y.id:18!null\n" +
 			"         ├─ LeftOuterLookupJoin\n" +
 			"         │   ├─ Eq\n" +
 			"         │   │   ├─ JGT2H.FFTBJ:8\n" +
-			"         │   │   └─ RIIW6.id:43!null\n" +
+			"         │   │   └─ RIIW6.id:16!null\n" +
 			"         │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   ├─ Eq\n" +
 			"         │   │   │   ├─ JGT2H.BRQP2:7\n" +
-			"         │   │   │   └─ SDLLR.id:26!null\n" +
+			"         │   │   │   └─ SDLLR.id:14!null\n" +
 			"         │   │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ rn.HHVLX:2!null\n" +
-			"         │   │   │   │   └─ AYFCD.id:16!null\n" +
+			"         │   │   │   │   └─ AYFCD.id:10!null\n" +
 			"         │   │   │   ├─ LeftOuterLookupJoin\n" +
 			"         │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   ├─ rn.WNUNU:1!null\n" +
 			"         │   │   │   │   │   └─ JGT2H.id:6!null\n" +
 			"         │   │   │   │   ├─ TableAlias(rn)\n" +
 			"         │   │   │   │   │   └─ Table\n" +
-			"         │   │   │   │   │       └─ name: QYWQD\n" +
+			"         │   │   │   │   │       ├─ name: QYWQD\n" +
+			"         │   │   │   │   │       └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"         │   │   │   │   └─ TableAlias(JGT2H)\n" +
 			"         │   │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │   │           └─ index: [NOXN3.id]\n" +
+			"         │   │   │   │           ├─ index: [NOXN3.id]\n" +
+			"         │   │   │   │           └─ columns: [id brqp2 fftbj letoe]\n" +
 			"         │   │   │   └─ TableAlias(AYFCD)\n" +
 			"         │   │   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │           └─ index: [NOXN3.id]\n" +
+			"         │   │   │           ├─ index: [NOXN3.id]\n" +
+			"         │   │   │           └─ columns: [id fftbj numk2 letoe]\n" +
 			"         │   │   └─ TableAlias(SDLLR)\n" +
 			"         │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │           └─ index: [E2I7U.id]\n" +
+			"         │   │           ├─ index: [E2I7U.id]\n" +
+			"         │   │           └─ columns: [id tw55n]\n" +
 			"         │   └─ TableAlias(RIIW6)\n" +
 			"         │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │           └─ index: [E2I7U.id]\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           └─ columns: [id tw55n]\n" +
 			"         └─ TableAlias(FA75Y)\n" +
 			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 └─ index: [E2I7U.id]\n" +
+			"                 ├─ index: [E2I7U.id]\n" +
+			"                 └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -13655,24 +13829,27 @@ INNER JOIN E2I7U nd
 INNER JOIN XOAOP pa
     ON QNRBH.CH3FR = pa.id`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [pa.DZLIM:4!null as ECUWU, nd.TW55N:9!null]\n" +
+			" ├─ columns: [pa.DZLIM:3!null as ECUWU, nd.TW55N:5!null]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ QNRBH.LUEVY:2!null\n" +
-			"     │   └─ nd.id:6!null\n" +
+			"     │   ├─ QNRBH.LUEVY:1!null\n" +
+			"     │   └─ nd.id:4!null\n" +
 			"     ├─ LookupJoin\n" +
 			"     │   ├─ Eq\n" +
-			"     │   │   ├─ QNRBH.CH3FR:1!null\n" +
-			"     │   │   └─ pa.id:3!null\n" +
+			"     │   │   ├─ QNRBH.CH3FR:0!null\n" +
+			"     │   │   └─ pa.id:2!null\n" +
 			"     │   ├─ TableAlias(QNRBH)\n" +
 			"     │   │   └─ Table\n" +
-			"     │   │       └─ name: JJGQT\n" +
+			"     │   │       ├─ name: JJGQT\n" +
+			"     │   │       └─ columns: [ch3fr luevy]\n" +
 			"     │   └─ TableAlias(pa)\n" +
 			"     │       └─ IndexedTableAccess(XOAOP)\n" +
-			"     │           └─ index: [XOAOP.id]\n" +
+			"     │           ├─ index: [XOAOP.id]\n" +
+			"     │           └─ columns: [id dzlim]\n" +
 			"     └─ TableAlias(nd)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
-			"             └─ index: [E2I7U.id]\n" +
+			"             ├─ index: [E2I7U.id]\n" +
+			"             └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -13829,18 +14006,20 @@ WHERE nd.FGG57 IS NOT NULL AND nd.KNG7T IS NULL`,
 			"             ├─ columns: [gn.id:17!null]\n" +
 			"             └─ Filter\n" +
 			"                 ├─ Eq\n" +
-			"                 │   ├─ ltnm.FGG57:22!null\n" +
+			"                 │   ├─ ltnm.FGG57:19!null\n" +
 			"                 │   └─ nd.FGG57:6\n" +
 			"                 └─ LookupJoin\n" +
 			"                     ├─ Eq\n" +
-			"                     │   ├─ ltnm.SSHPJ:23!null\n" +
-			"                     │   └─ gn.SSHPJ:19!null\n" +
+			"                     │   ├─ ltnm.SSHPJ:20!null\n" +
+			"                     │   └─ gn.SSHPJ:18!null\n" +
 			"                     ├─ TableAlias(gn)\n" +
 			"                     │   └─ Table\n" +
-			"                     │       └─ name: WE72E\n" +
+			"                     │       ├─ name: WE72E\n" +
+			"                     │       └─ columns: [id sshpj]\n" +
 			"                     └─ TableAlias(ltnm)\n" +
 			"                         └─ IndexedTableAccess(TDRVG)\n" +
-			"                             └─ index: [TDRVG.SSHPJ]\n" +
+			"                             ├─ index: [TDRVG.SSHPJ]\n" +
+			"                             └─ columns: [fgg57 sshpj]\n" +
 			"        )\n" +
 			"         └─ Filter\n" +
 			"             ├─ AND\n" +
@@ -14014,36 +14193,39 @@ FROM
 			"             │           ├─ outerVisibility: false\n" +
 			"             │           ├─ cacheable: true\n" +
 			"             │           └─ Project\n" +
-			"             │               ├─ columns: [sn.id:10!null as DRIWM, SKPM6.id:0!null as JIEVY, sn.ECDKM:15 as HVHRZ]\n" +
+			"             │               ├─ columns: [sn.id:2!null as DRIWM, SKPM6.id:0!null as JIEVY, sn.ECDKM:4 as HVHRZ]\n" +
 			"             │               └─ Filter\n" +
 			"             │                   ├─ AND\n" +
-			"             │                   │   ├─ rn.WNUNU:21 IS NULL\n" +
-			"             │                   │   └─ rn.HHVLX:22 IS NULL\n" +
+			"             │                   │   ├─ rn.WNUNU:6 IS NULL\n" +
+			"             │                   │   └─ rn.HHVLX:7 IS NULL\n" +
 			"             │                   └─ LeftOuterLookupJoin\n" +
 			"             │                       ├─ AND\n" +
 			"             │                       │   ├─ Eq\n" +
-			"             │                       │   │   ├─ rn.WNUNU:21!null\n" +
-			"             │                       │   │   └─ sn.id:10!null\n" +
+			"             │                       │   │   ├─ rn.WNUNU:6!null\n" +
+			"             │                       │   │   └─ sn.id:2!null\n" +
 			"             │                       │   └─ Eq\n" +
-			"             │                       │       ├─ rn.HHVLX:22!null\n" +
+			"             │                       │       ├─ rn.HHVLX:7!null\n" +
 			"             │                       │       └─ SKPM6.id:0!null\n" +
 			"             │                       ├─ LookupJoin\n" +
 			"             │                       │   ├─ Eq\n" +
 			"             │                       │   │   ├─ SKPM6.BRQP2:1!null\n" +
-			"             │                       │   │   └─ sn.FFTBJ:12!null\n" +
+			"             │                       │   │   └─ sn.FFTBJ:3!null\n" +
 			"             │                       │   ├─ TableAlias(SKPM6)\n" +
 			"             │                       │   │   └─ Table\n" +
-			"             │                       │   │       └─ name: NOXN3\n" +
+			"             │                       │   │       ├─ name: NOXN3\n" +
+			"             │                       │   │       └─ columns: [id brqp2]\n" +
 			"             │                       │   └─ Filter\n" +
 			"             │                       │       ├─ Eq\n" +
-			"             │                       │       │   ├─ sn.NUMK2:6!null\n" +
+			"             │                       │       │   ├─ sn.NUMK2:3!null\n" +
 			"             │                       │       │   └─ 1 (tinyint)\n" +
 			"             │                       │       └─ TableAlias(sn)\n" +
 			"             │                       │           └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                       │               └─ index: [NOXN3.FFTBJ]\n" +
+			"             │                       │               ├─ index: [NOXN3.FFTBJ]\n" +
+			"             │                       │               └─ columns: [id fftbj ecdkm numk2]\n" +
 			"             │                       └─ TableAlias(rn)\n" +
 			"             │                           └─ IndexedTableAccess(QYWQD)\n" +
-			"             │                               └─ index: [QYWQD.HHVLX]\n" +
+			"             │                               ├─ index: [QYWQD.HHVLX]\n" +
+			"             │                               └─ columns: [wnunu hhvlx]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF((NOT(Eq\n" +
@@ -14212,7 +14394,7 @@ WHERE
 			"             │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   └─ Project\n" +
-			"             │       │       ├─ columns: [bs.id:61!null]\n" +
+			"             │       │       ├─ columns: [bs.id:33!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
 			"             │       │           │   ├─ cla.FTQLQ:32!null\n" +
@@ -14220,13 +14402,15 @@ WHERE
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
 			"             │       │               │   ├─ cla.id:31!null\n" +
-			"             │       │               │   └─ bs.IXUXU:63\n" +
+			"             │       │               │   └─ bs.IXUXU:34\n" +
 			"             │       │               ├─ TableAlias(cla)\n" +
 			"             │       │               │   └─ IndexedTableAccess(YK2GW)\n" +
-			"             │       │               │       └─ index: [YK2GW.FTQLQ]\n" +
+			"             │       │               │       ├─ index: [YK2GW.FTQLQ]\n" +
+			"             │       │               │       └─ columns: [id ftqlq]\n" +
 			"             │       │               └─ TableAlias(bs)\n" +
 			"             │       │                   └─ IndexedTableAccess(THNTS)\n" +
-			"             │       │                       └─ index: [THNTS.IXUXU]\n" +
+			"             │       │                       ├─ index: [THNTS.IXUXU]\n" +
+			"             │       │                       └─ columns: [id ixuxu]\n" +
 			"             │       │   as GXLUB, nd.id:11!null as LUEVY, nd.XQDYT:20!null as XQDYT, (ufc.AMYXQ:3 + 0 (decimal(2,1))) as AMYXQ, CASE  WHEN Eq\n" +
 			"             │       │   ├─ YBBG5.DZLIM:29!null\n" +
 			"             │       │   └─ KTNZ2 (longtext)\n" +
@@ -14353,18 +14537,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
 			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"             │       │                       └─ index: [YK2GW.id]\n" +
+			"             │       │                       ├─ index: [YK2GW.id]\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -14470,18 +14656,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
 			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"             │       │                       └─ index: [YK2GW.id]\n" +
+			"             │       │                       ├─ index: [YK2GW.id]\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -14587,18 +14775,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
 			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"             │       │                       └─ index: [YK2GW.id]\n" +
+			"             │       │                       ├─ index: [YK2GW.id]\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -14704,18 +14894,20 @@ WHERE
 			"             │       │       ├─ columns: [bs.id:7!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ cla.FTQLQ:12!null\n" +
+			"             │       │           │   ├─ cla.FTQLQ:10!null\n" +
 			"             │       │           │   └─ ums.T4IBQ:1\n" +
 			"             │       │           └─ LookupJoin\n" +
 			"             │       │               ├─ Eq\n" +
-			"             │       │               │   ├─ cla.id:11!null\n" +
-			"             │       │               │   └─ bs.IXUXU:9\n" +
+			"             │       │               │   ├─ cla.id:9!null\n" +
+			"             │       │               │   └─ bs.IXUXU:8\n" +
 			"             │       │               ├─ TableAlias(bs)\n" +
 			"             │       │               │   └─ Table\n" +
-			"             │       │               │       └─ name: THNTS\n" +
+			"             │       │               │       ├─ name: THNTS\n" +
+			"             │       │               │       └─ columns: [id ixuxu]\n" +
 			"             │       │               └─ TableAlias(cla)\n" +
 			"             │       │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"             │       │                       └─ index: [YK2GW.id]\n" +
+			"             │       │                       ├─ index: [YK2GW.id]\n" +
+			"             │       │                       └─ columns: [id ftqlq]\n" +
 			"             │       │   as GXLUB, Subquery\n" +
 			"             │       │   ├─ cacheable: true\n" +
 			"             │       │   └─ Project\n" +
@@ -14984,25 +15176,27 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │       ├─ columns: [nd_for_id_overridden.id:67!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ nd_for_id_overridden.TW55N:70!null\n" +
+			"             │       │           │   ├─ nd_for_id_overridden.TW55N:68!null\n" +
 			"             │       │           │   └─ TJ5D2.H4DMT:63\n" +
 			"             │       │           └─ TableAlias(nd_for_id_overridden)\n" +
 			"             │       │               └─ IndexedTableAccess(E2I7U)\n" +
-			"             │       │                   └─ index: [E2I7U.TW55N]\n" +
+			"             │       │                   ├─ index: [E2I7U.TW55N]\n" +
+			"             │       │                   └─ columns: [id tw55n]\n" +
 			"             │       │   ELSE Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   └─ Project\n" +
 			"             │       │       ├─ columns: [nd_for_id.id:67!null]\n" +
 			"             │       │       └─ Filter\n" +
 			"             │       │           ├─ AND\n" +
-			"             │       │           │   ├─ (NOT(nd_for_id.FGG57:73 IS NULL))\n" +
+			"             │       │           │   ├─ (NOT(nd_for_id.FGG57:68 IS NULL))\n" +
 			"             │       │           │   └─ Eq\n" +
-			"             │       │           │       ├─ nd_for_id.FGG57:73\n" +
+			"             │       │           │       ├─ nd_for_id.FGG57:68\n" +
 			"             │       │           │       └─ umf.FGG57:2\n" +
 			"             │       │           └─ TableAlias(nd_for_id)\n" +
 			"             │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"             │       │                   ├─ index: [E2I7U.FGG57]\n" +
-			"             │       │                   └─ static: [{(NULL, ∞)}]\n" +
+			"             │       │                   ├─ static: [{(NULL, ∞)}]\n" +
+			"             │       │                   └─ columns: [id fgg57]\n" +
 			"             │       │   END as LUEVY, CASE  WHEN Eq\n" +
 			"             │       │   ├─ umf.SYPKF:8\n" +
 			"             │       │   └─ N/A (longtext)\n" +
@@ -15026,7 +15220,8 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │       │           │   └─ umf.SYPKF:8\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
 			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │       │                   └─ index: [TPXBU.BTXC5]\n" +
+			"             │       │                   ├─ index: [TPXBU.BTXC5]\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   END as M22QN, umf.TJPT7:6 as TJPT7, umf.ARN5P:7 as ARN5P, umf.XOSD4:13 as XOSD4, umf.IDE43:10 as IDE43, CASE  WHEN (NOT(Eq\n" +
 			"             │       │   ├─ umf.HMW4H:14\n" +
 			"             │       │   └─ N/A (longtext)\n" +
@@ -15225,24 +15420,27 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			"                 │   ├─ outerVisibility: false\n" +
 			"                 │   ├─ cacheable: true\n" +
 			"                 │   └─ Project\n" +
-			"                 │       ├─ columns: [mf.id:0!null as id, umf.AZ6SP:28 as AZ6SP]\n" +
+			"                 │       ├─ columns: [mf.id:0!null as id, umf.AZ6SP:3 as AZ6SP]\n" +
 			"                 │       └─ LookupJoin\n" +
 			"                 │           ├─ Eq\n" +
-			"                 │           │   ├─ umf.id:17!null\n" +
-			"                 │           │   └─ mf.TEUJA:14\n" +
+			"                 │           │   ├─ umf.id:2!null\n" +
+			"                 │           │   └─ mf.TEUJA:1\n" +
 			"                 │           ├─ TableAlias(mf)\n" +
 			"                 │           │   └─ Table\n" +
-			"                 │           │       └─ name: HGMQ6\n" +
+			"                 │           │       ├─ name: HGMQ6\n" +
+			"                 │           │       └─ columns: [id teuja]\n" +
 			"                 │           └─ Filter\n" +
 			"                 │               ├─ HashIn\n" +
 			"                 │               │   ├─ umf.id:0!null\n" +
 			"                 │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
 			"                 │               └─ TableAlias(umf)\n" +
 			"                 │                   └─ IndexedTableAccess(NZKPM)\n" +
-			"                 │                       └─ index: [NZKPM.id]\n" +
+			"                 │                       ├─ index: [NZKPM.id]\n" +
+			"                 │                       └─ columns: [id az6sp]\n" +
 			"                 └─ TableAlias(vc)\n" +
 			"                     └─ Table\n" +
-			"                         └─ name: D34QP\n" +
+			"                         ├─ name: D34QP\n" +
+			"                         └─ columns: [id twmsr]\n" +
 			"",
 	},
 	{
@@ -15389,7 +15587,8 @@ FROM
 			"             │                   │           │   └─ TIZHK.IDUT2:21\n" +
 			"             │                   │           └─ TableAlias(G3YXS)\n" +
 			"             │                   │               └─ Table\n" +
-			"             │                   │                   └─ name: YYBCX\n" +
+			"             │                   │                   ├─ name: YYBCX\n" +
+			"             │                   │                   └─ columns: [id esfvy sl76b]\n" +
 			"             │                   │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU]\n" +
 			"             │                   └─ Filter\n" +
 			"             │                       ├─ AND\n" +
@@ -15479,7 +15678,8 @@ FROM
 			"                     │           │   └─ BPNW2.SYPKF:3\n" +
 			"                     │           └─ TableAlias(aac)\n" +
 			"                     │               └─ IndexedTableAccess(TPXBU)\n" +
-			"                     │                   └─ index: [TPXBU.BTXC5]\n" +
+			"                     │                   ├─ index: [TPXBU.BTXC5]\n" +
+			"                     │                   └─ columns: [id btxc5]\n" +
 			"                     │   as M22QN, BPNW2.NZ4MQ:4 as NZ4MQ, BPNW2.MU3KG:0!null as ETPQV, BPNW2.I4NDZ:7 as PRUV2, BPNW2.YKSSU:6 as YKSSU, BPNW2.FHCYT:5 as FHCYT]\n" +
 			"                     └─ SubqueryAlias\n" +
 			"                         ├─ name: BPNW2\n" +
@@ -15493,22 +15693,24 @@ FROM
 			"                                 │       ├─ columns: [overridden_nd_mutant.id:54!null]\n" +
 			"                                 │       └─ Filter\n" +
 			"                                 │           ├─ Eq\n" +
-			"                                 │           │   ├─ overridden_nd_mutant.TW55N:57!null\n" +
+			"                                 │           │   ├─ overridden_nd_mutant.TW55N:55!null\n" +
 			"                                 │           │   └─ NHMXW.FZXV5:15\n" +
 			"                                 │           └─ TableAlias(overridden_nd_mutant)\n" +
 			"                                 │               └─ IndexedTableAccess(E2I7U)\n" +
-			"                                 │                   └─ index: [E2I7U.TW55N]\n" +
+			"                                 │                   ├─ index: [E2I7U.TW55N]\n" +
+			"                                 │                   └─ columns: [id tw55n]\n" +
 			"                                 │   ELSE J4JYP.id:20 END as FV24E, CASE  WHEN (NOT(NHMXW.DQYGV:16 IS NULL)) THEN Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
 			"                                 │   └─ Project\n" +
 			"                                 │       ├─ columns: [overridden_QI2IEner.id:54!null]\n" +
 			"                                 │       └─ Filter\n" +
 			"                                 │           ├─ Eq\n" +
-			"                                 │           │   ├─ overridden_QI2IEner.TW55N:57!null\n" +
+			"                                 │           │   ├─ overridden_QI2IEner.TW55N:55!null\n" +
 			"                                 │           │   └─ NHMXW.DQYGV:16\n" +
 			"                                 │           └─ TableAlias(overridden_QI2IEner)\n" +
 			"                                 │               └─ Table\n" +
-			"                                 │                   └─ name: E2I7U\n" +
+			"                                 │                   ├─ name: E2I7U\n" +
+			"                                 │                   └─ columns: [id tw55n]\n" +
 			"                                 │   ELSE RHUZN.id:37 END as UJ6XY, TIZHK.SYPKF:3 as SYPKF, Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
 			"                                 │   └─ Project\n" +
@@ -15519,7 +15721,8 @@ FROM
 			"                                 │           │   └─ TIZHK.IDUT2:4\n" +
 			"                                 │           └─ TableAlias(G3YXS)\n" +
 			"                                 │               └─ Table\n" +
-			"                                 │                   └─ name: YYBCX\n" +
+			"                                 │                   ├─ name: YYBCX\n" +
+			"                                 │                   └─ columns: [id esfvy sl76b]\n" +
 			"                                 │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU, NHMXW.id:10 as I4NDZ]\n" +
 			"                                 └─ Filter\n" +
 			"                                     ├─ (NOT(NHMXW.id:10 IS NULL))\n" +
@@ -15975,7 +16178,8 @@ WHERE
 			"             │       │           │   └─ PQSXB.BTXC5:10\n" +
 			"             │       │           └─ TableAlias(aac)\n" +
 			"             │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │       │                   └─ index: [TPXBU.BTXC5]\n" +
+			"             │       │                   ├─ index: [TPXBU.BTXC5]\n" +
+			"             │       │                   └─ columns: [id btxc5]\n" +
 			"             │       │   as M22QN, PQSXB.OVE3E:1 as OVE3E, PQSXB.NRURT:2!null as NRURT, PQSXB.OCA7E:3 as OCA7E, PQSXB.XMM6Q:4 as XMM6Q, PQSXB.V5DPX:5 as V5DPX, PQSXB.S3Q3Y:6 as S3Q3Y, PQSXB.ZRV3B:7 as ZRV3B, PQSXB.FHCYT:8 as FHCYT]\n" +
 			"             │       └─ InnerJoin\n" +
 			"             │           ├─ Or\n" +
@@ -16041,25 +16245,27 @@ WHERE
 			"             │           │           │           │               │   ├─ cacheable: false\n" +
 			"             │           │           │           │               │   └─ Limit(1)\n" +
 			"             │           │           │           │               │       └─ Project\n" +
-			"             │           │           │           │               │           ├─ columns: [nd.DKCAJ:29!null]\n" +
+			"             │           │           │           │               │           ├─ columns: [nd.DKCAJ:28!null]\n" +
 			"             │           │           │           │               │           └─ Filter\n" +
 			"             │           │           │           │               │               ├─ Eq\n" +
-			"             │           │           │           │               │               │   ├─ nd.ZH72S:35\n" +
+			"             │           │           │           │               │               │   ├─ nd.ZH72S:29\n" +
 			"             │           │           │           │               │               │   └─ uct.ZH72S:2\n" +
 			"             │           │           │           │               │               └─ TableAlias(nd)\n" +
 			"             │           │           │           │               │                   └─ IndexedTableAccess(E2I7U)\n" +
-			"             │           │           │           │               │                       └─ index: [E2I7U.ZH72S]\n" +
+			"             │           │           │           │               │                       ├─ index: [E2I7U.ZH72S]\n" +
+			"             │           │           │           │               │                       └─ columns: [dkcaj zh72s]\n" +
 			"             │           │           │           │               │   ELSE Subquery\n" +
 			"             │           │           │           │               │   ├─ cacheable: false\n" +
 			"             │           │           │           │               │   └─ Project\n" +
-			"             │           │           │           │               │       ├─ columns: [nd.DKCAJ:29!null]\n" +
+			"             │           │           │           │               │       ├─ columns: [nd.DKCAJ:28!null]\n" +
 			"             │           │           │           │               │       └─ Filter\n" +
 			"             │           │           │           │               │           ├─ Eq\n" +
-			"             │           │           │           │               │           │   ├─ nd.TW55N:31!null\n" +
+			"             │           │           │           │               │           │   ├─ nd.TW55N:29!null\n" +
 			"             │           │           │           │               │           │   └─ I7HCR.FVUCX:17\n" +
 			"             │           │           │           │               │           └─ TableAlias(nd)\n" +
 			"             │           │           │           │               │               └─ IndexedTableAccess(E2I7U)\n" +
-			"             │           │           │           │               │                   └─ index: [E2I7U.TW55N]\n" +
+			"             │           │           │           │               │                   ├─ index: [E2I7U.TW55N]\n" +
+			"             │           │           │           │               │                   └─ columns: [dkcaj tw55n]\n" +
 			"             │           │           │           │               │   END]\n" +
 			"             │           │           │           │               └─ Table\n" +
 			"             │           │           │           │                   └─ name: \n" +
@@ -16450,14 +16656,15 @@ WHERE
 			"             │       │           │       └─ Subquery\n" +
 			"             │       │           │           ├─ cacheable: false\n" +
 			"             │       │           │           └─ Project\n" +
-			"             │       │           │               ├─ columns: [nd.DKCAJ:20!null]\n" +
+			"             │       │           │               ├─ columns: [nd.DKCAJ:19!null]\n" +
 			"             │       │           │               └─ Filter\n" +
 			"             │       │           │                   ├─ Eq\n" +
-			"             │       │           │                   │   ├─ nd.TW55N:22!null\n" +
+			"             │       │           │                   │   ├─ nd.TW55N:20!null\n" +
 			"             │       │           │                   │   └─ TVTJS.I3VTA:2!null\n" +
 			"             │       │           │                   └─ TableAlias(nd)\n" +
 			"             │       │           │                       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │       │           │                           └─ index: [E2I7U.TW55N]\n" +
+			"             │       │           │                           ├─ index: [E2I7U.TW55N]\n" +
+			"             │       │           │                           └─ columns: [dkcaj tw55n]\n" +
 			"             │       │           └─ Table\n" +
 			"             │       │               └─ name: SFEGG\n" +
 			"             │       │   as OVE3E, NULL (null) as NRURT, NULL (null) as OCA7E, TVTJS.id:0!null as XMM6Q, TVTJS.V5DPX:4!null as V5DPX, (TVTJS.IDPK7:6!null + 0 (decimal(2,1))) as S3Q3Y, TVTJS.ZRV3B:8!null as ZRV3B, TVTJS.FHCYT:12 as FHCYT]\n" +

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -21,14 +21,17 @@ import (
 // query plan results. Handy when you've made a large change to the analyzer or node formatting, and you want to examine
 // how query plans have changed without a lot of manual copying and pasting.
 func TestWriteQueryPlans(t *testing.T) {
+	t.Skip()
 	writePlans(t, setup.PlanSetup, queries.PlanTests, "PlanTests", 1, true)
 }
 
 func TestWriteIndexQueryPlans(t *testing.T) {
+	t.Skip()
 	writePlans(t, setup.ComplexIndexSetup, queries.IndexPlanTests, "IndexPlanTests", 1, true)
 }
 
 func TestWriteIntegrationQueryPlans(t *testing.T) {
+	t.Skip()
 	writePlans(t, [][]setup.SetupScript{setup.MydbData, setup.Integration_testData}, queries.IntegrationPlanTests, "IntegrationPlanTests", 1, true)
 }
 

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -26,7 +26,7 @@ func TestWriteQueryPlans(t *testing.T) {
 }
 
 func TestWriteIndexQueryPlans(t *testing.T) {
-	t.Skip()
+	// t.Skip()
 	writePlans(t, setup.ComplexIndexSetup, queries.IndexPlanTests, "IndexPlanTests", 1, true)
 }
 

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -21,17 +21,14 @@ import (
 // query plan results. Handy when you've made a large change to the analyzer or node formatting, and you want to examine
 // how query plans have changed without a lot of manual copying and pasting.
 func TestWriteQueryPlans(t *testing.T) {
-	t.Skip()
 	writePlans(t, setup.PlanSetup, queries.PlanTests, "PlanTests", 1, true)
 }
 
 func TestWriteIndexQueryPlans(t *testing.T) {
-	t.Skip()
 	writePlans(t, setup.ComplexIndexSetup, queries.IndexPlanTests, "IndexPlanTests", 1, true)
 }
 
 func TestWriteIntegrationQueryPlans(t *testing.T) {
-	t.Skip()
 	writePlans(t, [][]setup.SetupScript{setup.MydbData, setup.Integration_testData}, queries.IntegrationPlanTests, "IntegrationPlanTests", 1, true)
 }
 

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -26,12 +26,12 @@ func TestWriteQueryPlans(t *testing.T) {
 }
 
 func TestWriteIndexQueryPlans(t *testing.T) {
-	// t.Skip()
+	t.Skip()
 	writePlans(t, setup.ComplexIndexSetup, queries.IndexPlanTests, "IndexPlanTests", 1, true)
 }
 
 func TestWriteIntegrationQueryPlans(t *testing.T) {
-	t.Skip()
+	// t.Skip()
 	writePlans(t, [][]setup.SetupScript{setup.MydbData, setup.Integration_testData}, queries.IntegrationPlanTests, "IntegrationPlanTests", 1, true)
 }
 

--- a/enginetest/testgen_test.go
+++ b/enginetest/testgen_test.go
@@ -31,7 +31,7 @@ func TestWriteIndexQueryPlans(t *testing.T) {
 }
 
 func TestWriteIntegrationQueryPlans(t *testing.T) {
-	// t.Skip()
+	t.Skip()
 	writePlans(t, [][]setup.SetupScript{setup.MydbData, setup.Integration_testData}, queries.IntegrationPlanTests, "IntegrationPlanTests", 1, true)
 }
 

--- a/memory/table.go
+++ b/memory/table.go
@@ -1033,10 +1033,6 @@ func (t *Table) IndexedAccess(i sql.IndexLookup) sql.IndexedTable {
 
 // WithProjections implements sql.ProjectedTable
 func (t *Table) WithProjections(cols []string) sql.Table {
-	if len(cols) == 0 {
-		return t
-	}
-
 	nt := *t
 	columns, err := nt.columnIndexes(cols)
 	if err != nil {

--- a/memory/table.go
+++ b/memory/table.go
@@ -365,13 +365,14 @@ func (i *tableIter) Next(ctx *sql.Context) (sql.Row, error) {
 		}
 	}
 
-	if len(i.columns) > 0 {
+	if i.columns != nil {
 		resultRow := make(sql.Row, len(i.columns))
 		for i, j := range i.columns {
 			resultRow[i] = row[j]
 		}
 		return resultRow, nil
 	}
+	
 	return row, nil
 }
 
@@ -1057,7 +1058,7 @@ func (t *Table) Projections() []string {
 }
 
 func (t *Table) columnIndexes(colNames []string) ([]int, error) {
-	var columns []int
+	columns := make([]int, 0, len(colNames))
 
 	for _, name := range colNames {
 		i := t.schema.IndexOf(name, t.name)

--- a/sql/analyzer/resolve_subqueries_test.go
+++ b/sql/analyzer/resolve_subqueries_test.go
@@ -50,7 +50,7 @@ func TestResolveSubqueries(t *testing.T) {
 	testCases := []analyzerFnTestCase{
 		{
 			// Test with a query containing a subquery alias that has outer scope visibility
-			name: `SELECT (select MAX(a) from (select a) sqa1) FROM foo`,
+			name: `SELECT (select MAX(a) from (select a from bar) sqa1) FROM foo`,
 			node: plan.NewProject(
 				[]sql.Expression{
 					plan.NewSubquery(
@@ -73,7 +73,7 @@ func TestResolveSubqueries(t *testing.T) {
 							newSubqueryAlias("sqa1", "select a from bar", true, false,
 								plan.NewProject(
 									[]sql.Expression{expression.NewGetFieldWithTable(0, types.Int64, "foo", "a", false)},
-									plan.NewResolvedTable(bar, db, nil)),
+									plan.NewResolvedTable(bar.WithProjections(make([]string, 0)), db, nil)),
 							),
 						), "select MAX(a) from (select a from bar) sqa1",
 					),
@@ -303,7 +303,7 @@ func TestResolveSubqueryExpressions(t *testing.T) {
 									gf(1, "mytable", "x"),
 									gf(0, "mytable", "i"),
 								),
-								plan.NewResolvedTable(table2, db, nil),
+								plan.NewResolvedTable(table2.WithProjections(make([]string, 0)), db, nil),
 							),
 						),
 						""),

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -293,12 +293,20 @@ func transferProjections(ctx *sql.Context, from, to *plan.ResolvedTable) *plan.R
 		return to
 	}
 
-	if _, ok := toTable.(sql.FilteredTable); ok {
+	changed := false
+
+	if _, ok := toTable.(sql.FilteredTable); ok && filters != nil {
 		toTable = toTable.(sql.FilteredTable).WithFilters(ctx, filters)
+		changed = true
 	}
 
-	if _, ok := toTable.(sql.ProjectedTable); ok {
+	if _, ok := toTable.(sql.ProjectedTable); ok && projections != nil {
 		toTable = toTable.(sql.ProjectedTable).WithProjections(projections)
+		changed = true
+	}
+
+	if !changed {
+		return to
 	}
 
 	return plan.NewResolvedTable(toTable, to.Database, to.AsOf)

--- a/sql/analyzer/symbol_resolution.go
+++ b/sql/analyzer/symbol_resolution.go
@@ -188,7 +188,7 @@ func pruneTableCols(
 		return n, transform.SameTree, nil
 	}
 
-	var cols []string
+	cols := make([]string, 0)
 	source := strings.ToLower(t.Name())
 	for _, col := range t.Schema() {
 		c := tableCol{table: source, col: strings.ToLower(col.Name)}

--- a/sql/analyzer/symbol_resolution.go
+++ b/sql/analyzer/symbol_resolution.go
@@ -191,7 +191,7 @@ func pruneTableCols(
 	cols := make([]string, 0)
 	source := strings.ToLower(t.Name())
 	for _, col := range t.Schema() {
-		c := tableCol{table: source, col: strings.ToLower(col.Name)}
+		c := tableCol{table: strings.ToLower(source), col: strings.ToLower(col.Name)}
 		if selectStar || parentCols[c] > 0 {
 			cols = append(cols, c.col)
 		}
@@ -276,8 +276,8 @@ func gatherTableAlias(
 			starred = true
 		}
 		for _, col := range n.Schema() {
-			baseCol := tableCol{table: base, col: col.Name}
-			aliasCol := tableCol{table: alias, col: col.Name}
+			baseCol := tableCol{table: strings.ToLower(base), col: strings.ToLower(col.Name)}
+			aliasCol := tableCol{table: strings.ToLower(alias), col: strings.ToLower(col.Name)}
 			if starred || parentCols[aliasCol] > 0 {
 				// if the outer scope requests an aliased column
 				// a table lower in the tree must provide the source

--- a/sql/analyzer/symbol_resolution.go
+++ b/sql/analyzer/symbol_resolution.go
@@ -197,14 +197,11 @@ func pruneTableCols(
 		}
 	}
 
-	if len(cols) == 0 {
-		return n, transform.SameTree, nil
-	}
-
 	ret, err := n.WithTable(ptab.WithProjections(cols))
 	if err != nil {
 		return n, transform.SameTree, nil
 	}
+
 	return ret, transform.NewTree, nil
 }
 

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -280,16 +280,20 @@ func (i *IndexedTableAccess) DebugString() string {
 		children = append(children, fmt.Sprintf("static: %s", i.lookup.Ranges.DebugString()))
 	}
 
-	if pt, ok := i.Table.(sql.ProjectedTable); ok {
+	var columns []string
+	if pt, ok := i.Table.(sql.ProjectedTable); ok && pt.Projections() != nil {
 		projections := pt.Projections()
-		if projections != nil {
-			columns := make([]string, len(projections))
-			for i, c := range projections {
-				columns[i] = strings.ToLower(c)
-			}
-			children = append(children, fmt.Sprintf("columns: %v", columns))
+		columns = make([]string, len(projections))
+		for i, c := range projections {
+			columns[i] = strings.ToLower(c)
+		}
+	} else {
+		columns = make([]string, len(i.Table.Schema()))
+		for i, c := range i.Table.Schema() {
+			columns[i] = strings.ToLower(c.Name)
 		}
 	}
+	children = append(children, fmt.Sprintf("columns: %v", columns))
 
 	if ft, ok := i.Table.(sql.FilteredTable); ok {
 		var filters []string

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -237,15 +237,18 @@ func (i *IndexedTableAccess) String() string {
 	if !i.lookup.IsEmpty() {
 		children = append(children, fmt.Sprintf("filters: %s", i.lookup.Ranges.DebugString()))
 	}
+
 	if pt, ok := i.Table.(sql.ProjectedTable); ok {
-		var columns []string
-		for _, c := range pt.Projections() {
-			columns = append(columns, strings.ToLower(c))
-		}
-		if len(pt.Projections()) > 0 {
+		projections := pt.Projections()
+		if projections != nil {
+			columns := make([]string, len(projections))
+			for i, c := range projections {
+				columns[i] = strings.ToLower(c)
+			}
 			children = append(children, fmt.Sprintf("columns: %v", columns))
 		}
 	}
+
 	if ft, ok := i.Table.(sql.FilteredTable); ok {
 		var filters []string
 		for _, f := range ft.Filters() {
@@ -255,6 +258,7 @@ func (i *IndexedTableAccess) String() string {
 			pr.WriteChildren(fmt.Sprintf("filters: %v", filters))
 		}
 	}
+
 	pr.WriteChildren(children...)
 	return pr.String()
 }
@@ -269,21 +273,24 @@ func formatIndexDecoratorString(idx sql.Index) string {
 
 func (i *IndexedTableAccess) DebugString() string {
 	pr := sql.NewTreePrinter()
-	pr.WriteNode("IndexedTableAccess")
+	pr.WriteNode("IndexedTableAccess(%s)", i.ResolvedTable.Name())
 	var children []string
 	children = append(children, fmt.Sprintf("index: %s", formatIndexDecoratorString(i.Index())))
 	if !i.lookup.IsEmpty() {
 		children = append(children, fmt.Sprintf("static: %s", i.lookup.Ranges.DebugString()))
 	}
+
 	if pt, ok := i.Table.(sql.ProjectedTable); ok {
-		if len(pt.Projections()) > 0 {
-			var columns []string
-			for _, c := range pt.Projections() {
-				columns = append(columns, strings.ToLower(c))
+		projections := pt.Projections()
+		if projections != nil {
+			columns := make([]string, len(projections))
+			for i, c := range projections {
+				columns[i] = strings.ToLower(c)
 			}
 			children = append(children, fmt.Sprintf("columns: %v", columns))
 		}
 	}
+
 	if ft, ok := i.Table.(sql.FilteredTable); ok {
 		var filters []string
 		for _, f := range ft.Filters() {
@@ -293,7 +300,7 @@ func (i *IndexedTableAccess) DebugString() string {
 			pr.WriteChildren(fmt.Sprintf("filters: %v", filters))
 		}
 	}
-	children = append(children, sql.DebugString(i.Table))
+
 	pr.WriteChildren(children...)
 	return pr.String()
 }

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -88,16 +88,20 @@ func (t *ResolvedTable) DebugString() string {
 	table := seethroughTableWrapper(t)
 	children := []string{fmt.Sprintf("name: %s", t.Name())}
 
-	if pt, ok := table.(sql.ProjectedTable); ok {
+	var columns []string
+	if pt, ok := table.(sql.ProjectedTable); ok && pt.Projections() != nil {
 		projections := pt.Projections()
-		if projections != nil {
-			columns := make([]string, len(projections))
-			for i, c := range projections {
-				columns[i] = strings.ToLower(c)
-			}
-			children = append(children, fmt.Sprintf("columns: %v", columns))
+		columns = make([]string, len(projections))
+		for i, c := range projections {
+			columns[i] = strings.ToLower(c)
+		}
+	} else {
+		columns = make([]string, len(table.Schema()))
+		for i, c := range table.Schema() {
+			columns[i] = strings.ToLower(c.Name)
 		}
 	}
+	children = append(children, fmt.Sprintf("columns: %v", columns))
 
 	if ft, ok := table.(sql.FilteredTable); ok {
 		var filters []string

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -56,15 +56,18 @@ func (t *ResolvedTable) String() string {
 	pr.WriteNode("Table")
 	table := seethroughTableWrapper(t)
 	children := []string{fmt.Sprintf("name: %s", t.Name())}
+
 	if pt, ok := table.(sql.ProjectedTable); ok {
-		var columns []string
-		for _, c := range pt.Projections() {
-			columns = append(columns, strings.ToLower(c))
-		}
-		if len(columns) > 0 {
+		projections := pt.Projections()
+		if projections != nil {
+			columns := make([]string, len(projections))
+			for i, c := range projections {
+				columns[i] = strings.ToLower(c)
+			}
 			children = append(children, fmt.Sprintf("columns: %v", columns))
 		}
 	}
+
 	if ft, ok := table.(sql.FilteredTable); ok {
 		var filters []string
 		for _, f := range ft.Filters() {
@@ -74,6 +77,7 @@ func (t *ResolvedTable) String() string {
 			children = append(children, fmt.Sprintf("filters: %v", filters))
 		}
 	}
+
 	pr.WriteChildren(children...)
 	return pr.String()
 }
@@ -83,15 +87,18 @@ func (t *ResolvedTable) DebugString() string {
 	pr.WriteNode("Table")
 	table := seethroughTableWrapper(t)
 	children := []string{fmt.Sprintf("name: %s", t.Name())}
+
 	if pt, ok := table.(sql.ProjectedTable); ok {
-		var columns []string
-		for _, c := range pt.Projections() {
-			columns = append(columns, strings.ToLower(c))
-		}
-		if len(columns) > 0 {
+		projections := pt.Projections()
+		if projections != nil {
+			columns := make([]string, len(projections))
+			for i, c := range projections {
+				columns[i] = strings.ToLower(c)
+			}
 			children = append(children, fmt.Sprintf("columns: %v", columns))
 		}
 	}
+
 	if ft, ok := table.(sql.FilteredTable); ok {
 		var filters []string
 		for _, f := range ft.Filters() {
@@ -101,8 +108,8 @@ func (t *ResolvedTable) DebugString() string {
 			children = append(children, fmt.Sprintf("filters: %v", filters))
 		}
 	}
-	pr.WriteChildren(children...)
 
+	pr.WriteChildren(children...)
 	return pr.String()
 }
 

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -70,15 +70,15 @@ type FilteredTable interface {
 }
 
 // ProjectedTable is a table that can return only a subset of its columns from RowIter. This provides a very large
-// efficiency gain during table scans. Tables that implement this interface must return only the projected columns 
+// efficiency gain during table scans. Tables that implement this interface must return only the projected columns
 // in future calls to Schema.
 type ProjectedTable interface {
 	Table
 	// WithProjections returns a version of this table with only the subset of columns named. Calls to Schema must
-	// only include these columns. A zero-length slice of column names is valid and indicates that rows from this table 
+	// only include these columns. A zero-length slice of column names is valid and indicates that rows from this table
 	// should be spooled, but no columns should be returned. A nil slice will never be provided.
 	WithProjections(colNames []string) Table
-	// Projections returns the names of the column projections applied to this table, or nil if no projection is applied 
+	// Projections returns the names of the column projections applied to this table, or nil if no projection is applied
 	// and all columns of the schema will be returned.
 	Projections() []string
 }

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -70,14 +70,16 @@ type FilteredTable interface {
 }
 
 // ProjectedTable is a table that can return only a subset of its columns from RowIter. This provides a very large
-// efficiency gain during table scans. Tables that implement this interface must return the projected column in future
-// calls to Schema
+// efficiency gain during table scans. Tables that implement this interface must return only the projected columns 
+// in future calls to Schema.
 type ProjectedTable interface {
 	Table
 	// WithProjections returns a version of this table with only the subset of columns named. Calls to Schema must
-	// only include these columns.
+	// only include these columns. A zero-length slice of column names is valid and indicates that rows from this table 
+	// should be spooled, but no columns should be returned. A nil slice will never be provided.
 	WithProjections(colNames []string) Table
-	// Projections returns the names of the column projections applied to this table.
+	// Projections returns the names of the column projections applied to this table, or nil if no projection is applied 
+	// and all columns of the schema will be returned.
 	Projections() []string
 }
 


### PR DESCRIPTION
Started with tightening the semantics of the `ProjectedTable` interface as it relates to an empty projection (nil v. empty slice). Then made changes to printing of `ResolvedTable` and `IndexedTableAccess`. This revealed problems in the prune columns rule when all columns were being pruned. Fixed those, which had been masking other bugs, where we hadn't been pruning when we could have been. This was in turn caused by other bugs in the prune rule dealing with case sensitivity.

We should now be able to prune more columns than before, and we can see an empty column projection in plans.