### PR TITLE
Streamlined FK RESTRICT processing

### DIFF
--- a/sql/constraints.go
+++ b/sql/constraints.go
@@ -62,6 +62,17 @@ func (f *ForeignKeyConstraint) DebugString() string {
 	)
 }
 
+// IsEquivalentToRestrict returns whether the referential action is equivalent to RESTRICT. In MySQL, although there are
+// a number of referential actions, the majority of them are functionally ignored and default to RESTRICT.
+func (f ForeignKeyReferentialAction) IsEquivalentToRestrict() bool {
+	switch f {
+	case ForeignKeyReferentialAction_Cascade, ForeignKeyReferentialAction_SetNull:
+		return false
+	default:
+		return true
+	}
+}
+
 // CheckDefinition defines a trigger. Integrators are not expected to parse or understand the trigger definitions,
 // but must store and return them when asked.
 type CheckDefinition struct {

--- a/sql/plan/foreign_key_editor.go
+++ b/sql/plan/foreign_key_editor.go
@@ -346,7 +346,6 @@ func (fkEditor *ForeignKeyEditor) ColumnsUpdated(refActionData ForeignKeyRefActi
 
 // Close closes this handler along with all child handlers.
 func (fkEditor *ForeignKeyEditor) Close(ctx *sql.Context) error {
-	//TODO: remove this once the table collection has been added
 	err := fkEditor.Editor.Close(ctx)
 	for _, child := range fkEditor.RefActions {
 		nErr := child.Editor.Close(ctx)


### PR DESCRIPTION
One of the strategies I mentioned in https://github.com/dolthub/dolt/issues/5508 was foregoing loading child editors when all referential actions for a foreign key are `RESTRICT`. Turns out that all we needed to do is to not add the updater (which is housed inside of the editor) to the chain.

I was going to implement something a bit more complex, as we should be able to ignore all updaters that aren't actually used using runtime analysis, however I backtracked those changes as it was getting quite complex, and the added complexity did not seem worth it at all.

There are no additional tests, as this is strictly a performance improvement. Foreign keys are one of our most well-tested features, so I'm confident that it is correct with all of the tests passing.