### PR TITLE
Timezone improvements

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5721,11 +5721,14 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 	})
 
 	t.Run("DATETIME/TIMESTAMP NOW/CURRENT_TIMESTAMP current_timestamp", func(t *testing.T) {
+		e.Query(ctx, "set @@session.time_zone='SYSTEM';")
+		// TODO: NOW() and CURRENT_TIMESTAMP() are supposed to be the same function in MySQL, but we have two different
+		//       implementations with slightly different behavior.
 		TestQueryWithContext(t, ctx, e, harness, "CREATE TABLE t10(pk BIGINT PRIMARY KEY, v1 DATETIME DEFAULT NOW(), v2 DATETIME DEFAULT CURRENT_TIMESTAMP(),"+
 			"v3 TIMESTAMP DEFAULT NOW(), v4 TIMESTAMP DEFAULT CURRENT_TIMESTAMP())", []sql.Row{{types.NewOkResult(0)}}, nil, nil)
 
 		// truncating time to microseconds for compatibility with integrators who may store more precision (go gives nanos)
-		now := time.Now().Truncate(time.Microsecond)
+		now := time.Now().Truncate(time.Microsecond).UTC()
 		sql.RunWithNowFunc(func() time.Time {
 			return now
 		}, func() error {
@@ -5733,7 +5736,7 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 			return nil
 		})
 		TestQueryWithContext(t, ctx, e, harness, "select * from t10 order by 1", []sql.Row{
-			{1, now.UTC(), now.UTC().Truncate(time.Second), now.UTC(), now.UTC().Truncate(time.Second)},
+			{1, now, now.Truncate(time.Second), now, now.Truncate(time.Second)},
 		}, nil, nil)
 	})
 

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1564,7 +1564,6 @@ var ScriptTests = []ScriptTest{
 	{
 		Name: "Issue #499", // https://github.com/dolthub/go-mysql-server/issues/499
 		SetUpScript: []string{
-			"set time_zone = '+0:00';",
 			"CREATE TABLE test (time TIMESTAMP, value DOUBLE);",
 			`INSERT INTO test VALUES 
 			("2021-07-04 10:00:00", 1.0),
@@ -3171,6 +3170,135 @@ var ScriptTests = []ScriptTest{
 			{
 				Query:    "show tables;",
 				Expected: []sql.Row{{"myview"}, {"t1"}, {"v1"}},
+			},
+		},
+	},
+	{
+		Name: "timezone default settings",
+		Assertions: []ScriptTestAssertion{
+			{
+				// To match MySQL's behavior, this should come from the operating system's timezone setting, but
+				// currently we default to UTC.
+				// TODO: When the value of @@system_time_zone is read, it should invoke time.Now() and return the
+				//       Zone() information. This should be done dynamically when @@system_time_zone is read, since
+				//       the system time_zone offset can change while the process is running (e.g. daylight savings).
+				Query:    `select @@system_time_zone;`,
+				Expected: []sql.Row{{"UTC"}},
+			},
+			{
+				// The default time_zone setting for MySQL is SYSTEM, which means timezone comes from @@system_time_zone
+				Query:    `select @@time_zone;`,
+				Expected: []sql.Row{{"SYSTEM"}},
+			},
+		},
+	},
+	{
+		Name: "current time functions",
+		Assertions: []ScriptTestAssertion{
+			{
+				// Smoke test that NOW() and UTC_TIMESTAMP() return non-null values with the SYSTEM time zone
+				Query:    `select @@time_zone, NOW() IS NOT NULL, UTC_TIMESTAMP() IS NOT NULL;`,
+				Expected: []sql.Row{{"SYSTEM", true, true}},
+			},
+			{
+				// CURTIME() returns the same time as NOW() with the SYSTEM timezone
+				// TODO: TIME(NOW()) would be simpler test logic, but doesn't work correctly here.
+				Query:    `select @@time_zone, NOW() LIKE CONCAT('%', CURTIME(), '%');`,
+				Expected: []sql.Row{{"SYSTEM", true}},
+			},
+			{
+				// Set the timezone set to UTC as an offset
+				Query:    `set @@time_zone='+00:00';`,
+				Expected: []sql.Row{{}},
+			},
+			{
+				// When the session's time zone is set to UTC, NOW() and UTC_TIMESTAMP() should return the same value
+				Query:    `select @@time_zone, NOW() = UTC_TIMESTAMP();`,
+				Expected: []sql.Row{{"+00:00", true}},
+			},
+			{
+				// CURTIME() returns the same time as NOW() with UTC's timezone offset
+				Query:    `select @@time_zone, NOW() LIKE CONCAT('%', CURTIME(), '%');`,
+				Expected: []sql.Row{{"+00:00", true}},
+			},
+			{
+				Query:    `set @@time_zone='+02:00';`,
+				Expected: []sql.Row{{}},
+			},
+			{
+				// When the session's time zone is set to +2:00, NOW() should report two hours ahead of UTC_TIMESTAMP()
+				Query:    `select @@time_zone, TIMESTAMPDIFF(MINUTE, NOW(), UTC_TIMESTAMP());`,
+				Expected: []sql.Row{{"+02:00", -120}},
+			},
+			{
+				// CURTIME() returns the same time as NOW() with a +2:00 timezone offset
+				Query:    `select @@time_zone, NOW() LIKE CONCAT('%', CURTIME(), '%');`,
+				Expected: []sql.Row{{"+02:00", true}},
+			},
+		},
+	},
+	{
+		Name: "timestamp timezone conversion",
+		SetUpScript: []string{
+			"set time_zone='+00:00';",
+			"create table timezonetest(pk int primary key, dt datetime, ts timestamp);",
+			"insert into timezonetest values(1, '2020-02-14 12:00:00', '2020-02-14 12:00:00');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// When reading back the datetime and timestamp values in the same time zone we entered them,
+				// we should get the exact same results back.
+				Query: `select * from timezonetest;`,
+				Expected: []sql.Row{{1,
+					time.Date(2020, time.February, 14, 12, 0, 0, 0, time.UTC),
+					time.Date(2020, time.February, 14, 12, 0, 0, 0, time.UTC)}},
+			},
+			{
+				Query:    `set @@time_zone='-08:00';`,
+				Expected: []sql.Row{{}},
+			},
+			{
+				// TODO: Unskip after adding support for converting timestamp values to/from session time_zone
+				Skip: true,
+				// After changing the session's time zone, we should get back a different result for the timestamp
+				// column, but the same result for the datetime column.
+				Query: `select * from timezonetest;`,
+				Expected: []sql.Row{{1,
+					time.Date(2020, time.February, 14, 12, 0, 0, 0, time.UTC),
+					time.Date(2020, time.February, 14, 4, 0, 0, 0, time.UTC)}},
+			},
+			{
+				Query:    `set @@time_zone='+5:00';`,
+				Expected: []sql.Row{{}},
+			},
+			{
+				// Test with explicit timezone in datetime literal
+				Query:    `insert into timezonetest values(3, '2020-02-16 12:00:00 +0800 CST', '2020-02-16 12:00:00 +0800 CST');`,
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				// TODO: Unskip after adding support for converting timestamp values to/from session time_zone
+				Skip:  true,
+				Query: `select * from timezonetest;`,
+				Expected: []sql.Row{
+					{1, time.Date(2020, time.February, 14, 12, 0, 0, 0, time.UTC),
+						time.Date(2020, time.February, 14, 17, 0, 0, 0, time.UTC)},
+					{3, time.Date(2020, time.February, 16, 9, 0, 0, 0, time.UTC),
+						time.Date(2020, time.February, 16, 9, 0, 0, 0, time.UTC)}},
+			},
+			{
+				Query:    `set @@time_zone='+0:00';`,
+				Expected: []sql.Row{{}},
+			},
+			{
+				// TODO: Unskip after adding support for converting timestamp values to/from session time_zone
+				Skip:  true,
+				Query: `select * from timezonetest;`,
+				Expected: []sql.Row{
+					{1, time.Date(2020, time.February, 14, 12, 0, 0, 0, time.UTC),
+						time.Date(2020, time.February, 14, 12, 0, 0, 0, time.UTC)},
+					{3, time.Date(2020, time.February, 16, 9, 0, 0, 0, time.UTC),
+						time.Date(2020, time.February, 16, 4, 0, 0, 0, time.UTC)}},
 			},
 		},
 	},

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -1,0 +1,113 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package time contains low-level utility functions for working with time.Time values and timezones.
+package time
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"regexp"
+	"time"
+)
+
+// offsetRegex is a regex for matching MySQL offsets (e.g. +01:00).
+var offsetRegex = regexp.MustCompile(`(?m)^([+\-])(\d{2}):(\d{2})$`)
+
+// ConvertTimeZone converts |datetime| from one timezone to another. |fromLocation| and |toLocation|
+// can be either the name of a timezone (e.g. "UTC") or a timezone offset (e.g. "+01:00"), but
+// currently, both must be in the same format. If the time was converted successfully, then
+// the second return value will be true, otherwise the time was not able to be converted.
+func ConvertTimeZone(datetime time.Time, fromLocation string, toLocation string) (time.Time, bool) {
+	// TODO: we can't currently deal with mixed use of timezone name (e.g. "UTC") and offset (e.g. "+0:00")
+	converted, success := convertTimeZoneByLocationString(datetime, fromLocation, toLocation)
+	if success {
+		return converted, success
+	}
+
+	// If we weren't successful converting by timezone try converting via offsets.
+	return convertTimeZoneByTimeOffset(datetime, fromLocation, toLocation)
+}
+
+// DeltaToDuration takes in a MySQL timezone offset (e.g. "+01:00") and returns it as a time.Duration.
+// If any problems are encountered, an error is returned.
+func DeltaToDuration(d string) (time.Duration, error) {
+	matches := offsetRegex.FindStringSubmatch(d)
+	if len(matches) == 4 {
+		symbol := matches[1]
+		hours := matches[2]
+		mins := matches[3]
+		return time.ParseDuration(symbol + hours + "h" + mins + "m")
+	} else {
+		return -1, errors.New("error: unable to process time")
+	}
+}
+
+// SystemDelta returns the current system timezone offset as a MySQL timezone offset (e.g. "+01:00").
+func SystemDelta() string {
+	t := time.Now()
+	_, offset := t.Zone()
+
+	seconds := offset % (60 * 60 * 24)
+	hours := math.Floor(float64(seconds) / 60 / 60)
+	seconds = offset % (60 * 60)
+	minutes := math.Floor(float64(seconds) / 60)
+
+	result := fmt.Sprintf("%02d:%02d", int(math.Abs(hours)), int(math.Abs(minutes)))
+	if offset >= 0 {
+		result = fmt.Sprintf("+%s", result)
+	} else {
+		result = fmt.Sprintf("-%s", result)
+	}
+
+	return result
+}
+
+// convertTimeZoneByLocationString returns the conversion of t from timezone fromLocation to toLocation.
+func convertTimeZoneByLocationString(datetime time.Time, fromLocation string, toLocation string) (time.Time, bool) {
+	fLoc, err := time.LoadLocation(fromLocation)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	tLoc, err := time.LoadLocation(toLocation)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	delta := getCopy(datetime, fLoc).Sub(getCopy(datetime, tLoc))
+
+	return datetime.Add(delta), true
+}
+
+// getCopy recreates the time t in the wanted timezone.
+func getCopy(t time.Time, loc *time.Location) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc).UTC()
+}
+
+// convertTimeZoneByTimeOffset returns the conversion of t to t + (endDuration - startDuration) and a boolean indicating success.
+func convertTimeZoneByTimeOffset(t time.Time, startDuration string, endDuration string) (time.Time, bool) {
+	fromDuration, err := DeltaToDuration(startDuration)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	toDuration, err := DeltaToDuration(endDuration)
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	return t.Add(toDuration - fromDuration), true
+}

--- a/sql/expression/function/convert_tz.go
+++ b/sql/expression/function/convert_tz.go
@@ -97,14 +97,12 @@ func (c *ConvertTz) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	globalTimeZone, _, _ := sql.SystemVariables.GetGlobal("time_zone")
-
 	fromStr, ok := from.(string)
 	if !ok {
 		return nil, nil
 	}
 
-	if fromStr == globalTimeZone.Default {
+	if fromStr == "SYSTEM" {
 		fromStr = gmstime.SystemTimezoneOffset()
 	}
 
@@ -113,7 +111,7 @@ func (c *ConvertTz) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	if toStr == globalTimeZone.Default {
+	if toStr == "SYSTEM" {
 		toStr = gmstime.SystemTimezoneOffset()
 	}
 

--- a/sql/expression/function/convert_tz.go
+++ b/sql/expression/function/convert_tz.go
@@ -16,6 +16,7 @@ package function
 
 import (
 	"fmt"
+
 	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"

--- a/sql/expression/function/convert_tz.go
+++ b/sql/expression/function/convert_tz.go
@@ -105,7 +105,7 @@ func (c *ConvertTz) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	if fromStr == globalTimeZone.Default {
-		fromStr = gmstime.SystemDelta()
+		fromStr = gmstime.SystemTimezoneOffset()
 	}
 
 	toStr, ok := to.(string)
@@ -114,7 +114,7 @@ func (c *ConvertTz) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	if toStr == globalTimeZone.Default {
-		toStr = gmstime.SystemDelta()
+		toStr = gmstime.SystemTimezoneOffset()
 	}
 
 	converted, success := gmstime.ConvertTimeZone(datetime, fromStr, toStr)

--- a/sql/expression/function/convert_tz_test.go
+++ b/sql/expression/function/convert_tz_test.go
@@ -85,6 +85,20 @@ func TestConvertTz(t *testing.T) {
 			expectedResult: time.Date(2010, 6, 3, 21, 12, 12, 0, time.UTC),
 		},
 		{
+			name:           "From location string to offset string",
+			datetime:       "2004-01-01 12:00:00",
+			fromTimeZone:   "UTC",
+			toTimeZone:     "-10:00",
+			expectedResult: time.Date(2004, 1, 1, 2, 0, 0, 0, time.UTC),
+		},
+		{
+			name:           "From offset string to location string",
+			datetime:       "2004-01-01 17:00:00",
+			fromTimeZone:   "+10:00",
+			toTimeZone:     "US/Central",
+			expectedResult: time.Date(2004, 1, 1, 1, 0, 0, 0, time.UTC),
+		},
+		{
 			name:           "Bad timezone conversion",
 			datetime:       "2004-01-01 12:00:00",
 			fromTimeZone:   "GMT",

--- a/sql/expression/function/convert_tz_test.go
+++ b/sql/expression/function/convert_tz_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestConvertTz(t *testing.T) {
-	// TODO: CONVERT_TZ can't deal with mixed use of timezone name (e.g. "UTC") and offset (e.g. "+0:00")
 	tests := []struct {
 		name           string
 		datetime       interface{}

--- a/sql/expression/function/convert_tz_test.go
+++ b/sql/expression/function/convert_tz_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestConvertTz(t *testing.T) {
+	// TODO: CONVERT_TZ can't deal with mixed use of timezone name (e.g. "UTC") and offset (e.g. "+0:00")
 	tests := []struct {
 		name           string
 		datetime       interface{}


### PR DESCRIPTION
This PR starts handling some timezone differences between GMS and MySQL:
- The `NOW()` and `CURTIME()` functions now respect the sessions's current time zone
- Allows `CONVERT_TZ` to mix use of timezone names (e.g. `UTC`) and timezone offset strings (e.g. `+00:00`)
- Adds some skipped tests for `timestamp` input/output session timezone conversion