### PR TITLE
fix `/` and `div` operations on value of decimal type column

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3445,6 +3445,10 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{uint64(18446744073709551615)}},
 	},
 	{
+		Query:    "select -1.00 div 2;",
+		Expected: []sql.Row{{0}},
+	},
+	{
 		Query:    "select 'a' div 'a';",
 		Expected: []sql.Row{{nil}},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2823,6 +2823,23 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "division and int division operation on negative, small and big value for decimal type column of table",
+		SetUpScript: []string{
+			"create table t (d decimal(25,10) primary key);",
+			"insert into t values (-4990), (2), (22336578);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select d div 314990 from t order by d;",
+				Expected: []sql.Row{{0}, {0}, {70}},
+			},
+			{
+				Query:    "select d / 314990 from t order by d;",
+				Expected: []sql.Row{{"-0.01584177275469"}, {"0.00000634940792"}, {"70.91202260389219"}},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -740,12 +740,14 @@ func intDiv(ctx *sql.Context, lval, rval interface{}) (interface{}, error) {
 				return nil, nil
 			}
 
-			// intDiv operation gets the integer part of the divided value
-			divRes := l.DivRound(r, 2)
+			// intDiv operation gets the integer part of the divided value without rounding the result with 0 precision
+			// We get division result with non-zero precision and then truncate it to get integer part without it being rounded
+			divRes := l.DivRound(r, 2).Truncate(0)
+
 			// cannot use IntPart() function of decimal.Decimal package as it returns 0 as undefined value for out of range value
 			// it causes valid result value of 0 to be the same as invalid out of range value of 0. The fraction part
 			// should not be rounded, so truncate the result wih 0 precision.
-			intPart, err := strconv.ParseInt(divRes.Truncate(0).String(), 10, 64)
+			intPart, err := strconv.ParseInt(divRes.String(), 10, 64)
 			if err != nil {
 				return nil, ErrIntDivDataOutOfRange.New(l.StringFixed(l.Exponent()), r.StringFixed(r.Exponent()))
 			}


### PR DESCRIPTION
The cases fixed are:
- the scale of decimal type column is bigger than the value stored. For example, the decimal column type is `DECIMAL(25,10)` and the value stored is `4990`. This value is evaluated with 0 scale, whereas this should be evaluated as value with scale of 10.
- the `IntPart()` function of [decimal package](https://pkg.go.dev/github.com/shopspring/decimal@v1.3.1) returns 0 as undefined value for out of range values. This causes it hard to differentiate between cases where the final result is valid value of 0 and the final result is out of range value.