### PR TITLE
Update logger field when a session's database is changed

### DIFF
--- a/server/context.go
+++ b/server/context.go
@@ -133,7 +133,6 @@ func (s *SessionManager) SetDB(conn *mysql.Conn, db string) error {
 		return sql.ErrDatabaseNotFound.New(db)
 	}
 
-	sess.SetLogger(ctx.GetLogger().WithField(sql.ConnectionDbLogField, db))
 	sess.SetCurrentDatabase(db)
 	return nil
 }

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -278,6 +278,7 @@ func (s *BaseSession) SetCurrentDatabase(dbName string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.currentDB = dbName
+	s.SetLogger(s.GetLogger().WithField(ConnectionDbLogField, dbName))
 }
 
 // ID implements the Session interface.

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -61,10 +61,14 @@ func (s *BaseSession) GetLogger() *logrus.Entry {
 	defer s.mu.Unlock()
 
 	if s.logger == nil {
-		log := logrus.StandardLogger()
-		s.logger = logrus.NewEntry(log)
+		s.logger = s.newLogger()
 	}
 	return s.logger
+}
+
+func (s *BaseSession) newLogger() *logrus.Entry {
+	log := logrus.StandardLogger()
+	return logrus.NewEntry(log)
 }
 
 func (s *BaseSession) SetLogger(logger *logrus.Entry) {
@@ -278,7 +282,11 @@ func (s *BaseSession) SetCurrentDatabase(dbName string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.currentDB = dbName
-	s.SetLogger(s.GetLogger().WithField(ConnectionDbLogField, dbName))
+	logger := s.logger
+	if logger == nil {
+		logger = s.newLogger()
+	}
+	s.logger = logger.WithField(ConnectionDbLogField, dbName)
 }
 
 // ID implements the Session interface.

--- a/sql/plan/use.go
+++ b/sql/plan/use.go
@@ -66,7 +66,6 @@ func (u *Use) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	}
 
 	ctx.SetCurrentDatabase(db.Name())
-	ctx.SetLogger(ctx.GetLogger().WithField(sql.ConnectionDbLogField, db.Name()))
 
 	return sql.RowsToRowIter(), nil
 }


### PR DESCRIPTION
We use a `connectionDb` field to log the session's current database, but we don't always consistently update that logger field in every place where we set the session's current db. This change moves that logger field update directly into `BaseSession.SetCurrentDatabase(string)` to ensure it always stays in sync. 