### PR TITLE
Attempt to identify and fix alias ambiguity issues with subqueries.

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -29,11 +29,11 @@ type JoinOpTests struct {
 	Skip     bool
 }
 
-var biasedCosters = []analyzer.Coster{
-	analyzer.NewInnerBiasedCoster(),
-	analyzer.NewLookupBiasedCoster(),
-	analyzer.NewHashBiasedCoster(),
-	analyzer.NewMergeBiasedCoster(),
+var biasedCosters = map[string]analyzer.Coster{
+	"inner":  analyzer.NewInnerBiasedCoster(),
+	"lookup": analyzer.NewLookupBiasedCoster(),
+	"hash":   analyzer.NewHashBiasedCoster(),
+	"merge":  analyzer.NewMergeBiasedCoster(),
 }
 
 func TestJoinOps(t *testing.T, harness Harness) {
@@ -52,10 +52,10 @@ func TestJoinOps(t *testing.T, harness Harness) {
 					RunQueryWithContext(t, e, harness, ctx, statement)
 				}
 			}
-			for i, c := range []string{"inner", "lookup", "hash", "merge"} {
-				e.Analyzer.Coster = biasedCosters[i]
+			for k, c := range biasedCosters {
+				e.Analyzer.Coster = c
 				for _, tt := range tt.tests {
-					evalJoinCorrectness(t, harness, e, fmt.Sprintf("%s join: %s", c, tt.Query), tt.Query, tt.Expected, tt.Skip)
+					evalJoinCorrectness(t, harness, e, fmt.Sprintf("%s join: %s", k, tt.Query), tt.Query, tt.Expected, tt.Skip)
 				}
 			}
 		})
@@ -78,10 +78,11 @@ func TestJoinOpsPrepared(t *testing.T, harness Harness) {
 					RunQueryWithContext(t, e, harness, ctx, statement)
 				}
 			}
-			for i, c := range []string{"inner", "lookup", "hash", "merge"} {
-				e.Analyzer.Coster = biasedCosters[i]
+
+			for k, c := range biasedCosters {
+				e.Analyzer.Coster = c
 				for _, tt := range tt.tests {
-					evalJoinCorrectnessPrepared(t, harness, e, fmt.Sprintf("%s join: %s", c, tt.Query), tt.Query, tt.Expected, tt.Skip)
+					evalJoinCorrectnessPrepared(t, harness, e, fmt.Sprintf("%s join: %s", k, tt.Query), tt.Query, tt.Expected, tt.Skip)
 				}
 			}
 		})
