### PR TITLE
Added a permissive collation coercibility model

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5346,19 +5346,26 @@ type customFunc struct {
 	expression.UnaryExpression
 }
 
-func (c customFunc) String() string {
+var _ sql.Expression = (*customFunc)(nil)
+var _ sql.CollationCoercible = (*customFunc)(nil)
+
+func (c *customFunc) String() string {
 	return "customFunc(" + c.Child.String() + ")"
 }
 
-func (c customFunc) Type() sql.Type {
+func (c *customFunc) Type() sql.Type {
 	return types.Uint32
 }
 
-func (c customFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+func (c *customFunc) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, c.Child)
+}
+
+func (c *customFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return int64(5), nil
 }
 
-func (c customFunc) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+func (c *customFunc) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return &customFunc{expression.UnaryExpression{children[0]}}, nil
 }
 

--- a/enginetest/queries/collation_coercion.go
+++ b/enginetest/queries/collation_coercion.go
@@ -1,0 +1,351 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queries
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// CollationCoercionTest is used to test the resulting collation and coercion of a SQL expression
+type CollationCoercionTest struct {
+	Parameters   string
+	Collation    sql.CollationID
+	Coercibility int64
+	Error        bool
+}
+
+// CollationCoercionSetup is the setup that is run before every CollationCoercionTest
+var CollationCoercionSetup = []string{
+	`SET CHARACTER SET "utf8mb4";`,
+	`SET collation_connection = "utf8mb4_0900_bin";`,
+	`SET character_set_results = "binary";`,
+	`CREATE TABLE temp_tbl (v1 VARCHAR(200) COLLATE utf8mb4_0900_bin,
+    v2 VARCHAR(200) COLLATE utf8mb4_0900_as_cs DEFAULT 'z',
+    v3 VARCHAR(200) COLLATE utf8mb4_0900_ai_ci,
+    v4 VARCHAR(200) COLLATE utf8mb3_bin,
+    v5 VARCHAR(200) COLLATE utf8mb3_general_ci,
+    v6 VARCHAR(200) COLLATE latin1_bin,
+    v7 VARCHAR(200) COLLATE latin1_general_ci,
+    v8 VARBINARY(200));`,
+	`INSERT INTO temp_tbl VALUES ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h');`,
+}
+
+var CollationCoercionTests = []CollationCoercionTest{
+	{
+		Parameters:   `'26:27:28'`,
+		Collation:    sql.Collation_utf8mb4_0900_bin,
+		Coercibility: 4,
+	},
+	{
+		Parameters:   `'str' COLLATE utf8mb4_bin`,
+		Collation:    sql.Collation_utf8mb4_bin,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `1001`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `2002.5`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CONVERT('2020-02-20 20:20:20', DATETIME)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CONVERT('2020-02-20', DATE)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CONVERT('23:24:25', TIME)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CONVERT('34', BINARY)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `CONVERT('34', SIGNED)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CONVERT('34', UNSIGNED)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CONVERT('[1]', JSON)`,
+		Collation:    sql.Collation_utf8mb4_bin,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `CURDATE()`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CURRENT_USER()`,
+		Collation:    sql.Collation_utf8_general_ci,
+		Coercibility: 3,
+	},
+	{
+		Parameters:   `FALSE`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `TRUE`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `NOW()`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `NULL`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 6,
+	},
+	{
+		Parameters:   `UUID()`,
+		Collation:    sql.Collation_utf8_general_ci,
+		Coercibility: 4,
+	},
+	{
+		Parameters:   `v1`,
+		Collation:    sql.Collation_utf8mb4_0900_bin,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v1 COLLATE utf8mb4_0900_bin`,
+		Collation:    sql.Collation_utf8mb4_0900_bin,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `v2`,
+		Collation:    sql.Collation_utf8mb4_0900_as_cs,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v2 COLLATE utf8mb4_0900_as_cs`,
+		Collation:    sql.Collation_utf8mb4_0900_as_cs,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `v3`,
+		Collation:    sql.Collation_utf8mb4_0900_ai_ci,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v3 COLLATE utf8mb4_0900_ai_ci`,
+		Collation:    sql.Collation_utf8mb4_0900_ai_ci,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `v4`,
+		Collation:    sql.Collation_utf8_bin,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v4 COLLATE utf8mb3_bin`,
+		Collation:    sql.Collation_utf8_bin,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `v5`,
+		Collation:    sql.Collation_utf8_general_ci,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v5 COLLATE utf8mb3_general_ci`,
+		Collation:    sql.Collation_utf8_general_ci,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `v6`,
+		Collation:    sql.Collation_latin1_bin,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v6 COLLATE latin1_bin`,
+		Collation:    sql.Collation_latin1_bin,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `v7`,
+		Collation:    sql.Collation_latin1_general_ci,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v7 COLLATE latin1_general_ci`,
+		Collation:    sql.Collation_latin1_general_ci,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `v8`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `v8 COLLATE 'binary'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `!('26:27:28')`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `!('str' COLLATE utf8mb4_bin)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `-(CONVERT('2020-02-20', DATE))`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `-(CONVERT('34', BINARY))`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `-(v6)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `NOT('{"a": 1, "b": {"c": 30}}')`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CURRENT_TIME() != '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `v4 != '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `FALSE * '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `FALSE * '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `v5 + '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `v5 COLLATE utf8mb3_general_ci + '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `v6 + '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `v6 COLLATE latin1_bin + '26:27:28'`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `'str' - CURRENT_TIME()`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `v2 / 1001`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `v2 COLLATE utf8mb4_0900_as_cs / 1001`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `1001 < CONVERT('34', CHAR)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `2002.5 < CONVERT('34', CHAR)`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `1001 <= RAND()`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `2002.5 <= RAND()`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `CONVERT('23:24:25', TIME) DIV NOW()`,
+		Collation:    sql.Collation_binary,
+		Coercibility: 5,
+	},
+	{
+		Parameters:   `NULLIF('str' COLLATE utf8mb4_bin, '26:27:28')`,
+		Collation:    sql.Collation_utf8mb4_bin,
+		Coercibility: 0,
+	},
+	{
+		Parameters:   `NULLIF('{"a": 1, "b": {"c": 30}}', '26:27:28')`,
+		Collation:    sql.Collation_utf8mb4_0900_bin,
+		Coercibility: 4,
+	},
+	{
+		Parameters:   `REPEAT(v1, 1001)`,
+		Collation:    sql.Collation_utf8mb4_0900_bin,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `SUBSTR(v6, CONVERT('2020-02-20 20:20:20', DATETIME))`,
+		Collation:    sql.Collation_latin1_bin,
+		Coercibility: 2,
+	},
+	{
+		Parameters:   `SUBSTR(v6 COLLATE latin1_bin, CONVERT('2020-02-20 20:20:20', DATETIME))`,
+		Collation:    sql.Collation_latin1_bin,
+		Coercibility: 0,
+	},
+}

--- a/memory/sequence_table.go
+++ b/memory/sequence_table.go
@@ -10,6 +10,7 @@ import (
 )
 
 var _ sql.TableFunction = (*IntSequenceTable)(nil)
+var _ sql.CollationCoercible = (*IntSequenceTable)(nil)
 
 // IntSequenceTable a simple table function that returns a sequence
 // of integers.
