### PR TITLE
Memo includes costs and stars best plan

### DIFF
--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -185,10 +185,6 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *Scope) (
 		return nil, err
 	}
 
-	if a.Verbose && a.Debug {
-		a.Log(m.String())
-	}
-
 	if hint := extractJoinHint(n); !hint.IsEmpty() {
 		// this should probably happen earlier, but the root is not
 		// populated before reordering
@@ -199,6 +195,11 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *Scope) (
 	if err != nil {
 		return nil, err
 	}
+
+	if a.Verbose && a.Debug {
+		a.Log(m.String())
+	}
+
 	return m.bestRootPlan()
 }
 

--- a/sql/analyzer/memo.go
+++ b/sql/analyzer/memo.go
@@ -443,15 +443,16 @@ func (e *exprGroup) String() string {
 		b.WriteString(fmt.Sprintf("(%s", formatRelExpr(n)))
 		if e.best != nil {
 			b.WriteString(fmt.Sprintf(" %.1f", n.cost()))
-		}
-		b.WriteString(")")
 
-		childCost := 0.0
-		for _, c := range n.children() {
-			childCost += c.cost
-		}
-		if e.cost == n.cost()+childCost {
-			b.WriteString("*")
+			childCost := 0.0
+			for _, c := range n.children() {
+				childCost += c.cost
+			}
+			if e.cost == n.cost()+childCost {
+				b.WriteString(")*")
+			}
+		} else {
+			b.WriteString(")")
 		}
 		sep = " "
 		n = n.next()

--- a/sql/analyzer/memo.go
+++ b/sql/analyzer/memo.go
@@ -109,6 +109,7 @@ func (m *Memo) optimizeMemoGroup(grp *exprGroup) error {
 		if err != nil {
 			return err
 		}
+		n.setCost(relCost)
 		cost += relCost
 		m.updateBest(grp, n, cost)
 		n = n.next()
@@ -439,7 +440,19 @@ func (e *exprGroup) String() string {
 	sep := ""
 	for n != nil {
 		b.WriteString(sep)
-		b.WriteString(fmt.Sprintf("(%s)", formatRelExpr(n)))
+		b.WriteString(fmt.Sprintf("(%s", formatRelExpr(n)))
+		if e.best != nil {
+			b.WriteString(fmt.Sprintf(" %.1f", n.cost()))
+		}
+		b.WriteString(")")
+
+		childCost := 0.0
+		for _, c := range n.children() {
+			childCost += c.cost
+		}
+		if e.cost == n.cost()+childCost {
+			b.WriteString("*")
+		}
 		sep = " "
 		n = n.next()
 	}
@@ -472,6 +485,8 @@ type relExpr interface {
 	setNext(relExpr)
 	children() []*exprGroup
 	setGroup(g *exprGroup)
+	setCost(c float64)
+	cost() float64
 }
 
 type relBase struct {
@@ -517,6 +532,10 @@ func (r *relBase) setNext(rel relExpr) {
 
 func (r *relBase) setCost(c float64) {
 	r.c = c
+}
+
+func (r *relBase) cost() float64 {
+	return r.c
 }
 
 func tableIdForSource(id GroupId) TableId {


### PR DESCRIPTION
Debugger memo print includes physical expression incremental processing costs, and stars the group best. The value corresponds to the incremental processing delta of executing an operator compared to a sequential processing of the inputs. The total for a group will be the group costs plus child group costs (recursively).

Example:
```
 memo:
├── G1: (tableAlias: r 11444774.0)*
├── G2: (tableAlias: i 161.0)*
├── G3: (mergeJoin 1 2 114447.7) (mergeJoin 2 1 1.6) (hashJoin 1 2 114930.7) (hashJoin 2 1 34334323.6) (lookupJoin 1 2 23003834.7) (lookupJoin 2 1 -11444450.2)* (innerJoin 2 1 1861034699.1) (innerJoin 1 2 1861034699.1)
├── G4: (tableAlias: c 12293.0)*
├── G5: (hashJoin 3 4 36879.2) (hashJoin 2 12 4058.3) (hashJoin 12 2 496.5) (hashJoin 4 3 176.1) (lookupJoin 3 4 -12257.4)* (lookupJoin 12 2 2557.0) (innerJoin 4 3 219885.1) (innerJoin 12 2 219885.1) (innerJoin 2 12 219885.1) (innerJoin 3 4 219885.1)
├── G6: (tableAlias: pm 646.0)*
├── G7: (hashJoin 5 6 1938.0) (hashJoin 2 15 22.9) (hashJoin 15 2 483.1) (hashJoin 4 14 128.2) (hashJoin 14 4 36879.0) (hashJoin 6 5 11.8) (lookupJoin 5 6 -642.4) (lookupJoin 15 2 -146.7) (lookupJoin 14 4 -12289.4)* (innerJoin 6 5 1154.5) (innerJoin 14 4 21987.6) (innerJoin 4 14 21987.6) (innerJoin 15 2 1154.5) (innerJoin 2 15 1154.5) (innerJoin 5 6 1154.5)
├── G8: (tableAlias: trf 39874374.0)*
├── G9: (hashJoin 7 8 119623122.0) (hashJoin 2 22 3.7) (hashJoin 22 2 483.0) (hashJoin 4 21 123.5) (hashJoin 21 4 36879.0) (hashJoin 6 19 7.0) (hashJoin 19 6 1938.0) (hashJoin 8 7 398744.3) (lookupJoin 7 8 -39874373.6) (lookupJoin 22 2 -159.6) (lookupJoin 21 4 -12292.6) (lookupJoin 19 6 -645.6)* (innerJoin 8 7 7132368.2) (innerJoin 19 6 114.6) (innerJoin 6 19 114.6) (innerJoin 21 4 2197.9) (innerJoin 4 21 2197.9) (innerJoin 22 2 114.6) (innerJoin 2 22 114.6) (innerJoin 7 8 7132368.2)
├── G10: (tableAlias: nt 8735.0)*
├── G11: (hashJoin 9 10 26205.0) (hashJoin 2 30 1.8) (hashJoin 30 2 483.0) (hashJoin 4 29 123.0) (hashJoin 29 4 36879.0) (hashJoin 6 27 6.5) (hashJoin 27 6 1938.0) (hashJoin 7 23 2882.6) (hashJoin 23 7 10.1) (hashJoin 10 9 87.4) (lookupJoin 9 10 -8735.0)* (lookupJoin 30 2 -160.8) (lookupJoin 29 4 -12293.0) (lookupJoin 27 6 -646.0) (innerJoin 10 9 155.2) (innerJoin 23 7 170.9) (innerJoin 7 23 170.9) (innerJoin 27 6 11.7) (innerJoin 6 27 11.7) (innerJoin 29 4 240.9) (innerJoin 4 29 240.9) (innerJoin 30 2 11.7) (innerJoin 2 30 11.7) (innerJoin 9 10 155.2)
├── G12: (mergeJoin 1 4 114447.7) (mergeJoin 4 1 122.9) (hashJoin 1 4 151326.7) (hashJoin 4 1 34334444.9) (lookupJoin 1 4 22991702.7) (lookupJoin 4 1 -11420052.8)* (innerJoin 4 1 142097512848.8) (innerJoin 1 4 142097512848.8)
├── G13: (mergeJoin 1 6 114447.7) (mergeJoin 6 1 6.5) (hashJoin 1 6 116385.7) (hashJoin 6 1 34334328.5) (lookupJoin 1 6 23003349.7) (lookupJoin 6 1 -11443474.9)* (innerJoin 6 1 7467257243.0) (innerJoin 1 6 7467257243.0)
├── G14: (hashJoin 2 13 214.8) (hashJoin 13 2 483.7) (hashJoin 3 6 1938.2) (hashJoin 6 3 59.6) (lookupJoin 13 2 -18.2) (lookupJoin 3 6 -610.4)* (innerJoin 6 3 11554.1) (innerJoin 3 6 11554.1) (innerJoin 13 2 11554.1) (innerJoin 2 13 11554.1)
├── G15: (hashJoin 4 13 336.1) (hashJoin 13 4 36879.7) (hashJoin 12 6 1951.5) (hashJoin 6 12 4063.2) (lookupJoin 13 4 -12150.2)* (lookupJoin 12 6 2072.0) (innerJoin 6 12 882275.0) (innerJoin 12 6 882275.0) (innerJoin 13 4 882275.0) (innerJoin 4 13 882275.0)
├── G16: (mergeJoin 1 8 114447.7) (mergeJoin 8 1 398743.7) (hashJoin 1 8 119737569.7) (hashJoin 8 1 34733065.7) (lookupJoin 1 8 -16870378.3)* (lookupJoin 8 1 68702717.7) (innerJoin 8 1 460916730809689.8) (innerJoin 1 8 460916730809689.8)
├── G17: (hashJoin 2 16 3433433.8) (hashJoin 16 2 11927.8) (hashJoin 3 8 119623122.2) (hashJoin 8 3 398796.9) (lookupJoin 16 2 2300238.6) (lookupJoin 3 8 -39874338.4)* (innerJoin 8 3 713236914.2) (innerJoin 3 8 713236914.2) (innerJoin 16 2 186103469.0) (innerJoin 2 16 186103469.0)
├── G18: (hashJoin 4 16 3433555.1) (hashJoin 16 4 48323.8) (hashJoin 12 8 119623135.5) (hashJoin 8 12 402800.4) (lookupJoin 16 4 2288106.6) (lookupJoin 12 8 -39871656.0)* (innerJoin 8 12 54458518000.6) (innerJoin 12 8 54458518000.6) (innerJoin 16 4 14209751284.0) (innerJoin 4 16 14209751284.0)
├── G19: (hashJoin 2 18 407.3) (hashJoin 18 2 484.4) (hashJoin 4 17 128.2) (hashJoin 17 4 36879.0) (hashJoin 5 8 119623122.0) (hashJoin 8 5 398749.1) (lookupJoin 18 2 110.8) (lookupJoin 17 4 -12289.4)* (lookupJoin 5 8 -39874370.4) (innerJoin 8 5 71323690.5) (innerJoin 5 8 71323690.5) (innerJoin 17 4 21987.6) (innerJoin 4 17 21987.6) (innerJoin 18 2 21987.6) (innerJoin 2 18 21987.6)
├── G20: (hashJoin 6 16 3433438.7) (hashJoin 16 6 13382.8) (hashJoin 13 8 119623122.7) (hashJoin 8 13 398956.9) (lookupJoin 16 6 2299753.6) (lookupJoin 13 8 -39874231.2)* (innerJoin 8 13 2861807745.6) (innerJoin 13 8 2861807745.6) (innerJoin 16 6 746725723.4) (innerJoin 6 16 746725723.4)
├── G21: (hashJoin 2 20 22.9) (hashJoin 20 2 483.1) (hashJoin 6 17 11.8) (hashJoin 17 6 1938.0) (hashJoin 14 8 119623122.0) (hashJoin 8 14 398749.1) (lookupJoin 20 2 -146.7) (lookupJoin 17 6 -642.4)* (lookupJoin 14 8 -39874370.4) (innerJoin 8 14 71323690.5) (innerJoin 14 8 71323690.5) (innerJoin 17 6 1154.5) (innerJoin 6 17 1154.5) (innerJoin 20 2 1154.5) (innerJoin 2 20 1154.5)
├── G22: (hashJoin 4 20 144.2) (hashJoin 20 4 36879.1) (hashJoin 6 18 412.1) (hashJoin 18 6 1939.4) (hashJoin 15 8 119623122.1) (hashJoin 8 15 398765.1) (lookupJoin 20 4 -12278.7) (lookupJoin 18 6 -374.2) (lookupJoin 15 8 -39874359.7)* (innerJoin 8 15 286180773.7) (innerJoin 15 8 286180773.7) (innerJoin 18 6 88226.6) (innerJoin 6 18 88226.6) (innerJoin 20 4 88226.6) (innerJoin 4 20 88226.6)
├── G23: (mergeJoin 8 10 398743.7) (mergeJoin 10 8 87.4) (hashJoin 8 10 424948.7) (hashJoin 10 8 119623209.3) (lookupJoin 8 10 80178631.1) (lookupJoin 10 8 -39856807.9)* (innerJoin 10 8 351785683457.9) (innerJoin 8 10 351785683457.9)
├── G24: (hashJoin 1 23 117330.3) (hashJoin 23 1 34334331.6) (hashJoin 16 10 37649.8) (hashJoin 10 16 3433519.6) (lookupJoin 23 1 -11442842.7)* (lookupJoin 16 10 2292809.1) (innerJoin 10 16 10096980188.9) (innerJoin 16 10 10096980188.9) (innerJoin 23 1 11106678207.9) (innerJoin 1 23 11106678207.9)
├── G25: (hashJoin 2 24 289.9) (hashJoin 24 2 484.0) (hashJoin 3 23 2882.7) (hashJoin 23 3 62.7) (hashJoin 17 10 26205.0) (hashJoin 10 17 92.7) (lookupJoin 24 2 32.1) (lookupJoin 17 10 -8731.4)* (innerJoin 10 17 15623.4) (innerJoin 17 10 15623.4) (innerJoin 23 3 17185.8) (innerJoin 3 23 17185.8) (innerJoin 24 2 15623.4) (innerJoin 2 24 15623.4)
├── G26: (hashJoin 4 24 411.2) (hashJoin 24 4 36880.0) (hashJoin 12 23 2896.1) (hashJoin 23 12 4066.3) (hashJoin 18 10 26206.4) (hashJoin 10 18 493.0) (lookupJoin 24 4 -12099.9)* (lookupJoin 18 10 -8463.1) (innerJoin 10 18 1192983.6) (innerJoin 18 10 1192983.6) (innerJoin 23 12 1312282.1) (innerJoin 12 23 1312282.1) (innerJoin 24 4 1192983.6) (innerJoin 4 24 1192983.6)
├── G27: (hashJoin 2 26 30.4) (hashJoin 26 2 483.1) (hashJoin 4 25 123.5) (hashJoin 25 4 36879.0) (hashJoin 5 23 2882.6) (hashJoin 23 5 14.9) (hashJoin 19 10 26205.0) (hashJoin 10 19 87.9) (lookupJoin 26 2 -141.7) (lookupJoin 25 4 -12292.6) (lookupJoin 19 10 -8734.6)* (innerJoin 10 19 1561.4) (innerJoin 19 10 1561.4) (innerJoin 23 5 1717.7) (innerJoin 5 23 1717.7) (innerJoin 25 4 2417.7) (innerJoin 4 25 2417.7) (innerJoin 26 2 1561.4) (innerJoin 2 26 1561.4)
├── G28: (hashJoin 6 24 294.7) (hashJoin 24 6 1939.0) (hashJoin 13 23 2883.3) (hashJoin 23 13 222.8) (hashJoin 20 10 26205.1) (hashJoin 10 20 108.7) (lookupJoin 24 6 -452.9) (lookupJoin 20 10 -8720.7)* (innerJoin 10 20 62690.6) (innerJoin 20 10 62690.6) (innerJoin 23 13 68959.8) (innerJoin 13 23 68959.8) (innerJoin 24 6 62690.6) (innerJoin 6 24 62690.6)
├── G29: (hashJoin 2 28 4.0) (hashJoin 28 2 483.0) (hashJoin 6 25 7.0) (hashJoin 25 6 1938.0) (hashJoin 14 23 2882.6) (hashJoin 23 14 14.9) (hashJoin 21 10 26205.0) (hashJoin 10 21 87.9) (lookupJoin 28 2 -159.4) (lookupJoin 25 6 -645.6) (lookupJoin 21 10 -8734.6)* (innerJoin 10 21 1561.4) (innerJoin 21 10 1561.4) (innerJoin 23 14 1717.7) (innerJoin 14 23 1717.7) (innerJoin 25 6 126.1) (innerJoin 6 25 126.1) (innerJoin 28 2 126.1) (innerJoin 2 28 126.1)
└── G30: (hashJoin 4 28 125.3) (hashJoin 28 4 36879.0) (hashJoin 6 26 35.3) (hashJoin 26 6 1938.1) (hashJoin 15 23 2882.6) (hashJoin 23 15 30.9) (hashJoin 22 10 26205.0) (hashJoin 10 22 89.5) (lookupJoin 28 4 -12291.4) (lookupJoin 26 6 -626.7) (lookupJoin 22 10 -8733.6)* (innerJoin 10 22 6268.2) (innerJoin 22 10 6268.2) (innerJoin 23 15 6895.1) (innerJoin 15 23 6895.1) (innerJoin 26 6 6268.2) (innerJoin 6 26 6268.2) (innerJoin 28 4 9704.0) (innerJoin 4 28 9704.0)
```