### PR TITLE
Handle Quotes in Default Column Values

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1830,6 +1830,12 @@ func TestViews(t *testing.T, harness Harness) {
 			sql.NewRow(int64(2), "second row"),
 		}, nil, nil)
 	})
+
+	// Newer Tests should be put in view_queries.go
+	harness.Setup(setup.MydbData)
+	for _, script := range queries.ViewScripts {
+		TestScript(t, harness, script)
+	}
 }
 
 func TestRecursiveViewDefinition(t *testing.T, harness Harness) {

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1790,6 +1790,44 @@ var InsertScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/5411
+		Name: "Defaults with escaped strings",
+		SetUpScript: []string{
+			`CREATE TABLE escpe (
+                               id int NOT NULL AUTO_INCREMENT,
+                               t1 varchar(15) DEFAULT 'foo''s baz',
+                               t2 varchar(15) DEFAULT 'who\'s dat',
+                               t3 varchar(15) DEFAULT "joe\'s bar",
+                               t4 varchar(15) DEFAULT "quote""bazzar",
+                               t5 varchar(15) DEFAULT 'back\\''slash',
+                               PRIMARY KEY (id)
+                     );`,
+			"INSERT INTO escpe VALUES ();",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT t1 from escpe",
+				Expected: []sql.Row{{"foo's baz"}},
+			},
+			{
+				Query:    "SELECT t2 from escpe",
+				Expected: []sql.Row{{"who's dat"}},
+			},
+			{
+				Query:    "SELECT t3 from escpe",
+				Expected: []sql.Row{{"joe's bar"}},
+			},
+			{
+				Query:    "SELECT t4 from escpe",
+				Expected: []sql.Row{{"quote\"bazzar"}},
+			},
+			{
+				Query:    "SELECT t5 from escpe",
+				Expected: []sql.Row{{"back\\'slash"}},
+			},
+		},
+	},
 }
 
 var InsertErrorTests = []GenericErrorQueryTest{

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1801,6 +1801,8 @@ var InsertScripts = []ScriptTest{
                                t3 varchar(15) DEFAULT "joe\'s bar",
                                t4 varchar(15) DEFAULT "quote""bazzar",
                                t5 varchar(15) DEFAULT 'back\\''slash',
+                               t6 varchar(15) DEFAULT 'tab\ttab',
+                               t7 varchar(15) DEFAULT 'new\nline',
                                PRIMARY KEY (id)
                      );`,
 			"INSERT INTO escpe VALUES ();",
@@ -1826,6 +1828,14 @@ var InsertScripts = []ScriptTest{
 				Query:    "SELECT t5 from escpe",
 				Expected: []sql.Row{{"back\\'slash"}},
 			},
+			{
+				Query:    "SELECT t6 from escpe",
+				Expected: []sql.Row{{"tab\ttab"}},
+			},
+			{
+				Query:    "SELECT t7 from escpe",
+				Expected: []sql.Row{{"new\nline"}},
+			},
 		},
 	},
 	{
@@ -1836,21 +1846,25 @@ var InsertScripts = []ScriptTest{
                                    val varchar(15) NOT NULL CHECK (val IN ('joe''s',
                                                                            "jan's",
                                                                            'mia\\''s',
-                                                                           'bob\'s')),
+                                                                           'bob\'s',
+                                                                           'tab\tvs\tcoke',
+                                                                           'percent\%')),
                                    PRIMARY KEY (id));`,
 			`INSERT INTO quoted VALUES (0,"joe's");`,
 			`INSERT INTO quoted VALUES (0,"jan's");`,
 			`INSERT INTO quoted VALUES (0,"mia\\'s");`,
 			`INSERT INTO quoted VALUES (0,"bob's");`,
+			`INSERT INTO quoted VALUES (0,"tab\tvs\tcoke");`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "SELECT val from quoted",
+				Query: "SELECT val from quoted order by id",
 				Expected: []sql.Row{
 					{"joe's"},
 					{"jan's"},
 					{"mia\\'s"},
-					{"bob's"}},
+					{"bob's"},
+					{"tab\tvs\tcoke"}},
 			},
 		},
 	},

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1828,6 +1828,32 @@ var InsertScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/5411
+		Name: "check constrains with escaped strings",
+		SetUpScript: []string{
+			`CREATE TABLE quoted ( id int NOT NULL AUTO_INCREMENT,
+                                   val varchar(15) NOT NULL CHECK (val IN ('joe''s',
+                                                                           "jan's",
+                                                                           'mia\\''s',
+                                                                           'bob\'s')),
+                                   PRIMARY KEY (id));`,
+			`INSERT INTO quoted VALUES (0,"joe's");`,
+			`INSERT INTO quoted VALUES (0,"jan's");`,
+			`INSERT INTO quoted VALUES (0,"mia\\'s");`,
+			`INSERT INTO quoted VALUES (0,"bob's");`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT val from quoted",
+				Expected: []sql.Row{
+					{"joe's"},
+					{"jan's"},
+					{"mia\\'s"},
+					{"bob's"}},
+			},
+		},
+	},
 }
 
 var InsertErrorTests = []GenericErrorQueryTest{

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -2105,6 +2105,29 @@ var ProcedureCallTests = []ScriptTest{
 			},
 		},
 	},
