### PR TITLE
OrderedDistinct passes join tree row during exec

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -185,7 +185,7 @@ SELECT SUM(x) FROM xy WHERE x IN (
     )
   ) AND
   x = 2;`,
-				Expected: []sql.Row{{2}},
+				Expected: []sql.Row{{float64(2)}},
 			},
 			{
 				Query:    "select * from ab left join uv on a = u where exists (select * from uv where false)",

--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -178,6 +178,16 @@ var joinOpTests = []struct {
 		},
 		tests: []JoinOpTests{
 			{
+				Query: `
+SELECT SUM(x) FROM xy WHERE x IN (
+  SELECT u FROM uv WHERE u IN (
+    SELECT a FROM ab WHERE a = 2
+    )
+  ) AND
+  x = 2;`,
+				Expected: []sql.Row{{2}},
+			},
+			{
 				Query:    "select * from ab left join uv on a = u where exists (select * from uv where false)",
 				Expected: []sql.Row{},
 			},

--- a/sql/plan/distinct.go
+++ b/sql/plan/distinct.go
@@ -169,7 +169,7 @@ func (d *OrderedDistinct) Resolved() bool {
 func (d *OrderedDistinct) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	span, ctx := ctx.Span("plan.OrderedDistinct")
 
-	it, err := d.Child.RowIter(ctx, nil)
+	it, err := d.Child.RowIter(ctx, row)
 	if err != nil {
 		span.End()
 		return nil, err


### PR DESCRIPTION
Re: https://github.com/dolthub/dolt/issues/5700

OrderedDistinct dropped a parent row while executing a join tree, which caused a field index error in the child.

The query below has a slightly different plan, but the OrderedDistinct in the right half of a join tree, with a join `SEMI_JOIN(scalarSubq0, scalarSubq1)` as a child is the issue.
```
Project
 ├─ columns: [SUM(xy.x):0!null as SUM(x)]
 └─ GroupBy
     ├─ select: SUM(xy.x:0!null)
     ├─ group: 
     └─ Project
         ├─ columns: [xy.x:0!null, xy.y:1]
         └─ HashJoin
             ├─ Eq
             │   ├─ xy.x:0!null
             │   └─ scalarSubq0.u:2!null
             ├─ Filter
             │   ├─ Eq
             │   │   ├─ xy.x:0!null
             │   │   └─ 2 (tinyint)
             │   └─ Table
             │       ├─ name: xy
             │       └─ columns: [x y]
             └─ HashLookup
                 ├─ source: TUPLE(xy.x:0!null)
                 ├─ target: TUPLE(scalarSubq0.u:0!null)
                 └─ CachedResults
                     └─ OrderedDistinct
                         └─ Project
                             ├─ columns: [scalarSubq0.u:0!null]
                             └─ SemiJoin
                                 ├─ Eq
                                 │   ├─ scalarSubq0.u:2!null
                                 │   └─ scalarSubq1.a:4!null
                                 ├─ TableAlias(scalarSubq0)
                                 │   └─ Table
                                 │       ├─ name: uv
                                 │       └─ columns: [u v]
                                 └─ Filter
                                     ├─ Eq
                                     │   ├─ scalarSubq1.a:0!null
                                     │   └─ 2 (tinyint)
                                     └─ TableAlias(scalarSubq1)
                                         └─ Table
                                             ├─ name: ab
                                             └─ columns: [a]
```