### PR TITLE
Adding a new GH action to label incoming issues and PRs from customers

### DIFF
--- a/.github/workflows/label-customer-issues.yaml
+++ b/.github/workflows/label-customer-issues.yaml
@@ -1,0 +1,19 @@
+name: Label Customer Issues
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    branches: [main]
+    types: [opened]
+
+jobs:
+  label_customer_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dolthub/label-customer-issues@main
+        with:
+          repo-token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          issue-label: customer-issue
+          pr-label: contribution
+          exclude: dependabot


### PR DESCRIPTION
This same workflow has been [running in the `dolt` repo](https://github.com/dolthub/dolt/pull/5554) for a couple weeks now. This PR rolls it out to `go-mysql-server`. 

The intent is to label issues and pull requests from customers to help us see them more easily in all the other issues and pull requests we create. 