### PR TITLE
Fix hoisted scope renaming error

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -431,6 +431,14 @@ WHERE EXISTS (
 				types: []plan.JoinType{plan.JoinTypeSemi},
 				exp:   []sql.Row{{0, 2}},
 			},
+			{
+				q: `
+select x from xy where
+  not exists (select a from ab where a = x and a = 1) and
+  not exists (select a from ab where a = x and a = 2)`,
+				types: []plan.JoinType{plan.JoinTypeAntiLookup, plan.JoinTypeAntiLookup},
+				exp:   []sql.Row{{0}, {3}},
+			},
 		},
 	},
 	{

--- a/sql/analyzer/hoist_select_exists.go
+++ b/sql/analyzer/hoist_select_exists.go
@@ -312,6 +312,11 @@ func decorrelateOuterCols(e *plan.Subquery, scopeLen int, aliasDisambig *aliasDi
 				return nil, err
 			}
 
+			filtersToKeep, err = renameAliasesInExpressions(filtersToKeep, conflict, newAlias)
+			if err != nil {
+				return nil, err
+			}
+
 			// alias was renamed, need to get the renamed target before adding to the outside aliases collection
 			nodeAliases, err = getTableAliases(n, nil)
 			if err != nil {


### PR DESCRIPTION
Disambiguating a hoisted scope requires renaming all references. We were missing intra-scope filter renames.

re: https://github.com/dolthub/dolt/issues/5654