### PR TITLE
driver/conn: implement conn, execer, and queryer interfaces

### DIFF
--- a/driver/conn.go
+++ b/driver/conn.go
@@ -36,13 +36,18 @@ func (c *Conn) Session() sql.Session { return c.session }
 
 // Prepare validates the query and returns a statement.
 func (c *Conn) Prepare(query string) (driver.Stmt, error) {
-	ctx, err := c.newContextWithQuery(context.Background(), query)
+	return c.newStmt(context.Background(), query)
+}
+
+// newStmt builds a new statement with the query.
+func (c *Conn) newStmt(ctx context.Context, query string) (*Stmt, error) {
+	sctx, err := c.newContextWithQuery(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
 	// validate the query
-	_, err = c.dbConn.engine.PrepareQuery(ctx, query)
+	_, err = c.dbConn.engine.PrepareQuery(sctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +65,70 @@ func (c *Conn) Begin() (driver.Tx, error) {
 	return fakeTransaction{}, nil
 }
 
+// Exec executes a query that doesn't return rows.
+func (c *Conn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	stmt, err := c.newStmt(context.Background(), query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Exec(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+// ExecContext executes a query that doesn't return rows.
+func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	stmt, err := c.newStmt(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	res, err := stmt.ExecContext(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// Query executes a query that may return rows.
+func (c *Conn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	stmt, err := c.newStmt(context.Background(), query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.Query(args)
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+// QueryContext executes a query that may return rows.
+func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	stmt, err := c.newStmt(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer stmt.Close()
+
+	rows, err := stmt.QueryContext(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+
+	return rows, nil
+}
+
 func (c *Conn) newContextWithQuery(ctx context.Context, query string) (*sql.Context, error) {
 	return c.contexts.NewContext(ctx, c,
 		sql.WithSession(c.session),
@@ -73,3 +142,12 @@ type fakeTransaction struct{}
 
 func (fakeTransaction) Commit() error   { return nil }
 func (fakeTransaction) Rollback() error { return nil }
+
+// _ is a type assertion
+var (
+	_ driver.Conn           = ((*Conn)(nil))
+	_ driver.Execer         = ((*Conn)(nil))
+	_ driver.ExecerContext  = ((*Conn)(nil))
+	_ driver.Queryer        = ((*Conn)(nil))
+	_ driver.QueryerContext = ((*Conn)(nil))
+)


### PR DESCRIPTION
Implement more of the driver.Conn interfaces:

- driver.Conn
- driver.Execer
- driver.ExecerContext
- driver.Queryer
- driver.QueryerContext