### PR TITLE
SHOW PROCESSLIST improvements.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -327,10 +327,10 @@ func clearAutocommitTransaction(ctx *sql.Context) error {
 }
 
 // CloseSession deletes session specific prepared statement data
-func (e *Engine) CloseSession(ctx *sql.Context) {
+func (e *Engine) CloseSession(connID uint32) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.PreparedDataCache.DeleteSessionData(ctx.Session.ID())
+	e.PreparedDataCache.DeleteSessionData(connID)
 }
 
 // Count number of BindVars in given tree

--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -327,7 +327,7 @@ func TestTrackProcess(t *testing.T) {
 
 	procs := ctx.ProcessList.Processes()
 	require.Len(procs, 1)
-	require.Equal(procs[0].Command, "Sleep")
+	require.Equal(procs[0].Command, sql.ProcessCommandSleep)
 	require.Error(ctx.Err())
 }
 

--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -115,14 +115,16 @@ func TestLocks(t *testing.T) {
 	analyzer := analyzer.NewDefault(pro)
 	engine := sqle.New(analyzer, new(sqle.Config))
 
-	ctx := enginetest.NewContext(enginetest.NewDefaultMemoryHarness()).WithCurrentDB("db")
+	ctx := enginetest.NewContext(enginetest.NewDefaultMemoryHarness())
+	ctx.SetCurrentDatabase("db")
 	sch, iter, err := engine.Query(ctx, "LOCK TABLES t1 READ, t2 WRITE, t3 READ")
 	require.NoError(err)
 
 	_, err = sql.RowIterToRows(ctx, sch, iter)
 	require.NoError(err)
 
-	ctx = enginetest.NewContext(enginetest.NewDefaultMemoryHarness()).WithCurrentDB("db")
+	ctx = enginetest.NewContext(enginetest.NewDefaultMemoryHarness())
+	ctx.SetCurrentDatabase("db")
 	sch, iter, err = engine.Query(ctx, "UNLOCK TABLES")
 	require.NoError(err)
 
@@ -370,7 +372,8 @@ func TestUnlockTables(t *testing.T) {
 
 	catalog := analyzer.NewCatalog(sql.NewDatabaseProvider(db))
 
-	ctx := sql.NewContext(context.Background()).WithCurrentDB("db").WithCurrentDB("db")
+	ctx := sql.NewContext(context.Background())
+	ctx.SetCurrentDatabase("db")
 	catalog.LockTable(ctx, "foo")
 	catalog.LockTable(ctx, "bar")
 

--- a/enginetest/example_test.go
+++ b/enginetest/example_test.go
@@ -30,7 +30,8 @@ func Example() {
 	db := createTestDatabase()
 	e := sqle.NewDefault(sql.NewDatabaseProvider(db))
 
-	ctx := sql.NewContext(context.Background()).WithCurrentDB("test")
+	ctx := sql.NewContext(context.Background())
+	ctx.SetCurrentDatabase("test")
 
 	_, r, err := e.Query(ctx, `SELECT name, count(*) FROM mytable
 	WHERE name = 'John Doe'

--- a/enginetest/initialization.go
+++ b/enginetest/initialization.go
@@ -78,7 +78,7 @@ func NewSession(harness Harness) *sql.Context {
 	currentDB := ctx.GetCurrentDatabase()
 	if currentDB == "" {
 		currentDB = "mydb"
-		ctx.WithCurrentDB(currentDB)
+		ctx.SetCurrentDatabase(currentDB)
 	}
 
 	_ = ctx.GetViewRegistry().Register(currentDB,

--- a/enginetest/sqllogictest/harness/memory_harness.go
+++ b/enginetest/sqllogictest/harness/memory_harness.go
@@ -66,7 +66,8 @@ func (h *memoryHarness) ExecuteStatement(statement string) error {
 var pid uint32
 
 func (h *memoryHarness) newContext() *sql.Context {
-	ctx := h.harness.NewContext().WithCurrentDB("mydb")
+	ctx := h.harness.NewContext()
+	ctx.SetCurrentDatabase("mydb")
 	ctx.ApplyOpts(sql.WithPid(uint64(atomic.AddUint32(&pid, 1))))
 	return ctx
 }

--- a/enginetest/testdata.go
+++ b/enginetest/testdata.go
@@ -29,7 +29,8 @@ import (
 // wrapInTransaction runs the function given surrounded in a transaction. If the db provided doesn't implement
 // sql.TransactionDatabase, then the function is simply run and the transaction logic is a no-op.
 func wrapInTransaction(t *testing.T, db sql.Database, harness Harness, fn func()) {
-	ctx := NewContext(harness).WithCurrentDB(db.Name())
+	ctx := NewContext(harness)
+	ctx.SetCurrentDatabase(db.Name())
 	if privilegedDatabase, ok := db.(mysql_db.PrivilegedDatabase); ok {
 		db = privilegedDatabase.Unwrap()
 	}

--- a/processlist.go
+++ b/processlist.go
@@ -73,7 +73,9 @@ func (pl *ProcessList) AddProcess(
 
 	pl.procs[ctx.Pid()] = &sql.Process{
 		Pid:        ctx.Pid(),
-		Connection: ctx.ID(),
+		Connection: ctx.Session.ID(),
+		Host:       ctx.Session.Client().Address,
+		Database:   ctx.Session.GetCurrentDatabase(),
 		Query:      query,
 		Progress:   make(map[string]sql.TableProgress),
 		User:       ctx.Session.Client().User,

--- a/processlist.go
+++ b/processlist.go
@@ -64,7 +64,7 @@ func (pl *ProcessList) AddConnection(id uint32, addr string) {
 	defer pl.mu.Unlock()
 	pl.procs[id] = &sql.Process{
 		Connection: id,
-		Command:    "Connect",
+		Command:    sql.ProcessCommandConnect,
 		Host:       addr,
 		User:       "unauthenticated user",
 		StartedAt:  time.Now(),
@@ -76,7 +76,7 @@ func (pl *ProcessList) ConnectionReady(sess sql.Session) {
 	defer pl.mu.Unlock()
 	pl.procs[sess.ID()] = &sql.Process{
 		Connection: sess.ID(),
-		Command:    "Sleep",
+		Command:    sql.ProcessCommandSleep,
 		Host:       sess.Client().Address,
 		User:       sess.Client().User,
 		StartedAt:  time.Now(),
@@ -115,7 +115,7 @@ func (pl *ProcessList) BeginQuery(
 	newCtx, cancel := context.WithCancel(ctx)
 	ctx = ctx.WithContext(newCtx)
 
-	p.Command = "Query"
+	p.Command = sql.ProcessCommandQuery
 	p.Query = query
 	p.QueryPid = pid
 	p.StartedAt = time.Now()
@@ -135,7 +135,7 @@ func (pl *ProcessList) EndQuery(ctx *sql.Context) {
 	delete(pl.byQueryPid, pid)
 	p := pl.procs[id]
 	if p != nil && p.QueryPid == pid {
-		p.Command = "Sleep"
+		p.Command = sql.ProcessCommandSleep
 		p.Query = ""
 		p.StartedAt = time.Now()
 		p.Kill()

--- a/processlist.go
+++ b/processlist.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -27,14 +28,16 @@ import (
 // ProcessList is a structure that keeps track of all the processes and their
 // status.
 type ProcessList struct {
-	mu    sync.RWMutex
-	procs map[uint64]*sql.Process
+	mu         sync.RWMutex
+	procs      map[uint32]*sql.Process
+	byQueryPid map[uint64]uint32
 }
 
 // NewProcessList creates a new process list.
 func NewProcessList() *ProcessList {
 	return &ProcessList{
-		procs: make(map[uint64]*sql.Process),
+		procs:      make(map[uint32]*sql.Process),
+		byQueryPid: make(map[uint64]uint32),
 	}
 }
 
@@ -56,34 +59,90 @@ func (pl *ProcessList) Processes() []sql.Process {
 	return result
 }
 
-// AddProcess adds a new process to the list given a process type and a query
-func (pl *ProcessList) AddProcess(
+func (pl *ProcessList) AddConnection(id uint32, addr string) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	pl.procs[id] = &sql.Process{
+		Connection: id,
+		Command:    "Connect",
+		Host:       addr,
+		User:       "unauthenticated user",
+		StartedAt:  time.Now(),
+	}
+}
+
+func (pl *ProcessList) ConnectionReady(sess sql.Session) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	pl.procs[sess.ID()] = &sql.Process{
+		Connection: sess.ID(),
+		Command:    "Sleep",
+		Host:       sess.Client().Address,
+		User:       sess.Client().User,
+		StartedAt:  time.Now(),
+	}
+}
+
+func (pl *ProcessList) RemoveConnection(connID uint32) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	p := pl.procs[connID]
+	if p != nil {
+		if p.Kill != nil {
+			p.Kill()
+		}
+		delete(pl.byQueryPid, p.QueryPid)
+		delete(pl.procs, connID)
+	}
+}
+
+func (pl *ProcessList) BeginQuery(
 	ctx *sql.Context,
 	query string,
 ) (*sql.Context, error) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
-
-	if _, ok := pl.procs[ctx.Pid()]; ok {
-		return nil, sql.ErrPidAlreadyUsed.New(ctx.Pid())
+	id := ctx.Session.ID()
+	pid := ctx.Pid()
+	p := pl.procs[id]
+	if p == nil {
+		return nil, errors.New("internal error: connection not registered with process list")
+	}
+	if _, ok := pl.byQueryPid[pid]; ok {
+		return nil, sql.ErrPidAlreadyUsed.New(pid)
 	}
 
 	newCtx, cancel := context.WithCancel(ctx)
 	ctx = ctx.WithContext(newCtx)
 
-	pl.procs[ctx.Pid()] = &sql.Process{
-		Pid:        ctx.Pid(),
-		Connection: ctx.Session.ID(),
-		Host:       ctx.Session.Client().Address,
-		Database:   ctx.Session.GetCurrentDatabase(),
-		Query:      query,
-		Progress:   make(map[string]sql.TableProgress),
-		User:       ctx.Session.Client().User,
-		StartedAt:  time.Now(),
-		Kill:       cancel,
-	}
+	p.Command = "Query"
+	p.Query = query
+	p.QueryPid = pid
+	p.StartedAt = time.Now()
+	p.Kill = cancel
+	p.Progress = make(map[string]sql.TableProgress)
+
+	pl.byQueryPid[ctx.Pid()] = ctx.Session.ID()
 
 	return ctx, nil
+}
+
+func (pl *ProcessList) EndQuery(ctx *sql.Context) {
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	id := ctx.Session.ID()
+	pid := ctx.Pid()
+	delete(pl.byQueryPid, pid)
+	p := pl.procs[id]
+	if p != nil && p.QueryPid == pid {
+		p.Command = "Sleep"
+		p.Query = ""
+		p.StartedAt = time.Now()
+		p.Kill()
+		p.Kill = nil
+		p.QueryPid = 0
+		p.Progress = nil
+	}
 }
 
 // UpdateTableProgress updates the progress of the table with the given name for the
@@ -92,7 +151,11 @@ func (pl *ProcessList) UpdateTableProgress(pid uint64, name string, delta int64)
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	p, ok := pl.procs[pid]
+	id, ok := pl.byQueryPid[pid]
+	if !ok {
+		return
+	}
+	p, ok := pl.procs[id]
 	if !ok {
 		return
 	}
@@ -112,7 +175,11 @@ func (pl *ProcessList) UpdatePartitionProgress(pid uint64, tableName, partitionN
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	p, ok := pl.procs[pid]
+	id, ok := pl.byQueryPid[pid]
+	if !ok {
+		return
+	}
+	p, ok := pl.procs[id]
 	if !ok {
 		return
 	}
@@ -137,7 +204,11 @@ func (pl *ProcessList) AddTableProgress(pid uint64, name string, total int64) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	p, ok := pl.procs[pid]
+	id, ok := pl.byQueryPid[pid]
+	if !ok {
+		return
+	}
+	p, ok := pl.procs[id]
 	if !ok {
 		return
 	}
@@ -156,7 +227,11 @@ func (pl *ProcessList) AddPartitionProgress(pid uint64, tableName, partitionName
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	p, ok := pl.procs[pid]
+	id, ok := pl.byQueryPid[pid]
+	if !ok {
+		return
+	}
+	p, ok := pl.procs[id]
 	if !ok {
 		return
 	}
@@ -181,7 +256,11 @@ func (pl *ProcessList) RemoveTableProgress(pid uint64, name string) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	p, ok := pl.procs[pid]
+	id, ok := pl.byQueryPid[pid]
+	if !ok {
+		return
+	}
+	p, ok := pl.procs[id]
 	if !ok {
 		return
 	}
@@ -195,7 +274,11 @@ func (pl *ProcessList) RemovePartitionProgress(pid uint64, tableName, partitionN
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	p, ok := pl.procs[pid]
+	id, ok := pl.byQueryPid[pid]
+	if !ok {
+		return
+	}
+	p, ok := pl.procs[id]
 	if !ok {
 		return
 	}
@@ -213,24 +296,9 @@ func (pl *ProcessList) Kill(connID uint32) {
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	for pid, proc := range pl.procs {
-		if proc.Connection == connID {
-			logrus.Infof("kill query: pid %d", pid)
-			proc.Done()
-			delete(pl.procs, pid)
-		}
+	p := pl.procs[connID]
+	if p != nil && p.Kill != nil {
+		logrus.Infof("kill query: pid %d", p.QueryPid)
+		p.Kill()
 	}
-}
-
-// Done removes the finished process with the given pid from the process list.
-// If the process does not exist, it will do nothing.
-func (pl *ProcessList) Done(pid uint64) {
-	pl.mu.Lock()
-	defer pl.mu.Unlock()
-
-	if proc, ok := pl.procs[pid]; ok {
-		proc.Done()
-	}
-
-	delete(pl.procs, pid)
 }

--- a/processlist_test.go
+++ b/processlist_test.go
@@ -53,7 +53,7 @@ func TestProcessList(t *testing.T) {
 		},
 		User:      "foo",
 		Query:     "SELECT foo",
-		Command:   "Query",
+		Command:   sql.ProcessCommandQuery,
 		StartedAt: p.procs[1].StartedAt,
 	}
 	require.NotNil(p.procs[1].Kill)
@@ -119,7 +119,7 @@ func TestProcessList(t *testing.T) {
 	require.Len(p.procs, 2)
 	proc, ok := p.procs[2]
 	require.True(ok)
-	require.Equal("Sleep", proc.Command)
+	require.Equal(sql.ProcessCommandSleep, proc.Command)
 }
 
 func sortById(slice []sql.Process) {

--- a/processlist_test.go
+++ b/processlist_test.go
@@ -27,8 +27,9 @@ import (
 func TestProcessList(t *testing.T) {
 	require := require.New(t)
 
+	clientHost := "127.0.0.1:34567"
 	p := NewProcessList()
-	sess := sql.NewBaseSessionWithClientServer("0.0.0.0:3306", sql.Client{Address: "127.0.0.1:34567", User: "foo"}, 1)
+	sess := sql.NewBaseSessionWithClientServer("0.0.0.0:3306", sql.Client{Address: clientHost, User: "foo"}, 1)
 	ctx := sql.NewContext(context.Background(), sql.WithPid(1), sql.WithSession(sess))
 	ctx, err := p.AddProcess(ctx, "SELECT foo")
 	require.NoError(err)
@@ -42,6 +43,7 @@ func TestProcessList(t *testing.T) {
 	expectedProcess := &sql.Process{
 		Pid:        1,
 		Connection: 1,
+		Host:       clientHost,
 		Progress: map[string]sql.TableProgress{
 			"a": {sql.Progress{Name: "a", Done: 0, Total: 5}, map[string]sql.PartitionProgress{}},
 			"b": {sql.Progress{Name: "b", Done: 0, Total: 6}, map[string]sql.PartitionProgress{}},

--- a/server/handler.go
+++ b/server/handler.go
@@ -92,7 +92,7 @@ func (h *Handler) NewConnection(c *mysql.Conn) {
 		h.sel.ClientConnected()
 	}
 
-	h.sm.BeginConn(c)
+	h.sm.AddConn(c)
 
 	c.DisableClientMultiStatements = h.disableMultiStmts
 	logrus.WithField(sql.ConnectionIdLogField, c.ConnectionID).WithField("DisableClientMultiStatements", c.DisableClientMultiStatements).Infof("NewConnection")
@@ -146,7 +146,7 @@ func (h *Handler) ConnectionClosed(c *mysql.Conn) {
 		}
 	}()
 
-	defer h.sm.CloseConn(c)
+	defer h.sm.RemoveConn(c)
 	defer h.e.CloseSession(c.ConnectionID)
 
 	if ctx, err := h.sm.NewContextWithQuery(c, ""); err != nil {

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -531,7 +531,8 @@ func TestHandlerKill(t *testing.T) {
 	conn2 := newConn(2)
 	handler.NewConnection(conn2)
 
-	require.Len(handler.sm.sessions, 2)
+	require.Len(handler.sm.connections, 2)
+	require.Len(handler.sm.sessions, 0)
 
 	handler.ComInitDB(conn2, "test")
 	err := handler.ComQuery(conn2, "KILL QUERY 1", func(res *sqltypes.Result, more bool) error {
@@ -540,6 +541,8 @@ func TestHandlerKill(t *testing.T) {
 	require.NoError(err)
 
 	require.False(conn1.Conn.(*mockConn).closed)
+	require.Len(handler.sm.connections, 2)
+	require.Len(handler.sm.sessions, 1)
 
 	err = handler.sm.SetDB(conn1, "test")
 	require.NoError(err)

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -19,11 +19,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"reflect"
 	"strconv"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -42,7 +40,7 @@ import (
 func TestHandlerOutput(t *testing.T) {
 
 	e := setupMemDB(require.New(t))
-	dummyConn := &mysql.Conn{ConnectionID: 1}
+	dummyConn := newConn(1)
 	handler := NewHandler(
 		e,
 		NewSessionManager(
@@ -165,7 +163,7 @@ func TestHandlerOutput(t *testing.T) {
 
 func TestHandlerComPrepare(t *testing.T) {
 	e := setupMemDB(require.New(t))
-	dummyConn := &mysql.Conn{ConnectionID: 1}
+	dummyConn := newConn(1)
 	handler := NewHandler(
 		e,
 		NewSessionManager(
@@ -239,7 +237,7 @@ func TestHandlerComPrepare(t *testing.T) {
 
 func TestHandlerComPrepareExecute(t *testing.T) {
 	e := setupMemDB(require.New(t))
-	dummyConn := &mysql.Conn{ConnectionID: 1}
+	dummyConn := newConn(1)
 	handler := NewHandler(
 		e,
 		NewSessionManager(
@@ -316,7 +314,7 @@ func TestHandlerComPrepareExecute(t *testing.T) {
 
 func TestHandlerComPrepareExecuteWithPreparedDisabled(t *testing.T) {
 	e := setupMemDB(require.New(t))
-	dummyConn := &mysql.Conn{ConnectionID: 1}
+	dummyConn := newConn(1)
 	handler := NewHandler(
 		e,
 		NewSessionManager(
@@ -533,23 +531,21 @@ func TestHandlerKill(t *testing.T) {
 	conn2 := newConn(2)
 	handler.NewConnection(conn2)
 
-	require.Len(handler.sm.sessions, 0)
+	require.Len(handler.sm.sessions, 2)
 
 	handler.ComInitDB(conn2, "test")
 	err := handler.ComQuery(conn2, "KILL QUERY 1", func(res *sqltypes.Result, more bool) error {
 		return nil
 	})
-
 	require.NoError(err)
 
-	require.Len(handler.sm.sessions, 1)
-	assertNoConnProcesses(t, e, conn2.ConnectionID)
+	require.False(conn1.Conn.(*mockConn).closed)
 
 	err = handler.sm.SetDB(conn1, "test")
 	require.NoError(err)
 	ctx1, err := handler.sm.NewContextWithQuery(conn1, "SELECT 1")
 	require.NoError(err)
-	ctx1, err = handler.e.ProcessList.AddProcess(ctx1, "SELECT 1")
+	ctx1, err = handler.e.ProcessList.BeginQuery(ctx1, "SELECT 1")
 	require.NoError(err)
 
 	err = handler.ComQuery(conn2, "KILL "+fmt.Sprint(ctx1.ID()), func(res *sqltypes.Result, more bool) error {
@@ -557,18 +553,10 @@ func TestHandlerKill(t *testing.T) {
 	})
 	require.NoError(err)
 
+	require.Error(ctx1.Err())
+	require.True(conn1.Conn.(*mockConn).closed)
+	handler.ConnectionClosed(conn1)
 	require.Len(handler.sm.sessions, 1)
-	assertNoConnProcesses(t, e, conn1.ConnectionID)
-}
-
-func assertNoConnProcesses(t *testing.T, e *sqle.Engine, conn uint32) {
-	t.Helper()
-
-	for _, p := range e.ProcessList.Processes() {
-		if p.Connection == conn {
-			t.Errorf("expecting no processes with connection id %d", conn)
-		}
-	}
 }
 
 func TestSchemaToFields(t *testing.T) {
@@ -916,7 +904,7 @@ func TestBindingsToExprs(t *testing.T) {
 // Tests the CLIENT_FOUND_ROWS capabilities flag
 func TestHandlerFoundRowsCapabilities(t *testing.T) {
 	e := setupMemDB(require.New(t))
-	dummyConn := &mysql.Conn{ConnectionID: 1}
+	dummyConn := newConn(1)
 
 	// Set the capabilities to include found rows
 	dummyConn.Capabilities = mysql.CapabilityClientFoundRows
@@ -1064,20 +1052,31 @@ func testSessionBuilder(ctx context.Context, c *mysql.Conn, addr string) (sql.Se
 
 type mockConn struct {
 	net.Conn
+	closed bool
 }
 
-func (c *mockConn) Close() error { return nil }
+func (c *mockConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *mockConn) RemoteAddr() net.Addr {
+	return mockAddr{}
+}
+
+type mockAddr struct{}
+
+func (mockAddr) Network() string {
+	return "tcp"
+}
+
+func (mockAddr) String() string {
+	return "localhost"
+}
 
 func newConn(id uint32) *mysql.Conn {
-	conn := &mysql.Conn{
+	return &mysql.Conn{
 		ConnectionID: id,
+		Conn:         new(mockConn),
 	}
-
-	// Set conn so it does not panic when we close it
-	val := reflect.ValueOf(conn).Elem()
-	field := val.FieldByName("Conn")
-	field = reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem()
-	field.Set(reflect.ValueOf(new(mockConn)))
-
-	return conn
 }

--- a/sql/analyzer/analyzer_test.go
+++ b/sql/analyzer/analyzer_test.go
@@ -60,7 +60,8 @@ func TestMaxIterations(t *testing.T) {
 			return n, transform.NewTree, nil
 		}).Build())
 
-	ctx := sql.NewContext(context.Background()).WithCurrentDB("mydb")
+	ctx := sql.NewContext(context.Background())
+	ctx.SetCurrentDatabase("mydb")
 	notAnalyzed := plan.NewUnresolvedTable(tName, "")
 	analyzed, err := a.Analyze(ctx, notAnalyzed, nil)
 	require.Error(err)

--- a/sql/analyzer/assign_catalog_test.go
+++ b/sql/analyzer/assign_catalog_test.go
@@ -33,7 +33,8 @@ func TestAssignCatalog(t *testing.T) {
 	provider := sql.NewDatabaseProvider(db)
 
 	a := NewDefault(provider)
-	ctx := sql.NewContext(context.Background()).WithCurrentDB("foo")
+	ctx := sql.NewContext(context.Background())
+	ctx.SetCurrentDatabase("foo")
 
 	tbl := memory.NewTable("foo", sql.PrimaryKeySchema{}, db.GetForeignKeyCollection())
 

--- a/sql/analyzer/process.go
+++ b/sql/analyzer/process.go
@@ -135,7 +135,7 @@ func trackProcess(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel R
 	}
 
 	return plan.NewQueryProcess(node, func() {
-		processList.Done(ctx.Pid())
+		processList.EndQuery(ctx)
 		if span := ctx.RootSpan(); span != nil {
 			span.End()
 		}

--- a/sql/analyzer/resolve_subqueries_test.go
+++ b/sql/analyzer/resolve_subqueries_test.go
@@ -132,7 +132,8 @@ func TestResolveSubqueries(t *testing.T) {
 		},
 	}
 
-	ctx := sql.NewContext(context.Background()).WithCurrentDB("mydb")
+	ctx := sql.NewContext(context.Background())
+	ctx.SetCurrentDatabase("mydb")
 	resolveSubqueries := getRule(resolveSubqueriesId)
 	cacheSubqueryResults := getRule(cacheSubqueryResultsId)
 	finalizeSubqueries := getRule(finalizeSubqueriesId)
@@ -425,7 +426,8 @@ func TestResolveSubqueryExpressions(t *testing.T) {
 		},
 	}
 
-	ctx := sql.NewContext(context.Background()).WithCurrentDB("mydb")
+	ctx := sql.NewContext(context.Background())
+	ctx.SetCurrentDatabase("mydb")
 	runTestCases(t, ctx, testCases, a, getRule(resolveSubqueriesId))
 }
 
@@ -474,7 +476,8 @@ func TestFinalizeSubqueryExpressions(t *testing.T) {
 		},
 	}
 
-	ctx := sql.NewContext(context.Background()).WithCurrentDB("mydb")
+	ctx := sql.NewContext(context.Background())
+	ctx.SetCurrentDatabase("mydb")
 	runTestCases(t, ctx, testCases, a, getRule(finalizeSubqueriesId))
 }
 

--- a/sql/analyzer/resolve_tables_test.go
+++ b/sql/analyzer/resolve_tables_test.go
@@ -35,7 +35,8 @@ func TestResolveTables(t *testing.T) {
 	db.AddTableAsOf("mytable", table, "2019-01-01")
 
 	a := NewBuilder(sql.NewDatabaseProvider(db)).AddPostAnalyzeRule(f.Id, f.Apply).Build()
-	ctx := sql.NewEmptyContext().WithCurrentDB("mydb")
+	ctx := sql.NewEmptyContext()
+	ctx.SetCurrentDatabase("mydb")
 
 	var notAnalyzed sql.Node = plan.NewUnresolvedTable("mytable", "")
 	analyzed, _, err := f.Apply(ctx, a, notAnalyzed, nil, DefaultRuleSelector)
@@ -102,7 +103,8 @@ func TestResolveTablesNested(t *testing.T) {
 	db2.AddTable("my_other_table", table2)
 
 	a := NewBuilder(sql.NewDatabaseProvider(db, db2)).AddPostAnalyzeRule(f.Id, f.Apply).Build()
-	ctx := sql.NewEmptyContext().WithCurrentDB("mydb")
+	ctx := sql.NewEmptyContext()
+	ctx.SetCurrentDatabase("mydb")
 
 	notAnalyzed := plan.NewProject(
 		[]sql.Expression{expression.NewGetField(0, types.Int32, "i", true)},

--- a/sql/analyzer/resolve_views_test.go
+++ b/sql/analyzer/resolve_views_test.go
@@ -69,7 +69,8 @@ func TestResolveViews(t *testing.T) {
 
 	sess := sql.NewBaseSession()
 	sess.SetViewRegistry(viewReg)
-	ctx := sql.NewContext(context.Background(), sql.WithSession(sess)).WithCurrentDB("mydb")
+	ctx := sql.NewContext(context.Background(), sql.WithSession(sess))
+	ctx.SetCurrentDatabase("mydb")
 
 	// AS OF expressions on a view should be pushed down to unresolved tables
 	var notAnalyzed sql.Node = plan.NewUnresolvedTable("myview1", "")

--- a/sql/plan/processlist.go
+++ b/sql/plan/processlist.go
@@ -34,11 +34,15 @@ type process struct {
 }
 
 func (p process) toRow() sql.Row {
+	var db interface{}
+	if p.db != "" {
+		db = p.db
+	}
 	return sql.NewRow(
 		p.id,
 		p.user,
 		p.host,
-		p.db,
+		db,
 		p.command,
 		p.time,
 		p.state,
@@ -127,9 +131,9 @@ func (p *ShowProcessList) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, e
 			time:    int64(proc.Seconds()),
 			state:   strings.Join(status, ""),
 			command: "Query",
-			host:    ctx.Session.Client().Address,
+			host:    proc.Host,
 			info:    proc.Query,
-			db:      p.Database,
+			db:      proc.Database,
 		}.toRow()
 	}
 

--- a/sql/plan/processlist.go
+++ b/sql/plan/processlist.go
@@ -121,7 +121,7 @@ func (p *ShowProcessList) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, e
 			status = append(status, printer.String())
 		}
 
-		if len(status) == 0 && proc.Command == "Query" {
+		if len(status) == 0 && proc.Command == sql.ProcessCommandQuery {
 			status = []string{"running"}
 		}
 
@@ -130,7 +130,7 @@ func (p *ShowProcessList) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, e
 			user:    proc.User,
 			time:    int64(proc.Seconds()),
 			state:   strings.Join(status, ""),
-			command: proc.Command,
+			command: string(proc.Command),
 			host:    proc.Host,
 			info:    proc.Query,
 			db:      proc.Database,

--- a/sql/plan/processlist.go
+++ b/sql/plan/processlist.go
@@ -121,7 +121,7 @@ func (p *ShowProcessList) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, e
 			status = append(status, printer.String())
 		}
 
-		if len(status) == 0 {
+		if len(status) == 0 && proc.Command == "Query" {
 			status = []string{"running"}
 		}
 
@@ -130,7 +130,7 @@ func (p *ShowProcessList) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, e
 			user:    proc.User,
 			time:    int64(proc.Seconds()),
 			state:   strings.Join(status, ""),
-			command: "Query",
+			command: proc.Command,
 			host:    proc.Host,
 			info:    proc.Query,
 			db:      proc.Database,

--- a/sql/plan/showtablestatus_test.go
+++ b/sql/plan/showtablestatus_test.go
@@ -40,7 +40,8 @@ func TestShowTableStatus(t *testing.T) {
 	node := NewShowTableStatus(db1)
 	node.Catalog = catalog
 
-	ctx := sql.NewEmptyContext().WithCurrentDB("a")
+	ctx := sql.NewEmptyContext()
+	ctx.SetCurrentDatabase("a")
 	iter, err := node.RowIter(ctx, nil)
 	require.NoError(err)
 

--- a/sql/processlist.go
+++ b/sql/processlist.go
@@ -68,17 +68,25 @@ type ProcessList interface {
 	RemovePartitionProgress(pid uint64, tableName, partitionName string)
 }
 
+type ProcessCommand string
+const (
+	// During initial connection and handshake.
+	ProcessCommandConnect ProcessCommand = "Connect"
+	// Connected, not running a query.
+	ProcessCommandSleep ProcessCommand = "Sleep"
+	// Currently running a query, possibly streaming the response.
+	ProcessCommandQuery ProcessCommand = "Query"
+)
+
 // Process represents a process in the SQL server.
 type Process struct {
 	Connection uint32
 	Host       string
 	Database   string
 	User       string
-	// Connect, on initial connection
-	// Sleep, while the connection is idle.
-	// Query, while a query is running.
-	Command string
-	// The time of the last Query transition...
+	Command    ProcessCommand
+
+	// The time of the last Command transition...
 	StartedAt time.Time
 
 	QueryPid uint64

--- a/sql/processlist.go
+++ b/sql/processlist.go
@@ -69,6 +69,7 @@ type ProcessList interface {
 }
 
 type ProcessCommand string
+
 const (
 	// During initial connection and handshake.
 	ProcessCommandConnect ProcessCommand = "Connect"

--- a/sql/processlist.go
+++ b/sql/processlist.go
@@ -24,14 +24,24 @@ type ProcessList interface {
 	// Processes returns the list of current running processes
 	Processes() []Process
 
-	// AddProcess adds a new process to the list and returns a new context that can be used to cancel it
-	AddProcess(ctx *Context, query string) (*Context, error)
+	// AddConnection adds a new connection to the process list. Must be matched with RemoveConnection.
+	AddConnection(connID uint32, addr string)
+
+	// Transitions a connection from Connect to Sleep.
+	ConnectionReady(sess Session)
+
+	// RemoveConnection removes the connection from the process list.
+	RemoveConnection(connID uint32)
+
+	// BeginQuery transitions an existing connection in the processlist from Command "Sleep" to Command "Query".
+	// Returns a new context which will be canceled when this query is done.
+	BeginQuery(ctx *Context, query string) (*Context, error)
+
+	// EndQuery transitions a previously transitioned connection from Command "Query" to Command "Sleep".
+	EndQuery(ctx *Context)
 
 	// Kill terminates all queries for a given connection id
 	Kill(connID uint32)
-
-	// Done removes the finished process with the given pid from the process list
-	Done(pid uint64)
 
 	// UpdateTableProgress updates the progress of the table with the given name for the
 	// process with the given pid.
@@ -60,15 +70,21 @@ type ProcessList interface {
 
 // Process represents a process in the SQL server.
 type Process struct {
-	Pid        uint64
 	Connection uint32
 	Host       string
 	Database   string
 	User       string
-	Query      string
-	Progress   map[string]TableProgress
-	StartedAt  time.Time
-	Kill       context.CancelFunc
+	// Connect, on initial connection
+	// Sleep, while the connection is idle.
+	// Query, while a query is running.
+	Command string
+	// The time of the last Query transition...
+	StartedAt time.Time
+
+	QueryPid uint64
+	Query    string
+	Progress map[string]TableProgress
+	Kill     context.CancelFunc
 }
 
 // Done needs to be called when this process has finished.
@@ -133,9 +149,14 @@ func (e EmptyProcessList) Processes() []Process {
 	return nil
 }
 
-func (e EmptyProcessList) AddProcess(ctx *Context, query string) (*Context, error) {
+func (e EmptyProcessList) AddConnection(id uint32, addr string) {}
+func (e EmptyProcessList) ConnectionReady(Session)              {}
+func (e EmptyProcessList) RemoveConnection(uint32)              {}
+
+func (e EmptyProcessList) BeginQuery(ctx *Context, query string) (*Context, error) {
 	return ctx, nil
 }
+func (e EmptyProcessList) EndQuery(ctx *Context) {}
 
 func (e EmptyProcessList) Kill(connID uint32)                                       {}
 func (e EmptyProcessList) Done(pid uint64)                                          {}

--- a/sql/processlist.go
+++ b/sql/processlist.go
@@ -62,6 +62,8 @@ type ProcessList interface {
 type Process struct {
 	Pid        uint64
 	Connection uint32
+	Host       string
+	Database   string
 	User       string
 	Query      string
 	Progress   map[string]TableProgress

--- a/sql/session.go
+++ b/sql/session.go
@@ -223,19 +223,10 @@ type Context struct {
 	queryTime   time.Time
 	tracer      trace.Tracer
 	rootSpan    trace.Span
-	initialDb   string
 }
 
 // ContextOption is a function to configure the context.
 type ContextOption func(*Context)
-
-// WithInitialDatabase adds the initial database name to the context.
-// Calls ctx.SetCurrentDatabase after constructing the context.
-func WithInitialDatabase(dbName string) ContextOption {
-	return func(ctx *Context) {
-		ctx.initialDb = dbName
-	}
-}
 
 // WithSession adds the given session to the context.
 func WithSession(s Session) ContextOption {
@@ -343,9 +334,6 @@ func NewContext(
 	if c.Session == nil {
 		c.Session = NewBaseSession()
 	}
-	if c.initialDb != "" {
-		c.Session.SetCurrentDatabase(c.initialDb)
-	}
 
 	return c
 }
@@ -402,11 +390,6 @@ func (c *Context) NewSubContext() (*Context, context.CancelFunc) {
 	ctx, cancelFunc := context.WithCancel(c.Context)
 
 	return c.WithContext(ctx), cancelFunc
-}
-
-func (c *Context) WithCurrentDB(db string) *Context {
-	c.SetCurrentDatabase(db)
-	return c
 }
 
 // WithContext returns a new context with the given underlying context.


### PR DESCRIPTION
Show the correct database and client address of the connection.

Include idle and connecting connections in the list, instead of just connections which are currently running queries.

Allow `KILL [ID]` to kill connections which are currently connecting.