### PR TITLE
allow renaming views with `RENAME TABLE` statement

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2242,8 +2242,6 @@ func TestRenameTable(t *testing.T, harness Harness) {
 	defer e.Close()
 	ctx := NewContext(harness)
 
-	RunQueryWithContext(t, e, harness, ctx, "CREATE VIEW view1 AS SELECT * FROM othertable")
-
 	db, err := e.Analyzer.Catalog.Database(NewContext(harness), "mydb")
 	require.NoError(err)
 
@@ -2260,26 +2258,6 @@ func TestRenameTable(t *testing.T, harness Harness) {
 	_, ok, err = db.GetTableInsensitive(NewContext(harness), "newTableName")
 	require.NoError(err)
 	require.True(ok)
-
-	TestQueryWithContext(t, ctx, e, harness, "RENAME TABLE view1 TO newViewName", []sql.Row{{types.NewOkResult(0)}}, nil, nil)
-
-	viewDb, vdbOk := db.(sql.ViewDatabase)
-	if !vdbOk {
-		viewRegistry := ctx.GetViewRegistry()
-		ok = viewRegistry.Exists(db.Name(), "view1")
-		require.False(ok)
-
-		ok = viewRegistry.Exists(db.Name(), "newViewName")
-		require.True(ok)
-	} else {
-		_, ok, err = viewDb.GetViewDefinition(ctx, "view1")
-		require.NoError(err)
-		require.False(ok)
-
-		_, ok, err = viewDb.GetViewDefinition(ctx, "newViewName")
-		require.NoError(err)
-		require.True(ok)
-	}
 
 	_, ok, err = db.GetTableInsensitive(NewContext(harness), "mytable")
 	require.NoError(err)

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2259,14 +2259,6 @@ func TestRenameTable(t *testing.T, harness Harness) {
 	require.NoError(err)
 	require.True(ok)
 
-	_, ok, err = db.GetTableInsensitive(NewContext(harness), "mytable")
-	require.NoError(err)
-	require.False(ok)
-
-	_, ok, err = db.GetTableInsensitive(NewContext(harness), "newTableName")
-	require.NoError(err)
-	require.True(ok)
-
 	TestQueryWithContext(t, ctx, e, harness, "RENAME TABLE othertable to othertable2, newTableName to mytable", []sql.Row{{types.NewOkResult(0)}}, nil, nil)
 
 	_, ok, err = db.GetTableInsensitive(NewContext(harness), "othertable")

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2902,6 +2902,35 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "rename views with RENAME TABLE ... TO .. statement",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, v1 int);",
+			"create view v1 as select * from t1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"t1"}, {"v1"}},
+			},
+			{
+				Query:    "rename table v1 to view1",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 0}}},
+			},
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"t1"}, {"view1"}},
+			},
+			{
+				Query:    "rename table view1 to newViewName, t1 to newTableName",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 0}}},
+			},
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"newTableName"}, {"newViewName"}},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/resolve_views.go
+++ b/sql/analyzer/resolve_views.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
@@ -51,11 +50,7 @@ func resolveViews(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel R
 				return nil, transform.SameTree, err
 			}
 
