### PR TITLE
prevent large varbinary column from being created

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8757,7 +8757,7 @@ var ErrorQueries = []QueryErrorTest{
 	},
 	{
 		Query:          "create table vb_tbl (vb varbinary(123456789));",
-		ExpectedErrStr: "",
+		ExpectedErrStr: "length is 123456789 but max allowed is 65535",
 	},
 }
 

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8756,7 +8756,7 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: analyzererrors.ErrStarUnsupported,
 	},
 	{
-		Query:       "create table vb_tbl (vb varbinary(123456789));",
+		Query:          "create table vb_tbl (vb varbinary(123456789));",
 		ExpectedErrStr: "",
 	},
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8755,6 +8755,10 @@ var ErrorQueries = []QueryErrorTest{
 		Query:       "select SUM(*) from dual;",
 		ExpectedErr: analyzererrors.ErrStarUnsupported,
 	},
+	{
+		Query:       "create table vb_tbl (vb varbinary(123456789));",
+		ExpectedErrStr: "",
+	},
 }
 
 var BrokenErrorQueries = []QueryErrorTest{

--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -308,6 +308,10 @@ func ColumnTypeToType(ct *sqlparser.ColumnType) (sql.Type, error) {
 		if err != nil {
 			return nil, err
 		}
+		// we need to have a separate check for varbinary, as CreateString checks varbinary against json limit
+		if length > varcharVarbinaryMax {
+			return nil, ErrLengthTooLarge.New(length, varcharVarbinaryMax)
+		}
 		return CreateString(sqltypes.VarBinary, length, sql.Collation_binary)
 	case "year":
 		return Year, nil


### PR DESCRIPTION
We don't enforce column size limit for `varbinary`, causing panics.

fix for: https://github.com/dolthub/dolt/issues/5059