### PR TITLE
Change how we hoist filters from a subquery

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -1229,6 +1229,22 @@ var joinCostTests = []struct {
           AND EXISTS (SELECT * FROM rs Alias2 WHERE Alias2.r = (xy.x + 2)));`,
 				Expected: []sql.Row{{3, 3}},
 			},
+			{
+				Query: `SELECT *
+FROM ab A0
+WHERE EXISTS (
+    SELECT U0.a
+    FROM
+    (
+        ab U0
+        LEFT OUTER JOIN
+        xy U1
+        ON (U0.a = U1.x)
+    )
+    WHERE (U1.x IS NULL AND U0.a = A0.a)
+);`,
+				Expected: []sql.Row{},
+			},
 		},
 	},
 }

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -391,14 +391,14 @@ order by 1;`,
 				q: `SELECT * FROM xy WHERE (
       				EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
       				AND EXISTS (SELECT * FROM uv Alias2 WHERE Alias2.u = (xy.x + 2)));`,
-				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeSemiLookup},
+				types: []plan.JoinType{},
 				exp:   []sql.Row{{0, 2}, {1, 0}},
 			},
 			{
 				q: `SELECT * FROM xy WHERE (
       				EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
       				AND EXISTS (SELECT * FROM uv Alias1 WHERE Alias1.u = (xy.x + 2)));`,
-				types: []plan.JoinType{plan.JoinTypeSemiLookup, plan.JoinTypeSemiLookup},
+				types: []plan.JoinType{},
 				exp:   []sql.Row{{0, 2}, {1, 0}},
 			},
 		},

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -383,6 +383,11 @@ order by 1;`,
 				exp:   []sql.Row{{2, 1}},
 			},
 			{
+				q:     "select * from xy Alias where (Alias.x,Alias.y+1) = (select u,v from uv Alias where Alias.v = 2 order by 1 limit 1) order by 1;",
+				types: []plan.JoinType{plan.JoinTypeSemi},
+				exp:   []sql.Row{{2, 1}},
+			},
+			{
 				q:     "select * from xy where x in (select cnt from (select count(u) as cnt from uv group by v having cnt > 0) sq) order by 1,2;",
 				types: []plan.JoinType{plan.JoinTypeRightSemiLookup},
 				exp:   []sql.Row{{2, 1}},
@@ -398,6 +403,13 @@ order by 1;`,
 				q: `SELECT * FROM xy WHERE (
       				EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
       				AND EXISTS (SELECT * FROM uv Alias1 WHERE Alias1.u = (xy.x + 2)));`,
+				types: []plan.JoinType{},
+				exp:   []sql.Row{{0, 2}, {1, 0}},
+			},
+			{
+				q: `SELECT * FROM xy WHERE (
+    EXISTS (SELECT * FROM xy Alias1 WHERE Alias1.x = (xy.x + 1))
+    AND EXISTS (SELECT * FROM (select * from uv) Alias1 WHERE Alias1.u = (xy.x + 2)));`,
 				types: []plan.JoinType{},
 				exp:   []sql.Row{{0, 2}, {1, 0}},
 			},

--- a/optgen/cmd/support/memo_gen.go
+++ b/optgen/cmd/support/memo_gen.go
@@ -165,14 +165,21 @@ func (g *MemoGen) genFormatters(defines []MemoDef) {
 	fmt.Fprintf(g.w, "}\n\n")
 
 	fmt.Fprintf(g.w, "func buildRelExpr(b *ExecBuilder, r relExpr, input sql.Schema, children ...sql.Node) (sql.Node, error) {\n")
+	fmt.Fprintf(g.w, "  var result sql.Node\n")
+	fmt.Fprintf(g.w, "  var err error\n\n")
 	fmt.Fprintf(g.w, "  switch r := r.(type) {\n")
 	for _, d := range defines {
 		fmt.Fprintf(g.w, "  case *%s:\n", d.Name)
-		fmt.Fprintf(g.w, "  return b.build%s(r, input, children...)\n", strings.Title(d.Name))
+		fmt.Fprintf(g.w, "  result, err = b.build%s(r, input, children...)\n", strings.Title(d.Name))
 	}
 	fmt.Fprintf(g.w, "  default:\n")
 	fmt.Fprintf(g.w, "    panic(fmt.Sprintf(\"unknown relExpr type: %%T\", r))\n")
-	fmt.Fprintf(g.w, "  }\n")
+	fmt.Fprintf(g.w, "  }\n\n")
+	fmt.Fprintf(g.w, "  if err != nil {\n")
+	fmt.Fprintf(g.w, "    return nil, err\n")
+	fmt.Fprintf(g.w, "  }\n\n")
+	fmt.Fprintf(g.w, "  result = r.group().finalize(result)\n")
+	fmt.Fprintf(g.w, "  return result, nil\n")
 
 	fmt.Fprintf(g.w, "}\n\n")
 }

