### PR TITLE
Allow uppercase collations

### DIFF
--- a/enginetest/queries/charset_collation_engine.go
+++ b/enginetest/queries/charset_collation_engine.go
@@ -44,6 +44,19 @@ type CharsetCollationEngineTestQuery struct {
 // engine. Return values should all have the `utf8mb4` encoding, as it's returning the internal encoding type.
 var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 	{
+		Name: "Uppercase and lowercase collations",
+		Queries: []CharsetCollationEngineTestQuery{
+			{
+				Query:    "CREATE TABLE test1 (v1 VARCHAR(255) COLLATE utf16_unicode_ci, v2 VARCHAR(255) COLLATE UTF16_UNICODE_CI);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "CREATE TABLE test2 (v1 VARCHAR(255) CHARACTER SET utf16, v2 VARCHAR(255) CHARACTER SET UTF16);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+		},
+	},
+	{
 		Name: "Insert multiple character sets",
 		SetUpScript: []string{
 			"CREATE TABLE test (v1 VARCHAR(255) COLLATE utf16_unicode_ci);",

--- a/enginetest/queries/charset_collation_wire.go
+++ b/enginetest/queries/charset_collation_wire.go
@@ -37,6 +37,19 @@ type CharsetCollationWireTestQuery struct {
 // wire. Return values should all have the table encoding, as it's returning the table's encoding type.
 var CharsetCollationWireTests = []CharsetCollationWireTest{
 	{
+		Name: "Uppercase and lowercase collations",
+		Queries: []CharsetCollationWireTestQuery{
+			{
+				Query:    "CREATE TABLE test1 (v1 VARCHAR(255) COLLATE utf16_unicode_ci, v2 VARCHAR(255) COLLATE UTF16_UNICODE_CI);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "CREATE TABLE test2 (v1 VARCHAR(255) CHARACTER SET utf16, v2 VARCHAR(255) CHARACTER SET UTF16);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+		},
+	},
+	{
 		Name: "Insert multiple character sets",
 		SetUpScript: []string{
 			"SET character_set_results = 'binary';",

--- a/sql/charactersets.go
+++ b/sql/charactersets.go
@@ -14,7 +14,11 @@
 
 package sql
 
-import "github.com/dolthub/go-mysql-server/sql/encodings"
+import (
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/encodings"
+)
 
 // CharacterSet represents the character set of a string.
 type CharacterSet struct {
@@ -204,7 +208,7 @@ var SupportedCharsets = []CharacterSetID{
 // ParseCharacterSet takes in a string representing a CharacterSet and returns the result if a match is found, or an
 // error if not.
 func ParseCharacterSet(str string) (CharacterSetID, error) {
-	if cs, ok := characterSetStringToID[str]; ok {
+	if cs, ok := characterSetStringToID[strings.ToLower(str)]; ok {
 		return cs, nil
 	}
 	// It is valid recognize an empty string as the invalid charset, as some analyzer steps may temporarily use the


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/5699
We were comparing the raw strings, which failed when they were anything but lowercase. Now we just force all strings to lowercase.