### PR TITLE
allow renaming views with `RENAME TABLE` statement

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1896,10 +1896,6 @@ func TestRecursiveViewDefinition(t *testing.T, harness Harness) {
 	db, err := e.Analyzer.Catalog.Database(ctx, "mydb")
 	require.NoError(t, err)
 
-	if pdb, ok := db.(mysql_db.PrivilegedDatabase); ok {
-		db = pdb.Unwrap()
-	}
-
 	vdb, ok := db.(sql.ViewDatabase)
 	require.True(t, ok, "expected sql.ViewDatabase")
 

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2986,6 +2986,35 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "rename views with RENAME TABLE ... TO .. statement",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, v1 int);",
+			"create view v1 as select * from t1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"t1"}, {"v1"}},
+			},
+			{
+				Query:    "rename table v1 to view1",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 0}}},
+			},
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"t1"}, {"view1"}},
+			},
+			{
+				Query:    "rename table view1 to newViewName, t1 to newTableName",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 0}}},
+			},
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"newTableName"}, {"newViewName"}},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3015,6 +3015,27 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "renaming views with ALTER TABLE ... RENAME .. statement should fail",
+		SetUpScript: []string{
+			"create table t1 (id int primary key, v1 int);",
+			"create view v1 as select * from t1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"t1"}, {"v1"}},
+			},
+			{
+				Query:       "alter table v1 rename to view1",
+				ExpectedErr: sql.ErrNotBaseTable,
+			},
+			{
+				Query:    "show tables;",
+				Expected: []sql.Row{{"myview"}, {"t1"}, {"v1"}},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/resolve_views.go
+++ b/sql/analyzer/resolve_views.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
@@ -51,11 +50,7 @@ func resolveViews(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope, sel R
 				return nil, transform.SameTree, err
 			}
 
-			maybeVdb := db
-			if privilegedDatabase, ok := maybeVdb.(mysql_db.PrivilegedDatabase); ok {
-				maybeVdb = privilegedDatabase.Unwrap()
-			}
-			if vdb, vok := maybeVdb.(sql.ViewDatabase); vok {
+			if vdb, vok := db.(sql.ViewDatabase); vok {
 				viewDef, vdok, verr := vdb.GetViewDefinition(ctx, viewName)
 				if verr != nil {
 					return nil, transform.SameTree, verr

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -558,6 +558,9 @@ var (
 	// ErrViewsNotSupported is returned when attempting to access a view on a database that doesn't support them.
 	ErrViewsNotSupported = errors.NewKind("database '%s' doesn't support views")
 
+	// ErrNotBaseTable is returned when attempting to rename a view using ALTER TABLE statement.
+	ErrNotBaseTable = errors.NewKind("'%s' is not BASE TABLE")
+
 	// ErrExistingView is returned when a CREATE VIEW statement uses a name that already exists
 	ErrExistingView = errors.NewKind("the view %s.%s already exists")
 

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -555,6 +555,9 @@ var (
 	// are automatically rolled back. Clients receiving this error must retry the transaction.
 	ErrLockDeadlock = errors.NewKind("serialization failure: %s, try restarting transaction.")
 
+	// ErrViewsNotSupported is returned when attempting to access a view on a database that doesn't support them.
+	ErrViewsNotSupported = errors.NewKind("database '%s' doesn't support views")
+
 	// ErrExistingView is returned when a CREATE VIEW statement uses a name that already exists
 	ErrExistingView = errors.NewKind("the view %s.%s already exists")
 

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -2793,9 +2793,6 @@ func viewsInDatabase(ctx *Context, db Database) ([]ViewDefinition, error) {
 	var views []ViewDefinition
 	dbName := db.Name()
 
-	if privilegedDatabase, ok := db.(mysql_db.PrivilegedDatabase); ok {
-		db = privilegedDatabase.Unwrap()
-	}
 	if vdb, ok := db.(ViewDatabase); ok {
 		dbViews, err := vdb.AllViews(ctx)
 		if err != nil {

--- a/sql/mysql_db/privileged_database_provider.go
+++ b/sql/mysql_db/privileged_database_provider.go
@@ -116,6 +116,7 @@ var _ sql.TableCopierDatabase = PrivilegedDatabase{}
 var _ sql.ReadOnlyDatabase = PrivilegedDatabase{}
 var _ sql.TemporaryTableDatabase = PrivilegedDatabase{}
 var _ sql.CollatedDatabase = PrivilegedDatabase{}
+var _ sql.ViewDatabase = PrivilegedDatabase{}
 
 // NewPrivilegedDatabase returns a new PrivilegedDatabase.
 func NewPrivilegedDatabase(grantTables *MySQLDb, db sql.Database) sql.Database {
@@ -382,6 +383,38 @@ func (pdb PrivilegedDatabase) UpdateEvent(ctx *sql.Context, ed sql.EventDefiniti
 		return db.UpdateEvent(ctx, ed)
 	}
 	return sql.ErrEventsNotSupported.New(pdb.db.Name())
+}
+
+// CreateView implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) CreateView(ctx *sql.Context, name string, selectStatement, createViewStmt string) error {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.CreateView(ctx, name, selectStatement, createViewStmt)
+	}
+	return sql.ErrViewsNotSupported.New(pdb.db.Name())
+}
+
+// DropView implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) DropView(ctx *sql.Context, name string) error {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.DropView(ctx, name)
+	}
+	return sql.ErrViewsNotSupported.New(pdb.db.Name())
+}
+
+// GetViewDefinition implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) GetViewDefinition(ctx *sql.Context, viewName string) (sql.ViewDefinition, bool, error) {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.GetViewDefinition(ctx, viewName)
+	}
+	return sql.ViewDefinition{}, false, sql.ErrViewsNotSupported.New(pdb.db.Name())
+}
+
+// AllViews implements sql.ViewDatabase
+func (pdb PrivilegedDatabase) AllViews(ctx *sql.Context) ([]sql.ViewDefinition, error) {
+	if db, ok := pdb.db.(sql.ViewDatabase); ok {
+		return db.AllViews(ctx)
+	}
+	return nil, sql.ErrViewsNotSupported.New(pdb.db.Name())
 }
 
 // CopyTableData implements the interface sql.TableCopierDatabase.

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -128,7 +128,7 @@ func ParseColumnTypeString(ctx *sql.Context, columnType string) (sql.Type, error
 	if err != nil {
 		return nil, err
 	}
-	node, err := convertDDL(ctx, createStmt, parseResult.(*sqlparser.DDL))
+	node, err := convertDDL(ctx, createStmt, parseResult.(*sqlparser.DDL), false)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func convert(ctx *sql.Context, stmt sqlparser.Statement, query string) (sql.Node
 		}
 		return convertShow(ctx, n, query)
 	case *sqlparser.DDL:
-		return convertDDL(ctx, query, n)
+		return convertDDL(ctx, query, n, false)
 	case *sqlparser.MultiAlterDDL:
 		return convertMultiAlterDDL(ctx, query, n)
 	case *sqlparser.DBDDL:
@@ -1237,7 +1237,7 @@ func cteExprToCte(ctx *sql.Context, expr sqlparser.TableExpr) (*plan.CommonTable
 	return plan.NewCommonTableExpression(subquery.(*plan.SubqueryAlias), columns), nil
 }
 
-func convertDDL(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.Node, error) {
+func convertDDL(ctx *sql.Context, query string, c *sqlparser.DDL, multiAlterDDL bool) (sql.Node, error) {
 	switch strings.ToLower(c.Action) {
 	case sqlparser.CreateStr:
 		if c.TriggerSpec != nil {
@@ -1272,7 +1272,7 @@ func convertDDL(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.Node, err
 	case sqlparser.AlterStr:
 		return convertAlterTable(ctx, c)
 	case sqlparser.RenameStr:
-		return convertRenameTable(ctx, c)
+		return convertRenameTable(ctx, c, multiAlterDDL)
 	case sqlparser.TruncateStr:
 		return convertTruncateTable(ctx, c)
 	default:
@@ -1283,12 +1283,12 @@ func convertDDL(ctx *sql.Context, query string, c *sqlparser.DDL) (sql.Node, err
 func convertMultiAlterDDL(ctx *sql.Context, query string, c *sqlparser.MultiAlterDDL) (sql.Node, error) {
 	statementsLen := len(c.Statements)
 	if statementsLen == 1 {
-		return convertDDL(ctx, query, c.Statements[0])
+		return convertDDL(ctx, query, c.Statements[0], true)
 	}
 	statements := make([]sql.Node, statementsLen)
 	var err error
 	for i := 0; i < statementsLen; i++ {
-		statements[i], err = convertDDL(ctx, query, c.Statements[i])
+		statements[i], err = convertDDL(ctx, query, c.Statements[i], true)
 		if err != nil {
 			return nil, err
 		}
@@ -1851,7 +1851,7 @@ func convertSignalConditionItemName(name sqlparser.SignalConditionItemName) (pla
 	}
 }
 
-func convertRenameTable(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
+func convertRenameTable(ctx *sql.Context, ddl *sqlparser.DDL, alterTbl bool) (sql.Node, error) {
 	if len(ddl.FromTables) != len(ddl.ToTables) {
 		panic("Expected from tables and to tables of equal length")
 	}
@@ -1864,7 +1864,7 @@ func convertRenameTable(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) 
 		toTables = append(toTables, table.Name.String())
 	}
 
-	return plan.NewRenameTable(sql.UnresolvedDatabase(""), fromTables, toTables), nil
+	return plan.NewRenameTable(sql.UnresolvedDatabase(""), fromTables, toTables, alterTbl), nil
 }
 
 func convertAlterTable(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -1103,27 +1103,19 @@ CREATE TABLE t2
 		},
 		{
 			input: `RENAME TABLE foo TO bar`,
-			plan: plan.NewRenameTable(
-				sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-			),
+			plan:  plan.NewRenameTable(sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"}, false),
 		},
 		{
 			input: `RENAME TABLE foo TO bar, baz TO qux`,
-			plan: plan.NewRenameTable(
-				sql.UnresolvedDatabase(""), []string{"foo", "baz"}, []string{"bar", "qux"},
-			),
+			plan:  plan.NewRenameTable(sql.UnresolvedDatabase(""), []string{"foo", "baz"}, []string{"bar", "qux"}, false),
 		},
 		{
 			input: `ALTER TABLE foo RENAME bar`,
-			plan: plan.NewRenameTable(
-				sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-			),
+			plan:  plan.NewRenameTable(sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"}, true),
 		},
 		{
 			input: `ALTER TABLE foo RENAME TO bar`,
-			plan: plan.NewRenameTable(
-				sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"},
-			),
+			plan:  plan.NewRenameTable(sql.UnresolvedDatabase(""), []string{"foo"}, []string{"bar"}, true),
 		},
 		{
 			input: `ALTER TABLE foo RENAME COLUMN bar TO baz`,

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -56,7 +56,6 @@ func (r *RenameTable) String() string {
 }
 
 func (r *RenameTable) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
-	// TODO: 'ALTER TABLE newViewName RENAME view1' should fail on renaming views - should be fixed in vitess
 	renamer, _ := r.Db.(sql.TableRenamer)
 	viewDb, _ := r.Db.(sql.ViewDatabase)
 	viewRegistry := ctx.GetViewRegistry()

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -193,11 +193,8 @@ func (b *BaseBuilder) buildShowTables(ctx *sql.Context, n *plan.ShowTables, row 
 	}
 
 	// TODO: currently there is no way to see views AS OF a particular time
-	maybeVdb := n.Database()
-	if privilegedDatabase, ok := maybeVdb.(mysql_db.PrivilegedDatabase); ok {
-		maybeVdb = privilegedDatabase.Unwrap()
-	}
-	if vdb, ok := maybeVdb.(sql.ViewDatabase); ok {
+	db := n.Database()
+	if vdb, ok := db.(sql.ViewDatabase); ok {
 		views, err := vdb.AllViews(ctx)
 		if err != nil {
 			return nil, err
@@ -211,7 +208,7 @@ func (b *BaseBuilder) buildShowTables(ctx *sql.Context, n *plan.ShowTables, row 
 		}
 	}
 
-	for _, view := range ctx.GetViewRegistry().ViewsInDatabase(maybeVdb.Name()) {
+	for _, view := range ctx.GetViewRegistry().ViewsInDatabase(db.Name()) {
 		row := sql.Row{view.Name()}
 		if n.Full {
 			row = append(row, "VIEW")


### PR DESCRIPTION
This is the same PR as https://github.com/dolthub/go-mysql-server/pull/1712 (it was reverted)

- allows renaming views using `RENAME TABLE` statement
- fails on renaming views using `ALTER TABLE ... RENAME ...` statement