@@ -102,6 +103,7 @@ var joinCostTests = []struct {
 			setup.Pk_tablesData[0],
 			setup.NiltableData[0],
 			setup.TabletestData[0],
+			setup.XyData[0],
 		},
 		tests: []JoinOpTests{
 			{
@@ -1080,6 +1082,41 @@ var joinCostTests = []struct {
 					{2, "second row"},
 					{3, "third row"},
 				},
+			},
+
+			{
+				Query: `SELECT * FROM mytable WHERE (
+			EXISTS (SELECT * FROM mytable Alias1 JOIN mytable Alias2 WHERE Alias1.i = (mytable.i + 1))
+			AND EXISTS (SELECT * FROM othertable Alias1 JOIN othertable Alias2 WHERE Alias1.i2 = (mytable.i + 2)));`,
+				Expected: []sql.Row{{1, "first row"}},
+			},
+			{
+				Query: `SELECT * FROM ab WHERE (
+			EXISTS (SELECT * FROM ab Alias1 JOIN ab Alias2 WHERE Alias1.a = (ab.a + 1))
+			AND EXISTS (SELECT * FROM xy Alias1 JOIN xy Alias2 WHERE Alias1.x = (ab.a + 2)));`,
+				Expected: []sql.Row{
+					{0, 2},
+					{1, 2}},
+			},
+			{
+				// verify that duplicate aliases in different subqueries are allowed
+				Query: `SELECT * FROM mytable Alias0 WHERE (
+				      	EXISTS (SELECT * FROM mytable Alias WHERE Alias.i = Alias0.i + 1)
+				      	AND EXISTS (SELECT * FROM othertable Alias WHERE Alias.i2 = Alias0.i + 2));`,
+				Expected: []sql.Row{{1, "first row"}},
+			},
+			{
+				Query: `SELECT * FROM mytable
+						WHERE
+  							i = (SELECT i2 FROM othertable alias1 WHERE i2 = 2) AND
+  							i+1 = (SELECT i2 FROM othertable alias1 WHERE i2 = 3);`,
+				Expected: []sql.Row{{2, "second row"}},
+			},
+			{
+				Query: `SELECT * FROM mytable WHERE (
+      					EXISTS (SELECT * FROM mytable Alias1 join mytable Alias2 WHERE Alias1.i = (mytable.i + 1))
+      					AND EXISTS (SELECT * FROM othertable Alias1 join othertable Alias2 WHERE Alias1.i2 = (mytable.i + 2)))`,
+				Expected: []sql.Row{{1, "first row"}},
 			},
 		},
 	},

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -388,19 +388,17 @@ order by 1;`,
 				exp:   []sql.Row{{2, 1}},
 			},
 			{
-				q: `
-SELECT * FROM xy WHERE (
-      EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
-      AND EXISTS (SELECT * FROM uv Alias2 WHERE Alias2.u = (xy.x + 2)));`,
-				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeMerge},
+				q: `SELECT * FROM xy WHERE (
+      				EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
+      				AND EXISTS (SELECT * FROM uv Alias2 WHERE Alias2.u = (xy.x + 2)));`,
+				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeSemiLookup},
 				exp:   []sql.Row{{0, 2}, {1, 0}},
 			},
 			{
-				q: `
-SELECT * FROM xy WHERE (
-      EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
-      AND EXISTS (SELECT * FROM uv Alias1 WHERE Alias1.u = (xy.x + 2)));`,
-				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeMerge},
+				q: `SELECT * FROM xy WHERE (
+      				EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
+      				AND EXISTS (SELECT * FROM uv Alias1 WHERE Alias1.u = (xy.x + 2)));`,
+				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeSemiLookup},
 				exp:   []sql.Row{{0, 2}, {1, 0}},
 			},
 		},
@@ -533,11 +531,11 @@ SELECT * FROM xy WHERE (
 			},
 			{
 				q:     "select /*+ JOIN_ORDER(b,c,a) */ 1 from xy a join xy b on a.x+3 = b.x WHERE EXISTS (select 1 from uv c where c.u = a.x+2)",
-				order: []string{"b", "c", "a"},
+				order: []string{"b", "a"},
 			},
 			{
 				q:     "select /*+ JOIN_ORDER(b,applySubq0,a) */ 1 from xy a join xy b on a.x+3 = b.x WHERE a.x in (select u from uv c)",
-				order: []string{"b", "applySubq0", "a"},
+				order: []string{"b", "a"},
 			},
 		},
 	},

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -395,6 +395,14 @@ SELECT * FROM xy WHERE (
 				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeMerge},
 				exp:   []sql.Row{{0, 2}, {1, 0}},
 			},
+			{
+				q: `
+SELECT * FROM xy WHERE (
+      EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
+      AND EXISTS (SELECT * FROM uv Alias1 WHERE Alias1.u = (xy.x + 2)));`,
+				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeMerge},
+				exp:   []sql.Row{{0, 2}, {1, 0}},
+			},
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7152,24 +7152,22 @@ With c as (
 	},
 	{
 		// verify that duplicate aliases in different subqueries are allowed
-		Query: `SELECT COUNT(*) FROM mytable Alias0 WHERE (
-				      EXISTS (SELECT * FROM mytable Alias WHERE Alias.i = Alias0.i + 1)
-				      AND EXISTS (SELECT * FROM othertable Alias WHERE Alias.i2 = Alias0.i + 2));`,
-		Expected: []sql.Row{{1}},
+		Query: `SELECT * FROM mytable Alias0 WHERE (
+			  	EXISTS (SELECT * FROM mytable Alias WHERE Alias.i = Alias0.i + 1)
+			 	AND EXISTS (SELECT * FROM othertable Alias WHERE Alias.i2 = Alias0.i + 2));`,
+		Expected: []sql.Row{{1, "first row"}},
 	},
 	{
-		Query: `
-select * from mytable
-where
-  i = (select i2 from othertable alias1 where i2 = 2) and
-  i+1 = (select i2 from othertable alias1 where i2 = 3);`,
+		Query: `SELECT * FROM mytable
+				WHERE
+  					i = (SELECT i2 FROM othertable alias1 WHERE i2 = 2) AND
+  					i+1 = (SELECT i2 FROM othertable alias1 WHERE i2 = 3);`,
 		Expected: []sql.Row{{2, "second row"}},
 	},
 	{
-		Query: `
-SELECT * FROM mytable WHERE (
-      EXISTS (SELECT * FROM mytable Alias1 join mytable Alias2 WHERE Alias1.i = (mytable.i + 1))
-      AND EXISTS (SELECT * FROM othertable Alias1 join othertable Alias2 WHERE Alias1.i2 = (mytable.i + 2)))`,
+		Query: `SELECT * FROM mytable WHERE (
+      			EXISTS (SELECT * FROM mytable Alias1 join mytable Alias2 WHERE Alias1.i = (mytable.i + 1))
+      			AND EXISTS (SELECT * FROM othertable Alias1 join othertable Alias2 WHERE Alias1.i2 = (mytable.i + 2)))`,
 		Expected: []sql.Row{{1, "first row"}},
 	},
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7150,6 +7150,13 @@ With c as (
 		Query:    "SELECT 4294967296;",
 		Expected: []sql.Row{{int64(4294967296)}},
 	},
+	{
+		// verify that duplicate aliases in different subqueries are allowed
+		Query: `SELECT COUNT(*) FROM mytable Alias0 WHERE (
+				      EXISTS (SELECT * FROM mytable Alias WHERE Alias.i = Alias0.i + 1)
+				      AND EXISTS (SELECT * FROM othertable Alias WHERE Alias.i2 = Alias0.i + 2));`,
+		Expected: []sql.Row{{1}},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7165,6 +7165,13 @@ where
   i+1 = (select i2 from othertable alias1 where i2 = 3);`,
 		Expected: []sql.Row{{2, "second row"}},
 	},
