### PR TITLE
Unions finalize subquery expressions

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -742,6 +742,16 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
+		Query: `
+Select * from (
+  With recursive cte(s) as (select 1 union select x from xy join cte on x = s)
+  Select * from cte
+  Union
+  Select x from xy where x in (select * from cte)
+ ) dt;`,
+		Expected: []sql.Row{{1}},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/5642
 		Query:    "SELECT count(*) FROM mytable WHERE i = 3720481604718463778705849469618542795;",
 		Expected: []sql.Row{{0}},

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -437,6 +437,9 @@ func NewFinalizeUnionSel(sel RuleSelector) RuleSelector {
 			resolveUnionsId,
 			parallelizeId:
 			return false
+		case finalizeSubqueriesId,
+			hoistOutOfScopeFiltersId:
+			return true
 		}
 		return sel(id)
 	}


### PR DESCRIPTION
The SUBQUERY -> UNION -> SUBQUERY_EXPR pattern was subject to an edge case where the outer SUBQUERY disabled recursively finalizing the inner SUBQUERY_EXPR. The intervening UNION node blocked the outer reach, but failed to re-enable finalizeSubquery during finalizeUnion. This PR edits the finalizeUnionSelector to explicitly re-enable finalize nested subqueries.

This PR also touches `hoistOutOfScopeFilters` for the same edge case.

Issue: https://github.com/dolthub/dolt/issues/5875