### PR TITLE
Separate cardinality from costing, convert semi to inner join

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -1,597 +1,1072 @@
-// Copyright 2022 Dolthub, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package enginetest
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
-	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/plan"
-	"github.com/dolthub/go-mysql-server/sql/transform"
+	"github.com/dolthub/go-mysql-server/sql/analyzer"
 )
 
-type JoinOpTest struct {
-	q     string
-	types []plan.JoinType
-	exp   []sql.Row
-	skip  bool
+type JoinOpTests struct {
+	Query    string
+	Expected []sql.Row
+	Skip     bool
 }
 
-var JoinOpTests = []struct {
-	name  string
-	setup []string
-	tests []JoinOpTest
-}{
-	{
-		name: "merge join unary index",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int, index y_idx(y));",
-			"create table rs (r int primary key, s int, index s_idx(s));",
-			"CREATE table uv (u int primary key, v int);",
-			"CREATE table ab (a int primary key, b int);",
-			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
-			"insert into rs values (0,0), (1,0), (2,0), (4,4), (5,4);",
-			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
-			"insert into ab values (0,2), (1,2), (2,2), (3,1);",
-			"update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs';",
-			"update information_schema.statistics set cardinality = 1000000000 where table_name = 'ab'",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select u,a,y from uv join (select /*+ JOIN_ORDER(ab, xy) */ * from ab join xy on y = a) r on u = r.a order by 1",
-				types: []plan.JoinType{plan.JoinTypeLookup, plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 0}, {1, 1, 1}, {2, 2, 2}, {3, 3, 3}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(ab, xy) */ * from ab join xy on y = a order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 2, 1, 0}, {1, 2, 2, 1}, {2, 2, 0, 2}, {3, 1, 3, 3}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs left join xy on y = s order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 1, 0}, {2, 0, 1, 0}, {4, 4, nil, nil}, {5, 4, nil, nil}},
-			},
-			{
-				// extra join condition does not filter left-only rows
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs left join xy on y = s and y+s = 0 order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 1, 0}, {2, 0, 1, 0}, {4, 4, nil, nil}, {5, 4, nil, nil}},
-			},
-			{
-				// extra join condition does not filter left-only rows
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs left join xy on y+2 = s and s-y = 2 order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterMerge},
-				exp:   []sql.Row{{0, 0, nil, nil}, {1, 0, nil, nil}, {2, 0, nil, nil}, {4, 4, 0, 2}, {5, 4, 0, 2}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = r order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 2, 1}, {2, 0, 0, 2}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on r = y order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 2, 1}, {2, 0, 0, 2}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 1, 0}, {2, 0, 1, 0}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s and y = r order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y+2 = s order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{4, 4, 0, 2}, {5, 4, 0, 2}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s-1 order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeHash},
-				exp:   []sql.Row{{4, 4, 3, 3}, {5, 4, 3, 3}},
-			},
-			//{
-			// TODO: cannot hash join on compound expressions
-			//	q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = mod(s,2) order by 1, 3",
-			//	types: []plan.JoinType{plan.JoinTypeInner},
-			//	exp:   []sql.Row{{0,0,1,0},{0, 0, 1, 0},{2,0,1,0},{4,4,1,0}},
-			//},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on 2 = s+y order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeInner},
-				exp:   []sql.Row{{0, 0, 0, 2}, {1, 0, 0, 2}, {2, 0, 0, 2}},
-			},
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y > s+2 order by 1, 3",
-				types: []plan.JoinType{plan.JoinTypeInner},
-				exp:   []sql.Row{{0, 0, 3, 3}, {1, 0, 3, 3}, {2, 0, 3, 3}},
-			},
-		},
-	},
-	{
-		name: "merge join multi match",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int, index y_idx(y));",
-			"create table rs (r int primary key, s int, index s_idx(s));",
-			"insert into xy values (1,0), (2,1), (0,8), (3,7), (5,4), (4,0);",
-			"insert into rs values (0,0),(2,3),(3,0), (4,8), (5,4);",
-			"update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs';",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {0, 0, 4, 0}, {3, 0, 1, 0}, {3, 0, 4, 0}, {4, 8, 0, 8}, {5, 4, 5, 4}},
-			},
-		},
-	},
-	{
-		name: "merge join zero rows",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int, index y_idx(y));",
-			"create table rs (r int primary key, s int, index s_idx(s));",
-			"insert into xy values (1,0);",
-			"update information_schema.statistics set cardinality = 10 where table_name = 'xy';",
-			"update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs';",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{},
-			},
-		},
-	},
-	{
-		name: "merge join multi arity",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int, index yx_idx(y,x));",
-			"create table rs (r int primary key, s int, index s_idx(s));",
-			"insert into xy values (1,0), (2,1), (0,8), (3,7), (5,4), (4,0);",
-			"insert into rs values (0,0),(2,3),(3,0), (4,8), (5,4);",
-			"update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs';",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {0, 0, 4, 0}, {3, 0, 1, 0}, {3, 0, 4, 0}, {4, 8, 0, 8}, {5, 4, 5, 4}},
-			},
-		},
-	},
-	{
-		name: "merge join keyless index",
-		setup: []string{
-			"CREATE table xy (x int, y int, index yx_idx(y,x));",
-			"create table rs (r int, s int, index s_idx(s));",
-			"insert into xy values (1,0), (2,1), (0,8), (3,7), (5,4), (4,0);",
-			"insert into rs values (0,0),(2,3),(3,0), (4,8), (5,4);",
-			"update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs';",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
-				types: []plan.JoinType{plan.JoinTypeMerge},
-				exp:   []sql.Row{{0, 0, 1, 0}, {0, 0, 4, 0}, {3, 0, 1, 0}, {3, 0, 4, 0}, {4, 8, 0, 8}, {5, 4, 5, 4}},
-			},
-		},
-	},
-	{
-		name: "partial [lookup] join tests",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int);",
-			"create table rs (r int primary key, s int);",
-			"CREATE table uv (u int primary key, v int);",
-			"CREATE table ab (a int primary key, b int);",
-			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
-			"insert into rs values (0,0), (1,0), (2,0), (4,4);",
-			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
-			"insert into ab values (0,2), (1,2), (2,2), (3,1);",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select * from xy where y+1 not in (select u from uv);",
-				types: []plan.JoinType{plan.JoinTypeAntiLookup},
-				exp:   []sql.Row{{3, 3}},
-			},
-			{
-				q:     "select * from xy where x not in (select u from uv where u not in (select a from ab where a not in (select r from rs where r = 1))) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeAnti, plan.JoinTypeAnti, plan.JoinTypeAntiLookup},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				q:     "select * from xy where x != (select r from rs where r = 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeAnti},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				// anti join will be cross-join-right, be passed non-nil parent row
-				q:     "select x,a from ab, (select * from xy where x != (select r from rs where r = 1) order by 1) sq where x = 2 and b = 2 order by 1,2;",
-				types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeAnti},
-				exp:   []sql.Row{{2, 0}, {2, 1}, {2, 2}},
-			},
-			{
-				// scope and parent row are non-nil
-				q: `
-select * from uv where u > (
-  select x from ab, (
-    select x from xy where x != (
-      select r from rs where r = 1
-    ) order by 1
-  ) sq
-  order by 1 limit 1
-)
-order by 1;`,
-				types: []plan.JoinType{plan.JoinTypeSemi, plan.JoinTypeCross, plan.JoinTypeAnti},
-				exp:   []sql.Row{{1, 1}, {2, 2}, {3, 2}},
-			},
-			{
-				// cast prevents scope merging
-				q:     "select * from xy where x != (select cast(r as signed) from rs where r = 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeAnti},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				// order by will be discarded
-				q:     "select * from xy where x != (select r from rs where r = 1 order by 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeAnti},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				// limit prevents scope merging
-				q:     "select * from xy where x != (select r from rs where r = 1 limit 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeAnti},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				q:     "select * from xy where y-1 in (select u from uv) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemiLookup},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				// semi join will be right-side, be passed non-nil parent row
-				q:     "select x,a from ab, (select * from xy where x = (select r from rs where r = 1) order by 1) sq order by 1,2",
-				types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeRightSemiLookup},
-				exp:   []sql.Row{{1, 0}, {1, 1}, {1, 2}, {1, 3}},
-			},
-			//{
-			// scope and parent row are non-nil
-			// TODO: subquery alias unable to track parent row from a different scope
-			//				q: `
-			//select * from uv where u > (
-			//  select x from ab, (
-			//    select x from xy where x = (
-			//      select r from rs where r = 1
-			//    ) order by 1
-			//  ) sq
-			//  order by 1 limit 1
-			//)
-			//order by 1;`,
-			//types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeRightSemiLookup},
-			//exp:   []sql.Row{{2, 2}, {3, 2}},
-			//},
-			{
-				q:     "select * from xy where y-1 in (select cast(u as signed) from uv) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				q:     "select * from xy where y-1 in (select u from uv order by 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemiLookup},
-				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
-			},
-			{
-				q:     "select * from xy where y-1 in (select u from uv order by 1 limit 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{2, 1}},
-			},
-			{
-				q:     "select * from xy where x in (select u from uv join ab on u = a and a = 2) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeRightSemiLookup, plan.JoinTypeLookup},
-				exp:   []sql.Row{{2, 1}},
-			},
-			{
-				q:     "select * from xy where x = (select u from uv join ab on u = a and a = 2) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeRightSemiLookup, plan.JoinTypeLookup},
-				exp:   []sql.Row{{2, 1}},
-			},
-			{
-				// group by doesn't transform
-				q:     "select * from xy where y-1 in (select u from uv group by v having v = 2 order by 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{3, 3}},
-			},
-			{
-				// window doesn't transform
-				q:     "select * from xy where y-1 in (select row_number() over (order by v) from uv) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{0, 2}, {3, 3}},
-			},
-		},
-	},
-	{
-		name: "empty join tests",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int);",
-			"CREATE table uv (u int primary key, v int);",
-			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
-			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select * from xy where y-1 = (select u from uv limit 1 offset 5);",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{},
-			},
-			{
-				q:     "select * from xy where x != (select u from uv limit 1 offset 5);",
-				types: []plan.JoinType{plan.JoinTypeAnti},
-				exp:   []sql.Row{},
-			},
-		},
-	},
-	{
-		name: "unnest with scope filters",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int);",
-			"CREATE table uv (u int primary key, v int);",
-			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
-			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select * from xy where y-1 = (select u from uv where v = 2 order by 1 limit 1);",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{3, 3}},
-			},
-			{
-				q:     "select * from xy where x != (select u from uv where v = 2 order by 1 limit 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeAnti},
-				exp:   []sql.Row{{0, 2}, {1, 0}, {3, 3}},
-			},
-			{
-				q:     "select * from xy where x != (select distinct u from uv where v = 2 order by 1 limit 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeAnti},
-				exp:   []sql.Row{{0, 2}, {1, 0}, {3, 3}},
-			},
-			{
-				q:     "select * from xy where (x,y+1) = (select u,v from uv where v = 2 order by 1 limit 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{2, 1}},
-			},
-			{
-				q:     "select * from xy where x in (select cnt from (select count(u) as cnt from uv group by v having cnt > 0) sq) order by 1,2;",
-				types: []plan.JoinType{plan.JoinTypeRightSemiLookup},
-				exp:   []sql.Row{{2, 1}},
-			},
-		},
-	},
-	{
-		name: "unnest non-equality comparisons",
-		setup: []string{
-			"CREATE table xy (x int primary key, y int);",
-			"CREATE table uv (u int primary key, v int);",
-			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
-			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
-		},
-		tests: []JoinOpTest{
-			{
-				q:     "select * from xy where y >= (select u from uv where u = 2) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{0, 2}, {3, 3}},
-			},
-			{
-				q:     "select * from xy where x <= (select u from uv where u = 2) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{0, 2}, {1, 0}, {2, 1}},
-			},
-			{
-				q:     "select * from xy where x < (select u from uv where u = 2) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{0, 2}, {1, 0}},
-			},
-			{
-				q:     "select * from xy where x > (select u from uv where u = 2) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{3, 3}},
-			},
-			{
-				q:     "select * from uv where v <=> (select u from uv where u = 2) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeSemi},
-				exp:   []sql.Row{{2, 2}, {3, 2}},
-			},
-		},
-	},
+var biasedCosters = []analyzer.Coster{
+	analyzer.NewInnerBiasedCoster(),
+	analyzer.NewLookupBiasedCoster(),
+	analyzer.NewHashBiasedCoster(),
+	analyzer.NewMergeBiasedCoster(),
 }
 
 func TestJoinOps(t *testing.T, harness Harness) {
-	for _, tt := range JoinOpTests {
+	for _, tt := range joinCostTests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := mustNewEngine(t, harness)
 			defer e.Close()
-			for _, statement := range tt.setup {
-				if sh, ok := harness.(SkippingHarness); ok {
-					if sh.SkipQueryTest(statement) {
-						t.Skip()
+			for _, setup := range tt.setup {
+				for _, statement := range setup {
+					if sh, ok := harness.(SkippingHarness); ok {
+						if sh.SkipQueryTest(statement) {
+							t.Skip()
+						}
 					}
+					ctx := NewContext(harness)
+					RunQueryWithContext(t, e, harness, ctx, statement)
 				}
-				ctx := NewContext(harness)
-				RunQueryWithContext(t, e, harness, ctx, statement)
 			}
-			for _, tt := range tt.tests {
-				evalJoinTypeTest(t, harness, e, tt)
-				evalJoinCorrectnessTest(t, harness, e, tt)
+			for i, c := range []string{"inner", "lookup", "hash", "merge"} {
+				e.Analyzer.Coster = biasedCosters[i]
+				for _, tt := range tt.tests {
+					evalJoinCorrectness(t, harness, e, fmt.Sprintf("%s join: %s", c, tt.Query), tt.Query, tt.Expected, tt.Skip)
+				}
 			}
 		})
 	}
-}
-
-func evalJoinTypeTest(t *testing.T, harness Harness, e *sqle.Engine, tt JoinOpTest) {
-	t.Run(tt.q+" join types", func(t *testing.T) {
-		if tt.skip {
-			t.Skip()
-		}
-
-		ctx := NewContext(harness)
-		ctx = ctx.WithQuery(tt.q)
-
-		a, err := e.AnalyzeQuery(ctx, tt.q)
-		require.NoError(t, err)
-
-		jts := collectJoinTypes(a)
-		require.Equal(t, tt.types, jts, fmt.Sprintf("unexpected plan:\n%s", sql.DebugString(a)))
-	})
-}
-
-func evalJoinCorrectnessTest(t *testing.T, harness Harness, e *sqle.Engine, tt JoinOpTest) {
-	t.Run(tt.q, func(t *testing.T) {
-		if tt.skip {
-			t.Skip()
-		}
-
-		ctx := NewContext(harness)
-		ctx = ctx.WithQuery(tt.q)
-
-		sch, iter, err := e.QueryWithBindings(ctx, tt.q, nil)
-		require.NoError(t, err, "Unexpected error for query %s: %s", tt.q, err)
-
-		rows, err := sql.RowIterToRows(ctx, sch, iter)
-		require.NoError(t, err, "Unexpected error for query %s: %s", tt.q, err)
-
-		if tt.exp != nil {
-			checkResults(t, tt.exp, nil, sch, rows, tt.q)
-		}
-
-		require.Equal(t, 0, ctx.Memory.NumCaches())
-		validateEngine(t, ctx, harness, e)
-	})
-}
-
-func collectJoinTypes(n sql.Node) []plan.JoinType {
-	var types []plan.JoinType
-	transform.Inspect(n, func(n sql.Node) bool {
-		if n == nil {
-			return true
-		}
-		j, ok := n.(*plan.JoinNode)
-		if ok {
-			types = append(types, j.Op)
-		}
-
-		if ex, ok := n.(sql.Expressioner); ok {
-			for _, e := range ex.Expressions() {
-				transform.InspectExpr(e, func(e sql.Expression) bool {
-					sq, ok := e.(*plan.Subquery)
-					if !ok {
-						return false
-					}
-					types = append(types, collectJoinTypes(sq.Query)...)
-					return false
-				})
-			}
-		}
-		return true
-	})
-	return types
 }
 
 func TestJoinOpsPrepared(t *testing.T, harness Harness) {
-	for _, tt := range JoinOpTests {
+	for _, tt := range joinCostTests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := mustNewEngine(t, harness)
 			defer e.Close()
-			for _, statement := range tt.setup {
-				if sh, ok := harness.(SkippingHarness); ok {
-					if sh.SkipQueryTest(statement) {
-						t.Skip()
+			for _, setup := range tt.setup {
+				for _, statement := range setup {
+					if sh, ok := harness.(SkippingHarness); ok {
+						if sh.SkipQueryTest(statement) {
+							t.Skip()
+						}
 					}
+					ctx := NewContext(harness)
+					RunQueryWithContext(t, e, harness, ctx, statement)
 				}
-				ctx := NewContext(harness)
-				RunQueryWithContext(t, e, harness, ctx, statement)
 			}
-			for _, tt := range tt.tests {
-				evalJoinTypeTestPrepared(t, harness, e, tt)
-				evalJoinCorrectnessTestPrepared(t, harness, e, tt)
+			for i, c := range []string{"inner", "lookup", "hash", "merge"} {
+				e.Analyzer.Coster = biasedCosters[i]
+				for _, tt := range tt.tests {
+					evalJoinCorrectnessPrepared(t, harness, e, fmt.Sprintf("%s join: %s", c, tt.Query), tt.Query, tt.Expected, tt.Skip)
+				}
 			}
 		})
 	}
 }
 
-func evalJoinTypeTestPrepared(t *testing.T, harness Harness, e *sqle.Engine, tt JoinOpTest) {
-	t.Run(tt.q+" join types", func(t *testing.T) {
-		if tt.skip {
-			t.Skip()
-		}
+var joinCostTests = []struct {
+	name  string
+	setup [][]string
+	tests []JoinOpTests
+}{
+	{
+		name: "4-way join tests",
+		setup: [][]string{
+			setup.MydbData[0],
+			setup.MytableData[0],
+			setup.OthertableData[0],
+			setup.Pk_tablesData[0],
+			setup.NiltableData[0],
+			setup.TabletestData[0],
+		},
+		tests: []JoinOpTests{
+			{
+				Query: `SELECT i, s, i2, s2 FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT (s2 <=> s)`,
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query: `SELECT i, s, i2, s2 FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND NOT (s2 = s)`,
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query: `SELECT i, s, i2, s2 FROM MYTABLE JOIN OTHERTABLE ON i = i2 AND CONCAT(s, s2) IS NOT NULL`,
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query: `SELECT * FROM mytable mt JOIN othertable ot ON ot.i2 = (SELECT i2 FROM othertable WHERE s2 = "second") AND mt.i = ot.i2 JOIN mytable mt2 ON mt.i = mt2.i`,
+				Expected: []sql.Row{
+					{2, "second row", "second", 2, 2, "second row"},
+				},
+			},
+			{
+				Query:    "SELECT l.i, r.i2 FROM niltable l INNER JOIN niltable r ON l.i2 = r.i2 ORDER BY 1",
+				Expected: []sql.Row{{2, 2}, {4, 4}, {6, 6}},
+			},
+			{
+				Query:    "SELECT l.i, r.i2 FROM niltable l INNER JOIN niltable r ON l.i2 != r.i2 ORDER BY 1, 2",
+				Expected: []sql.Row{{2, 4}, {2, 6}, {4, 2}, {4, 6}, {6, 2}, {6, 4}},
+			},
+			{
+				Query:    "SELECT l.i, r.i2 FROM niltable l INNER JOIN niltable r ON l.i2 <=> r.i2 ORDER BY 1 ASC",
+				Expected: []sql.Row{{1, nil}, {1, nil}, {1, nil}, {2, 2}, {3, nil}, {3, nil}, {3, nil}, {4, 4}, {5, nil}, {5, nil}, {5, nil}, {6, 6}},
+			},
+			{
+				// TODO: ORDER BY should apply to the union. The parser is wrong.
+				Query: `SELECT s2, i2, i
+			FROM (SELECT * FROM mytable) mytable
+			RIGHT JOIN
+				((SELECT i2, s2 FROM othertable ORDER BY i2 ASC)
+				 UNION ALL
+				 SELECT CAST(4 AS SIGNED) AS i2, "not found" AS s2 FROM DUAL) othertable
+			ON i2 = i`,
+				Expected: []sql.Row{
+					{"third", 1, 1},
+					{"second", 2, 2},
+					{"first", 3, 3},
+					{"not found", 4, nil},
+				},
+			},
+			{
+				Query: `SELECT
+			"testing" AS s,
+			(SELECT max(i)
+			 FROM (SELECT * FROM mytable) mytable
+			 RIGHT JOIN
+				((SELECT i2, s2 FROM othertable ORDER BY i2 ASC)
+				 UNION ALL
+				 SELECT CAST(4 AS SIGNED) AS i2, "not found" AS s2 FROM DUAL) othertable
+				ON i2 = i) AS rj
+			FROM DUAL`,
+				Expected: []sql.Row{
+					{"testing", 3},
+				},
+			},
+			{
+				Query: `SELECT
+			"testing" AS s,
+			(SELECT max(i2)
+			 FROM (SELECT * FROM mytable) mytable
+			 RIGHT JOIN
+				((SELECT i2, s2 FROM othertable ORDER BY i2 ASC)
+				 UNION ALL
+				 SELECT CAST(4 AS SIGNED) AS i2, "not found" AS s2 FROM DUAL) othertable
+				ON i2 = i) AS rj
+			FROM DUAL`,
+				Expected: []sql.Row{
+					{"testing", 4},
+				},
+			},
 
-		ctx := NewContext(harness)
-		ctx = ctx.WithQuery(tt.q)
-
-		bindings, err := injectBindVarsAndPrepare(t, ctx, e, tt.q)
-		require.NoError(t, err)
-
-		p, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), tt.q)
-		require.True(t, ok, "prepared statement not found")
-
-		if len(bindings) > 0 {
-			var usedBindings map[string]bool
-			p, usedBindings, err = plan.ApplyBindings(p, bindings)
-			require.NoError(t, err)
-			for binding := range bindings {
-				require.True(t, usedBindings[binding], "unused binding %s", binding)
-			}
-		}
-
-		a, _, err := e.Analyzer.AnalyzePrepared(ctx, p, nil)
-		require.NoError(t, err)
-
-		jts := collectJoinTypes(a)
-		require.Equal(t, tt.types, jts)
-	})
-}
-
-func evalJoinCorrectnessTestPrepared(t *testing.T, harness Harness, e *sqle.Engine, tt JoinOpTest) {
-	t.Run(tt.q, func(t *testing.T) {
-		if tt.skip {
-			t.Skip()
-		}
-
-		ctx := NewContext(harness)
-		ctx = ctx.WithQuery(tt.q)
-
-		bindings, err := injectBindVarsAndPrepare(t, ctx, e, tt.q)
-		require.NoError(t, err)
-
-		sch, iter, err := e.QueryWithBindings(ctx, tt.q, bindings)
-		require.NoError(t, err, "Unexpected error for query %s: %s", tt.q, err)
-
-		rows, err := sql.RowIterToRows(ctx, sch, iter)
-		require.NoError(t, err, "Unexpected error for query %s: %s", tt.q, err)
-
-		if tt.exp != nil {
-			checkResults(t, tt.exp, nil, sch, rows, tt.q)
-		}
-
-		require.Equal(t, 0, ctx.Memory.NumCaches())
-		validateEngine(t, ctx, harness, e)
-	})
+			{
+				Query: "SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
+				Expected: []sql.Row{
+					{"third"},
+					{"secon"},
+					{"first"},
+				},
+			},
+			{
+				Query: "SELECT t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "SELECT /*+ JOIN_ORDER(t1,t2) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "SELECT /*+ JOIN_ORDER(t2,t1) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "SELECT /*+ JOIN_ORDER(t1) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "SELECT /*+ JOIN_ORDER(t1, mytable) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "SELECT /*+ JOIN_ORDER(t1, not_exist) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "SELECT /*+ NOTHING(abc) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "SELECT /*+ JOIN_ORDER( */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: "select mytable.i as i2, othertable.i2 as i from mytable join othertable on i = i2 order by 1",
+				Expected: []sql.Row{
+					{1, 1},
+					{2, 2},
+					{3, 3},
+				},
+			},
+			{
+				Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR s = s2 order by 1",
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 order by 1, 3",
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{1, "first row", 3, "first"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 1, "third"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 OR SUBSTRING_INDEX(s, ' ', 2) = s2 order by 1, 3",
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{1, "first row", 3, "first"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 1, "third"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR SUBSTRING_INDEX(s, ' ', 2) = s2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 order by 1, 3",
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{1, "first row", 3, "first"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 1, "third"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON SUBSTRING_INDEX(s, ' ', 2) = s2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 OR i = i2 order by 1, 3",
+				Expected: []sql.Row{
+					{1, "first row", 1, "third"},
+					{1, "first row", 3, "first"},
+					{2, "second row", 2, "second"},
+					{3, "third row", 1, "third"},
+					{3, "third row", 3, "first"},
+				},
+			},
+			{
+				Query:    "SELECT t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 3",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
+				Expected: []sql.Row{
+					{int64(1), int64(1), "third"},
+					{int64(2), int64(2), "second"},
+					{int64(3), int64(3), "first"},
+				},
+			},
+			{
+				Query: "SELECT i, i2, s2 FROM mytable as OTHERTABLE INNER JOIN othertable as MYTABLE ON i = i2 ORDER BY i",
+				Expected: []sql.Row{
+					{int64(1), int64(1), "third"},
+					{int64(2), int64(2), "second"},
+					{int64(3), int64(3), "first"},
+				},
+			},
+			{
+				Query: "SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
+				Expected: []sql.Row{
+					{"third", int64(1), int64(1)},
+					{"second", int64(2), int64(2)},
+					{"first", int64(3), int64(3)},
+				},
+			},
+			{
+				Query: "SELECT i, i2, s2 FROM othertable JOIN mytable  ON i = i2 ORDER BY i",
+				Expected: []sql.Row{
+					{int64(1), int64(1), "third"},
+					{int64(2), int64(2), "second"},
+					{int64(3), int64(3), "first"},
+				},
+			},
+			{
+				Query: "SELECT s2, i2, i FROM othertable JOIN mytable ON i = i2 ORDER BY i",
+				Expected: []sql.Row{
+					{"third", int64(1), int64(1)},
+					{"second", int64(2), int64(2)},
+					{"first", int64(3), int64(3)},
+				},
+			},
+			{
+				Query: "SELECT s FROM mytable INNER JOIN othertable " +
+					"ON substring(s2, 1, 2) != '' AND i = i2 ORDER BY 1",
+				Expected: []sql.Row{
+					{"first row"},
+					{"second row"},
+					{"third row"},
+				},
+			},
+			{
+				Query: `SELECT i FROM mytable NATURAL JOIN tabletest`,
+				Expected: []sql.Row{
+					{int64(1)},
+					{int64(2)},
+					{int64(3)},
+				},
+			},
+			{
+				Query: `SELECT i FROM mytable AS t NATURAL JOIN tabletest AS test`,
+				Expected: []sql.Row{
+					{int64(1)},
+					{int64(2)},
+					{int64(3)},
+				},
+			},
+			{
+				Query: `SELECT t.i, test.s FROM mytable AS t NATURAL JOIN tabletest AS test`,
+				Expected: []sql.Row{
+					{int64(1), "first row"},
+					{int64(2), "second row"},
+					{int64(3), "third row"},
+				},
+			},
+			{
+				Query: `SELECT * FROM tabletest, mytable mt INNER JOIN othertable ot ON mt.i = ot.i2`,
+				Expected: []sql.Row{
+					{int64(1), "first row", int64(1), "first row", "third", int64(1)},
+					{int64(1), "first row", int64(2), "second row", "second", int64(2)},
+					{int64(1), "first row", int64(3), "third row", "first", int64(3)},
+					{int64(2), "second row", int64(1), "first row", "third", int64(1)},
+					{int64(2), "second row", int64(2), "second row", "second", int64(2)},
+					{int64(2), "second row", int64(3), "third row", "first", int64(3)},
+					{int64(3), "third row", int64(1), "first row", "third", int64(1)},
+					{int64(3), "third row", int64(2), "second row", "second", int64(2)},
+					{int64(3), "third row", int64(3), "third row", "first", int64(3)},
+				},
+			},
+			{
+				Query: `SELECT * FROM tabletest join mytable mt INNER JOIN othertable ot ON tabletest.i = ot.i2 order by 1,3,6`,
+				Expected: []sql.Row{
+					{int64(1), "first row", int64(1), "first row", "third", int64(1)},
+					{int64(1), "first row", int64(2), "second row", "third", int64(1)},
+					{int64(1), "first row", int64(3), "third row", "third", int64(1)},
+					{int64(2), "second row", int64(1), "first row", "second", int64(2)},
+					{int64(2), "second row", int64(2), "second row", "second", int64(2)},
+					{int64(2), "second row", int64(3), "third row", "second", int64(2)},
+					{int64(3), "third row", int64(1), "first row", "first", int64(3)},
+					{int64(3), "third row", int64(2), "second row", "first", int64(3)},
+					{int64(3), "third row", int64(3), "third row", "first", int64(3)},
+				},
+			},
+			{
+				Query: `SELECT * FROM mytable mt INNER JOIN othertable ot ON mt.i = ot.i2 AND mt.i > 2`,
+				Expected: []sql.Row{
+					{int64(3), "third row", "first", int64(3)},
+				},
+			},
+			{
+				Query: `SELECT * FROM othertable ot INNER JOIN mytable mt ON mt.i = ot.i2 AND mt.i > 2`,
+				Expected: []sql.Row{
+					{"first", int64(3), int64(3), "third row"},
+				},
+			},
+			{
+				Query: "SELECT i, i2, s2 FROM mytable LEFT JOIN othertable ON i = i2 - 1",
+				Expected: []sql.Row{
+					{int64(1), int64(2), "second"},
+					{int64(2), int64(3), "first"},
+					{int64(3), nil, nil},
+				},
+			},
+			{
+				Query: "SELECT i, i2, s2 FROM mytable RIGHT JOIN othertable ON i = i2 - 1",
+				Expected: []sql.Row{
+					{nil, int64(1), "third"},
+					{int64(1), int64(2), "second"},
+					{int64(2), int64(3), "first"},
+				},
+			},
+			{
+				Query: "SELECT i, i2, s2 FROM mytable LEFT OUTER JOIN othertable ON i = i2 - 1",
+				Expected: []sql.Row{
+					{int64(1), int64(2), "second"},
+					{int64(2), int64(3), "first"},
+					{int64(3), nil, nil},
+				},
+			},
+			{
+				Query: "SELECT i, i2, s2 FROM mytable RIGHT OUTER JOIN othertable ON i = i2 - 1",
+				Expected: []sql.Row{
+					{nil, int64(1), "third"},
+					{int64(1), int64(2), "second"},
+					{int64(2), int64(3), "first"},
+				},
+			},
+			{
+				Query: `SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2
+				FROM othertable ot INNER JOIN
+					(SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub
+				ON sub.i = ot.i2 order by 1`,
+				Expected: []sql.Row{
+					{1, 1, "third", 1, "third"},
+					{2, 2, "second", 2, "second"},
+					{3, 3, "first", 3, "first"},
+				},
+			},
+			{
+				Query: `SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2
+				FROM (SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub
+				INNER JOIN othertable ot
+				ON sub.i = ot.i2 order by 1`,
+				Expected: []sql.Row{
+					{1, 1, "third", 1, "third"},
+					{2, 2, "second", 2, "second"},
+					{3, 3, "first", 3, "first"},
+				},
+			},
+			{
+				Query: "SELECT one_pk.c5,pk1,pk2 FROM one_pk JOIN two_pk ON pk=pk1 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{4, 0, 0},
+					{4, 0, 1},
+					{14, 1, 0},
+					{14, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT opk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=pk1 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{4, 0, 0},
+					{4, 0, 1},
+					{14, 1, 0},
+					{14, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT opk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{4, 0, 0},
+					{4, 0, 1},
+					{14, 1, 0},
+					{14, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{1, 0, 1},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0},
+					{1, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 AND opk.pk=tpk.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0},
+					{1, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=tpk.pk1 AND pk=tpk.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0},
+					{1, 1, 1},
+				},
+			},
+			{
+				Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
+						LEFT JOIN two_pk tpk ON one_pk.pk=tpk.pk1 AND one_pk.pk-1=tpk.pk2
+						LEFT JOIN two_pk tpk2 ON tpk2.pk1=TPK.pk2 AND TPK2.pk2=tpk.pk1
+						ORDER BY 1`,
+				Expected: []sql.Row{
+					{0, nil, nil, nil, nil},
+					{1, 1, 0, 0, 1},
+					{2, nil, nil, nil, nil},
+					{3, nil, nil, nil, nil},
+				},
+			},
+			{
+				Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
+						JOIN two_pk tpk ON pk=tpk.pk1 AND pk-1=tpk.pk2
+						JOIN two_pk tpk2 ON pk-1=TPK2.pk1 AND pk=tpk2.pk2
+						ORDER BY 1`,
+				Expected: []sql.Row{
+					{1, 1, 0, 0, 1},
+				},
+			},
+			{
+				Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
+						JOIN two_pk tpk ON pk=tpk.pk1 AND pk-1=tpk.pk2
+						JOIN two_pk tpk2 ON pk-1=TPK2.pk1 AND pk=tpk2.pk2
+						ORDER BY 1`,
+				Expected: []sql.Row{
+					{1, 1, 0, 0, 1},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0},
+					{1, 1, 1},
+					{2, nil, nil},
+					{3, nil, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk RIGHT JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{nil, 0, 1},
+					{nil, 1, 0},
+					{0, 0, 0},
+					{1, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT i,pk1,pk2 FROM mytable JOIN two_pk ON i-1=pk1 AND i-2=pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{int64(2), 1, 0},
+				},
+			},
+			{
+				Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON a.pk1=b.pk2 AND a.pk2=b.pk1 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0, 0},
+					{0, 1, 1, 0},
+					{1, 0, 0, 1},
+					{1, 1, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON a.pk1=b.pk1 AND a.pk2=b.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0, 0},
+					{0, 1, 0, 1},
+					{1, 0, 1, 0},
+					{1, 1, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a, two_pk b WHERE a.pk1=b.pk1 AND a.pk2=b.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0, 0},
+					{0, 1, 0, 1},
+					{1, 0, 1, 0},
+					{1, 1, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON b.pk1=a.pk1 AND a.pk2=b.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0, 0},
+					{0, 1, 0, 1},
+					{1, 0, 1, 0},
+					{1, 1, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON a.pk1+1=b.pk1 AND a.pk2+1=b.pk2 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk ON pk=pk1 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0},
+					{0, 0, 1},
+					{1, 1, 0},
+					{1, 1, 1},
+					{2, nil, nil},
+					{3, nil, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i2 ORDER BY 1",
+				Expected: []sql.Row{
+					{0, nil, nil},
+					{1, nil, nil},
+					{2, int64(2), nil},
+					{3, nil, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i2 ORDER BY 2,3",
+				Expected: []sql.Row{
+					{nil, nil, nil},
+					{nil, nil, nil},
+					{nil, nil, 5.0},
+					{2, int64(2), nil},
+					{nil, int64(4), 4.0},
+					{nil, int64(6), 6.0},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i2 AND f IS NOT NULL ORDER BY 1", // AND clause causes right table join miss
+				Expected: []sql.Row{
+					{0, nil, nil},
+					{1, nil, nil},
+					{2, nil, nil},
+					{3, nil, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i2 and pk > 0 ORDER BY 2,3", // > 0 clause in join condition is ignored
+				Expected: []sql.Row{
+					{nil, nil, nil},
+					{nil, nil, nil},
+					{nil, nil, 5.0},
+					{2, int64(2), nil},
+					{nil, int64(4), 4.0},
+					{nil, int64(6), 6.0},
+				},
+			},
+			{
+				Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE f IS NULL AND pk < 2 ORDER BY 1",
+				Expected: []sql.Row{
+					{0, nil, nil},
+					{1, 1, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i WHERE f IS NOT NULL ORDER BY 2,3",
+				Expected: []sql.Row{
+					{nil, nil, 5.0},
+					{nil, int64(4), 4.0},
+					{nil, int64(6), 6.0},
+				},
+			},
+			{
+				Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE pk > 1 ORDER BY 1",
+				Expected: []sql.Row{
+					{2, 2, nil},
+					{3, 3, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE c1 > 10 ORDER BY 1",
+				Expected: []sql.Row{
+					{2, 2, nil},
+					{3, 3, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i WHERE f IS NOT NULL ORDER BY 2,3",
+				Expected: []sql.Row{
+					{nil, 4, 4.0},
+					{nil, 5, 5.0},
+					{nil, 6, 6.0},
+				},
+			},
+			{
+				Query: "SELECT t1.i,t1.i2 FROM niltable t1 LEFT JOIN niltable t2 ON t1.i=t2.i2 WHERE t2.f IS NULL ORDER BY 1,2",
+				Expected: []sql.Row{
+					{1, nil},
+					{2, 2},
+					{3, nil},
+					{5, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE i2 > 1 ORDER BY 1",
+				Expected: []sql.Row{
+					{2, 2, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE i > 1 ORDER BY 1",
+				Expected: []sql.Row{
+					{2, 2, nil},
+					{3, 3, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE i2 IS NOT NULL ORDER BY 1",
+				Expected: []sql.Row{
+					{2, int64(2), nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i2 WHERE pk > 1 ORDER BY 1",
+				Expected: []sql.Row{
+					{2, int64(2), nil},
+					{3, nil, nil},
+				},
+			},
+			{
+				Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i2 WHERE pk > 0 ORDER BY 2,3",
+				Expected: []sql.Row{
+					{2, int64(2), nil},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0, 0, 0},
+					{1, 0, 1, 10, 10},
+					{2, 1, 0, 20, 20},
+					{3, 1, 1, 30, 30},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2,one_pk.c1 AS foo,two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 WHERE one_pk.c1=10",
+				Expected: []sql.Row{
+					{1, 0, 1, 10, 10},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON pk1-pk>0 AND pk2<1",
+				Expected: []sql.Row{
+					{0, 1, 0},
+				},
+			},
+			{
+				Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ORDER BY 1,2,3",
+				Expected: []sql.Row{
+					{0, 0, 0},
+					{0, 0, 1},
+					{0, 1, 0},
+					{0, 1, 1},
+					{1, 0, 0},
+					{1, 0, 1},
+					{1, 1, 0},
+					{1, 1, 1},
+					{2, 0, 0},
+					{2, 0, 1},
+					{2, 1, 0},
+					{2, 1, 1},
+					{3, 0, 0},
+					{3, 0, 1},
+					{3, 1, 0},
+					{3, 1, 1},
+				},
+			},
+			{
+				Query: "SELECT a.pk,b.pk FROM one_pk a JOIN one_pk b ON a.pk = b.pk order by a.pk",
+				Expected: []sql.Row{
+					{0, 0},
+					{1, 1},
+					{2, 2},
+					{3, 3},
+				},
+			},
+			{
+				Query: "SELECT a.pk,b.pk FROM one_pk a, one_pk b WHERE a.pk = b.pk order by a.pk",
+				Expected: []sql.Row{
+					{0, 0},
+					{1, 1},
+					{2, 2},
+					{3, 3},
+				},
+			},
+			{
+				Query: "SELECT one_pk.pk,b.pk FROM one_pk JOIN one_pk b ON one_pk.pk = b.pk order by one_pk.pk",
+				Expected: []sql.Row{
+					{0, 0},
+					{1, 1},
+					{2, 2},
+					{3, 3},
+				},
+			},
+			{
+				Query: "SELECT one_pk.pk,b.pk FROM one_pk, one_pk b WHERE one_pk.pk = b.pk order by one_pk.pk",
+				Expected: []sql.Row{
+					{0, 0},
+					{1, 1},
+					{2, 2},
+					{3, 3},
+				},
+			},
+			{
+				Query: "select sum(x.i) + y.i from mytable as x, mytable as y where x.i = y.i GROUP BY x.i",
+				Expected: []sql.Row{
+					{int64(2)},
+					{int64(4)},
+					{int64(6)},
+				},
+			},
+			{
+				Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
+						LEFT JOIN two_pk tpk ON one_pk.pk=tpk.pk1 AND one_pk.pk=tpk.pk2
+						JOIN two_pk tpk2 ON tpk2.pk1=TPK.pk2 AND TPK2.pk2=tpk.pk1`,
+				Expected: []sql.Row{
+					{0, 0, 0, 0, 0},
+					{1, 1, 1, 1, 1},
+				},
+			},
+			{
+				Query: `SELECT pk,nt.i,nt2.i FROM one_pk
+						RIGHT JOIN niltable nt ON pk=nt.i
+						RIGHT JOIN niltable nt2 ON pk=nt2.i - 1
+						ORDER BY 3`,
+				Expected: []sql.Row{
+					{nil, nil, 1},
+					{1, 1, 2},
+					{2, 2, 3},
+					{3, 3, 4},
+					{nil, nil, 5},
+					{nil, nil, 6},
+				},
+			},
+			{
+				Query: `SELECT pk,pk2,
+							(SELECT opk.c5 FROM one_pk opk JOIN two_pk tpk ON pk=pk1 ORDER BY 1 LIMIT 1)
+							FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2`,
+				Expected: []sql.Row{
+					{1, 1, 4},
+					{1, 1, 4},
+				},
+			},
+			{
+				Query: `SELECT pk,pk2,
+							(SELECT opk.c5 FROM one_pk opk JOIN two_pk tpk ON opk.c5=tpk.c5 ORDER BY 1 LIMIT 1)
+							FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2`,
+				Expected: []sql.Row{
+					{1, 1, 4},
+					{1, 1, 4},
+				},
+			},
+			{
+				Query: `SELECT /*+ JOIN_ORDER(mytable, othertable) */ s2, i2, i FROM mytable INNER JOIN (SELECT * FROM othertable) othertable ON i2 = i`,
+				Expected: []sql.Row{
+					{"third", 1, 1},
+					{"second", 2, 2},
+					{"first", 3, 3},
+				},
+			},
+			{
+				Query: `SELECT lefttable.i, righttable.s
+			FROM (SELECT * FROM mytable) lefttable
+			JOIN (SELECT * FROM mytable) righttable
+			ON lefttable.i = righttable.i AND righttable.s = lefttable.s
+			ORDER BY lefttable.i ASC`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b where a.i = b.i`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b where a.i = b.i OR a.i = 1`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{1, "first row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b where NOT(a.i = b.i OR a.s = b.i)`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{1, "first row"},
+					{2, "second row"},
+					{2, "second row"},
+					{3, "third row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where NOT(a.i = b.i OR a.s = b.i)`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{1, "first row"},
+					{2, "second row"},
+					{2, "second row"},
+					{3, "third row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b where a.i = b.s OR a.s = b.i IS FALSE`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = b.s OR a.s = b.i IS FALSE`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b where a.i >= b.i`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{2, "second row"},
+					{3, "third row"},
+					{3, "third row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query:    `SELECT a.* FROM mytable a, mytable b where a.i = a.s`,
+				Expected: []sql.Row{},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b where a.i in (2, 432, 7)`,
+				Expected: []sql.Row{
+					{2, "second row"},
+					{2, "second row"},
+					{2, "second row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.i = c.i AND c.i = d.i AND c.i = 2`,
+				Expected: []sql.Row{
+					{2, "second row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.i = c.i AND (c.i = d.s OR c.i = 2)`,
+				Expected: []sql.Row{
+					{2, "second row"},
+					{2, "second row"},
+					{2, "second row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.s = c.s`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = b.i`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = b.i OR a.i = 1`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{1, "first row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i >= b.i`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{2, "second row"},
+					{3, "third row"},
+					{3, "third row"},
+					{3, "third row"},
+				},
+			},
+			{
+				Query:    `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = a.s`,
+				Expected: []sql.Row{},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b CROSS JOIN mytable c CROSS JOIN mytable d where a.i = b.i AND b.i = c.i AND c.i = d.i AND c.i = 2`,
+				Expected: []sql.Row{
+					{2, "second row"},
+				},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b CROSS JOIN mytable c CROSS JOIN mytable d where a.i = b.i AND b.i = c.i AND (c.i = d.s OR c.i = 2)`,
+				Expected: []sql.Row{
+					{2, "second row"},
+					{2, "second row"},
+					{2, "second row"}},
+			},
+			{
+				Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b CROSS JOIN mytable c CROSS JOIN mytable d where a.i = b.i AND b.s = c.s`,
+				Expected: []sql.Row{
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+					{1, "first row"},
+					{2, "second row"},
+					{3, "third row"},
+				},
+			},
+		},
+	},
 }

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -1,0 +1,658 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+)
+
+type JoinPlanTest struct {
+	q     string
+	types []plan.JoinType
+	exp   []sql.Row
+	skip  bool
+}
+
+var JoinPlanningTests = []struct {
+	name  string
+	setup []string
+	tests []JoinPlanTest
+}{
+	{
+		name: "merge join unary index",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int, index y_idx(y));",
+			"create table rs (r int primary key, s int, index s_idx(s));",
+			"CREATE table uv (u int primary key, v int);",
+			"CREATE table ab (a int primary key, b int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into rs values (0,0), (1,0), (2,0), (4,4), (5,4);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+			"insert into ab values (0,2), (1,2), (2,2), (3,1);",
+			"update information_schema.statistics set cardinality = 1000 where table_name in ('ab', 'rs', 'xy', 'uv');",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select u,a,y from uv join (select /*+ JOIN_ORDER(ab, xy) */ * from ab join xy on y = a) r on u = r.a order by 1",
+				types: []plan.JoinType{plan.JoinTypeLookup, plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 0}, {1, 1, 1}, {2, 2, 2}, {3, 3, 3}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(ab, xy) */ * from ab join xy on y = a order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 2, 1, 0}, {1, 2, 2, 1}, {2, 2, 0, 2}, {3, 1, 3, 3}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs left join xy on y = s order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeLeftOuterMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 1, 0}, {2, 0, 1, 0}, {4, 4, nil, nil}, {5, 4, nil, nil}},
+			},
+			{
+				// extra join condition does not filter left-only rows
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs left join xy on y = s and y+s = 0 order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeLeftOuterMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 1, 0}, {2, 0, 1, 0}, {4, 4, nil, nil}, {5, 4, nil, nil}},
+			},
+			{
+				// extra join condition does not filter left-only rows
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs left join xy on y+2 = s and s-y = 2 order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeLeftOuterMerge},
+				exp:   []sql.Row{{0, 0, nil, nil}, {1, 0, nil, nil}, {2, 0, nil, nil}, {4, 4, 0, 2}, {5, 4, 0, 2}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = r order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 2, 1}, {2, 0, 0, 2}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on r = y order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 2, 1}, {2, 0, 0, 2}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {1, 0, 1, 0}, {2, 0, 1, 0}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s and y = r order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y+2 = s order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{4, 4, 0, 2}, {5, 4, 0, 2}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s-1 order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeLookup},
+				exp:   []sql.Row{{4, 4, 3, 3}, {5, 4, 3, 3}},
+			},
+			//{
+			// TODO: cannot hash join on compound expressions
+			//	q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = mod(s,2) order by 1, 3",
+			//	types: []plan.JoinType{plan.JoinTypeInner},
+			//	exp:   []sql.Row{{0,0,1,0},{0, 0, 1, 0},{2,0,1,0},{4,4,1,0}},
+			//},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on 2 = s+y order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeInner},
+				exp:   []sql.Row{{0, 0, 0, 2}, {1, 0, 0, 2}, {2, 0, 0, 2}},
+			},
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y > s+2 order by 1, 3",
+				types: []plan.JoinType{plan.JoinTypeInner},
+				exp:   []sql.Row{{0, 0, 3, 3}, {1, 0, 3, 3}, {2, 0, 3, 3}},
+			},
+		},
+	},
+	{
+		name: "merge join multi match",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int, index y_idx(y));",
+			"create table rs (r int primary key, s int, index s_idx(s));",
+			"insert into xy values (1,0), (2,1), (0,8), (3,7), (5,4), (4,0);",
+			"insert into rs values (0,0),(2,3),(3,0), (4,8), (5,4);",
+			"update information_schema.statistics set cardinality = 1000 where table_name in ('rs', 'xy');",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {0, 0, 4, 0}, {3, 0, 1, 0}, {3, 0, 4, 0}, {4, 8, 0, 8}, {5, 4, 5, 4}},
+			},
+		},
+	},
+	{
+		name: "merge join zero rows",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int, index y_idx(y));",
+			"create table rs (r int primary key, s int, index s_idx(s));",
+			"insert into xy values (1,0);",
+			"update information_schema.statistics set cardinality = 10 where table_name = 'xy';",
+			"update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs';",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{},
+			},
+		},
+	},
+	{
+		name: "merge join multi arity",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int, index yx_idx(y,x));",
+			"create table rs (r int primary key, s int, index s_idx(s));",
+			"insert into xy values (1,0), (2,1), (0,8), (3,7), (5,4), (4,0);",
+			"insert into rs values (0,0),(2,3),(3,0), (4,8), (5,4);",
+			"update information_schema.statistics set cardinality = 1000 where table_name in ('xy', 'rs');",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {0, 0, 4, 0}, {3, 0, 1, 0}, {3, 0, 4, 0}, {4, 8, 0, 8}, {5, 4, 5, 4}},
+			},
+		},
+	},
+	{
+		name: "merge join keyless index",
+		setup: []string{
+			"CREATE table xy (x int, y int, index yx_idx(y,x));",
+			"create table rs (r int, s int, index s_idx(s));",
+			"insert into xy values (1,0), (2,1), (0,8), (3,7), (5,4), (4,0);",
+			"insert into rs values (0,0),(2,3),(3,0), (4,8), (5,4);",
+			"update information_schema.statistics set cardinality = 1000 where table_name in ('xy', 'rs');",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select /*+ JOIN_ORDER(rs, xy) */ * from rs join xy on y = s order by 1,3",
+				types: []plan.JoinType{plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 0, 1, 0}, {0, 0, 4, 0}, {3, 0, 1, 0}, {3, 0, 4, 0}, {4, 8, 0, 8}, {5, 4, 5, 4}},
+			},
+		},
+	},
+	{
+		name: "partial [lookup] join tests",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int);",
+			"create table rs (r int primary key, s int);",
+			"CREATE table uv (u int primary key, v int);",
+			"CREATE table ab (a int primary key, b int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into rs values (0,0), (1,0), (2,0), (4,4);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+			"insert into ab values (0,2), (1,2), (2,2), (3,1);",
+			"update information_schema.statistics set cardinality = 100 where table_name in ('xy', 'rs', 'uv', 'ab');",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select * from xy where y+1 not in (select u from uv);",
+				types: []plan.JoinType{plan.JoinTypeAntiLookup},
+				exp:   []sql.Row{{3, 3}},
+			},
+			{
+				q:     "select * from xy where x not in (select u from uv where u not in (select a from ab where a not in (select r from rs where r = 1))) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeAnti, plan.JoinTypeAnti, plan.JoinTypeAntiLookup},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where x != (select r from rs where r = 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				// anti join will be cross-join-right, be passed non-nil parent row
+				q:     "select x,a from ab, (select * from xy where x != (select r from rs where r = 1) order by 1) sq where x = 2 and b = 2 order by 1,2;",
+				types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeAnti},
+				exp:   []sql.Row{{2, 0}, {2, 1}, {2, 2}},
+			},
+			{
+				// scope and parent row are non-nil
+				q: `
+select * from uv where u > (
+  select x from ab, (
+    select x from xy where x != (
+      select r from rs where r = 1
+    ) order by 1
+  ) sq
+  order by 1 limit 1
+)
+order by 1;`,
+				types: []plan.JoinType{plan.JoinTypeSemi, plan.JoinTypeCross, plan.JoinTypeAnti},
+				exp:   []sql.Row{{1, 1}, {2, 2}, {3, 2}},
+			},
+			{
+				// cast prevents scope merging
+				q:     "select * from xy where x != (select cast(r as signed) from rs where r = 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				// order by will be discarded
+				q:     "select * from xy where x != (select r from rs where r = 1 order by 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				// limit prevents scope merging
+				q:     "select * from xy where x != (select r from rs where r = 1 limit 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where y-1 in (select u from uv) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemiLookup},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				// semi join will be right-side, be passed non-nil parent row
+				q:     "select x,a from ab, (select * from xy where x = (select r from rs where r = 1) order by 1) sq order by 1,2",
+				types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeRightSemiLookup},
+				exp:   []sql.Row{{1, 0}, {1, 1}, {1, 2}, {1, 3}},
+			},
+			//{
+			// scope and parent row are non-nil
+			// TODO: subquery alias unable to track parent row from a different scope
+			//				q: `
+			//select * from uv where u > (
+			//  select x from ab, (
+			//    select x from xy where x = (
+			//      select r from rs where r = 1
+			//    ) order by 1
+			//  ) sq
+			//  order by 1 limit 1
+			//)
+			//order by 1;`,
+			//types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeRightSemiLookup},
+			//exp:   []sql.Row{{2, 2}, {3, 2}},
+			//},
+			{
+				q:     "select * from xy where y-1 in (select cast(u as signed) from uv) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where y-1 in (select u from uv order by 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemiLookup},
+				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where y-1 in (select u from uv order by 1 limit 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{2, 1}},
+			},
+			{
+				q:     "select * from xy where x in (select u from uv join ab on u = a and a = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeRightSemiLookup, plan.JoinTypeMerge},
+				exp:   []sql.Row{{2, 1}},
+			},
+			{
+				q:     "select * from xy where x = (select u from uv join ab on u = a and a = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeRightSemiLookup, plan.JoinTypeMerge},
+				exp:   []sql.Row{{2, 1}},
+			},
+			{
+				// group by doesn't transform
+				q:     "select * from xy where y-1 in (select u from uv group by v having v = 2 order by 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{3, 3}},
+			},
+			{
+				// window doesn't transform
+				q:     "select * from xy where y-1 in (select row_number() over (order by v) from uv) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {3, 3}},
+			},
+		},
+	},
+	{
+		name: "empty join tests",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int);",
+			"CREATE table uv (u int primary key, v int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select * from xy where y-1 = (select u from uv limit 1 offset 5);",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{},
+			},
+			{
+				q:     "select * from xy where x != (select u from uv limit 1 offset 5);",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{},
+			},
+		},
+	},
+	{
+		name: "unnest with scope filters",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int);",
+			"CREATE table uv (u int primary key, v int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select * from xy where y-1 = (select u from uv where v = 2 order by 1 limit 1);",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{3, 3}},
+			},
+			{
+				q:     "select * from xy where x != (select u from uv where v = 2 order by 1 limit 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{{0, 2}, {1, 0}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where x != (select distinct u from uv where v = 2 order by 1 limit 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeAnti},
+				exp:   []sql.Row{{0, 2}, {1, 0}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where (x,y+1) = (select u,v from uv where v = 2 order by 1 limit 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{2, 1}},
+			},
+			{
+				q:     "select * from xy where x in (select cnt from (select count(u) as cnt from uv group by v having cnt > 0) sq) order by 1,2;",
+				types: []plan.JoinType{plan.JoinTypeRightSemiLookup},
+				exp:   []sql.Row{{2, 1}},
+			},
+		},
+	},
+	{
+		name: "unnest non-equality comparisons",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int);",
+			"CREATE table uv (u int primary key, v int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select * from xy where y >= (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where x <= (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {1, 0}, {2, 1}},
+			},
+			{
+				q:     "select * from xy where x < (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {1, 0}},
+			},
+			{
+				q:     "select * from xy where x > (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{3, 3}},
+			},
+			{
+				q:     "select * from uv where v <=> (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{2, 2}, {3, 2}},
+			},
+		},
+	},
+	{
+		name: "convert semi to lookup join",
+		setup: []string{
+			"CREATE table xy (x int, y int, primary key(x,y));",
+			"CREATE table uv (u int primary key, v int);",
+			"CREATE table ab (a int primary key, b int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+			"insert into ab values (0,2), (1,2), (2,2), (3,1);",
+			"update information_schema.statistics set cardinality = 100 where table_name = 'xy' and table_schema = 'mydb';",
+			"update information_schema.statistics set cardinality = 100 where table_name = 'ab' and table_schema = 'mydb';",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select * from xy where x in (select u from uv join ab on u = a and a = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeLookup, plan.JoinTypeLookup},
+				exp:   []sql.Row{{2, 1}},
+			},
+			{
+				q: `select x from xy where x in (
+	select (select u from uv where u = sq.a)
+    from (select a from ab) sq);`,
+				types: []plan.JoinType{plan.JoinTypeLookup},
+				exp:   []sql.Row{{0}, {1}, {2}, {3}},
+			},
+			{
+				q:     "select * from xy where y >= (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {3, 3}},
+			},
+			{
+				q:     "select * from xy where x <= (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {1, 0}, {2, 1}},
+			},
+			{
+				q:     "select * from xy where x < (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{0, 2}, {1, 0}},
+			},
+			{
+				q:     "select * from xy where x > (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{3, 3}},
+			},
+			{
+				q:     "select * from uv where v <=> (select u from uv where u = 2) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{2, 2}, {3, 2}},
+			},
+		},
+	},
+}
+
+func TestJoinPlanning(t *testing.T, harness Harness) {
+	for _, tt := range JoinPlanningTests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := mustNewEngine(t, harness)
+			defer e.Close()
+			for _, statement := range tt.setup {
+				if sh, ok := harness.(SkippingHarness); ok {
+					if sh.SkipQueryTest(statement) {
+						t.Skip()
+					}
+				}
+				ctx := NewContext(harness)
+				RunQueryWithContext(t, e, harness, ctx, statement)
+			}
+			for _, tt := range tt.tests {
+				evalJoinTypeTest(t, harness, e, tt)
+				//evalJoinCorrectnessTest(t, harness, e, tt)
+				evalJoinCorrectness(t, harness, e, tt.q, tt.q, tt.exp, tt.skip)
+			}
+		})
+	}
+}
+
+func evalJoinTypeTest(t *testing.T, harness Harness, e *sqle.Engine, tt JoinPlanTest) {
+	t.Run(tt.q+" join types", func(t *testing.T) {
+		if tt.skip {
+			t.Skip()
+		}
+
+		ctx := NewContext(harness)
+		ctx = ctx.WithQuery(tt.q)
+
+		a, err := e.AnalyzeQuery(ctx, tt.q)
+		require.NoError(t, err)
+
+		jts := collectJoinTypes(a)
+		var exp []string
+		for _, t := range tt.types {
+			exp = append(exp, t.String())
+		}
+		var cmp []string
+		for _, t := range jts {
+			cmp = append(cmp, t.String())
+		}
+		require.Equal(t, exp, cmp, fmt.Sprintf("unexpected plan:\n%s", sql.DebugString(a)))
+	})
+}
+
+func evalJoinCorrectness(t *testing.T, harness Harness, e *sqle.Engine, name, q string, exp []sql.Row, skip bool) {
+	t.Run(name, func(t *testing.T) {
+		if skip {
+			t.Skip()
+		}
+
+		ctx := NewContext(harness)
+		ctx = ctx.WithQuery(q)
+
+		sch, iter, err := e.QueryWithBindings(ctx, q, nil)
+		require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
+
+		rows, err := sql.RowIterToRows(ctx, sch, iter)
+		require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
+
+		if exp != nil {
+			checkResults(t, exp, nil, sch, rows, q)
+		}
+
+		require.Equal(t, 0, ctx.Memory.NumCaches())
+		validateEngine(t, ctx, harness, e)
+	})
+}
+
+func collectJoinTypes(n sql.Node) []plan.JoinType {
+	var types []plan.JoinType
+	transform.Inspect(n, func(n sql.Node) bool {
+		if n == nil {
+			return true
+		}
+		j, ok := n.(*plan.JoinNode)
+		if ok {
+			types = append(types, j.Op)
+		}
+
+		if ex, ok := n.(sql.Expressioner); ok {
+			for _, e := range ex.Expressions() {
+				transform.InspectExpr(e, func(e sql.Expression) bool {
+					sq, ok := e.(*plan.Subquery)
+					if !ok {
+						return false
+					}
+					types = append(types, collectJoinTypes(sq.Query)...)
+					return false
+				})
+			}
+		}
+		return true
+	})
+	return types
+}
+
+func TestJoinPlanningPrepared(t *testing.T, harness Harness) {
+	for _, tt := range JoinPlanningTests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := mustNewEngine(t, harness)
+			defer e.Close()
+			for _, statement := range tt.setup {
+				if sh, ok := harness.(SkippingHarness); ok {
+					if sh.SkipQueryTest(statement) {
+						t.Skip()
+					}
+				}
+				ctx := NewContext(harness)
+				RunQueryWithContext(t, e, harness, ctx, statement)
+			}
+			for _, tt := range tt.tests {
+				evalJoinTypeTestPrepared(t, harness, e, tt)
+				evalJoinCorrectnessPrepared(t, harness, e, tt.q, tt.q, tt.exp, tt.skip)
+			}
+		})
+	}
+}
+
+func evalJoinTypeTestPrepared(t *testing.T, harness Harness, e *sqle.Engine, tt JoinPlanTest) {
+	t.Run(tt.q+" join types", func(t *testing.T) {
+		if tt.skip {
+			t.Skip()
+		}
+
+		ctx := NewContext(harness)
+		ctx = ctx.WithQuery(tt.q)
+
+		bindings, err := injectBindVarsAndPrepare(t, ctx, e, tt.q)
+		require.NoError(t, err)
+
+		p, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), tt.q)
+		require.True(t, ok, "prepared statement not found")
+
+		if len(bindings) > 0 {
+			var usedBindings map[string]bool
+			p, usedBindings, err = plan.ApplyBindings(p, bindings)
+			require.NoError(t, err)
+			for binding := range bindings {
+				require.True(t, usedBindings[binding], "unused binding %s", binding)
+			}
+		}
+
+		a, _, err := e.Analyzer.AnalyzePrepared(ctx, p, nil)
+		require.NoError(t, err)
+
+		jts := collectJoinTypes(a)
+		require.Equal(t, tt.types, jts)
+	})
+}
+
+func evalJoinCorrectnessPrepared(t *testing.T, harness Harness, e *sqle.Engine, name, q string, exp []sql.Row, skip bool) {
+	t.Run(q, func(t *testing.T) {
+		if skip {
+			t.Skip()
+		}
+
+		ctx := NewContext(harness)
+		ctx = ctx.WithQuery(q)
+
+		bindings, err := injectBindVarsAndPrepare(t, ctx, e, q)
+		require.NoError(t, err)
+
+		sch, iter, err := e.QueryWithBindings(ctx, q, bindings)
+		require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
+
+		rows, err := sql.RowIterToRows(ctx, sch, iter)
+		require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
+
+		if exp != nil {
+			checkResults(t, exp, nil, sch, rows, q)
+		}
+
+		require.Equal(t, 0, ctx.Memory.NumCaches())
+		validateEngine(t, ctx, harness, e)
+	})
+}

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -509,7 +509,6 @@ func TestJoinPlanning(t *testing.T, harness Harness) {
 			}
 			for _, tt := range tt.tests {
 				evalJoinTypeTest(t, harness, e, tt)
-				//evalJoinCorrectnessTest(t, harness, e, tt)
 				evalJoinCorrectness(t, harness, e, tt.q, tt.q, tt.exp, tt.skip)
 			}
 		})

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -474,6 +474,23 @@ order by 1;`,
 			},
 		},
 	},
+	{
+		name: "join concat tests",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int);",
+			"CREATE table uv (u int primary key, v int);",
+			"insert into xy values (1,0), (2,1), (0,2), (3,3);",
+			"insert into uv values (0,1), (1,1), (2,2), (3,2);",
+			"update information_schema.statistics set cardinality = 100 where table_name in ('xy', 'uv');",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select x, u from xy inner join uv on u+1 = x OR u+2 = x OR u+3 = x;",
+				types: []plan.JoinType{plan.JoinTypeLookup},
+				exp:   []sql.Row{{3, 0}, {2, 0}, {1, 0}, {3, 1}, {2, 1}, {3, 2}},
+			},
+		},
+	},
 }
 
 func TestJoinPlanning(t *testing.T, harness Harness) {

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -122,6 +122,16 @@ func TestJoinQueriesPrepared(t *testing.T) {
 	enginetest.TestJoinQueriesPrepared(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
 }
 
+// TestJoinPlanning runs join-specific tests for merge
+func TestJoinPlanning(t *testing.T) {
+	enginetest.TestJoinPlanning(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
+}
+
+// TestJoinPlanningPrepared runs prepared join-specific tests for merge
+func TestJoinPlanningPrepared(t *testing.T) {
+	enginetest.TestJoinPlanningPrepared(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
+}
+
 // TestJoinOps runs join-specific tests for merge
 func TestJoinOps(t *testing.T) {
 	enginetest.TestJoinOps(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
@@ -153,7 +163,7 @@ func TestSingleQuery(t *testing.T) {
 	t.Skip()
 	var test queries.QueryTest
 	test = queries.QueryTest{
-		Query: "SELECT pk, count(*) over (order by v2) FROM one_pk_three_idx ORDER BY pk",
+		Query: "select pk, v1, v2 from one_pk_three_idx where v1 in (select max(a.v1) from one_pk_three_idx a cross join (select 'foo' from dual) b);",
 		Expected: []sql.Row{
 			{0, 4},
 			{1, 4},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -163,7 +163,7 @@ func TestSingleQuery(t *testing.T) {
 	t.Skip()
 	var test queries.QueryTest
 	test = queries.QueryTest{
-		Query: "select pk, v1, v2 from one_pk_three_idx where v1 in (select max(a.v1) from one_pk_three_idx a cross join (select 'foo' from dual) b);",
+		Query: "SELECT pk, count(*) over (order by v2) FROM one_pk_three_idx ORDER BY pk",
 		Expected: []sql.Row{
 			{0, 4},
 			{1, 4},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1221,13 +1221,13 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query: `SELECT JSON_MERGE_PRESERVE(val1, val2)