@@ -86,6 +87,11 @@ func (s IntSequenceTable) WithChildren(_ ...sql.Node) (sql.Node, error) {
 
 func (s IntSequenceTable) CheckPrivileges(_ *sql.Context, _ sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (IntSequenceTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (s IntSequenceTable) Expressions() []sql.Expression {

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -328,7 +328,7 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *Scope,
 				return e, transform.SameTree, nil
 			case *expression.Like:
 				// if the charset is not utf8mb4, the last character used in optimization rule does not work
-				coll, _ := expression.GetCollationViaCoercion(e.Left)
+				coll, _ := sql.GetCoercibility(ctx, e.Left)
 				charset := coll.CharacterSet()
 				if charset != sql.CharacterSet_utf8mb4 {
 					return e, transform.SameTree, nil

--- a/sql/analyzer/releaser.go
+++ b/sql/analyzer/releaser.go
@@ -26,6 +26,9 @@ type Releaser struct {
 	Release func()
 }
 
+var _ sql.Node = (*Releaser)(nil)
+var _ sql.CollationCoercible = (*Releaser)(nil)
+
 func (r *Releaser) Resolved() bool {
 	return r.Child.Resolved()
 }
@@ -58,6 +61,11 @@ func (r *Releaser) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (r *Releaser) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return r.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (r *Releaser) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, r.Child)
 }
 
 func (r *Releaser) String() string {

--- a/sql/analyzer/validation_rules_test.go
+++ b/sql/analyzer/validation_rules_test.go
@@ -703,6 +703,9 @@ func TestValidateSubqueryColumns(t *testing.T) {
 
 type dummyNode struct{ resolved bool }
 
+var _ sql.Node = dummyNode{}
+var _ sql.CollationCoercible = dummyNode{}
+
 func (n dummyNode) String() string                                   { return "dummynode" }
 func (n dummyNode) Resolved() bool                                   { return n.resolved }
 func (dummyNode) Schema() sql.Schema                                 { return nil }
@@ -711,6 +714,9 @@ func (dummyNode) RowIter(*sql.Context, sql.Row) (sql.RowIter, error) { return ni
 func (dummyNode) WithChildren(...sql.Node) (sql.Node, error)         { return nil, nil }
 func (dummyNode) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+func (dummyNode) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func getValidationRule(id RuleId) Rule {

--- a/sql/coercibility.go
+++ b/sql/coercibility.go
@@ -1,0 +1,96 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import "strings"
+
+// CollationCoercible represents the coercibility of an expression or node. Although the resulting value from the node
+// or expression may be NULL, this interface returns the coercibility as though a NULL would not be returned.
+type CollationCoercible interface {
+	// CollationCoercibility returns the collation and coercibility of the expression or node.
+	CollationCoercibility(ctx *Context) (collation CollationID, coercibility byte)
+}
+
+// ResolveCoercibility returns the collation to use by comparing coercibility, along with giving priority to binary
+// collations. This is an approximation of MySQL's coercibility rules:
+// https://dev.mysql.com/doc/refman/8.0/en/charset-collation-coercibility.html
+// As we do not implement the full coercion pipeline, we make some assumptions when information is missing, and never
+// error even when MySQL would find an expression invalid.
+func ResolveCoercibility(leftCollation CollationID, leftCoercibility byte, rightCollation CollationID, rightCoercibility byte) (CollationID, byte) {
+	if leftCoercibility < rightCoercibility {
+		return leftCollation, leftCoercibility
+	} else if leftCoercibility > rightCoercibility {
+		return rightCollation, rightCoercibility
+	} else if leftCollation == rightCollation {
+		return leftCollation, leftCoercibility
+	} else if leftCollation == Collation_Unspecified {
+		return rightCollation, rightCoercibility
+	} else if rightCollation == Collation_Unspecified {
+		return leftCollation, leftCoercibility
+	} else { // Collations are not equal
+		leftCharset := leftCollation.CharacterSet()
+		rightCharset := rightCollation.CharacterSet()
+		if leftCharset != rightCharset {
+			if leftCharset.MaxLength() == 1 && rightCharset.MaxLength() > 1 { // Left non-Unicode, Right Unicode
+				return rightCollation, rightCoercibility
+			} else if leftCharset.MaxLength() > 1 && rightCharset.MaxLength() == 1 { // Left Unicode, Right non-Unicode
+				return leftCollation, leftCoercibility
+			} else {
+				return Collation_binary, 7
+			}
+		} else { // Character sets are equal
+			// If the right collation is not _bin, then we default to the left collation (regardless of whether it is
+			// or is not _bin).
+			if strings.HasSuffix(rightCollation.Name(), "_bin") {
+				return rightCollation, rightCoercibility
+			} else {
+				return leftCollation, leftCoercibility
+			}
+		}
+	}
+}
+
+// GetCoercibility returns the coercibility of the given node or expression.
+func GetCoercibility(ctx *Context, nodeOrExpr interface{}) (collation CollationID, coercibility byte) {
+	if nodeOrExpr == nil {
+		return Collation_binary, 6
+	}
+	if cc, ok := nodeOrExpr.(CollationCoercible); ok {
+		return cc.CollationCoercibility(ctx)
+	}
+	collation = Collation_binary
+	coercibility = 7
+	// We check for Node, Expressioner, and Expression and take the lowest coercibility since CollationCoercible was
+	// not explicitly implemented
+	if n, ok := nodeOrExpr.(Node); ok {
+		for _, child := range n.Children() {
+			nextCollation, nextCoercibility := GetCoercibility(ctx, child)
+			collation, coercibility = ResolveCoercibility(collation, coercibility, nextCollation, nextCoercibility)
+		}
+	}
+	if e, ok := nodeOrExpr.(Expressioner); ok {
+		for _, child := range e.Expressions() {
+			nextCollation, nextCoercibility := GetCoercibility(ctx, child)
+			collation, coercibility = ResolveCoercibility(collation, coercibility, nextCollation, nextCoercibility)
+		}
+	}
+	if e, ok := nodeOrExpr.(Expression); ok {
+		for _, child := range e.Children() {
+			nextCollation, nextCoercibility := GetCoercibility(ctx, child)
+			collation, coercibility = ResolveCoercibility(collation, coercibility, nextCollation, nextCoercibility)
+		}
+	}
+	return collation, coercibility
+}

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -36,6 +36,7 @@ type ColumnDefaultValue struct {
 }
 
 var _ Expression = (*ColumnDefaultValue)(nil)
+var _ CollationCoercible = (*ColumnDefaultValue)(nil)
 
 // NewColumnDefaultValue returns a new ColumnDefaultValue expression.
 func NewColumnDefaultValue(expr Expression, outType Type, representsLiteral bool, parenthesized bool, mayReturnNil bool) (*ColumnDefaultValue, error) {
@@ -171,6 +172,14 @@ func (e *ColumnDefaultValue) Type() Type {
 	return e.outType
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (e *ColumnDefaultValue) CollationCoercibility(ctx *Context) (collation CollationID, coercibility byte) {
+	if e == nil {
+		return Collation_binary, 6
+	}
+	return GetCoercibility(ctx, e.Expression)
+}
+
 // WithChildren implements sql.Expression
 func (e *ColumnDefaultValue) WithChildren(children ...Expression) (Expression, error) {
 	if e == nil && len(children) == 0 {
@@ -209,6 +218,9 @@ type UnresolvedColumnDefault struct {
 	exprString string
 }
 
+var _ Expression = UnresolvedColumnDefault{}
+var _ CollationCoercible = UnresolvedColumnDefault{}
+
 func (u UnresolvedColumnDefault) Resolved() bool {
 	return false
 }
@@ -219,6 +231,11 @@ func (u UnresolvedColumnDefault) String() string {
 
 func (u UnresolvedColumnDefault) Type() Type {
 	panic("UnresolvedColumnDefault is a placeholder node, but Type() was called")
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (UnresolvedColumnDefault) CollationCoercibility(ctx *Context) (collation CollationID, coercibility byte) {
+	return Collation_binary, 7
 }
 
 func (u UnresolvedColumnDefault) IsNullable() bool {

--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -59,6 +59,11 @@ func (a AliasReference) Type() sql.Type {
 	return types.Null
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (AliasReference) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func (a AliasReference) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return nil, fmt.Errorf("tried to call eval on an unresolved AliasReference")
 }
@@ -71,12 +76,16 @@ func (a AliasReference) WithChildren(children ...sql.Expression) (sql.Expression
 }
 
 var _ sql.Expression = (*AliasReference)(nil)
+var _ sql.CollationCoercible = (*AliasReference)(nil)
 
 // Alias is a node that gives a name to an expression.
 type Alias struct {
 	UnaryExpression
 	name string
 }
+
+var _ sql.Expression = (*Alias)(nil)
+var _ sql.CollationCoercible = (*Alias)(nil)
 
 // NewAlias returns a new Alias node.
 func NewAlias(name string, expr sql.Expression) *Alias {
@@ -86,6 +95,11 @@ func NewAlias(name string, expr sql.Expression) *Alias {
 // Type returns the type of the expression.
 func (e *Alias) Type() sql.Type {
 	return e.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (e *Alias) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, e.Child)
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/arithmetic.go
+++ b/sql/expression/arithmetic.go
@@ -61,6 +61,7 @@ type ArithmeticOp interface {
 }
 
 var _ ArithmeticOp = (*Arithmetic)(nil)
+var _ sql.CollationCoercible = (*Arithmetic)(nil)
 
 // Arithmetic expressions include plus, minus and multiplication (+, -, *) operations.
 type Arithmetic struct {
@@ -162,6 +163,11 @@ func (a *Arithmetic) Type() sql.Type {
 	}
 
 	return floatOrDecimalType(a)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Arithmetic) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // WithChildren implements the Expression interface.
@@ -570,6 +576,9 @@ type UnaryMinus struct {
 	UnaryExpression
 }
 
+var _ sql.Expression = (*UnaryMinus)(nil)
+var _ sql.CollationCoercible = (*UnaryMinus)(nil)
+
 // NewUnaryMinus creates a new UnaryMinus expression node.
 func NewUnaryMinus(child sql.Expression) *UnaryMinus {
 	return &UnaryMinus{UnaryExpression{Child: child}}
@@ -641,6 +650,11 @@ func (e *UnaryMinus) Type() sql.Type {
 	}
 
 	return e.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UnaryMinus) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (e *UnaryMinus) String() string {

--- a/sql/expression/auto_increment.go
+++ b/sql/expression/auto_increment.go
@@ -36,6 +36,9 @@ type AutoIncrement struct {
 	autoCol *sql.Column
 }
 
+var _ sql.Expression = (*AutoIncrement)(nil)
+var _ sql.CollationCoercible = (*AutoIncrement)(nil)
+
 // NewAutoIncrement creates a new AutoIncrement expression.
 func NewAutoIncrement(ctx *sql.Context, table sql.Table, given sql.Expression) (*AutoIncrement, error) {
 	autoTbl, ok := table.(sql.AutoIncrementTable)
@@ -83,6 +86,11 @@ func (i *AutoIncrement) IsNullable() bool {
 // Type implements the Expression interface.
 func (i *AutoIncrement) Type() sql.Type {
 	return i.autoCol.Type
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (i *AutoIncrement) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, i.Child)
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -28,6 +28,9 @@ type Between struct {
 	Upper sql.Expression
 }
 
+var _ sql.Expression = (*Between)(nil)
+var _ sql.CollationCoercible = (*Between)(nil)
+
 // NewBetween creates a new Between expression.
 func NewBetween(val, lower, upper sql.Expression) *Between {
 	return &Between{val, lower, upper}
@@ -48,6 +51,11 @@ func (b *Between) Children() []sql.Expression {
 
 // Type implements the Expression interface.
 func (*Between) Type() sql.Type { return types.Boolean }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (b *Between) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, b.Val)
+}
 
 // IsNullable implements the Expression interface.
 func (b *Between) IsNullable() bool {

--- a/sql/expression/binary.go
+++ b/sql/expression/binary.go
@@ -31,6 +31,9 @@ type Binary struct {
 	UnaryExpression
 }
 
+var _ sql.Expression = (*Binary)(nil)
+var _ sql.CollationCoercible = (*Binary)(nil)
+
 func NewBinary(e sql.Expression) sql.Expression {
 	return &Binary{UnaryExpression{Child: e}}
 }
@@ -41,6 +44,11 @@ func (b *Binary) String() string {
 
 func (b *Binary) Type() sql.Type {
 	return types.LongBlob
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Binary) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 2
 }
 
 func (b *Binary) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {

--- a/sql/expression/bindvar.go
+++ b/sql/expression/bindvar.go
@@ -24,6 +24,9 @@ type BindVar struct {
 	Typ  sql.Type
 }
 
+var _ sql.Expression = (*BindVar)(nil)
+var _ sql.CollationCoercible = (*BindVar)(nil)
+
 func NewBindVar(name string) sql.Expression {
 	return &BindVar{Name: name, Typ: types.NewDeferredType(name)}
 }
@@ -38,6 +41,11 @@ func (bv *BindVar) String() string {
 
 func (bv *BindVar) Type() sql.Type {
 	return bv.Typ
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (bv *BindVar) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return bv.Typ.CollationCoercibility(ctx)
 }
 
 func (bv *BindVar) IsNullable() bool {

--- a/sql/expression/bit_ops.go
+++ b/sql/expression/bit_ops.go
@@ -34,6 +34,9 @@ type BitOp struct {
 	Op string
 }
 
+var _ sql.Expression = (*BitOp)(nil)
+var _ sql.CollationCoercible = (*BitOp)(nil)
+
 // NewBitOp creates a new BitOp sql.Expression.
 func NewBitOp(left, right sql.Expression, op string) *BitOp {
 	return &BitOp{BinaryExpression{Left: left, Right: right}, op}
@@ -99,6 +102,11 @@ func (b *BitOp) Type() sql.Type {
 	}
 
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*BitOp) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/boolean.go
+++ b/sql/expression/boolean.go
@@ -26,6 +26,9 @@ type Not struct {
 	UnaryExpression
 }
 
+var _ sql.Expression = (*Not)(nil)
+var _ sql.CollationCoercible = (*Not)(nil)
+
 // NewNot returns a new Not node.
 func NewNot(child sql.Expression) *Not {
 	return &Not{UnaryExpression{child}}
@@ -34,6 +37,11 @@ func NewNot(child sql.Expression) *Not {
 // Type implements the Expression interface.
 func (e *Not) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Not) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/case.go
+++ b/sql/expression/case.go
@@ -35,6 +35,9 @@ type Case struct {
 	Else     sql.Expression
 }
 
+var _ sql.Expression = (*Case)(nil)
+var _ sql.CollationCoercible = (*Case)(nil)
+
 // NewCase returns an new Case expression.
 func NewCase(expr sql.Expression, branches []CaseBranch, elseExpr sql.Expression) *Case {
 	return &Case{expr, branches, elseExpr}
@@ -97,6 +100,13 @@ func (c *Case) Type() sql.Type {
 		curr = combinedCaseBranchType(curr, c.Else.Type())
 	}
 	return curr
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *Case) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// This should be calculated during the expression's evaluation, but that's not possible with the
+	// current abstraction
+	return c.Type().CollationCoercibility(ctx)
 }
 
 // IsNullable implements the sql.Expression interface.

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -64,6 +64,9 @@ type Convert struct {
 	castToType string
 }
 
+var _ sql.Expression = (*Convert)(nil)
+var _ sql.CollationCoercible = (*Convert)(nil)
+
 // NewConvert creates a new Convert expression.
 func NewConvert(expr sql.Expression, castToType string) *Convert {
 	return &Convert{
@@ -108,6 +111,34 @@ func (c *Convert) Type() sql.Type {
 		return types.Uint64
 	default:
 		return types.Null
+	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *Convert) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	switch c.castToType {
+	case ConvertToBinary:
+		return sql.Collation_binary, 2
+	case ConvertToChar, ConvertToNChar:
+		return ctx.GetCollation(), 2
+	case ConvertToDate:
+		return sql.Collation_binary, 5
+	case ConvertToDatetime:
+		return sql.Collation_binary, 5
+	case ConvertToDecimal:
+		return sql.Collation_binary, 5
+	case ConvertToDouble, ConvertToReal:
+		return sql.Collation_binary, 5
+	case ConvertToJSON:
+		return ctx.GetCharacterSet().BinaryCollation(), 2
+	case ConvertToSigned:
+		return sql.Collation_binary, 5
+	case ConvertToTime:
+		return sql.Collation_binary, 5
+	case ConvertToUnsigned:
+		return sql.Collation_binary, 5
+	default:
+		return sql.Collation_binary, 7
 	}
 }
 

--- a/sql/expression/default.go
+++ b/sql/expression/default.go
@@ -23,6 +23,9 @@ type DefaultColumn struct {
 	name string
 }
 
+var _ sql.Expression = (*DefaultColumn)(nil)
+var _ sql.CollationCoercible = (*DefaultColumn)(nil)
+
 // NewDefaultColumn creates a new NewDefaultColumn expression.
 func NewDefaultColumn(name string) *DefaultColumn {
 	return &DefaultColumn{name: name}
@@ -50,6 +53,11 @@ func (*DefaultColumn) IsNullable() bool {
 // The function always panics!
 func (*DefaultColumn) Type() sql.Type {
 	panic("default column is a placeholder node, but Type was called")
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DefaultColumn) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Name implements the sql.Nameable interface.

--- a/sql/expression/distinct.go
+++ b/sql/expression/distinct.go
@@ -14,7 +14,9 @@ type DistinctExpression struct {
 	Child   sql.Expression
 }
 
+var _ sql.Expression = (*DistinctExpression)(nil)
 var _ sql.Disposable = (*DistinctExpression)(nil)
+var _ sql.CollationCoercible = (*DistinctExpression)(nil)
 
 func NewDistinctExpression(e sql.Expression) *DistinctExpression {
 	return &DistinctExpression{
@@ -64,6 +66,11 @@ func (de *DistinctExpression) String() string {
 
 func (de *DistinctExpression) Type() sql.Type {
 	return de.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (de *DistinctExpression) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, de.Child)
 }
 
 func (de *DistinctExpression) IsNullable() bool {

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -41,6 +41,7 @@ const divIntermediatePrecisionInc = 9
 const ERDivisionByZero = 1365
 
 var _ ArithmeticOp = (*Div)(nil)
+var _ sql.CollationCoercible = (*Div)(nil)
 
 // Div expression represents "/" arithmetic operation
 type Div struct {
@@ -111,6 +112,11 @@ func (d *Div) Type() sql.Type {
 	// for division operation, it's either float or decimal.Decimal type
 	// except invalid value will result it either 0 or nil
 	return floatOrDecimalType(d)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Div) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // WithChildren implements the Expression interface.
@@ -559,6 +565,7 @@ func getPrecInc(e sql.Expression, cur int) int {
 }
 
 var _ ArithmeticOp = (*IntDiv)(nil)
+var _ sql.CollationCoercible = (*IntDiv)(nil)
 
 // IntDiv expression represents integer "div" arithmetic operation
 type IntDiv struct {
@@ -632,6 +639,11 @@ func (i *IntDiv) Type() sql.Type {
 	// using max precision which is 65.
 	defType := types.MustCreateDecimalType(65, 0)
 	return defType
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IntDiv) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/function/absval.go
+++ b/sql/expression/function/absval.go
@@ -29,6 +29,7 @@ type AbsVal struct {
 }
 
 var _ sql.FunctionExpression = (*AbsVal)(nil)
+var _ sql.CollationCoercible = (*AbsVal)(nil)
 
 // NewAbsVal creates a new AbsVal expression.
 func NewAbsVal(e sql.Expression) sql.Expression {
@@ -131,4 +132,9 @@ func (t *AbsVal) WithChildren(children ...sql.Expression) (sql.Expression, error
 // Type implements the Expression interface.
 func (t *AbsVal) Type() sql.Type {
 	return t.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*AbsVal) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }

--- a/sql/expression/function/aggregation/common.go
+++ b/sql/expression/function/aggregation/common.go
@@ -36,6 +36,7 @@ type unaryAggBase struct {
 }
 
 var _ sql.Aggregation = (*unaryAggBase)(nil)
+var _ sql.CollationCoercible = (*unaryAggBase)(nil)
 
 func (a *unaryAggBase) NewWindowFunction() (sql.WindowFunction, error) {
 	panic("unaryAggBase is a base type, type must implement NewWindowFunction")
@@ -62,6 +63,11 @@ func (a *unaryAggBase) String() string {
 
 func (a *unaryAggBase) Type() sql.Type {
 	return a.typ
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (a *unaryAggBase) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, a.Child)
 }
 
 func (a *unaryAggBase) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {

--- a/sql/expression/function/aggregation/count_distinct.go
+++ b/sql/expression/function/aggregation/count_distinct.go
@@ -33,6 +33,7 @@ type CountDistinct struct {
 var _ sql.FunctionExpression = (*CountDistinct)(nil)
 var _ sql.Aggregation = (*CountDistinct)(nil)
 var _ sql.WindowAdaptableExpression = (*CountDistinct)(nil)
+var _ sql.CollationCoercible = (*CountDistinct)(nil)
 
 func NewCountDistinct(exprs ...sql.Expression) *CountDistinct {
 	return &CountDistinct{
@@ -43,6 +44,11 @@ func NewCountDistinct(exprs ...sql.Expression) *CountDistinct {
 // Type implements the Expression interface.
 func (a *CountDistinct) Type() sql.Type {
 	return types.Int64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CountDistinct) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/aggregation/json_agg.go
+++ b/sql/expression/function/aggregation/json_agg.go
@@ -44,6 +44,7 @@ type JSONObjectAgg struct {
 var _ sql.FunctionExpression = (*JSONObjectAgg)(nil)
 var _ sql.Aggregation = (*JSONObjectAgg)(nil)
 var _ sql.WindowAdaptableExpression = (*JSONObjectAgg)(nil)
+var _ sql.CollationCoercible = (*JSONObjectAgg)(nil)
 
 // NewJSONObjectAgg creates a new JSONObjectAgg function.
 func NewJSONObjectAgg(key, value sql.Expression) sql.Expression {
@@ -72,6 +73,11 @@ func (j *JSONObjectAgg) String() string {
 // Type implements the Expression interface.
 func (j *JSONObjectAgg) Type() sql.Type {
 	return types.JSON
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*JSONObjectAgg) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCharacterSet().BinaryCollation(), 2
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/aggregation/unary_aggs.og.go
+++ b/sql/expression/function/aggregation/unary_aggs.og.go
@@ -18,6 +18,7 @@ type AnyValue struct {
 var _ sql.FunctionExpression = (*AnyValue)(nil)
 var _ sql.Aggregation = (*AnyValue)(nil)
 var _ sql.WindowAdaptableExpression = (*AnyValue)(nil)
+var _ sql.CollationCoercible = (*AnyValue)(nil)
 
 func NewAnyValue(e sql.Expression) *AnyValue {
 	return &AnyValue{
@@ -92,6 +93,7 @@ type Avg struct {
 var _ sql.FunctionExpression = (*Avg)(nil)
 var _ sql.Aggregation = (*Avg)(nil)
 var _ sql.WindowAdaptableExpression = (*Avg)(nil)
+var _ sql.CollationCoercible = (*Avg)(nil)
 
 func NewAvg(e sql.Expression) *Avg {
 	return &Avg{
@@ -166,6 +168,7 @@ type BitAnd struct {
 var _ sql.FunctionExpression = (*BitAnd)(nil)
 var _ sql.Aggregation = (*BitAnd)(nil)
 var _ sql.WindowAdaptableExpression = (*BitAnd)(nil)
+var _ sql.CollationCoercible = (*BitAnd)(nil)
 
 func NewBitAnd(e sql.Expression) *BitAnd {
 	return &BitAnd{
@@ -240,6 +243,7 @@ type BitOr struct {
 var _ sql.FunctionExpression = (*BitOr)(nil)
 var _ sql.Aggregation = (*BitOr)(nil)
 var _ sql.WindowAdaptableExpression = (*BitOr)(nil)
+var _ sql.CollationCoercible = (*BitOr)(nil)
 
 func NewBitOr(e sql.Expression) *BitOr {
 	return &BitOr{
@@ -314,6 +318,7 @@ type BitXor struct {
 var _ sql.FunctionExpression = (*BitXor)(nil)
 var _ sql.Aggregation = (*BitXor)(nil)
 var _ sql.WindowAdaptableExpression = (*BitXor)(nil)
+var _ sql.CollationCoercible = (*BitXor)(nil)
 
 func NewBitXor(e sql.Expression) *BitXor {
 	return &BitXor{
@@ -388,6 +393,7 @@ type Count struct {
 var _ sql.FunctionExpression = (*Count)(nil)
 var _ sql.Aggregation = (*Count)(nil)
 var _ sql.WindowAdaptableExpression = (*Count)(nil)
+var _ sql.CollationCoercible = (*Count)(nil)
 
 func NewCount(e sql.Expression) *Count {
 	return &Count{
@@ -462,6 +468,7 @@ type First struct {
 var _ sql.FunctionExpression = (*First)(nil)
 var _ sql.Aggregation = (*First)(nil)
 var _ sql.WindowAdaptableExpression = (*First)(nil)
+var _ sql.CollationCoercible = (*First)(nil)
 
 func NewFirst(e sql.Expression) *First {
 	return &First{
@@ -536,6 +543,7 @@ type JsonArray struct {
 var _ sql.FunctionExpression = (*JsonArray)(nil)
 var _ sql.Aggregation = (*JsonArray)(nil)
 var _ sql.WindowAdaptableExpression = (*JsonArray)(nil)
+var _ sql.CollationCoercible = (*JsonArray)(nil)
 
 func NewJsonArray(e sql.Expression) *JsonArray {
 	return &JsonArray{
@@ -610,6 +618,7 @@ type Last struct {
 var _ sql.FunctionExpression = (*Last)(nil)
 var _ sql.Aggregation = (*Last)(nil)
 var _ sql.WindowAdaptableExpression = (*Last)(nil)
+var _ sql.CollationCoercible = (*Last)(nil)
 
 func NewLast(e sql.Expression) *Last {
 	return &Last{
@@ -684,6 +693,7 @@ type Max struct {
 var _ sql.FunctionExpression = (*Max)(nil)
 var _ sql.Aggregation = (*Max)(nil)
 var _ sql.WindowAdaptableExpression = (*Max)(nil)
+var _ sql.CollationCoercible = (*Max)(nil)
 
 func NewMax(e sql.Expression) *Max {
 	return &Max{
@@ -758,6 +768,7 @@ type Min struct {
 var _ sql.FunctionExpression = (*Min)(nil)
 var _ sql.Aggregation = (*Min)(nil)
 var _ sql.WindowAdaptableExpression = (*Min)(nil)
+var _ sql.CollationCoercible = (*Min)(nil)
 
 func NewMin(e sql.Expression) *Min {
 	return &Min{
@@ -832,6 +843,7 @@ type Sum struct {
 var _ sql.FunctionExpression = (*Sum)(nil)
 var _ sql.Aggregation = (*Sum)(nil)
 var _ sql.WindowAdaptableExpression = (*Sum)(nil)
+var _ sql.CollationCoercible = (*Sum)(nil)
 
 func NewSum(e sql.Expression) *Sum {
 	return &Sum{

--- a/sql/expression/function/aggregation/window/dense_rank.go
+++ b/sql/expression/function/aggregation/window/dense_rank.go
@@ -30,6 +30,7 @@ type DenseRank struct {
 var _ sql.FunctionExpression = (*DenseRank)(nil)
 var _ sql.WindowAggregation = (*DenseRank)(nil)
 var _ sql.WindowAdaptableExpression = (*DenseRank)(nil)
+var _ sql.CollationCoercible = (*DenseRank)(nil)
 
 func NewDenseRank() sql.Expression {
 	return &DenseRank{}
@@ -77,6 +78,11 @@ func (p *DenseRank) FunctionName() string {
 // Type implements sql.Expression
 func (p *DenseRank) Type() sql.Type {
 	return types.Uint64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DenseRank) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/aggregation/window/first_value.go
+++ b/sql/expression/function/aggregation/window/first_value.go
@@ -34,6 +34,7 @@ type FirstValue struct {
 var _ sql.FunctionExpression = (*FirstValue)(nil)
 var _ sql.WindowAggregation = (*FirstValue)(nil)
 var _ sql.WindowAdaptableExpression = (*FirstValue)(nil)
+var _ sql.CollationCoercible = (*FirstValue)(nil)
 
 func NewFirstValue(e sql.Expression) sql.Expression {
 	return &FirstValue{nil, expression.UnaryExpression{Child: e}, 0}
@@ -82,6 +83,11 @@ func (f *FirstValue) FunctionName() string {
 // Type implements sql.Expression
 func (f *FirstValue) Type() sql.Type {
 	return f.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (f *FirstValue) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, f.Child)
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/aggregation/window/lag.go
+++ b/sql/expression/function/aggregation/window/lag.go
@@ -35,6 +35,7 @@ type Lag struct {
 var _ sql.FunctionExpression = (*Lag)(nil)
 var _ sql.WindowAggregation = (*Lag)(nil)
 var _ sql.WindowAdaptableExpression = (*Lag)(nil)
+var _ sql.CollationCoercible = (*Lag)(nil)
 
 // NewLag accepts variadic arguments to create a new Lag node:
 // If 1 expression, use default values for [default] and [offset]
@@ -117,6 +118,16 @@ func (l *Lag) FunctionName() string {
 // Type implements sql.Expression
 func (l *Lag) Type() sql.Type {
 	return l.ChildExpressions[0].Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (l *Lag) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// We're returning the type of the first child, so we'll return the coercibility of the first child
+	// as well
+	if l == nil || len(l.ChildExpressions) == 0 {
+		return sql.Collation_binary, 6
+	}
+	return sql.GetCoercibility(ctx, l.ChildExpressions[0])
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/aggregation/window/last_value.go
+++ b/sql/expression/function/aggregation/window/last_value.go
@@ -34,6 +34,7 @@ type LastValue struct {
 var _ sql.FunctionExpression = (*LastValue)(nil)
 var _ sql.WindowAggregation = (*LastValue)(nil)
 var _ sql.WindowAdaptableExpression = (*LastValue)(nil)
+var _ sql.CollationCoercible = (*LastValue)(nil)
 
 func NewLastValue(e sql.Expression) sql.Expression {
 	return &LastValue{nil, expression.UnaryExpression{Child: e}, 0}
@@ -82,6 +83,11 @@ func (f *LastValue) FunctionName() string {
 // Type implements sql.Expression
 func (f *LastValue) Type() sql.Type {
 	return f.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (f *LastValue) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, f.Child)
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/aggregation/window/lead.go
+++ b/sql/expression/function/aggregation/window/lead.go
@@ -35,6 +35,7 @@ type Lead struct {
 var _ sql.FunctionExpression = (*Lead)(nil)
 var _ sql.WindowAggregation = (*Lead)(nil)
 var _ sql.WindowAdaptableExpression = (*Lead)(nil)
+var _ sql.CollationCoercible = (*Lead)(nil)
 
 // NewLead accepts variadic arguments to create a new Lead node:
 // If 1 expression, use default values for [default] and [offset]
@@ -117,6 +118,15 @@ func (l *Lead) FunctionName() string {
 // Type implements sql.Expression
 func (l *Lead) Type() sql.Type {
 	return l.ChildExpressions[0].Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (l *Lead) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// We use the first child for the Type, so we'll use the first child for the coercibility as well
+	if l == nil || len(l.ChildExpressions) == 0 {
+		return sql.Collation_binary, 6
+	}
+	return sql.GetCoercibility(ctx, l.ChildExpressions[0])
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/aggregation/window/percent_rank.go
+++ b/sql/expression/function/aggregation/window/percent_rank.go
@@ -30,6 +30,7 @@ type PercentRank struct {
 var _ sql.FunctionExpression = (*PercentRank)(nil)
 var _ sql.WindowAggregation = (*PercentRank)(nil)
 var _ sql.WindowAdaptableExpression = (*PercentRank)(nil)
+var _ sql.CollationCoercible = (*PercentRank)(nil)
 
 func NewPercentRank() sql.Expression {
 	return &PercentRank{}
@@ -77,6 +78,11 @@ func (p *PercentRank) FunctionName() string {
 // Type implements sql.Expression
 func (p *PercentRank) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*PercentRank) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/aggregation/window/rank.go
+++ b/sql/expression/function/aggregation/window/rank.go
@@ -30,6 +30,7 @@ type Rank struct {
 var _ sql.FunctionExpression = (*Rank)(nil)
 var _ sql.WindowAggregation = (*Rank)(nil)
 var _ sql.WindowAdaptableExpression = (*Rank)(nil)
+var _ sql.CollationCoercible = (*Rank)(nil)
 
 func NewRank() sql.Expression {
 	return &Rank{}
@@ -77,6 +78,11 @@ func (p *Rank) FunctionName() string {
 // Type implements sql.Expression
 func (p *Rank) Type() sql.Type {
 	return types.Uint64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Rank) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/aggregation/window/row_number.go
+++ b/sql/expression/function/aggregation/window/row_number.go
@@ -30,6 +30,7 @@ type RowNumber struct {
 var _ sql.FunctionExpression = (*RowNumber)(nil)
 var _ sql.WindowAggregation = (*RowNumber)(nil)
 var _ sql.WindowAdaptableExpression = (*RowNumber)(nil)
+var _ sql.CollationCoercible = (*RowNumber)(nil)
 
 func NewRowNumber() sql.Expression {
 	return &RowNumber{}
@@ -78,6 +79,11 @@ func (r *RowNumber) FunctionName() string {
 // Type implements sql.Expression
 func (r *RowNumber) Type() sql.Type {
 	return types.Int64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*RowNumber) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/ceil_round_floor.go
+++ b/sql/expression/function/ceil_round_floor.go
@@ -33,6 +33,7 @@ type Ceil struct {
 }
 
 var _ sql.FunctionExpression = (*Ceil)(nil)
+var _ sql.CollationCoercible = (*Ceil)(nil)
 
 // NewCeil creates a new Ceil expression.
 func NewCeil(num sql.Expression) sql.Expression {
@@ -56,6 +57,11 @@ func (c *Ceil) Type() sql.Type {
 		return childType
 	}
 	return types.Int32
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Ceil) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (c *Ceil) String() string {
@@ -111,6 +117,7 @@ type Floor struct {
 }
 
 var _ sql.FunctionExpression = (*Floor)(nil)
+var _ sql.CollationCoercible = (*Floor)(nil)
 
 // NewFloor returns a new Floor expression.
 func NewFloor(num sql.Expression) sql.Expression {
@@ -134,6 +141,11 @@ func (f *Floor) Type() sql.Type {
 		return childType
 	}
 	return types.Int32
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Floor) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (f *Floor) String() string {
@@ -192,6 +204,7 @@ type Round struct {
 }
 
 var _ sql.FunctionExpression = (*Round)(nil)
+var _ sql.CollationCoercible = (*Round)(nil)
 
 // NewRound returns a new Round expression.
 func NewRound(args ...sql.Expression) (sql.Expression, error) {
@@ -369,6 +382,11 @@ func (r *Round) Type() sql.Type {
 		return leftChildType
 	}
 	return types.Int32
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Round) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/function/coalesce.go
+++ b/sql/expression/function/coalesce.go
@@ -27,6 +27,7 @@ type Coalesce struct {
 }
 
 var _ sql.FunctionExpression = (*Coalesce)(nil)
+var _ sql.CollationCoercible = (*Coalesce)(nil)
 
 // NewCoalesce creates a new Coalesce sql.Expression.
 func NewCoalesce(args ...sql.Expression) (sql.Expression, error) {
@@ -62,6 +63,15 @@ func (c *Coalesce) Type() sql.Type {
 	}
 
 	return nil
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *Coalesce) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// Preferably, this would be done during evaluation, but that's not possible with the current abstraction
+	if typ := c.Type(); typ != nil {
+		return typ.CollationCoercibility(ctx)
+	}
+	return sql.Collation_binary, 6
 }
 
 // IsNullable implements the sql.Expression interface.

--- a/sql/expression/function/collation.go
+++ b/sql/expression/function/collation.go
@@ -1,0 +1,146 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql/types"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+)
+
+// Collation is a function that returns the collation of the inner expression.
+type Collation struct {
+	expression.UnaryExpression
+}
+
+var _ sql.FunctionExpression = (*Collation)(nil)
+var _ sql.CollationCoercible = (*Collation)(nil)
+
+// NewCollation creates a new Collation expression.
+func NewCollation(e sql.Expression) sql.Expression {
+	return &Collation{expression.UnaryExpression{Child: e}}
+}
+
+// FunctionName implements sql.FunctionExpression
+func (c *Collation) FunctionName() string {
+	return "collation"
+}
+
+// Description implements sql.FunctionExpression
+func (c *Collation) Description() string {
+	return "Returns the collation of the inner expression"
+}
+
+// Eval implements the sql.Expression.
+func (c *Collation) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	val, err := c.Child.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	// If the value is nil, then we return 'binary'
+	if val == nil {
+		return sql.Collation_binary.Name(), nil
+	}
+	// Otherwise, we return the collation calculated from the expression
+	collation, _ := sql.GetCoercibility(ctx, c.Child)
+	return collation.Name(), nil
+}
+
+// String implements the fmt.Stringer interface.
+func (c *Collation) String() string {
+	return fmt.Sprintf("%s(%s)", c.FunctionName(), c.Child.String())
+}
+
+// WithChildren implements the Expression interface.
+func (c *Collation) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
+	}
+	return NewCollation(children[0]), nil
+}
+
+// Type implements the Expression interface.
+func (c *Collation) Type() sql.Type {
+	return types.LongText
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Collation) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 4
+}
+
+// Coercibility is a function that returns the coercibility of the inner expression.
+type Coercibility struct {
+	expression.UnaryExpression
+}
+
+var _ sql.FunctionExpression = (*Coercibility)(nil)
+var _ sql.CollationCoercible = (*Coercibility)(nil)
+
+// NewCoercibility creates a new Coercibility expression.
+func NewCoercibility(e sql.Expression) sql.Expression {
+	return &Coercibility{expression.UnaryExpression{Child: e}}
+}
+
+// FunctionName implements sql.FunctionExpression
+func (c *Coercibility) FunctionName() string {
+	return "coercibility"
+}
+
+// Description implements sql.FunctionExpression
+func (c *Coercibility) Description() string {
+	return "Returns the coercibility of the inner expression"
+}
+
+// Eval implements the sql.Expression.
+func (c *Coercibility) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	val, err := c.Child.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	// If the value is nil, then we return 'binary'
+	if val == nil {
+		return 6, nil
+	}
+	// Otherwise, we return the collation calculated from the expression
+	_, coercibility := sql.GetCoercibility(ctx, c.Child)
+	return coercibility, nil
+}
+
+// String implements the fmt.Stringer interface.
+func (c *Coercibility) String() string {
+	return fmt.Sprintf("%s(%s)", c.FunctionName(), c.Child.String())
+}
+
+// WithChildren implements the Expression interface.
+func (c *Coercibility) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
+	}
+	return NewCoercibility(children[0]), nil
+}
+
+// Type implements the Expression interface.
+func (c *Coercibility) Type() sql.Type {
+	return types.Int8
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Coercibility) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}

--- a/sql/expression/function/concat.go
+++ b/sql/expression/function/concat.go
@@ -28,6 +28,7 @@ type Concat struct {
 }
 
 var _ sql.FunctionExpression = (*Concat)(nil)
+var _ sql.CollationCoercible = (*Concat)(nil)
 
 // NewConcat creates a new Concat UDF.
 func NewConcat(args ...sql.Expression) (sql.Expression, error) {
@@ -50,6 +51,19 @@ func (c *Concat) Description() string {
 
 // Type implements the Expression interface.
 func (c *Concat) Type() sql.Type { return types.LongText }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *Concat) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	if len(c.args) == 0 {
+		return sql.Collation_binary, 6
+	}
+	collation, coercibility = sql.GetCoercibility(ctx, c.args[0])
+	for i := 1; i < len(c.args); i++ {
+		nextCollation, nextCoercibility := sql.GetCoercibility(ctx, c.args[i])
+		collation, coercibility = sql.ResolveCoercibility(collation, coercibility, nextCollation, nextCoercibility)
+	}
+	return collation, coercibility
+}
 
 // IsNullable implements the Expression interface.
 func (c *Concat) IsNullable() bool {

--- a/sql/expression/function/conv.go
+++ b/sql/expression/function/conv.go
@@ -32,6 +32,7 @@ type Conv struct {
 }
 
 var _ sql.FunctionExpression = (*Conv)(nil)
+var _ sql.CollationCoercible = (*Conv)(nil)
 
 // NewConv returns a new Conv expression.
 func NewConv(n, from, to sql.Expression) sql.Expression {
@@ -50,6 +51,11 @@ func (c *Conv) Description() string {
 
 // Type implements the Expression interface.
 func (c *Conv) Type() sql.Type { return types.LongText }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Conv) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
+}
 
 // IsNullable implements the Expression interface.
 func (c *Conv) IsNullable() bool {

--- a/sql/expression/function/convert_tz.go
+++ b/sql/expression/function/convert_tz.go
@@ -34,6 +34,7 @@ type ConvertTz struct {
 }
 
 var _ sql.FunctionExpression = (*ConvertTz)(nil)
+var _ sql.CollationCoercible = (*ConvertTz)(nil)
 
 // NewConvertTz returns an implementation of the CONVERT_TZ() function.
 func NewConvertTz(dt, fromTz, toTz sql.Expression) sql.Expression {
@@ -67,6 +68,11 @@ func (c *ConvertTz) String() string {
 // Type implements the sql.Expression interface.
 func (c *ConvertTz) Type() sql.Type {
 	return types.Datetime
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ConvertTz) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements the sql.Expression interface.

--- a/sql/expression/function/database.go
+++ b/sql/expression/function/database.go
@@ -29,6 +29,7 @@ func (db *Database) IsNonDeterministic() bool {
 }
 
 var _ sql.FunctionExpression = (*Database)(nil)
+var _ sql.CollationCoercible = (*Database)(nil)
 
 // NewDatabase returns a new Database function
 func NewDatabase() sql.Expression {
@@ -47,6 +48,11 @@ func (db *Database) Description() string {
 
 // Type implements the sql.Expression (sql.LongText)
 func (db *Database) Type() sql.Type { return types.LongText }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Database) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 3
+}
 
 // IsNullable implements the sql.Expression interface.
 // The function returns always true

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -31,6 +31,7 @@ type DateAdd struct {
 }
 
 var _ sql.FunctionExpression = (*DateAdd)(nil)
+var _ sql.CollationCoercible = (*DateAdd)(nil)
 
 // NewDateAdd creates a new date add function.
 func NewDateAdd(args ...sql.Expression) (sql.Expression, error) {
@@ -75,6 +76,11 @@ func (d *DateAdd) IsNullable() bool {
 func (d *DateAdd) Type() sql.Type {
 	sqlType := dateOffsetType(d.Date, d.Interval)
 	return sqlType
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DateAdd) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // WithChildren implements the Expression interface.
@@ -128,6 +134,7 @@ type DateSub struct {
 }
 
 var _ sql.FunctionExpression = (*DateSub)(nil)
+var _ sql.CollationCoercible = (*DateSub)(nil)
 
 // NewDateSub creates a new date add function.
 func NewDateSub(args ...sql.Expression) (sql.Expression, error) {
@@ -172,6 +179,11 @@ func (d *DateSub) IsNullable() bool {
 func (d *DateSub) Type() sql.Type {
 	sqlType := dateOffsetType(d.Date, d.Interval)
 	return sqlType
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DateSub) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // WithChildren implements the Expression interface.
@@ -224,6 +236,7 @@ type TimestampConversion struct {
 }
 
 var _ sql.FunctionExpression = (*TimestampConversion)(nil)
+var _ sql.CollationCoercible = (*TimestampConversion)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (t *TimestampConversion) FunctionName() string {
@@ -245,6 +258,11 @@ func (t *TimestampConversion) String() string {
 
 func (t *TimestampConversion) Type() sql.Type {
 	return types.Timestamp
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*TimestampConversion) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (t *TimestampConversion) IsNullable() bool {
@@ -283,6 +301,7 @@ type DatetimeConversion struct {
 }
 
 var _ sql.FunctionExpression = (*DatetimeConversion)(nil)
+var _ sql.CollationCoercible = (*DatetimeConversion)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (t *DatetimeConversion) FunctionName() string {
@@ -304,6 +323,11 @@ func (t *DatetimeConversion) String() string {
 
 func (t *DatetimeConversion) Type() sql.Type {
 	return types.Datetime
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DatetimeConversion) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (t *DatetimeConversion) IsNullable() bool {
@@ -346,6 +370,7 @@ type UnixTimestamp struct {
 }
 
 var _ sql.FunctionExpression = (*UnixTimestamp)(nil)
+var _ sql.CollationCoercible = (*UnixTimestamp)(nil)
 
 func NewUnixTimestamp(args ...sql.Expression) (sql.Expression, error) {
 	if len(args) > 1 {
@@ -387,6 +412,11 @@ func (ut *UnixTimestamp) IsNullable() bool {
 
 func (ut *UnixTimestamp) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UnixTimestamp) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (ut *UnixTimestamp) WithChildren(children ...sql.Expression) (sql.Expression, error) {
@@ -435,6 +465,7 @@ type FromUnixtime struct {
 }
 
 var _ sql.FunctionExpression = (*FromUnixtime)(nil)
+var _ sql.CollationCoercible = (*FromUnixtime)(nil)
 
 func NewFromUnixtime(arg sql.Expression) sql.Expression {
 	return &FromUnixtime{NewUnaryFunc(arg, "FROM_UNIXTIME", types.Datetime)}
@@ -443,6 +474,11 @@ func NewFromUnixtime(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (r *FromUnixtime) Description() string {
 	return "formats Unix timestamp as a date."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*FromUnixtime) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (r *FromUnixtime) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -479,6 +515,7 @@ func (c CurrDate) IsNonDeterministic() bool {
 }
 
 var _ sql.FunctionExpression = CurrDate{}
+var _ sql.CollationCoercible = CurrDate{}
 
 // Description implements sql.FunctionExpression
 func (c CurrDate) Description() string {
@@ -505,6 +542,11 @@ func currDateLogic(ctx *sql.Context, _ sql.Row) (interface{}, error) {
 // Eval implements sql.Expression
 func (c CurrDate) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return currDateLogic(ctx, row)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (CurrDate) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // WithChildren implements sql.Expression

--- a/sql/expression/function/date_format.go
+++ b/sql/expression/function/date_format.go
@@ -255,6 +255,7 @@ type DateFormat struct {
 }
 
 var _ sql.FunctionExpression = (*DateFormat)(nil)
+var _ sql.CollationCoercible = (*DateFormat)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (f *DateFormat) FunctionName() string {
@@ -320,6 +321,11 @@ func (f *DateFormat) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 // Type implements the Expression interface.
 func (f *DateFormat) Type() sql.Type {
 	return types.Text
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DateFormat) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/extract.go
+++ b/sql/expression/function/extract.go
@@ -29,6 +29,7 @@ type Extract struct {
 }
 
 var _ sql.FunctionExpression = (*Extract)(nil)
+var _ sql.CollationCoercible = (*Extract)(nil)
 
 // NewExtract creates a new Extract expression.
 func NewExtract(e1, e2 sql.Expression) sql.Expression {
@@ -52,6 +53,11 @@ func (td *Extract) Description() string {
 
 // Type implements the Expression interface.
 func (td *Extract) Type() sql.Type { return types.Int64 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Extract) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (td *Extract) String() string {
 	return fmt.Sprintf("%s(%s from %s)", td.FunctionName(), td.Left, td.Right)

--- a/sql/expression/function/format.go
+++ b/sql/expression/function/format.go
@@ -36,6 +36,7 @@ type Format struct {
 }
 
 var _ sql.FunctionExpression = (*Format)(nil)
+var _ sql.CollationCoercible = (*Format)(nil)
 
 // NewFormat returns a new Format expression.
 func NewFormat(args ...sql.Expression) (sql.Expression, error) {
@@ -67,6 +68,11 @@ func (f *Format) Description() string {
 
 // Type implements the Expression interface.
 func (f *Format) Type() sql.Type { return types.LongText }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Format) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
+}
 
 // IsNullable implements the Expression interface.
 func (f *Format) IsNullable() bool {

--- a/sql/expression/function/hash.go
+++ b/sql/expression/function/hash.go
@@ -36,6 +36,7 @@ type MD5 struct {
 }
 
 var _ sql.FunctionExpression = (*MD5)(nil)
+var _ sql.CollationCoercible = (*MD5)(nil)
 
 // NewMD5 returns a new MD5 function expression
 func NewMD5(arg sql.Expression) sql.Expression {
@@ -45,6 +46,11 @@ func NewMD5(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (f *MD5) Description() string {
 	return "calculates MD5 checksum."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MD5) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // Eval implements sql.Expression
@@ -85,6 +91,7 @@ type SHA1 struct {
 }
 
 var _ sql.FunctionExpression = (*SHA1)(nil)
+var _ sql.CollationCoercible = (*SHA1)(nil)
 
 // NewSHA1 returns a new SHA1 function expression
 func NewSHA1(arg sql.Expression) sql.Expression {
@@ -94,6 +101,11 @@ func NewSHA1(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (f *SHA1) Description() string {
 	return "calculates an SHA-1 160-bit checksum."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*SHA1) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // Eval implements sql.Expression
@@ -134,6 +146,7 @@ type SHA2 struct {
 }
 
 var _ sql.FunctionExpression = (*SHA2)(nil)
+var _ sql.CollationCoercible = (*SHA2)(nil)
 
 // NewSHA2 returns a new SHA2 function expression
 func NewSHA2(arg, count sql.Expression) sql.Expression {
@@ -143,6 +156,11 @@ func NewSHA2(arg, count sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (f *SHA2) Description() string {
 	return "calculates an SHA-2 checksum."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*SHA2) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // Eval implements sql.Expression

--- a/sql/expression/function/if.go
+++ b/sql/expression/function/if.go
@@ -29,6 +29,7 @@ type If struct {
 }
 
 var _ sql.FunctionExpression = (*If)(nil)
+var _ sql.CollationCoercible = (*If)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (f *If) FunctionName() string {
@@ -37,7 +38,7 @@ func (f *If) FunctionName() string {
 
 // Description implements sql.FunctionExpression
 func (f *If) Description() string {
-	return "if expr1 evaluates to true, retuns expr2. Otherwise returns expr3."
+	return "if expr evaluates to true, returns ifTrue. Otherwise returns ifFalse."
 }
 
 func (f *If) Resolved() bool {
@@ -86,6 +87,13 @@ func (f *If) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 // Type implements the Expression interface.
 func (f *If) Type() sql.Type {
 	return f.ifTrue.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (f *If) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// We would need to evaluate the condition to return the correct result here, so we'll copy
+	// Type and just return the true result
+	return sql.GetCoercibility(ctx, f.ifTrue)
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/ifnull.go
+++ b/sql/expression/function/ifnull.go
@@ -28,6 +28,7 @@ type IfNull struct {
 }
 
 var _ sql.FunctionExpression = (*IfNull)(nil)
+var _ sql.CollationCoercible = (*IfNull)(nil)
 
 // NewIfNull returns a new IFNULL UDF
 func NewIfNull(ex, value sql.Expression) sql.Expression {
@@ -75,6 +76,17 @@ func (f *IfNull) Type() sql.Type {
 		return f.Right.Type()
 	}
 	return f.Left.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (f *IfNull) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	if types.IsNull(f.Left) {
+		if types.IsNull(f.Right) {
+			return sql.Collation_binary, 6
+		}
+		return sql.GetCoercibility(ctx, f.Right)
+	}
+	return sql.GetCoercibility(ctx, f.Left)
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/inet_convert.go
+++ b/sql/expression/function/inet_convert.go
@@ -32,6 +32,7 @@ type InetAton struct {
 }
 
 var _ sql.FunctionExpression = (*InetAton)(nil)
+var _ sql.CollationCoercible = (*InetAton)(nil)
 
 func NewInetAton(val sql.Expression) sql.Expression {
 	return &InetAton{expression.UnaryExpression{Child: val}}
@@ -53,6 +54,11 @@ func (i *InetAton) String() string {
 
 func (i *InetAton) Type() sql.Type {
 	return types.Uint32
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*InetAton) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (i *InetAton) WithChildren(children ...sql.Expression) (sql.Expression, error) {
@@ -106,6 +112,7 @@ type Inet6Aton struct {
 }
 
 var _ sql.FunctionExpression = (*Inet6Aton)(nil)
+var _ sql.CollationCoercible = (*Inet6Aton)(nil)
 
 func NewInet6Aton(val sql.Expression) sql.Expression {
 	return &Inet6Aton{expression.UnaryExpression{Child: val}}
@@ -127,6 +134,11 @@ func (i *Inet6Aton) String() string {
 
 func (i *Inet6Aton) Type() sql.Type {
 	return types.LongBlob
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Inet6Aton) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (i *Inet6Aton) WithChildren(children ...sql.Expression) (sql.Expression, error) {
@@ -180,6 +192,7 @@ type InetNtoa struct {
 }
 
 var _ sql.FunctionExpression = (*InetNtoa)(nil)
+var _ sql.CollationCoercible = (*InetNtoa)(nil)
 
 func NewInetNtoa(val sql.Expression) sql.Expression {
 	return &InetNtoa{expression.UnaryExpression{Child: val}}
@@ -201,6 +214,11 @@ func (i *InetNtoa) String() string {
 
 func (i *InetNtoa) Type() sql.Type {
 	return types.LongText
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*InetNtoa) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 func (i *InetNtoa) WithChildren(children ...sql.Expression) (sql.Expression, error) {
@@ -247,6 +265,7 @@ type Inet6Ntoa struct {
 }
 
 var _ sql.FunctionExpression = (*Inet6Ntoa)(nil)
+var _ sql.CollationCoercible = (*Inet6Ntoa)(nil)
 
 func NewInet6Ntoa(val sql.Expression) sql.Expression {
 	return &Inet6Ntoa{expression.UnaryExpression{Child: val}}
@@ -268,6 +287,11 @@ func (i *Inet6Ntoa) String() string {
 
 func (i *Inet6Ntoa) Type() sql.Type {
 	return types.LongText
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Inet6Ntoa) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 func (i *Inet6Ntoa) WithChildren(children ...sql.Expression) (sql.Expression, error) {

--- a/sql/expression/function/is_ip.go
+++ b/sql/expression/function/is_ip.go
@@ -30,6 +30,7 @@ type IsIPv4 struct {
 }
 
 var _ sql.FunctionExpression = (*IsIPv4)(nil)
+var _ sql.CollationCoercible = (*IsIPv4)(nil)
 
 func NewIsIPv4(val sql.Expression) sql.Expression {
 	return &IsIPv4{expression.UnaryExpression{Child: val}}
@@ -50,6 +51,11 @@ func (i *IsIPv4) String() string {
 }
 
 func (i *IsIPv4) Type() sql.Type { return types.Boolean }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsIPv4) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (i *IsIPv4) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 1 {
@@ -92,6 +98,7 @@ type IsIPv6 struct {
 }
 
 var _ sql.FunctionExpression = (*IsIPv6)(nil)
+var _ sql.CollationCoercible = (*IsIPv6)(nil)
 
 func NewIsIPv6(val sql.Expression) sql.Expression {
 	return &IsIPv6{expression.UnaryExpression{Child: val}}
@@ -112,6 +119,11 @@ func (i *IsIPv6) String() string {
 }
 
 func (i *IsIPv6) Type() sql.Type { return types.Boolean }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsIPv6) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (i *IsIPv6) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 1 {
@@ -154,6 +166,7 @@ type IsIPv4Compat struct {
 }
 
 var _ sql.FunctionExpression = (*IsIPv4Compat)(nil)
+var _ sql.CollationCoercible = (*IsIPv4Compat)(nil)
 
 func NewIsIPv4Compat(val sql.Expression) sql.Expression {
 	return &IsIPv4Compat{expression.UnaryExpression{Child: val}}
@@ -174,6 +187,11 @@ func (i *IsIPv4Compat) String() string {
 }
 
 func (i *IsIPv4Compat) Type() sql.Type { return types.Boolean }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsIPv4Compat) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (i *IsIPv4Compat) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 1 {
@@ -220,6 +238,7 @@ type IsIPv4Mapped struct {
 }
 
 var _ sql.FunctionExpression = (*IsIPv4Mapped)(nil)
+var _ sql.CollationCoercible = (*IsIPv4Mapped)(nil)
 
 func NewIsIPv4Mapped(val sql.Expression) sql.Expression {
 	return &IsIPv4Mapped{expression.UnaryExpression{Child: val}}
@@ -240,6 +259,11 @@ func (i *IsIPv4Mapped) String() string {
 }
 
 func (i *IsIPv4Mapped) Type() sql.Type { return types.Boolean }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsIPv4Mapped) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (i *IsIPv4Mapped) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 1 {

--- a/sql/expression/function/isbinary.go
+++ b/sql/expression/function/isbinary.go
@@ -29,6 +29,7 @@ type IsBinary struct {
 }
 
 var _ sql.FunctionExpression = (*IsBinary)(nil)
+var _ sql.CollationCoercible = (*IsBinary)(nil)
 
 // NewIsBinary creates a new IsBinary expression.
 func NewIsBinary(e sql.Expression) sql.Expression {
@@ -82,6 +83,11 @@ func (ib *IsBinary) WithChildren(children ...sql.Expression) (sql.Expression, er
 // Type implements the Expression interface.
 func (ib *IsBinary) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsBinary) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 const sniffLen = 8000

--- a/sql/expression/function/isnull.go
+++ b/sql/expression/function/isnull.go
@@ -28,6 +28,7 @@ type IsNull struct {
 }
 
 var _ sql.FunctionExpression = (*IsNull)(nil)
+var _ sql.CollationCoercible = (*IsNull)(nil)
 
 // NewIsNull creates a new IsNull expression.
 func NewIsNull(e sql.Expression) sql.Expression {
@@ -73,4 +74,9 @@ func (ib *IsNull) WithChildren(children ...sql.Expression) (sql.Expression, erro
 // Type implements the Expression interface.
 func (ib *IsNull) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsNull) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }

--- a/sql/expression/function/json_array.go
+++ b/sql/expression/function/json_array.go
@@ -33,6 +33,7 @@ type JSONArray struct {
 }
 
 var _ sql.FunctionExpression = (*JSONArray)(nil)
+var _ sql.CollationCoercible = (*JSONArray)(nil)
 
 // NewJSONArray creates a new JSONArray function.
 func NewJSONArray(args ...sql.Expression) (sql.Expression, error) {
@@ -79,6 +80,11 @@ func (j *JSONArray) String() string {
 // Type implements the Expression interface.
 func (j *JSONArray) Type() sql.Type {
 	return types.JSON
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (JSONArray) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCharacterSet().BinaryCollation(), 2
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/json_contains.go
+++ b/sql/expression/function/json_contains.go
@@ -54,6 +54,7 @@ type JSONContains struct {
 }
 
 var _ sql.FunctionExpression = (*JSONContains)(nil)
+var _ sql.CollationCoercible = (*JSONContains)(nil)
 
 // NewJSONContains creates a new JSONContains function.
 func NewJSONContains(args ...sql.Expression) (sql.Expression, error) {
@@ -106,6 +107,11 @@ func (j *JSONContains) String() string {
 
 func (j *JSONContains) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*JSONContains) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (j *JSONContains) IsNullable() bool {

--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -32,6 +32,7 @@ type JSONExtract struct {
 }
 
 var _ sql.FunctionExpression = (*JSONExtract)(nil)
+var _ sql.CollationCoercible = (*JSONExtract)(nil)
 
 // NewJSONExtract creates a new JSONExtract UDF.
 func NewJSONExtract(args ...sql.Expression) (sql.Expression, error) {
@@ -69,6 +70,11 @@ func (j *JSONExtract) Resolved() bool {
 
 // Type implements the sql.Expression interface.
 func (j *JSONExtract) Type() sql.Type { return types.JSON }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*JSONExtract) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCharacterSet().BinaryCollation(), 2
+}
 
 // Eval implements the sql.Expression interface.
 func (j *JSONExtract) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {

--- a/sql/expression/function/json_merge_preserve.go
+++ b/sql/expression/function/json_merge_preserve.go
@@ -49,6 +49,7 @@ type JSONMergePreserve struct {
 }
 
 var _ sql.FunctionExpression = (*JSONMergePreserve)(nil)
+var _ sql.CollationCoercible = (*JSONMergePreserve)(nil)
 
 // NewJSONMergePreserve creates a new JSONMergePreserve function.
 func NewJSONMergePreserve(args ...sql.Expression) (sql.Expression, error) {
@@ -99,6 +100,11 @@ func (j *JSONMergePreserve) String() string {
 // Type implements the Expression interface.
 func (j *JSONMergePreserve) Type() sql.Type {
 	return types.JSON
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*JSONMergePreserve) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCharacterSet().BinaryCollation(), 2
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/json_object.go
+++ b/sql/expression/function/json_object.go
@@ -32,6 +32,7 @@ type JSONObject struct {
 }
 
 var _ sql.FunctionExpression = JSONObject{}
+var _ sql.CollationCoercible = JSONObject{}
 
 // NewJSONObject creates a new JSONObject function.
 func NewJSONObject(exprs ...sql.Expression) (sql.Expression, error) {
@@ -80,6 +81,11 @@ func (j JSONObject) String() string {
 
 func (j JSONObject) Type() sql.Type {
 	return types.JSON
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (JSONObject) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCharacterSet().BinaryCollation(), 2
 }
 
 func (j JSONObject) IsNullable() bool {

--- a/sql/expression/function/json_unquote.go
+++ b/sql/expression/function/json_unquote.go
@@ -32,6 +32,7 @@ type JSONUnquote struct {
 }
 
 var _ sql.FunctionExpression = (*JSONUnquote)(nil)
+var _ sql.CollationCoercible = (*JSONUnquote)(nil)
 
 // NewJSONUnquote creates a new JSONUnquote UDF.
 func NewJSONUnquote(json sql.Expression) sql.Expression {
@@ -60,6 +61,11 @@ func (js *JSONUnquote) String() string {
 // Type implements the Expression interface.
 func (*JSONUnquote) Type() sql.Type {
 	return types.LongText
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*JSONUnquote) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCharacterSet().BinaryCollation(), 4
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/function/length.go
+++ b/sql/expression/function/length.go
@@ -33,6 +33,7 @@ type Length struct {
 }
 
 var _ sql.FunctionExpression = (*Length)(nil)
+var _ sql.CollationCoercible = (*Length)(nil)
 
 // CountType is the kind of length count.
 type CountType bool
@@ -87,6 +88,11 @@ func (l *Length) WithChildren(children ...sql.Expression) (sql.Expression, error
 
 // Type implements the sql.Expression interface.
 func (l *Length) Type() sql.Type { return types.Int32 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Length) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (l *Length) String() string {
 	if l.CountType == NumBytes {

--- a/sql/expression/function/load_file.go
+++ b/sql/expression/function/load_file.go
@@ -28,6 +28,7 @@ type LoadFile struct {
 }
 
 var _ sql.FunctionExpression = (*LoadFile)(nil)
+var _ sql.CollationCoercible = (*LoadFile)(nil)
 
 // NewLoadFile returns a LoadFile object for the LOAD_FILE() function.
 func NewLoadFile(fileName sql.Expression) sql.Expression {
@@ -54,6 +55,11 @@ func (l *LoadFile) String() string {
 // Type implements sql.Expression.
 func (l *LoadFile) Type() sql.Type {
 	return types.LongBlob
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*LoadFile) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression.

--- a/sql/expression/function/locate.go
+++ b/sql/expression/function/locate.go
@@ -31,6 +31,7 @@ type Locate struct {
 }
 
 var _ sql.FunctionExpression = (*Locate)(nil)
+var _ sql.CollationCoercible = (*Locate)(nil)
 
 // NewLocate returns a new Locate function.
 func NewLocate(exprs ...sql.Expression) (sql.Expression, error) {
@@ -62,6 +63,11 @@ func (l *Locate) WithChildren(children ...sql.Expression) (sql.Expression, error
 
 // Type implements the sql.Expression interface.
 func (l *Locate) Type() sql.Type { return types.Int32 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Locate) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (l *Locate) String() string {
 	switch len(l.ChildExpressions) {

--- a/sql/expression/function/locks.go
+++ b/sql/expression/function/locks.go
@@ -122,6 +122,7 @@ type IsFreeLock struct {
 }
 
 var _ sql.FunctionExpression = &IsFreeLock{}
+var _ sql.CollationCoercible = &IsFreeLock{}
 
 func NewIsFreeLock(ls *sql.LockSubsystem) sql.CreateFunc1Args {
 	return func(e sql.Expression) sql.Expression {
@@ -141,6 +142,11 @@ func (i *IsFreeLock) Description() string {
 	return "returns whether the named lock is free."
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsFreeLock) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 func (i *IsFreeLock) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return i.evalLockLogic(ctx, IsFreeLockFunc, row)
 }
@@ -158,6 +164,7 @@ type IsUsedLock struct {
 }
 
 var _ sql.FunctionExpression = &IsUsedLock{}
+var _ sql.CollationCoercible = &IsUsedLock{}
 
 func NewIsUsedLock(ls *sql.LockSubsystem) sql.CreateFunc1Args {
 	return func(e sql.Expression) sql.Expression {
@@ -177,6 +184,11 @@ func (i *IsUsedLock) Description() string {
 	return "returns whether the named lock is in use; return connection identifier if true."
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsUsedLock) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 func (i *IsUsedLock) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return i.evalLockLogic(ctx, IsUsedLockFunc, row)
 }
@@ -194,6 +206,7 @@ type ReleaseLock struct {
 }
 
 var _ sql.FunctionExpression = &ReleaseLock{}
+var _ sql.CollationCoercible = &ReleaseLock{}
 
 func NewReleaseLock(ls *sql.LockSubsystem) sql.CreateFunc1Args {
 	return func(e sql.Expression) sql.Expression {
@@ -211,6 +224,11 @@ func NewReleaseLock(ls *sql.LockSubsystem) sql.CreateFunc1Args {
 // Description implements sql.FunctionExpression
 func (i *ReleaseLock) Description() string {
 	return "release the named lock."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ReleaseLock) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (i *ReleaseLock) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -256,6 +274,7 @@ type GetLock struct {
 }
 
 var _ sql.FunctionExpression = (*GetLock)(nil)
+var _ sql.CollationCoercible = (*GetLock)(nil)
 
 // CreateNewGetLock returns a new GetLock object
 func CreateNewGetLock(ls *sql.LockSubsystem) func(e1, e2 sql.Expression) sql.Expression {
@@ -357,12 +376,18 @@ func (gl *GetLock) Type() sql.Type {
 	return types.Int8
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GetLock) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 type ReleaseAllLocks struct {
 	NoArgFunc
 	ls *sql.LockSubsystem
 }
 
 var _ sql.FunctionExpression = ReleaseAllLocks{}
+var _ sql.CollationCoercible = ReleaseAllLocks{}
 
 func NewReleaseAllLocks(ls *sql.LockSubsystem) func() sql.Expression {
 	return func() sql.Expression {
@@ -376,6 +401,11 @@ func NewReleaseAllLocks(ls *sql.LockSubsystem) func() sql.Expression {
 // Description implements sql.FunctionExpression
 func (r ReleaseAllLocks) Description() string {
 	return "release all current named locks."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (ReleaseAllLocks) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (r ReleaseAllLocks) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {

--- a/sql/expression/function/logarithm.go
+++ b/sql/expression/function/logarithm.go
@@ -44,6 +44,7 @@ type LogBase struct {
 }
 
 var _ sql.FunctionExpression = (*LogBase)(nil)
+var _ sql.CollationCoercible = (*LogBase)(nil)
 
 // NewLogBase creates a new LogBase expression.
 func NewLogBase(base float64, e sql.Expression) sql.Expression {
@@ -104,6 +105,11 @@ func (l *LogBase) Type() sql.Type {
 	return types.Float64
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*LogBase) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // IsNullable implements the sql.Expression interface.
 func (l *LogBase) IsNullable() bool {
 	return l.base == float64(1) || l.base <= float64(0) || l.Child.IsNullable()
@@ -136,6 +142,7 @@ type Log struct {
 }
 
 var _ sql.FunctionExpression = (*Log)(nil)
+var _ sql.CollationCoercible = (*Log)(nil)
 
 // NewLog creates a new Log expression.
 func NewLog(args ...sql.Expression) (sql.Expression, error) {
@@ -178,6 +185,11 @@ func (l *Log) Children() []sql.Expression {
 // Type returns the resultant type of the function.
 func (l *Log) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Log) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/lower_upper.go
+++ b/sql/expression/function/lower_upper.go
@@ -28,6 +28,7 @@ type Lower struct {
 }
 
 var _ sql.FunctionExpression = (*Lower)(nil)
+var _ sql.CollationCoercible = (*Lower)(nil)
 
 // NewLower creates a new Lower expression.
 func NewLower(e sql.Expression) sql.Expression {
@@ -82,12 +83,18 @@ func (l *Lower) Type() sql.Type {
 	return l.Child.Type()
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (l *Lower) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, l.Child)
+}
+
 // Upper is a function that returns the UPPERCASE of the text provided.
 type Upper struct {
 	expression.UnaryExpression
 }
 
 var _ sql.FunctionExpression = (*Upper)(nil)
+var _ sql.CollationCoercible = (*Upper)(nil)
 
 // NewUpper creates a new Lower expression.
 func NewUpper(e sql.Expression) sql.Expression {
@@ -140,4 +147,9 @@ func (u *Upper) WithChildren(children ...sql.Expression) (sql.Expression, error)
 // Type implements the Expression interface.
 func (u *Upper) Type() sql.Type {
 	return u.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (u *Upper) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, u.Child)
 }

--- a/sql/expression/function/math.go
+++ b/sql/expression/function/math.go
@@ -40,6 +40,7 @@ type Rand struct {
 var _ sql.Expression = (*Rand)(nil)
 var _ sql.NonDeterministicExpression = (*Rand)(nil)
 var _ sql.FunctionExpression = (*Rand)(nil)
+var _ sql.CollationCoercible = (*Rand)(nil)
 
 // NewRand creates a new Rand expression.
 func NewRand(exprs ...sql.Expression) (sql.Expression, error) {
@@ -65,6 +66,11 @@ func (r *Rand) Description() string {
 // Type implements sql.Expression.
 func (r *Rand) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Rand) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNonDeterministic implements sql.NonDeterministicExpression
@@ -140,6 +146,7 @@ type Sin struct {
 }
 
 var _ sql.FunctionExpression = (*Sin)(nil)
+var _ sql.CollationCoercible = (*Sin)(nil)
 
 // NewSin returns a new SIN function expression
 func NewSin(arg sql.Expression) sql.Expression {
@@ -149,6 +156,11 @@ func NewSin(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (s *Sin) Description() string {
 	return "returns the sine of the expression given."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Sin) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -183,6 +195,7 @@ type Cos struct {
 }
 
 var _ sql.FunctionExpression = (*Cos)(nil)
+var _ sql.CollationCoercible = (*Cos)(nil)
 
 // NewCos returns a new COS function expression
 func NewCos(arg sql.Expression) sql.Expression {
@@ -192,6 +205,11 @@ func NewCos(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (s *Cos) Description() string {
 	return "returns the cosine of an expression."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Cos) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -226,6 +244,7 @@ type Tan struct {
 }
 
 var _ sql.FunctionExpression = (*Tan)(nil)
+var _ sql.CollationCoercible = (*Tan)(nil)
 
 // NewTan returns a new TAN function expression
 func NewTan(arg sql.Expression) sql.Expression {
@@ -235,6 +254,11 @@ func NewTan(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (t *Tan) Description() string {
 	return "returns the tangent of the expression given."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Tan) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -269,6 +293,7 @@ type Asin struct {
 }
 
 var _ sql.FunctionExpression = (*Asin)(nil)
+var _ sql.CollationCoercible = (*Asin)(nil)
 
 // NewAsin returns a new ASIN function expression
 func NewAsin(arg sql.Expression) sql.Expression {
@@ -278,6 +303,11 @@ func NewAsin(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (a *Asin) Description() string {
 	return "returns the arcsin of an expression."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Asin) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -312,6 +342,7 @@ type Acos struct {
 }
 
 var _ sql.FunctionExpression = (*Acos)(nil)
+var _ sql.CollationCoercible = (*Acos)(nil)
 
 // NewAcos returns a new ACOS function expression
 func NewAcos(arg sql.Expression) sql.Expression {
@@ -321,6 +352,11 @@ func NewAcos(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (a *Acos) Description() string {
 	return "returns the arccos of an expression."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Acos) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -355,6 +391,7 @@ type Atan struct {
 }
 
 var _ sql.FunctionExpression = (*Atan)(nil)
+var _ sql.CollationCoercible = (*Atan)(nil)
 
 // NewAtan returns a new ATAN function expression
 func NewAtan(arg sql.Expression) sql.Expression {
@@ -364,6 +401,11 @@ func NewAtan(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (a *Atan) Description() string {
 	return "returns the arctan of an expression."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Atan) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -398,6 +440,7 @@ type Cot struct {
 }
 
 var _ sql.FunctionExpression = (*Cot)(nil)
+var _ sql.CollationCoercible = (*Cot)(nil)
 
 // NewCot returns a new COT function expression
 func NewCot(arg sql.Expression) sql.Expression {
@@ -407,6 +450,11 @@ func NewCot(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (c *Cot) Description() string {
 	return "returns the arctangent of an expression."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Cot) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -441,6 +489,7 @@ type Degrees struct {
 }
 
 var _ sql.FunctionExpression = (*Degrees)(nil)
+var _ sql.CollationCoercible = (*Degrees)(nil)
 
 // NewDegrees returns a new DEGREES function expression
 func NewDegrees(arg sql.Expression) sql.Expression {
@@ -455,6 +504,11 @@ func (d *Degrees) FunctionName() string {
 // Description implements sql.FunctionExpression
 func (d *Degrees) Description() string {
 	return "returns the number of degrees in the radian expression given."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Degrees) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -489,6 +543,7 @@ type Radians struct {
 }
 
 var _ sql.FunctionExpression = (*Radians)(nil)
+var _ sql.CollationCoercible = (*Radians)(nil)
 
 // NewRadians returns a new RADIANS function expression
 func NewRadians(arg sql.Expression) sql.Expression {
@@ -498,6 +553,11 @@ func NewRadians(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (r *Radians) Description() string {
 	return "returns the radian value of the degrees argument given."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Radians) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -532,6 +592,7 @@ type Crc32 struct {
 }
 
 var _ sql.FunctionExpression = (*Crc32)(nil)
+var _ sql.CollationCoercible = (*Crc32)(nil)
 
 // NewCrc32 returns a new CRC32 function expression
 func NewCrc32(arg sql.Expression) sql.Expression {
@@ -541,6 +602,11 @@ func NewCrc32(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (c *Crc32) Description() string {
 	return "returns the cyclic redundancy check value of a given string as a 32-bit unsigned value."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Crc32) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression
@@ -617,6 +683,7 @@ type Sign struct {
 }
 
 var _ sql.FunctionExpression = (*Sign)(nil)
+var _ sql.CollationCoercible = (*Sign)(nil)
 
 // NewSign returns a new SIGN function expression
 func NewSign(arg sql.Expression) sql.Expression {
@@ -629,6 +696,11 @@ var positiveSignRegex = regexp.MustCompile(`^+?[0-9]*\.?[0-9]*[1-9]`)
 // Description implements sql.FunctionExpression
 func (s *Sign) Description() string {
 	return "returns the sign of the argument."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Sign) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements sql.Expression

--- a/sql/expression/function/nullif.go
+++ b/sql/expression/function/nullif.go
@@ -28,6 +28,7 @@ type NullIf struct {
 }
 
 var _ sql.FunctionExpression = (*NullIf)(nil)
+var _ sql.CollationCoercible = (*NullIf)(nil)
 
 // NewNullIf returns a new NULLIF UDF
 func NewNullIf(ex1, ex2 sql.Expression) sql.Expression {
@@ -73,6 +74,14 @@ func (f *NullIf) Type() sql.Type {
 	}
 
 	return f.Left.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (f *NullIf) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	if types.IsNull(f.Left) {
+		return sql.Collation_binary, 6
+	}
+	return sql.GetCoercibility(ctx, f.Left)
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/queryinfo.go
+++ b/sql/expression/function/queryinfo.go
@@ -20,6 +20,7 @@ func NewRowCount() sql.Expression {
 }
 
 var _ sql.FunctionExpression = RowCount{}
+var _ sql.CollationCoercible = RowCount{}
 
 // Description implements sql.FunctionExpression
 func (r RowCount) Description() string {
@@ -39,6 +40,11 @@ func (r RowCount) String() string {
 // Type implements sql.Expression
 func (r RowCount) Type() sql.Type {
 	return types.Int64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (RowCount) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression
@@ -87,6 +93,7 @@ func NewLastInsertId(children ...sql.Expression) (sql.Expression, error) {
 }
 
 var _ sql.FunctionExpression = LastInsertId{}
+var _ sql.CollationCoercible = LastInsertId{}
 
 // Description implements sql.FunctionExpression
 func (r LastInsertId) Description() string {
@@ -106,6 +113,11 @@ func (r LastInsertId) String() string {
 // Type implements sql.Expression
 func (r LastInsertId) Type() sql.Type {
 	return types.Int64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (LastInsertId) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression
@@ -164,6 +176,7 @@ func NewFoundRows() sql.Expression {
 }
 
 var _ sql.FunctionExpression = FoundRows{}
+var _ sql.CollationCoercible = FoundRows{}
 
 // FunctionName implements sql.FunctionExpression
 func (r FoundRows) FunctionName() string {
@@ -188,6 +201,11 @@ func (r FoundRows) String() string {
 // Type implements sql.Expression
 func (r FoundRows) Type() sql.Type {
 	return types.Int64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (FoundRows) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements sql.Expression

--- a/sql/expression/function/regexp_like.go
+++ b/sql/expression/function/regexp_like.go
@@ -42,6 +42,7 @@ type RegexpLike struct {
 }
 
 var _ sql.FunctionExpression = (*RegexpLike)(nil)
+var _ sql.CollationCoercible = (*RegexpLike)(nil)
 
 // NewRegexpLike creates a new RegexpLike expression.
 func NewRegexpLike(args ...sql.Expression) (sql.Expression, error) {
@@ -76,6 +77,13 @@ func (r *RegexpLike) Description() string {
 
 // Type implements the sql.Expression interface.
 func (r *RegexpLike) Type() sql.Type { return types.Int8 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (r *RegexpLike) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	leftCollation, leftCoercibility := sql.GetCoercibility(ctx, r.Text)
+	rightCollation, rightCoercibility := sql.GetCoercibility(ctx, r.Pattern)
+	return sql.ResolveCoercibility(leftCollation, leftCoercibility, rightCollation, rightCoercibility)
+}
 
 // IsNullable implements the sql.Expression interface.
 func (r *RegexpLike) IsNullable() bool { return true }

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -50,6 +50,8 @@ var BuiltIns = []sql.Function{
 	sql.Function1{Name: "char_length", Fn: NewCharLength},
 	sql.Function1{Name: "character_length", Fn: NewCharLength},
 	sql.FunctionN{Name: "coalesce", Fn: NewCoalesce},
+	sql.Function1{Name: "coercibility", Fn: NewCoercibility},
+	sql.Function1{Name: "collation", Fn: NewCollation},
 	sql.FunctionN{Name: "concat", Fn: NewConcat},
 	sql.FunctionN{Name: "concat_ws", Fn: NewConcatWithSeparator},
 	sql.NewFunction0("connection_id", NewConnectionID),

--- a/sql/expression/function/rpad_lpad.go
+++ b/sql/expression/function/rpad_lpad.go
@@ -61,6 +61,7 @@ type Pad struct {
 }
 
 var _ sql.FunctionExpression = (*Pad)(nil)
+var _ sql.CollationCoercible = (*Pad)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (p *Pad) FunctionName() string {
@@ -101,6 +102,13 @@ func (p *Pad) IsNullable() bool {
 
 // Type implements the Expression interface.
 func (p *Pad) Type() sql.Type { return types.LongText }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p *Pad) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	leftCollation, leftCoercibility := sql.GetCoercibility(ctx, p.str)
+	rightCollation, rightCoercibility := sql.GetCoercibility(ctx, p.padStr)
+	return sql.ResolveCoercibility(leftCollation, leftCoercibility, rightCollation, rightCoercibility)
+}
 
 func (p *Pad) String() string {
 	if p.padType == lPadType {

--- a/sql/expression/function/sleep.go
+++ b/sql/expression/function/sleep.go
@@ -32,6 +32,7 @@ type Sleep struct {
 }
 
 var _ sql.FunctionExpression = (*Sleep)(nil)
+var _ sql.CollationCoercible = (*Sleep)(nil)
 
 // NewSleep creates a new Sleep expression.
 func NewSleep(e sql.Expression) sql.Expression {
@@ -97,4 +98,9 @@ func (s *Sleep) WithChildren(children ...sql.Expression) (sql.Expression, error)
 // Type implements the Expression interface.
 func (s *Sleep) Type() sql.Type {
 	return types.Int32
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Sleep) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }

--- a/sql/expression/function/soundex.go
+++ b/sql/expression/function/soundex.go
@@ -33,6 +33,7 @@ type Soundex struct {
 }
 
 var _ sql.FunctionExpression = (*Soundex)(nil)
+var _ sql.CollationCoercible = (*Soundex)(nil)
 
 // NewSoundex creates a new Soundex expression.
 func NewSoundex(e sql.Expression) sql.Expression {
@@ -125,4 +126,9 @@ func (s *Soundex) WithChildren(children ...sql.Expression) (sql.Expression, erro
 // Type implements the Expression interface.
 func (s *Soundex) Type() sql.Type {
 	return types.LongText
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Soundex) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }

--- a/sql/expression/function/spatial/geojson.go
+++ b/sql/expression/function/spatial/geojson.go
@@ -19,6 +19,7 @@ type AsGeoJSON struct {
 }
 
 var _ sql.FunctionExpression = (*AsGeoJSON)(nil)
+var _ sql.CollationCoercible = (*AsGeoJSON)(nil)
 
 // NewAsGeoJSON creates a new point expression.
 func NewAsGeoJSON(args ...sql.Expression) (sql.Expression, error) {
@@ -41,6 +42,11 @@ func (g *AsGeoJSON) Description() string {
 // Type implements the sql.Expression interface.
 func (g *AsGeoJSON) Type() sql.Type {
 	return types.JSON
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (f *AsGeoJSON) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 2
 }
 
 func (g *AsGeoJSON) String() string {
@@ -380,6 +386,7 @@ type GeomFromGeoJSON struct {
 }
 
 var _ sql.FunctionExpression = (*GeomFromGeoJSON)(nil)
+var _ sql.CollationCoercible = (*GeomFromGeoJSON)(nil)
 
 // NewGeomFromGeoJSON creates a new point expression.
 func NewGeomFromGeoJSON(args ...sql.Expression) (sql.Expression, error) {
@@ -402,6 +409,11 @@ func (g *GeomFromGeoJSON) Description() string {
 // Type implements the sql.Expression interface.
 func (g *GeomFromGeoJSON) Type() sql.Type {
 	return types.GeometryType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GeomFromGeoJSON) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (g *GeomFromGeoJSON) String() string {

--- a/sql/expression/function/spatial/geometry_collection.go
+++ b/sql/expression/function/spatial/geometry_collection.go
@@ -30,6 +30,7 @@ type GeomColl struct {
 }
 
 var _ sql.FunctionExpression = (*GeomColl)(nil)
+var _ sql.CollationCoercible = (*GeomColl)(nil)
 
 // NewGeomColl creates a new geometrycollection expression.
 func NewGeomColl(args ...sql.Expression) (sql.Expression, error) {
@@ -49,6 +50,11 @@ func (g *GeomColl) Description() string {
 // Type implements the sql.Expression interface.
 func (g *GeomColl) Type() sql.Type {
 	return types.GeomCollType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GeomColl) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (g *GeomColl) String() string {

--- a/sql/expression/function/spatial/linestring.go
+++ b/sql/expression/function/spatial/linestring.go
@@ -30,6 +30,7 @@ type LineString struct {
 }
 
 var _ sql.FunctionExpression = (*LineString)(nil)
+var _ sql.CollationCoercible = (*LineString)(nil)
 
 // NewLineString creates a new LineString.
 func NewLineString(args ...sql.Expression) (sql.Expression, error) {
@@ -52,6 +53,11 @@ func (l *LineString) Description() string {
 // Type implements the sql.Expression interface.
 func (l *LineString) Type() sql.Type {
 	return types.LineStringType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*LineString) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (l *LineString) String() string {

--- a/sql/expression/function/spatial/multilinestring.go
+++ b/sql/expression/function/spatial/multilinestring.go
@@ -30,6 +30,7 @@ type MultiLineString struct {
 }
 
 var _ sql.FunctionExpression = (*MultiLineString)(nil)
+var _ sql.CollationCoercible = (*MultiLineString)(nil)
 
 // NewMultiLineString creates a new multilinestring expression.
 func NewMultiLineString(args ...sql.Expression) (sql.Expression, error) {
@@ -52,6 +53,11 @@ func (p *MultiLineString) Description() string {
 // Type implements the sql.Expression interface.
 func (p *MultiLineString) Type() sql.Type {
 	return types.MultiLineStringType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MultiLineString) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (p *MultiLineString) String() string {

--- a/sql/expression/function/spatial/multipoint.go
+++ b/sql/expression/function/spatial/multipoint.go
@@ -30,6 +30,7 @@ type MultiPoint struct {
 }
 
 var _ sql.FunctionExpression = (*MultiPoint)(nil)
+var _ sql.CollationCoercible = (*MultiPoint)(nil)
 
 // NewMultiPoint creates a new MultiPoint.
 func NewMultiPoint(args ...sql.Expression) (sql.Expression, error) {
@@ -52,6 +53,11 @@ func (l *MultiPoint) Description() string {
 // Type implements the sql.Expression interface.
 func (l *MultiPoint) Type() sql.Type {
 	return types.MultiPointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MultiPoint) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (l *MultiPoint) String() string {

--- a/sql/expression/function/spatial/multipolygon.go
+++ b/sql/expression/function/spatial/multipolygon.go
@@ -30,6 +30,7 @@ type MultiPolygon struct {
 }
 
 var _ sql.FunctionExpression = (*MultiPolygon)(nil)
+var _ sql.CollationCoercible = (*MultiPolygon)(nil)
 
 // NewMultiPolygon creates a new multipolygon expression.
 func NewMultiPolygon(args ...sql.Expression) (sql.Expression, error) {
@@ -52,6 +53,11 @@ func (p *MultiPolygon) Description() string {
 // Type implements the sql.Expression interface.
 func (p *MultiPolygon) Type() sql.Type {
 	return types.MultiPolygonType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MultiPolygon) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (p *MultiPolygon) String() string {

--- a/sql/expression/function/spatial/point.go
+++ b/sql/expression/function/spatial/point.go
@@ -28,6 +28,7 @@ type Point struct {
 }
 
 var _ sql.FunctionExpression = (*Point)(nil)
+var _ sql.CollationCoercible = (*Point)(nil)
 
 // NewPoint creates a new point expression.
 func NewPoint(e1, e2 sql.Expression) sql.Expression {
@@ -62,6 +63,11 @@ func (p *Point) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (p *Point) Type() sql.Type {
 	return types.PointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Point) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (p *Point) String() string {

--- a/sql/expression/function/spatial/polygon.go
+++ b/sql/expression/function/spatial/polygon.go
@@ -32,6 +32,7 @@ type Polygon struct {
 }
 
 var _ sql.FunctionExpression = (*Polygon)(nil)
+var _ sql.CollationCoercible = (*Polygon)(nil)
 
 // NewPolygon creates a new polygon expression.
 func NewPolygon(args ...sql.Expression) (sql.Expression, error) {
@@ -54,6 +55,11 @@ func (p *Polygon) Description() string {
 // Type implements the sql.Expression interface.
 func (p *Polygon) Type() sql.Type {
 	return types.PolygonType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Polygon) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (p *Polygon) String() string {

--- a/sql/expression/function/spatial/st_area.go
+++ b/sql/expression/function/spatial/st_area.go
@@ -28,6 +28,7 @@ type Area struct {
 }
 
 var _ sql.FunctionExpression = (*Area)(nil)
+var _ sql.CollationCoercible = (*Area)(nil)
 
 // NewArea creates a new Area expression.
 func NewArea(arg sql.Expression) sql.Expression {
@@ -47,6 +48,11 @@ func (a *Area) Description() string {
 // Type implements the sql.Expression interface.
 func (a *Area) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Area) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (a *Area) String() string {

--- a/sql/expression/function/spatial/st_dimension.go
+++ b/sql/expression/function/spatial/st_dimension.go
@@ -28,6 +28,7 @@ type Dimension struct {
 }
 
 var _ sql.FunctionExpression = (*Dimension)(nil)
+var _ sql.CollationCoercible = (*Dimension)(nil)
 
 // NewDimension creates a new point expression.
 func NewDimension(e sql.Expression) sql.Expression {
@@ -52,6 +53,11 @@ func (p *Dimension) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (p *Dimension) Type() sql.Type {
 	return types.Int32
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Dimension) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (p *Dimension) String() string {

--- a/sql/expression/function/spatial/st_distance.go
+++ b/sql/expression/function/spatial/st_distance.go
@@ -32,6 +32,7 @@ type Distance struct {
 }
 
 var _ sql.FunctionExpression = (*Distance)(nil)
+var _ sql.CollationCoercible = (*Distance)(nil)
 
 // ErrNoUnits is thrown when the specified SRID does not have units
 var ErrNoUnits = errors.NewKind("the geometry passed to function st_distance is in SRID %v, which doesn't specify a length unit. Can't convert to '%v'.")
@@ -57,6 +58,11 @@ func (d *Distance) Description() string {
 // Type implements the sql.Expression interface.
 func (d *Distance) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Distance) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (d *Distance) String() string {

--- a/sql/expression/function/spatial/st_intersects.go
+++ b/sql/expression/function/spatial/st_intersects.go
@@ -29,6 +29,7 @@ type Intersects struct {
 }
 
 var _ sql.FunctionExpression = (*Intersects)(nil)
+var _ sql.CollationCoercible = (*Intersects)(nil)
 
 // NewIntersects creates a new Intersects expression.
 func NewIntersects(g1, g2 sql.Expression) sql.Expression {
@@ -53,6 +54,11 @@ func (i *Intersects) Description() string {
 // Type implements the sql.Expression interface.
 func (i *Intersects) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Intersects) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (i *Intersects) String() string {

--- a/sql/expression/function/spatial/st_length.go
+++ b/sql/expression/function/spatial/st_length.go
@@ -30,6 +30,7 @@ type STLength struct {
 }
 
 var _ sql.FunctionExpression = (*STLength)(nil)
+var _ sql.CollationCoercible = (*STLength)(nil)
 
 // NewSTLength creates a new STLength expression.
 func NewSTLength(args ...sql.Expression) (sql.Expression, error) {
@@ -52,6 +53,11 @@ func (s *STLength) Description() string {
 // Type implements the sql.Expression interface.
 func (s *STLength) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*STLength) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (s *STLength) String() string {

--- a/sql/expression/function/spatial/st_linestring.go
+++ b/sql/expression/function/spatial/st_linestring.go
@@ -28,6 +28,7 @@ type StartPoint struct {
 }
 
 var _ sql.FunctionExpression = (*StartPoint)(nil)
+var _ sql.CollationCoercible = (*StartPoint)(nil)
 
 // NewStartPoint creates a new StartPoint expression.
 func NewStartPoint(arg sql.Expression) sql.Expression {
@@ -47,6 +48,11 @@ func (s *StartPoint) Description() string {
 // Type implements the sql.Expression interface.
 func (s *StartPoint) Type() sql.Type {
 	return types.PointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*StartPoint) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (s *StartPoint) String() string {
@@ -94,6 +100,7 @@ type EndPoint struct {
 }
 
 var _ sql.FunctionExpression = (*EndPoint)(nil)
+var _ sql.CollationCoercible = (*EndPoint)(nil)
 
 // NewEndPoint creates a new EndPoint expression.
 func NewEndPoint(arg sql.Expression) sql.Expression {
@@ -113,6 +120,11 @@ func (e *EndPoint) Description() string {
 // Type implements the sql.Expression interface.
 func (e *EndPoint) Type() sql.Type {
 	return types.PointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*EndPoint) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (e *EndPoint) String() string {
@@ -160,6 +172,7 @@ type IsClosed struct {
 }
 
 var _ sql.FunctionExpression = (*IsClosed)(nil)
+var _ sql.CollationCoercible = (*IsClosed)(nil)
 
 // NewIsClosed creates a new EndPoint expression.
 func NewIsClosed(arg sql.Expression) sql.Expression {
@@ -179,6 +192,11 @@ func (i *IsClosed) Description() string {
 // Type implements the sql.Expression interface.
 func (i *IsClosed) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsClosed) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (i *IsClosed) String() string {

--- a/sql/expression/function/spatial/st_perimeter.go
+++ b/sql/expression/function/spatial/st_perimeter.go
@@ -30,6 +30,7 @@ type Perimeter struct {
 }
 
 var _ sql.FunctionExpression = (*Perimeter)(nil)
+var _ sql.CollationCoercible = (*Perimeter)(nil)
 
 // NewSTLength creates a new STX expression.
 func NewPerimeter(args ...sql.Expression) (sql.Expression, error) {
@@ -52,6 +53,11 @@ func (p *Perimeter) Description() string {
 // Type implements the sql.Expression interface.
 func (p *Perimeter) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Perimeter) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (p *Perimeter) String() string {

--- a/sql/expression/function/spatial/st_srid.go
+++ b/sql/expression/function/spatial/st_srid.go
@@ -31,6 +31,7 @@ type SRID struct {
 }
 
 var _ sql.FunctionExpression = (*SRID)(nil)
+var _ sql.CollationCoercible = (*SRID)(nil)
 
 var ErrInvalidSRID = errors.NewKind("There's no spatial reference with SRID %d")
 
@@ -59,6 +60,11 @@ func (s *SRID) Type() sql.Type {
 	} else {
 		return s.ChildExpressions[0].Type()
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*SRID) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (s *SRID) String() string {

--- a/sql/expression/function/spatial/st_swapxy.go
+++ b/sql/expression/function/spatial/st_swapxy.go
@@ -28,6 +28,7 @@ type SwapXY struct {
 }
 
 var _ sql.FunctionExpression = (*SwapXY)(nil)
+var _ sql.CollationCoercible = (*SwapXY)(nil)
 
 // NewSwapXY creates a new point expression.
 func NewSwapXY(e sql.Expression) sql.Expression {
@@ -52,6 +53,11 @@ func (s *SwapXY) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (s *SwapXY) Type() sql.Type {
 	return s.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*SwapXY) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (s *SwapXY) String() string {

--- a/sql/expression/function/spatial/st_within.go
+++ b/sql/expression/function/spatial/st_within.go
@@ -29,6 +29,7 @@ type Within struct {
 }
 
 var _ sql.FunctionExpression = (*Within)(nil)
+var _ sql.CollationCoercible = (*Within)(nil)
 
 // NewWithin creates a new Within expression.
 func NewWithin(g1, g2 sql.Expression) sql.Expression {
@@ -53,6 +54,11 @@ func (w *Within) Description() string {
 // Type implements the sql.Expression interface.
 func (w *Within) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Within) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (w *Within) String() string {

--- a/sql/expression/function/spatial/wkb.go
+++ b/sql/expression/function/spatial/wkb.go
@@ -29,6 +29,7 @@ type AsWKB struct {
 }
 
 var _ sql.FunctionExpression = (*AsWKB)(nil)
+var _ sql.CollationCoercible = (*AsWKB)(nil)
 
 // NewAsWKB creates a new point expression.
 func NewAsWKB(e sql.Expression) sql.Expression {
@@ -53,6 +54,11 @@ func (a *AsWKB) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (a *AsWKB) Type() sql.Type {
 	return types.LongBlob
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*AsWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (a *AsWKB) String() string {
@@ -95,6 +101,7 @@ type GeomFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*GeomFromWKB)(nil)
+var _ sql.CollationCoercible = (*GeomFromWKB)(nil)
 
 // NewGeomFromWKB creates a new geometry expression.
 func NewGeomFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -117,6 +124,11 @@ func (g *GeomFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (g *GeomFromWKB) Type() sql.Type {
 	return types.PointType{} // TODO: replace with generic geometry type
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GeomFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (g *GeomFromWKB) String() string {
@@ -257,6 +269,7 @@ type PointFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*PointFromWKB)(nil)
+var _ sql.CollationCoercible = (*PointFromWKB)(nil)
 
 // NewPointFromWKB creates a new point expression.
 func NewPointFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -279,6 +292,11 @@ func (p *PointFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (p *PointFromWKB) Type() sql.Type {
 	return types.PointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*PointFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *PointFromWKB) String() string {
@@ -309,6 +327,7 @@ type LineFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*LineFromWKB)(nil)
+var _ sql.CollationCoercible = (*LineFromWKB)(nil)
 
 // NewLineFromWKB creates a new point expression.
 func NewLineFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -331,6 +350,11 @@ func (l *LineFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (l *LineFromWKB) Type() sql.Type {
 	return types.LineStringType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*LineFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (l *LineFromWKB) String() string {
@@ -361,6 +385,7 @@ type PolyFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*PolyFromWKB)(nil)
+var _ sql.CollationCoercible = (*PolyFromWKB)(nil)
 
 // NewPolyFromWKB creates a new point expression.
 func NewPolyFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -383,6 +408,11 @@ func (p *PolyFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (p *PolyFromWKB) Type() sql.Type {
 	return types.PolygonType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*PolyFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *PolyFromWKB) String() string {
@@ -413,6 +443,7 @@ type MPointFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*MPointFromWKB)(nil)
+var _ sql.CollationCoercible = (*MPointFromWKB)(nil)
 
 // NewMPointFromWKB creates a new point expression.
 func NewMPointFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -435,6 +466,11 @@ func (p *MPointFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (p *MPointFromWKB) Type() sql.Type {
 	return types.MultiPointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MPointFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *MPointFromWKB) String() string {
@@ -465,6 +501,7 @@ type MLineFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*MLineFromWKB)(nil)
+var _ sql.CollationCoercible = (*MLineFromWKB)(nil)
 
 // NewMLineFromWKB creates a new point expression.
 func NewMLineFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -487,6 +524,11 @@ func (l *MLineFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (l *MLineFromWKB) Type() sql.Type {
 	return types.PolygonType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MLineFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (l *MLineFromWKB) String() string {
@@ -517,6 +559,7 @@ type MPolyFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*MPolyFromWKB)(nil)
+var _ sql.CollationCoercible = (*MPolyFromWKB)(nil)
 
 // NewMPolyFromWKB creates a new multipolygon expression.
 func NewMPolyFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -539,6 +582,11 @@ func (p *MPolyFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (p *MPolyFromWKB) Type() sql.Type {
 	return types.MultiPolygonType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MPolyFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *MPolyFromWKB) String() string {
@@ -569,6 +617,7 @@ type GeomCollFromWKB struct {
 }
 
 var _ sql.FunctionExpression = (*GeomCollFromWKB)(nil)
+var _ sql.CollationCoercible = (*GeomCollFromWKB)(nil)
 
 // NewGeomCollFromWKB creates a new geometrycollection expression.
 func NewGeomCollFromWKB(args ...sql.Expression) (sql.Expression, error) {
@@ -591,6 +640,11 @@ func (g *GeomCollFromWKB) Description() string {
 // Type implements the sql.Expression interface.
 func (g *GeomCollFromWKB) Type() sql.Type {
 	return types.GeomCollType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GeomCollFromWKB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (g *GeomCollFromWKB) String() string {

--- a/sql/expression/function/spatial/wkt.go
+++ b/sql/expression/function/spatial/wkt.go
@@ -30,6 +30,7 @@ type AsWKT struct {
 }
 
 var _ sql.FunctionExpression = (*AsWKT)(nil)
+var _ sql.CollationCoercible = (*AsWKT)(nil)
 
 // NewAsWKT creates a new point expression.
 func NewAsWKT(e sql.Expression) sql.Expression {
@@ -54,6 +55,11 @@ func (p *AsWKT) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (p *AsWKT) Type() sql.Type {
 	return types.LongText
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*AsWKT) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 func (p *AsWKT) String() string {
@@ -198,6 +204,7 @@ type GeomFromText struct {
 }
 
 var _ sql.FunctionExpression = (*GeomFromText)(nil)
+var _ sql.CollationCoercible = (*GeomFromText)(nil)
 
 // NewGeomFromText creates a new point expression.
 func NewGeomFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -221,6 +228,11 @@ func (g *GeomFromText) Description() string {
 func (g *GeomFromText) Type() sql.Type {
 	// TODO: return type is determined after Eval, use Geometry for now?
 	return types.GeometryType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GeomFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (g *GeomFromText) String() string {
@@ -627,6 +639,7 @@ type PointFromText struct {
 }
 
 var _ sql.FunctionExpression = (*PointFromText)(nil)
+var _ sql.CollationCoercible = (*PointFromText)(nil)
 
 // NewPointFromText creates a new point expression.
 func NewPointFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -649,6 +662,11 @@ func (p *PointFromText) Description() string {
 // Type implements the sql.Expression interface.
 func (p *PointFromText) Type() sql.Type {
 	return types.PointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*PointFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *PointFromText) String() string {
@@ -679,6 +697,7 @@ type LineFromText struct {
 }
 
 var _ sql.FunctionExpression = (*LineFromText)(nil)
+var _ sql.CollationCoercible = (*LineFromText)(nil)
 
 // NewLineFromText creates a new point expression.
 func NewLineFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -701,6 +720,11 @@ func (l *LineFromText) Description() string {
 // Type implements the sql.Expression interface.
 func (l *LineFromText) Type() sql.Type {
 	return types.LineStringType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*LineFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (l *LineFromText) String() string {
@@ -731,6 +755,7 @@ type PolyFromText struct {
 }
 
 var _ sql.FunctionExpression = (*PolyFromText)(nil)
+var _ sql.CollationCoercible = (*PolyFromText)(nil)
 
 // NewPolyFromText creates a new polygon expression.
 func NewPolyFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -753,6 +778,11 @@ func (p *PolyFromText) Description() string {
 // Type implements the sql.Expression interface.
 func (p *PolyFromText) Type() sql.Type {
 	return types.PolygonType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*PolyFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *PolyFromText) String() string {
@@ -783,6 +813,7 @@ type MPointFromText struct {
 }
 
 var _ sql.FunctionExpression = (*MPointFromText)(nil)
+var _ sql.CollationCoercible = (*MPointFromText)(nil)
 
 // NewMPointFromText creates a new MultiPoint expression.
 func NewMPointFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -805,6 +836,11 @@ func (p *MPointFromText) Description() string {
 // Type implements the sql.Expression interface.
 func (p *MPointFromText) Type() sql.Type {
 	return types.MultiPointType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MPointFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *MPointFromText) String() string {
@@ -835,6 +871,7 @@ type MLineFromText struct {
 }
 
 var _ sql.FunctionExpression = (*MLineFromText)(nil)
+var _ sql.CollationCoercible = (*MLineFromText)(nil)
 
 // NewMLineFromText creates a new multilinestring expression.
 func NewMLineFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -857,6 +894,11 @@ func (l *MLineFromText) Description() string {
 // Type implements the sql.Expression interface.
 func (l *MLineFromText) Type() sql.Type {
 	return types.MultiLineStringType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MLineFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (l *MLineFromText) String() string {
@@ -887,6 +929,7 @@ type MPolyFromText struct {
 }
 
 var _ sql.FunctionExpression = (*MPolyFromText)(nil)
+var _ sql.CollationCoercible = (*MPolyFromText)(nil)
 
 // NewMPolyFromText creates a new multilinestring expression.
 func NewMPolyFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -909,6 +952,11 @@ func (p *MPolyFromText) Description() string {
 // Type implements the sql.Expression interface.
 func (p *MPolyFromText) Type() sql.Type {
 	return types.MultiPolygonType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MPolyFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *MPolyFromText) String() string {
@@ -939,6 +987,7 @@ type GeomCollFromText struct {
 }
 
 var _ sql.FunctionExpression = (*GeomCollFromText)(nil)
+var _ sql.CollationCoercible = (*GeomCollFromText)(nil)
 
 // NewGeomCollFromText creates a new multilinestring expression.
 func NewGeomCollFromText(args ...sql.Expression) (sql.Expression, error) {
@@ -961,6 +1010,11 @@ func (p *GeomCollFromText) Description() string {
 // Type implements the sql.Expression interface.
 func (p *GeomCollFromText) Type() sql.Type {
 	return types.GeomCollType{}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GeomCollFromText) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (p *GeomCollFromText) String() string {

--- a/sql/expression/function/spatial/x_y_latitude_longitude.go
+++ b/sql/expression/function/spatial/x_y_latitude_longitude.go
@@ -31,6 +31,7 @@ type STX struct {
 }
 
 var _ sql.FunctionExpression = (*STX)(nil)
+var _ sql.CollationCoercible = (*STX)(nil)
 
 var ErrInvalidType = errors.NewKind("%s received non-point type")
 
@@ -59,6 +60,11 @@ func (s *STX) Type() sql.Type {
 	} else {
 		return types.PointType{}
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*STX) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (s *STX) String() string {
@@ -125,6 +131,7 @@ type STY struct {
 }
 
 var _ sql.FunctionExpression = (*STY)(nil)
+var _ sql.CollationCoercible = (*STY)(nil)
 
 // NewSTY creates a new STY expression.
 func NewSTY(args ...sql.Expression) (sql.Expression, error) {
@@ -151,6 +158,11 @@ func (s *STY) Type() sql.Type {
 	} else {
 		return types.PointType{}
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*STY) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (s *STY) String() string {
@@ -217,6 +229,7 @@ type Longitude struct {
 }
 
 var _ sql.FunctionExpression = (*Longitude)(nil)
+var _ sql.CollationCoercible = (*Longitude)(nil)
 
 var ErrNonGeographic = errors.NewKind("function %s is only defined for geographic spatial reference systems, but one of its argument is in SRID %v, which is not geographic")
 var ErrLatitudeOutOfRange = errors.NewKind("latitude %v is out of range in function %s. it must be within [-90.0, 90.0]")
@@ -247,6 +260,11 @@ func (l *Longitude) Type() sql.Type {
 	} else {
 		return types.PointType{}
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Longitude) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (l *Longitude) String() string {
@@ -324,6 +342,7 @@ type Latitude struct {
 }
 
 var _ sql.FunctionExpression = (*Latitude)(nil)
+var _ sql.CollationCoercible = (*Latitude)(nil)
 
 // NewLatitude creates a new ST_LATITUDE expression.
 func NewLatitude(args ...sql.Expression) (sql.Expression, error) {
@@ -350,6 +369,11 @@ func (l *Latitude) Type() sql.Type {
 	} else {
 		return types.PointType{}
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Latitude) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (l *Latitude) String() string {

--- a/sql/expression/function/sqrt_power.go
+++ b/sql/expression/function/sqrt_power.go
@@ -29,6 +29,7 @@ type Sqrt struct {
 }
 
 var _ sql.FunctionExpression = (*Sqrt)(nil)
+var _ sql.CollationCoercible = (*Sqrt)(nil)
 
 // NewSqrt creates a new Sqrt expression.
 func NewSqrt(e sql.Expression) sql.Expression {
@@ -52,6 +53,11 @@ func (s *Sqrt) String() string {
 // Type implements the Expression interface.
 func (s *Sqrt) Type() sql.Type {
 	return types.Float64
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Sqrt) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements the Expression interface.
@@ -93,6 +99,7 @@ type Power struct {
 }
 
 var _ sql.FunctionExpression = (*Power)(nil)
+var _ sql.CollationCoercible = (*Power)(nil)
 
 // NewPower creates a new Power expression.
 func NewPower(e1, e2 sql.Expression) sql.Expression {
@@ -116,6 +123,11 @@ func (p *Power) Description() string {
 
 // Type implements the Expression interface.
 func (p *Power) Type() sql.Type { return types.Float64 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Power) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // IsNullable implements the Expression interface.
 func (p *Power) IsNullable() bool { return p.Left.IsNullable() || p.Right.IsNullable() }

--- a/sql/expression/function/str_to_date.go
+++ b/sql/expression/function/str_to_date.go
@@ -26,6 +26,7 @@ type StrToDate struct {
 }
 
 var _ sql.FunctionExpression = (*StrToDate)(nil)
+var _ sql.CollationCoercible = (*StrToDate)(nil)
 
 // Description implements sql.FunctionExpression
 func (s StrToDate) Description() string {
@@ -46,6 +47,11 @@ func (s StrToDate) String() string {
 // Type returns the expression type.
 func (s StrToDate) Type() sql.Type {
 	return types.Datetime
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (StrToDate) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable returns whether the expression can be null.

--- a/sql/expression/function/strcmp.go
+++ b/sql/expression/function/strcmp.go
@@ -28,6 +28,7 @@ type StrCmp struct {
 }
 
 var _ sql.FunctionExpression = (*StrCmp)(nil)
+var _ sql.CollationCoercible = (*StrCmp)(nil)
 
 // NewStrCmp creates a new NewStrCmp UDF.
 func NewStrCmp(e1, e2 sql.Expression) sql.Expression {
@@ -52,6 +53,13 @@ func (s *StrCmp) Description() string {
 // Type implements the Expression interface.
 func (s *StrCmp) Type() sql.Type {
 	return types.Int8
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (s *StrCmp) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	leftCollation, leftCoercibility := sql.GetCoercibility(ctx, s.Left)
+	rightCollation, rightCoercibility := sql.GetCoercibility(ctx, s.Right)
+	return sql.ResolveCoercibility(leftCollation, leftCoercibility, rightCollation, rightCoercibility)
 }
 
 func (s *StrCmp) String() string {
@@ -87,9 +95,7 @@ func (s *StrCmp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	leftCollation, leftCoercibility := expression.GetCollationViaCoercion(s.Left)
-	rightCollation, rightCoercibility := expression.GetCollationViaCoercion(s.Right)
-	collationPreference, err := expression.ResolveCoercibility(leftCollation, leftCoercibility, rightCollation, rightCoercibility)
+	collationPreference, _ := s.CollationCoercibility(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/expression/function/string.go
+++ b/sql/expression/function/string.go
@@ -36,6 +36,7 @@ type Ascii struct {
 }
 
 var _ sql.FunctionExpression = (*Ascii)(nil)
+var _ sql.CollationCoercible = (*Ascii)(nil)
 
 func NewAscii(arg sql.Expression) sql.Expression {
 	return &Ascii{NewUnaryFunc(arg, "ASCII", types.Uint8)}
@@ -44,6 +45,11 @@ func NewAscii(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (a *Ascii) Description() string {
 	return "returns the numeric value of the leftmost character."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Ascii) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements the sql.Expression interface
@@ -93,6 +99,7 @@ type Hex struct {
 }
 
 var _ sql.FunctionExpression = (*Hex)(nil)
+var _ sql.CollationCoercible = (*Hex)(nil)
 
 func NewHex(arg sql.Expression) sql.Expression {
 	// Although this may seem convoluted, the Collation_Default is NOT guaranteed to be the character set's default
@@ -105,6 +112,11 @@ func NewHex(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (h *Hex) Description() string {
 	return "returns the hexadecimal representation of the string or numeric value."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Hex) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // Eval implements the sql.Expression interface
@@ -252,6 +264,7 @@ type Unhex struct {
 }
 
 var _ sql.FunctionExpression = (*Unhex)(nil)
+var _ sql.CollationCoercible = (*Unhex)(nil)
 
 func NewUnhex(arg sql.Expression) sql.Expression {
 	return &Unhex{NewUnaryFunc(arg, "UNHEX", types.LongBlob)}
@@ -260,6 +273,11 @@ func NewUnhex(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (h *Unhex) Description() string {
 	return "returns a string containing hex representation of a number."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Unhex) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 // Eval implements the sql.Expression interface
@@ -330,6 +348,7 @@ type Bin struct {
 }
 
 var _ sql.FunctionExpression = (*Bin)(nil)
+var _ sql.CollationCoercible = (*Bin)(nil)
 
 func NewBin(arg sql.Expression) sql.Expression {
 	return &Bin{NewUnaryFunc(arg, "BIN", types.Text)}
@@ -343,6 +362,11 @@ func (b *Bin) FunctionName() string {
 // Description implements sql.FunctionExpression
 func (b *Bin) Description() string {
 	return "returns the binary representation of a number."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Bin) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // Eval implements the sql.Expression interface
@@ -465,6 +489,7 @@ type Bitlength struct {
 }
 
 var _ sql.FunctionExpression = (*Bitlength)(nil)
+var _ sql.CollationCoercible = (*Bitlength)(nil)
 
 func NewBitlength(arg sql.Expression) sql.Expression {
 	return &Bitlength{NewUnaryFunc(arg, "BIT_LENGTH", types.Int32)}
@@ -478,6 +503,11 @@ func (b *Bitlength) FunctionName() string {
 // Description implements sql.FunctionExpression
 func (b *Bitlength) Description() string {
 	return "returns the data length of the argument in bits."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Bitlength) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements the sql.Expression interface

--- a/sql/expression/function/substring.go
+++ b/sql/expression/function/substring.go
@@ -36,6 +36,7 @@ type Substring struct {
 }
 
 var _ sql.FunctionExpression = (*Substring)(nil)
+var _ sql.CollationCoercible = (*Substring)(nil)
 
 // NewSubstring creates a new substring UDF.
 func NewSubstring(args ...sql.Expression) (sql.Expression, error) {
@@ -169,6 +170,11 @@ func (s *Substring) Resolved() bool {
 // Type implements the Expression interface.
 func (s *Substring) Type() sql.Type { return s.str.Type() }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (s *Substring) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, s.str)
+}
+
 // WithChildren implements the Expression interface.
 func (*Substring) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return NewSubstring(children...)
@@ -185,6 +191,7 @@ type SubstringIndex struct {
 }
 
 var _ sql.FunctionExpression = (*SubstringIndex)(nil)
+var _ sql.CollationCoercible = (*SubstringIndex)(nil)
 
 // NewSubstringIndex creates a new SubstringIndex UDF.
 func NewSubstringIndex(str, delim, count sql.Expression) sql.Expression {
@@ -289,6 +296,11 @@ func (s *SubstringIndex) Resolved() bool {
 // Type implements the Expression interface.
 func (*SubstringIndex) Type() sql.Type { return types.LongText }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (s *SubstringIndex) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, s.str)
+}
+
 // WithChildren implements the Expression interface.
 func (s *SubstringIndex) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 3 {
@@ -304,6 +316,7 @@ type Left struct {
 }
 
 var _ sql.FunctionExpression = Left{}
+var _ sql.CollationCoercible = Left{}
 
 // NewLeft creates a new LEFT function.
 func NewLeft(str, len sql.Expression) sql.Expression {
@@ -389,6 +402,11 @@ func (l Left) Resolved() bool {
 // Type implements the Expression interface.
 func (Left) Type() sql.Type { return types.LongText }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (l Left) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, l.str)
+}
+
 // WithChildren implements the Expression interface.
 func (l Left) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 2 {
@@ -404,6 +422,7 @@ type Right struct {
 }
 
 var _ sql.FunctionExpression = Right{}
+var _ sql.CollationCoercible = Right{}
 
 // NewRight creates a new RIGHT function.
 func NewRight(str, len sql.Expression) sql.Expression {
@@ -500,6 +519,11 @@ func (r Right) Resolved() bool {
 // Type implements the Expression interface.
 func (Right) Type() sql.Type { return types.LongText }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (r Right) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, r.str)
+}
+
 // WithChildren implements the Expression interface.
 func (r Right) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 2 {
@@ -514,6 +538,7 @@ type Instr struct {
 }
 
 var _ sql.FunctionExpression = Instr{}
+var _ sql.CollationCoercible = Instr{}
 
 // NewInstr creates a new instr UDF.
 func NewInstr(str, substr sql.Expression) sql.Expression {
@@ -605,6 +630,11 @@ func (i Instr) Resolved() bool {
 
 // Type implements the Expression interface.
 func (Instr) Type() sql.Type { return types.Int64 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (Instr) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // WithChildren implements the Expression interface.
 func (i Instr) WithChildren(children ...sql.Expression) (sql.Expression, error) {

--- a/sql/expression/function/system.go
+++ b/sql/expression/function/system.go
@@ -32,6 +32,7 @@ func connIDFuncLogic(ctx *sql.Context, _ sql.Row) (interface{}, error) {
 }
 
 var _ sql.FunctionExpression = ConnectionID{}
+var _ sql.CollationCoercible = ConnectionID{}
 
 func NewConnectionID() sql.Expression {
 	return ConnectionID{
@@ -47,6 +48,11 @@ func (c ConnectionID) FunctionName() string {
 // Description implements sql.FunctionExpression
 func (c ConnectionID) Description() string {
 	return "returns the current connection ID."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (ConnectionID) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 3
 }
 
 // Eval implements sql.Expression
@@ -76,10 +82,16 @@ func userFuncLogic(ctx *sql.Context, _ sql.Row) (interface{}, error) {
 }
 
 var _ sql.FunctionExpression = User{}
+var _ sql.CollationCoercible = User{}
 
 // Description implements sql.FunctionExpression
 func (c User) Description() string {
 	return "returns the authenticated user name and host name."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (User) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 3
 }
 
 func NewUser() sql.Expression {

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -74,6 +74,7 @@ type Year struct {
 }
 
 var _ sql.FunctionExpression = (*Year)(nil)
+var _ sql.CollationCoercible = (*Year)(nil)
 
 // NewYear creates a new Year UDF.
 func NewYear(date sql.Expression) sql.Expression {
@@ -95,6 +96,11 @@ func (y *Year) String() string { return fmt.Sprintf("%s(%s)", y.FunctionName(), 
 // Type implements the Expression interface.
 func (y *Year) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Year) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (y *Year) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, y.UnaryExpression, row, year)
@@ -114,6 +120,7 @@ type Month struct {
 }
 
 var _ sql.FunctionExpression = (*Month)(nil)
+var _ sql.CollationCoercible = (*Month)(nil)
 
 // NewMonth creates a new Month UDF.
 func NewMonth(date sql.Expression) sql.Expression {
@@ -135,6 +142,11 @@ func (m *Month) String() string { return fmt.Sprintf("%s(%s)", m.FunctionName(),
 // Type implements the Expression interface.
 func (m *Month) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Month) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (m *Month) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, m.UnaryExpression, row, month)
@@ -154,6 +166,7 @@ type Day struct {
 }
 
 var _ sql.FunctionExpression = (*Day)(nil)
+var _ sql.CollationCoercible = (*Day)(nil)
 
 // NewDay creates a new Day UDF.
 func NewDay(date sql.Expression) sql.Expression {
@@ -175,6 +188,11 @@ func (d *Day) String() string { return fmt.Sprintf("%s(%s)", d.FunctionName(), d
 // Type implements the Expression interface.
 func (d *Day) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Day) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (d *Day) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, d.UnaryExpression, row, day)
@@ -195,6 +213,7 @@ type Weekday struct {
 }
 
 var _ sql.FunctionExpression = (*Weekday)(nil)
+var _ sql.CollationCoercible = (*Weekday)(nil)
 
 // NewWeekday creates a new Weekday UDF.
 func NewWeekday(date sql.Expression) sql.Expression {
@@ -216,6 +235,11 @@ func (d *Weekday) String() string { return fmt.Sprintf("%s(%s)", d.FunctionName(
 // Type implements the Expression interface.
 func (d *Weekday) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Weekday) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (d *Weekday) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, d.UnaryExpression, row, weekday)
@@ -235,6 +259,7 @@ type Hour struct {
 }
 
 var _ sql.FunctionExpression = (*Hour)(nil)
+var _ sql.CollationCoercible = (*Hour)(nil)
 
 // NewHour creates a new Hour UDF.
 func NewHour(date sql.Expression) sql.Expression {
@@ -256,6 +281,11 @@ func (h *Hour) String() string { return fmt.Sprintf("%s(%s)", h.FunctionName(), 
 // Type implements the Expression interface.
 func (h *Hour) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Hour) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (h *Hour) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, h.UnaryExpression, row, hour)
@@ -275,6 +305,7 @@ type Minute struct {
 }
 
 var _ sql.FunctionExpression = (*Minute)(nil)
+var _ sql.CollationCoercible = (*Minute)(nil)
 
 // NewMinute creates a new Minute UDF.
 func NewMinute(date sql.Expression) sql.Expression {
@@ -296,6 +327,11 @@ func (m *Minute) String() string { return fmt.Sprintf("%s(%d)", m.FunctionName()
 // Type implements the Expression interface.
 func (m *Minute) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Minute) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (m *Minute) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, m.UnaryExpression, row, minute)
@@ -315,6 +351,7 @@ type Second struct {
 }
 
 var _ sql.FunctionExpression = (*Second)(nil)
+var _ sql.CollationCoercible = (*Second)(nil)
 
 // NewSecond creates a new Second UDF.
 func NewSecond(date sql.Expression) sql.Expression {
@@ -336,6 +373,11 @@ func (s *Second) String() string { return fmt.Sprintf("%s(%s)", s.FunctionName()
 // Type implements the Expression interface.
 func (s *Second) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Second) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (s *Second) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, s.UnaryExpression, row, second)
@@ -356,6 +398,7 @@ type DayOfWeek struct {
 }
 
 var _ sql.FunctionExpression = (*DayOfWeek)(nil)
+var _ sql.CollationCoercible = (*DayOfWeek)(nil)
 
 // NewDayOfWeek creates a new DayOfWeek UDF.
 func NewDayOfWeek(date sql.Expression) sql.Expression {
@@ -377,6 +420,11 @@ func (d *DayOfWeek) String() string { return fmt.Sprintf("DAYOFWEEK(%s)", d.Chil
 // Type implements the Expression interface.
 func (d *DayOfWeek) Type() sql.Type { return types.Int32 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DayOfWeek) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (d *DayOfWeek) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	return getDatePart(ctx, d.UnaryExpression, row, dayOfWeek)
@@ -396,6 +444,7 @@ type DayOfYear struct {
 }
 
 var _ sql.FunctionExpression = (*DayOfYear)(nil)
+var _ sql.CollationCoercible = (*DayOfYear)(nil)
 
 // NewDayOfYear creates a new DayOfYear UDF.
 func NewDayOfYear(date sql.Expression) sql.Expression {
@@ -416,6 +465,11 @@ func (d *DayOfYear) String() string { return fmt.Sprintf("DAYOFYEAR(%s)", d.Chil
 
 // Type implements the Expression interface.
 func (d *DayOfYear) Type() sql.Type { return types.Int32 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DayOfYear) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // Eval implements the Expression interface.
 func (d *DayOfYear) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -449,6 +503,7 @@ type YearWeek struct {
 }
 
 var _ sql.FunctionExpression = (*YearWeek)(nil)
+var _ sql.CollationCoercible = (*YearWeek)(nil)
 
 // NewYearWeek creates a new YearWeek UDF
 func NewYearWeek(args ...sql.Expression) (sql.Expression, error) {
@@ -482,6 +537,11 @@ func (d *YearWeek) String() string { return fmt.Sprintf("YEARWEEK(%s, %d)", d.da
 
 // Type implements the Expression interface.
 func (d *YearWeek) Type() sql.Type { return types.Int32 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*YearWeek) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // Eval implements the Expression interface.
 func (d *YearWeek) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -546,6 +606,7 @@ type Week struct {
 }
 
 var _ sql.FunctionExpression = (*Week)(nil)
+var _ sql.CollationCoercible = (*Week)(nil)
 
 // NewWeek creates a new Week UDF
 func NewWeek(args ...sql.Expression) (sql.Expression, error) {
@@ -577,6 +638,11 @@ func (d *Week) String() string { return fmt.Sprintf("WEEK(%s, %d)", d.date, d.mo
 
 // Type implements the Expression interface.
 func (d *Week) Type() sql.Type { return types.Int32 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Week) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // Eval implements the Expression interface.
 func (d *Week) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -762,6 +828,7 @@ func (n *Now) IsNonDeterministic() bool {
 }
 
 var _ sql.FunctionExpression = (*Now)(nil)
+var _ sql.CollationCoercible = (*Now)(nil)
 
 // NewNow returns a new Now node.
 func NewNow(args ...sql.Expression) (sql.Expression, error) {
@@ -837,6 +904,11 @@ func (n *Now) Type() sql.Type {
 	return types.Datetime
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Now) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 func (n *Now) String() string {
 	if n.precision == nil {
 		return "NOW()"
@@ -883,6 +955,7 @@ type UTCTimestamp struct {
 }
 
 var _ sql.FunctionExpression = (*UTCTimestamp)(nil)
+var _ sql.CollationCoercible = (*UTCTimestamp)(nil)
 
 // NewUTCTimestamp returns a new UTCTimestamp node.
 func NewUTCTimestamp(args ...sql.Expression) (sql.Expression, error) {
@@ -930,6 +1003,11 @@ func (ut *UTCTimestamp) Type() sql.Type {
 	return types.Datetime
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UTCTimestamp) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 func (ut *UTCTimestamp) String() string {
 	if ut.precision == nil {
 		return "UTC_TIMESTAMP()"
@@ -965,6 +1043,7 @@ type Date struct {
 }
 
 var _ sql.FunctionExpression = (*Date)(nil)
+var _ sql.CollationCoercible = (*Date)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (d *Date) FunctionName() string {
@@ -985,6 +1064,11 @@ func (d *Date) String() string { return fmt.Sprintf("DATE(%s)", d.Child) }
 
 // Type implements the Expression interface.
 func (d *Date) Type() sql.Type { return types.Date }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Date) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // Eval implements the Expression interface.
 func (d *Date) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -1068,6 +1152,11 @@ func (d *DayName) Description() string {
 	return "returns the name of the weekday."
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DayName) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
+}
+
 func (d *DayName) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	val, err := d.EvalChild(ctx, row)
 	if err != nil {
@@ -1091,10 +1180,16 @@ type Microsecond struct {
 }
 
 var _ sql.FunctionExpression = (*Microsecond)(nil)
+var _ sql.CollationCoercible = (*Microsecond)(nil)
 
 // Description implements sql.FunctionExpression
 func (m *Microsecond) Description() string {
 	return "returns the microseconds from argument."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Microsecond) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func NewMicrosecond(arg sql.Expression) sql.Expression {
@@ -1124,6 +1219,7 @@ type MonthName struct {
 }
 
 var _ sql.FunctionExpression = (*MonthName)(nil)
+var _ sql.CollationCoercible = (*MonthName)(nil)
 
 func NewMonthName(arg sql.Expression) sql.Expression {
 	return &MonthName{NewUnaryDatetimeFunc(arg, "MONTHNAME", types.Text)}
@@ -1132,6 +1228,11 @@ func NewMonthName(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (d *MonthName) Description() string {
 	return "returns the name of the month."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*MonthName) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 func (d *MonthName) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -1157,6 +1258,7 @@ type TimeToSec struct {
 }
 
 var _ sql.FunctionExpression = (*TimeToSec)(nil)
+var _ sql.CollationCoercible = (*TimeToSec)(nil)
 
 func NewTimeToSec(arg sql.Expression) sql.Expression {
 	return &TimeToSec{NewUnaryDatetimeFunc(arg, "TIME_TO_SEC", types.Uint64)}
@@ -1165,6 +1267,11 @@ func NewTimeToSec(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (m *TimeToSec) Description() string {
 	return "returns the argument converted to seconds."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*TimeToSec) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (m *TimeToSec) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -1190,6 +1297,7 @@ type WeekOfYear struct {
 }
 
 var _ sql.FunctionExpression = (*WeekOfYear)(nil)
+var _ sql.CollationCoercible = (*WeekOfYear)(nil)
 
 func NewWeekOfYear(arg sql.Expression) sql.Expression {
 	return &WeekOfYear{NewUnaryDatetimeFunc(arg, "WEEKOFYEAR", types.Uint64)}
@@ -1198,6 +1306,11 @@ func NewWeekOfYear(arg sql.Expression) sql.Expression {
 // Description implements sql.FunctionExpression
 func (m *WeekOfYear) Description() string {
 	return "returns the calendar week of the date (1-53)."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*WeekOfYear) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (m *WeekOfYear) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -1227,10 +1340,16 @@ func (c CurrTime) IsNonDeterministic() bool {
 }
 
 var _ sql.FunctionExpression = CurrTime{}
+var _ sql.CollationCoercible = CurrTime{}
 
 // Description implements sql.FunctionExpression
 func (c CurrTime) Description() string {
 	return "returns the current time."
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (CurrTime) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func NewCurrTime() sql.Expression {
@@ -1271,10 +1390,16 @@ func (c *CurrTimestamp) IsNonDeterministic() bool {
 }
 
 var _ sql.FunctionExpression = (*CurrTimestamp)(nil)
+var _ sql.CollationCoercible = (*CurrTimestamp)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (c *CurrTimestamp) FunctionName() string {
 	return "current_timestamp"
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CurrTimestamp) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Description implements sql.FunctionExpression
@@ -1395,6 +1520,9 @@ type Time struct {
 	expression.UnaryExpression
 }
 
+var _ sql.Expression = (*Time)(nil)
+var _ sql.CollationCoercible = (*Time)(nil)
+
 // NewTime returns a new Date node.
 func NewTime(time sql.Expression) sql.Expression {
 	return &Time{expression.UnaryExpression{Child: time}}
@@ -1407,6 +1535,11 @@ func (t *Time) String() string {
 // Type implements the Expression interface.
 func (t *Time) Type() sql.Type {
 	return types.Time
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Time) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/function/time_format.go
+++ b/sql/expression/function/time_format.go
@@ -77,6 +77,7 @@ type TimeFormat struct {
 }
 
 var _ sql.FunctionExpression = (*TimeFormat)(nil)
+var _ sql.CollationCoercible = (*TimeFormat)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (f *TimeFormat) FunctionName() string {
@@ -141,6 +142,11 @@ func (f *TimeFormat) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 // Type implements the Expression interface.
 func (f *TimeFormat) Type() sql.Type {
 	return types.Text
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*TimeFormat) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/function/timediff.go
+++ b/sql/expression/function/timediff.go
@@ -33,6 +33,7 @@ type TimeDiff struct {
 }
 
 var _ sql.FunctionExpression = (*TimeDiff)(nil)
+var _ sql.CollationCoercible = (*TimeDiff)(nil)
 
 // NewTimeDiff creates a new NewTimeDiff expression.
 func NewTimeDiff(e1, e2 sql.Expression) sql.Expression {
@@ -56,6 +57,11 @@ func (td *TimeDiff) Description() string {
 
 // Type implements the Expression interface.
 func (td *TimeDiff) Type() sql.Type { return types.Time }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*TimeDiff) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 func (td *TimeDiff) String() string {
 	return fmt.Sprintf("%s(%s,%s)", td.FunctionName(), td.Left, td.Right)
@@ -146,6 +152,7 @@ type DateDiff struct {
 }
 
 var _ sql.FunctionExpression = (*DateDiff)(nil)
+var _ sql.CollationCoercible = (*DateDiff)(nil)
 
 // NewDateDiff creates a new DATEDIFF() function.
 func NewDateDiff(expr1, expr2 sql.Expression) sql.Expression {
@@ -169,6 +176,11 @@ func (d *DateDiff) Description() string {
 
 // Type implements the sql.Expression interface.
 func (d *DateDiff) Type() sql.Type { return types.Int64 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DateDiff) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // WithChildren implements the Expression interface.
 func (d *DateDiff) WithChildren(children ...sql.Expression) (sql.Expression, error) {
@@ -236,6 +248,7 @@ type TimestampDiff struct {
 }
 
 var _ sql.FunctionExpression = (*TimestampDiff)(nil)
+var _ sql.CollationCoercible = (*TimestampDiff)(nil)
 
 // NewTimestampDiff creates a new TIMESTAMPDIFF() function.
 func NewTimestampDiff(u, e1, e2 sql.Expression) sql.Expression {
@@ -269,6 +282,11 @@ func (t *TimestampDiff) IsNullable() bool {
 
 // Type implements the sql.Expression interface.
 func (t *TimestampDiff) Type() sql.Type { return types.Int64 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*TimestampDiff) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // WithChildren implements the Expression interface.
 func (t *TimestampDiff) WithChildren(children ...sql.Expression) (sql.Expression, error) {

--- a/sql/expression/function/tobase64_frombase64.go
+++ b/sql/expression/function/tobase64_frombase64.go
@@ -34,6 +34,7 @@ type ToBase64 struct {
 }
 
 var _ sql.FunctionExpression = (*ToBase64)(nil)
+var _ sql.CollationCoercible = (*ToBase64)(nil)
 
 // NewToBase64 creates a new ToBase64 expression.
 func NewToBase64(e sql.Expression) sql.Expression {
@@ -130,6 +131,11 @@ func (t *ToBase64) Type() sql.Type {
 	return types.LongText
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ToBase64) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return ctx.GetCollation(), 4
+}
+
 // FromBase64 is a function to decode a Base64-formatted string
 // using the same dialect that MySQL's FROM_BASE64 uses
 type FromBase64 struct {
@@ -137,6 +143,7 @@ type FromBase64 struct {
 }
 
 var _ sql.FunctionExpression = (*FromBase64)(nil)
+var _ sql.CollationCoercible = (*FromBase64)(nil)
 
 // NewFromBase64 creates a new FromBase64 expression.
 func NewFromBase64(e sql.Expression) sql.Expression {
@@ -199,4 +206,9 @@ func (t *FromBase64) WithChildren(children ...sql.Expression) (sql.Expression, e
 // Type implements the Expression interface.
 func (t *FromBase64) Type() sql.Type {
 	return types.LongBlob
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*FromBase64) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }

--- a/sql/expression/function/trim_ltrim_rtrim.go
+++ b/sql/expression/function/trim_ltrim_rtrim.go
@@ -33,6 +33,7 @@ type Trim struct {
 }
 
 var _ sql.FunctionExpression = (*Trim)(nil)
+var _ sql.CollationCoercible = (*Trim)(nil)
 
 func NewTrim(str sql.Expression, pat sql.Expression, dir string) sql.Expression {
 	return &Trim{str, pat, dir}
@@ -134,6 +135,13 @@ func (t Trim) Resolved() bool {
 
 func (t Trim) Type() sql.Type { return t.str.Type() }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t Trim) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	leftCollation, leftCoercibility := sql.GetCoercibility(ctx, t.str)
+	rightCollation, rightCoercibility := sql.GetCoercibility(ctx, t.pat)
+	return sql.ResolveCoercibility(leftCollation, leftCoercibility, rightCollation, rightCoercibility)
+}
+
 func (t Trim) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	if len(children) != 2 {
 		return nil, sql.ErrInvalidChildrenNumber.New(t, len(children), 2)
@@ -150,6 +158,7 @@ func NewLeftTrim(str sql.Expression) sql.Expression {
 }
 
 var _ sql.FunctionExpression = (*LeftTrim)(nil)
+var _ sql.CollationCoercible = (*LeftTrim)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (t *LeftTrim) FunctionName() string {
@@ -162,6 +171,11 @@ func (t *LeftTrim) Description() string {
 }
 
 func (t *LeftTrim) Type() sql.Type { return t.Child.Type() }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t *LeftTrim) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, t.Child)
+}
 
 func (t *LeftTrim) String() string {
 	return fmt.Sprintf("ltrim(%s)", t.Child)
@@ -207,6 +221,7 @@ func NewRightTrim(str sql.Expression) sql.Expression {
 }
 
 var _ sql.FunctionExpression = (*RightTrim)(nil)
+var _ sql.CollationCoercible = (*RightTrim)(nil)
 
 // FunctionName implements sql.FunctionExpression
 func (t *RightTrim) FunctionName() string {
@@ -219,6 +234,11 @@ func (t *RightTrim) Description() string {
 }
 
 func (t *RightTrim) Type() sql.Type { return t.Child.Type() }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t *RightTrim) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, t.Child)
+}
 
 func (t *RightTrim) String() string {
 	return fmt.Sprintf("rtrim(%s)", t.Child)

--- a/sql/expression/function/uuid.go
+++ b/sql/expression/function/uuid.go
@@ -59,6 +59,7 @@ func (u UUIDFunc) IsNonDeterministic() bool {
 }
 
 var _ sql.FunctionExpression = &UUIDFunc{}
+var _ sql.CollationCoercible = &UUIDFunc{}
 
 func NewUUIDFunc() sql.Expression {
 	return UUIDFunc{}
@@ -75,6 +76,11 @@ func (u UUIDFunc) String() string {
 
 func (u UUIDFunc) Type() sql.Type {
 	return types.MustCreateStringWithDefaults(sqltypes.VarChar, 36)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (UUIDFunc) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 4
 }
 
 func (u UUIDFunc) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -120,6 +126,7 @@ type IsUUID struct {
 }
 
 var _ sql.FunctionExpression = &IsUUID{}
+var _ sql.CollationCoercible = &IsUUID{}
 
 func NewIsUUID(arg sql.Expression) sql.Expression {
 	return IsUUID{child: arg}
@@ -141,6 +148,11 @@ func (u IsUUID) String() string {
 
 func (u IsUUID) Type() sql.Type {
 	return types.Int8
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (IsUUID) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (u IsUUID) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -224,6 +236,7 @@ type UUIDToBin struct {
 }
 
 var _ sql.FunctionExpression = (*UUIDToBin)(nil)
+var _ sql.CollationCoercible = (*UUIDToBin)(nil)
 
 func NewUUIDToBin(args ...sql.Expression) (sql.Expression, error) {
 	switch len(args) {
@@ -251,6 +264,11 @@ func (ub UUIDToBin) String() string {
 
 func (ub UUIDToBin) Type() sql.Type {
 	return types.MustCreateBinary(query.Type_VARBINARY, int64(16))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (UUIDToBin) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 4
 }
 
 func (ub UUIDToBin) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -379,6 +397,7 @@ type BinToUUID struct {
 }
 
 var _ sql.FunctionExpression = (*BinToUUID)(nil)
+var _ sql.CollationCoercible = (*BinToUUID)(nil)
 
 func NewBinToUUID(args ...sql.Expression) (sql.Expression, error) {
 	switch len(args) {
@@ -411,6 +430,11 @@ func (bu BinToUUID) String() string {
 
 func (bu BinToUUID) Type() sql.Type {
 	return types.MustCreateStringWithDefaults(sqltypes.VarChar, 36)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (BinToUUID) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 4
 }
 
 func (bu BinToUUID) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {

--- a/sql/expression/function/values.go
+++ b/sql/expression/function/values.go
@@ -31,6 +31,7 @@ type Values struct {
 }
 
 var _ sql.FunctionExpression = (*Values)(nil)
+var _ sql.CollationCoercible = (*Values)(nil)
 
 // NewValues creates a new Values function.
 func NewValues(col sql.Expression) sql.Expression {
@@ -65,6 +66,11 @@ func (v *Values) String() string {
 // Type implements sql.FunctionExpression.
 func (v *Values) Type() sql.Type {
 	return v.Child.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (v *Values) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, v.Child)
 }
 
 // WithChildren implements sql.FunctionExpression.

--- a/sql/expression/function/version.go
+++ b/sql/expression/function/version.go
@@ -32,6 +32,7 @@ func (f Version) IsNonDeterministic() bool {
 }
 
 var _ sql.FunctionExpression = (Version)("")
+var _ sql.CollationCoercible = (Version)("")
 
 // NewVersion creates a new Version UDF.
 func NewVersion(versionPostfix string) func(...sql.Expression) (sql.Expression, error) {
@@ -52,6 +53,11 @@ func (f Version) Description() string {
 
 // Type implements the Expression interface.
 func (f Version) Type() sql.Type { return types.LongText }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (Version) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 3
+}
 
 // IsNullable implements the Expression interface.
 func (f Version) IsNullable() bool {

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -35,6 +35,7 @@ type GetField struct {
 
 var _ sql.Expression = (*GetField)(nil)
 var _ sql.Expression2 = (*GetField)(nil)
+var _ sql.CollationCoercible = (*GetField)(nil)
 
 // NewGetField creates a GetField expression.
 func NewGetField(index int, fieldType sql.Type, fieldName string, nullable bool) *GetField {
@@ -152,6 +153,12 @@ func (p *GetField) WithIndex(n int) sql.Expression {
 	p2 := *p
 	p2.fieldIndex = n
 	return &p2
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p *GetField) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	collation, _ = p.fieldType.CollationCoercibility(ctx)
+	return collation, 2
 }
 
 // SchemaToGetFields takes a schema and returns an expression array of GetFields.

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -30,6 +30,7 @@ type InTuple struct {
 
 // We implement Comparer because we have a Left() and a Right(), but we can't be Compare()d
 var _ Comparer = (*InTuple)(nil)
+var _ sql.CollationCoercible = (*InTuple)(nil)
 
 func (in *InTuple) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 	panic("Compare not implemented for InTuple")
@@ -37,6 +38,11 @@ func (in *InTuple) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 
 func (in *InTuple) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*InTuple) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 func (in *InTuple) Left() sql.Expression {
@@ -159,6 +165,7 @@ type HashInTuple struct {
 }
 
 var _ Comparer = (*InTuple)(nil)
+var _ sql.CollationCoercible = (*InTuple)(nil)
 
 // NewHashInTuple creates an InTuple expression.
 func NewHashInTuple(ctx *sql.Context, left, right sql.Expression) (*HashInTuple, error) {

--- a/sql/expression/interval.go
+++ b/sql/expression/interval.go
@@ -33,6 +33,9 @@ type Interval struct {
 	Unit string
 }
 
+var _ sql.Expression = (*Interval)(nil)
+var _ sql.CollationCoercible = (*Interval)(nil)
+
 // NewInterval creates a new interval expression.
 func NewInterval(child sql.Expression, unit string) *Interval {
 	return &Interval{UnaryExpression{Child: child}, strings.ToUpper(unit)}
@@ -40,6 +43,11 @@ func NewInterval(child sql.Expression, unit string) *Interval {
 
 // Type implements the sql.Expression interface.
 func (i *Interval) Type() sql.Type { return types.Uint64 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Interval) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
 
 // IsNullable implements the sql.Expression interface.
 func (i *Interval) IsNullable() bool { return i.Child.IsNullable() }

--- a/sql/expression/isnull.go
+++ b/sql/expression/isnull.go
@@ -24,6 +24,9 @@ type IsNull struct {
 	UnaryExpression
 }
 
+var _ sql.Expression = (*IsNull)(nil)
+var _ sql.CollationCoercible = (*IsNull)(nil)
+
 // NewIsNull creates a new IsNull expression.
 func NewIsNull(child sql.Expression) *IsNull {
 	return &IsNull{UnaryExpression{child}}
@@ -32,6 +35,11 @@ func NewIsNull(child sql.Expression) *IsNull {
 // Type implements the Expression interface.
 func (e *IsNull) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsNull) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/istrue.go
+++ b/sql/expression/istrue.go
@@ -27,6 +27,9 @@ type IsTrue struct {
 	invert bool
 }
 
+var _ sql.Expression = (*IsTrue)(nil)
+var _ sql.CollationCoercible = (*IsTrue)(nil)
+
 const IsTrueStr = "IS TRUE"
 const IsFalseStr = "IS FALSE"
 
@@ -43,6 +46,11 @@ func NewIsFalse(child sql.Expression) *IsTrue {
 // Type implements the Expression interface.
 func (*IsTrue) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*IsTrue) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsNullable implements the Expression interface.

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -22,6 +22,7 @@ import (
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // Literal represents a literal expression (string, number, bool, ...).
@@ -33,6 +34,7 @@ type Literal struct {
 
 var _ sql.Expression = &Literal{}
 var _ sql.Expression2 = &Literal{}
+var _ sql.CollationCoercible = &Literal{}
 
 // NewLiteral creates a new Literal expression.
 func NewLiteral(value interface{}, fieldType sql.Type) *Literal {
@@ -57,6 +59,15 @@ func (lit *Literal) IsNullable() bool {
 // Type implements the Expression interface.
 func (lit *Literal) Type() sql.Type {
 	return lit.fieldType
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (lit *Literal) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	if types.IsText(lit.fieldType) {
+		collation, _ = lit.fieldType.CollationCoercibility(ctx)
+		return collation, 4
+	}
+	return sql.Collation_binary, 5
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -26,6 +26,9 @@ type And struct {
 	BinaryExpression
 }
 
+var _ sql.Expression = (*And)(nil)
+var _ sql.CollationCoercible = (*And)(nil)
+
 // NewAnd creates a new And expression.
 func NewAnd(left, right sql.Expression) sql.Expression {
 	return &And{BinaryExpression{Left: left, Right: right}}
@@ -80,6 +83,11 @@ func (*And) Type() sql.Type {
 	return types.Boolean
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*And) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Eval implements the Expression interface.
 func (a *And) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	lval, err := a.Left.Eval(ctx, row)
@@ -124,6 +132,9 @@ type Or struct {
 	BinaryExpression
 }
 
+var _ sql.Expression = (*Or)(nil)
+var _ sql.CollationCoercible = (*Or)(nil)
+
 // NewOr creates a new Or expression.
 func NewOr(left, right sql.Expression) sql.Expression {
 	return &Or{BinaryExpression{Left: left, Right: right}}
@@ -144,6 +155,11 @@ func (o *Or) DebugString() string {
 // Type implements the Expression interface.
 func (*Or) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Or) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements the Expression interface.
@@ -192,6 +208,9 @@ type Xor struct {
 	BinaryExpression
 }
 
+var _ sql.Expression = (*Xor)(nil)
+var _ sql.CollationCoercible = (*Xor)(nil)
+
 // NewXor creates a new Xor expression.
 func NewXor(left, right sql.Expression) sql.Expression {
 	return &Xor{BinaryExpression{Left: left, Right: right}}
@@ -208,6 +227,11 @@ func (x *Xor) DebugString() string {
 // Type implements the Expression interface.
 func (*Xor) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Xor) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/mod.go
+++ b/sql/expression/mod.go
@@ -26,6 +26,7 @@ import (
 )
 
 var _ ArithmeticOp = (*Mod)(nil)
+var _ sql.CollationCoercible = (*Mod)(nil)
 
 // Mod expression represents "%" arithmetic operation
 type Mod struct {
@@ -89,6 +90,11 @@ func (m *Mod) Type() sql.Type {
 	// for division operation, it's either float or decimal.Decimal type
 	// except invalid value will result it either 0 or nil
 	return floatOrDecimalType(m)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Mod) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/namedliteral.go
+++ b/sql/expression/namedliteral.go
@@ -26,6 +26,7 @@ type NamedLiteral struct {
 
 var _ sql.Expression = NamedLiteral{}
 var _ sql.Expression2 = NamedLiteral{}
+var _ sql.CollationCoercible = NamedLiteral{}
 
 // NewNamedLiteral returns a new NamedLiteral.
 func NewNamedLiteral(name string, value interface{}, fieldType sql.Type) NamedLiteral {

--- a/sql/expression/procedurereference.go
+++ b/sql/expression/procedurereference.go
@@ -320,6 +320,9 @@ type ProcedureParam struct {
 	hasBeenSet bool
 }
 
+var _ sql.Expression = (*ProcedureParam)(nil)
+var _ sql.CollationCoercible = (*ProcedureParam)(nil)
+
 // NewProcedureParam creates a new ProcedureParam expression.
 func NewProcedureParam(name string) *ProcedureParam {
 	return &ProcedureParam{name: strings.ToLower(name)}
@@ -343,6 +346,12 @@ func (*ProcedureParam) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (pp *ProcedureParam) Type() sql.Type {
 	return pp.pRef.GetVariableType(pp.name)
+}
+
+// CollationCoercibility implements the sql.CollationCoercible interface.
+func (pp *ProcedureParam) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	collation, _ = pp.pRef.GetVariableType(pp.name).CollationCoercibility(ctx)
+	return collation, 2
 }
 
 // Name implements the Nameable interface.
@@ -385,6 +394,9 @@ type UnresolvedProcedureParam struct {
 	name string
 }
 
+var _ sql.Expression = (*UnresolvedProcedureParam)(nil)
+var _ sql.CollationCoercible = (*UnresolvedProcedureParam)(nil)
+
 // NewUnresolvedProcedureParam creates a new UnresolvedProcedureParam expression.
 func NewUnresolvedProcedureParam(name string) *UnresolvedProcedureParam {
 	return &UnresolvedProcedureParam{name: strings.ToLower(name)}
@@ -408,6 +420,11 @@ func (*UnresolvedProcedureParam) IsNullable() bool {
 // Type implements the sql.Expression interface.
 func (*UnresolvedProcedureParam) Type() sql.Type {
 	return types.Null
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UnresolvedProcedureParam) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Name implements the Nameable interface.

--- a/sql/expression/set.go
+++ b/sql/expression/set.go
@@ -30,6 +30,9 @@ type SetField struct {
 	BinaryExpression
 }
 
+var _ sql.Expression = (*SetField)(nil)
+var _ sql.CollationCoercible = (*SetField)(nil)
+
 // NewSetField creates a new SetField expression.
 func NewSetField(left, expr sql.Expression) sql.Expression {
 	return &SetField{BinaryExpression{Left: left, Right: expr}}
@@ -46,6 +49,11 @@ func (s *SetField) DebugString() string {
 // Type implements the Expression interface.
 func (s *SetField) Type() sql.Type {
 	return s.Left.Type()
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (s *SetField) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, s.Left)
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/star.go
+++ b/sql/expression/star.go
@@ -27,6 +27,9 @@ type Star struct {
 	Table string
 }
 
+var _ sql.Expression = (*Star)(nil)
+var _ sql.CollationCoercible = (*Star)(nil)
+
 // NewStar returns a new Star expression.
 func NewStar() *Star {
 	return new(Star)
@@ -55,6 +58,11 @@ func (*Star) IsNullable() bool {
 // Type implements the Expression interface.
 func (*Star) Type() sql.Type {
 	panic("star is just a placeholder node, but Type was called")
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Star) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (s *Star) String() string {

--- a/sql/expression/unresolved.go
+++ b/sql/expression/unresolved.go
@@ -33,6 +33,7 @@ type UnresolvedColumn struct {
 
 var _ sql.Expression = (*UnresolvedColumn)(nil)
 var _ sql.Expression2 = (*UnresolvedColumn)(nil)
+var _ sql.CollationCoercible = (*UnresolvedColumn)(nil)
 
 // NewUnresolvedColumn creates a new UnresolvedColumn expression.
 func NewUnresolvedColumn(name string) *UnresolvedColumn {
@@ -63,6 +64,11 @@ func (*UnresolvedColumn) IsNullable() bool {
 // Type implements the Expression interface.
 func (*UnresolvedColumn) Type() sql.Type {
 	panic("unresolved column is a placeholder node, but Type was called")
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UnresolvedColumn) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (uc *UnresolvedColumn) Eval2(ctx *sql.Context, row sql.Row2) (sql.Value, error) {
@@ -112,6 +118,9 @@ type UnresolvedTableFunction struct {
 	Arguments []sql.Expression
 	database  sql.Database
 }
+
+var _ sql.Node = (*UnresolvedTableFunction)(nil)
+var _ sql.CollationCoercible = (*UnresolvedTableFunction)(nil)
 
 // NewUnresolvedTableFunction creates a new UnresolvedTableFunction node for a sql plan.
 func NewUnresolvedTableFunction(name string, arguments []sql.Expression) *UnresolvedTableFunction {
@@ -188,6 +197,11 @@ func (utf UnresolvedTableFunction) CheckPrivileges(ctx *sql.Context, opChecker s
 	return false
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (UnresolvedTableFunction) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // Resolved implements the Resolvable interface
 func (utf *UnresolvedTableFunction) Resolved() bool {
 	return false
@@ -204,6 +218,7 @@ func (utf *UnresolvedTableFunction) String() string {
 }
 
 var _ sql.Expression = (*UnresolvedFunction)(nil)
+var _ sql.CollationCoercible = (*UnresolvedFunction)(nil)
 
 // UnresolvedFunction represents a function that is not yet resolved.
 // This is a placeholder node, so its methods Type, IsNullable and Eval are not
@@ -258,6 +273,11 @@ func (*UnresolvedFunction) IsNullable() bool {
 // Type implements the Expression interface.
 func (*UnresolvedFunction) Type() sql.Type {
 	panic("unresolved function is a placeholder node, but Type was called")
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UnresolvedFunction) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Name implements the Nameable interface.

--- a/sql/expression/wrapper.go
+++ b/sql/expression/wrapper.go
@@ -28,6 +28,7 @@ type Wrapper struct {
 }
 
 var _ sql.Expression = (*Wrapper)(nil)
+var _ sql.CollationCoercible = (*Wrapper)(nil)
 
 // WrapExpression takes in an expression and wraps it, returning the resulting Wrapper expression. Useful for when
 // an expression is nil.
@@ -106,4 +107,12 @@ func (w *Wrapper) WithChildren(children ...sql.Expression) (sql.Expression, erro
 		return nil, sql.ErrInvalidChildrenNumber.New(w, len(children), 1)
 	}
 	return WrapExpression(children[0]), nil
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (w *Wrapper) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	if w.inner == nil {
+		return sql.Collation_binary, 6
+	}
+	return sql.GetCoercibility(ctx, w.inner)
 }

--- a/sql/index_registry_test.go
+++ b/sql/index_registry_test.go
@@ -463,6 +463,7 @@ type dummyExpr struct {
 }
 
 var _ Expression = (*dummyExpr)(nil)
+var _ CollationCoercible = (*dummyExpr)(nil)
 
 func (dummyExpr) Children() []Expression                  { return nil }
 func (dummyExpr) Eval(*Context, Row) (interface{}, error) { panic("not implemented") }
@@ -475,6 +476,9 @@ func (dummyExpr) Resolved() bool   { return false }
 func (dummyExpr) Type() Type       { panic("not implemented") }
 func (e dummyExpr) WithIndex(idx int) Expression {
 	return &dummyExpr{idx, e.colName}
+}
+func (dummyExpr) CollationCoercibility(ctx *Context) (collation CollationID, coercibility byte) {
+	return Collation_binary, 7
 }
 
 type checksumTable struct {

--- a/sql/plan/alter_auto_increment.go
+++ b/sql/plan/alter_auto_increment.go
@@ -26,6 +26,9 @@ type AlterAutoIncrement struct {
 	autoVal uint64
 }
 
+var _ sql.Node = (*AlterAutoIncrement)(nil)
+var _ sql.CollationCoercible = (*AlterAutoIncrement)(nil)
+
 func NewAlterAutoIncrement(database sql.Database, table sql.Node, autoVal uint64) *AlterAutoIncrement {
 	return &AlterAutoIncrement{
 		ddlNode: ddlNode{db: database},
@@ -95,6 +98,11 @@ func (p *AlterAutoIncrement) Resolved() bool {
 func (p *AlterAutoIncrement) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(p.Database().Name(), getTableName(p.Table), "", sql.PrivilegeType_Alter))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p *AlterAutoIncrement) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (p *AlterAutoIncrement) Schema() sql.Schema { return nil }

--- a/sql/plan/alter_check.go
+++ b/sql/plan/alter_check.go
@@ -38,10 +38,16 @@ type CreateCheck struct {
 	Check *sql.CheckConstraint
 }
 
+var _ sql.Node = (*CreateCheck)(nil)
+var _ sql.CollationCoercible = (*CreateCheck)(nil)
+
 type DropCheck struct {
 	UnaryNode
 	Name string
 }
+
+var _ sql.Node = (*DropCheck)(nil)
+var _ sql.CollationCoercible = (*DropCheck)(nil)
 
 func NewAlterAddCheck(table sql.Node, check *sql.CheckConstraint) *CreateCheck {
 	return &CreateCheck{
@@ -158,6 +164,11 @@ func (c *CreateCheck) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileged
 		sql.NewPrivilegedOperation(GetDatabaseName(c.Child), getTableName(c.Child), "", sql.PrivilegeType_Alter))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *CreateCheck) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func (c *CreateCheck) Schema() sql.Schema { return nil }
 
 func (c *CreateCheck) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
@@ -210,6 +221,11 @@ func (p *DropCheck) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOp
 		sql.NewPrivilegedOperation(GetDatabaseName(p.Child), getTableName(p.Child), "", sql.PrivilegeType_Alter))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p *DropCheck) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func (p *DropCheck) Schema() sql.Schema { return nil }
 
 func (p DropCheck) String() string {
@@ -248,6 +264,9 @@ type DropConstraint struct {
 	Name string
 }
 
+var _ sql.Node = (*DropConstraint)(nil)
+var _ sql.CollationCoercible = (*DropConstraint)(nil)
+
 func (d *DropConstraint) String() string {
 	tp := sql.NewTreePrinter()
 	_ = tp.WriteNode("DropConstraint(%s)", d.Name)
@@ -273,6 +292,11 @@ func (d DropConstraint) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (d *DropConstraint) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(GetDatabaseName(d.Child), getTableName(d.Child), "", sql.PrivilegeType_Alter))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (d *DropConstraint) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // NewDropConstraint returns a new DropConstraint node

--- a/sql/plan/alter_default.go
+++ b/sql/plan/alter_default.go
@@ -32,8 +32,10 @@ type AlterDefaultSet struct {
 	targetSchema sql.Schema
 }
 
+var _ sql.Node = (*AlterDefaultSet)(nil)
 var _ sql.Expressioner = (*AlterDefaultSet)(nil)
 var _ sql.SchemaTarget = (*AlterDefaultSet)(nil)
+var _ sql.CollationCoercible = (*AlterDefaultSet)(nil)
 
 // AlterDefaultDrop represents the ALTER COLUMN DROP DEFAULT statement.
 type AlterDefaultDrop struct {
@@ -45,6 +47,7 @@ type AlterDefaultDrop struct {
 
 var _ sql.Node = (*AlterDefaultDrop)(nil)
 var _ sql.SchemaTarget = (*AlterDefaultDrop)(nil)
+var _ sql.CollationCoercible = (*AlterDefaultDrop)(nil)
 
 // NewAlterDefaultSet returns a *AlterDefaultSet node.
 func NewAlterDefaultSet(database sql.Database, table sql.Node, columnName string, defVal *sql.ColumnDefaultValue) *AlterDefaultSet {
@@ -111,6 +114,11 @@ func (d *AlterDefaultSet) Children() []sql.Node {
 func (d *AlterDefaultSet) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(d.Database().Name(), getTableName(d.Table), "", sql.PrivilegeType_Alter))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (d *AlterDefaultSet) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Resolved implements the sql.Node interface.
@@ -240,6 +248,11 @@ func (d AlterDefaultDrop) WithExpressions(exprs ...sql.Expression) (sql.Node, er
 func (d *AlterDefaultDrop) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(d.db.Name(), getTableName(d.Table), d.ColumnName, sql.PrivilegeType_Alter))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (d *AlterDefaultDrop) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // WithDatabase implements the sql.Databaser interface.

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -49,6 +49,7 @@ type CreateForeignKey struct {
 var _ sql.Node = (*CreateForeignKey)(nil)
 var _ sql.MultiDatabaser = (*CreateForeignKey)(nil)
 var _ sql.Databaseable = (*CreateForeignKey)(nil)
+var _ sql.CollationCoercible = (*CreateForeignKey)(nil)
 
 func NewAlterAddForeignKey(fkDef *sql.ForeignKeyConstraint) *CreateForeignKey {
 	return &CreateForeignKey{
@@ -80,6 +81,11 @@ func (p *CreateForeignKey) WithChildren(children ...sql.Node) (sql.Node, error) 
 func (p *CreateForeignKey) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(p.FkDef.ParentDatabase, p.FkDef.ParentTable, "", sql.PrivilegeType_References))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateForeignKey) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Schema implements the interface sql.Node.
@@ -356,6 +362,7 @@ type DropForeignKey struct {
 var _ sql.Node = (*DropForeignKey)(nil)
 var _ sql.MultiDatabaser = (*DropForeignKey)(nil)
 var _ sql.Databaseable = (*DropForeignKey)(nil)
+var _ sql.CollationCoercible = (*DropForeignKey)(nil)
 
 func NewAlterDropForeignKey(db, table, name string) *DropForeignKey {
 	return &DropForeignKey{
@@ -404,6 +411,11 @@ func (p *DropForeignKey) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (p *DropForeignKey) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(p.database, p.Table, "", sql.PrivilegeType_Alter))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropForeignKey) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Schema implements the interface sql.Node.

--- a/sql/plan/alter_index.go
+++ b/sql/plan/alter_index.go
@@ -74,6 +74,8 @@ type AlterIndex struct {
 
 var _ sql.SchemaTarget = (*AlterIndex)(nil)
 var _ sql.Expressioner = (*AlterIndex)(nil)
+var _ sql.Node = (*AlterIndex)(nil)
+var _ sql.CollationCoercible = (*AlterIndex)(nil)
 
 func NewAlterCreateIndex(db sql.Database, table sql.Node, indexName string, using sql.IndexUsing, constraint sql.IndexConstraint, columns []sql.IndexColumn, comment string) *AlterIndex {
 	return &AlterIndex{
@@ -364,6 +366,11 @@ func (p AlterIndex) WithExpressions(expressions ...sql.Expression) (sql.Node, er
 func (p *AlterIndex) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(p.ddlNode.Database().Name(), getTableName(p.Table), "", sql.PrivilegeType_Index))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*AlterIndex) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // WithDatabase implements the sql.Databaser interface.

--- a/sql/plan/alter_pk.go
+++ b/sql/plan/alter_pk.go
@@ -45,8 +45,10 @@ type AlterPK struct {
 	targetSchema sql.Schema
 }
 
+var _ sql.Node = (*AlterPK)(nil)
 var _ sql.Databaser = (*AlterPK)(nil)
 var _ sql.SchemaTarget = (*AlterPK)(nil)
+var _ sql.CollationCoercible = (*AlterPK)(nil)
 
 func NewAlterCreatePk(db sql.Database, table sql.Node, columns []sql.IndexColumn) *AlterPK {
 	return &AlterPK{
@@ -363,4 +365,9 @@ func (a AlterPK) WithDatabase(database sql.Database) (sql.Node, error) {
 func (a *AlterPK) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(a.Database().Name(), getTableName(a.Table), "", sql.PrivilegeType_Alter))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*AlterPK) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/analyze.go
+++ b/sql/plan/analyze.go
@@ -15,6 +15,9 @@ type AnalyzeTable struct {
 	Tables []sql.DbTable
 }
 
+var _ sql.Node = (*AnalyzeTable)(nil)
+var _ sql.CollationCoercible = (*AnalyzeTable)(nil)
+
 var analyzeSchema = sql.Schema{
 	{Name: "Table", Type: types.LongText},
 	{Name: "Op", Type: types.LongText},
@@ -82,6 +85,11 @@ func (n *AnalyzeTable) WithChildren(_ ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (n *AnalyzeTable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*AnalyzeTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/begin_end_block.go
+++ b/sql/plan/begin_end_block.go
@@ -39,6 +39,7 @@ func NewBeginEndBlock(label string, block *Block) *BeginEndBlock {
 }
 
 var _ sql.Node = (*BeginEndBlock)(nil)
+var _ sql.CollationCoercible = (*BeginEndBlock)(nil)
 var _ sql.DebugStringer = (*BeginEndBlock)(nil)
 var _ expression.ProcedureReferencable = (*BeginEndBlock)(nil)
 var _ RepresentsLabeledBlock = (*BeginEndBlock)(nil)
@@ -88,6 +89,11 @@ func (b *BeginEndBlock) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (b *BeginEndBlock) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return b.Block.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (b *BeginEndBlock) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return b.Block.CollationCoercibility(ctx)
 }
 
 // WithParamReference implements the interface expression.ProcedureReferencable.

--- a/sql/plan/cached_results.go
+++ b/sql/plan/cached_results.go
@@ -72,6 +72,9 @@ type CachedResults struct {
 	disposed bool
 }
 
+var _ sql.Node = (*CachedResults)(nil)
+var _ sql.CollationCoercible = (*CachedResults)(nil)
+
 func (n *CachedResults) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
@@ -127,6 +130,11 @@ func (n *CachedResults) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (n *CachedResults) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return n.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (n *CachedResults) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, n.Child)
 }
 
 func (n *CachedResults) getCachedResults() []sql.Row {

--- a/sql/plan/call.go
+++ b/sql/plan/call.go
@@ -31,6 +31,7 @@ type Call struct {
 }
 
 var _ sql.Node = (*Call)(nil)
+var _ sql.CollationCoercible = (*Call)(nil)
 var _ sql.Expressioner = (*Call)(nil)
 var _ Versionable = (*Call)(nil)
 
@@ -82,6 +83,11 @@ func (c *Call) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (c *Call) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(c.Database().Name(), "", "", sql.PrivilegeType_Execute))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *Call) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return c.Procedure.CollationCoercibility(ctx)
 }
 
 // Expressions implements the sql.Expressioner interface.

--- a/sql/plan/case.go
+++ b/sql/plan/case.go
@@ -34,6 +34,7 @@ type CaseStatement struct {
 var _ sql.Node = (*CaseStatement)(nil)
 var _ sql.DebugStringer = (*CaseStatement)(nil)
 var _ sql.Expressioner = (*CaseStatement)(nil)
+var _ sql.CollationCoercible = (*CaseStatement)(nil)
 
 // NewCaseStatement creates a new *NewCaseStatement or *IfElseBlock node.
 func NewCaseStatement(caseExpr sql.Expression, ifConditionals []*IfConditional, elseStatement sql.Node) sql.Node {
@@ -123,6 +124,11 @@ func (c *CaseStatement) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileg
 	return c.IfElse.CheckPrivileges(ctx, opChecker)
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *CaseStatement) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return c.IfElse.CollationCoercibility(ctx)
+}
+
 // RowIter implements the interface sql.Node.
 func (c *CaseStatement) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	caseValue, err := c.Expr.Eval(ctx, row)
@@ -201,6 +207,11 @@ func (e elseCaseError) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (e elseCaseError) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (e elseCaseError) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/close.go
+++ b/sql/plan/close.go
@@ -30,6 +30,7 @@ type Close struct {
 }
 
 var _ sql.Node = (*Close)(nil)
+var _ sql.CollationCoercible = (*Close)(nil)
 var _ expression.ProcedureReferencable = (*Close)(nil)
 
 // NewClose returns a new *Close node.
@@ -67,6 +68,11 @@ func (c *Close) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (c *Close) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Close) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/concat.go
+++ b/sql/plan/concat.go
@@ -22,13 +22,14 @@ import (
 
 // Concat is a node that returns everything in Left and then everything in
 // Right, but it excludes any results in Right that already appeared in Left.
-// Similar to Distinct(Union(...)) but allows Left to return return the same
-// row more than once.
+// Similar to Distinct(Union(...)) but allows Left to return the same row
+// more than once.
 type Concat struct {
 	BinaryNode
 }
 
 var _ sql.Node = (*Concat)(nil)
+var _ sql.CollationCoercible = (*Concat)(nil)
 
 // NewConcat creates a new Concat node with the given children.
 // See concatJoin memo expression for more details.
@@ -81,6 +82,12 @@ func (c *Concat) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (c *Concat) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return c.left.CheckPrivileges(ctx, opChecker) && c.right.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Concat) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// As this is similar to UNION, it isn't possible to determine what the resulting coercibility may be
+	return sql.Collation_binary, 7
 }
 
 func (c Concat) String() string {

--- a/sql/plan/create_index.go
+++ b/sql/plan/create_index.go
@@ -53,7 +53,9 @@ type CreateIndex struct {
 	CurrentDatabase string
 }
 
+var _ sql.Node = (*CreateIndex)(nil)
 var _ sql.Databaseable = (*CreateIndex)(nil)
+var _ sql.CollationCoercible = (*CreateIndex)(nil)
 
 // NewCreateIndex creates a new CreateIndex node.
 func NewCreateIndex(
@@ -290,6 +292,11 @@ func (c *CreateIndex) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (c *CreateIndex) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(GetDatabaseName(c.Table), getTableName(c.Table), "", sql.PrivilegeType_Index))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateIndex) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // GetColumnsAndPrepareExpressions extracts the unique columns required by all

--- a/sql/plan/create_role.go
+++ b/sql/plan/create_role.go
@@ -42,6 +42,7 @@ func NewCreateRole(ifNotExists bool, roles []UserName) *CreateRole {
 }
 
 var _ sql.Node = (*CreateRole)(nil)
+var _ sql.CollationCoercible = (*CreateRole)(nil)
 
 // Schema implements the interface sql.Node.
 func (n *CreateRole) Schema() sql.Schema {
@@ -99,6 +100,11 @@ func (n *CreateRole) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedO
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_CreateRole)) ||
 		opChecker.UserHasPrivileges(ctx,
 			sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_CreateUser))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateRole) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/create_user.go
+++ b/sql/plan/create_user.go
@@ -39,6 +39,7 @@ type CreateUser struct {
 
 var _ sql.Node = (*CreateUser)(nil)
 var _ sql.Databaser = (*CreateUser)(nil)
+var _ sql.CollationCoercible = (*CreateUser)(nil)
 
 // Schema implements the interface sql.Node.
 func (n *CreateUser) Schema() sql.Schema {
@@ -93,6 +94,11 @@ func (n *CreateUser) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (n *CreateUser) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_CreateUser))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateUser) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -42,6 +42,9 @@ type CreateView struct {
 	CheckOpt         string
 }
 
+var _ sql.Node = (*CreateView)(nil)
+var _ sql.CollationCoercible = (*CreateView)(nil)
+
 // NewCreateView creates a CreateView node with the specified parameters,
 // setting its catalog to nil.
 func NewCreateView(
@@ -156,6 +159,11 @@ func (cv *CreateView) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileged
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(cv.database.Name(), "", "", sql.PrivilegeType_CreateView)) &&
 		cv.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateView) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Database implements the Databaser interface, and it returns the database in

--- a/sql/plan/dbddl.go
+++ b/sql/plan/dbddl.go
@@ -33,6 +33,9 @@ type CreateDB struct {
 	Collation   sql.CollationID
 }
 
+var _ sql.Node = (*CreateDB)(nil)
+var _ sql.CollationCoercible = (*CreateDB)(nil)
+
 func (c *CreateDB) Resolved() bool {
 	return true
 }
@@ -93,6 +96,11 @@ func (c *CreateDB) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpe
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_Create))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateDB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // Database returns the name of the database that will be used.
 func (c *CreateDB) Database() string {
 	return c.dbName
@@ -112,6 +120,9 @@ type DropDB struct {
 	dbName   string
 	IfExists bool
 }
+
+var _ sql.Node = (*DropDB)(nil)
+var _ sql.CollationCoercible = (*DropDB)(nil)
 
 func (d *DropDB) Resolved() bool {
 	return true
@@ -177,6 +188,11 @@ func (d *DropDB) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpera
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_Drop))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropDB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func NewDropDatabase(dbName string, ifExists bool) *DropDB {
 	return &DropDB{
 		dbName:   dbName,
@@ -190,6 +206,9 @@ type AlterDB struct {
 	dbName    string
 	Collation sql.CollationID
 }
+
+var _ sql.Node = (*AlterDB)(nil)
+var _ sql.CollationCoercible = (*AlterDB)(nil)
 
 // Resolved implements the interface sql.Node.
 func (c *AlterDB) Resolved() bool {
@@ -252,6 +271,11 @@ func (c *AlterDB) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (c *AlterDB) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(c.Database(ctx), "", "", sql.PrivilegeType_Alter))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*AlterDB) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Database returns the name of the database that will be used.

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -137,6 +137,7 @@ var _ sql.Databaser = (*CreateTable)(nil)
 var _ sql.Node = (*CreateTable)(nil)
 var _ sql.Expressioner = (*CreateTable)(nil)
 var _ sql.SchemaTarget = (*CreateTable)(nil)
+var _ sql.CollationCoercible = (*CreateTable)(nil)
 
 // NewCreateTable creates a new CreateTable node
 func NewCreateTable(db sql.Database, name string, ifn IfNotExistsOption, temp TempTableOption, tableSpec *TableSpec) *CreateTable {
@@ -525,6 +526,11 @@ func (c *CreateTable) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileged
 	}
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func (c *CreateTable) String() string {
 	ifNotExists := ""
 	if c.ifNotExists {
@@ -706,6 +712,7 @@ type DropTable struct {
 }
 
 var _ sql.Node = (*DropTable)(nil)
+var _ sql.CollationCoercible = (*DropTable)(nil)
 
 // NewDropTable creates a new DropTable node
 func NewDropTable(tbls []sql.Node, ifExists bool) *DropTable {
@@ -846,6 +853,11 @@ func (d *DropTable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOp
 		}
 	}
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // String implements the sql.Node interface.

--- a/sql/plan/ddl_procedure.go
+++ b/sql/plan/ddl_procedure.go
@@ -33,6 +33,7 @@ type CreateProcedure struct {
 var _ sql.Node = (*CreateProcedure)(nil)
 var _ sql.Databaser = (*CreateProcedure)(nil)
 var _ sql.DebugStringer = (*CreateProcedure)(nil)
+var _ sql.CollationCoercible = (*CreateProcedure)(nil)
 
 // NewCreateProcedure returns a *CreateProcedure node.
 func NewCreateProcedure(
@@ -110,6 +111,11 @@ func (c *CreateProcedure) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (c *CreateProcedure) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(c.db.Name(), "", "", sql.PrivilegeType_CreateRoutine))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateProcedure) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // String implements the sql.Node interface.

--- a/sql/plan/ddl_trigger.go
+++ b/sql/plan/ddl_trigger.go
@@ -45,6 +45,9 @@ type CreateTrigger struct {
 	Definer             string
 }
 
+var _ sql.Node = (*CreateTrigger)(nil)
+var _ sql.CollationCoercible = (*CreateTrigger)(nil)
+
 func NewCreateTrigger(triggerDb sql.Database,
 	triggerName,
 	triggerTime,
@@ -108,6 +111,11 @@ func (c *CreateTrigger) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (c *CreateTrigger) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(GetDatabaseName(c.Table), getTableName(c.Table), "", sql.PrivilegeType_Trigger))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*CreateTrigger) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (c *CreateTrigger) String() string {

--- a/sql/plan/declare_condition.go
+++ b/sql/plan/declare_condition.go
@@ -28,6 +28,7 @@ type DeclareCondition struct {
 }
 
 var _ sql.Node = (*DeclareCondition)(nil)
+var _ sql.CollationCoercible = (*DeclareCondition)(nil)
 
 // NewDeclareCondition returns a *DeclareCondition node.
 func NewDeclareCondition(name string, errCode int64, sqlStateValue string) *DeclareCondition {
@@ -72,6 +73,11 @@ func (d *DeclareCondition) WithChildren(children ...sql.Node) (sql.Node, error) 
 // CheckPrivileges implements the interface sql.Node.
 func (d *DeclareCondition) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DeclareCondition) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the sql.Node interface.

--- a/sql/plan/declare_cursor.go
+++ b/sql/plan/declare_cursor.go
@@ -31,6 +31,7 @@ type DeclareCursor struct {
 }
 
 var _ sql.Node = (*DeclareCursor)(nil)
+var _ sql.CollationCoercible = (*DeclareCursor)(nil)
 var _ sql.DebugStringer = (*DeclareCursor)(nil)
 var _ expression.ProcedureReferencable = (*DeclareCursor)(nil)
 
@@ -81,6 +82,11 @@ func (d *DeclareCursor) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (d *DeclareCursor) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return d.Select.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DeclareCursor) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/declare_handler.go
+++ b/sql/plan/declare_handler.go
@@ -39,6 +39,7 @@ type DeclareHandler struct {
 }
 
 var _ sql.Node = (*DeclareHandler)(nil)
+var _ sql.CollationCoercible = (*DeclareHandler)(nil)
 var _ sql.DebugStringer = (*DeclareHandler)(nil)
 var _ expression.ProcedureReferencable = (*DeclareHandler)(nil)
 
@@ -110,6 +111,11 @@ func (d *DeclareHandler) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (d *DeclareHandler) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DeclareHandler) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/declare_variables.go
+++ b/sql/plan/declare_variables.go
@@ -32,6 +32,7 @@ type DeclareVariables struct {
 }
 
 var _ sql.Node = (*DeclareVariables)(nil)
+var _ sql.CollationCoercible = (*DeclareVariables)(nil)
 var _ expression.ProcedureReferencable = (*DeclareVariables)(nil)
 
 // NewDeclareVariables returns a new *DeclareVariables node.
@@ -71,6 +72,11 @@ func (d *DeclareVariables) WithChildren(children ...sql.Node) (sql.Node, error) 
 // CheckPrivileges implements the interface sql.Node.
 func (d *DeclareVariables) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DeclareVariables) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/delete.go
+++ b/sql/plan/delete.go
@@ -37,6 +37,7 @@ type DeleteFrom struct {
 
 var _ sql.Databaseable = (*DeleteFrom)(nil)
 var _ sql.Node = (*DeleteFrom)(nil)
+var _ sql.CollationCoercible = (*DeleteFrom)(nil)
 
 // NewDeleteFrom creates a DeleteFrom node.
 func NewDeleteFrom(n sql.Node, targets []sql.Node) *DeleteFrom {
@@ -331,6 +332,11 @@ func (p *DeleteFrom) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedO
 	}
 
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DeleteFrom) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (p *DeleteFrom) String() string {

--- a/sql/plan/describe.go
+++ b/sql/plan/describe.go
@@ -26,6 +26,9 @@ type Describe struct {
 	UnaryNode
 }
 
+var _ sql.Node = (*Describe)(nil)
+var _ sql.CollationCoercible = (*Describe)(nil)
+
 // NewDescribe creates a new Describe node.
 func NewDescribe(child sql.Node) *Describe {
 	return &Describe{UnaryNode{child}}
@@ -61,6 +64,11 @@ func (d *Describe) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpe
 	return d.Child.CheckPrivileges(ctx, opChecker)
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Describe) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func (d Describe) String() string {
 	p := sql.NewTreePrinter()
 	_ = p.WriteNode("Describe")
@@ -93,6 +101,9 @@ type DescribeQuery struct {
 	Format string
 }
 
+var _ sql.Node = (*DescribeQuery)(nil)
+var _ sql.CollationCoercible = (*DescribeQuery)(nil)
+
 func (d *DescribeQuery) Resolved() bool {
 	return d.child.Resolved()
 }
@@ -111,6 +122,11 @@ func (d *DescribeQuery) WithChildren(node ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (d *DescribeQuery) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return d.child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DescribeQuery) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // DescribeSchema is the schema returned by a DescribeQuery node.

--- a/sql/plan/distinct.go
+++ b/sql/plan/distinct.go
@@ -25,6 +25,9 @@ type Distinct struct {
 	UnaryNode
 }
 
+var _ sql.Node = (*Distinct)(nil)
+var _ sql.CollationCoercible = (*Distinct)(nil)
+
 // NewDistinct creates a new Distinct node.
 func NewDistinct(child sql.Node) *Distinct {
 	return &Distinct{
@@ -62,6 +65,11 @@ func (d *Distinct) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (d *Distinct) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return d.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (d *Distinct) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, d.Child)
 }
 
 func (d Distinct) String() string {
@@ -142,6 +150,9 @@ type OrderedDistinct struct {
 	UnaryNode
 }
 
+var _ sql.Node = (*OrderedDistinct)(nil)
+var _ sql.CollationCoercible = (*OrderedDistinct)(nil)
+
 // NewOrderedDistinct creates a new OrderedDistinct node.
 func NewOrderedDistinct(child sql.Node) *OrderedDistinct {
 	return &OrderedDistinct{
@@ -179,6 +190,11 @@ func (d *OrderedDistinct) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (d *OrderedDistinct) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return d.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (d *OrderedDistinct) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, d.Child)
 }
 
 func (d OrderedDistinct) String() string {

--- a/sql/plan/drop_index.go
+++ b/sql/plan/drop_index.go
@@ -46,7 +46,9 @@ func NewDropIndex(name string, table sql.Node) *DropIndex {
 	return &DropIndex{name, table, nil, ""}
 }
 
+var _ sql.Node = (*DropIndex)(nil)
 var _ sql.Databaseable = (*DropIndex)(nil)
+var _ sql.CollationCoercible = (*DropIndex)(nil)
 
 func (d *DropIndex) Database() string { return d.CurrentDatabase }
 
@@ -144,4 +146,9 @@ func (d *DropIndex) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (d *DropIndex) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(GetDatabaseName(d.Table), getTableName(d.Table), "", sql.PrivilegeType_Index))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropIndex) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/drop_procedure.go
+++ b/sql/plan/drop_procedure.go
@@ -29,6 +29,7 @@ type DropProcedure struct {
 
 var _ sql.Databaser = (*DropProcedure)(nil)
 var _ sql.Node = (*DropProcedure)(nil)
+var _ sql.CollationCoercible = (*DropProcedure)(nil)
 
 // NewDropProcedure creates a new *DropProcedure node.
 func NewDropProcedure(db sql.Database, procedureName string, ifExists bool) *DropProcedure {
@@ -92,6 +93,11 @@ func (d *DropProcedure) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (d *DropProcedure) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(d.db.Name(), "", "", sql.PrivilegeType_AlterRoutine))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropProcedure) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Database implements the sql.Databaser interface.

--- a/sql/plan/drop_role.go
+++ b/sql/plan/drop_role.go
@@ -41,6 +41,7 @@ func NewDropRole(ifExists bool, roles []UserName) *DropRole {
 
 var _ sql.Node = (*DropRole)(nil)
 var _ sql.Databaser = (*DropRole)(nil)
+var _ sql.CollationCoercible = (*DropRole)(nil)
 
 // Schema implements the interface sql.Node.
 func (n *DropRole) Schema() sql.Schema {
@@ -98,6 +99,11 @@ func (n *DropRole) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpe
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_DropRole)) ||
 		opChecker.UserHasPrivileges(ctx,
 			sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_CreateUser))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropRole) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/drop_trigger.go
+++ b/sql/plan/drop_trigger.go
@@ -29,6 +29,7 @@ type DropTrigger struct {
 
 var _ sql.Databaser = (*DropTrigger)(nil)
 var _ sql.Node = (*DropTrigger)(nil)
+var _ sql.CollationCoercible = (*DropTrigger)(nil)
 
 // NewDropTrigger creates a new NewDropTrigger node for DROP TRIGGER statements.
 func NewDropTrigger(db sql.Database, trigger string, ifExists bool) *DropTrigger {
@@ -92,6 +93,11 @@ func (d *DropTrigger) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (d *DropTrigger) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(d.db.Name(), d.TriggerName, "", sql.PrivilegeType_Trigger))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropTrigger) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Database implements the sql.Databaser interface.

--- a/sql/plan/drop_user.go
+++ b/sql/plan/drop_user.go
@@ -33,6 +33,7 @@ type DropUser struct {
 
 var _ sql.Node = (*DropUser)(nil)
 var _ sql.Databaser = (*DropUser)(nil)
+var _ sql.CollationCoercible = (*DropUser)(nil)
 
 // NewDropUser returns a new DropUser node.
 func NewDropUser(ifExists bool, users []UserName) *DropUser {
@@ -96,6 +97,11 @@ func (n *DropUser) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (n *DropUser) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_CreateUser))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropUser) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/drop_view.go
+++ b/sql/plan/drop_view.go
@@ -29,6 +29,9 @@ type SingleDropView struct {
 	viewName string
 }
 
+var _ sql.Node = (*SingleDropView)(nil)
+var _ sql.CollationCoercible = (*SingleDropView)(nil)
+
 // NewSingleDropView creates a SingleDropView.
 func NewSingleDropView(
 	database sql.Database,
@@ -82,6 +85,11 @@ func (dv *SingleDropView) CheckPrivileges(ctx *sql.Context, opChecker sql.Privil
 		sql.NewPrivilegedOperation(dv.database.Name(), "", "", sql.PrivilegeType_Drop))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*SingleDropView) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // Database implements the sql.Databaser interface. It returns the node's database.
 func (dv *SingleDropView) Database() sql.Database {
 	return dv.database
@@ -105,6 +113,9 @@ type DropView struct {
 	children []sql.Node
 	ifExists bool
 }
+
+var _ sql.Node = (*DropView)(nil)
+var _ sql.CollationCoercible = (*DropView)(nil)
 
 // NewDropView creates a DropView node with the specified parameters,
 // setting its catalog to nil.
@@ -193,4 +204,9 @@ func (dvs *DropView) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedO
 		}
 	}
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DropView) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/empty_table.go
+++ b/sql/plan/empty_table.go
@@ -25,6 +25,7 @@ func NewEmptyTableWithSchema(schema sql.Schema) sql.Node {
 }
 
 var _ sql.Node = (*EmptyTable)(nil)
+var _ sql.CollationCoercible = (*EmptyTable)(nil)
 
 type EmptyTable struct {
 	schema sql.Schema
@@ -52,4 +53,9 @@ func (e *EmptyTable) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (e *EmptyTable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*EmptyTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/exchange_test.go
+++ b/sql/plan/exchange_test.go
@@ -152,6 +152,7 @@ type partitionable struct {
 }
 
 var _ sql.Table = partitionable{}
+var _ sql.CollationCoercible = partitionable{}
 
 // WithChildren implements the Node interface.
 func (p *partitionable) WithChildren(children ...sql.Node) (sql.Node, error) {
@@ -165,6 +166,11 @@ func (p *partitionable) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (p *partitionable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return p.Node.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p partitionable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, p.Node)
 }
 
 func (partitionable) Children() []sql.Node { return nil }

--- a/sql/plan/existssubquery.go
+++ b/sql/plan/existssubquery.go
@@ -29,6 +29,7 @@ type ExistsSubquery struct {
 }
 
 var _ sql.Expression = (*ExistsSubquery)(nil)
+var _ sql.CollationCoercible = (*ExistsSubquery)(nil)
 
 // NewExistsSubquery created an ExistsSubquery expression.
 func NewExistsSubquery(sq *Subquery) *ExistsSubquery {
@@ -83,4 +84,9 @@ func (e *ExistsSubquery) String() string {
 // Type implements the Expression interface.
 func (e *ExistsSubquery) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ExistsSubquery) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }

--- a/sql/plan/external_procedure.go
+++ b/sql/plan/external_procedure.go
@@ -37,6 +37,7 @@ type ExternalProcedure struct {
 
 var _ sql.Node = (*ExternalProcedure)(nil)
 var _ sql.Expressioner = (*ExternalProcedure)(nil)
+var _ sql.CollationCoercible = (*ExternalProcedure)(nil)
 
 // Resolved implements the interface sql.Node.
 func (n *ExternalProcedure) Resolved() bool {
@@ -93,6 +94,11 @@ func (n *ExternalProcedure) WithExpressions(expressions ...sql.Expression) (sql.
 func (n *ExternalProcedure) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: when DEFINER is implemented for stored procedures then this should be added
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ExternalProcedure) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/fetch.go
+++ b/sql/plan/fetch.go
@@ -35,6 +35,7 @@ type Fetch struct {
 }
 
 var _ sql.Node = (*Fetch)(nil)
+var _ sql.CollationCoercible = (*Fetch)(nil)
 var _ expression.ProcedureReferencable = (*Fetch)(nil)
 
 // NewFetch returns a new *Fetch node.
@@ -91,6 +92,11 @@ func (f *Fetch) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (f *Fetch) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Fetch) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/filter.go
+++ b/sql/plan/filter.go
@@ -24,6 +24,9 @@ type Filter struct {
 	Expression sql.Expression
 }
 
+var _ sql.Node = (*Filter)(nil)
+var _ sql.CollationCoercible = (*Filter)(nil)
+
 // NewFilter creates a new filter node.
 func NewFilter(expression sql.Expression, child sql.Node) *Filter {
 	return &Filter{
@@ -62,6 +65,11 @@ func (f *Filter) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (f *Filter) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return f.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (f *Filter) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, f.UnaryNode.Child)
 }
 
 // WithExpressions implements the Expressioner interface.

--- a/sql/plan/flush.go
+++ b/sql/plan/flush.go
@@ -27,6 +27,7 @@ type FlushPrivileges struct {
 }
 
 var _ sql.Node = (*FlushPrivileges)(nil)
+var _ sql.CollationCoercible = (*FlushPrivileges)(nil)
 var _ sql.Databaser = (*FlushPrivileges)(nil)
 
 // NewFlushPrivileges creates a new FlushPrivileges node.
@@ -70,6 +71,11 @@ func (f *FlushPrivileges) CheckPrivileges(ctx *sql.Context, opChecker sql.Privil
 		return true
 	}
 	return false
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*FlushPrivileges) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Resolved implements the interface sql.Node.

--- a/sql/plan/foreign_key_handler.go
+++ b/sql/plan/foreign_key_handler.go
@@ -31,6 +31,7 @@ type ForeignKeyHandler struct {
 }
 
 var _ sql.Node = (*ForeignKeyHandler)(nil)
+var _ sql.CollationCoercible = (*ForeignKeyHandler)(nil)
 var _ sql.Table = (*ForeignKeyHandler)(nil)
 var _ sql.InsertableTable = (*ForeignKeyHandler)(nil)
 var _ sql.ReplaceableTable = (*ForeignKeyHandler)(nil)
@@ -92,6 +93,11 @@ func (n *ForeignKeyHandler) WithChildren(children ...sql.Node) (sql.Node, error)
 // CheckPrivileges implements the interface sql.Node.
 func (n *ForeignKeyHandler) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return n.OriginalNode.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ForeignKeyHandler) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Name implements the interface sql.Table.

--- a/sql/plan/grant.go
+++ b/sql/plan/grant.go
@@ -37,6 +37,7 @@ type Grant struct {
 
 var _ sql.Node = (*Grant)(nil)
 var _ sql.Databaser = (*Grant)(nil)
+var _ sql.CollationCoercible = (*Grant)(nil)
 
 // NewGrant returns a new Grant node.
 func NewGrant(db sql.Database, privileges []Privilege, objType ObjectType, level PrivilegeLevel, users []UserName, withGrant bool, as *GrantUserAssumption, granter string) (*Grant, error) {
@@ -197,6 +198,11 @@ func (n *Grant) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperat
 			sql.NewPrivilegedOperation(n.PrivilegeLevel.Database, n.PrivilegeLevel.TableRoutine, "",
 				convertToSqlPrivilegeType(true, n.Privileges...)...))
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Grant) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.
@@ -588,6 +594,7 @@ type GrantRole struct {
 
 var _ sql.Node = (*GrantRole)(nil)
 var _ sql.Databaser = (*GrantRole)(nil)
+var _ sql.CollationCoercible = (*GrantRole)(nil)
 
 // NewGrantRole returns a new GrantRole node.
 func NewGrantRole(roles []UserName, users []UserName, withAdmin bool) *GrantRole {
@@ -688,6 +695,11 @@ func (n *GrantRole) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOp
 	return true
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GrantRole) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // RowIter implements the interface sql.Node.
 func (n *GrantRole) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	mysqlDb, ok := n.MySQLDb.(*mysql_db.MySQLDb)
@@ -731,6 +743,7 @@ type GrantProxy struct {
 }
 
 var _ sql.Node = (*GrantProxy)(nil)
+var _ sql.CollationCoercible = (*GrantProxy)(nil)
 
 // NewGrantProxy returns a new GrantProxy node.
 func NewGrantProxy(on UserName, to []UserName, withGrant bool) *GrantProxy {
@@ -777,6 +790,11 @@ func (n *GrantProxy) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (n *GrantProxy) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: add this when proxy support is added
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*GrantProxy) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/group_by.go
+++ b/sql/plan/group_by.go
@@ -42,6 +42,7 @@ type GroupBy struct {
 var _ sql.Expressioner = (*GroupBy)(nil)
 var _ sql.Node = (*GroupBy)(nil)
 var _ sql.Projector = (*GroupBy)(nil)
+var _ sql.CollationCoercible = (*GroupBy)(nil)
 
 // NewGroupBy creates a new GroupBy node. Like Project, GroupBy is a top-level node, and contains all the fields that
 // will appear in the output of the query. Some of these fields may be aggregate functions, some may be columns or
@@ -124,6 +125,11 @@ func (g *GroupBy) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (g *GroupBy) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return g.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (g *GroupBy) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, g.Child)
 }
 
 // WithExpressions implements the Node interface.

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -47,7 +47,9 @@ type HashLookup struct {
 	lookup map[interface{}][]sql.Row
 }
 
+var _ sql.Node = (*HashLookup)(nil)
 var _ sql.Expressioner = (*HashLookup)(nil)
+var _ sql.CollationCoercible = (*HashLookup)(nil)
 
 func (n *HashLookup) Expressions() []sql.Expression {
 	return []sql.Expression{n.inner, n.outer}
@@ -100,6 +102,11 @@ func (n *HashLookup) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (n *HashLookup) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return n.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (n *HashLookup) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, n.Child)
 }
 
 func (n *HashLookup) RowIter(ctx *sql.Context, r sql.Row) (sql.RowIter, error) {

--- a/sql/plan/having.go
+++ b/sql/plan/having.go
@@ -25,7 +25,9 @@ type Having struct {
 	Cond sql.Expression
 }
 
+var _ sql.Node = (*Having)(nil)
 var _ sql.Expressioner = (*Having)(nil)
+var _ sql.CollationCoercible = (*Having)(nil)
 
 // NewHaving creates a new having node.
 func NewHaving(cond sql.Expression, child sql.Node) *Having {
@@ -50,6 +52,11 @@ func (h *Having) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (h *Having) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return h.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (h *Having) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, h.Child)
 }
 
 // WithExpressions implements the Expressioner interface.

--- a/sql/plan/if_else.go
+++ b/sql/plan/if_else.go
@@ -30,6 +30,7 @@ type IfConditional struct {
 var _ sql.Node = (*IfConditional)(nil)
 var _ sql.DebugStringer = (*IfConditional)(nil)
 var _ sql.Expressioner = (*IfConditional)(nil)
+var _ sql.CollationCoercible = (*IfConditional)(nil)
 var _ RepresentsBlock = (*IfConditional)(nil)
 
 // NewIfConditional creates a new *IfConditional node.
@@ -87,6 +88,11 @@ func (ic *IfConditional) CheckPrivileges(ctx *sql.Context, opChecker sql.Privile
 	return ic.Body.CheckPrivileges(ctx, opChecker)
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (ic *IfConditional) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, ic.Body)
+}
+
 // Expressions implements the sql.Expressioner interface.
 func (ic *IfConditional) Expressions() []sql.Expression {
 	return []sql.Expression{ic.Condition}
@@ -118,6 +124,7 @@ type IfElseBlock struct {
 }
 
 var _ sql.Node = (*IfElseBlock)(nil)
+var _ sql.CollationCoercible = (*IfElseBlock)(nil)
 var _ sql.DebugStringer = (*IfElseBlock)(nil)
 var _ RepresentsBlock = (*IfElseBlock)(nil)
 
@@ -217,6 +224,13 @@ func (ieb *IfElseBlock) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileg
 		return ieb.Else.CheckPrivileges(ctx, opChecker)
 	}
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (ieb *IfElseBlock) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// We'll only be able to know which branch was taken during the RowIter, so we can't rely on that here.
+	// I'm going to make the assumption that this will never need to be used, so we'll return 7 here.
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the sql.Node interface.

--- a/sql/plan/indexed_in_subquery_filter.go
+++ b/sql/plan/indexed_in_subquery_filter.go
@@ -57,6 +57,7 @@ type IndexedInSubqueryFilter struct {
 var _ sql.Node = (*IndexedInSubqueryFilter)(nil)
 var _ sql.Disposable = (*IndexedInSubqueryFilter)(nil)
 var _ sql.Expressioner = (*IndexedInSubqueryFilter)(nil)
+var _ sql.CollationCoercible = (*IndexedInSubqueryFilter)(nil)
 
 func (i *IndexedInSubqueryFilter) Resolved() bool {
 	return i.subquery.Resolved() && i.child.Resolved()
@@ -106,6 +107,13 @@ func (i *IndexedInSubqueryFilter) WithChildren(children ...sql.Node) (sql.Node, 
 // CheckPrivileges implements the interface sql.Node.
 func (i *IndexedInSubqueryFilter) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return i.subquery.Query.CheckPrivileges(ctx, opChecker) && i.child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (i *IndexedInSubqueryFilter) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// I truly have zero clue if this is the correct field to pull coercibility from (or if this needs to return
+	// coercibility at all), but I'll leave this here until we identify that it needs to be changed.
+	return sql.GetCoercibility(ctx, i.child)
 }
 
 // Expressions implements the interface sql.Expressioner.

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -41,6 +41,7 @@ var _ sql.Node = (*IndexedTableAccess)(nil)
 var _ sql.Nameable = (*IndexedTableAccess)(nil)
 var _ sql.Node2 = (*IndexedTableAccess)(nil)
 var _ sql.Expressioner = (*IndexedTableAccess)(nil)
+var _ sql.CollationCoercible = (*IndexedTableAccess)(nil)
 
 // NewIndexedTableAccess returns a new IndexedTableAccess node that will use
 // the LookupBuilder to build lookups. An index lookup will be calculated and
@@ -152,6 +153,11 @@ func (i *IndexedTableAccess) Database() sql.Database {
 
 func (i *IndexedTableAccess) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return i.ResolvedTable.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (i *IndexedTableAccess) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return i.ResolvedTable.CollationCoercibility(ctx)
 }
 
 func (i *IndexedTableAccess) Index() sql.Index {

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -80,6 +80,7 @@ type InsertInto struct {
 var _ sql.Databaser = (*InsertInto)(nil)
 var _ sql.Node = (*InsertInto)(nil)
 var _ sql.Expressioner = (*InsertInto)(nil)
+var _ sql.CollationCoercible = (*InsertInto)(nil)
 var _ DisjointedChildrenNode = (*InsertInto)(nil)
 
 // NewInsertInto creates an InsertInto node.
@@ -130,7 +131,9 @@ type InsertDestination struct {
 	Sch sql.Schema
 }
 
+var _ sql.Node = (*InsertDestination)(nil)
 var _ sql.Expressioner = (*InsertDestination)(nil)
+var _ sql.CollationCoercible = (*InsertDestination)(nil)
 
 func NewInsertDestination(schema sql.Schema, node sql.Node) *InsertDestination {
 	return &InsertDestination{
@@ -204,6 +207,11 @@ func (id InsertDestination) WithChildren(children ...sql.Node) (sql.Node, error)
 // CheckPrivileges implements the interface sql.Node.
 func (id *InsertDestination) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return id.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (id *InsertDestination) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, id.Child)
 }
 
 type insertIter struct {
@@ -697,6 +705,11 @@ func (ii *InsertInto) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileged
 		return opChecker.UserHasPrivileges(ctx,
 			sql.NewPrivilegedOperation(ii.db.Name(), getTableName(ii.Destination), "", sql.PrivilegeType_Insert))
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*InsertInto) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // DisjointedChildren implements the interface DisjointedChildrenNode.

--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -30,10 +30,16 @@ type InSubquery struct {
 }
 
 var _ sql.Expression = (*InSubquery)(nil)
+var _ sql.CollationCoercible = (*InSubquery)(nil)
 
 // Type implements sql.Expression
 func (in *InSubquery) Type() sql.Type {
 	return types.Boolean
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*InSubquery) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // NewInSubquery creates an InSubquery expression.

--- a/sql/plan/into.go
+++ b/sql/plan/into.go
@@ -31,6 +31,9 @@ type Into struct {
 	IntoVars []sql.Expression
 }
 
+var _ sql.Node = (*Into)(nil)
+var _ sql.CollationCoercible = (*Into)(nil)
+
 func NewInto(child sql.Node, variables []sql.Expression) *Into {
 	return &Into{
 		UnaryNode: UnaryNode{child},
@@ -123,6 +126,11 @@ func (i *Into) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (i *Into) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return i.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (i *Into) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, i.Child)
 }
 
 // WithExpressions implements the sql.Expressioner interface.

--- a/sql/plan/iterate.go
+++ b/sql/plan/iterate.go
@@ -27,6 +27,7 @@ type Iterate struct {
 }
 
 var _ sql.Node = (*Iterate)(nil)
+var _ sql.CollationCoercible = (*Iterate)(nil)
 
 // NewIterate returns a new *Iterate node.
 func NewIterate(label string) *Iterate {
@@ -63,6 +64,11 @@ func (i *Iterate) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (i *Iterate) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Iterate) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -232,7 +232,7 @@ func shouldUseMemoryJoinsByEnv() bool {
 	return v == "on" || v == "1"
 }
 
-// JoinNode contains all the common data fields and implements the commom sql.Node getters for all join types.
+// JoinNode contains all the common data fields and implements the common sql.Node getters for all join types.
 type JoinNode struct {
 	BinaryNode
 	Filter     sql.Expression
@@ -240,6 +240,9 @@ type JoinNode struct {
 	CommentStr string
 	ScopeLen   int
 }
+
+var _ sql.Node = (*JoinNode)(nil)
+var _ sql.CollationCoercible = (*JoinNode)(nil)
 
 func NewJoin(left, right sql.Node, op JoinType, cond sql.Expression) *JoinNode {
 	return &JoinNode{
@@ -296,6 +299,12 @@ func (j *JoinNode) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
 
 func (j *JoinNode) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return j.left.CheckPrivileges(ctx, opChecker) && j.right.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*JoinNode) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// Joins make use of coercibility, but they don't return anything themselves
+	return sql.Collation_binary, 7
 }
 
 func (j *JoinNode) JoinType() JoinType {

--- a/sql/plan/json_table.go
+++ b/sql/plan/json_table.go
@@ -105,6 +105,7 @@ type JSONTable struct {
 var _ sql.Table = &JSONTable{}
 var _ sql.Node = &JSONTable{}
 var _ sql.Expressioner = &JSONTable{}
+var _ sql.CollationCoercible = &JSONTable{}
 
 // Name implements the sql.Table interface
 func (t *JSONTable) Name() string {
@@ -197,6 +198,11 @@ func (t *JSONTable) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the sql.Node interface
 func (t *JSONTable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*JSONTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Expressions implements the sql.Expressioner interface

--- a/sql/plan/kill.go
+++ b/sql/plan/kill.go
@@ -45,6 +45,9 @@ type Kill struct {
 	connID uint32
 }
 
+var _ sql.Node = (*Kill)(nil)
+var _ sql.CollationCoercible = (*Kill)(nil)
+
 func NewKill(kt KillType, connID uint32) *Kill {
 	return &Kill{kt, connID}
 }
@@ -69,6 +72,11 @@ func (k *Kill) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperati
 	//TODO: If the user doesn't have the SUPER privilege, they should still be able to kill their own threads
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_Super))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Kill) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (k *Kill) Schema() sql.Schema {

--- a/sql/plan/leave.go
+++ b/sql/plan/leave.go
@@ -26,6 +26,7 @@ type Leave struct {
 }
 
 var _ sql.Node = (*Leave)(nil)
+var _ sql.CollationCoercible = (*Leave)(nil)
 
 // NewLeave returns a new *Leave node.
 func NewLeave(label string) *Leave {
@@ -62,6 +63,11 @@ func (l *Leave) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (l *Leave) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Leave) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/limit.go
+++ b/sql/plan/limit.go
@@ -31,6 +31,9 @@ type Limit struct {
 	CalcFoundRows bool
 }
 
+var _ sql.Node = (*Limit)(nil)
+var _ sql.CollationCoercible = (*Limit)(nil)
+
 // NewLimit creates a new Limit node with the given size.
 func NewLimit(size sql.Expression, child sql.Node) *Limit {
 	return &Limit{
@@ -135,6 +138,11 @@ func (l *Limit) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (l *Limit) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return l.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (l *Limit) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, l.Child)
 }
 
 func (l Limit) String() string {

--- a/sql/plan/load_data.go
+++ b/sql/plan/load_data.go
@@ -46,6 +46,9 @@ type LoadData struct {
 	linesStartingByDelim    string
 }
 
+var _ sql.Node = (*LoadData)(nil)
+var _ sql.CollationCoercible = (*LoadData)(nil)
+
 // Default values as defined here: https://dev.mysql.com/doc/refman/8.0/en/load-data.html
 const (
 	defaultFieldsTerminatedByDelim = "\t"
@@ -399,6 +402,11 @@ func (l *LoadData) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (l *LoadData) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_File))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*LoadData) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func NewLoadData(local bool, file string, destination sql.Node, cols []string, fields *sqlparser.Fields, lines *sqlparser.Lines, ignoreNum int64) *LoadData {

--- a/sql/plan/lock.go
+++ b/sql/plan/lock.go
@@ -35,6 +35,9 @@ type LockTables struct {
 	Locks   []*TableLock
 }
 
+var _ sql.Node = (*LockTables)(nil)
+var _ sql.CollationCoercible = (*LockTables)(nil)
+
 // NewLockTables creates a new LockTables node.
 func NewLockTables(locks []*TableLock) *LockTables {
 	return &LockTables{Locks: locks}
@@ -128,6 +131,11 @@ func (t *LockTables) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedO
 	return opChecker.UserHasPrivileges(ctx, operations...)
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*LockTables) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // ErrTableNotLockable is returned whenever a lockable table can't be found.
 var ErrTableNotLockable = errors.NewKind("table %s is not lockable")
 
@@ -157,6 +165,9 @@ func getLockableTable(table sql.Table) (sql.Lockable, error) {
 type UnlockTables struct {
 	Catalog sql.Catalog
 }
+
+var _ sql.Node = (*UnlockTables)(nil)
+var _ sql.CollationCoercible = (*UnlockTables)(nil)
 
 // NewUnlockTables returns a new UnlockTables node.
 func NewUnlockTables() *UnlockTables {
@@ -203,4 +214,9 @@ func (t *UnlockTables) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (t *UnlockTables) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: Can't quite figure out the privileges for this one, needs more testing
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UnlockTables) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/loop.go
+++ b/sql/plan/loop.go
@@ -36,6 +36,7 @@ type Loop struct {
 var _ sql.Node = (*Loop)(nil)
 var _ sql.DebugStringer = (*Loop)(nil)
 var _ sql.Expressioner = (*Loop)(nil)
+var _ sql.CollationCoercible = (*Loop)(nil)
 var _ RepresentsLabeledBlock = (*Loop)(nil)
 
 // NewLoop returns a new *Loop node.
@@ -117,6 +118,11 @@ func (l *Loop) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (l *Loop) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return l.Block.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (l *Loop) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return l.Block.CollationCoercibility(ctx)
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/namedwindows.go
+++ b/sql/plan/namedwindows.go
@@ -30,6 +30,7 @@ type NamedWindows struct {
 }
 
 var _ sql.Node = (*NamedWindows)(nil)
+var _ sql.CollationCoercible = (*NamedWindows)(nil)
 
 func NewNamedWindows(windowDefs map[string]*sql.WindowDefinition, child sql.Node) *NamedWindows {
 	return &NamedWindows{
@@ -86,4 +87,9 @@ func (n *NamedWindows) WithChildren(nodes ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements sql.Node
 func (n *NamedWindows) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return n.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (n *NamedWindows) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, n.Child)
 }

--- a/sql/plan/nothing.go
+++ b/sql/plan/nothing.go
@@ -21,6 +21,9 @@ var Nothing nothing
 
 type nothing struct{}
 
+var _ sql.Node = nothing{}
+var _ sql.CollationCoercible = nothing{}
+
 func (nothing) String() string       { return "NOTHING" }
 func (nothing) Resolved() bool       { return true }
 func (nothing) Schema() sql.Schema   { return nil }
@@ -41,4 +44,9 @@ func (n nothing) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (nothing) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (nothing) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/offset.go
+++ b/sql/plan/offset.go
@@ -27,6 +27,9 @@ type Offset struct {
 	Offset sql.Expression
 }
 
+var _ sql.Node = (*Offset)(nil)
+var _ sql.CollationCoercible = (*Offset)(nil)
+
 // NewOffset creates a new Offset node.
 func NewOffset(n sql.Expression, child sql.Node) *Offset {
 	return &Offset{
@@ -82,6 +85,11 @@ func (o *Offset) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (o *Offset) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return o.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (o *Offset) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, o.Child)
 }
 
 func (o Offset) String() string {

--- a/sql/plan/open.go
+++ b/sql/plan/open.go
@@ -30,6 +30,7 @@ type Open struct {
 }
 
 var _ sql.Node = (*Open)(nil)
+var _ sql.CollationCoercible = (*Open)(nil)
 var _ expression.ProcedureReferencable = (*Open)(nil)
 
 // NewOpen returns a new *Open node.
@@ -67,6 +68,11 @@ func (o *Open) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (o *Open) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Open) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/prepare.go
+++ b/sql/plan/prepare.go
@@ -28,6 +28,7 @@ type PrepareQuery struct {
 }
 
 var _ sql.Node = (*PrepareQuery)(nil)
+var _ sql.CollationCoercible = (*PrepareQuery)(nil)
 
 // NewPrepareQuery creates a new PrepareQuery node.
 func NewPrepareQuery(name string, child sql.Node) *PrepareQuery {
@@ -75,6 +76,11 @@ func (p *PrepareQuery) CheckPrivileges(ctx *sql.Context, opChecker sql.Privilege
 	return p.Child.CheckPrivileges(ctx, opChecker)
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*PrepareQuery) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func (p *PrepareQuery) String() string {
 	return fmt.Sprintf("Prepare(%s)", p.Child.String())
 }
@@ -86,6 +92,7 @@ type ExecuteQuery struct {
 }
 
 var _ sql.Node = (*ExecuteQuery)(nil)
+var _ sql.CollationCoercible = (*ExecuteQuery)(nil)
 
 // NewExecuteQuery executes a prepared statement
 func NewExecuteQuery(name string, bindVars ...sql.Expression) *ExecuteQuery {
@@ -121,6 +128,11 @@ func (p *ExecuteQuery) CheckPrivileges(ctx *sql.Context, opChecker sql.Privilege
 	panic("ExecuteQuery methods shouldn't be used")
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ExecuteQuery) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 func (p *ExecuteQuery) String() string {
 	panic("ExecuteQuery methods shouldn't be used")
 }
@@ -131,6 +143,7 @@ type DeallocateQuery struct {
 }
 
 var _ sql.Node = (*DeallocateQuery)(nil)
+var _ sql.CollationCoercible = (*DeallocateQuery)(nil)
 
 // NewDeallocateQuery executes a prepared statement
 func NewDeallocateQuery(name string) *DeallocateQuery {
@@ -167,6 +180,11 @@ func (p *DeallocateQuery) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (p *DeallocateQuery) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DeallocateQuery) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (p *DeallocateQuery) String() string {

--- a/sql/plan/procedure.go
+++ b/sql/plan/procedure.go
@@ -88,6 +88,7 @@ type Procedure struct {
 
 var _ sql.Node = (*Procedure)(nil)
 var _ sql.DebugStringer = (*Procedure)(nil)
+var _ sql.CollationCoercible = (*Procedure)(nil)
 var _ RepresentsBlock = (*Procedure)(nil)
 
 // NewProcedure returns a *Procedure. All names contained within are lowercase, and all methods are case-insensitive.
@@ -165,6 +166,11 @@ func (p *Procedure) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (p *Procedure) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return p.Body.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p *Procedure) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, p.Body)
 }
 
 // RowIter implements the sql.Node interface.

--- a/sql/plan/procedure_resolved_table.go
+++ b/sql/plan/procedure_resolved_table.go
@@ -31,6 +31,7 @@ var _ sql.Node = (*ProcedureResolvedTable)(nil)
 var _ sql.DebugStringer = (*ProcedureResolvedTable)(nil)
 var _ sql.TableWrapper = (*ProcedureResolvedTable)(nil)
 var _ sql.Table = (*ProcedureResolvedTable)(nil)
+var _ sql.CollationCoercible = (*ProcedureResolvedTable)(nil)
 
 // NewProcedureResolvedTable returns a *ProcedureResolvedTable.
 func NewProcedureResolvedTable(rt *ResolvedTable) *ProcedureResolvedTable {
@@ -97,6 +98,11 @@ func (t *ProcedureResolvedTable) WithChildren(children ...sql.Node) (sql.Node, e
 // CheckPrivileges implements the interface sql.Node.
 func (t *ProcedureResolvedTable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return t.ResolvedTable.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t *ProcedureResolvedTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return t.ResolvedTable.CollationCoercibility(ctx)
 }
 
 // Underlying implements the sql.TableWrapper interface.

--- a/sql/plan/process.go
+++ b/sql/plan/process.go
@@ -34,6 +34,7 @@ type QueryProcess struct {
 
 var _ sql.Node = (*QueryProcess)(nil)
 var _ sql.Node2 = (*QueryProcess)(nil)
+var _ sql.CollationCoercible = (*QueryProcess)(nil)
 
 // NotifyFunc is a function to notify about some event.
 type NotifyFunc func()
@@ -59,6 +60,11 @@ func (p *QueryProcess) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (p *QueryProcess) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return p.Child().CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p *QueryProcess) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, p.Child())
 }
 
 // RowIter implements the sql.Node interface.

--- a/sql/plan/processlist.go
+++ b/sql/plan/processlist.go
@@ -66,6 +66,9 @@ type ShowProcessList struct {
 	Database string
 }
 
+var _ sql.Node = (*ShowProcessList)(nil)
+var _ sql.CollationCoercible = (*ShowProcessList)(nil)
+
 // NewShowProcessList creates a new ProcessList node.
 func NewShowProcessList() *ShowProcessList { return new(ShowProcessList) }
 
@@ -88,6 +91,11 @@ func (p *ShowProcessList) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (p *ShowProcessList) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_Process))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowProcessList) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Schema implements the Node interface.

--- a/sql/plan/project.go
+++ b/sql/plan/project.go
@@ -36,6 +36,7 @@ type Project struct {
 var _ sql.Expressioner = (*Project)(nil)
 var _ sql.Node = (*Project)(nil)
 var _ sql.Projector = (*Project)(nil)
+var _ sql.CollationCoercible = (*Project)(nil)
 
 // NewProject creates a new projection.
 func NewProject(expressions []sql.Expression, child sql.Node) *Project {
@@ -131,6 +132,11 @@ func (p *Project) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (p *Project) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return p.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (p *Project) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, p.Child)
 }
 
 // WithExpressions implements the Expressioner interface.

--- a/sql/plan/recursive_cte.go
+++ b/sql/plan/recursive_cte.go
@@ -60,6 +60,7 @@ type RecursiveCte struct {
 var _ sql.Node = (*RecursiveCte)(nil)
 var _ sql.Nameable = (*RecursiveCte)(nil)
 var _ sql.Expressioner = (*RecursiveCte)(nil)
+var _ sql.CollationCoercible = (*RecursiveCte)(nil)
 
 func NewRecursiveCte(initial, recursive sql.Node, name string, outputCols []string, deduplicate bool, l sql.Expression, sf sql.SortFields) *RecursiveCte {
 	return &RecursiveCte{
@@ -165,6 +166,11 @@ func (r *RecursiveCte) Children() []sql.Node {
 
 func (r *RecursiveCte) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return r.union.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*RecursiveCte) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (r *RecursiveCte) Expressions() []sql.Expression {
@@ -349,6 +355,9 @@ type RecursiveTable struct {
 	buf    []sql.Row
 }
 
+var _ sql.Node = (*RecursiveTable)(nil)
+var _ sql.CollationCoercible = (*RecursiveTable)(nil)
+
 func (r *RecursiveTable) Resolved() bool {
 	return true
 }
@@ -380,6 +389,11 @@ func (r *RecursiveTable) WithChildren(node ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (r *RecursiveTable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*RecursiveTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 var _ sql.Node = (*RecursiveTable)(nil)

--- a/sql/plan/rename_user.go
+++ b/sql/plan/rename_user.go
@@ -29,6 +29,7 @@ type RenameUser struct {
 }
 
 var _ sql.Node = (*RenameUser)(nil)
+var _ sql.CollationCoercible = (*RenameUser)(nil)
 
 // NewRenameUser returns a new RenameUser node.
 func NewRenameUser(oldNames []UserName, newNames []UserName) *RenameUser {
@@ -75,6 +76,11 @@ func (n *RenameUser) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (n *RenameUser) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_CreateUser))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*RenameUser) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/repeat.go
+++ b/sql/plan/repeat.go
@@ -27,6 +27,7 @@ type Repeat struct {
 var _ sql.Node = (*Repeat)(nil)
 var _ sql.DebugStringer = (*Repeat)(nil)
 var _ sql.Expressioner = (*Repeat)(nil)
+var _ sql.CollationCoercible = (*Repeat)(nil)
 var _ RepresentsLabeledBlock = (*Repeat)(nil)
 
 // NewRepeat returns a new *Repeat node.

--- a/sql/plan/replication_commands.go
+++ b/sql/plan/replication_commands.go
@@ -50,6 +50,7 @@ type ChangeReplicationSource struct {
 }
 
 var _ sql.Node = (*ChangeReplicationSource)(nil)
+var _ sql.CollationCoercible = (*ChangeReplicationSource)(nil)
 var _ BinlogReplicaControllerCommand = (*ChangeReplicationSource)(nil)
 
 func NewChangeReplicationSource(options []binlogreplication.ReplicationOption) *ChangeReplicationSource {
@@ -112,6 +113,11 @@ func (c *ChangeReplicationSource) CheckPrivileges(ctx *sql.Context, opChecker sq
 		sql.NewDynamicPrivilegedOperation(DynamicPrivilege_ReplicationSlaveAdmin))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ChangeReplicationSource) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // ChangeReplicationFilter is a plan node for the "CHANGE REPLICATION FILTER" statement.
 // https://dev.mysql.com/doc/refman/8.0/en/change-replication-filter.html
 type ChangeReplicationFilter struct {
@@ -120,6 +126,7 @@ type ChangeReplicationFilter struct {
 }
 
 var _ sql.Node = (*ChangeReplicationFilter)(nil)
+var _ sql.CollationCoercible = (*ChangeReplicationFilter)(nil)
 var _ BinlogReplicaControllerCommand = (*ChangeReplicationFilter)(nil)
 
 func NewChangeReplicationFilter(options []binlogreplication.ReplicationOption) *ChangeReplicationFilter {
@@ -185,6 +192,11 @@ func (c *ChangeReplicationFilter) CheckPrivileges(ctx *sql.Context, opChecker sq
 		sql.NewDynamicPrivilegedOperation(DynamicPrivilege_ReplicationSlaveAdmin))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ChangeReplicationFilter) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // StartReplica is a plan node for the "START REPLICA" statement.
 // https://dev.mysql.com/doc/refman/8.0/en/start-replica.html
 type StartReplica struct {
@@ -192,6 +204,7 @@ type StartReplica struct {
 }
 
 var _ sql.Node = (*StartReplica)(nil)
+var _ sql.CollationCoercible = (*StartReplica)(nil)
 var _ BinlogReplicaControllerCommand = (*StartReplica)(nil)
 
 func NewStartReplica() *StartReplica {
@@ -244,6 +257,11 @@ func (s *StartReplica) CheckPrivileges(ctx *sql.Context, opChecker sql.Privilege
 		sql.NewDynamicPrivilegedOperation(DynamicPrivilege_ReplicationSlaveAdmin))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*StartReplica) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // StopReplica is the plan node for the "STOP REPLICA" statement.
 // https://dev.mysql.com/doc/refman/8.0/en/stop-replica.html
 type StopReplica struct {
@@ -251,6 +269,7 @@ type StopReplica struct {
 }
 
 var _ sql.Node = (*StopReplica)(nil)
+var _ sql.CollationCoercible = (*StopReplica)(nil)
 var _ BinlogReplicaControllerCommand = (*StopReplica)(nil)
 
 func NewStopReplica() *StopReplica {
@@ -303,6 +322,11 @@ func (s *StopReplica) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileged
 		sql.NewDynamicPrivilegedOperation(DynamicPrivilege_ReplicationSlaveAdmin))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*StopReplica) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // ResetReplica is a plan node for the "RESET REPLICA" statement.
 // https://dev.mysql.com/doc/refman/8.0/en/reset-replica.html
 type ResetReplica struct {
@@ -311,6 +335,7 @@ type ResetReplica struct {
 }
 
 var _ sql.Node = (*ResetReplica)(nil)
+var _ sql.CollationCoercible = (*ResetReplica)(nil)
 var _ BinlogReplicaControllerCommand = (*ResetReplica)(nil)
 
 func NewResetReplica(all bool) *ResetReplica {
@@ -368,4 +393,9 @@ func (r *ResetReplica) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (r *ResetReplica) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_Reload))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ResetReplica) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -33,6 +33,7 @@ type ResolvedTable struct {
 var _ sql.Node = (*ResolvedTable)(nil)
 var _ sql.Node2 = (*ResolvedTable)(nil)
 var _ sql.RenameableNode = (*ResolvedTable)(nil)
+var _ sql.CollationCoercible = (*ResolvedTable)(nil)
 
 // Can't embed Table2 like we do Table1 as it's an extension not everyone implements
 var _ sql.Table2 = (*ResolvedTable)(nil)
@@ -175,6 +176,11 @@ func (t *ResolvedTable) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileg
 
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(t.Database.Name(), t.Table.Name(), "", sql.PrivilegeType_Select))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ResolvedTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // WithTable returns this Node with the given table. The new table should have the same name as the previous table.

--- a/sql/plan/revoke.go
+++ b/sql/plan/revoke.go
@@ -35,6 +35,7 @@ type Revoke struct {
 
 var _ sql.Node = (*Revoke)(nil)
 var _ sql.Databaser = (*Revoke)(nil)
+var _ sql.CollationCoercible = (*Revoke)(nil)
 
 // NewRevoke returns a new Revoke node.
 func NewRevoke(privileges []Privilege, objType ObjectType, level PrivilegeLevel, users []UserName, revoker string) (*Revoke, error) {
@@ -193,6 +194,11 @@ func (n *Revoke) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpera
 			sql.NewPrivilegedOperation(n.PrivilegeLevel.Database, n.PrivilegeLevel.TableRoutine, "",
 				convertToSqlPrivilegeType(true, n.Privileges...)...))
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Revoke) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.
@@ -477,6 +483,7 @@ type RevokeAll struct {
 }
 
 var _ sql.Node = (*RevokeAll)(nil)
+var _ sql.CollationCoercible = (*RevokeAll)(nil)
 
 // NewRevokeAll returns a new RevokeAll node.
 func NewRevokeAll(users []UserName) *RevokeAll {
@@ -527,6 +534,11 @@ func (n *RevokeAll) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOp
 			sql.NewPrivilegedOperation("mysql", "", "", sql.PrivilegeType_Update))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*RevokeAll) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // RowIter implements the interface sql.Node.
 func (n *RevokeAll) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	return nil, fmt.Errorf("not yet implemented")
@@ -541,6 +553,7 @@ type RevokeRole struct {
 
 var _ sql.Node = (*RevokeRole)(nil)
 var _ sql.Databaser = (*RevokeRole)(nil)
+var _ sql.CollationCoercible = (*RevokeRole)(nil)
 
 // NewRevokeRole returns a new RevokeRole node.
 func NewRevokeRole(roles []UserName, users []UserName) *RevokeRole {
@@ -640,6 +653,11 @@ func (n *RevokeRole) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedO
 	return true
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*RevokeRole) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // RowIter implements the interface sql.Node.
 func (n *RevokeRole) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	mysqlDb, ok := n.MySQLDb.(*mysql_db.MySQLDb)
@@ -682,6 +700,7 @@ type RevokeProxy struct {
 }
 
 var _ sql.Node = (*RevokeProxy)(nil)
+var _ sql.CollationCoercible = (*RevokeProxy)(nil)
 
 // NewRevokeProxy returns a new RevokeProxy node.
 func NewRevokeProxy(on UserName, from []UserName) *RevokeProxy {
@@ -727,6 +746,11 @@ func (n *RevokeProxy) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (n *RevokeProxy) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: add this when proxy support is added
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*RevokeProxy) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/row_update_accumulator.go
+++ b/sql/plan/row_update_accumulator.go
@@ -44,6 +44,9 @@ type RowUpdateAccumulator struct {
 	RowUpdateType
 }
 
+var _ sql.Node = RowUpdateAccumulator{}
+var _ sql.CollationCoercible = RowUpdateAccumulator{}
+
 // NewRowUpdateResult returns a new RowUpdateResult with the given node to wrap.
 func NewRowUpdateAccumulator(n sql.Node, updateType RowUpdateType) *RowUpdateAccumulator {
 	return &RowUpdateAccumulator{
@@ -72,6 +75,11 @@ func (r RowUpdateAccumulator) WithChildren(children ...sql.Node) (sql.Node, erro
 // CheckPrivileges implements the interface sql.Node.
 func (r RowUpdateAccumulator) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return r.Child().CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (r RowUpdateAccumulator) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, r.Child())
 }
 
 func (r RowUpdateAccumulator) String() string {

--- a/sql/plan/set.go
+++ b/sql/plan/set.go
@@ -28,6 +28,9 @@ type Set struct {
 	Exprs []sql.Expression
 }
 
+var _ sql.Node = (*Set)(nil)
+var _ sql.CollationCoercible = (*Set)(nil)
+
 // NewSet creates a new Set node.
 func NewSet(vars []sql.Expression) *Set {
 	return &Set{Exprs: vars}
@@ -59,6 +62,11 @@ func (s *Set) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (s *Set) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: determine which variables cannot be set without a privilege check
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Set) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // WithExpressions implements the sql.Expressioner interface.

--- a/sql/plan/show_charset.go
+++ b/sql/plan/show_charset.go
@@ -26,6 +26,9 @@ type ShowCharset struct {
 	CharacterSetTable sql.Node
 }
 
+var _ sql.Node = (*ShowCharset)(nil)
+var _ sql.CollationCoercible = (*ShowCharset)(nil)
+
 // NewShowCharset returns a new ShowCharset reference.
 func NewShowCharset() *ShowCharset {
 	return &ShowCharset{}
@@ -49,6 +52,11 @@ func (sc *ShowCharset) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (sc *ShowCharset) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowCharset) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (sc *ShowCharset) String() string {

--- a/sql/plan/show_create_database.go
+++ b/sql/plan/show_create_database.go
@@ -38,7 +38,9 @@ func NewShowCreateDatabase(db sql.Database, ifNotExists bool) *ShowCreateDatabas
 	return &ShowCreateDatabase{db, ifNotExists}
 }
 
+var _ sql.Node = (*ShowCreateDatabase)(nil)
 var _ sql.Databaser = (*ShowCreateDatabase)(nil)
+var _ sql.CollationCoercible = (*ShowCreateDatabase)(nil)
 
 // Database implements the sql.Databaser interface.
 func (s *ShowCreateDatabase) Database() sql.Database {
@@ -108,4 +110,9 @@ func (s *ShowCreateDatabase) WithChildren(children ...sql.Node) (sql.Node, error
 func (s *ShowCreateDatabase) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	// The database won't be visible during the resolution step if the user doesn't have the correct privileges
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowCreateDatabase) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/show_create_procedure.go
+++ b/sql/plan/show_create_procedure.go
@@ -30,6 +30,7 @@ type ShowCreateProcedure struct {
 
 var _ sql.Databaser = (*ShowCreateProcedure)(nil)
 var _ sql.Node = (*ShowCreateProcedure)(nil)
+var _ sql.CollationCoercible = (*ShowCreateProcedure)(nil)
 
 var showCreateProcedureSchema = sql.Schema{
 	&sql.Column{Name: "Procedure", Type: types.LongText, Nullable: false},
@@ -136,6 +137,11 @@ func (s *ShowCreateProcedure) CheckPrivileges(ctx *sql.Context, opChecker sql.Pr
 		opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(s.db.Name(), "", "", sql.PrivilegeType_CreateRoutine)) ||
 		opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(s.db.Name(), "", "", sql.PrivilegeType_AlterRoutine)) ||
 		opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(s.db.Name(), "", "", sql.PrivilegeType_Execute))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowCreateProcedure) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Database implements the sql.Databaser interface.

--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -41,6 +41,7 @@ type ShowCreateTable struct {
 var _ sql.Node = (*ShowCreateTable)(nil)
 var _ sql.Expressioner = (*ShowCreateTable)(nil)
 var _ sql.SchemaTarget = (*ShowCreateTable)(nil)
+var _ sql.CollationCoercible = (*ShowCreateTable)(nil)
 var _ Versionable = (*ShowCreateTable)(nil)
 
 // NewShowCreateTable creates a new ShowCreateTable node.
@@ -92,6 +93,11 @@ func (sc ShowCreateTable) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (sc *ShowCreateTable) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	// The table won't be visible during the resolution step if the user doesn't have the correct privileges
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowCreateTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (sc ShowCreateTable) WithTargetSchema(schema sql.Schema) (sql.Node, error) {

--- a/sql/plan/show_create_trigger.go
+++ b/sql/plan/show_create_trigger.go
@@ -29,6 +29,7 @@ type ShowCreateTrigger struct {
 
 var _ sql.Databaser = (*ShowCreateTrigger)(nil)
 var _ sql.Node = (*ShowCreateTrigger)(nil)
+var _ sql.CollationCoercible = (*ShowCreateTrigger)(nil)
 
 var showCreateTriggerSchema = sql.Schema{
 	&sql.Column{Name: "Trigger", Type: types.LongText, Nullable: false},
@@ -116,6 +117,11 @@ func (s *ShowCreateTrigger) WithChildren(children ...sql.Node) (sql.Node, error)
 func (s *ShowCreateTrigger) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: figure out what privileges are needed here
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowCreateTrigger) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Database implements the sql.Databaser interface.

--- a/sql/plan/show_grants.go
+++ b/sql/plan/show_grants.go
@@ -34,6 +34,7 @@ type ShowGrants struct {
 
 var _ sql.Node = (*ShowGrants)(nil)
 var _ sql.Databaser = (*ShowGrants)(nil)
+var _ sql.CollationCoercible = (*ShowGrants)(nil)
 
 // NewShowGrants returns a new ShowGrants node.
 func NewShowGrants(currentUser bool, targetUser *UserName, using []UserName) *ShowGrants {
@@ -113,6 +114,11 @@ func (n *ShowGrants) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedO
 		return opChecker.UserHasPrivileges(ctx,
 			sql.NewPrivilegedOperation("mysql", "", "", sql.PrivilegeType_Select))
 	}
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowGrants) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // generatePrivStrings creates a formatted GRANT <privilege_list> on <global/database/table> to <user@host> string

--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -36,6 +36,7 @@ func NewShowIndexes(table sql.Node) sql.Node {
 }
 
 var _ sql.Node = (*ShowIndexes)(nil)
+var _ sql.CollationCoercible = (*ShowIndexes)(nil)
 
 // WithChildren implements the Node interface.
 func (n *ShowIndexes) WithChildren(children ...sql.Node) (sql.Node, error) {
@@ -53,6 +54,11 @@ func (n *ShowIndexes) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (n *ShowIndexes) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: figure out what privileges are required
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowIndexes) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // String implements the fmt.Stringer interface.

--- a/sql/plan/show_privileges.go
+++ b/sql/plan/show_privileges.go
@@ -23,6 +23,7 @@ import (
 type ShowPrivileges struct{}
 
 var _ sql.Node = (*ShowPrivileges)(nil)
+var _ sql.CollationCoercible = (*ShowPrivileges)(nil)
 
 // NewShowPrivileges returns a new ShowPrivileges node.
 func NewShowPrivileges() *ShowPrivileges {
@@ -64,6 +65,11 @@ func (n *ShowPrivileges) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (n *ShowPrivileges) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowPrivileges) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the interface sql.Node.

--- a/sql/plan/show_replica_status.go
+++ b/sql/plan/show_replica_status.go
@@ -32,6 +32,7 @@ type ShowReplicaStatus struct {
 }
 
 var _ sql.Node = (*ShowReplicaStatus)(nil)
+var _ sql.CollationCoercible = (*ShowReplicaStatus)(nil)
 var _ BinlogReplicaControllerCommand = (*ShowReplicaStatus)(nil)
 
 func NewShowReplicaStatus() *ShowReplicaStatus {
@@ -217,4 +218,9 @@ func (s *ShowReplicaStatus) WithChildren(children ...sql.Node) (sql.Node, error)
 func (s *ShowReplicaStatus) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation("", "", "", sql.PrivilegeType_ReplicationClient))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowReplicaStatus) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/show_status.go
+++ b/sql/plan/show_status.go
@@ -32,6 +32,7 @@ type ShowStatus struct {
 }
 
 var _ sql.Node = (*ShowStatus)(nil)
+var _ sql.CollationCoercible = (*ShowStatus)(nil)
 
 type ShowStatusModifier byte
 
@@ -102,4 +103,9 @@ func (s *ShowStatus) WithChildren(node ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (s *ShowStatus) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowStatus) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/plan/show_tables.go
+++ b/sql/plan/show_tables.go
@@ -43,6 +43,7 @@ func NewShowTables(database sql.Database, full bool, asOf sql.Expression) *ShowT
 
 var _ sql.Databaser = (*ShowTables)(nil)
 var _ sql.Expressioner = (*ShowTables)(nil)
+var _ sql.CollationCoercible = (*ShowTables)(nil)
 var _ Versionable = (*ShowTables)(nil)
 
 // Database implements the sql.Databaser interface.
@@ -178,6 +179,11 @@ func (p *ShowTables) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (p *ShowTables) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	// Some tables won't be visible during the resolution step if the user doesn't have the correct privileges
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowTables) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (p ShowTables) String() string {

--- a/sql/plan/show_triggers.go
+++ b/sql/plan/show_triggers.go
@@ -28,6 +28,7 @@ type ShowTriggers struct {
 
 var _ sql.Databaser = (*ShowTriggers)(nil)
 var _ sql.Node = (*ShowTriggers)(nil)
+var _ sql.CollationCoercible = (*ShowTriggers)(nil)
 
 var showTriggersSchema = sql.Schema{
 	&sql.Column{Name: "Trigger", Type: types.LongText, Nullable: false},
@@ -116,6 +117,11 @@ func (s *ShowTriggers) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (s *ShowTriggers) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	//TODO: figure out what privileges are needed here
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowTriggers) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Database implements the sql.Databaser interface.

--- a/sql/plan/showcolumns.go
+++ b/sql/plan/showcolumns.go
@@ -64,6 +64,7 @@ func NewShowColumns(full bool, child sql.Node) *ShowColumns {
 var _ sql.Node = (*ShowColumns)(nil)
 var _ sql.Expressioner = (*ShowColumns)(nil)
 var _ sql.SchemaTarget = (*ShowColumns)(nil)
+var _ sql.CollationCoercible = (*ShowColumns)(nil)
 
 // Schema implements the sql.Node interface.
 func (s *ShowColumns) Schema() sql.Schema {
@@ -214,6 +215,11 @@ func (s *ShowColumns) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (s *ShowColumns) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	// The table won't be visible during the resolution step if the user doesn't have the correct privileges
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowColumns) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (s *ShowColumns) String() string {

--- a/sql/plan/showdatabases.go
+++ b/sql/plan/showdatabases.go
@@ -27,6 +27,9 @@ type ShowDatabases struct {
 	Catalog sql.Catalog
 }
 
+var _ sql.Node = (*ShowDatabases)(nil)
+var _ sql.CollationCoercible = (*ShowDatabases)(nil)
+
 // NewShowDatabases creates a new show databases node.
 func NewShowDatabases() *ShowDatabases {
 	return new(ShowDatabases)
@@ -83,6 +86,11 @@ func (p *ShowDatabases) CheckPrivileges(ctx *sql.Context, opChecker sql.Privileg
 	//TODO: Having the "SHOW DATABASES" privilege should allow one to see all databases
 	// Currently, only shows databases that the user has access to
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowDatabases) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (p ShowDatabases) String() string {

--- a/sql/plan/showtablestatus.go
+++ b/sql/plan/showtablestatus.go
@@ -25,7 +25,9 @@ type ShowTableStatus struct {
 	Catalog sql.Catalog
 }
 
+var _ sql.Node = (*ShowTableStatus)(nil)
 var _ sql.Databaser = (*ShowTableStatus)(nil)
+var _ sql.CollationCoercible = (*ShowTableStatus)(nil)
 
 // NewShowTableStatus creates a new ShowTableStatus node.
 func NewShowTableStatus(db sql.Database) *ShowTableStatus {
@@ -125,6 +127,11 @@ func (s *ShowTableStatus) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (s *ShowTableStatus) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	// Some tables won't be visible in RowIter if the user doesn't have the correct privileges
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowTableStatus) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // cc here: https://dev.mysql.com/doc/refman/8.0/en/show-table-status.html

--- a/sql/plan/showvariables.go
+++ b/sql/plan/showvariables.go
@@ -28,6 +28,9 @@ type ShowVariables struct {
 	global bool
 }
 
+var _ sql.Node = (*ShowVariables)(nil)
+var _ sql.CollationCoercible = (*ShowVariables)(nil)
+
 // NewShowVariables returns a new ShowVariables reference.
 func NewShowVariables(filter sql.Expression, isGlobal bool) *ShowVariables {
 	return &ShowVariables{
@@ -53,6 +56,11 @@ func (sv *ShowVariables) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (sv *ShowVariables) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowVariables) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // String implements the fmt.Stringer interface.

--- a/sql/plan/showwarnings.go
+++ b/sql/plan/showwarnings.go
@@ -22,6 +22,9 @@ import (
 // ShowWarnings is a node that shows the session warnings
 type ShowWarnings []*sql.Warning
 
+var _ sql.Node = (*ShowWarnings)(nil)
+var _ sql.CollationCoercible = (*ShowWarnings)(nil)
+
 // Resolved implements sql.Node interface. The function always returns true.
 func (ShowWarnings) Resolved() bool {
 	return true
@@ -39,6 +42,11 @@ func (sw ShowWarnings) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (sw ShowWarnings) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (ShowWarnings) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // String implements the fmt.Stringer interface.

--- a/sql/plan/signal.go
+++ b/sql/plan/signal.go
@@ -80,6 +80,8 @@ type SignalName struct {
 var _ sql.Node = (*Signal)(nil)
 var _ sql.Node = (*SignalName)(nil)
 var _ sql.Expressioner = (*Signal)(nil)
+var _ sql.CollationCoercible = (*Signal)(nil)
+var _ sql.CollationCoercible = (*SignalName)(nil)
 
 // NewSignal returns a *Signal node.
 func NewSignal(sqlstate string, info map[SignalConditionItemName]SignalInfo) *Signal {
@@ -252,6 +254,11 @@ func (s *Signal) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpera
 	return true
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Signal) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // RowIter implements the sql.Node interface.
 func (s *Signal) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	//TODO: implement CLASS_ORIGIN
@@ -331,6 +338,11 @@ func (s *SignalName) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (s *SignalName) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*SignalName) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the sql.Node interface.

--- a/sql/plan/sort.go
+++ b/sql/plan/sort.go
@@ -42,6 +42,7 @@ func NewSort(sortFields []sql.SortField, child sql.Node) *Sort {
 var _ sql.Expressioner = (*Sort)(nil)
 var _ sql.Node = (*Sort)(nil)
 var _ sql.Node2 = (*Sort)(nil)
+var _ sql.CollationCoercible = (*Sort)(nil)
 
 // Resolved implements the Resolvable interface.
 func (s *Sort) Resolved() bool {
@@ -118,6 +119,11 @@ func (s *Sort) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (s *Sort) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return s.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (s *Sort) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, s.Child)
 }
 
 // WithExpressions implements the Expressioner interface.
@@ -282,7 +288,9 @@ func NewTopN(fields sql.SortFields, limit sql.Expression, child sql.Node) *TopN 
 	}
 }
 
+var _ sql.Node = (*TopN)(nil)
 var _ sql.Expressioner = (*TopN)(nil)
+var _ sql.CollationCoercible = (*TopN)(nil)
 
 // Resolved implements the Resolvable interface.
 func (n *TopN) Resolved() bool {
@@ -358,6 +366,11 @@ func (n *TopN) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (n *TopN) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return n.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (n *TopN) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, n.Child)
 }
 
 // WithExpressions implements the Expressioner interface.

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -32,6 +32,9 @@ type SubqueryAlias struct {
 	CanCacheResults      bool
 }
 
+var _ sql.Node = (*SubqueryAlias)(nil)
+var _ sql.CollationCoercible = (*SubqueryAlias)(nil)
+
 // NewSubqueryAlias creates a new SubqueryAlias node.
 func NewSubqueryAlias(name, textDefinition string, node sql.Node) *SubqueryAlias {
 	return &SubqueryAlias{
@@ -96,6 +99,11 @@ func (sq *SubqueryAlias) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (sq *SubqueryAlias) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return sq.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (sq *SubqueryAlias) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, sq.Child)
 }
 
 func (sq *SubqueryAlias) WithChild(n sql.Node) *SubqueryAlias {

--- a/sql/plan/table_copier.go
+++ b/sql/plan/table_copier.go
@@ -20,6 +20,7 @@ type TableCopier struct {
 
 var _ sql.Databaser = (*TableCopier)(nil)
 var _ sql.Node = (*TableCopier)(nil)
+var _ sql.CollationCoercible = (*TableCopier)(nil)
 
 type CopierProps struct {
 	replace bool
@@ -154,6 +155,11 @@ func (tc *TableCopier) CheckPrivileges(ctx *sql.Context, opChecker sql.Privilege
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(tc.db.Name(), "", "", sql.PrivilegeType_Create)) &&
 		tc.source.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*TableCopier) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (tc *TableCopier) Resolved() bool {

--- a/sql/plan/tablealias.go
+++ b/sql/plan/tablealias.go
@@ -30,6 +30,7 @@ type TableAlias struct {
 }
 
 var _ sql.RenameableNode = (*TableAlias)(nil)
+var _ sql.CollationCoercible = (*TableAlias)(nil)
 
 // NewTableAlias returns a new Table alias node.
 func NewTableAlias(name string, node sql.Node) *TableAlias {
@@ -69,6 +70,14 @@ func (t *TableAlias) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedO
 		return t.UnaryNode.Child.CheckPrivileges(ctx, opChecker)
 	}
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t *TableAlias) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	if t.UnaryNode != nil {
+		return sql.GetCoercibility(ctx, t.UnaryNode.Child)
+	}
+	return sql.Collation_binary, 7
 }
 
 // RowIter implements the Node interface.

--- a/sql/plan/transaction.go
+++ b/sql/plan/transaction.go
@@ -32,6 +32,11 @@ func (transactionNode) CheckPrivileges(ctx *sql.Context, opChecker sql.Privilege
 	return true
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*transactionNode) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // Resolved implements the sql.Node interface.
 func (transactionNode) Resolved() bool {
 	return true
@@ -50,6 +55,7 @@ type StartTransaction struct {
 }
 
 var _ sql.Node = (*StartTransaction)(nil)
+var _ sql.CollationCoercible = (*StartTransaction)(nil)
 
 // NewStartTransaction creates a new StartTransaction node.
 func NewStartTransaction(transactionChar sql.TransactionCharacteristic) *StartTransaction {
@@ -108,6 +114,7 @@ type Commit struct {
 }
 
 var _ sql.Node = (*Commit)(nil)
+var _ sql.CollationCoercible = (*Commit)(nil)
 
 // NewCommit creates a new Commit node.
 func NewCommit() *Commit {
@@ -156,6 +163,7 @@ type Rollback struct {
 }
 
 var _ sql.Node = (*Rollback)(nil)
+var _ sql.CollationCoercible = (*Rollback)(nil)
 
 // NewRollback creates a new Rollback node.
 func NewRollback() *Rollback {
@@ -206,6 +214,7 @@ type CreateSavepoint struct {
 }
 
 var _ sql.Node = (*CreateSavepoint)(nil)
+var _ sql.CollationCoercible = (*CreateSavepoint)(nil)
 
 // NewCreateSavepoint creates a new CreateSavepoint node.
 func NewCreateSavepoint(name string) *CreateSavepoint {
@@ -252,6 +261,7 @@ type RollbackSavepoint struct {
 }
 
 var _ sql.Node = (*RollbackSavepoint)(nil)
+var _ sql.CollationCoercible = (*RollbackSavepoint)(nil)
 
 // NewRollbackSavepoint creates a new RollbackSavepoint node.
 func NewRollbackSavepoint(name string) *RollbackSavepoint {
@@ -300,6 +310,7 @@ type ReleaseSavepoint struct {
 }
 
 var _ sql.Node = (*ReleaseSavepoint)(nil)
+var _ sql.CollationCoercible = (*ReleaseSavepoint)(nil)
 
 // NewReleaseSavepoint creates a new ReleaseSavepoint node.
 func NewReleaseSavepoint(name string) *ReleaseSavepoint {

--- a/sql/plan/transaction_committing_iter.go
+++ b/sql/plan/transaction_committing_iter.go
@@ -43,6 +43,7 @@ type TransactionCommittingNode struct {
 
 var _ sql.Node = (*TransactionCommittingNode)(nil)
 var _ sql.Node2 = (*TransactionCommittingNode)(nil)
+var _ sql.CollationCoercible = (*TransactionCommittingNode)(nil)
 
 // NewTransactionCommittingNode returns a TransactionCommittingNode.
 func NewTransactionCommittingNode(child sql.Node) *TransactionCommittingNode {
@@ -93,6 +94,11 @@ func (t *TransactionCommittingNode) WithChildren(children ...sql.Node) (sql.Node
 // CheckPrivileges implements the sql.Node interface.
 func (t *TransactionCommittingNode) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return t.Child().CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*TransactionCommittingNode) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // Child implements the sql.UnaryNode interface.

--- a/sql/plan/transformed_named_node.go
+++ b/sql/plan/transformed_named_node.go
@@ -23,6 +23,9 @@ type TransformedNamedNode struct {
 	name string
 }
 
+var _ sql.Node = (*TransformedNamedNode)(nil)
+var _ sql.CollationCoercible = (*TransformedNamedNode)(nil)
+
 // TransformedNamedNode is a wrapper for arbitrary logic to represent a table
 // factor assembled from other nodes at some point in by the analyzer. See
 // e.g., Concat.
@@ -52,6 +55,11 @@ func (n *TransformedNamedNode) WithChildren(children ...sql.Node) (sql.Node, err
 // CheckPrivileges implements the interface sql.Node.
 func (n *TransformedNamedNode) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return n.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (n *TransformedNamedNode) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, n.Child)
 }
 
 func (n *TransformedNamedNode) String() string {

--- a/sql/plan/trigger.go
+++ b/sql/plan/trigger.go
@@ -48,6 +48,9 @@ type TriggerExecutor struct {
 	TriggerDefinition sql.TriggerDefinition
 }
 
+var _ sql.Node = (*TriggerExecutor)(nil)
+var _ sql.CollationCoercible = (*TriggerExecutor)(nil)
+
 func NewTriggerExecutor(child, triggerLogic sql.Node, triggerEvent TriggerEvent, triggerTime TriggerTime, triggerDefinition sql.TriggerDefinition) *TriggerExecutor {
 	return &TriggerExecutor{
 		BinaryNode: BinaryNode{
@@ -91,6 +94,11 @@ func (t *TriggerExecutor) CheckPrivileges(ctx *sql.Context, opChecker sql.Privil
 	// TODO: Figure out exactly how triggers work, not exactly clear whether trigger creator AND user needs the privileges
 	return t.left.CheckPrivileges(ctx, opChecker) && opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(GetDatabaseName(t.right), getTableName(t.right), "", sql.PrivilegeType_Trigger))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t *TriggerExecutor) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, t.left)
 }
 
 type triggerIter struct {
@@ -245,6 +253,9 @@ type TriggerRollback struct {
 	UnaryNode
 }
 
+var _ sql.Node = (*TriggerRollback)(nil)
+var _ sql.CollationCoercible = (*TriggerRollback)(nil)
+
 func NewTriggerRollback(child sql.Node) *TriggerRollback {
 	return &TriggerRollback{
 		UnaryNode: UnaryNode{Child: child},
@@ -262,6 +273,11 @@ func (t *TriggerRollback) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (t *TriggerRollback) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return t.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t *TriggerRollback) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, t.Child)
 }
 
 func (t *TriggerRollback) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
@@ -348,6 +364,9 @@ type NoopTriggerRollback struct {
 	UnaryNode
 }
 
+var _ sql.Node = (*NoopTriggerRollback)(nil)
+var _ sql.CollationCoercible = (*NoopTriggerRollback)(nil)
+
 func NewNoopTriggerRollback(child sql.Node) *NoopTriggerRollback {
 	return &NoopTriggerRollback{
 		UnaryNode: UnaryNode{Child: child},
@@ -365,6 +384,11 @@ func (t *NoopTriggerRollback) WithChildren(children ...sql.Node) (sql.Node, erro
 // CheckPrivileges implements the interface sql.Node.
 func (t *NoopTriggerRollback) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return t.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (t *NoopTriggerRollback) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, t.Child)
 }
 
 func (t *NoopTriggerRollback) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {

--- a/sql/plan/trigger_begin_end_block.go
+++ b/sql/plan/trigger_begin_end_block.go
@@ -32,6 +32,7 @@ type TriggerBeginEndBlock struct {
 
 var _ sql.Node = (*TriggerBeginEndBlock)(nil)
 var _ sql.DebugStringer = (*TriggerBeginEndBlock)(nil)
+var _ sql.CollationCoercible = (*TriggerBeginEndBlock)(nil)
 var _ RepresentsLabeledBlock = (*TriggerBeginEndBlock)(nil)
 var _ RepresentsScope = (*TriggerBeginEndBlock)(nil)
 

--- a/sql/plan/truncate.go
+++ b/sql/plan/truncate.go
@@ -32,6 +32,7 @@ type Truncate struct {
 
 var _ sql.Node = (*Truncate)(nil)
 var _ sql.DebugStringer = (*Truncate)(nil)
+var _ sql.CollationCoercible = (*Truncate)(nil)
 
 // NewTruncate creates a Truncate node.
 func NewTruncate(db string, table sql.Node) *Truncate {
@@ -129,6 +130,11 @@ func (p *Truncate) WithChildren(children ...sql.Node) (sql.Node, error) {
 func (p *Truncate) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(p.db, getTableName(p.Child), "", sql.PrivilegeType_Drop))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Truncate) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // String implements the Node interface.

--- a/sql/plan/union.go
+++ b/sql/plan/union.go
@@ -29,7 +29,9 @@ type Union struct {
 	SortFields sql.SortFields
 }
 
+var _ sql.Node = (*Union)(nil)
 var _ sql.Expressioner = (*Union)(nil)
+var _ sql.CollationCoercible = (*Union)(nil)
 
 // NewUnion creates a new Union node with the given children.
 func NewUnion(left, right sql.Node, distinct bool, limit sql.Expression, sortFields sql.SortFields) *Union {
@@ -165,6 +167,12 @@ func (u *Union) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (u *Union) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return u.left.CheckPrivileges(ctx, opChecker) && u.right.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Union) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	// Unions are able to return differing values, therefore they cannot be used to determine coercibility
+	return sql.Collation_binary, 7
 }
 
 func (u Union) String() string {

--- a/sql/plan/unresolved.go
+++ b/sql/plan/unresolved.go
@@ -35,6 +35,7 @@ type UnresolvedTable struct {
 var _ sql.Node = (*UnresolvedTable)(nil)
 var _ sql.Expressioner = (*UnresolvedTable)(nil)
 var _ sql.UnresolvedTable = (*UnresolvedTable)(nil)
+var _ sql.CollationCoercible = (*UnresolvedTable)(nil)
 var _ Versionable = (*UnresolvedTable)(nil)
 
 // NewUnresolvedTable creates a new Unresolved table.
@@ -93,6 +94,11 @@ func (t *UnresolvedTable) CheckPrivileges(ctx *sql.Context, opChecker sql.Privil
 		sql.NewPrivilegedOperation(t.Database(), t.name, "", sql.PrivilegeType_Select))
 }
 
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*UnresolvedTable) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
 // WithAsOf implements sql.UnresolvedTable
 func (t *UnresolvedTable) WithAsOf(asOf sql.Expression) (sql.Node, error) {
 	t2 := *t
@@ -142,6 +148,7 @@ type DeferredAsOfTable struct {
 var _ sql.Node = (*DeferredAsOfTable)(nil)
 var _ sql.Expressioner = (*DeferredAsOfTable)(nil)
 var _ sql.UnresolvedTable = (*DeferredAsOfTable)(nil)
+var _ sql.CollationCoercible = (*DeferredAsOfTable)(nil)
 var _ Versionable = (*DeferredAsOfTable)(nil)
 
 func NewDeferredAsOfTable(t *ResolvedTable, asOf sql.Expression) *DeferredAsOfTable {
@@ -200,6 +207,7 @@ type DeferredFilteredTable struct {
 }
 
 var _ sql.Node = (*DeferredFilteredTable)(nil)
+var _ sql.CollationCoercible = (*DeferredFilteredTable)(nil)
 
 func NewDeferredFilteredTable(t *ResolvedTable) *DeferredFilteredTable {
 	return &DeferredFilteredTable{

--- a/sql/plan/update.go
+++ b/sql/plan/update.go
@@ -34,7 +34,9 @@ type Update struct {
 	Ignore bool
 }
 
+var _ sql.Node = (*Update)(nil)
 var _ sql.Databaseable = (*Update)(nil)
+var _ sql.CollationCoercible = (*Update)(nil)
 
 // NewUpdate creates an Update node.
 func NewUpdate(n sql.Node, ignore bool, updateExprs []sql.Expression) *Update {
@@ -314,6 +316,11 @@ func (u *Update) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOpera
 	// We would need SELECT privileges on both the "y" and "z" columns as they're retrieving values
 	return opChecker.UserHasPrivileges(ctx,
 		sql.NewPrivilegedOperation(u.Database(), getTableName(u.Child), "", sql.PrivilegeType_Update))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Update) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (u *Update) String() string {

--- a/sql/plan/update_join.go
+++ b/sql/plan/update_join.go
@@ -36,6 +36,7 @@ func NewUpdateJoin(editorMap map[string]sql.RowUpdater, child sql.Node) *UpdateJ
 }
 
 var _ sql.Node = (*UpdateJoin)(nil)
+var _ sql.CollationCoercible = (*UpdateJoin)(nil)
 
 // String implements the sql.Node interface.
 func (u *UpdateJoin) String() string {
@@ -82,6 +83,11 @@ func (u *UpdateJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (u *UpdateJoin) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return u.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (u *UpdateJoin) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, u.Child)
 }
 
 // updateJoinIter wraps the child UpdateSource projectIter and returns join row in such a way that updates per table row are

--- a/sql/plan/update_source.go
+++ b/sql/plan/update_source.go
@@ -30,6 +30,9 @@ type UpdateSource struct {
 	Ignore      bool
 }
 
+var _ sql.Node = (*UpdateSource)(nil)
+var _ sql.CollationCoercible = (*UpdateSource)(nil)
+
 // NewUpdateSource returns a new UpdateSource from the node and expressions given.
 func NewUpdateSource(node sql.Node, ignore bool, updateExprs []sql.Expression) *UpdateSource {
 	return &UpdateSource{
@@ -183,4 +186,9 @@ func (u *UpdateSource) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (u *UpdateSource) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return u.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (u *UpdateSource) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, u.Child)
 }

--- a/sql/plan/use.go
+++ b/sql/plan/use.go
@@ -33,6 +33,7 @@ func NewUse(db sql.Database) *Use {
 
 var _ sql.Node = (*Use)(nil)
 var _ sql.Databaser = (*Use)(nil)
+var _ sql.CollationCoercible = (*Use)(nil)
 
 // Database implements the sql.Databaser interface.
 func (u *Use) Database() sql.Database {
@@ -84,6 +85,11 @@ func (u *Use) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperatio
 	// The given database will not be visible if the user does not have the appropriate privileges, so we can just
 	// return true here.
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Use) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // String implements the sql.Node interface.

--- a/sql/plan/values.go
+++ b/sql/plan/values.go
@@ -26,6 +26,9 @@ type Values struct {
 	ExpressionTuples [][]sql.Expression
 }
 
+var _ sql.Node = (*Values)(nil)
+var _ sql.CollationCoercible = (*Values)(nil)
+
 // NewValues creates a Values node with the given tuples.
 func NewValues(tuples [][]sql.Expression) *Values {
 	return &Values{tuples}
@@ -152,6 +155,11 @@ func (p *Values) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (p *Values) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Values) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 // WithExpressions implements the Expressioner interface.

--- a/sql/plan/values_derived_table.go
+++ b/sql/plan/values_derived_table.go
@@ -17,6 +17,9 @@ type ValueDerivedTable struct {
 	sch     sql.Schema
 }
 
+var _ sql.Node = (*ValueDerivedTable)(nil)
+var _ sql.CollationCoercible = (*ValueDerivedTable)(nil)
+
 func NewValueDerivedTable(values *Values, name string) *ValueDerivedTable {
 	var s sql.Schema
 	if values.Resolved() && len(values.ExpressionTuples) != 0 {

--- a/sql/plan/while.go
+++ b/sql/plan/while.go
@@ -26,6 +26,7 @@ type While struct {
 var _ sql.Node = (*While)(nil)
 var _ sql.DebugStringer = (*While)(nil)
 var _ sql.Expressioner = (*While)(nil)
+var _ sql.CollationCoercible = (*While)(nil)
 var _ RepresentsLabeledBlock = (*While)(nil)
 
 // NewWhile returns a new *While node.

--- a/sql/plan/window.go
+++ b/sql/plan/window.go
@@ -34,6 +34,7 @@ type Window struct {
 var _ sql.Expressioner = (*Window)(nil)
 var _ sql.Node = (*Window)(nil)
 var _ sql.Projector = (*Window)(nil)
+var _ sql.CollationCoercible = (*Window)(nil)
 
 func NewWindow(selectExprs []sql.Expression, node sql.Node) *Window {
 	return &Window{
@@ -92,6 +93,11 @@ func (w *Window) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (w *Window) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return w.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (w *Window) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, w.Child)
 }
 
 // Expressions implements sql.Expressioner

--- a/sql/plan/with.go
+++ b/sql/plan/with.go
@@ -30,6 +30,7 @@ type With struct {
 }
 
 var _ sql.Node = (*With)(nil)
+var _ sql.CollationCoercible = (*With)(nil)
 var _ DisjointedChildrenNode = (*With)(nil)
 
 func NewWith(child sql.Node, ctes []*CommonTableExpression, recursive bool) *With {
@@ -83,6 +84,11 @@ func (w *With) WithChildren(children ...sql.Node) (sql.Node, error) {
 // CheckPrivileges implements the interface sql.Node.
 func (w *With) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return w.Child.CheckPrivileges(ctx, opChecker)
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (w *With) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.GetCoercibility(ctx, w.Child)
 }
 
 // DisjointedChildren implements the interface DisjointedChildrenNode.

--- a/sql/transform/node_test.go
+++ b/sql/transform/node_test.go
@@ -260,6 +260,7 @@ type nodeC struct {
 }
 
 var _ sql.Node = (*nodeA)(nil)
+var _ sql.CollationCoercible = (*nodeA)(nil)
 
 func a(nodes ...sql.Node) *nodeA {
 	return &nodeA{testNode{children: nodes}}
@@ -302,6 +303,7 @@ type testNode struct {
 }
 
 var _ sql.Node = (*testNode)(nil)
+var _ sql.CollationCoercible = (*testNode)(nil)
 
 func (n *testNode) Resolved() bool {
 	return true
@@ -331,4 +333,9 @@ func (n *testNode) WithChildren(nodes ...sql.Node) (sql.Node, error) {
 
 func (n *testNode) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
 	return true
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*testNode) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/type.go
+++ b/sql/type.go
@@ -59,6 +59,7 @@ const (
 
 // Type represents a SQL type.
 type Type interface {
+	CollationCoercible
 	// Compare returns an integer comparing two values.
 	// The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
 	Compare(interface{}, interface{}) (int, error)

--- a/sql/types/bit.go
+++ b/sql/types/bit.go
@@ -234,6 +234,11 @@ func (t BitType_) ValueType() reflect.Type {
 	return bitValueType
 }
 
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (BitType_) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // Zero implements Type interface. Returns a uint64 value.
 func (t BitType_) Zero() interface{} {
 	return uint64(0)

--- a/sql/types/datetime.go
+++ b/sql/types/datetime.go
@@ -90,6 +90,9 @@ type datetimeType struct {
 	baseType query.Type
 }
 
+var _ sql.DatetimeType = datetimeType{}
+var _ sql.CollationCoercible = datetimeType{}
+
 // CreateDatetimeType creates a Type dealing with all temporal types that are not TIME nor YEAR.
 func CreateDatetimeType(baseType query.Type) (sql.DatetimeType, error) {
 	switch baseType {
@@ -407,6 +410,11 @@ func (t datetimeType) ValueType() reflect.Type {
 
 func (t datetimeType) Zero() interface{} {
 	return zeroTime
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (datetimeType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // MaximumTime is the latest accepted time for this type.

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -325,6 +325,11 @@ func (t DecimalType_) Zero() interface{} {
 	return decimal.NewFromInt(0)
 }
 
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (DecimalType_) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
 // ExclusiveUpperBound implements DecimalType interface.
 func (t DecimalType_) ExclusiveUpperBound() decimal.Decimal {
 	return t.exclusiveUpperBound

--- a/sql/types/deferred.go
+++ b/sql/types/deferred.go
@@ -28,6 +28,7 @@ type deferredType struct {
 }
 
 var _ sql.DeferredType = (*deferredType)(nil)
+var _ sql.CollationCoercible = (*deferredType)(nil)
 
 func NewDeferredType(name string) sql.Type {
 	return &deferredType{bindVar: name}
@@ -95,6 +96,11 @@ func (t deferredType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t deferredType) Zero() interface{} {
 	return nil
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (deferredType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }
 
 func (t deferredType) IsDeferred() bool {

--- a/sql/types/enum.go
+++ b/sql/types/enum.go
@@ -52,6 +52,7 @@ type EnumType struct {
 }
 
 var _ sql.EnumType = EnumType{}
+var _ sql.CollationCoercible = EnumType{}
 var _ sql.TypeWithCollation = EnumType{}
 
 // CreateEnumType creates a EnumType.
@@ -270,6 +271,11 @@ func (t EnumType) Type() query.Type {
 // ValueType implements Type interface.
 func (t EnumType) ValueType() reflect.Type {
 	return enumValueType
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (t EnumType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return t.collation, 4
 }
 
 // Zero implements Type interface.

--- a/sql/types/geometry.go
+++ b/sql/types/geometry.go
@@ -49,6 +49,7 @@ type GeometryValue interface {
 
 var _ sql.Type = GeometryType{}
 var _ sql.SpatialColumnType = GeometryType{}
+var _ sql.CollationCoercible = GeometryType{}
 
 var (
 	ErrNotGeometry = errors.NewKind("Value of type %T is not a geometry")
@@ -505,6 +506,11 @@ func (t GeometryType) Zero() interface{} {
 	// ERROR 1416 (22003): Cannot get geometry object from data you send to the GEOMETRY field
 	// So, we don't implement a zero type for this function.
 	return nil
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (GeometryType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // GetSpatialTypeSRID implements SpatialColumnType interface.

--- a/sql/types/geometrycollection.go
+++ b/sql/types/geometrycollection.go
@@ -41,6 +41,7 @@ type GeomColl struct {
 
 var _ sql.Type = GeomCollType{}
 var _ sql.SpatialColumnType = GeomCollType{}
+var _ sql.CollationCoercible = GeomCollType{}
 var _ GeometryValue = GeomColl{}
 
 var (
@@ -140,6 +141,11 @@ func (t GeomCollType) Zero() interface{} {
 // ValueType implements Type interface.
 func (t GeomCollType) ValueType() reflect.Type {
 	return geomcollValueType
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (GeomCollType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // GetSpatialTypeSRID implements SpatialColumnType interface.

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -31,6 +31,7 @@ var (
 )
 
 var JSON sql.Type = JsonType{}
+var _ sql.CollationCoercible = JsonType{}
 
 type JsonType struct{}
 
@@ -151,6 +152,11 @@ func (t JsonType) Zero() interface{} {
 	// MySQL throws an error for INSERT IGNORE, UPDATE IGNORE, etc. when bad json is encountered:
 	// ERROR 3140 (22032): Invalid JSON text: "Invalid value." at position 0 in value for column 'table.column'.
 	return nil
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (JsonType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_Default, 5
 }
 
 // DeepCopyJson implements deep copy of JSON document

--- a/sql/types/linestring.go
+++ b/sql/types/linestring.go
@@ -40,6 +40,7 @@ type LineString struct {
 
 var _ sql.Type = LineStringType{}
 var _ sql.SpatialColumnType = LineStringType{}
+var _ sql.CollationCoercible = LineStringType{}
 var _ GeometryValue = LineString{}
 
 var (
@@ -124,6 +125,11 @@ func (t LineStringType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t LineStringType) Zero() interface{} {
 	return LineString{Points: []Point{{}, {}}}
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (LineStringType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // GetSpatialTypeSRID implements SpatialColumnType interface.

--- a/sql/types/multilinestring.go
+++ b/sql/types/multilinestring.go
@@ -47,6 +47,7 @@ var (
 
 var _ sql.Type = MultiLineStringType{}
 var _ sql.SpatialColumnType = MultiLineStringType{}
+var _ sql.CollationCoercible = MultiLineStringType{}
 var _ GeometryValue = MultiLineString{}
 
 // Compare implements Type interface.
@@ -127,6 +128,11 @@ func (t MultiLineStringType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t MultiLineStringType) Zero() interface{} {
 	return MultiLineString{Lines: []LineString{LineStringType{}.Zero().(LineString)}}
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (MultiLineStringType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // GetSpatialTypeSRID implements SpatialColumnType interface.

--- a/sql/types/multipoint.go
+++ b/sql/types/multipoint.go
@@ -41,6 +41,7 @@ type MultiPoint struct {
 
 var _ sql.Type = MultiPointType{}
 var _ sql.SpatialColumnType = MultiPointType{}
+var _ sql.CollationCoercible = MultiPointType{}
 var _ GeometryValue = MultiPoint{}
 
 var (
@@ -131,6 +132,11 @@ func (t MultiPointType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t MultiPointType) Zero() interface{} {
 	return MultiPoint{Points: []Point{{}}}
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (MultiPointType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // GetSpatialTypeSRID implements SpatialColumnType interface.

--- a/sql/types/multipolygon.go
+++ b/sql/types/multipolygon.go
@@ -47,6 +47,7 @@ var (
 
 var _ sql.Type = MultiPolygonType{}
 var _ sql.SpatialColumnType = MultiPolygonType{}
+var _ sql.CollationCoercible = MultiPolygonType{}
 var _ GeometryValue = MultiPolygon{}
 
 // Compare implements Type interface.
@@ -127,6 +128,11 @@ func (t MultiPolygonType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t MultiPolygonType) Zero() interface{} {
 	return MultiPolygon{Polygons: []Polygon{PolygonType{}.Zero().(Polygon)}}
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (MultiPolygonType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // GetSpatialTypeSRID implements SpatialColumnType interface.

--- a/sql/types/null.go
+++ b/sql/types/null.go
@@ -97,3 +97,8 @@ func (t nullType) ValueType() reflect.Type {
 func (t nullType) Zero() interface{} {
 	return nil
 }
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (nullType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 6
+}

--- a/sql/types/number.go
+++ b/sql/types/number.go
@@ -88,6 +88,7 @@ type NumberTypeImpl_ struct {
 
 var _ sql.Type = NumberTypeImpl_{}
 var _ sql.Type2 = NumberTypeImpl_{}
+var _ sql.CollationCoercible = NumberTypeImpl_{}
 
 // CreateNumberType creates a NumberType.
 func CreateNumberType(baseType query.Type) (sql.NumberType, error) {
@@ -703,6 +704,11 @@ func (t NumberTypeImpl_) Zero() interface{} {
 	default:
 		panic(fmt.Sprintf("%v is not a valid number base type", t.baseType.String()))
 	}
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (NumberTypeImpl_) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // IsFloat implements NumberType interface.

--- a/sql/types/point.go
+++ b/sql/types/point.go
@@ -42,6 +42,7 @@ type Point struct {
 
 var _ sql.Type = PointType{}
 var _ sql.SpatialColumnType = PointType{}
+var _ sql.CollationCoercible = PointType{}
 var _ GeometryValue = Point{}
 
 var (
@@ -134,6 +135,11 @@ func (t PointType) Type() query.Type {
 // Zero implements Type interface.
 func (t PointType) Zero() interface{} {
 	return Point{X: 0.0, Y: 0.0}
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (PointType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // ValueType implements Type interface.

--- a/sql/types/polygon.go
+++ b/sql/types/polygon.go
@@ -41,6 +41,7 @@ type Polygon struct {
 
 var _ sql.Type = PolygonType{}
 var _ sql.SpatialColumnType = PolygonType{}
+var _ sql.CollationCoercible = PolygonType{}
 var _ GeometryValue = Polygon{}
 
 var (
@@ -127,6 +128,11 @@ func (t PolygonType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t PolygonType) Zero() interface{} {
 	return Polygon{Lines: []LineString{{Points: []Point{{}, {}, {}, {}}}}}
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (PolygonType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // GetSpatialTypeSRID implements SpatialColumnType interface.

--- a/sql/types/set.go
+++ b/sql/types/set.go
@@ -49,6 +49,7 @@ type SetType struct {
 
 var _ sql.SetType = SetType{}
 var _ sql.TypeWithCollation = SetType{}
+var _ sql.CollationCoercible = SetType{}
 
 // CreateSetType creates a SetType.
 func CreateSetType(values []string, collation sql.CollationID) (sql.SetType, error) {
@@ -265,6 +266,11 @@ func (t SetType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t SetType) Zero() interface{} {
 	return uint64(0)
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (t SetType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return t.collation, 4
 }
 
 // CharacterSet implements SetType interface.

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -71,6 +71,7 @@ type StringType struct {
 
 var _ sql.StringType = StringType{}
 var _ sql.TypeWithCollation = StringType{}
+var _ sql.CollationCoercible = StringType{}
 
 // CreateString creates a new StringType based on the specified type, length, and collation. Length is interpreted as
 // the length of bytes in the new StringType for SQL types that are based on bytes (i.e. TEXT, BLOB, BINARY, and
@@ -563,6 +564,11 @@ func (t StringType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t StringType) Zero() interface{} {
 	return ""
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (t StringType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return t.collation, 4
 }
 
 func (t StringType) CharacterSet() sql.CharacterSetID {

--- a/sql/types/system_bool.go
+++ b/sql/types/system_bool.go
@@ -34,6 +34,7 @@ type SystemBoolType_ struct {
 }
 
 var _ sql.SystemVariableType = SystemBoolType_{}
+var _ sql.CollationCoercible = SystemBoolType_{}
 
 // NewSystemBoolType returns a new systemBoolType.
 func NewSystemBoolType(varName string) sql.SystemVariableType {
@@ -175,6 +176,11 @@ func (t SystemBoolType_) String() string {
 // Type implements Type interface.
 func (t SystemBoolType_) Type() query.Type {
 	return sqltypes.Int8
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (SystemBoolType_) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // ValueType implements Type interface.

--- a/sql/types/system_double.go
+++ b/sql/types/system_double.go
@@ -35,6 +35,7 @@ type systemDoubleType struct {
 }
 
 var _ sql.SystemVariableType = systemDoubleType{}
+var _ sql.CollationCoercible = systemDoubleType{}
 
 // NewSystemDoubleType returns a new systemDoubleType.
 func NewSystemDoubleType(varName string, lowerbound, upperbound float64) sql.SystemVariableType {
@@ -170,6 +171,11 @@ func (t systemDoubleType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t systemDoubleType) Zero() interface{} {
 	return float64(0)
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (systemDoubleType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // EncodeValue implements SystemVariableType interface.

--- a/sql/types/system_enum.go
+++ b/sql/types/system_enum.go
@@ -35,6 +35,7 @@ type systemEnumType struct {
 }
 
 var _ sql.SystemVariableType = systemEnumType{}
+var _ sql.CollationCoercible = systemEnumType{}
 
 // NewSystemEnumType returns a new systemEnumType.
 func NewSystemEnumType(varName string, values ...string) sql.SystemVariableType {
@@ -188,6 +189,11 @@ func (t systemEnumType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t systemEnumType) Zero() interface{} {
 	return ""
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (systemEnumType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 3
 }
 
 // EncodeValue implements SystemVariableType interface.

--- a/sql/types/system_int.go
+++ b/sql/types/system_int.go
@@ -36,6 +36,7 @@ type systemIntType struct {
 }
 
 var _ sql.SystemVariableType = systemIntType{}
+var _ sql.CollationCoercible = systemIntType{}
 
 // NewSystemIntType returns a new systemIntType.
 func NewSystemIntType(varName string, lowerbound, upperbound int64, negativeOne bool) sql.SystemVariableType {
@@ -178,6 +179,11 @@ func (t systemIntType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t systemIntType) Zero() interface{} {
 	return int64(0)
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (systemIntType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // EncodeValue implements SystemVariableType interface.

--- a/sql/types/system_set.go
+++ b/sql/types/system_set.go
@@ -31,6 +31,7 @@ type systemSetType struct {
 }
 
 var _ sql.SystemVariableType = systemSetType{}
+var _ sql.CollationCoercible = systemSetType{}
 
 // NewSystemSetType returns a new systemSetType.
 func NewSystemSetType(varName string, values ...string) sql.SystemVariableType {
@@ -168,6 +169,11 @@ func (t systemSetType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t systemSetType) Zero() interface{} {
 	return ""
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (systemSetType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 3
 }
 
 // EncodeValue implements SystemVariableType interface.

--- a/sql/types/system_string.go
+++ b/sql/types/system_string.go
@@ -31,6 +31,7 @@ type systemStringType struct {
 }
 
 var _ sql.SystemVariableType = systemStringType{}
+var _ sql.CollationCoercible = systemStringType{}
 
 // NewSystemStringType returns a new systemStringType.
 func NewSystemStringType(varName string) sql.SystemVariableType {
@@ -133,6 +134,11 @@ func (t systemStringType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t systemStringType) Zero() interface{} {
 	return ""
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (t systemStringType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_utf8mb3_general_ci, 3
 }
 
 // EncodeValue implements SystemVariableType interface.

--- a/sql/types/system_uint.go
+++ b/sql/types/system_uint.go
@@ -35,6 +35,7 @@ type systemUintType struct {
 }
 
 var _ sql.SystemVariableType = systemUintType{}
+var _ sql.CollationCoercible = systemUintType{}
 
 // NewSystemUintType returns a new systemUintType.
 func NewSystemUintType(varName string, lowerbound, upperbound uint64) sql.SystemVariableType {
@@ -174,6 +175,11 @@ func (t systemUintType) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t systemUintType) Zero() interface{} {
 	return uint64(0)
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (systemUintType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // EncodeValue implements SystemVariableType interface.

--- a/sql/types/time.go
+++ b/sql/types/time.go
@@ -68,6 +68,9 @@ type TimeType interface {
 
 type TimespanType_ struct{}
 
+var _ TimeType = TimespanType_{}
+var _ sql.CollationCoercible = TimespanType_{}
+
 // MaxTextResponseByteLength implements the Type interface
 func (t TimespanType_) MaxTextResponseByteLength() uint32 {
 	// 10 digits are required for a text representation without microseconds, but with microseconds
@@ -292,6 +295,11 @@ func (t TimespanType_) ValueType() reflect.Type {
 // Zero implements Type interface.
 func (t TimespanType_) Zero() interface{} {
 	return Timespan(0)
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (TimespanType_) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
 }
 
 // No built in for absolute values on int64

--- a/sql/types/tuple.go
+++ b/sql/types/tuple.go
@@ -30,6 +30,7 @@ var tupleValueType = reflect.TypeOf((*[]interface{})(nil)).Elem()
 type TupleType []sql.Type
 
 var _ sql.Type = TupleType{nil}
+var _ sql.CollationCoercible = TupleType{nil}
 
 // CreateTuple returns a new tuple type with the given element types.
 func CreateTuple(types ...sql.Type) sql.Type {
@@ -148,4 +149,9 @@ func (t TupleType) Zero() interface{} {
 		zeroes[i] = tt.Zero()
 	}
 	return zeroes
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (TupleType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
 }

--- a/sql/types/year.go
+++ b/sql/types/year.go
@@ -196,3 +196,8 @@ func (t YearType_) ValueType() reflect.Type {
 func (t YearType_) Zero() interface{} {
 	return int16(0)
 }
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (YearType_) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}


### PR DESCRIPTION
This PR adds support for collation coercion by granting every expression, node, and type the ability to report their own coercibility. In addition, we're extremely permissible now, and do not report any coercibility errors, which deviates from MySQL. This still attempts to adhere to MySQL's coercibility rules as much as possible though.