### PR TITLE
[no-release-notes] adding skipped tests for bad `ONLY_FULL_GROUP_BY` behavior

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8802,6 +8802,17 @@ var BrokenErrorQueries = []QueryErrorTest{
 		Query: "select mod(pk2, 2) from two_pk group by pk1 + 1, mod(pk2, 2)",
 		// No error
 	},
+	{
+		// Grouping over functions and math expressions over PK does not count, and must appear in select
+		Query: "select mod(pk2, 2) from two_pk group by pk1 + 1, mod(pk2, 2)",
+		// No error
+	},
+	{
+		Query: `SELECT any_value(pk), (SELECT max(pk) FROM one_pk WHERE pk < opk.pk) AS x
+						FROM one_pk opk WHERE (SELECT max(pk) FROM one_pk WHERE pk < opk.pk) > 0
+						GROUP BY (SELECT max(pk) FROM one_pk WHERE pk < opk.pk) ORDER BY x`,
+		// No error, but we get opk.pk does not exist
+	},
 }
 
 // WriteQueryTest is a query test for INSERT, UPDATE, etc. statements. It has a query to run and a select query to

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8784,12 +8784,12 @@ var BrokenErrorQueries = []QueryErrorTest{
 		// No error
 	},
 	{
-		Query: "select * from two_pk group by pk1",
+		Query:       "select * from two_pk group by pk1",
 		ExpectedErr: analyzererrors.ErrValidationGroupBy,
 	},
 	{
 		// Grouping over functions and math expressions over PK does not count, and must appear in select
-		Query: "select * from two_pk group by pk1 + 1, mod(pk2, 2)",
+		Query:       "select * from two_pk group by pk1 + 1, mod(pk2, 2)",
 		ExpectedErr: analyzererrors.ErrValidationGroupBy,
 	},
 	{


### PR DESCRIPTION
This PR documents behavior where we don't match MySQL when in `ONLY_FULL_GROUP_BY` sql_mode.

related: https://github.com/dolthub/dolt/issues/4998