### PR TITLE
update stored procedure timestamps to be accurate

### DIFF
--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -2363,6 +2363,50 @@ var ProcedureShowStatus = []ScriptTest{
 					},
 				},
 			},
+			{
+				Query: "SHOW PROCEDURE STATUS",
+				Expected: []sql.Row{
+					{
+						"mydb",                // Db
+						"p1",                  // Name
+						"PROCEDURE",           // Type
+						"",                    // Definer
+						time.Unix(0, 0).UTC(), // Modified
+						time.Unix(0, 0).UTC(), // Created
+						"DEFINER",             // Security_type
+						"hi",                  // Comment
+						"utf8mb4",             // character_set_client
+						"utf8mb4_0900_bin",    // collation_connection
+						"utf8mb4_0900_bin",    // Database Collation
+					},
+					{
+						"mydb",                // Db
+						"p2",                  // Name
+						"PROCEDURE",           // Type
+						"user@%",              // Definer
+						time.Unix(0, 0).UTC(), // Modified
+						time.Unix(0, 0).UTC(), // Created
+						"INVOKER",             // Security_type
+						"",                    // Comment
+						"utf8mb4",             // character_set_client
+						"utf8mb4_0900_bin",    // collation_connection
+						"utf8mb4_0900_bin",    // Database Collation
+					},
+					{
+						"mydb",                // Db
+						"p21",                 // Name
+						"PROCEDURE",           // Type
+						"",                    // Definer
+						time.Unix(0, 0).UTC(), // Modified
+						time.Unix(0, 0).UTC(), // Created
+						"DEFINER",             // Security_type
+						"",                    // Comment
+						"utf8mb4",             // character_set_client
+						"utf8mb4_0900_bin",    // collation_connection
+						"utf8mb4_0900_bin",    // Database Collation
+					},
+				},
+			},
 		},
 	},
 }

--- a/sql/analyzer/stored_procedures.go
+++ b/sql/analyzer/stored_procedures.go
@@ -69,6 +69,9 @@ func loadStoredProcedures(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scop
 					procToRegister = analyzedProc
 				}
 
+				procToRegister.CreatedAt = procedure.CreatedAt
+				procToRegister.ModifiedAt = procedure.ModifiedAt
+
 				err = scope.procedures.Register(database.Name(), procToRegister)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
Currently when we load non-built-in stored procedures, we re-analyze the sql string which also re-creates all the metadata. This means that the `Created At` and `Modified At` fields can re-set every time the procedure is loaded in, instead of showing the correct timestamp. This change updates the loaded in procedure with the correct timestamps.

fixes: https://github.com/dolthub/dolt/issues/3081