### PR TITLE
Add support for `ALTER TABLE <table> MODIFY COLUMN <col> <type> UNIQUE`

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1340,7 +1340,7 @@ var ScriptTests = []ScriptTest{
 						"  `pk` int NOT NULL,\n" +
 						"  `uk` int,\n" +
 						"  PRIMARY KEY (`pk`),\n" +
-						"  UNIQUE KEY `col1` (`col1`),\n" +
+						"  UNIQUE KEY `uk` (`uk`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1327,6 +1327,26 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "ALTER TABLE MODIFY column making UNIQUE",
+		SetUpScript: []string{
+			"CREATE table test (pk int primary key, uk int)",
+			"ALTER TABLE `test` MODIFY column uk int unique",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show create table test",
+				Expected: []sql.Row{
+					{"test", "CREATE TABLE `test` (\n" +
+						"  `pk` int NOT NULL,\n" +
+						"  `uk` int,\n" +
+						"  PRIMARY KEY (`pk`),\n" +
+						"  UNIQUE KEY `col1` (`col1`),\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
 		Name: "ALTER TABLE MODIFY column with KEY",
 		SetUpScript: []string{
 			"CREATE table test (pk int primary key, mk int, index (mk))",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1334,15 +1334,8 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "show create table test",
-				Expected: []sql.Row{
-					{"test", "CREATE TABLE `test` (\n" +
-						"  `pk` int NOT NULL,\n" +
-						"  `uk` int,\n" +
-						"  PRIMARY KEY (`pk`),\n" +
-						"  UNIQUE KEY `uk` (`uk`)\n" +
-						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
-				},
+				Query:       "INSERT INTO test VALUES (1, 1), (2, 1)",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
 			},
 		},
 	},

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -530,7 +530,7 @@ func resolveColumnDefaults(ctx *sql.Context, _ *Analyzer, n sql.Node, _ *Scope, 
 
 		switch node := n.(type) {
 		case *plan.InsertDestination:
-			return transform.NodeExprs(node, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+			return transform.OneNodeExpressions(node, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				eWrapper, ok := e.(*expression.Wrapper)
 				if !ok {
 					return e, transform.SameTree, nil
@@ -549,7 +549,7 @@ func resolveColumnDefaults(ctx *sql.Context, _ *Analyzer, n sql.Node, _ *Scope, 
 		case *plan.InsertInto:
 			// node.Source needs to be explicitly handled here because it's not a
 			// registered child of InsertInto
-			newSource, identity, err := transform.NodeExprs(node.Source, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+			newSource, identity, err := transform.OneNodeExpressions(node.Source, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				eWrapper, ok := e.(*expression.Wrapper)
 				if !ok {
 					return e, transform.SameTree, nil
@@ -599,7 +599,7 @@ func resolveColumnDefaults(ctx *sql.Context, _ *Analyzer, n sql.Node, _ *Scope, 
 			}
 			return newNode, transform.NewTree, nil
 		case sql.SchemaTarget:
-			return transform.NodeExprs(n, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+			return transform.OneNodeExpressions(n, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				eWrapper, ok := e.(*expression.Wrapper)
 				if !ok {
 					return e, transform.SameTree, nil

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -1986,8 +1986,7 @@ func newColumnAction(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
 
 func convertAlterTable(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
 	if ddl.IndexSpec != nil {
-		table := tableNameToUnresolvedTable(ddl.Table)
-		return convertAlterIndex(ctx, ddl, table)
+		return convertAlterIndex(ctx, ddl)
 	}
 	if ddl.ConstraintAction != "" && len(ddl.TableSpec.Constraints) == 1 {
 		table := tableNameToUnresolvedTable(ddl.Table)
@@ -2080,7 +2079,8 @@ func tableNameToUnresolvedTableAsOf(tableName sqlparser.TableName, asOf sql.Expr
 	return plan.NewUnresolvedTableAsOf(tableName.Name.String(), tableName.Qualifier.String(), asOf)
 }
 
-func convertAlterIndex(ctx *sql.Context, ddl *sqlparser.DDL, table sql.Node) (sql.Node, error) {
+func convertAlterIndex(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
+	table := tableNameToUnresolvedTable(ddl.Table)
 	switch strings.ToLower(ddl.IndexSpec.Action) {
 	case sqlparser.CreateStr:
 		var using sql.IndexUsing

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2037,7 +2037,7 @@ func convertAlterTable(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
 		}
 		if ddl.TableSpec != nil {
 			if len(ddl.TableSpec.Columns) != 1 {
-				return nil, fmt.Errorf("Adding multiple columns in ALTER TABLE <table> MODIFY is not currently supported")
+				return nil, fmt.Errorf("adding multiple columns in ALTER TABLE <table> MODIFY is not currently supported")
 			}
 			for _, column := range ddl.TableSpec.Columns {
 				isUnique, err := isUniqueColumn(ddl.TableSpec, column.Name.String())

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2062,10 +2062,7 @@ func convertAlterTable(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
 				}
 				columns := []sql.IndexColumn{sql.IndexColumn{Name: column.Name.String()}}
 				if constraint == sql.IndexConstraint_Primary {
-					alteredTable, err = plan.NewAlterCreatePk(sql.UnresolvedDatabase(ddl.Table.Qualifier.String()), alteredTable, columns), nil
-					if err != nil {
-						return nil, err
-					}
+					// The new primary key index will be created when the new column is added. No work needs to be done here.
 				} else if constraint != sql.IndexConstraint_None {
 					alteredTable, err = plan.NewAlterCreateIndex(sql.UnresolvedDatabase(ddl.Table.Qualifier.String()), alteredTable, ddl.IndexSpec.ToName.String(), sql.IndexUsing_BTree, constraint, columns, comment), nil
 					if err != nil {


### PR DESCRIPTION
This is a MySql syntax that is effectively syntactic sugar for 

```sql
ALTER TABLE <table> MODIFY COLUMN <col> <type>;
ALTER TABLE <table> ADD UNIQUE INDEX `<col>` (col);
```