### PR TITLE
prevent spatial index for fk

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3361,11 +3361,11 @@ var SpatialIndexScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "alter table child1 add foreign key (p) references parent (p)",
+				Query:       "alter table child1 add foreign key (p) references parent (p)",
 				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
 			},
 			{
-				Query: "create table child2 (p point not null srid 0, spatial index (p), foreign key (p) references parent (p))",
+				Query:       "create table child2 (p point not null srid 0, spatial index (p), foreign key (p) references parent (p))",
 				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3353,6 +3353,23 @@ var SpatialIndexScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "spatial indexes do not work as foreign keys",
+		SetUpScript: []string{
+			"create table parent (i int primary key, p point not null srid 0, spatial index (p))",
+			"create table child1 (j int primary key, p point not null srid 0, spatial index (p))",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "alter table child1 add foreign key (p) references parent (p)",
+				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
+			},
+			{
+				Query: "create table child2 (p point not null srid 0, spatial index (p), foreign key (p) references parent (p))",
+				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
+			},
+		},
+	},
 }
 
 var CreateCheckConstraintsScripts = []ScriptTest{

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -531,8 +531,9 @@ func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexAddressableTable, prefix
 	}
 	// ignore indexes with prefix lengths; they are unsupported in MySQL
 	// https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html#:~:text=Index%20prefixes%20on%20foreign%20key%20columns%20are%20not%20supported.
+	// ignore spatial indexes; MySQL will not pick them as the underlying secondary index for foreign keys
 	for _, idx := range indexes {
-		if len(idx.PrefixLengths()) > 0 {
+		if len(idx.PrefixLengths()) > 0 || idx.IsSpatial(){
 			ignoredIndexesMap[idx.ID()] = struct{}{}
 		}
 	}

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -533,7 +533,7 @@ func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexAddressableTable, prefix
 	// https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html#:~:text=Index%20prefixes%20on%20foreign%20key%20columns%20are%20not%20supported.
 	// ignore spatial indexes; MySQL will not pick them as the underlying secondary index for foreign keys
 	for _, idx := range indexes {
-		if len(idx.PrefixLengths()) > 0 || idx.IsSpatial(){
+		if len(idx.PrefixLengths()) > 0 || idx.IsSpatial() {
 			ignoredIndexesMap[idx.ID()] = struct{}{}
 		}
 	}


### PR DESCRIPTION
MySQL won't pick SPATIAL indexes as the underlying index for foreign keys; it throws a "Missing index constraint for ..." error. I couldn't find any docs specifically saying this.

Based off how `SPATIAL` indexes work for our stuff, it seems like it would work just fine for us.
However since MySQL doesn't support it, we won't either.