### PR TITLE
Support for recursive CTEs with no union

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1754,6 +1754,12 @@ var QueryTests = []QueryTest{
 		},
 	},
 	{
+		Query: "with recursive a as (select 1) select * from a union select * from a;",
+		Expected: []sql.Row{
+			{1},
+		},
+	},
+	{
 		Query:    "with cte(x) as (select 0) select x from cte where cte.x in (with cte(x) as (select 42) select x from cte);",
 		Expected: []sql.Row{},
 	},

--- a/sql/analyzer/resolve_ctes.go
+++ b/sql/analyzer/resolve_ctes.go
@@ -162,9 +162,9 @@ func stripWith(
 			subquery = subquery.WithColumns(cte.Columns)
 		}
 
-		if with.Recursive {
+		if u, ok := subquery.Child.(*plan.Union); with.Recursive && ok {
 			// TODO maybe split into a separate rule
-			rCte, err := convertUnionToRecursiveCTE(subquery)
+			rCte, err := convertUnionToRecursiveCTE(subquery, u)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -295,8 +295,7 @@ func hoistRecursiveCte(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, 
 	})
 }
 
-func convertUnionToRecursiveCTE(sq *plan.SubqueryAlias) (*plan.RecursiveCte, error) {
-	u := sq.Child.(*plan.Union)
+func convertUnionToRecursiveCTE(sq *plan.SubqueryAlias, u *plan.Union) (*plan.RecursiveCte, error) {
 	l, r := splitRecursiveCteUnion(sq.Name(), u)
 	return plan.NewRecursiveCte(l, r, sq.Name(), sq.Columns, u.Distinct, u.Limit, u.SortFields), nil
 }


### PR DESCRIPTION
Ex:
```sql
with recursive a as (select 1) select * from a union select * from a;
```

Re: https://github.com/dolthub/dolt/issues/5657