-			maybeVdb := db
-			if privilegedDatabase, ok := maybeVdb.(mysql_db.PrivilegedDatabase); ok {
-				maybeVdb = privilegedDatabase.Unwrap()
-			}
-			if vdb, vok := maybeVdb.(sql.ViewDatabase); vok {
+			if vdb, vok := db.(sql.ViewDatabase); vok {
 				viewDef, vdok, verr := vdb.GetViewDefinition(ctx, viewName)
 				if verr != nil {
 					return nil, transform.SameTree, verr

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -555,6 +555,9 @@ var (
 	// are automatically rolled back. Clients receiving this error must retry the transaction.
 	ErrLockDeadlock = errors.NewKind("serialization failure: %s, try restarting transaction.")
 
+	// ErrViewsNotSupported is returned when attempting to access a view on a database that doesn't support them.
+	ErrViewsNotSupported = errors.NewKind("database '%s' doesn't support views")
+
 	// ErrExistingView is returned when a CREATE VIEW statement uses a name that already exists
 	ErrExistingView = errors.NewKind("the view %s.%s already exists")
 

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -2793,9 +2793,6 @@ func viewsInDatabase(ctx *Context, db Database) ([]ViewDefinition, error) {
 	var views []ViewDefinition
 	dbName := db.Name()
 
-	if privilegedDatabase, ok := db.(mysql_db.PrivilegedDatabase); ok {
-		db = privilegedDatabase.Unwrap()
-	}
 	if vdb, ok := db.(ViewDatabase); ok {
 		dbViews, err := vdb.AllViews(ctx)
 		if err != nil {

--- a/sql/mysql_db/privileged_database_provider.go
+++ b/sql/mysql_db/privileged_database_provider.go
@@ -116,6 +116,7 @@ var _ sql.TableCopierDatabase = PrivilegedDatabase{}
 var _ sql.ReadOnlyDatabase = PrivilegedDatabase{}
 var _ sql.TemporaryTableDatabase = PrivilegedDatabase{}
 var _ sql.CollatedDatabase = PrivilegedDatabase{}
+var _ sql.ViewDatabase = PrivilegedDatabase{}
 
 // NewPrivilegedDatabase returns a new PrivilegedDatabase.
 func NewPrivilegedDatabase(grantTables *MySQLDb, db sql.Database) sql.Database {
@@ -382,6 +383,38 @@ func (pdb PrivilegedDatabase) UpdateEvent(ctx *sql.Context, ed sql.EventDefiniti
 		return db.UpdateEvent(ctx, ed)
 	}
 	return sql.ErrEventsNotSupported.New(pdb.db.Name())
+}
+
+// CreateView implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) CreateView(ctx *sql.Context, name string, selectStatement, createViewStmt string) error {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.CreateView(ctx, name, selectStatement, createViewStmt)
+	}
+	return sql.ErrViewsNotSupported.New(pdb.db.Name())
+}
+
+// DropView implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) DropView(ctx *sql.Context, name string) error {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.DropView(ctx, name)
+	}
+	return sql.ErrViewsNotSupported.New(pdb.db.Name())
+}
+
+// GetViewDefinition implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) GetViewDefinition(ctx *sql.Context, viewName string) (sql.ViewDefinition, bool, error) {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.GetViewDefinition(ctx, viewName)
+	}
+	return sql.ViewDefinition{}, false, sql.ErrViewsNotSupported.New(pdb.db.Name())
+}
+
+// AllViews implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) AllViews(ctx *sql.Context) ([]sql.ViewDefinition, error) {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.AllViews(ctx)
+	}
+	return nil, sql.ErrViewsNotSupported.New(pdb.db.Name())
 }
 
 // CopyTableData implements the interface sql.TableCopierDatabase.

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -193,11 +193,8 @@ func (b *BaseBuilder) buildShowTables(ctx *sql.Context, n *plan.ShowTables, row 
 	}
 
 	// TODO: currently there is no way to see views AS OF a particular time
-	maybeVdb := n.Database()
-	if privilegedDatabase, ok := maybeVdb.(mysql_db.PrivilegedDatabase); ok {
-		maybeVdb = privilegedDatabase.Unwrap()
-	}
-	if vdb, ok := maybeVdb.(sql.ViewDatabase); ok {
+	db := n.Database()
+	if vdb, ok := db.(sql.ViewDatabase); ok {
 		views, err := vdb.AllViews(ctx)
 		if err != nil {
 			return nil, err
@@ -211,7 +208,7 @@ func (b *BaseBuilder) buildShowTables(ctx *sql.Context, n *plan.ShowTables, row 
 		}
 	}
 
-	for _, view := range ctx.GetViewRegistry().ViewsInDatabase(maybeVdb.Name()) {
+	for _, view := range ctx.GetViewRegistry().ViewsInDatabase(db.Name()) {
 		row := sql.Row{view.Name()}
 		if n.Full {
 			row = append(row, "VIEW")


### PR DESCRIPTION
- Added renaming of views with `RENAME TABLE ... TO ...` statement
- Added `ViewDatabase` implementation for `PrivilegedDatabase`

TODO: `ALTER TABLE ... RENAME ...` should fail for renaming of views. Currently, `vitess` parses both the statements into the same node, which makes `GMS` parser not be able to detect the difference. 
Should return error: `ERROR 1347 (HY000): 'mydb.myview' is not BASE TABLE`