+	{
+		Query: `
+SELECT * FROM mytable WHERE (
+      EXISTS (SELECT * FROM mytable Alias1 join mytable Alias2 WHERE Alias1.i = (mytable.i + 1))
+      AND EXISTS (SELECT * FROM othertable Alias1 join othertable Alias2 WHERE Alias1.i2 = (mytable.i + 2)))`,
+		Expected: []sql.Row{{1, "first row"}},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7150,26 +7150,6 @@ With c as (
 		Query:    "SELECT 4294967296;",
 		Expected: []sql.Row{{int64(4294967296)}},
 	},
-	{
-		// verify that duplicate aliases in different subqueries are allowed
-		Query: `SELECT * FROM mytable Alias0 WHERE (
-			  	EXISTS (SELECT * FROM mytable Alias WHERE Alias.i = Alias0.i + 1)
-			 	AND EXISTS (SELECT * FROM othertable Alias WHERE Alias.i2 = Alias0.i + 2));`,
-		Expected: []sql.Row{{1, "first row"}},
-	},
-	{
-		Query: `SELECT * FROM mytable
-				WHERE
-  					i = (SELECT i2 FROM othertable alias1 WHERE i2 = 2) AND
-  					i+1 = (SELECT i2 FROM othertable alias1 WHERE i2 = 3);`,
-		Expected: []sql.Row{{2, "second row"}},
-	},
-	{
-		Query: `SELECT * FROM mytable WHERE (
-      			EXISTS (SELECT * FROM mytable Alias1 join mytable Alias2 WHERE Alias1.i = (mytable.i + 1))
-      			AND EXISTS (SELECT * FROM othertable Alias1 join othertable Alias2 WHERE Alias1.i2 = (mytable.i + 2)))`,
-		Expected: []sql.Row{{1, "first row"}},
-	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7157,6 +7157,14 @@ With c as (
 				      AND EXISTS (SELECT * FROM othertable Alias WHERE Alias.i2 = Alias0.i + 2));`,
 		Expected: []sql.Row{{1}},
 	},
+	{
+		Query: `
+select * from mytable
+where
+  i = (select i2 from othertable alias1 where i2 = 2) and
+  i+1 = (select i2 from othertable alias1 where i2 = 3);`,
+		Expected: []sql.Row{{2, "second row"}},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/analyzer/hoist_select_exists.go
+++ b/sql/analyzer/hoist_select_exists.go
@@ -16,6 +16,7 @@ package analyzer
 
 import (
 	"fmt"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -305,14 +305,13 @@ func convertSemiToInnerJoin(a *Analyzer, m *Memo) error {
 		onlyEquality := true
 		for _, f := range semi.filter {
 			transform.InspectExpr(f, func(e sql.Expression) bool {
-				switch e.(type) {
+				switch e := e.(type) {
 				case *expression.GetField:
 					// getField expressions tell us which columns are used, so we can create the correct project
-					gf, _ := e.(*expression.GetField)
-					tableName := strings.ToLower(gf.Table())
+					tableName := strings.ToLower(e.Table())
 					isRightOutTable := stringContains(rightOutTables, tableName)
 					if isRightOutTable {
-						projectExpressions = append(projectExpressions, gf)
+						projectExpressions = append(projectExpressions, e)
 					}
 				case *expression.Literal, *expression.BindVar,
 					*expression.And, *expression.Or, *expression.Equals, *expression.Arithmetic:

--- a/sql/analyzer/memo.go
+++ b/sql/analyzer/memo.go
@@ -366,6 +366,21 @@ func (p *tableProps) getId(n string) (GroupId, bool) {
 	return id, ok
 }
 
+func (p *tableProps) getTableNames(f sql.FastIntSet) []string {
+	var names []string
+	for idx, ok := f.Next(0); ok; idx, ok = f.Next(idx + 1) {
+		if ok {
+			groupId := GroupId(idx + 1)
+			table, ok := p.getTable(groupId)
+			if !ok {
+				panic(fmt.Sprintf("table not found for group %d", groupId))
+			}
+			names = append(names, table)
+		}
+	}
+	return names
+}
+
 // exprGroup is a linked list of plans that return the same result set
 // defined by row count and schema.
 type exprGroup struct {


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/5138

The new file `sql/analyzer/aliases_disambiguate.go` has a header with documentation on how the new rule works.