### PR TITLE
allow safe drops when column is referenced in check constraint

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5401,22 +5401,54 @@ func TestAlterTable(t *testing.T, harness Harness) {
 		}, checks)
 	})
 
-	t.Run("drop column preserves check constraints", func(t *testing.T) {
+	t.Run("drop column drops check constraint", func(t *testing.T) {
 		RunQuery(t, e, harness, "create table t34 (i bigint primary key, s varchar(20))")
-		RunQuery(t, e, harness, "ALTER TABLE t34 ADD COLUMN j int, ADD COLUMN k int")
+		RunQuery(t, e, harness, "ALTER TABLE t34 ADD COLUMN j int")
 		RunQuery(t, e, harness, "ALTER TABLE t34 ADD CONSTRAINT test_check CHECK (j < 12345)")
-
-		AssertErr(t, e, harness, "ALTER TABLE t34 DROP COLUMN j", sql.ErrCheckConstraintInvalidatedByColumnAlter)
-
-		RunQuery(t, e, harness, "ALTER TABLE t34 DROP COLUMN k")
+		RunQuery(t, e, harness, "ALTER TABLE t34 DROP COLUMN j")
 		tt := queries.QueryTest{
 			Query: "show create table t34",
 			Expected: []sql.Row{{"t34", "CREATE TABLE `t34` (\n" +
 				"  `i` bigint NOT NULL,\n" +
 				"  `s` varchar(20),\n" +
-				"  `j` int,\n" +
+				"  PRIMARY KEY (`i`)\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		}
+		TestQueryWithEngine(t, harness, e, tt)
+	})
+
+	t.Run("drop column drops all relevant check constraints", func(t *testing.T) {
+		RunQuery(t, e, harness, "create table t42 (i bigint primary key, s varchar(20))")
+		RunQuery(t, e, harness, "ALTER TABLE t42 ADD COLUMN j int")
+		RunQuery(t, e, harness, "ALTER TABLE t42 ADD CONSTRAINT check1 CHECK (j < 12345)")
+		RunQuery(t, e, harness, "ALTER TABLE t42 ADD CONSTRAINT check2 CHECK (j > 0)")
+		RunQuery(t, e, harness, "ALTER TABLE t42 DROP COLUMN j")
+		tt := queries.QueryTest{
+			Query: "show create table t42",
+			Expected: []sql.Row{{"t42", "CREATE TABLE `t42` (\n" +
+				"  `i` bigint NOT NULL,\n" +
+				"  `s` varchar(20),\n" +
+				"  PRIMARY KEY (`i`)\n" +
+				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		}
+		TestQueryWithEngine(t, harness, e, tt)
+	})
+
+	t.Run("drop column drops correct check constraint", func(t *testing.T) {
+		RunQuery(t, e, harness, "create table t41 (i bigint primary key, s varchar(20))")
+		RunQuery(t, e, harness, "ALTER TABLE t41 ADD COLUMN j int")
+		RunQuery(t, e, harness, "ALTER TABLE t41 ADD COLUMN k int")
+		RunQuery(t, e, harness, "ALTER TABLE t41 ADD CONSTRAINT j_check CHECK (j < 12345)")
+		RunQuery(t, e, harness, "ALTER TABLE t41 ADD CONSTRAINT k_check CHECK (k < 123)")
+		RunQuery(t, e, harness, "ALTER TABLE t41 DROP COLUMN j")
+		tt := queries.QueryTest{
+			Query: "show create table t41",
+			Expected: []sql.Row{{"t41", "CREATE TABLE `t41` (\n" +
+				"  `i` bigint NOT NULL,\n" +
+				"  `s` varchar(20),\n" +
+				"  `k` int,\n" +
 				"  PRIMARY KEY (`i`),\n" +
-				"  CONSTRAINT `test_check` CHECK ((`j` < 12345))\n" +
+				"  CONSTRAINT `k_check` CHECK ((`k` < 123))\n" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 		}
 		TestQueryWithEngine(t, harness, e, tt)

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3717,6 +3717,22 @@ var PreparedScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Drop column with check constraint, multiple constraints",
+		SetUpScript: []string{
+			"create table mytable (pk int primary key);",
+			"ALTER TABLE mytable ADD COLUMN col2 text NOT NULL;",
+			"ALTER TABLE mytable ADD COLUMN col3 text NOT NULL;",
+			"ALTER TABLE mytable ADD CONSTRAINT ok_check CHECK (col2 LIKE '%myregex%');",
+			"ALTER TABLE mytable ADD CONSTRAINT bad_check CHECK (col2 LIKE col3);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "ALTER TABLE mytable DROP COLUMN col2",
+				ExpectedErr: sql.ErrCheckConstraintInvalidatedByColumnAlter,
+			},
+		},
+	},
 }
 
 var BrokenScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3673,6 +3673,50 @@ var PreparedScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Drop column with check constraint, no other columns",
+		SetUpScript: []string{
+			"create table mytable (pk int primary key);",
+			"ALTER TABLE mytable ADD COLUMN col2 text NOT NULL;",
+			"ALTER TABLE mytable ADD CONSTRAINT constraint_check CHECK (col2 LIKE '%myregex%');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "ALTER TABLE mytable DROP COLUMN col2",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+		},
+	},
+	{
+		Name: "Drop column with check constraint, other column referenced first",
+		SetUpScript: []string{
+			"create table mytable (pk int primary key);",
+			"ALTER TABLE mytable ADD COLUMN col2 text NOT NULL;",
+			"ALTER TABLE mytable ADD COLUMN col3 text NOT NULL;",
+			"ALTER TABLE mytable ADD CONSTRAINT constraint_check CHECK (col3 LIKE col2);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "ALTER TABLE mytable DROP COLUMN col2",
+				ExpectedErr: sql.ErrCheckConstraintInvalidatedByColumnAlter,
+			},
+		},
+	},
+	{
+		Name: "Drop column with check constraint, other column referenced second",
+		SetUpScript: []string{
+			"create table mytable (pk int primary key);",
+			"ALTER TABLE mytable ADD COLUMN col2 text NOT NULL;",
+			"ALTER TABLE mytable ADD COLUMN col3 text NOT NULL;",
+			"ALTER TABLE mytable ADD CONSTRAINT constraint_check CHECK (col2 LIKE col3);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "ALTER TABLE mytable DROP COLUMN col2",
+				ExpectedErr: sql.ErrCheckConstraintInvalidatedByColumnAlter,
+			},
+		},
+	},
 }
 
 var BrokenScriptTests = []ScriptTest{
@@ -3793,20 +3837,6 @@ var BrokenScriptTests = []ScriptTest{
 			{
 				Query:    "SELECT `t1`.`id`, `t1`.`name` FROM `person` AS `t1` WHERE (`t1`.`name` REGEXP 'N[1,3]') ORDER BY `t1`.`name`;",
 				Expected: []sql.Row{{1, "n1"}, {3, "n3"}},
-			},
-		},
-	},
-	{
-		Name: "Drop a column with a check constraint",
-		SetUpScript: []string{
-			"create table mytable (pk int primary key);",
-			"ALTER TABLE mytable ADD COLUMN col2 text NOT NULL;",
-			"ALTER TABLE mytable ADD CONSTRAINT constraint_check CHECK (col2 LIKE '%myregex%');",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:    "ALTER TABLE mytable DROP COLUMN col2",
-				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 		},
 	},

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -319,7 +319,7 @@ func validateDropColumn(initialSch, sch sql.Schema, dc *plan.DropColumn) (sql.Sc
 		return nil, sql.ErrTableColumnNotFound.New(nameable.Name(), dc.Column)
 	}
 
-	err := validateColumnNotUsedInCheckConstraint(dc.Column, dc.Checks)
+	err := validateColumnSafeToDropWithCheckConstraint(dc.Column, dc.Checks)
 	if err != nil {
 		return nil, err
 	}
@@ -343,6 +343,41 @@ func validateColumnNotUsedInCheckConstraint(columnName string, checks sql.CheckC
 			}
 			return false
 		})
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateColumnSafeToDropWithCheckConstraint validates that the specified column name is safe to drop, even if
+// referenced in a check constraint. Columns referenced in check constraints can be dropped if they are the only
+// column referenced in the check constraint.
+func validateColumnSafeToDropWithCheckConstraint(columnName string, checks sql.CheckConstraints) error {
+	var err error
+	hasOtherCol := false
+	hasMatchingCol := false
+	for _, check := range checks {
+		_ = transform.InspectExpr(check.Expr, func(e sql.Expression) bool {
+			if unresolvedColumn, ok := e.(*expression.UnresolvedColumn); ok {
+				if columnName == unresolvedColumn.Name() {
+					if hasOtherCol {
+						err = sql.ErrCheckConstraintInvalidatedByColumnAlter.New(columnName, check.Name)
+						return true
+					} else {
+						hasMatchingCol = true
+					}
+				} else {
+					hasOtherCol = true
+				}
+			}
+			return false
+		})
+
+		if hasOtherCol && hasMatchingCol {
+			err = sql.ErrCheckConstraintInvalidatedByColumnAlter.New(columnName, check.Name)
+		}
 
 		if err != nil {
 			return err

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -356,9 +356,9 @@ func validateColumnNotUsedInCheckConstraint(columnName string, checks sql.CheckC
 // column referenced in the check constraint.
 func validateColumnSafeToDropWithCheckConstraint(columnName string, checks sql.CheckConstraints) error {
 	var err error
-	hasOtherCol := false
-	hasMatchingCol := false
 	for _, check := range checks {
+		hasOtherCol := false
+		hasMatchingCol := false
 		_ = transform.InspectExpr(check.Expr, func(e sql.Expression) bool {
 			if unresolvedColumn, ok := e.(*expression.UnresolvedColumn); ok {
 				if columnName == unresolvedColumn.Name() {


### PR DESCRIPTION
MySQL allows columns which are referenced in check constraints to be dropped if they are the only column referenced in the constraint. This change updates dolt to match this behavior.

fixes: https://github.com/dolthub/dolt/issues/3147