### PR TITLE
Coalesce.Type() needs to handle type types.Null

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2966,6 +2966,26 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "coalesce tests",
+		SetUpScript: []string{
+			"create table c select coalesce(NULL, 1);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from c;",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "select COLUMN_NAME, DATA_TYPE from INFORMATION_SCHEMA.COLUMNS where TABLE_NAME='c';",
+				Expected: []sql.Row{
+					{"coalesce(NULL,1)", "tinyint"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/expression/function/coalesce.go
+++ b/sql/expression/function/coalesce.go
@@ -16,6 +16,7 @@ package function
 
 import (
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -56,7 +57,7 @@ func (c *Coalesce) Type() sql.Type {
 			continue
 		}
 		t := arg.Type()
-		if t == nil {
+		if t == nil || t == types.Null {
 			continue
 		}
 		return t

--- a/sql/expression/function/coalesce_test.go
+++ b/sql/expression/function/coalesce_test.go
@@ -72,10 +72,17 @@ func TestComposeCoalasce(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, v)
 
-	c, err := NewCoalesce(nil, c1, c2)
+	c3, err := NewCoalesce(nil, c1, c2)
 	require.NoError(t, err)
-	require.Equal(t, types.Int32, c.Type())
-	v, err = c.Eval(ctx, nil)
+	require.Equal(t, types.Int32, c3.Type())
+	v, err = c3.Eval(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, v)
+
+	c4, err := NewCoalesce(expression.NewLiteral(nil, types.Null), c1, c2)
+	require.NoError(t, err)
+	require.Equal(t, types.Int32, c4.Type())
+	v, err = c4.Eval(ctx, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, v)
 }


### PR DESCRIPTION
Coalesce.Type() only checks if its arguments to have type `nil`. But NULL constants have type `types.Null`, and we need to check for that too.