### PR TITLE
Error for out of range SRIDs

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8775,19 +8775,19 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErrStr: "length is 123456789 but max allowed is 65535",
 	},
 	{
-		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 1234)`,
+		Query:       `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 1234)`,
 		ExpectedErr: sql.ErrNoSRID,
 	},
 	{
-		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 4294967295)`,
+		Query:       `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 4294967295)`,
 		ExpectedErr: sql.ErrNoSRID,
 	},
 	{
-		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), -1)`,
+		Query:       `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), -1)`,
 		ExpectedErr: sql.ErrInvalidSRID,
 	},
 	{
-		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 4294967296)`,
+		Query:       `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 4294967296)`,
 		ExpectedErr: sql.ErrInvalidSRID,
 	},
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8774,6 +8774,22 @@ var ErrorQueries = []QueryErrorTest{
 		Query:          "create table vb_tbl (vb varbinary(123456789));",
 		ExpectedErrStr: "length is 123456789 but max allowed is 65535",
 	},
+	{
+		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 1234)`,
+		ExpectedErr: sql.ErrNoSRID,
+	},
+	{
+		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 4294967295)`,
+		ExpectedErr: sql.ErrNoSRID,
+	},
+	{
+		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), -1)`,
+		ExpectedErr: sql.ErrInvalidSRID,
+	},
+	{
+		Query:    `SELECT ST_GEOMFROMTEXT(ST_ASWKT(POINT(1,2)), 4294967296)`,
+		ExpectedErr: sql.ErrInvalidSRID,
+	},
 }
 
 var BrokenErrorQueries = []QueryErrorTest{

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -591,6 +591,12 @@ var (
 	// ErrBadSpatialIdxCol is thrown when attempting to define a SPATIAL index over a non-geometry column
 	ErrBadSpatialIdxCol = errors.NewKind("a SPATIAL index may only contain a geometrical type column")
 
+	// ErrNoSRID is thrown when attempting to create a Geometry with a non-existent SRID
+	ErrNoSRID = errors.NewKind("There's no spatial reference with SRID %d")
+
+	// ErrInvalidSRID is thrown when attempting to create a Geometry with an invalid SRID
+	ErrInvalidSRID = errors.NewKind("SRID value is out of range in %s")
+
 	// ErrUnsupportedSpatialIdx is thrown when attempting to create a SPATIAL index
 	// TODO: remove this error when spatial index are created
 	ErrUnsupportedSpatialIdx = errors.NewKind("unsupported index type: SPATIAL")

--- a/sql/expression/function/spatial/geojson.go
+++ b/sql/expression/function/spatial/geojson.go
@@ -229,7 +229,7 @@ func RoundFloatSlices(v interface{}, p float64) interface{} {
 	return nil
 }
 
-// getIntArg is a helper method that evaluates the given sql.Expression to an int type, errors on float32 and float 64,
+// getIntArg is a helper method that evaluates the given sql.Expression to an int type, errors on float32 and float64,
 // and returns nil
 func getIntArg(ctx *sql.Context, row sql.Row, expr sql.Expression) (interface{}, error) {
 	x, err := expr.Eval(ctx, row)
@@ -748,10 +748,10 @@ func (g *GeomFromGeoJSON) Eval(ctx *sql.Context, row sql.Row) (interface{}, erro
 	if err != nil {
 		return nil, errors.New("incorrect srid value")
 	}
-	srid := uint32(s.(int))
-	if err = ValidateSRID(srid); err != nil {
+	if err = ValidateSRID(s.(int), g.FunctionName()); err != nil {
 		return nil, err
 	}
+	srid := uint32(s.(int))
 	res = res.(types.GeometryValue).SetSRID(srid)
 	return res, nil
 }

--- a/sql/expression/function/spatial/st_srid.go
+++ b/sql/expression/function/spatial/st_srid.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/src-d/go-errors.v1"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -32,8 +30,6 @@ type SRID struct {
 
 var _ sql.FunctionExpression = (*SRID)(nil)
 var _ sql.CollationCoercible = (*SRID)(nil)
-
-var ErrInvalidSRID = errors.NewKind("There's no spatial reference with SRID %d")
 
 // NewSRID creates a new STX expression.
 func NewSRID(args ...sql.Expression) (sql.Expression, error) {
@@ -110,15 +106,15 @@ func (s *SRID) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	val, _, err := types.Uint32.Convert(v)
+	val, _, err := types.Int64.Convert(v)
 	if err != nil {
 		return nil, err
 	}
-	srid := val.(uint32)
 
-	if err = ValidateSRID(srid); err != nil {
+	if err = ValidateSRID(int(val.(int64)), s.FunctionName()); err != nil {
 		return nil, err
 	}
+	srid := uint32(val.(int64))
 
 	// Create new geometry object with matching SRID
 	switch g := g.(type) {

--- a/sql/expression/function/spatial/wkt.go
+++ b/sql/expression/function/spatial/wkt.go
@@ -579,14 +579,14 @@ func WKTToGeom(ctx *sql.Context, row sql.Row, exprs []sql.Expression, expectedGe
 		if s == nil {
 			return nil, nil
 		}
-		s, _, err = types.Uint32.Convert(s)
+		s, _, err = types.Int64.Convert(s)
 		if err != nil {
 			return nil, err
 		}
-		srid = s.(uint32)
-	}
-	if err = ValidateSRID(srid); err != nil {
-		return nil, err
+		if err = ValidateSRID(int(s.(int64)), "st_geomfromtext"); err != nil {
+			return nil, err
+		}
+		srid = uint32(s.(int64))
 	}
 
 	order := srid == types.GeoSpatialSRID


### PR DESCRIPTION
This PR fixes an error inconsistency between Dolt and MySQL.
For SRIDs that are out of range `[0, MAX_UINT32]`, MySQL throws a `ERROR: 1690: SRID value is out of range in '<func_name>'`.
For SRIDS that are in range, but just don't exist, MySQL throws a `ERROR: 3548: There's no spatial reference system with SRID <invalid srid>.`

Dolt used to only throw `ERROR 3548`, and would incorrectly report the negative numbers as overflowed positive `uint32`s

partial fix for: https://github.com/dolthub/dolt/issues/5948