-	               FROM (values
+	              FROM (values
 						 row('{ "a": 1, "b": 2 }','null'),
-	                    row('{ "a": 1, "b": 2 }','"row one"'),
-	                    row('{ "a": 3, "c": 4 }','4'),
-	                    row('{ "a": 5, "d": 6 }','[true, true]'),
-	                    row('{ "a": 5, "d": 6 }','{ "a": 3, "e": 2 }'))
-	               test (val1, val2)`,
+	                   row('{ "a": 1, "b": 2 }','"row one"'),
+	                   row('{ "a": 3, "c": 4 }','4'),
+	                   row('{ "a": 5, "d": 6 }','[true, true]'),
+	                   row('{ "a": 5, "d": 6 }','{ "a": 3, "e": 2 }'))
+	              test (val1, val2)`,
 		Expected: []sql.Row{
 			{types.MustJSON(`[{ "a": 1, "b": 2 }, null]`)},
 			{types.MustJSON(`[{ "a": 1, "b": 2 }, "row one"]`)},
@@ -1389,9 +1389,9 @@ var QueryTests = []QueryTest{
 		Query: `select mt.i,
 			((
 				select count(*) from mytable
-	      	where i in (
-	         		select mt2.i from mytable mt2 where mt2.i > mt.i
-	      	)
+	     	where i in (
+	        		select mt2.i from mytable mt2 where mt2.i > mt.i
+	     	)
 			)) as greater_count
 			from mytable mt order by 1`,
 		Expected: []sql.Row{{1, 2}, {2, 1}, {3, 0}},
@@ -1400,9 +1400,9 @@ var QueryTests = []QueryTest{
 		Query: `select mt.i,
 			((
 				select count(*) from mytable
-	      	where i in (
-	         		select mt2.i from mytable mt2 where mt2.i = mt.i
-	      	)
+	     	where i in (
+	        		select mt2.i from mytable mt2 where mt2.i = mt.i
+	     	)
 			)) as eq_count
 			from mytable mt order by 1`,
 		Expected: []sql.Row{{1, 1}, {2, 1}, {3, 1}},
@@ -3865,118 +3865,6 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query: "SELECT substring(mytable.s, 1, 5) AS s FROM mytable INNER JOIN othertable ON (substring(mytable.s, 1, 5) = SUBSTRING(othertable.s2, 1, 5)) GROUP BY 1",
-		Expected: []sql.Row{
-			{"third"},
-			{"secon"},
-			{"first"},
-		},
-	},
-	{
-		Query: "SELECT t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "SELECT /*+ JOIN_ORDER(t1,t2) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "SELECT /*+ JOIN_ORDER(t2,t1) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "SELECT /*+ JOIN_ORDER(t1) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "SELECT /*+ JOIN_ORDER(t1, mytable) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "SELECT /*+ JOIN_ORDER(t1, not_exist) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "SELECT /*+ NOTHING(abc) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "SELECT /*+ JOIN_ORDER( */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1",
-		Expected: []sql.Row{
-			{2},
-		},
-	},
-	{
-		Query: "select mytable.i as i2, othertable.i2 as i from mytable join othertable on i = i2 order by 1",
-		Expected: []sql.Row{
-			{1, 1},
-			{2, 2},
-			{3, 3},
-		},
-	},
-	{
-		Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR s = s2 order by 1",
-		Expected: []sql.Row{
-			{1, "first row", 1, "third"},
-			{2, "second row", 2, "second"},
-			{3, "third row", 3, "first"},
-		},
-	},
-	{
-		Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 order by 1, 3",
-		Expected: []sql.Row{
-			{1, "first row", 1, "third"},
-			{1, "first row", 3, "first"},
-			{2, "second row", 2, "second"},
-			{3, "third row", 1, "third"},
-			{3, "third row", 3, "first"},
-		},
-	},
-	{
-		Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 OR SUBSTRING_INDEX(s, ' ', 2) = s2 order by 1, 3",
-		Expected: []sql.Row{
-			{1, "first row", 1, "third"},
-			{1, "first row", 3, "first"},
-			{2, "second row", 2, "second"},
-			{3, "third row", 1, "third"},
-			{3, "third row", 3, "first"},
-		},
-	},
-	{
-		Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 OR SUBSTRING_INDEX(s, ' ', 2) = s2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 order by 1, 3",
-		Expected: []sql.Row{
-			{1, "first row", 1, "third"},
-			{1, "first row", 3, "first"},
-			{2, "second row", 2, "second"},
-			{3, "third row", 1, "third"},
-			{3, "third row", 3, "first"},
-		},
-	},
-	{
-		Query: "SELECT i, s, i2, s2 FROM mytable INNER JOIN othertable ON SUBSTRING_INDEX(s, ' ', 2) = s2 OR SUBSTRING_INDEX(s, ' ', 1) = s2 OR i = i2 order by 1, 3",
-		Expected: []sql.Row{
-			{1, "first row", 1, "third"},
-			{1, "first row", 3, "first"},
-			{2, "second row", 2, "second"},
-			{3, "third row", 1, "third"},
-			{3, "third row", 3, "first"},
-		},
-	},
-	{
 		Query: `select row_number() over (order by i desc), mytable.i as i2
 				from mytable join othertable on i = i2 order by 1`,
 		Expected: []sql.Row{
@@ -4012,9 +3900,9 @@ var QueryTests = []QueryTest{
 	},
 	{
 		Query: `select pk,
-                       percent_rank() over(partition by v2 order by pk),
-                       dense_rank() over(partition by v2 order by pk),
-                       rank() over(partition by v2 order by pk)
+	                  percent_rank() over(partition by v2 order by pk),
+	                  dense_rank() over(partition by v2 order by pk),
+	                  rank() over(partition by v2 order by pk)
 				from one_pk_three_idx order by pk`,
 		Expected: []sql.Row{
 			{0, float64(0), uint64(1), uint64(1)},
@@ -4048,26 +3936,6 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query:    "SELECT t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 3",
-		Expected: []sql.Row{},
-	},
-	{
-		Query: "SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
-		Expected: []sql.Row{
-			{int64(1), int64(1), "third"},
-			{int64(2), int64(2), "second"},
-			{int64(3), int64(3), "first"},
-		},
-	},
-	{
-		Query: "SELECT i, i2, s2 FROM mytable as OTHERTABLE INNER JOIN othertable as MYTABLE ON i = i2 ORDER BY i",
-		Expected: []sql.Row{
-			{int64(1), int64(1), "third"},
-			{int64(2), int64(2), "second"},
-			{int64(3), int64(3), "first"},
-		},
-	},
-	{
 		Query: `SELECT s2, i2 FROM othertable WHERE s2 >= "first" AND i2 >= 2 ORDER BY 1`,
 		Expected: []sql.Row{
 			{"first", int64(3)},
@@ -4091,30 +3959,6 @@ var QueryTests = []QueryTest{
 		Query: `SELECT s2, i2 FROM othertable WHERE "second" >= s2 AND 2 >= i2 ORDER BY 1`,
 		Expected: []sql.Row{
 			{"second", int64(2)},
-		},
-	},
-	{
-		Query: "SELECT s2, i2, i FROM mytable INNER JOIN othertable ON i = i2 ORDER BY i",
-		Expected: []sql.Row{
-			{"third", int64(1), int64(1)},
-			{"second", int64(2), int64(2)},
-			{"first", int64(3), int64(3)},
-		},
-	},
-	{
-		Query: "SELECT i, i2, s2 FROM othertable JOIN mytable  ON i = i2 ORDER BY i",
-		Expected: []sql.Row{
-			{int64(1), int64(1), "third"},
-			{int64(2), int64(2), "second"},
-			{int64(3), int64(3), "first"},
-		},
-	},
-	{
-		Query: "SELECT s2, i2, i FROM othertable JOIN mytable ON i = i2 ORDER BY i",
-		Expected: []sql.Row{
-			{"third", int64(1), int64(1)},
-			{"second", int64(2), int64(2)},
-			{"first", int64(3), int64(3)},
 		},
 	},
 	{
@@ -4143,39 +3987,6 @@ var QueryTests = []QueryTest{
 		Query: `SELECT substring("first", -1), substring("second", -2), substring("third", -3)`,
 		Expected: []sql.Row{
 			{"t", "nd", "ird"},
-		},
-	},
-	{
-		Query: "SELECT s FROM mytable INNER JOIN othertable " +
-			"ON substring(s2, 1, 2) != '' AND i = i2 ORDER BY 1",
-		Expected: []sql.Row{
-			{"first row"},
-			{"second row"},
-			{"third row"},
-		},
-	},
-	{
-		Query: `SELECT i FROM mytable NATURAL JOIN tabletest`,
-		Expected: []sql.Row{
-			{int64(1)},
-			{int64(2)},
-			{int64(3)},
-		},
-	},
-	{
-		Query: `SELECT i FROM mytable AS t NATURAL JOIN tabletest AS test`,
-		Expected: []sql.Row{
-			{int64(1)},
-			{int64(2)},
-			{int64(3)},
-		},
-	},
-	{
-		Query: `SELECT t.i, test.s FROM mytable AS t NATURAL JOIN tabletest AS test`,
-		Expected: []sql.Row{
-			{int64(1), "first row"},
-			{int64(2), "second row"},
-			{int64(3), "third row"},
 		},
 	},
 	{
@@ -4318,48 +4129,8 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{int64(3)}},
 	},
 	{
-		Query: `SELECT * FROM tabletest, mytable mt INNER JOIN othertable ot ON mt.i = ot.i2`,
-		Expected: []sql.Row{
-			{int64(1), "first row", int64(1), "first row", "third", int64(1)},
-			{int64(1), "first row", int64(2), "second row", "second", int64(2)},
-			{int64(1), "first row", int64(3), "third row", "first", int64(3)},
-			{int64(2), "second row", int64(1), "first row", "third", int64(1)},
-			{int64(2), "second row", int64(2), "second row", "second", int64(2)},
-			{int64(2), "second row", int64(3), "third row", "first", int64(3)},
-			{int64(3), "third row", int64(1), "first row", "third", int64(1)},
-			{int64(3), "third row", int64(2), "second row", "second", int64(2)},
-			{int64(3), "third row", int64(3), "third row", "first", int64(3)},
-		},
-	},
-	{
-		Query: `SELECT * FROM tabletest join mytable mt INNER JOIN othertable ot ON tabletest.i = ot.i2 order by 1,3,6`,
-		Expected: []sql.Row{
-			{int64(1), "first row", int64(1), "first row", "third", int64(1)},
-			{int64(1), "first row", int64(2), "second row", "third", int64(1)},
-			{int64(1), "first row", int64(3), "third row", "third", int64(1)},
-			{int64(2), "second row", int64(1), "first row", "second", int64(2)},
-			{int64(2), "second row", int64(2), "second row", "second", int64(2)},
-			{int64(2), "second row", int64(3), "third row", "second", int64(2)},
-			{int64(3), "third row", int64(1), "first row", "first", int64(3)},
-			{int64(3), "third row", int64(2), "second row", "first", int64(3)},
-			{int64(3), "third row", int64(3), "third row", "first", int64(3)},
-		},
-	},
-	{
 		Query:    `SELECT SUM(i) FROM mytable`,
 		Expected: []sql.Row{{float64(6)}},
-	},
-	{
-		Query: `SELECT * FROM mytable mt INNER JOIN othertable ot ON mt.i = ot.i2 AND mt.i > 2`,
-		Expected: []sql.Row{
-			{int64(3), "third row", "first", int64(3)},
-		},
-	},
-	{
-		Query: `SELECT * FROM othertable ot INNER JOIN mytable mt ON mt.i = ot.i2 AND mt.i > 2`,
-		Expected: []sql.Row{
-			{"first", int64(3), int64(3), "third row"},
-		},
 	},
 	{
 		Query: `SELECT i AS foo FROM mytable ORDER BY i DESC`,
@@ -5720,60 +5491,6 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{time.Date(1920, 2, 3, 7, 41, 11, 0, time.UTC)}},
 	},
 	{
-		Query: "SELECT i, i2, s2 FROM mytable LEFT JOIN othertable ON i = i2 - 1",
-		Expected: []sql.Row{
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-			{int64(3), nil, nil},
-		},
-	},
-	{
-		Query: "SELECT i, i2, s2 FROM mytable RIGHT JOIN othertable ON i = i2 - 1",
-		Expected: []sql.Row{
-			{nil, int64(1), "third"},
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-		},
-	},
-	{
-		Query: "SELECT i, i2, s2 FROM mytable LEFT OUTER JOIN othertable ON i = i2 - 1",
-		Expected: []sql.Row{
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-			{int64(3), nil, nil},
-		},
-	},
-	{
-		Query: "SELECT i, i2, s2 FROM mytable RIGHT OUTER JOIN othertable ON i = i2 - 1",
-		Expected: []sql.Row{
-			{nil, int64(1), "third"},
-			{int64(1), int64(2), "second"},
-			{int64(2), int64(3), "first"},
-		},
-	},
-	{
-		Query: `SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2
-				FROM othertable ot INNER JOIN
-					(SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub
-				ON sub.i = ot.i2 order by 1`,
-		Expected: []sql.Row{
-			{1, 1, "third", 1, "third"},
-			{2, 2, "second", 2, "second"},
-			{3, 3, "first", 3, "first"},
-		},
-	},
-	{
-		Query: `SELECT sub.i, sub.i2, sub.s2, ot.i2, ot.s2
-				FROM (SELECT i, i2, s2 FROM mytable INNER JOIN othertable ON i = i2) sub
-				INNER JOIN othertable ot
-				ON sub.i = ot.i2 order by 1`,
-		Expected: []sql.Row{
-			{1, 1, "third", 1, "third"},
-			{2, 2, "second", 2, "second"},
-			{3, 3, "first", 3, "first"},
-		},
-	},
-	{
 		Query:    `SELECT CHAR_LENGTH('áé'), LENGTH('àè')`,
 		Expected: []sql.Row{{int32(2), int32(4)}},
 	},
@@ -6674,285 +6391,6 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query: "SELECT one_pk.c5,pk1,pk2 FROM one_pk JOIN two_pk ON pk=pk1 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{4, 0, 0},
-			{4, 0, 1},
-			{14, 1, 0},
-			{14, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT opk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=pk1 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{4, 0, 0},
-			{4, 0, 1},
-			{14, 1, 0},
-			{14, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT opk.c5,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{4, 0, 0},
-			{4, 0, 1},
-			{14, 1, 0},
-			{14, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 WHERE pk=1 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{1, 0, 1},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0},
-			{1, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON opk.pk=tpk.pk1 AND opk.pk=tpk.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0},
-			{1, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk opk JOIN two_pk tpk ON pk=tpk.pk1 AND pk=tpk.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0},
-			{1, 1, 1},
-		},
-	},
-	{
-		Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
-						LEFT JOIN two_pk tpk ON one_pk.pk=tpk.pk1 AND one_pk.pk-1=tpk.pk2
-						LEFT JOIN two_pk tpk2 ON tpk2.pk1=TPK.pk2 AND TPK2.pk2=tpk.pk1
-						ORDER BY 1`,
-		Expected: []sql.Row{
-			{0, nil, nil, nil, nil},
-			{1, 1, 0, 0, 1},
-			{2, nil, nil, nil, nil},
-			{3, nil, nil, nil, nil},
-		},
-	},
-	{
-		Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
-						JOIN two_pk tpk ON pk=tpk.pk1 AND pk-1=tpk.pk2
-						JOIN two_pk tpk2 ON pk-1=TPK2.pk1 AND pk=tpk2.pk2
-						ORDER BY 1`,
-		Expected: []sql.Row{
-			{1, 1, 0, 0, 1},
-		},
-	},
-	{
-		Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
-						JOIN two_pk tpk ON pk=tpk.pk1 AND pk-1=tpk.pk2
-						JOIN two_pk tpk2 ON pk-1=TPK2.pk1 AND pk=tpk2.pk2
-						ORDER BY 1`,
-		Expected: []sql.Row{
-			{1, 1, 0, 0, 1},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0},
-			{1, 1, 1},
-			{2, nil, nil},
-			{3, nil, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk RIGHT JOIN two_pk ON one_pk.pk=two_pk.pk1 AND one_pk.pk=two_pk.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{nil, 0, 1},
-			{nil, 1, 0},
-			{0, 0, 0},
-			{1, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT i,pk1,pk2 FROM mytable JOIN two_pk ON i-1=pk1 AND i-2=pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{int64(2), 1, 0},
-		},
-	},
-	{
-		Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON a.pk1=b.pk2 AND a.pk2=b.pk1 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0, 0},
-			{0, 1, 1, 0},
-			{1, 0, 0, 1},
-			{1, 1, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON a.pk1=b.pk1 AND a.pk2=b.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0, 0},
-			{0, 1, 0, 1},
-			{1, 0, 1, 0},
-			{1, 1, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a, two_pk b WHERE a.pk1=b.pk1 AND a.pk2=b.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0, 0},
-			{0, 1, 0, 1},
-			{1, 0, 1, 0},
-			{1, 1, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON b.pk1=a.pk1 AND a.pk2=b.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0, 0},
-			{0, 1, 0, 1},
-			{1, 0, 1, 0},
-			{1, 1, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT a.pk1,a.pk2,b.pk1,b.pk2 FROM two_pk a JOIN two_pk b ON a.pk1+1=b.pk1 AND a.pk2+1=b.pk2 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk LEFT JOIN two_pk ON pk=pk1 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0},
-			{0, 0, 1},
-			{1, 1, 0},
-			{1, 1, 1},
-			{2, nil, nil},
-			{3, nil, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i2 ORDER BY 1",
-		Expected: []sql.Row{
-			{0, nil, nil},
-			{1, nil, nil},
-			{2, int64(2), nil},
-			{3, nil, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i2 ORDER BY 2,3",
-		Expected: []sql.Row{
-			{nil, nil, nil},
-			{nil, nil, nil},
-			{nil, nil, 5.0},
-			{2, int64(2), nil},
-			{nil, int64(4), 4.0},
-			{nil, int64(6), 6.0},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i2 AND f IS NOT NULL ORDER BY 1", // AND clause causes right table join miss
-		Expected: []sql.Row{
-			{0, nil, nil},
-			{1, nil, nil},
-			{2, nil, nil},
-			{3, nil, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i2 and pk > 0 ORDER BY 2,3", // > 0 clause in join condition is ignored
-		Expected: []sql.Row{
-			{nil, nil, nil},
-			{nil, nil, nil},
-			{nil, nil, 5.0},
-			{2, int64(2), nil},
-			{nil, int64(4), 4.0},
-			{nil, int64(6), 6.0},
-		},
-	},
-	{
-		Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE f IS NULL AND pk < 2 ORDER BY 1",
-		Expected: []sql.Row{
-			{0, nil, nil},
-			{1, 1, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i WHERE f IS NOT NULL ORDER BY 2,3",
-		Expected: []sql.Row{
-			{nil, nil, 5.0},
-			{nil, int64(4), 4.0},
-			{nil, int64(6), 6.0},
-		},
-	},
-	{
-		Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE pk > 1 ORDER BY 1",
-		Expected: []sql.Row{
-			{2, 2, nil},
-			{3, 3, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE c1 > 10 ORDER BY 1",
-		Expected: []sql.Row{
-			{2, 2, nil},
-			{3, 3, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i,f FROM one_pk RIGHT JOIN niltable ON pk=i WHERE f IS NOT NULL ORDER BY 2,3",
-		Expected: []sql.Row{
-			{nil, 4, 4.0},
-			{nil, 5, 5.0},
-			{nil, 6, 6.0},
-		},
-	},
-	{
-		Query: "SELECT t1.i,t1.i2 FROM niltable t1 LEFT JOIN niltable t2 ON t1.i=t2.i2 WHERE t2.f IS NULL ORDER BY 1,2",
-		Expected: []sql.Row{
-			{1, nil},
-			{2, 2},
-			{3, nil},
-			{5, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE i2 > 1 ORDER BY 1",
-		Expected: []sql.Row{
-			{2, 2, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE i > 1 ORDER BY 1",
-		Expected: []sql.Row{
-			{2, 2, nil},
-			{3, 3, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i WHERE i2 IS NOT NULL ORDER BY 1",
-		Expected: []sql.Row{
-			{2, int64(2), nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk LEFT JOIN niltable ON pk=i2 WHERE pk > 1 ORDER BY 1",
-		Expected: []sql.Row{
-			{2, int64(2), nil},
-			{3, nil, nil},
-		},
-	},
-	{
-		Query: "SELECT pk,i2,f FROM one_pk RIGHT JOIN niltable ON pk=i2 WHERE pk > 0 ORDER BY 2,3",
-		Expected: []sql.Row{
-			{2, int64(2), nil},
-		},
-	},
-	{
 		Query: "SELECT GREATEST(CAST(i AS CHAR), CAST(b AS CHAR)) FROM niltable order by i",
 		Expected: []sql.Row{
 			{nil},
@@ -6961,92 +6399,6 @@ var QueryTests = []QueryTest{
 			{nil},
 			{"5"},
 			{"6"},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0, 0, 0},
-			{1, 0, 1, 10, 10},
-			{2, 1, 0, 20, 20},
-			{3, 1, 1, 30, 30},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2,one_pk.c1 AS foo,two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 WHERE one_pk.c1=10",
-		Expected: []sql.Row{
-			{1, 0, 1, 10, 10},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ON pk1-pk>0 AND pk2<1",
-		Expected: []sql.Row{
-			{0, 1, 0},
-		},
-	},
-	{
-		Query: "SELECT pk,pk1,pk2 FROM one_pk JOIN two_pk ORDER BY 1,2,3",
-		Expected: []sql.Row{
-			{0, 0, 0},
-			{0, 0, 1},
-			{0, 1, 0},
-			{0, 1, 1},
-			{1, 0, 0},
-			{1, 0, 1},
-			{1, 1, 0},
-			{1, 1, 1},
-			{2, 0, 0},
-			{2, 0, 1},
-			{2, 1, 0},
-			{2, 1, 1},
-			{3, 0, 0},
-			{3, 0, 1},
-			{3, 1, 0},
-			{3, 1, 1},
-		},
-	},
-	{
-		Query: "SELECT a.pk,b.pk FROM one_pk a JOIN one_pk b ON a.pk = b.pk order by a.pk",
-		Expected: []sql.Row{
-			{0, 0},
-			{1, 1},
-			{2, 2},
-			{3, 3},
-		},
-	},
-	{
-		Query: "SELECT a.pk,b.pk FROM one_pk a, one_pk b WHERE a.pk = b.pk order by a.pk",
-		Expected: []sql.Row{
-			{0, 0},
-			{1, 1},
-			{2, 2},
-			{3, 3},
-		},
-	},
-	{
-		Query: "SELECT one_pk.pk,b.pk FROM one_pk JOIN one_pk b ON one_pk.pk = b.pk order by one_pk.pk",
-		Expected: []sql.Row{
-			{0, 0},
-			{1, 1},
-			{2, 2},
-			{3, 3},
-		},
-	},
-	{
-		Query: "SELECT one_pk.pk,b.pk FROM one_pk, one_pk b WHERE one_pk.pk = b.pk order by one_pk.pk",
-		Expected: []sql.Row{
-			{0, 0},
-			{1, 1},
-			{2, 2},
-			{3, 3},
-		},
-	},
-	{
-		Query: "select sum(x.i) + y.i from mytable as x, mytable as y where x.i = y.i GROUP BY x.i",
-		Expected: []sql.Row{
-			{int64(2)},
-			{int64(4)},
-			{int64(6)},
 		},
 	},
 	{
@@ -7331,67 +6683,6 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
-		Query: `SELECT pk,tpk.pk1,tpk2.pk1,tpk.pk2,tpk2.pk2 FROM one_pk
-						LEFT JOIN two_pk tpk ON one_pk.pk=tpk.pk1 AND one_pk.pk=tpk.pk2
-						JOIN two_pk tpk2 ON tpk2.pk1=TPK.pk2 AND TPK2.pk2=tpk.pk1`,
-		Expected: []sql.Row{
-			{0, 0, 0, 0, 0},
-			{1, 1, 1, 1, 1},
-		},
-	},
-	{
-		Query: `SELECT pk,nt.i,nt2.i FROM one_pk
-						RIGHT JOIN niltable nt ON pk=nt.i
-						RIGHT JOIN niltable nt2 ON pk=nt2.i - 1
-						ORDER BY 3`,
-		Expected: []sql.Row{
-			{nil, nil, 1},
-			{1, 1, 2},
-			{2, 2, 3},
-			{3, 3, 4},
-			{nil, nil, 5},
-			{nil, nil, 6},
-		},
-	},
-	{
-		Query: `SELECT pk,pk2,
-							(SELECT opk.c5 FROM one_pk opk JOIN two_pk tpk ON pk=pk1 ORDER BY 1 LIMIT 1)
-							FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2`,
-		Expected: []sql.Row{
-			{1, 1, 4},
-			{1, 1, 4},
-		},
-	},
-	{
-		Query: `SELECT pk,pk2,
-							(SELECT opk.c5 FROM one_pk opk JOIN two_pk tpk ON opk.c5=tpk.c5 ORDER BY 1 LIMIT 1)
-							FROM one_pk t1, two_pk t2 WHERE pk=1 AND pk2=1 ORDER BY 1,2`,
-		Expected: []sql.Row{
-			{1, 1, 4},
-			{1, 1, 4},
-		},
-	},
-	{
-		Query: `SELECT /*+ JOIN_ORDER(mytable, othertable) */ s2, i2, i FROM mytable INNER JOIN (SELECT * FROM othertable) othertable ON i2 = i`,
-		Expected: []sql.Row{
-			{"third", 1, 1},
-			{"second", 2, 2},
-			{"first", 3, 3},
-		},
-	},
-	{
-		Query: `SELECT lefttable.i, righttable.s
-			FROM (SELECT * FROM mytable) lefttable
-			JOIN (SELECT * FROM mytable) righttable
-			ON lefttable.i = righttable.i AND righttable.s = lefttable.s
-			ORDER BY lefttable.i ASC`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
 		Query: "SELECT BINARY 'hi'",
 		Expected: []sql.Row{
 			{[]byte("hi")},
@@ -7613,185 +6904,6 @@ var QueryTests = []QueryTest{
 		Query: `SHOW SESSION STATUS WHERE Value < 0`,
 		Expected: []sql.Row{
 			{"optimizer_trace_offset", -1},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b where a.i = b.i`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b where a.i = b.i OR a.i = 1`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{1, "first row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b where NOT(a.i = b.i OR a.s = b.i)`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{1, "first row"},
-			{2, "second row"},
-			{2, "second row"},
-			{3, "third row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where NOT(a.i = b.i OR a.s = b.i)`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{1, "first row"},
-			{2, "second row"},
-			{2, "second row"},
-			{3, "third row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b where a.i = b.s OR a.s = b.i IS FALSE`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = b.s OR a.s = b.i IS FALSE`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b where a.i >= b.i`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{2, "second row"},
-			{3, "third row"},
-			{3, "third row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query:    `SELECT a.* FROM mytable a, mytable b where a.i = a.s`,
-		Expected: []sql.Row{},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b where a.i in (2, 432, 7)`,
-		Expected: []sql.Row{
-			{2, "second row"},
-			{2, "second row"},
-			{2, "second row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.i = c.i AND c.i = d.i AND c.i = 2`,
-		Expected: []sql.Row{
-			{2, "second row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.i = c.i AND (c.i = d.s OR c.i = 2)`,
-		Expected: []sql.Row{
-			{2, "second row"},
-			{2, "second row"},
-			{2, "second row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.s = c.s`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = b.i`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = b.i OR a.i = 1`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{1, "first row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i >= b.i`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{2, "second row"},
-			{3, "third row"},
-			{3, "third row"},
-			{3, "third row"},
-		},
-	},
-	{
-		Query:    `SELECT a.* FROM mytable a CROSS JOIN mytable b where a.i = a.s`,
-		Expected: []sql.Row{},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b CROSS JOIN mytable c CROSS JOIN mytable d where a.i = b.i AND b.i = c.i AND c.i = d.i AND c.i = 2`,
-		Expected: []sql.Row{
-			{2, "second row"},
-		},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b CROSS JOIN mytable c CROSS JOIN mytable d where a.i = b.i AND b.i = c.i AND (c.i = d.s OR c.i = 2)`,
-		Expected: []sql.Row{
-			{2, "second row"},
-			{2, "second row"},
-			{2, "second row"}},
-	},
-	{
-		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b CROSS JOIN mytable c CROSS JOIN mytable d where a.i = b.i AND b.s = c.s`,
-		Expected: []sql.Row{
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
-			{1, "first row"},
-			{2, "second row"},
-			{3, "third row"},
 		},
 	},
 	{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -35,31 +35,32 @@ var PlanTests = []QueryPlanTest{
 			"     ├─ Eq\n" +
 			"     │   ├─ xy.x:1!null\n" +
 			"     │   └─ applySubq0.(select u from uv where u = sq.p):0\n" +
-			"     ├─ SubqueryAlias\n" +
-			"     │   ├─ name: applySubq0\n" +
-			"     │   ├─ outerVisibility: false\n" +
-			"     │   ├─ cacheable: true\n" +
-			"     │   └─ Project\n" +
-			"     │       ├─ columns: [Subquery\n" +
-			"     │       │   ├─ cacheable: false\n" +
-			"     │       │   └─ Filter\n" +
-			"     │       │       ├─ Eq\n" +
-			"     │       │       │   ├─ uv.u:1!null\n" +
-			"     │       │       │   └─ sq.p:0!null\n" +
-			"     │       │       └─ IndexedTableAccess\n" +
-			"     │       │           ├─ index: [uv.u]\n" +
-			"     │       │           ├─ columns: [u]\n" +
-			"     │       │           └─ Table\n" +
-			"     │       │               ├─ name: uv\n" +
-			"     │       │               └─ projections: [0]\n" +
-			"     │       │   as (select u from uv where u = sq.p)]\n" +
-			"     │       └─ SubqueryAlias\n" +
-			"     │           ├─ name: sq\n" +
-			"     │           ├─ outerVisibility: true\n" +
-			"     │           ├─ cacheable: true\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: pq\n" +
-			"     │               └─ columns: [p]\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ SubqueryAlias\n" +
+			"     │       ├─ name: applySubq0\n" +
+			"     │       ├─ outerVisibility: false\n" +
+			"     │       ├─ cacheable: true\n" +
+			"     │       └─ Project\n" +
+			"     │           ├─ columns: [Subquery\n" +
+			"     │           │   ├─ cacheable: false\n" +
+			"     │           │   └─ Filter\n" +
+			"     │           │       ├─ Eq\n" +
+			"     │           │       │   ├─ uv.u:1!null\n" +
+			"     │           │       │   └─ sq.p:0!null\n" +
+			"     │           │       └─ IndexedTableAccess\n" +
+			"     │           │           ├─ index: [uv.u]\n" +
+			"     │           │           ├─ columns: [u]\n" +
+			"     │           │           └─ Table\n" +
+			"     │           │               ├─ name: uv\n" +
+			"     │           │               └─ projections: [0]\n" +
+			"     │           │   as (select u from uv where u = sq.p)]\n" +
+			"     │           └─ SubqueryAlias\n" +
+			"     │               ├─ name: sq\n" +
+			"     │               ├─ outerVisibility: true\n" +
+			"     │               ├─ cacheable: true\n" +
+			"     │               └─ Table\n" +
+			"     │                   ├─ name: pq\n" +
+			"     │                   └─ columns: [p]\n" +
 			"     └─ IndexedTableAccess\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         └─ Table\n" +
@@ -99,10 +100,11 @@ var PlanTests = []QueryPlanTest{
 			"         ├─ Eq\n" +
 			"         │   ├─ mytable.i:1!null\n" +
 			"         │   └─ applySubq0.i2:0!null\n" +
-			"         ├─ TableAlias(applySubq0)\n" +
-			"         │   └─ Table\n" +
-			"         │       ├─ name: othertable\n" +
-			"         │       └─ columns: [i2]\n" +
+			"         ├─ Distinct\n" +
+			"         │   └─ TableAlias(applySubq0)\n" +
+			"         │       └─ Table\n" +
+			"         │           ├─ name: othertable\n" +
+			"         │           └─ columns: [i2]\n" +
 			"         └─ IndexedTableAccess\n" +
 			"             ├─ index: [mytable.i]\n" +
 			"             └─ Table\n" +
@@ -804,9 +806,10 @@ var PlanTests = []QueryPlanTest{
 			" │               ├─ Eq\n" +
 			" │               │   ├─ ab.a:4!null\n" +
 			" │               │   └─ uv.u:2!null\n" +
-			" │               ├─ Table\n" +
-			" │               │   ├─ name: uv\n" +
-			" │               │   └─ columns: [u v]\n" +
+			" │               ├─ Distinct\n" +
+			" │               │   └─ Table\n" +
+			" │               │       ├─ name: uv\n" +
+			" │               │       └─ columns: [u v]\n" +
 			" │               └─ IndexedTableAccess\n" +
 			" │                   ├─ index: [ab.a]\n" +
 			" │                   └─ Table\n" +
@@ -898,9 +901,10 @@ var PlanTests = []QueryPlanTest{
 			"         ├─ Eq\n" +
 			"         │   ├─ xy.x:0!null\n" +
 			"         │   └─ ab.a:2!null\n" +
-			"         ├─ Table\n" +
-			"         │   ├─ name: xy\n" +
-			"         │   └─ columns: [x y]\n" +
+			"         ├─ Distinct\n" +
+			"         │   └─ Table\n" +
+			"         │       ├─ name: xy\n" +
+			"         │       └─ columns: [x y]\n" +
 			"         └─ IndexedTableAccess\n" +
 			"             ├─ index: [ab.a]\n" +
 			"             └─ Table\n" +
@@ -913,13 +917,14 @@ var PlanTests = []QueryPlanTest{
 			" ├─ Eq\n" +
 			" │   ├─ cte.a:0!null\n" +
 			" │   └─ xy.x:2!null\n" +
-			" ├─ SubqueryAlias\n" +
-			" │   ├─ name: cte\n" +
-			" │   ├─ outerVisibility: true\n" +
-			" │   ├─ cacheable: true\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: ab\n" +
-			" │       └─ columns: [a b]\n" +
+			" ├─ Distinct\n" +
+			" │   └─ SubqueryAlias\n" +
+			" │       ├─ name: cte\n" +
+			" │       ├─ outerVisibility: true\n" +
+			" │       ├─ cacheable: true\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: ab\n" +
+			" │           └─ columns: [a b]\n" +
 			" └─ IndexedTableAccess\n" +
 			"     ├─ index: [xy.x]\n" +
 			"     └─ Table\n" +
@@ -1016,19 +1021,20 @@ where exists
 			" ├─ Eq\n" +
 			" │   ├─ ab.a:4!null\n" +
 			" │   └─ uv.u:0!null\n" +
-			" ├─ LeftOuterLookupJoin\n" +
-			" │   ├─ Eq\n" +
-			" │   │   ├─ uv.u:0!null\n" +
-			" │   │   └─ pq.p:2!null\n" +
-			" │   ├─ Table\n" +
-			" │   │   ├─ name: uv\n" +
-			" │   │   └─ columns: [u v]\n" +
-			" │   └─ IndexedTableAccess\n" +
-			" │       ├─ index: [pq.p]\n" +
-			" │       ├─ columns: [p q]\n" +
-			" │       └─ Table\n" +
-			" │           ├─ name: pq\n" +
-			" │           └─ projections: [0 1]\n" +
+			" ├─ Distinct\n" +
+			" │   └─ LeftOuterLookupJoin\n" +
+			" │       ├─ Eq\n" +
+			" │       │   ├─ uv.u:0!null\n" +
+			" │       │   └─ pq.p:2!null\n" +
+			" │       ├─ Table\n" +
+			" │       │   ├─ name: uv\n" +
+			" │       │   └─ columns: [u v]\n" +
+			" │       └─ IndexedTableAccess\n" +
+			" │           ├─ index: [pq.p]\n" +
+			" │           ├─ columns: [p q]\n" +
+			" │           └─ Table\n" +
+			" │               ├─ name: pq\n" +
+			" │               └─ projections: [0 1]\n" +
 			" └─ IndexedTableAccess\n" +
 			"     ├─ index: [ab.a]\n" +
 			"     └─ Table\n" +
@@ -1184,10 +1190,11 @@ inner join pq on true
 			"     ├─ Eq\n" +
 			"     │   ├─ a.i:1!null\n" +
 			"     │   └─ b.i:0!null\n" +
-			"     ├─ TableAlias(b)\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: mytable\n" +
-			"     │       └─ columns: [i]\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ TableAlias(b)\n" +
+			"     │       └─ Table\n" +
+			"     │           ├─ name: mytable\n" +
+			"     │           └─ columns: [i]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess\n" +
 			"             ├─ index: [mytable.i]\n" +
@@ -3473,10 +3480,11 @@ inner join pq on true
 			" ├─ Eq\n" +
 			" │   ├─ mytable.i:1!null\n" +
 			" │   └─ applySubq0.i2:0!null\n" +
-			" ├─ TableAlias(applySubq0)\n" +
-			" │   └─ Table\n" +
-			" │       ├─ name: othertable\n" +
-			" │       └─ columns: [i2]\n" +
+			" ├─ Distinct\n" +
+			" │   └─ TableAlias(applySubq0)\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: othertable\n" +
+			" │           └─ columns: [i2]\n" +
 			" └─ IndexedTableAccess\n" +
 			"     ├─ index: [mytable.i]\n" +
 			"     └─ Table\n" +
@@ -8017,56 +8025,57 @@ WHERE
 			" │   ├─ Eq\n" +
 			" │   │   ├─ TIZHK.id:1!null\n" +
 			" │   │   └─ applySubq0.id:0!null\n" +
-			" │   ├─ SubqueryAlias\n" +
-			" │   │   ├─ name: applySubq0\n" +
-			" │   │   ├─ outerVisibility: false\n" +
-			" │   │   ├─ cacheable: true\n" +
-			" │   │   └─ Distinct\n" +
-			" │   │       └─ Project\n" +
-			" │   │           ├─ columns: [TIZHK.id:17!null]\n" +
-			" │   │           └─ Filter\n" +
-			" │   │               ├─ Eq\n" +
-			" │   │               │   ├─ aac.BTXC5:62\n" +
-			" │   │               │   └─ TIZHK.SYPKF:20\n" +
-			" │   │               └─ LookupJoin\n" +
+			" │   ├─ Distinct\n" +
+			" │   │   └─ SubqueryAlias\n" +
+			" │   │       ├─ name: applySubq0\n" +
+			" │   │       ├─ outerVisibility: false\n" +
+			" │   │       ├─ cacheable: true\n" +
+			" │   │       └─ Distinct\n" +
+			" │   │           └─ Project\n" +
+			" │   │               ├─ columns: [TIZHK.id:17!null]\n" +
+			" │   │               └─ Filter\n" +
 			" │   │                   ├─ Eq\n" +
-			" │   │                   │   ├─ aac.id:61!null\n" +
-			" │   │                   │   └─ mf.M22QN:47!null\n" +
-			" │   │                   ├─ LookupJoin\n" +
-			" │   │                   │   ├─ Eq\n" +
-			" │   │                   │   │   ├─ mf.LUEVY:46!null\n" +
-			" │   │                   │   │   └─ J4JYP.id:0!null\n" +
-			" │   │                   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   ├─ RHUZN.ZH72S:34\n" +
-			" │   │                   │   │   │   └─ TIZHK.ZHITY:19\n" +
-			" │   │                   │   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   │   ├─ J4JYP.ZH72S:7\n" +
-			" │   │                   │   │   │   │   └─ TIZHK.TVNW2:18\n" +
-			" │   │                   │   │   │   ├─ TableAlias(J4JYP)\n" +
-			" │   │                   │   │   │   │   └─ Table\n" +
-			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
-			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
-			" │   │                   │   │   │           └─ Table\n" +
-			" │   │                   │   │   │               └─ name: WRZVO\n" +
-			" │   │                   │   │   └─ TableAlias(RHUZN)\n" +
-			" │   │                   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                   │   │           └─ Table\n" +
-			" │   │                   │   │               └─ name: E2I7U\n" +
-			" │   │                   │   └─ TableAlias(mf)\n" +
-			" │   │                   │       └─ IndexedTableAccess\n" +
-			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                   │           └─ Table\n" +
-			" │   │                   │               └─ name: HGMQ6\n" +
-			" │   │                   └─ TableAlias(aac)\n" +
-			" │   │                       └─ IndexedTableAccess\n" +
-			" │   │                           ├─ index: [TPXBU.id]\n" +
-			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: TPXBU\n" +
+			" │   │                   │   ├─ aac.BTXC5:62\n" +
+			" │   │                   │   └─ TIZHK.SYPKF:20\n" +
+			" │   │                   └─ LookupJoin\n" +
+			" │   │                       ├─ Eq\n" +
+			" │   │                       │   ├─ aac.id:61!null\n" +
+			" │   │                       │   └─ mf.M22QN:47!null\n" +
+			" │   │                       ├─ LookupJoin\n" +
+			" │   │                       │   ├─ Eq\n" +
+			" │   │                       │   │   ├─ mf.LUEVY:46!null\n" +
+			" │   │                       │   │   └─ J4JYP.id:0!null\n" +
+			" │   │                       │   ├─ LookupJoin\n" +
+			" │   │                       │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   ├─ RHUZN.ZH72S:34\n" +
+			" │   │                       │   │   │   └─ TIZHK.ZHITY:19\n" +
+			" │   │                       │   │   ├─ LookupJoin\n" +
+			" │   │                       │   │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   │   ├─ J4JYP.ZH72S:7\n" +
+			" │   │                       │   │   │   │   └─ TIZHK.TVNW2:18\n" +
+			" │   │                       │   │   │   ├─ TableAlias(J4JYP)\n" +
+			" │   │                       │   │   │   │   └─ Table\n" +
+			" │   │                       │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                       │   │   │   └─ TableAlias(TIZHK)\n" +
+			" │   │                       │   │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │   │           ├─ index: [WRZVO.TVNW2]\n" +
+			" │   │                       │   │   │           └─ Table\n" +
+			" │   │                       │   │   │               └─ name: WRZVO\n" +
+			" │   │                       │   │   └─ TableAlias(RHUZN)\n" +
+			" │   │                       │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			" │   │                       │   │           └─ Table\n" +
+			" │   │                       │   │               └─ name: E2I7U\n" +
+			" │   │                       │   └─ TableAlias(mf)\n" +
+			" │   │                       │       └─ IndexedTableAccess\n" +
+			" │   │                       │           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                       │           └─ Table\n" +
+			" │   │                       │               └─ name: HGMQ6\n" +
+			" │   │                       └─ TableAlias(aac)\n" +
+			" │   │                           └─ IndexedTableAccess\n" +
+			" │   │                               ├─ index: [TPXBU.id]\n" +
+			" │   │                               └─ Table\n" +
+			" │   │                                   └─ name: TPXBU\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
 			" │       └─ IndexedTableAccess\n" +
 			" │           ├─ index: [WRZVO.id]\n" +
@@ -8119,56 +8128,57 @@ WHERE
 			" │   ├─ Eq\n" +
 			" │   │   ├─ TIZHK.id:1!null\n" +
 			" │   │   └─ applySubq0.id:0!null\n" +
-			" │   ├─ SubqueryAlias\n" +
-			" │   │   ├─ name: applySubq0\n" +
-			" │   │   ├─ outerVisibility: false\n" +
-			" │   │   ├─ cacheable: true\n" +
-			" │   │   └─ Distinct\n" +
-			" │   │       └─ Project\n" +
-			" │   │           ├─ columns: [TIZHK.id:17!null]\n" +
-			" │   │           └─ Filter\n" +
-			" │   │               ├─ Eq\n" +
-			" │   │               │   ├─ aac.BTXC5:62\n" +
-			" │   │               │   └─ TIZHK.SYPKF:20\n" +
-			" │   │               └─ LookupJoin\n" +
+			" │   ├─ Distinct\n" +
+			" │   │   └─ SubqueryAlias\n" +
+			" │   │       ├─ name: applySubq0\n" +
+			" │   │       ├─ outerVisibility: false\n" +
+			" │   │       ├─ cacheable: true\n" +
+			" │   │       └─ Distinct\n" +
+			" │   │           └─ Project\n" +
+			" │   │               ├─ columns: [TIZHK.id:17!null]\n" +
+			" │   │               └─ Filter\n" +
 			" │   │                   ├─ Eq\n" +
-			" │   │                   │   ├─ aac.id:61!null\n" +
-			" │   │                   │   └─ mf.M22QN:47!null\n" +
-			" │   │                   ├─ LookupJoin\n" +
-			" │   │                   │   ├─ Eq\n" +
-			" │   │                   │   │   ├─ mf.LUEVY:46!null\n" +
-			" │   │                   │   │   └─ J4JYP.id:27!null\n" +
-			" │   │                   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   ├─ J4JYP.ZH72S:34\n" +
-			" │   │                   │   │   │   └─ TIZHK.TVNW2:18\n" +
-			" │   │                   │   │   ├─ LookupJoin\n" +
-			" │   │                   │   │   │   ├─ Eq\n" +
-			" │   │                   │   │   │   │   ├─ RHUZN.ZH72S:7\n" +
-			" │   │                   │   │   │   │   └─ TIZHK.ZHITY:19\n" +
-			" │   │                   │   │   │   ├─ TableAlias(RHUZN)\n" +
-			" │   │                   │   │   │   │   └─ Table\n" +
-			" │   │                   │   │   │   │       └─ name: E2I7U\n" +
-			" │   │                   │   │   │   └─ TableAlias(TIZHK)\n" +
-			" │   │                   │   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │   │           ├─ index: [WRZVO.ZHITY]\n" +
-			" │   │                   │   │   │           └─ Table\n" +
-			" │   │                   │   │   │               └─ name: WRZVO\n" +
-			" │   │                   │   │   └─ TableAlias(J4JYP)\n" +
-			" │   │                   │   │       └─ IndexedTableAccess\n" +
-			" │   │                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			" │   │                   │   │           └─ Table\n" +
-			" │   │                   │   │               └─ name: E2I7U\n" +
-			" │   │                   │   └─ TableAlias(mf)\n" +
-			" │   │                   │       └─ IndexedTableAccess\n" +
-			" │   │                   │           ├─ index: [HGMQ6.LUEVY]\n" +
-			" │   │                   │           └─ Table\n" +
-			" │   │                   │               └─ name: HGMQ6\n" +
-			" │   │                   └─ TableAlias(aac)\n" +
-			" │   │                       └─ IndexedTableAccess\n" +
-			" │   │                           ├─ index: [TPXBU.id]\n" +
-			" │   │                           └─ Table\n" +
-			" │   │                               └─ name: TPXBU\n" +
+			" │   │                   │   ├─ aac.BTXC5:62\n" +
+			" │   │                   │   └─ TIZHK.SYPKF:20\n" +
+			" │   │                   └─ LookupJoin\n" +
+			" │   │                       ├─ Eq\n" +
+			" │   │                       │   ├─ aac.id:61!null\n" +
+			" │   │                       │   └─ mf.M22QN:47!null\n" +
+			" │   │                       ├─ LookupJoin\n" +
+			" │   │                       │   ├─ Eq\n" +
+			" │   │                       │   │   ├─ mf.LUEVY:46!null\n" +
+			" │   │                       │   │   └─ J4JYP.id:27!null\n" +
+			" │   │                       │   ├─ LookupJoin\n" +
+			" │   │                       │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   ├─ J4JYP.ZH72S:34\n" +
+			" │   │                       │   │   │   └─ TIZHK.TVNW2:18\n" +
+			" │   │                       │   │   ├─ LookupJoin\n" +
+			" │   │                       │   │   │   ├─ Eq\n" +
+			" │   │                       │   │   │   │   ├─ RHUZN.ZH72S:7\n" +
+			" │   │                       │   │   │   │   └─ TIZHK.ZHITY:19\n" +
+			" │   │                       │   │   │   ├─ TableAlias(RHUZN)\n" +
+			" │   │                       │   │   │   │   └─ Table\n" +
+			" │   │                       │   │   │   │       └─ name: E2I7U\n" +
+			" │   │                       │   │   │   └─ TableAlias(TIZHK)\n" +
+			" │   │                       │   │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │   │           ├─ index: [WRZVO.ZHITY]\n" +
+			" │   │                       │   │   │           └─ Table\n" +
+			" │   │                       │   │   │               └─ name: WRZVO\n" +
+			" │   │                       │   │   └─ TableAlias(J4JYP)\n" +
+			" │   │                       │   │       └─ IndexedTableAccess\n" +
+			" │   │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			" │   │                       │   │           └─ Table\n" +
+			" │   │                       │   │               └─ name: E2I7U\n" +
+			" │   │                       │   └─ TableAlias(mf)\n" +
+			" │   │                       │       └─ IndexedTableAccess\n" +
+			" │   │                       │           ├─ index: [HGMQ6.LUEVY]\n" +
+			" │   │                       │           └─ Table\n" +
+			" │   │                       │               └─ name: HGMQ6\n" +
+			" │   │                       └─ TableAlias(aac)\n" +
+			" │   │                           └─ IndexedTableAccess\n" +
+			" │   │                               ├─ index: [TPXBU.id]\n" +
+			" │   │                               └─ Table\n" +
+			" │   │                                   └─ name: TPXBU\n" +
 			" │   └─ TableAlias(TIZHK)\n" +
 			" │       └─ IndexedTableAccess\n" +
 			" │           ├─ index: [WRZVO.id]\n" +
@@ -8944,55 +8954,56 @@ WHERE
 			"     ├─ Eq\n" +
 			"     │   ├─ TDRVG.id:1!null\n" +
 			"     │   └─ applySubq0.id:0\n" +
-			"     ├─ SubqueryAlias\n" +
-			"     │   ├─ name: applySubq0\n" +
-			"     │   ├─ outerVisibility: false\n" +
-			"     │   ├─ cacheable: true\n" +
-			"     │   └─ Project\n" +
-			"     │       ├─ columns: [Subquery\n" +
-			"     │       │   ├─ cacheable: false\n" +
-			"     │       │   └─ Limit(1)\n" +
-			"     │       │       └─ TopN(Limit: [1 (tinyint)]; TDRVG.id:2!null ASC nullsFirst)\n" +
-			"     │       │           └─ Project\n" +
-			"     │       │               ├─ columns: [TDRVG.id:2!null]\n" +
-			"     │       │               └─ Filter\n" +
-			"     │       │                   ├─ Eq\n" +
-			"     │       │                   │   ├─ TDRVG.SSHPJ:3!null\n" +
-			"     │       │                   │   └─ S7BYT.SSHPJ:0!null\n" +
-			"     │       │                   └─ Table\n" +
-			"     │       │                       ├─ name: TDRVG\n" +
-			"     │       │                       └─ columns: [id sshpj]\n" +
-			"     │       │   as id]\n" +
-			"     │       └─ AntiLookupJoin\n" +
-			"     │           ├─ Eq\n" +
-			"     │           │   ├─ S7BYT.SSHPJ:0!null\n" +
-			"     │           │   └─ applySubq0.SSHPJ:2!null\n" +
-			"     │           ├─ SubqueryAlias\n" +
-			"     │           │   ├─ name: S7BYT\n" +
-			"     │           │   ├─ outerVisibility: true\n" +
-			"     │           │   ├─ cacheable: true\n" +
-			"     │           │   └─ Distinct\n" +
-			"     │           │       └─ Project\n" +
-			"     │           │           ├─ columns: [S5KBM.SSHPJ:19!null as SSHPJ, S5KBM.SFJ6L:20!null as SFJ6L]\n" +
-			"     │           │           └─ LookupJoin\n" +
-			"     │           │               ├─ Eq\n" +
-			"     │           │               │   ├─ nd.FGG57:6\n" +
-			"     │           │               │   └─ S5KBM.FGG57:18!null\n" +
-			"     │           │               ├─ TableAlias(nd)\n" +
-			"     │           │               │   └─ Table\n" +
-			"     │           │               │       └─ name: E2I7U\n" +
-			"     │           │               └─ TableAlias(S5KBM)\n" +
-			"     │           │                   └─ IndexedTableAccess\n" +
-			"     │           │                       ├─ index: [TDRVG.FGG57]\n" +
-			"     │           │                       └─ Table\n" +
-			"     │           │                           └─ name: TDRVG\n" +
-			"     │           └─ TableAlias(applySubq0)\n" +
-			"     │               └─ IndexedTableAccess\n" +
-			"     │                   ├─ index: [WE72E.SSHPJ]\n" +
-			"     │                   ├─ columns: [sshpj]\n" +
-			"     │                   └─ Table\n" +
-			"     │                       ├─ name: WE72E\n" +
-			"     │                       └─ projections: [2]\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ SubqueryAlias\n" +
+			"     │       ├─ name: applySubq0\n" +
+			"     │       ├─ outerVisibility: false\n" +
+			"     │       ├─ cacheable: true\n" +
+			"     │       └─ Project\n" +
+			"     │           ├─ columns: [Subquery\n" +
+			"     │           │   ├─ cacheable: false\n" +
+			"     │           │   └─ Limit(1)\n" +
+			"     │           │       └─ TopN(Limit: [1 (tinyint)]; TDRVG.id:2!null ASC nullsFirst)\n" +
+			"     │           │           └─ Project\n" +
+			"     │           │               ├─ columns: [TDRVG.id:2!null]\n" +
+			"     │           │               └─ Filter\n" +
+			"     │           │                   ├─ Eq\n" +
+			"     │           │                   │   ├─ TDRVG.SSHPJ:3!null\n" +
+			"     │           │                   │   └─ S7BYT.SSHPJ:0!null\n" +
+			"     │           │                   └─ Table\n" +
+			"     │           │                       ├─ name: TDRVG\n" +
+			"     │           │                       └─ columns: [id sshpj]\n" +
+			"     │           │   as id]\n" +
+			"     │           └─ AntiLookupJoin\n" +
+			"     │               ├─ Eq\n" +
+			"     │               │   ├─ S7BYT.SSHPJ:0!null\n" +
+			"     │               │   └─ applySubq0.SSHPJ:2!null\n" +
+			"     │               ├─ SubqueryAlias\n" +
+			"     │               │   ├─ name: S7BYT\n" +
+			"     │               │   ├─ outerVisibility: true\n" +
+			"     │               │   ├─ cacheable: true\n" +
+			"     │               │   └─ Distinct\n" +
+			"     │               │       └─ Project\n" +
+			"     │               │           ├─ columns: [S5KBM.SSHPJ:19!null as SSHPJ, S5KBM.SFJ6L:20!null as SFJ6L]\n" +
+			"     │               │           └─ LookupJoin\n" +
+			"     │               │               ├─ Eq\n" +
+			"     │               │               │   ├─ nd.FGG57:6\n" +
+			"     │               │               │   └─ S5KBM.FGG57:18!null\n" +
+			"     │               │               ├─ TableAlias(nd)\n" +
+			"     │               │               │   └─ Table\n" +
+			"     │               │               │       └─ name: E2I7U\n" +
+			"     │               │               └─ TableAlias(S5KBM)\n" +
+			"     │               │                   └─ IndexedTableAccess\n" +
+			"     │               │                       ├─ index: [TDRVG.FGG57]\n" +
+			"     │               │                       └─ Table\n" +
+			"     │               │                           └─ name: TDRVG\n" +
+			"     │               └─ TableAlias(applySubq0)\n" +
+			"     │                   └─ IndexedTableAccess\n" +
+			"     │                       ├─ index: [WE72E.SSHPJ]\n" +
+			"     │                       ├─ columns: [sshpj]\n" +
+			"     │                       └─ Table\n" +
+			"     │                           ├─ name: WE72E\n" +
+			"     │                           └─ projections: [2]\n" +
 			"     └─ IndexedTableAccess\n" +
 			"         ├─ index: [TDRVG.id]\n" +
 			"         └─ Table\n" +
@@ -14343,25 +14354,26 @@ ORDER BY cla.FTQLQ ASC`,
 			"             ├─ Eq\n" +
 			"             │   ├─ cla.id:4!null\n" +
 			"             │   └─ applySubq0.IXUXU:2\n" +
-			"             ├─ Filter\n" +
-			"             │   ├─ AND\n" +
-			"             │   │   ├─ InSubquery\n" +
-			"             │   │   │   ├─ left: applySubq0.id:0!null\n" +
-			"             │   │   │   └─ right: Subquery\n" +
-			"             │   │   │       ├─ cacheable: true\n" +
-			"             │   │   │       └─ Table\n" +
-			"             │   │   │           ├─ name: HGMQ6\n" +
-			"             │   │   │           └─ columns: [gxlub]\n" +
-			"             │   │   └─ InSubquery\n" +
-			"             │   │       ├─ left: applySubq0.id:0!null\n" +
-			"             │   │       └─ right: Subquery\n" +
-			"             │   │           ├─ cacheable: true\n" +
-			"             │   │           └─ Table\n" +
-			"             │   │               ├─ name: AMYXQ\n" +
-			"             │   │               └─ columns: [gxlub]\n" +
-			"             │   └─ TableAlias(applySubq0)\n" +
-			"             │       └─ Table\n" +
-			"             │           └─ name: THNTS\n" +
+			"             ├─ Distinct\n" +
+			"             │   └─ Filter\n" +
+			"             │       ├─ AND\n" +
+			"             │       │   ├─ InSubquery\n" +
+			"             │       │   │   ├─ left: applySubq0.id:0!null\n" +
+			"             │       │   │   └─ right: Subquery\n" +
+			"             │       │   │       ├─ cacheable: true\n" +
+			"             │       │   │       └─ Table\n" +
+			"             │       │   │           ├─ name: HGMQ6\n" +
+			"             │       │   │           └─ columns: [gxlub]\n" +
+			"             │       │   └─ InSubquery\n" +
+			"             │       │       ├─ left: applySubq0.id:0!null\n" +
+			"             │       │       └─ right: Subquery\n" +
+			"             │       │           ├─ cacheable: true\n" +
+			"             │       │           └─ Table\n" +
+			"             │       │               ├─ name: AMYXQ\n" +
+			"             │       │               └─ columns: [gxlub]\n" +
+			"             │       └─ TableAlias(applySubq0)\n" +
+			"             │           └─ Table\n" +
+			"             │               └─ name: THNTS\n" +
 			"             └─ TableAlias(cla)\n" +
 			"                 └─ IndexedTableAccess\n" +
 			"                     ├─ index: [YK2GW.id]\n" +

--- a/enginetest/scriptgen/setup/scripts/xy
+++ b/enginetest/scriptgen/setup/scripts/xy
@@ -72,9 +72,13 @@ insert into rs values
 ----
 
 exec
-update information_schema.statistics set cardinality = 1000000000 where table_name = 'ab';
+update information_schema.statistics set cardinality = 1000 where table_name = 'ab';
 ----
 
 exec
-update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs'
+update information_schema.statistics set cardinality = 1000 where table_name = 'xy';
+----
+
+exec
+update information_schema.statistics set cardinality = 1000 where table_name = 'rs'
 ----

--- a/enginetest/scriptgen/setup/setup_data.sg.go
+++ b/enginetest/scriptgen/setup/setup_data.sg.go
@@ -2885,6 +2885,7 @@ var XyData = []SetupScript{{
   (2,0),
   (4,4),
   (5,4);`,
-	`update information_schema.statistics set cardinality = 1000000000 where table_name = 'ab';`,
-	`update information_schema.statistics set cardinality = 1000000000 where table_name = 'rs'`,
+	`update information_schema.statistics set cardinality = 1000 where table_name = 'ab';`,
+	`update information_schema.statistics set cardinality = 1000 where table_name = 'xy';`,
+	`update information_schema.statistics set cardinality = 1000 where table_name = 'rs'`,
 }}

--- a/optgen/cmd/support/memo_gen.go
+++ b/optgen/cmd/support/memo_gen.go
@@ -11,8 +11,8 @@ type MemoDef struct {
 
 	SourceType string
 
-	IsJoin    bool
-	JoinAttrs [][2]string
+	IsJoin bool
+	Attrs  [][2]string
 
 	IsUnary bool
 }
@@ -65,11 +65,12 @@ func (g *MemoGen) genType(define MemoDef) {
 		fmt.Fprintf(g.w, "  table %s\n", define.SourceType)
 	} else if define.IsJoin {
 		fmt.Fprintf(g.w, "  *joinBase\n")
-		for _, attr := range define.JoinAttrs {
-			fmt.Fprintf(g.w, "  %s %s\n", attr[0], attr[1])
-		}
 	} else if define.IsUnary {
+		fmt.Fprintf(g.w, "  *relBase\n")
 		fmt.Fprintf(g.w, "  child *exprGroup\n")
+	}
+	for _, attr := range define.Attrs {
+		fmt.Fprintf(g.w, "  %s %s\n", attr[0], attr[1])
 	}
 
 	fmt.Fprintf(g.w, "}\n\n")
@@ -123,9 +124,24 @@ func (g *MemoGen) genJoinRelInterface(define MemoDef) {
 }
 
 func (g *MemoGen) genUnaryRelInterface(define MemoDef) {
-	fmt.Fprintf(g.w, "func (r *%s) children() sql.Schema {\n", define.Name)
+	fmt.Fprintf(g.w, "func (r *%s) children() []*exprGroup {\n", define.Name)
 	fmt.Fprintf(g.w, "  return []*exprGroup{r.child}\n")
 	fmt.Fprintf(g.w, "}\n\n")
+
+	fmt.Fprintf(g.w, "func (r *%s) outputCols() sql.Schema {\n", define.Name)
+	switch define.Name {
+	case "project":
+		fmt.Fprintf(g.w, "  var s = make(sql.Schema, len(r.projections))\n")
+		fmt.Fprintf(g.w, "  for i, e := range r.projections {\n")
+		fmt.Fprintf(g.w, "    s[i] = transform.ExpressionToColumn(e)\n")
+		fmt.Fprintf(g.w, "  }\n")
+		fmt.Fprintf(g.w, "  return s\n")
+
+	default:
+		fmt.Fprintf(g.w, "  return r.child.relProps.OutputCols()\n")
+	}
+	fmt.Fprintf(g.w, "}\n\n")
+
 }
 
 func (g *MemoGen) genFormatters(defines []MemoDef) {
@@ -138,7 +154,7 @@ func (g *MemoGen) genFormatters(defines []MemoDef) {
 		} else if d.IsJoin {
 			fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s %%d %%d\", r.left.id, r.right.id)\n", d.Name)
 		} else if d.IsUnary {
-			fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s: %%s\", formatRelExpr(r.child))\n", d.Name)
+			fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s: %%d\", r.child.id)\n", d.Name)
 		} else {
 			panic("unreachable")
 		}

--- a/optgen/cmd/support/memo_gen_test.go
+++ b/optgen/cmd/support/memo_gen_test.go
@@ -92,7 +92,7 @@ func TestMemoGen(t *testing.T) {
 		{
 			Name:   "hashJoin",
 			IsJoin: true,
-			JoinAttrs: [][2]string{
+			Attrs: [][2]string{
 				{"innerAttrs", "[]sql.Expression"},
 				{"outerAttrs", "[]sql.Expression"},
 			},

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -285,9 +285,10 @@ type Analyzer struct {
 	// BinlogReplicaController holds an optional controller that receives forwarded binlog
 	// replication messages (e.g. "start replica").
 	BinlogReplicaController binlogreplication.BinlogReplicaController
-
-	Coster Coster
+	// Carder estimates the number of rows returned by a relational expression.
 	Carder Carder
+	// Coster estimates the incremental CPU+memory cost for execution operators.
+	Coster Coster
 }
 
 // NewDefault creates a default Analyzer instance with all default Rules and configuration.

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -263,6 +263,8 @@ func (ab *Builder) Build() *Analyzer {
 		Batches:      batches,
 		Catalog:      NewCatalog(ab.provider),
 		Parallelism:  ab.parallelism,
+		Coster:       NewDefaultCoster(),
+		Carder:       NewDefaultCarder(),
 	}
 }
 
@@ -283,6 +285,9 @@ type Analyzer struct {
 	// BinlogReplicaController holds an optional controller that receives forwarded binlog
 	// replication messages (e.g. "start replica").
 	BinlogReplicaController binlogreplication.BinlogReplicaController
+
+	Coster Coster
+	Carder Carder
 }
 
 // NewDefault creates a default Analyzer instance with all default Rules and configuration.
@@ -444,6 +449,8 @@ func newInsertSourceSelector(sel RuleSelector) RuleSelector {
 // Analyze applies the transformation rules to the node given. In the case of an error, the last successfully
 // transformed node is returned along with the error.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *Scope) (sql.Node, error) {
+	//a.Verbose = true
+	//a.Debug = true
 	n, _, err := a.analyzeWithSelector(ctx, n, scope, SelectAllBatches, DefaultRuleSelector)
 	return n, err
 }

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -449,8 +449,6 @@ func newInsertSourceSelector(sel RuleSelector) RuleSelector {
 // Analyze applies the transformation rules to the node given. In the case of an error, the last successfully
 // transformed node is returned along with the error.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *Scope) (sql.Node, error) {
-	//a.Verbose = true
-	//a.Debug = true
 	n, _, err := a.analyzeWithSelector(ctx, n, scope, SelectAllBatches, DefaultRuleSelector)
 	return n, err
 }

--- a/sql/analyzer/biased_coster_test.go
+++ b/sql/analyzer/biased_coster_test.go
@@ -1,0 +1,126 @@
+package analyzer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+var biasedCosters = []Coster{
+	NewInnerBiasedCoster(),
+	NewLookupBiasedCoster(),
+	NewHashBiasedCoster(),
+	NewMergeBiasedCoster(),
+}
+
+func TestBiasedCoster(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+
+	xy := memory.NewFilteredTable("xy", sql.NewPrimaryKeySchema(sql.Schema{
+		{Name: "x", Type: types.Int64, Source: "xy"},
+		{Name: "y", Type: types.Int64, Source: "xy"},
+	}, 0), nil)
+
+	ab := memory.NewFilteredTable("ab", sql.NewPrimaryKeySchema(sql.Schema{
+		{Name: "a", Type: types.Int64, Source: "ab"},
+		{Name: "b", Type: types.Int64, Source: "ab"},
+	}, 0), nil)
+
+	xy.EnablePrimaryKeyIndexes()
+	ab.EnablePrimaryKeyIndexes()
+
+	ab.Insert(ctx, sql.Row{int64(0), int64(0)})
+	ab.Insert(ctx, sql.Row{int64(1), int64(1)})
+	ab.Insert(ctx, sql.Row{int64(2), int64(2)})
+	xy.Insert(ctx, sql.Row{int64(0), int64(0)})
+	xy.Insert(ctx, sql.Row{int64(1), int64(1)})
+
+	db := memory.NewDatabase("mydb")
+	db.EnablePrimaryKeyIndexes()
+	db.AddTable("xy", xy)
+	db.AddTable("ab", ab)
+
+	a := NewDefault(sql.NewDatabaseProvider(db))
+
+	n := plan.NewInnerJoin(
+		plan.NewResolvedTable(xy, db, nil),
+		plan.NewResolvedTable(ab, db, nil),
+		expression.NewEquals(
+			expression.NewGetFieldWithTable(0, types.Int64, "xy", "x", false),
+			expression.NewGetFieldWithTable(0, types.Int64, "ab", "a", false),
+		),
+	)
+
+	tests := []struct {
+		name string
+		c    func() Coster
+		exp  plan.JoinType
+	}{
+		{
+			name: "inner",
+			c:    NewInnerBiasedCoster,
+			exp:  plan.JoinTypeInner,
+		},
+		{
+			name: "lookup",
+			c:    NewLookupBiasedCoster,
+			exp:  plan.JoinTypeLookup,
+		},
+		{
+			name: "hash",
+			c:    NewHashBiasedCoster,
+			exp:  plan.JoinTypeHash,
+		},
+		{
+			name: "merge",
+			c:    NewMergeBiasedCoster,
+			exp:  plan.JoinTypeMerge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s biased coster", tt.name), func(t *testing.T) {
+			a.Coster = tt.c()
+			cmp, err := replanJoin(ctx, n, a, nil)
+			require.NoError(t, err)
+			types := collectJoinTypes(cmp)[0]
+			require.Equal(t, tt.exp, types)
+		})
+	}
+}
+
+func collectJoinTypes(n sql.Node) []plan.JoinType {
+	var types []plan.JoinType
+	transform.Inspect(n, func(n sql.Node) bool {
+		if n == nil {
+			return true
+		}
+		j, ok := n.(*plan.JoinNode)
+		if ok {
+			types = append(types, j.Op)
+		}
+
+		if ex, ok := n.(sql.Expressioner); ok {
+			for _, e := range ex.Expressions() {
+				transform.InspectExpr(e, func(e sql.Expression) bool {
+					sq, ok := e.(*plan.Subquery)
+					if !ok {
+						return false
+					}
+					types = append(types, collectJoinTypes(sq.Query)...)
+					return false
+				})
+			}
+		}
+		return true
+	})
+	return types
+}

--- a/sql/analyzer/biased_coster_test.go
+++ b/sql/analyzer/biased_coster_test.go
@@ -14,13 +14,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
-var biasedCosters = []Coster{
-	NewInnerBiasedCoster(),
-	NewLookupBiasedCoster(),
-	NewHashBiasedCoster(),
-	NewMergeBiasedCoster(),
-}
-
 func TestBiasedCoster(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 

--- a/sql/analyzer/coster.go
+++ b/sql/analyzer/coster.go
@@ -21,150 +21,185 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
-type coster struct {
-	ctx *sql.Context
-	s   sql.StatsReadWriter
+const (
+	// reference https://github.com/postgres/postgres/blob/master/src/include/optimizer/cost.h
+	cpuCostFactor     = 0.01
+	seqIOCostFactor   = 1
+	randIOCostFactor  = 2
+	memCostFactor     = 2
+	concatCostFactor  = 0.75
+	degeneratePenalty = 2.0
+	optimisticJoinSel = .10
+	biasFactor        = 1e5
+)
+
+func NewDefaultCoster() Coster {
+	return &coster{}
 }
 
-func (c *coster) costRel(n relExpr) (float64, error) {
+type coster struct{}
+
+var _ Coster = (*coster)(nil)
+
+func (c *coster) EstimateCost(ctx *sql.Context, n relExpr, s sql.StatsReadWriter) (float64, error) {
+	return c.costRel(ctx, n, s)
+}
+
+// costRel returns the estimated compute cost for a given physical
+// operator. Two physical operators in the same expression group will have
+// the same input and output cardinalities, but different evaluation costs.
+func (c *coster) costRel(ctx *sql.Context, n relExpr, s sql.StatsReadWriter) (float64, error) {
 	switch n := n.(type) {
 	case *tableScan:
-		return c.costScan(n)
+		return c.costScan(ctx, n, s)
 	case *tableAlias:
-		return c.costTableAlias(n)
+		return c.costTableAlias(ctx, n, s)
 	case *values:
-		return c.costValues(n)
+		return c.costValues(ctx, n, s)
 	case *recursiveTable:
-		return c.costRecursiveTable(n)
+		return c.costRecursiveTable(ctx, n, s)
 	case *innerJoin:
-		return c.costInnerJoin(n)
+		return c.costInnerJoin(ctx, n, s)
 	case *crossJoin:
-		return c.costCrossJoin(n)
+		return c.costCrossJoin(ctx, n, s)
 	case *leftJoin:
-		return c.costLeftJoin(n)
+		return c.costLeftJoin(ctx, n, s)
 	case *hashJoin:
-		return c.costHashJoin(n)
+		return c.costHashJoin(ctx, n, s)
 	case *mergeJoin:
-		return c.costMergeJoin(n)
+		return c.costMergeJoin(ctx, n, s)
 	case *lookupJoin:
-		return c.costLookupJoin(n)
+		return c.costLookupJoin(ctx, n, s)
 	case *semiJoin:
-		return c.costSemiJoin(n)
+		return c.costSemiJoin(ctx, n, s)
 	case *antiJoin:
-		return c.costAntiJoin(n)
+		return c.costAntiJoin(ctx, n, s)
 	case *subqueryAlias:
-		return c.costSubqueryAlias(n)
+		return c.costSubqueryAlias(ctx, n, s)
 	case *max1Row:
-		return c.costMax1RowSubquery(n)
+		return c.costMax1RowSubquery(ctx, n, s)
 	case *tableFunc:
-		return c.costTableFunc(n)
+		return c.costTableFunc(ctx, n, s)
 	case *fullOuterJoin:
-		return c.costFullOuterJoin(n)
+		return c.costFullOuterJoin(ctx, n, s)
 	case *concatJoin:
-		return c.costConcatJoin(n)
+		return c.costConcatJoin(ctx, n, s)
 	case *selectSingleRel:
-		return c.costSelectSingleRel(n)
+		return c.costSelectSingleRel(ctx, n, s)
+	case *project:
+		return c.costProject(ctx, n, s)
+	case *distinct:
+		return c.costDistinct(ctx, n, s)
 	default:
 		panic(fmt.Sprintf("coster does not support type: %T", n))
 	}
 }
 
-func (c *coster) costTableAlias(n *tableAlias) (float64, error) {
+func (c *coster) costTableAlias(ctx *sql.Context, n *tableAlias, s sql.StatsReadWriter) (float64, error) {
 	switch n := n.table.Child.(type) {
 	case *plan.ResolvedTable:
-		return c.costRead(n.Table)
+		return c.costRead(ctx, n.Table, s)
 	default:
 		return 1000, nil
 	}
 }
 
-func (c *coster) costScan(t *tableScan) (float64, error) {
-	return c.costRead(t.table.Table)
+func (c *coster) costScan(ctx *sql.Context, t *tableScan, s sql.StatsReadWriter) (float64, error) {
+	return c.costRead(ctx, t.table.Table, s)
 }
 
-func (c *coster) costRead(t sql.Table) (float64, error) {
+func (c *coster) costRead(ctx *sql.Context, t sql.Table, s sql.StatsReadWriter) (float64, error) {
 	if w, ok := t.(sql.TableWrapper); ok {
 		t = w.Underlying()
 	}
 
-	db := c.ctx.GetCurrentDatabase()
-	card, ok, err := c.s.RowCount(c.ctx, db, t.Name())
+	db := ctx.GetCurrentDatabase()
+	card, ok, err := s.RowCount(ctx, db, t.Name())
 	if err != nil || !ok {
 		// TODO: better estimates for derived tables
 		return float64(1000), nil
 	}
-	return float64(card), nil
+	return float64(card) * seqIOCostFactor, nil
 }
 
-func (c *coster) costValues(v *values) (float64, error) {
-	return float64(len(v.table.ExpressionTuples)), nil
+func (c *coster) costValues(ctx *sql.Context, v *values, _ sql.StatsReadWriter) (float64, error) {
+	return float64(len(v.table.ExpressionTuples)) * cpuCostFactor, nil
 }
 
-func (c *coster) costRecursiveTable(t *recursiveTable) (float64, error) {
-	return float64(100), nil
+func (c *coster) costRecursiveTable(ctx *sql.Context, t *recursiveTable, _ sql.StatsReadWriter) (float64, error) {
+	return float64(100) * seqIOCostFactor, nil
 }
 
-func (c *coster) costInnerJoin(n *innerJoin) (float64, error) {
-	l := n.left.cost
-	r := n.right.cost
-	return l * r, nil
+func (c *coster) costInnerJoin(ctx *sql.Context, n *innerJoin, _ sql.StatsReadWriter) (float64, error) {
+	l := n.left.relProps.card
+	r := n.right.relProps.card
+	return (l*r-1)*seqIOCostFactor + (l*r)*cpuCostFactor, nil
 }
 
-func (c *coster) costCrossJoin(n *crossJoin) (float64, error) {
-	l := n.left.cost
-	r := n.right.cost
-	return l * r * 2, nil
-}
-func (c *coster) costLeftJoin(n *leftJoin) (float64, error) {
-	l := n.left.cost
-	r := n.right.cost
-	return l * r, nil
-}
-func (c *coster) costFullOuterJoin(n *fullOuterJoin) (float64, error) {
-	l := n.left.cost
-	r := n.right.cost
-	return l * r, nil
+func (c *coster) costCrossJoin(ctx *sql.Context, n *crossJoin, _ sql.StatsReadWriter) (float64, error) {
+	l := n.left.relProps.card
+	r := n.right.relProps.card
+	return ((l*r-1)*seqIOCostFactor + (l*r)*cpuCostFactor) * degeneratePenalty, nil
 }
 
-func (c *coster) costHashJoin(n *hashJoin) (float64, error) {
+func (c *coster) costLeftJoin(ctx *sql.Context, n *leftJoin, _ sql.StatsReadWriter) (float64, error) {
+	l := n.left.relProps.card
+	r := n.right.relProps.card
+	return (l*r-1)*seqIOCostFactor + (l*r)*cpuCostFactor, nil
+}
+func (c *coster) costFullOuterJoin(ctx *sql.Context, n *fullOuterJoin, _ sql.StatsReadWriter) (float64, error) {
+	l := n.left.relProps.card
+	r := n.right.relProps.card
+	return ((l*r-1)*seqIOCostFactor + (l*r)*cpuCostFactor) * degeneratePenalty, nil
+}
+
+func (c *coster) costHashJoin(ctx *sql.Context, n *hashJoin, _ sql.StatsReadWriter) (float64, error) {
 	if n.op.IsPartial() {
 		l, err := c.costPartial(n.left, n.right)
-		return l * 0.9, err
+		return l * 0.5, err
 	}
-	l := n.left.cost
-	r := n.right.cost
-	buildProbe := r / 2
-	return l + r + buildProbe, nil
+	l := n.left.relProps.card
+	r := n.right.relProps.card
+	return l*cpuCostFactor + r*(seqIOCostFactor+memCostFactor), nil
 }
 
-func (c *coster) costMergeJoin(n *mergeJoin) (float64, error) {
-	return n.left.cost + n.right.cost, nil
+func (c *coster) costMergeJoin(_ *sql.Context, n *mergeJoin, _ sql.StatsReadWriter) (float64, error) {
+	l := n.left.relProps.card
+	return l * cpuCostFactor, nil
 }
 
-func (c *coster) costLookupJoin(n *lookupJoin) (float64, error) {
-	l := n.left.cost
+func (c *coster) costLookupJoin(_ *sql.Context, n *lookupJoin, _ sql.StatsReadWriter) (float64, error) {
+	l := n.left.relProps.card
 	m := lookupMultiplier(n.lookup, len(n.filter))
-	return l * m, nil
+	return l*randIOCostFactor + l*m*cpuCostFactor - n.right.relProps.card*seqIOCostFactor, nil
 }
 
-func (c *coster) costConcatJoin(n *concatJoin) (float64, error) {
-	l := n.left.cost
+func (c *coster) costConcatJoin(_ *sql.Context, n *concatJoin, _ sql.StatsReadWriter) (float64, error) {
+	l := n.left.relProps.card
 	var mult float64
 	for _, l := range n.concat {
 		mult += lookupMultiplier(l, len(n.filter))
 	}
-	return l * mult * .75, nil
+	return l*mult*concatCostFactor*(randIOCostFactor+cpuCostFactor) - n.right.relProps.card*seqIOCostFactor, nil
 }
 
-func (c *coster) costSelectSingleRel(n *selectSingleRel) (float64, error) {
+func (c *coster) costSelectSingleRel(ctx *sql.Context, n *selectSingleRel, s sql.StatsReadWriter) (float64, error) {
 	switch t := n.table.Rel.(type) {
 	case *plan.TableAlias:
-		return c.costTableAlias(&tableAlias{relBase: n.relBase, table: t})
+		return c.costTableAlias(ctx, &tableAlias{relBase: n.relBase, table: t}, s)
 	case *plan.ResolvedTable:
-		return c.costScan(&tableScan{relBase: n.relBase, table: t})
+		return c.costScan(ctx, &tableScan{relBase: n.relBase, table: t}, s)
 	default:
 		return 0, fmt.Errorf("expected *selectSingleRel child to be *tableAlias or *tableScan, found %T", t)
 	}
+}
+
+func (c *coster) costProject(_ *sql.Context, n *project, _ sql.StatsReadWriter) (float64, error) {
+	return n.child.relProps.card * cpuCostFactor, nil
+}
+
+func (c *coster) costDistinct(_ *sql.Context, n *distinct, _ sql.StatsReadWriter) (float64, error) {
+	return n.child.cost * (cpuCostFactor + memCostFactor), nil
 }
 
 func lookupMultiplier(l *lookup, filterCnt int) float64 {
@@ -186,36 +221,217 @@ func lookupMultiplier(l *lookup, filterCnt int) float64 {
 	return mult
 }
 
-func (c *coster) costAntiJoin(n *antiJoin) (float64, error) {
+func (c *coster) costAntiJoin(_ *sql.Context, n *antiJoin, _ sql.StatsReadWriter) (float64, error) {
 	return c.costPartial(n.left, n.right)
 }
 
-func (c *coster) costSemiJoin(n *semiJoin) (float64, error) {
+func (c *coster) costSemiJoin(_ *sql.Context, n *semiJoin, _ sql.StatsReadWriter) (float64, error) {
 	return c.costPartial(n.left, n.right)
 }
 
 func (c *coster) costPartial(left, right *exprGroup) (float64, error) {
-	l, err := c.costRel(left.best)
-	if err != nil {
-		return float64(0), nil
-	}
-	r, err := c.costRel(right.best)
-	if err != nil {
-		return float64(0), nil
-	}
-	return l * (r / 2.0), nil
+	l := left.relProps.card
+	r := right.relProps.card
+	return l * (r / 2.0) * (seqIOCostFactor + cpuCostFactor), nil
 }
 
-func (c *coster) costSubqueryAlias(_ *subqueryAlias) (float64, error) {
+func (c *coster) costSubqueryAlias(_ *sql.Context, _ *subqueryAlias, _ sql.StatsReadWriter) (float64, error) {
 	// TODO: if the whole plan was memo, we would have accurate costs for subqueries
-	return 10000, nil
+	return 1000 * seqIOCostFactor, nil
 }
 
-func (c *coster) costMax1RowSubquery(_ *max1Row) (float64, error) {
+func (c *coster) costMax1RowSubquery(_ *sql.Context, _ *max1Row, _ sql.StatsReadWriter) (float64, error) {
+	return 1 * seqIOCostFactor, nil
+}
+
+func (c *coster) costTableFunc(_ *sql.Context, _ *tableFunc, _ sql.StatsReadWriter) (float64, error) {
+	// TODO: sql.TableFunction should expose RowCount()
+	return 10 * seqIOCostFactor, nil
+}
+
+func NewDefaultCarder() Carder {
+	return &carder{}
+}
+
+var _ Carder = (*carder)(nil)
+
+type carder struct{}
+
+func (c *carder) EstimateCard(ctx *sql.Context, n relExpr, s sql.StatsReadWriter) (float64, error) {
+	return c.cardRel(ctx, n, s)
+}
+
+// relStatistics provides estimates of operator cardinality. This
+// value is approximate for joins or filtered table scans, and
+// identical for all operators in the same expression group.
+func (c *carder) cardRel(ctx *sql.Context, n relExpr, s sql.StatsReadWriter) (float64, error) {
+	switch n := n.(type) {
+	case *tableScan:
+		return c.statsScan(ctx, n, s)
+	case *tableAlias:
+		return c.statsTableAlias(ctx, n, s)
+	case *values:
+		return c.statsValues(ctx, n, s)
+	case *recursiveTable:
+		return c.statsRecursiveTable(ctx, n, s)
+	case *subqueryAlias:
+		return c.statsSubqueryAlias(ctx, n, s)
+	case *max1Row:
+		return c.statsMax1RowSubquery(ctx, n, s)
+	case *tableFunc:
+		return c.statsTableFunc(ctx, n, s)
+	case *selectSingleRel:
+		return c.statsSelectSingleRel(ctx, n, s)
+	case joinRel:
+		jp := n.joinPrivate()
+		switch n := n.(type) {
+		case *lookupJoin:
+			return n.left.relProps.card * optimisticJoinSel * lookupMultiplier(n.lookup, len(jp.filter)), nil
+		case *concatJoin:
+			m := 0.0
+			for _, l := range n.concat {
+				m += lookupMultiplier(l, len(n.filter))
+			}
+			return n.left.relProps.card * optimisticJoinSel * m, nil
+		default:
+		}
+		if jp.op.IsPartial() {
+			return optimisticJoinSel * jp.left.relProps.card, nil
+		}
+		return optimisticJoinSel * jp.left.relProps.card * jp.right.relProps.card, nil
+	case *project:
+		return n.child.relProps.card, nil
+	case *distinct:
+		return n.child.relProps.card, nil
+	default:
+		panic(fmt.Sprintf("unknown type %T", n))
+	}
+}
+
+func (c *carder) statsTableAlias(ctx *sql.Context, n *tableAlias, s sql.StatsReadWriter) (float64, error) {
+	switch n := n.table.Child.(type) {
+	case *plan.ResolvedTable:
+		return c.statsRead(ctx, n.Table, s)
+	default:
+		return 1000, nil
+	}
+}
+
+func (c *carder) statsScan(ctx *sql.Context, t *tableScan, s sql.StatsReadWriter) (float64, error) {
+	return c.statsRead(ctx, t.table.Table, s)
+}
+
+func (c *carder) statsRead(ctx *sql.Context, t sql.Table, s sql.StatsReadWriter) (float64, error) {
+	if w, ok := t.(sql.TableWrapper); ok {
+		t = w.Underlying()
+	}
+
+	db := ctx.GetCurrentDatabase()
+	card, ok, err := s.RowCount(ctx, db, t.Name())
+	if err != nil || !ok {
+		// TODO: better estimates for derived tables
+		return float64(1000), nil
+	}
+	return float64(card) * seqIOCostFactor, nil
+}
+
+func (c *carder) statsValues(_ *sql.Context, v *values, _ sql.StatsReadWriter) (float64, error) {
+	return float64(len(v.table.ExpressionTuples)) * cpuCostFactor, nil
+}
+
+func (c *carder) statsRecursiveTable(_ *sql.Context, t *recursiveTable, _ sql.StatsReadWriter) (float64, error) {
+	return float64(100) * seqIOCostFactor, nil
+}
+
+func (c *carder) statsSelectSingleRel(ctx *sql.Context, n *selectSingleRel, s sql.StatsReadWriter) (float64, error) {
+	switch t := n.table.Rel.(type) {
+	case *plan.TableAlias:
+		return c.statsTableAlias(ctx, &tableAlias{relBase: n.relBase, table: t}, s)
+	case *plan.ResolvedTable:
+		return c.statsScan(ctx, &tableScan{relBase: n.relBase, table: t}, s)
+	default:
+		return 0, fmt.Errorf("expected *selectSingleRel child to be *tableAlias or *tableScan, found %T", t)
+	}
+}
+
+func (c *carder) statsSubqueryAlias(_ *sql.Context, _ *subqueryAlias, _ sql.StatsReadWriter) (float64, error) {
+	// TODO: if the whole plan was memo, we would have accurate costs for subqueries
+	return 1000, nil
+}
+
+func (c *carder) statsMax1RowSubquery(_ *sql.Context, _ *max1Row, _ sql.StatsReadWriter) (float64, error) {
 	return 1, nil
 }
 
-func (c *coster) costTableFunc(_ *tableFunc) (float64, error) {
+func (c *carder) statsTableFunc(_ *sql.Context, _ *tableFunc, _ sql.StatsReadWriter) (float64, error) {
 	// TODO: sql.TableFunction should expose RowCount()
 	return 10, nil
+}
+
+func NewInnerBiasedCoster() Coster {
+	return &innerBiasedCoster{coster: &coster{}}
+}
+
+type innerBiasedCoster struct {
+	*coster
+}
+
+func (c *innerBiasedCoster) EstimateCost(ctx *sql.Context, r relExpr, s sql.StatsReadWriter) (float64, error) {
+	switch r.(type) {
+	case *innerJoin:
+		return -biasFactor, nil
+	default:
+		return c.costRel(ctx, r, s)
+	}
+}
+
+func NewHashBiasedCoster() Coster {
+	return &hashBiasedCoster{coster: &coster{}}
+}
+
+type hashBiasedCoster struct {
+	*coster
+}
+
+func (c *hashBiasedCoster) EstimateCost(ctx *sql.Context, r relExpr, s sql.StatsReadWriter) (float64, error) {
+	switch r.(type) {
+	case *hashJoin:
+		return -biasFactor, nil
+	default:
+		return c.costRel(ctx, r, s)
+	}
+}
+
+func NewLookupBiasedCoster() Coster {
+	return &lookupBiasedCoster{coster: &coster{}}
+}
+
+type lookupBiasedCoster struct {
+	*coster
+}
+
+func (c *lookupBiasedCoster) EstimateCost(ctx *sql.Context, r relExpr, s sql.StatsReadWriter) (float64, error) {
+	switch r.(type) {
+	case *lookupJoin, *concatJoin:
+		return -biasFactor, nil
+	default:
+		return c.costRel(ctx, r, s)
+	}
+}
+
+func NewMergeBiasedCoster() Coster {
+	return &mergeBiasedCoster{coster: &coster{}}
+}
+
+type mergeBiasedCoster struct {
+	*coster
+}
+
+func (c *mergeBiasedCoster) EstimateCost(ctx *sql.Context, r relExpr, s sql.StatsReadWriter) (float64, error) {
+	switch r.(type) {
+	case *mergeJoin:
+		return -biasFactor, nil
+	default:
+		return c.costRel(ctx, r, s)
+	}
 }

--- a/sql/analyzer/coster.go
+++ b/sql/analyzer/coster.go
@@ -332,10 +332,6 @@ func (c *carder) statsRead(ctx *sql.Context, t sql.Table, db string, s sql.Stats
 		t = w.Underlying()
 	}
 
-	if db == "" {
-		db = ctx.GetCurrentDatabase()
-	}
-
 	card, ok, err := s.RowCount(ctx, db, t.Name())
 	if err != nil || !ok {
 		// TODO: better estimates for derived tables

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -164,10 +164,22 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *Scope) (
 	j := newJoinOrderBuilder(m)
 	j.reorderJoin(n)
 
-	addRightSemiJoins(m)
-	addLookupJoins(m)
-	addHashJoins(m)
-	addMergeJoins(m)
+	err = addRightSemiJoins(m)
+	if err != nil {
+		return nil, err
+	}
+	err = addLookupJoins(m)
+	if err != nil {
+		return nil, err
+	}
+	err = addHashJoins(m)
+	if err != nil {
+		return nil, err
+	}
+	err = addMergeJoins(m)
+	if err != nil {
+		return nil, err
+	}
 
 	if a.Verbose && a.Debug {
 		a.Log(m.String())
@@ -179,7 +191,10 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *Scope) (
 		m.WithJoinOrder(hint)
 	}
 
-	m.optimizeRoot()
+	err = m.optimizeRoot()
+	if err != nil {
+		return nil, err
+	}
 	return m.bestRootPlan()
 }
 

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -287,7 +287,10 @@ func addLookupJoins(m *Memo) error {
 }
 
 // convertSemiToInnerJoin adds inner join alternatives for semi joins.
-// The inner join plans can be explored further.
+// The inner join plans can be explored (optimized) further.
+// Example: semiJoin(xy ab) => project(ab) -> innerJoin(xy, distinct(ab))
+// Ref sction 2.1.1 of:
+// https://www.researchgate.net/publication/221311318_Cost-Based_Query_Transformation_in_Oracle
 // TODO: need more elegant way to extend the number of groups, interner
 func convertSemiToInnerJoin(m *Memo) error {
 	seen := make(map[GroupId]struct{})
@@ -300,11 +303,12 @@ func convertSemiToInnerJoin(m *Memo) error {
 		onlyEquality := true
 		for _, f := range semi.filter {
 			transform.InspectExpr(f, func(e sql.Expression) bool {
-				cmp, ok := e.(expression.Comparer)
-				if !ok {
-					return false
+				switch e.(type) {
+				case *expression.GetField, *expression.Literal, *expression.BindVar,
+					*expression.And, *expression.Or, *expression.Equals:
+				default:
+					onlyEquality = false
 				}
-				_, onlyEquality = cmp.(*expression.Equals)
 				return !onlyEquality
 			})
 			if !onlyEquality {

--- a/sql/analyzer/indexed_joins_test.go
+++ b/sql/analyzer/indexed_joins_test.go
@@ -47,7 +47,7 @@ func TestHashJoins(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := NewMemo(nil, nil, nil)
+			m := NewMemo(nil, nil, nil, NewDefaultCoster(), NewDefaultCarder())
 			j := newJoinOrderBuilder(m)
 			j.reorderJoin(tt.plan)
 			addHashJoins(m)

--- a/sql/analyzer/join_hint_test.go
+++ b/sql/analyzer/join_hint_test.go
@@ -93,7 +93,7 @@ func TestHintIndicatedDeps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			j := newJoinOrderBuilder(NewMemo(nil, nil, nil))
+			j := newJoinOrderBuilder(NewMemo(nil, nil, nil, NewDefaultCoster(), NewDefaultCarder()))
 			j.reorderJoin(tt.plan)
 			j.m.WithJoinOrder(JoinOrderHint{tables: tt.hint})
 			if tt.invalid {

--- a/sql/analyzer/join_order_builder_test.go
+++ b/sql/analyzer/join_order_builder_test.go
@@ -112,7 +112,7 @@ func TestJoinOrderBuilder(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			j := newJoinOrderBuilder(NewMemo(nil, nil, nil))
+			j := newJoinOrderBuilder(NewMemo(nil, nil, nil, NewDefaultCoster(), NewDefaultCarder()))
 			j.reorderJoin(tt.in)
 			require.Equal(t, tt.plans, j.m.String())
 		})
@@ -259,7 +259,7 @@ func TestJoinOrderBuilder_populateSubgraph(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := newJoinOrderBuilder(NewMemo(nil, nil, nil))
+			b := newJoinOrderBuilder(NewMemo(nil, nil, nil, NewDefaultCoster(), NewDefaultCarder()))
 			b.populateSubgraph(tt.join)
 			edgesEq(t, tt.expEdges, b.edges)
 		})

--- a/sql/analyzer/memo.go
+++ b/sql/analyzer/memo.go
@@ -393,7 +393,6 @@ func (e *exprGroup) children() []*exprGroup {
 
 func (e *exprGroup) updateBest(n relExpr, grpCost float64) {
 	if e.best == nil || grpCost <= e.cost || (!e.obeysOpHint(e.best) && e.obeysOpHint(n)) {
-		//log.Printf("chose: %s\n", n)
 		e.best = n
 		e.cost = grpCost
 	}

--- a/sql/analyzer/memo.go
+++ b/sql/analyzer/memo.go
@@ -38,7 +38,9 @@ type Memo struct {
 	root *exprGroup
 
 	orderHint *joinOrderDeps
-	c         *coster
+	c         Coster
+	s         Carder
+	statsRw   sql.StatsReadWriter
 	ctx       *sql.Context
 	scope     *Scope
 	scopeLen  int
@@ -46,10 +48,12 @@ type Memo struct {
 	tableProps *tableProps
 }
 
-func NewMemo(ctx *sql.Context, stats sql.StatsReadWriter, s *Scope) *Memo {
+func NewMemo(ctx *sql.Context, stats sql.StatsReadWriter, s *Scope, cost Coster, card Carder) *Memo {
 	return &Memo{
 		ctx:        ctx,
-		c:          &coster{ctx: ctx, s: stats},
+		c:          cost,
+		s:          card,
+		statsRw:    stats,
 		scope:      s,
 		scopeLen:   len(s.Schema()),
 		tableProps: newTableProps(),
@@ -101,7 +105,7 @@ func (m *Memo) optimizeMemoGroup(grp *exprGroup) error {
 			}
 			cost += g.cost
 		}
-		relCost, err := m.c.costRel(n)
+		relCost, err := m.c.EstimateCost(m.ctx, n, m.statsRw)
 		if err != nil {
 			return err
 		}
@@ -109,7 +113,13 @@ func (m *Memo) optimizeMemoGroup(grp *exprGroup) error {
 		m.updateBest(grp, n, cost)
 		n = n.next()
 	}
+
 	grp.done = true
+	var err error
+	grp.relProps.card, err = m.s.EstimateCard(m.ctx, grp.best, m.statsRw)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -219,6 +229,8 @@ type relProps struct {
 
 	outputCols   sql.Schema
 	outputTables sql.FastIntSet
+
+	card float64
 }
 
 func newRelProps(rel relExpr) *relProps {
@@ -248,25 +260,35 @@ func (p *relProps) populateOutputTables() {
 }
 
 func (p *relProps) populateOutputCols() {
-	if !p.grp.done {
-		panic("expression group not fixed")
-	}
-	switch r := p.grp.best.(type) {
+	p.outputCols = p.outputColsForRel(p.grp.best)
+}
+
+func (p *relProps) outputColsForRel(r relExpr) sql.Schema {
+	switch r := r.(type) {
 	case *semiJoin:
-		p.outputCols = r.left.relProps.OutputCols()
+		return r.left.relProps.OutputCols()
 	case *antiJoin:
-		p.outputCols = r.left.relProps.OutputCols()
+		return r.left.relProps.OutputCols()
 	case *lookupJoin:
 		if r.op.IsRightPartial() {
-			p.outputCols = r.right.relProps.OutputCols()
+			return r.right.relProps.OutputCols()
 		} else if r.op.IsPartial() {
-			p.outputCols = r.left.relProps.OutputCols()
+			return r.left.relProps.OutputCols()
 		} else {
-			p.outputCols = append(r.joinPrivate().left.relProps.OutputCols(), r.joinPrivate().right.relProps.OutputCols()...)
+			return append(r.joinPrivate().left.relProps.OutputCols(), r.joinPrivate().right.relProps.OutputCols()...)
 		}
 	case joinRel:
-		p.outputCols = append(r.joinPrivate().left.relProps.OutputCols(), r.joinPrivate().right.relProps.OutputCols()...)
+		return append(r.joinPrivate().left.relProps.OutputCols(), r.joinPrivate().right.relProps.OutputCols()...)
+	case *distinct:
+		return r.child.relProps.OutputCols()
+	case *project:
+		return r.child.relProps.OutputCols()
+	case sourceRel:
+		return r.outputCols()
+	default:
+		panic("unknown type")
 	}
+	return nil
 }
 
 // OutputCols returns the output schema of a node
@@ -342,6 +364,10 @@ func (e *exprGroup) obeysOpHint(n relExpr) bool {
 	switch n := n.(type) {
 	case joinRel:
 		return n.joinPrivate().op == e.opHint
+	case *distinct:
+		return e.obeysOpHint(n.child.best)
+	case *project:
+		return e.obeysOpHint(n.child.best)
 	default:
 		return true
 	}
@@ -367,6 +393,7 @@ func (e *exprGroup) children() []*exprGroup {
 
 func (e *exprGroup) updateBest(n relExpr, grpCost float64) {
 	if e.best == nil || grpCost <= e.cost || (!e.obeysOpHint(e.best) && e.obeysOpHint(n)) {
+		//log.Printf("chose: %s\n", n)
 		e.best = n
 		e.cost = grpCost
 	}
@@ -385,6 +412,14 @@ func (e *exprGroup) String() string {
 	return b.String()
 }
 
+type Coster interface {
+	EstimateCost(*sql.Context, relExpr, sql.StatsReadWriter) (float64, error)
+}
+
+type Carder interface {
+	EstimateCard(*sql.Context, relExpr, sql.StatsReadWriter) (float64, error)
+}
+
 // relExpr wraps a sql.Node for use as a exprGroup linked list node.
 // TODO: we need relExprs for every sql.Node and sql.Expression
 type relExpr interface {
@@ -393,7 +428,8 @@ type relExpr interface {
 	setNext(relExpr)
 	children() []*exprGroup
 	setGroup(g *exprGroup)
-	//constructTree(input sql.Schema, children ...sql.Node) (sql.Node, error)
+	card() float64
+	setCard(float64)
 }
 
 type relBase struct {
@@ -403,6 +439,8 @@ type relBase struct {
 	n relExpr
 	// c is this relation's cost while costing and plan reify are separate
 	c float64
+	// cnt is this relations output row count
+	cnt float64
 }
 
 // relKEy is a quick identifier for avoiding duplicate work on the same
@@ -435,12 +473,16 @@ func (r *relBase) setNext(rel relExpr) {
 	r.n = rel
 }
 
-func (r *relBase) cost(rel relExpr) float64 {
-	return r.c
-}
-
 func (r *relBase) setCost(c float64) {
 	r.c = c
+}
+
+func (r *relBase) card() float64 {
+	return r.cnt
+}
+
+func (r *relBase) setCard(c float64) {
+	r.cnt = c
 }
 
 func tableIdForSource(id GroupId) TableId {
@@ -450,6 +492,7 @@ func tableIdForSource(id GroupId) TableId {
 // sourceRel represents a data source, like a tableScan, subqueryAlias,
 // or list of values.
 type sourceRel interface {
+	relExpr
 	// outputCols retuns the output schema of this data source.
 	// TODO: this is more useful as a relExpr property, but we need
 	// this to fix up expression indexes currently
@@ -550,21 +593,21 @@ var ExprDefs support.GenDefs = []support.MemoDef{ // alphabetically sorted
 	{
 		Name:   "lookupJoin",
 		IsJoin: true,
-		JoinAttrs: [][2]string{
+		Attrs: [][2]string{
 			{"lookup", "*lookup"},
 		},
 	},
 	{
 		Name:   "concatJoin",
 		IsJoin: true,
-		JoinAttrs: [][2]string{
+		Attrs: [][2]string{
 			{"concat", "[]*lookup"},
 		},
 	},
 	{
 		Name:   "hashJoin",
 		IsJoin: true,
-		JoinAttrs: [][2]string{
+		Attrs: [][2]string{
 			{"innerAttrs", "[]sql.Expression"},
 			{"outerAttrs", "[]sql.Expression"},
 		},
@@ -572,7 +615,7 @@ var ExprDefs support.GenDefs = []support.MemoDef{ // alphabetically sorted
 	{
 		Name:   "mergeJoin",
 		IsJoin: true,
-		JoinAttrs: [][2]string{
+		Attrs: [][2]string{
 			{"innerScan", "*indexScan"},
 			{"outerScan", "*indexScan"},
 		},
@@ -616,5 +659,16 @@ var ExprDefs support.GenDefs = []support.MemoDef{ // alphabetically sorted
 	{
 		Name:       "selectSingleRel",
 		SourceType: "*plan.SelectSingleRel",
+	},
+	{
+		Name:    "project",
+		IsUnary: true,
+		Attrs: [][2]string{
+			{"projections", "[]sql.Expression"},
+		},
+	},
+	{
+		Name:    "distinct",
+		IsUnary: true,
 	},
 }

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -228,7 +228,11 @@ func transformPushdownFilters(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 					return nil, transform.SameTree, err
 				}
 				filters.markFiltersHandled(handled...)
-				return node, len(handled) == 0, nil
+				ret, err := plan.NewStaticIndexedAccessForResolvedTable(node.ResolvedTable, lookup.lookup)
+				if err != nil {
+					return node, transform.SameTree, err
+				}
+				return ret, len(handled) == 0, nil
 			case *plan.TableAlias, *plan.ResolvedTable, *plan.ValueDerivedTable:
 				n, samePred, err := pushdownFiltersToTable(ctx, a, node.(sql.NameableNode), scope, filters, tableAliases)
 				if plan.ErrInvalidLookupForIndexedTable.Is(err) {

--- a/sql/plan/merge_join.go
+++ b/sql/plan/merge_join.go
@@ -72,6 +72,7 @@ func newMergeJoinIter(ctx *sql.Context, j *JoinNode, row sql.Row) (sql.RowIter, 
 		typ:         j.Op,
 		fullRow:     fullRow,
 		scopeLen:    j.ScopeLen,
+		parentLen:   len(row) - j.ScopeLen,
 		leftRowLen:  len(j.left.Schema()),
 		rightRowLen: len(j.right.Schema()),
 	}
@@ -84,19 +85,28 @@ func newMergeJoinIter(ctx *sql.Context, j *JoinNode, row sql.Row) (sql.RowIter, 
 // not provide a directional ordering signal for index iteration
 // are evaluated separately.
 type mergeJoinIter struct {
-	cmp     expression.Comparer
+	// cmp is a directional indicator for row iter increments
+	cmp expression.Comparer
+	// filters is the remaining set of join conditions
 	filters []sql.Expression
 	left    sql.RowIter
 	right   sql.RowIter
 	fullRow sql.Row
 
-	// match lookahead buffers and state tracking
+	// match lookahead buffers and state tracking (private to match)
 	rightBuf  []sql.Row
 	bufI      int
 	rightPeek sql.Row
 	leftPeek  sql.Row
 	rightDone bool
 	leftDone  bool
+
+	// matchIncLeft indicates whether the most recent |i.incMatch|
+	// call incremented the left row.
+	matchIncLeft bool
+	// leftMatched indicates whether the current left in |i.fullRow|
+	// has satisfied the join condition.
+	leftMatched bool
 
 	// lifecycle maintenance
 	init           bool
@@ -109,6 +119,8 @@ type mergeJoinIter struct {
 	rightRowLen int
 	parentLen   int
 }
+
+var _ sql.RowIter = (*mergeJoinIter)(nil)
 
 func (i *mergeJoinIter) sel(ctx *sql.Context, row sql.Row) (bool, error) {
 	for _, f := range i.filters {
@@ -135,6 +147,7 @@ const (
 	msSelect
 	msRet
 	msRetLeft
+	msRejectNull
 )
 
 func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
@@ -142,6 +155,29 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 	var ret sql.Row
 	var res int
 
+	//  inner join match flow:
+	//  - check for io.EOF
+	//  - evaluate compare filter
+	//  - evaluate select filters
+	//  - initialize match state
+	//  - drain match state
+	//  - repeat
+	//
+	// left-join matching is unique. at any given time we need to know whether
+	// the unique left row: 1) has already matched, 2) has more right rows
+	// available for matching before we can return a nullified-row. Otherwise
+	// we may accidentally return nullfied rows that have matches (before or
+	// after the current row), or fail to return a nullified row that has no
+	// matches.
+	//
+	// we use two variables to manage the lookahead state management.
+	// |matchedleft| is a forward-looking indicator of whether the current left
+	// row has satisfied a join condition.  it is reset to false when we
+	// increment left. |matchincleft| is true when the most recent call to
+	// |incmatch| incremented the left row. the two vars combined let us
+	// lookahead during msselect to 1) identify proper nullified row matches,
+	// and 2) maintain forward-looking state for the next |i.fullrow|.
+	//
 	nextState := msInit
 	for {
 		switch nextState {
@@ -155,6 +191,7 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			nextState = msExhaustCheck
 		case msExhaustCheck:
 			if i.lojFinalize() {
+				ret = i.copyReturnRow()
 				nextState = msRetLeft
 			} else if i.exhausted() {
 				return nil, io.EOF
@@ -163,13 +200,21 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			}
 		case msCompare:
 			res, err = i.cmp.Compare(ctx, i.fullRow)
-			if err != nil {
+			if expression.ErrNilOperand.Is(err) {
+				nextState = msRejectNull
+				break
+			} else if err != nil {
 				return nil, err
 			}
 			switch {
 			case res < 0:
 				if i.typ.IsLeftOuter() {
-					nextState = msRetLeft
+					if i.leftMatched {
+						nextState = msIncLeft
+					} else {
+						ret = i.copyReturnRow()
+						nextState = msRetLeft
+					}
 				} else {
 					nextState = msIncLeft
 				}
@@ -177,6 +222,24 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 				nextState = msIncRight
 			case res == 0:
 				nextState = msSelect
+			}
+		case msRejectNull:
+			j := i.scopeLen + i.parentLen
+			for j < len(i.fullRow) {
+				if i.fullRow[j] == nil {
+					if j < i.scopeLen+i.parentLen+i.leftRowLen {
+						if i.typ.IsLeftOuter() && !i.leftMatched {
+							ret = i.copyReturnRow()
+							nextState = msRetLeft
+						} else {
+							nextState = msIncLeft
+						}
+					} else {
+						nextState = msIncRight
+					}
+					break
+				}
+				j++
 			}
 		case msIncLeft:
 			err = i.incLeft(ctx)
@@ -186,26 +249,46 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			nextState = msExhaustCheck
 		case msSelect:
 			ret = i.copyReturnRow()
-			if ok, err := i.sel(ctx, ret); err != nil {
+			currLeftMatched := i.leftMatched
+
+			ok, err := i.sel(ctx, ret)
+			if err != nil {
 				return nil, err
-			} else if !ok {
-				if i.typ.IsLeftOuter() {
-					nextState = msRetLeft
-				} else {
-					nextState = msIncLeft
-				}
-			} else {
-				nextState = msRet
 			}
-		case msRet:
 			err = i.incMatch(ctx)
 			if err != nil {
 				return nil, err
 			}
+			if ok {
+				if !i.matchIncLeft {
+					// |leftMatched| is forward-looking, sets state for current (next) i.fullRow
+					i.leftMatched = true
+				}
+
+				nextState = msRet
+				break
+			}
+
+			if !i.typ.IsLeftOuter() {
+				nextState = msExhaustCheck
+				break
+			}
+
+			if i.matchIncLeft && !currLeftMatched {
+				// |i.matchIncLeft| indicates whether the most recent
+				// |i.incMatch| call incremented the left row.
+				// |currLeftMatched| indicates whether |ret| has already
+				// successfully met a join condition.
+				return i.removeParentRow(i.nullifyRightRow(ret)), nil
+			} else {
+				nextState = msExhaustCheck
+			}
+
+		case msRet:
 			return i.removeParentRow(ret), nil
 			return ret, nil
 		case msRetLeft:
-			ret = i.removeParentRow(i.nullifyRightRow(i.copyReturnRow()))
+			ret = i.removeParentRow(i.nullifyRightRow(ret))
 			err = i.incLeft(ctx)
 			if err != nil {
 				return nil, err
@@ -222,7 +305,7 @@ func (i *mergeJoinIter) copyReturnRow() sql.Row {
 }
 
 // incMatch uses two phases to find all left and right rows that match their
-// companion rows for the given match stats. We accomplish this in 2 phases:
+// companion rows for the given match stats:
 //  1. collect all right rows that match the current left row into a buffer;
 //  2. for every left row that matches the original right row, match every
 //     right row.
@@ -231,8 +314,10 @@ func (i *mergeJoinIter) copyReturnRow() sql.Row {
 // there is no next non-matching row (io.EOF), we trigger |i.exhausted| at
 // the appropriate time depending on whether we are left-joining.
 func (i *mergeJoinIter) incMatch(ctx *sql.Context) error {
+	i.matchIncLeft = false
+
 	if !i.rightDone {
-		// drain right matches into buffer
+		// initialize right matches buffer
 		right := make(sql.Row, i.rightRowLen)
 		copy(right, i.fullRow[i.scopeLen+i.parentLen+i.leftRowLen:])
 		i.rightBuf = append(i.rightBuf, right)
@@ -257,10 +342,12 @@ func (i *mergeJoinIter) incMatch(ctx *sql.Context) error {
 		if err != nil {
 			return err
 		}
+
 	}
 
 	if i.bufI > len(i.rightBuf)-1 {
 		// matched entire right buffer to the current left row, reset
+		i.matchIncLeft = true
 		i.bufI = 0
 		match, peek, err := i.peekMatch(ctx, i.left)
 		if err != nil {
@@ -268,11 +355,13 @@ func (i *mergeJoinIter) incMatch(ctx *sql.Context) error {
 		} else if !match {
 			i.leftPeek = peek
 			i.leftDone = true
+		} else {
+			i.leftMatched = false
 		}
 	}
 
 	if !i.leftDone {
-		// rightBuf is safe, we don't need compare
+		// rightBuf has already been validated, we don't need compare
 		copySubslice(i.fullRow, i.rightBuf[i.bufI], i.scopeLen+i.parentLen+i.leftRowLen)
 		i.bufI++
 		return nil
@@ -298,6 +387,7 @@ func (i *mergeJoinIter) incMatch(ctx *sql.Context) error {
 
 	// both lookaheads fail the join condition. Drain
 	// lookahead rows / increment both iterators.
+	i.matchIncLeft = true
 	copySubslice(i.fullRow, i.leftPeek, i.scopeLen+i.parentLen)
 	copySubslice(i.fullRow, i.rightPeek, i.scopeLen+i.parentLen+i.leftRowLen)
 
@@ -398,22 +488,52 @@ func copySubslice(dst, src sql.Row, off int) {
 
 // incLeft updates |i.fullRow|'s left row
 func (i *mergeJoinIter) incLeft(ctx *sql.Context) error {
-	err := i.incIter(ctx, i.left, i.scopeLen+i.parentLen)
-	if errors.Is(err, io.EOF) {
-		i.leftExhausted = true
-		return nil
+	i.leftMatched = false
+	var row sql.Row
+	var err error
+	if i.leftPeek != nil {
+		row = i.leftPeek
+		i.leftPeek = nil
+	} else {
+		row, err = i.left.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			i.leftExhausted = true
+			return nil
+		} else if err != nil {
+			return err
+		}
 	}
-	return err
+
+	off := i.scopeLen + i.parentLen
+	for j, v := range row {
+		i.fullRow[off+j] = v
+	}
+
+	return nil
 }
 
 // incRight updates |i.fullRow|'s right row
 func (i *mergeJoinIter) incRight(ctx *sql.Context) error {
-	err := i.incIter(ctx, i.right, i.scopeLen+i.parentLen+i.leftRowLen)
-	if errors.Is(err, io.EOF) {
-		i.rightExhausted = true
-		return nil
+	var row sql.Row
+	var err error
+	if i.rightPeek != nil {
+		row = i.rightPeek
+		i.rightPeek = nil
+	} else {
+		row, err = i.right.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			i.rightExhausted = true
+			return nil
+		} else if err != nil {
+			return err
+		}
 	}
-	return err
+
+	off := i.scopeLen + i.parentLen + i.leftRowLen
+	for j, v := range row {
+		i.fullRow[off+j] = v
+	}
+	return nil
 }
 
 // incLeft updates |i.fullRow|'s |inRow|
@@ -429,8 +549,8 @@ func (i *mergeJoinIter) incIter(ctx *sql.Context, iter sql.RowIter, off int) err
 }
 
 func (i *mergeJoinIter) removeParentRow(r sql.Row) sql.Row {
-	copy(r[i.scopeLen:], r[i.parentLen:])
-	r = r[:len(r)-i.parentLen+i.scopeLen]
+	copy(r[i.scopeLen:], r[i.scopeLen+i.parentLen:])
+	r = r[:len(r)-i.parentLen]
 	return r
 }
 

--- a/sql/plan/merge_join.go
+++ b/sql/plan/merge_join.go
@@ -155,27 +155,27 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 	var ret sql.Row
 	var res int
 
-	//  inner join match flow:
-	//  - check for io.EOF
-	//  - evaluate compare filter
-	//  - evaluate select filters
-	//  - initialize match state
-	//  - drain match state
-	//  - repeat
+	//  The common inner join match flow:
+	//  1) check for io.EOF
+	//  2) evaluate compare filter
+	//  3) evaluate select filters
+	//  4) initialize match state
+	//  5) drain match state
+	//  6) repeat
 	//
-	// left-join matching is unique. at any given time we need to know whether
-	// the unique left row: 1) has already matched, 2) has more right rows
+	// Left-join matching is unique. At any given time, we need to know whether
+	// a unique left row: 1) has already matched, 2) has more right rows
 	// available for matching before we can return a nullified-row. Otherwise
-	// we may accidentally return nullfied rows that have matches (before or
+	// we may accidentally return nullified rows that have matches (before or
 	// after the current row), or fail to return a nullified row that has no
 	// matches.
 	//
-	// we use two variables to manage the lookahead state management.
+	// We use two variables to manage the lookahead state management.
 	// |matchedleft| is a forward-looking indicator of whether the current left
-	// row has satisfied a join condition.  it is reset to false when we
+	// row has satisfied a join condition. It is reset to false when we
 	// increment left. |matchincleft| is true when the most recent call to
-	// |incmatch| incremented the left row. the two vars combined let us
-	// lookahead during msselect to 1) identify proper nullified row matches,
+	// |incmatch| incremented the left row. The two vars combined let us
+	// lookahead during msSelect to 1) identify proper nullified row matches,
 	// and 2) maintain forward-looking state for the next |i.fullrow|.
 	//
 	nextState := msInit
@@ -261,7 +261,8 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			}
 			if ok {
 				if !i.matchIncLeft {
-					// |leftMatched| is forward-looking, sets state for current (next) i.fullRow
+					// |leftMatched| is forward-looking, sets state for
+					// current |i.fullRow| (next |ret|)
 					i.leftMatched = true
 				}
 

--- a/sql/plan/merge_join.go
+++ b/sql/plan/merge_join.go
@@ -228,6 +228,7 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			for j < len(i.fullRow) {
 				if i.fullRow[j] == nil {
 					if j < i.scopeLen+i.parentLen+i.leftRowLen {
+						// this range corresponds to left-row fields
 						if i.typ.IsLeftOuter() && !i.leftMatched {
 							ret = i.copyReturnRow()
 							nextState = msRetLeft


### PR DESCRIPTION
This started out as a semiJoin optimization: `semiJoin(xy ab) => project(ab) -> innerJoin(xy, distinct(ab))`.

Adding project and distinct to memo groups was hard because we did not differentiate between operator cost (estimation of compute time) and cardinality (number of rows returned by a relational expression). Refactoring costing to distinguish the two caused a lot of bugs. As a result, I converted many of the join tests into a format that will run each with a biased coster. All of those join op tests should be run with every join operator possible in its expression tree.

The biggest effect is that we now choose merge and hash joins a lot more often for small tables, which are most of our preexisting tests.

We also change a lot of integration test plans. The increase in testing makes me less worried about correctness and more worried about perf. But the current changes are necessary to bring us closer to histogram-based costing. I would rathe do this now, when we have more leeway for increasing perf compared to a month ago.

There is still room for improvements organizing costing, merge join, and join tests as a whole.