--- a/sql/analyzer/memo.go
+++ b/sql/analyzer/memo.go
@@ -233,6 +233,9 @@ type relProps struct {
 	outputTables sql.FastIntSet
 
 	card float64
+
+	limit  sql.Expression
+	filter sql.Expression
 }
 
 func newRelProps(rel relExpr) *relProps {
@@ -447,6 +450,18 @@ func (e *exprGroup) updateBest(n relExpr, grpCost float64) {
 		e.best = n
 		e.cost = grpCost
 	}
+}
+
+func (e *exprGroup) finalize(node sql.Node) sql.Node {
+	props := e.relProps
+	var result = node
+	if props.filter != nil {
+		result = plan.NewFilter(props.filter, result)
+	}
+	if props.limit != nil {
+		result = plan.NewLimit(props.limit, result)
+	}
+	return result
 }
 
 func (e *exprGroup) String() string {

--- a/sql/analyzer/memo.og.go
+++ b/sql/analyzer/memo.og.go
@@ -512,50 +512,60 @@ func formatRelExpr(r relExpr) string {
 }
 
 func buildRelExpr(b *ExecBuilder, r relExpr, input sql.Schema, children ...sql.Node) (sql.Node, error) {
+	var result sql.Node
+	var err error
+
 	switch r := r.(type) {
 	case *crossJoin:
-		return b.buildCrossJoin(r, input, children...)
+		result, err = b.buildCrossJoin(r, input, children...)
 	case *innerJoin:
-		return b.buildInnerJoin(r, input, children...)
+		result, err = b.buildInnerJoin(r, input, children...)
 	case *leftJoin:
-		return b.buildLeftJoin(r, input, children...)
+		result, err = b.buildLeftJoin(r, input, children...)
 	case *semiJoin:
-		return b.buildSemiJoin(r, input, children...)
+		result, err = b.buildSemiJoin(r, input, children...)
 	case *antiJoin:
-		return b.buildAntiJoin(r, input, children...)
+		result, err = b.buildAntiJoin(r, input, children...)
 	case *lookupJoin:
-		return b.buildLookupJoin(r, input, children...)
+		result, err = b.buildLookupJoin(r, input, children...)
 	case *concatJoin:
-		return b.buildConcatJoin(r, input, children...)
+		result, err = b.buildConcatJoin(r, input, children...)
 	case *hashJoin:
-		return b.buildHashJoin(r, input, children...)
+		result, err = b.buildHashJoin(r, input, children...)
 	case *mergeJoin:
-		return b.buildMergeJoin(r, input, children...)
+		result, err = b.buildMergeJoin(r, input, children...)
 	case *fullOuterJoin:
-		return b.buildFullOuterJoin(r, input, children...)
+		result, err = b.buildFullOuterJoin(r, input, children...)
 	case *tableScan:
-		return b.buildTableScan(r, input, children...)
+		result, err = b.buildTableScan(r, input, children...)
 	case *values:
-		return b.buildValues(r, input, children...)
+		result, err = b.buildValues(r, input, children...)
 	case *tableAlias:
-		return b.buildTableAlias(r, input, children...)
+		result, err = b.buildTableAlias(r, input, children...)
 	case *recursiveTable:
-		return b.buildRecursiveTable(r, input, children...)
+		result, err = b.buildRecursiveTable(r, input, children...)
 	case *recursiveCte:
-		return b.buildRecursiveCte(r, input, children...)
+		result, err = b.buildRecursiveCte(r, input, children...)
 	case *subqueryAlias:
-		return b.buildSubqueryAlias(r, input, children...)
+		result, err = b.buildSubqueryAlias(r, input, children...)
 	case *max1Row:
-		return b.buildMax1Row(r, input, children...)
+		result, err = b.buildMax1Row(r, input, children...)
 	case *tableFunc:
-		return b.buildTableFunc(r, input, children...)
+		result, err = b.buildTableFunc(r, input, children...)
 	case *selectSingleRel:
-		return b.buildSelectSingleRel(r, input, children...)
+		result, err = b.buildSelectSingleRel(r, input, children...)
 	case *project:
-		return b.buildProject(r, input, children...)
+		result, err = b.buildProject(r, input, children...)
 	case *distinct:
-		return b.buildDistinct(r, input, children...)
+		result, err = b.buildDistinct(r, input, children...)
 	default:
 		panic(fmt.Sprintf("unknown relExpr type: %T", r))
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	result = r.group().finalize(result)
+	return result, nil
 }

--- a/sql/plan/procedure.go
+++ b/sql/plan/procedure.go
@@ -232,6 +232,11 @@ func (p *Procedure) IsExternal() bool {
 	return false
 }
 
+func (p *Procedure) WithName(newName string) sql.Node {
+	p.Name = newName
+	return p
+}
+
 // String returns the original SQL representation.
 func (pst ProcedureSecurityContext) String() string {
 	switch pst {


### PR DESCRIPTION
Before hoisting a filter condition inside a subquery, check if the condition is using any of the subquery tables.

This also includes a minor renaming change: when hoisting a table and there's a possibility of a name collision, we now add an unambiguous table alias.

This resolves https://github.com/dolthub/dolt/issues/5342