### PR TITLE
Add output columns to filter and join descriptions.

### DIFF
--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -202,7 +202,7 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *Scope) (
 		a.Log(m.String())
 	}
 
-	return m.bestRootPlan()
+	return m.bestRootPlan(a)
 }
 
 // addLookupJoins prefixes memo join group expressions with indexed join

--- a/sql/analyzer/memo.go
+++ b/sql/analyzer/memo.go
@@ -164,8 +164,8 @@ func (m *Memo) updateBest(grp *exprGroup, n relExpr, cost float64) {
 	grp.updateBest(n, cost)
 }
 
-func (m *Memo) bestRootPlan() (sql.Node, error) {
-	b := NewExecBuilder()
+func (m *Memo) bestRootPlan(a *Analyzer) (sql.Node, error) {
+	b := NewExecBuilder(a)
 	return buildBestJoinPlan(b, m.root, nil)
 }
 

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -380,6 +381,14 @@ func (j *JoinNode) String() string {
 func (j *JoinNode) DebugString() string {
 	pr := sql.NewTreePrinter()
 	var children []string
+
+	var columns []string
+	columns = make([]string, len(j.Schema()))
+	for i, c := range j.Schema() {
+		columns[i] = strings.ToLower(c.Name)
+	}
+	children = append(children, fmt.Sprintf("columns: %v", columns))
+
 	if j.Filter != nil {
 		if j.Op.IsMerge() {
 			filters := expression.SplitConjunction(j.Filter)


### PR DESCRIPTION
This change adds output columns for filters and joins.
This change also adds `Analyzer` to ExecBuilder, so that code and whatever it calls can use the Analyzer for logging.

Below is the plan of this [complex test query](https://github.com/dolthub/go-mysql-server/blob/main/enginetest/queries/queries.go#L7101-L7122):
```sql
With c as (
  select * from (
    select a.s
    From mytable a
    Join (
      Select t2.*
      From mytable t2
      Where t2.i in (1,2)
    ) b
    On a.i = b.i
    Join (
      select t1.*
      from mytable t1
      Where t1.I in (2,3)
    ) e
    On b.I = e.i
  ) d   
) select * from c;
```

Plan:
```
QueryProcess
└─ SubqueryAlias
    ├─ name: c
    ├─ outerVisibility: false
    ├─ cacheable: true
    └─ SubqueryAlias
        ├─ name: d
        ├─ outerVisibility: false
        ├─ cacheable: true
        └─ Project
            ├─ columns: [a.s:1]
            └─ InnerJoin
                ├─ columns: [a.i a.s b.i b.s e.i e.s]
                ├─ Eq
                │   ├─ b.i:2!null
                │   └─ e.i:4!null
                ├─ InnerJoin
                │   ├─ columns: [a.i a.s b.i b.s]
                │   ├─ Eq
                │   │   ├─ a.i:0!null
                │   │   └─ b.i:2!null
                │   ├─ TableAlias(a)
                │   │   └─ Table
                │   │       ├─ name: mytable
                │   │       └─ columns: [i s]
                │   └─ SubqueryAlias
                │       ├─ name: b
                │       ├─ outerVisibility: false
                │       ├─ cacheable: true
                │       └─ Filter
                │           ├─ HashIn
                │           │   ├─ t2.i:0!null
                │           │   └─ TUPLE(1 (tinyint), 2 (tinyint))
                │           └─ TableAlias(t2)
                │               └─ IndexedTableAccess(mytable)
                │                   ├─ index: [mytable.i]
                │                   ├─ static: [{[1, 1]}, {[2, 2]}]
                │                   └─ columns: [i s]
                └─ SubqueryAlias
                    ├─ name: e
                    ├─ outerVisibility: false
                    ├─ cacheable: true
                    └─ Filter
                        ├─ HashIn
                        │   ├─ t1.i:0!null
                        │   └─ TUPLE(2 (tinyint), 3 (tinyint))
                        └─ TableAlias(t1)
                            └─ IndexedTableAccess(mytable)
                                ├─ index: [mytable.i]
                                ├─ static: [{[2, 2]}, {[3, 3]}]
                                └─ columns: [i s]
```