+
+	{
+		Name: "String literals with escaped chars",
+		SetUpScript: []string{
+			`CREATE PROCEDURE joe(IN str VARCHAR(15)) SELECT CONCAT('joe''s bar:', str);`,
+			`CREATE PROCEDURE jill(IN str VARCHAR(15)) SELECT CONCAT('jill\'s bar:', str);`,
+			`CREATE PROCEDURE stan(IN str VARCHAR(15)) SELECT CONCAT("stan\'s bar:", str);`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "CALL joe('open')",
+				Expected: []sql.Row{{"joe's bar:open"}},
+			},
+			{
+				Query:    "CALL jill('closed')",
+				Expected: []sql.Row{{"jill's bar:closed"}},
+			},
+			{
+				Query:    "CALL stan('quarantined')",
+				Expected: []sql.Row{{"stan's bar:quarantined"}},
+			},
+		},
+	},
 }
 
 var ProcedureDropTests = []ScriptTest{

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -483,6 +483,30 @@ var TriggerTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "trigger with escaped chars",
+		SetUpScript: []string{
+			"CREATE TABLE testInt(v1 BIGINT);",
+			"CREATE TABLE testStr(s1 VARCHAR(255), s2 VARCHAR(255), s3 VARCHAR(255));",
+			`CREATE TRIGGER tt BEFORE INSERT ON testInt FOR EACH ROW
+				BEGIN
+					insert into testStr values (CONCAT('joe''s:', NEW.v1),
+                                                CONCAT('jill\'s:', NEW.v1 + 1),
+                                                CONCAT("stan""s:", NEW.v1 + 2)
+                                               );
+				END;`,
+			"INSERT INTO testInt VALUES (1);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM testStr",
+				Expected: []sql.Row{
+					{"joe's:1", "jill's:2", "stan\"s:3"},
+				},
+			},
+		},
+	},
+
 	// UPDATE triggers
 	{
 		Name: "trigger after update, insert into other table",

--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -1,0 +1,50 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queries
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+var ViewScripts = []ScriptTest{
+	{
+		Name: "check view with escaped strings",
+		SetUpScript: []string{
+			`CREATE TABLE strs ( id int NOT NULL AUTO_INCREMENT,
+                                 str  varchar(15) NOT NULL,
+                                 PRIMARY KEY (id));`,
+			`CREATE VIEW quotes AS SELECT * FROM strs WHERE str IN ('joe''s',
+                                                                    "jan's",
+                                                                    'mia\\''s',
+                                                                    'bob\'s'
+                                                                   );`,
+			`INSERT INTO strs VALUES (0,"joe's");`,
+			`INSERT INTO strs VALUES (0,"mia\\'s");`,
+			`INSERT INTO strs VALUES (0,"bob's");`,
+			`INSERT INTO strs VALUES (0,"joe's");`,
+			`INSERT INTO strs VALUES (0,"notInView");`,
+			`INSERT INTO strs VALUES (0,"jan's");`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * from quotes order by id",
+				Expected: []sql.Row{
+					{1, "joe's"},
+					{2, "mia\\'s"},
+					{3, "bob's"},
+					{4, "joe's"},
+					{6, "jan's"}},
+			},
+		},
+	},
+}

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -16,6 +16,7 @@ package expression
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/shopspring/decimal"
@@ -64,24 +65,28 @@ func (lit *Literal) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 }
 
 func (lit *Literal) String() string {
-	switch v := lit.value.(type) {
+	switch litVal := lit.value.(type) {
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", v)
+		return fmt.Sprintf("%d", litVal)
 	case string:
 		switch lit.fieldType.Type() {
 		// utf8 charset cannot encode binary string
 		case query.Type_VARBINARY, query.Type_BINARY:
-			return fmt.Sprintf("'0x%X'", v)
+			return fmt.Sprintf("'0x%X'", litVal)
 		}
-		return fmt.Sprintf("'%s'", v)
+		// Conversion of \' to \'\' required as this string will be interpreted by the sql engine.
+		// Backslash chars also need to be replaced.
+		escaped := strings.ReplaceAll(litVal, "'", "''")
+		escaped = strings.ReplaceAll(escaped, "\\", "\\\\")
+		return fmt.Sprintf("'%s'", escaped)
 	case decimal.Decimal:
-		return v.StringFixed(v.Exponent() * -1)
+		return litVal.StringFixed(litVal.Exponent() * -1)
 	case []byte:
 		return "BLOB"
 	case nil:
 		return "NULL"
 	default:
-		return fmt.Sprint(v)
+		return fmt.Sprint(litVal)
 	}
 }
 


### PR DESCRIPTION
See Issue: https://github.com/dolthub/dolt/issues/5411

Both Default values and check constraints are impacted by the fact that we write strings to storage without escaping the single quote character or backslash appropriately. This change encodes both and adds tests to verify correct behavior. Tests were added for procedures, views, and triggers, they they weren't impacted by this particular defect.