### PR TITLE
order multi-alter statements

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4271,12 +4271,11 @@ var BrokenScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "alter table tbl_i add column j int, add check (j < 10);",
+				Query: "alter table tbl_i add column j int, add check (j < 10);",
 				Expected: []sql.Row{
 					{types.NewOkResult(0)},
 				},
 			},
 		},
 	},
-
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4132,7 +4132,7 @@ var BrokenScriptTests = []ScriptTest{
 		},
 	},
 	{
-		Name:        "ALTER TABLE RENAME on a column when another column has a default dependency on it",
+		Name: "ALTER TABLE RENAME on a column when another column has a default dependency on it",
 		SetUpScript: []string{
 			"CREATE TABLE `test` (`pk` bigint NOT NULL,`v2` int NOT NULL DEFAULT '100',`v3` int DEFAULT ((`v2` + 1)),PRIMARY KEY (`pk`));",
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2966,6 +2966,26 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "multi-alter ddl column statements",
+		SetUpScript: []string{
+			"create table tbl_i (i int primary key)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "alter table tbl_i add column j int, add index (j)",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "show create table tbl_i",
+				Expected: []sql.Row{
+					{"tbl_i", "CREATE TABLE `tbl_i` (\n  `i` int NOT NULL,\n  `j` int,\n  PRIMARY KEY (`i`),\n  KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{
@@ -4131,6 +4151,59 @@ var BrokenScriptTests = []ScriptTest{
 					{"v5", "int", "NO", "", "", ""},
 					{"v6", "int", "NO", "", "", ""},
 					{"v7", "int", "NO", "", "", ""},
+				},
+			},
+		},
+	},
+	{
+		Name: "multi-alter ddl column statements",
+		SetUpScript: []string{
+			"create table tbl_i (i int primary key)",
+			"create table tbl_ij (i int primary key, j int)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "alter table tbl_i add column j int, drop column j",
+				ExpectedErr: sql.ErrCantDropFieldOrKey,
+			},
+			{
+				Query: "alter table tbl_i add column j int, rename column j to k;",
+				ExpectedErr: sql.ErrUnknownColumn,
+			},
+			{
+				Query: "alter table tbl_ij add index (j), drop column j;",
+				ExpectedErr: sql.ErrKeyColumnDoesNotExist,
+			},
+			{
+				Query: "alter table tbl_ij drop column j, rename column j to k;",
+				ExpectedErr: sql.ErrUnknownColumn,
+			},
+			{
+				Query: "alter table tbl_ij drop column k, rename column j to k;",
+				ExpectedErr: sql.ErrCantDropFieldOrKey,
+			},
+			{
+				Query: "alter table tbl_i add index(j), add column j int;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "show create table tbl_i",
+				Expected: []sql.Row{
+					{"CREATE TABLE `tbl_i` (\n  `i` int NOT NULL,\n  `j` int DEFAULT NULL,\n  PRIMARY KEY (`i`),\n  KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},
+				},
+			},
+			{
+				Query: "alter table tbl_ij add index (j), drop column j, add column j int;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "show create table tbl_ij",
+				Expected: []sql.Row{
+					{"CREATE TABLE `tbl_ij` (\n  `i` int NOT NULL,\n  `j` int DEFAULT NULL,\n  PRIMARY KEY (`i`),\n  KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},
 				},
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2995,23 +2995,23 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "alter table tbl_i add column j int, drop column j",
+				Query:       "alter table tbl_i add column j int, drop column j",
 				ExpectedErr: sql.ErrTableColumnNotFound,
 			},
 			{
-				Query: "alter table tbl_i add column j int, rename column j to k;",
+				Query:       "alter table tbl_i add column j int, rename column j to k;",
 				ExpectedErr: sql.ErrTableColumnNotFound,
 			},
 			{
-				Query: "alter table tbl_ij add index (j), drop column j;",
+				Query:       "alter table tbl_ij add index (j), drop column j;",
 				ExpectedErr: sql.ErrKeyColumnDoesNotExist,
 			},
 			{
-				Query: "alter table tbl_ij drop column j, rename column j to k;",
+				Query:       "alter table tbl_ij drop column j, rename column j to k;",
 				ExpectedErr: sql.ErrTableColumnNotFound,
 			},
 			{
-				Query: "alter table tbl_ij drop column k, rename column j to k;",
+				Query:       "alter table tbl_ij drop column k, rename column j to k;",
 				ExpectedErr: sql.ErrTableColumnNotFound,
 			},
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3002,6 +3002,10 @@ var ScriptTests = []ScriptTest{
 				ExpectedErr: sql.ErrTableColumnNotFound,
 			},
 			{
+				Query:       "alter table tbl_i add column j int, modify column j varchar(10)",
+				ExpectedErr: sql.ErrTableColumnNotFound,
+			},
+			{
 				Query:       "alter table tbl_ij add index (j), drop column j;",
 				ExpectedErr: sql.ErrKeyColumnDoesNotExist,
 			},
@@ -4260,4 +4264,19 @@ var BrokenScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "non-existent procedure in trigger body",
+		SetUpScript: []string{
+			"create table tbl_I (i int primary key);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "alter table tbl_i add column j int, add check (j < 10);",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+		},
+	},
+
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2970,27 +2970,6 @@ var ScriptTests = []ScriptTest{
 		Name: "multi-alter ddl column statements",
 		SetUpScript: []string{
 			"create table tbl_i (i int primary key)",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query: "alter table tbl_i add column j int, add index (j)",
-				Expected: []sql.Row{
-					{types.NewOkResult(0)},
-				},
-			},
-			{
-				Query: "show create table tbl_i",
-				Expected: []sql.Row{
-					{"tbl_i", "CREATE TABLE `tbl_i` (\n  `i` int NOT NULL,\n  `j` int,\n  PRIMARY KEY (`i`),\n  KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
-				},
-			},
-		},
-	},
-
-	{
-		Name: "multi-alter ddl column statements",
-		SetUpScript: []string{
-			"create table tbl_i (i int primary key)",
 			"create table tbl_ij (i int primary key, j int)",
 		},
 		Assertions: []ScriptTestAssertion{

--- a/memory/database.go
+++ b/memory/database.go
@@ -194,7 +194,11 @@ func (d *BaseDatabase) CreateIndexedTable(ctx *sql.Context, name string, sch sql
 	}
 
 	for _, idxCol := range idxDef.Columns {
-		col := sch.Schema[sch.Schema.IndexOfColName(idxCol.Name)]
+		idx := sch.Schema.IndexOfColName(idxCol.Name)
+		if idx == -1 {
+			return sql.ErrColumnNotFound.New(idxCol.Name)
+		}
+		col := sch.Schema[idx]
 		if col.PrimaryKey && types.IsText(col.Type) && idxCol.Length > 0 {
 			return sql.ErrUnsupportedIndexPrefix.New(col.Name)
 		}

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -472,8 +472,10 @@ func validateColumnDefaults(ctx *sql.Context, _ *Analyzer, n sql.Node, _ *Scope,
 			table := getResolvedTable(node)
 			sch := table.Schema()
 			index := sch.IndexOfColName(node.ColumnName)
+			if index == -1 {
+				return nil, transform.SameTree, sql.ErrColumnNotFound.New(node.ColumnName)
+			}
 			col := sch[index]
-
 			eWrapper := expression.WrapExpression(node.Default)
 			err := validateColumnDefault(ctx, col, eWrapper)
 			if err != nil {
@@ -577,6 +579,9 @@ func resolveColumnDefaults(ctx *sql.Context, _ *Analyzer, n sql.Node, _ *Scope, 
 			table := getResolvedTable(node)
 			sch := table.Schema()
 			index := sch.IndexOfColName(node.ColumnName)
+			if index == -1 {
+				return nil, transform.SameTree, sql.ErrColumnNotFound.New(node.ColumnName)
+			}
 			col := sch[index]
 
 			eWrapper := expression.WrapExpression(node.Default)

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -406,7 +406,11 @@ func validateAlterIndex(ctx *sql.Context, initialSch, sch sql.Schema, ai *plan.A
 			if len(ai.Columns) != 1 {
 				return nil, sql.ErrTooManyKeyParts.New(1)
 			}
-			schCol := sch[sch.IndexOfColName(ai.Columns[0].Name)]
+			idx := sch.IndexOfColName(ai.Columns[0].Name)
+			if idx == -1 {
+				return nil, sql.ErrColumnNotFound.New(ai.Columns[0].Name)
+			}
+			schCol := sch[idx]
 			spatialCol, ok := schCol.Type.(sql.SpatialColumnType)
 			if !ok {
 				return nil, sql.ErrBadSpatialIdxCol.New()
@@ -489,7 +493,11 @@ func validatePrefixLength(ctx *sql.Context, schCol *sql.Column, idxCol sql.Index
 // validateIndexType prevents creating invalid indexes
 func validateIndexType(ctx *sql.Context, cols []sql.IndexColumn, sch sql.Schema) error {
 	for _, idxCol := range cols {
-		schCol := sch[sch.IndexOfColName(idxCol.Name)]
+		idx := sch.IndexOfColName(idxCol.Name)
+		if idx == -1 {
+			return sql.ErrColumnNotFound.New(idxCol.Name)
+		}
+		schCol := sch[idx]
 		err := validatePrefixLength(ctx, schCol, idxCol)
 		if err != nil {
 			return err

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1301,14 +1301,14 @@ func convertMultiAlterDDL(ctx *sql.Context, query string, c *sqlparser.MultiAlte
 		case *plan.RenameColumn:
 			switch statements[j].(type) {
 			case *plan.DropColumn,
-				 *plan.AddColumn,
-				 *plan.AlterIndex:
+				*plan.AddColumn,
+				*plan.AlterIndex:
 				return true
 			}
 		case *plan.DropColumn:
 			switch statements[j].(type) {
 			case *plan.AddColumn,
-				 *plan.AlterIndex:
+				*plan.AlterIndex:
 				return true
 			}
 		case *plan.AddColumn:

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1281,6 +1281,18 @@ func convertDDL(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.Node, err
 	}
 }
 
+// convertMultiAlterDDL converts MultiAlterDDL statements
+// If there are multiple alter statements, they are sorted in order of their precedence and placed inside a plan.Block
+// Currently, the precedence of DDL statements is:
+// 1.  RENAME COLUMN
+// 2.  DROP COLUMN
+// 3.  MODIFY COLUMN
+// 4.  ADD COLUMN
+// 5.  DROP CHECK/CONSTRAINT
+// 7.  CREATE CHECK/CONSTRAINT
+// 8.  RENAME INDEX
+// 9.  DROP INDEX
+// 10. ADD INDEX
 func convertMultiAlterDDL(ctx *sql.Context, query string, c *sqlparser.MultiAlterDDL) (sql.Node, error) {
 	statementsLen := len(c.Statements)
 	if statementsLen == 1 {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -2874,6 +2874,15 @@ CREATE TABLE t2
 			),
 		},
 		{
+			input: `alter table t add index (i), add column i int, drop column i, rename column i to j`,
+			plan: plan.NewBlock([]sql.Node{
+				plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "i", "j"),
+				plan.NewDropColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "i"),
+				plan.NewAddColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), &sql.Column{Name: "i", Type: types.Int32, Nullable: true, Source: "t"}, nil),
+				plan.NewAlterCreateIndex(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "", sql.IndexUsing_BTree, sql.IndexConstraint_None, []sql.IndexColumn{{Name: "i", Length: 0}}, ""),
+			}),
+		},
+		{
 			input: `DESCRIBE FORMAT=TREE SELECT * FROM foo`,
 			plan: plan.NewDescribeQuery(
 				"tree",

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -2874,11 +2874,16 @@ CREATE TABLE t2
 			),
 		},
 		{
-			input: `alter table t add index (i), add column i int, drop column i, rename column i to j`,
+			input: `alter table t add index (i), drop index i, add check (i = 0), drop check chk, drop constraint c, add column i int, modify column i text, drop column i, rename column i to j`,
 			plan: plan.NewBlock([]sql.Node{
 				plan.NewRenameColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "i", "j"),
 				plan.NewDropColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "i"),
+				plan.NewModifyColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "i", &sql.Column{Name: "i", Type: types.CreateText(sql.Collation_Unspecified), Nullable: true, Source: "t"}, nil),
 				plan.NewAddColumn(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), &sql.Column{Name: "i", Type: types.Int32, Nullable: true, Source: "t"}, nil),
+				plan.NewDropConstraint(plan.NewUnresolvedTable("t", ""), "c"),
+				plan.NewAlterDropCheck(plan.NewUnresolvedTable("t", ""), "chk"),
+				plan.NewAlterAddCheck(plan.NewUnresolvedTable("t", ""), &sql.CheckConstraint{Name: "", Expr: expression.NewEquals(expression.NewUnresolvedColumn("i"), expression.NewLiteral(int8(0), types.Int8)), Enforced: true}),
+				plan.NewAlterDropIndex(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "i"),
 				plan.NewAlterCreateIndex(sql.UnresolvedDatabase(""), plan.NewUnresolvedTable("t", ""), "", sql.IndexUsing_BTree, sql.IndexConstraint_None, []sql.IndexColumn{{Name: "i", Length: 0}}, ""),
 			}),
 		},

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -334,7 +334,7 @@ func (d *DropColumn) String() string {
 // TODO: move this check to analyzer
 func (d *DropColumn) Validate(ctx *sql.Context, tbl sql.Table) error {
 	colIdx := d.targetSchema.IndexOfColName(d.Column)
-	if colIdx < 0 {
+	if colIdx == -1 {
 		return sql.ErrTableColumnNotFound.New(tbl.Name(), d.Column)
 	}
 

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -422,7 +422,7 @@ func (i *modifyColumnIter) Close(context *sql.Context) error {
 // rewriteTable rewrites the table given if required or requested, and returns the whether it was rewritten
 func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) (bool, error) {
 	oldColIdx := i.m.TargetSchema().IndexOfColName(i.m.Column())
-	if oldColIdx < 0 {
+	if oldColIdx == -1 {
 		// Should be impossible, checked in analyzer
 		return false, sql.ErrTableColumnNotFound.New(rwt.Name(), i.m.Column())
 	}
@@ -589,6 +589,9 @@ func modifyColumnInSchema(schema sql.Schema, name string, column *sql.Column, or
 				}
 
 				newSchemaIdx := newSch.IndexOfColName(colName)
+				if newSchemaIdx == -1 {
+					return nil, transform.SameTree, sql.ErrColumnNotFound.New(colName)
+				}
 				return expression.NewGetFieldWithTable(newSchemaIdx, gf.Type(), gf.Table(), colName, gf.IsNullable()), transform.NewTree, nil
 			})
 			if err != nil {


### PR DESCRIPTION
When running multi-alter statements, MySQL reorders the alters. 
This PR adds a sort function to organize these statements; the precedence order is currently:
1. `RENAME COLUMN`
2. `DROP COLUMN`
3. `ADD COLUMN`
4. `ALTER INDEX`


Note: When this is supposed to work, it does, but when it doesn't our error messages are different than the ones returned by MySQL. There are existing alter tests that also return the incorrect error, but I don't think this is worth fixing right now.

I also unskipped one BrokenScriptTest and fix the expected results for the others.

Companion PR: https://github.com/dolthub/dolt/pull/5831