### PR TITLE
Fixed Issue #1621

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ func main() {
 
 func createTestDatabase(ctx *sql.Context) *memory.Database {
 	db := memory.NewDatabase(dbName)
+	db.EnablePrimaryKeyIndexes()
 	table := memory.NewTable(tableName, sql.NewPrimaryKeySchema(sql.Schema{
 		{Name: "name", Type: sql.Text, Nullable: false, Source: tableName, PrimaryKey: true},
 		{Name: "email", Type: sql.Text, Nullable: false, Source: tableName, PrimaryKey: true},

--- a/_example/main.go
+++ b/_example/main.go
@@ -80,6 +80,7 @@ func main() {
 
 func createTestDatabase(ctx *sql.Context) *memory.Database {
 	db := memory.NewDatabase(dbName)
+	db.EnablePrimaryKeyIndexes()
 	table := memory.NewTable(tableName, sql.NewPrimaryKeySchema(sql.Schema{
 		{Name: "name", Type: types.Text, Nullable: false, Source: tableName, PrimaryKey: true},
 		{Name: "email", Type: types.Text, Nullable: false, Source: tableName, PrimaryKey: true},


### PR DESCRIPTION
When using the example server, we had primary key indexes disabled for the in-memory database, so this just enables them as that is what people would expect.