### PR TITLE
only hash `expression.UnresolvedColumn` for OnDuplicateExpressions

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1868,6 +1868,25 @@ var InsertScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "check IN TUPLE constraint with duplicate key update",
+		SetUpScript: []string{
+			"create table alphabet (letter varchar(1), constraint `good_letters` check (letter in ('a','l','e','c')))",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// dolt table import with -u option generates a duplicate key update with values(col)
+				Query: "insert into alphabet values ('a') on duplicate key update letter = values(letter)",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "insert into alphabet values ('z') on duplicate key update letter = values(letter)",
+				ExpectedErr: sql.ErrCheckConstraintViolated,
+			},
+		},
+	},
 }
 
 var InsertDuplicateKeyKeyless = []ScriptTest{

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -315,7 +315,8 @@ func qualifyColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel
 
 		newNode, sameNode, err := transform.OneNodeExprsWithNode(n, func(n sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			evalSymbols := symbols
-			if in, ok := n.(*plan.InsertInto); ok && len(in.OnDupExprs) > 0 && onDupUpdateLeftExprs[e] {
+			_, isTuple := e.(expression.Tuple)
+			if in, ok := n.(*plan.InsertInto); ok && len(in.OnDupExprs) > 0 && !isTuple && onDupUpdateLeftExprs[e] {
 				evalSymbols = onDupUpdateSymbols
 			}
 			return qualifyExpression(e, n, evalSymbols)

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -240,12 +240,14 @@ func dedupStrings(in []string) []string {
 }
 
 // findOnDupUpdateLeftExprs gathers all the left expressions for statements in InsertInto.OnDupExprs
-// the
-func findOnDupUpdateLeftExprs(onDupExprs []sql.Expression) map[sql.Expression]bool {
-	onDupUpdateLeftExprs := map[sql.Expression]bool{}
+// onDupExprs are always set with a column on the left
+func findOnDupUpdateLeftExprs(onDupExprs []sql.Expression) map[*expression.UnresolvedColumn]bool {
+	onDupUpdateLeftExprs := map[*expression.UnresolvedColumn]bool{}
 	for _, e := range onDupExprs {
 		if sf, ok := e.(*expression.SetField); ok {
-			onDupUpdateLeftExprs[sf.Left] = true
+			if uc, ok := sf.Left.(*expression.UnresolvedColumn); ok {
+				onDupUpdateLeftExprs[uc] = true
+			}
 		}
 	}
 	return onDupUpdateLeftExprs
@@ -260,7 +262,7 @@ func qualifyColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel
 	symbols := getAvailableNamesByScope(n, scope)
 
 	var onDupUpdateSymbols availableNames
-	var onDupUpdateLeftExprs map[sql.Expression]bool
+	var onDupUpdateLeftExprs map[*expression.UnresolvedColumn]bool
 	if in, ok := n.(*plan.InsertInto); ok && len(in.OnDupExprs) > 0 {
 		inNoSrc := plan.NewInsertInto(
 			in.Database(),
@@ -315,8 +317,8 @@ func qualifyColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel
 
 		newNode, sameNode, err := transform.OneNodeExprsWithNode(n, func(n sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			evalSymbols := symbols
-			_, isTuple := e.(expression.Tuple)
-			if in, ok := n.(*plan.InsertInto); ok && len(in.OnDupExprs) > 0 && !isTuple && onDupUpdateLeftExprs[e] {
+			uc, isCol := e.(*expression.UnresolvedColumn)
+			if in, ok := n.(*plan.InsertInto); ok && len(in.OnDupExprs) > 0 && isCol && onDupUpdateLeftExprs[uc] {
 				evalSymbols = onDupUpdateSymbols
 			}
 			return qualifyExpression(e, n, evalSymbols)


### PR DESCRIPTION
Special logic is used to qualify columns for `InsertInto.OnDuplicateExprs`. Since qualify uses `transform.OneNodeExprWithNode` it will try to qualify all expressions (`Literals`, `Tuples`, etc). This change makes it so that we only try to qualify Columns.

fix for: https://github.com/dolthub/dolt/issues/5799