### PR TITLE
add tests for `on duplicate key update` for keyless tables

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1607,6 +1607,76 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "insert on duplicate key for keyless table",
+		SetUpScript: []string{
+			`create table t (i int unique, j varchar(128))`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       `insert into t values (0, "first")`,
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query:    `insert into t values (0, "second") on duplicate key update j = "third"`,
+				Expected: []sql.Row{
+					{types.NewOkResult(2)},
+				},
+			},
+			{
+				Query:    `select i, j from t order by i`,
+				Expected: []sql.Row{
+					{0, "third"},
+				},
+			},
+		},
+	},
+	{
+		Name: "insert on duplicate key for keyless table multiple unique columns",
+		SetUpScript: []string{
+			`create table t (c1 int, c2 int, c3 int, unique key(c1,c2))`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 0`,
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query:    `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, 0, 0},
+				},
+			},
+			{
+				Query:       `insert into t(c1, c2, c3) values (0, 0, 1) on duplicate key update c3 = 0`,
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query:    `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, 0, 0},
+				},
+			},
+			{
+				Query:       `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 1`,
+				Expected: []sql.Row{
+					{types.NewOkResult(2)},
+				},
+			},
+			{
+				Query:    `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, 0, 1},
+				},
+			},
+		},
+	},
+	{
 		Name: "Insert throws primary key violations",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY key);",

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -2440,5 +2440,4 @@ var InsertBrokenScripts = []ScriptTest{
 			},
 		},
 	},
-
 }

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1613,19 +1613,19 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:       `insert into t values (0, "first")`,
+				Query: `insert into t values (0, "first")`,
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
-				Query:    `insert into t values (0, "second") on duplicate key update j = "third"`,
+				Query: `insert into t values (0, "second") on duplicate key update j = "third"`,
 				Expected: []sql.Row{
 					{types.NewOkResult(2)},
 				},
 			},
 			{
-				Query:    `select i, j from t order by i`,
+				Query: `select i, j from t order by i`,
 				Expected: []sql.Row{
 					{0, "third"},
 				},
@@ -1639,37 +1639,37 @@ var InsertScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:       `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 0`,
+				Query: `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 0`,
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
-				Query:    `select c1, c2, c3 from t order by c1`,
+				Query: `select c1, c2, c3 from t order by c1`,
 				Expected: []sql.Row{
 					{0, 0, 0},
 				},
 			},
 			{
-				Query:       `insert into t(c1, c2, c3) values (0, 0, 1) on duplicate key update c3 = 0`,
+				Query: `insert into t(c1, c2, c3) values (0, 0, 1) on duplicate key update c3 = 0`,
 				Expected: []sql.Row{
 					{types.NewOkResult(0)},
 				},
 			},
 			{
-				Query:    `select c1, c2, c3 from t order by c1`,
+				Query: `select c1, c2, c3 from t order by c1`,
 				Expected: []sql.Row{
 					{0, 0, 0},
 				},
 			},
 			{
-				Query:       `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 1`,
+				Query: `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 1`,
 				Expected: []sql.Row{
 					{types.NewOkResult(2)},
 				},
 			},
 			{
-				Query:    `select c1, c2, c3 from t order by c1`,
+				Query: `select c1, c2, c3 from t order by c1`,
 				Expected: []sql.Row{
 					{0, 0, 1},
 				},

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1677,6 +1677,127 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "insert on duplicate key for keyless tables with nulls",
+		SetUpScript: []string{
+			`create table t (c1 int, c2 int, c3 int, unique key(c1, c2))`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `insert into t(c1, c2, c3) values (0, null, 0) on duplicate key update c3 = 0`,
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, nil, 0},
+				},
+			},
+			{
+				Query: `insert into t(c1, c2, c3) values (0, null, 1) on duplicate key update c3 = 0`,
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1, c2, c3`,
+				Expected: []sql.Row{
+					{0, nil, 0},
+					{0, nil, 1},
+				},
+			},
+			{
+				Query: `insert into t(c1, c2, c3) values (0, null, 0) on duplicate key update c3 = 1`,
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1, c2, c3`,
+				Expected: []sql.Row{
+					{0, nil, 0},
+					{0, nil, 0},
+					{0, nil, 1},
+				},
+			},
+			{
+				Query: `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = null`,
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1, c2, c3`,
+				Expected: []sql.Row{
+					{0, nil, 0},
+					{0, nil, 0},
+					{0, nil, 1},
+					{0, 0, 0},
+				},
+			},
+			{
+				Query: `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = null`,
+				Expected: []sql.Row{
+					{types.NewOkResult(2)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1, c2, c3`,
+				Expected: []sql.Row{
+					{0, nil, 0},
+					{0, nil, 0},
+					{0, nil, 1},
+					{0, 0, nil},
+				},
+			},
+		},
+	},
+	{
+		Name: "insert on duplicate key for keyless table mixed ordering",
+		SetUpScript: []string{
+			`create table t (c1 int, c2 int, c3 int, unique key(c2, c1))`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 0`,
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, 0, 0},
+				},
+			},
+			{
+				Query: `insert into t(c1, c2, c3) values (0, 0, 1) on duplicate key update c3 = 0`,
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, 0, 0},
+				},
+			},
+			{
+				Query: `insert into t(c1, c2, c3) values (0, 0, 0) on duplicate key update c3 = 1`,
+				Expected: []sql.Row{
+					{types.NewOkResult(2)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, 0, 1},
+				},
+			},
+		},
+	},
+	{
 		Name: "Insert throws primary key violations",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY key);",
@@ -2299,4 +2420,25 @@ var InsertBrokenScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "insert on duplicate key for keyless table multiple unique columns all at once",
+		SetUpScript: []string{
+			`create table t (c1 int, c2 int, c3 int, unique key(c1,c2))`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `insert into t(c1, c2, c3) values (0, 0, 0), (0, 0, 0), (0, 0, 1), (0, 0, 1) on duplicate key update c3 = 1`,
+				Expected: []sql.Row{
+					{types.NewOkResult(5)},
+				},
+			},
+			{
+				Query: `select c1, c2, c3 from t order by c1`,
+				Expected: []sql.Row{
+					{0, 0, 1},
+				},
+			},
+		},
+	},
+
 }

--- a/memory/table_editor.go
+++ b/memory/table_editor.go
@@ -615,6 +615,7 @@ func (k *keylessTableEditAccumulator) Insert(value sql.Row) error {
 
 		if eq {
 			k.deletes = append(k.deletes[:i], k.deletes[i+1:]...)
+			return nil
 		}
 	}
 
@@ -632,6 +633,7 @@ func (k *keylessTableEditAccumulator) Delete(value sql.Row) error {
 
 		if eq {
 			k.adds = append(k.adds[:i], k.adds[i+1:]...)
+			return nil
 		}
 
 	}


### PR DESCRIPTION
small change to in memory table edit accumulators to only remove rows once from `adds` and `deletes` for `Insert()` and `Delete()`

companion pr: https://github.com/dolthub/dolt/pull/5514