### PR TITLE
Returning `@@system_time_zone` based on OS time zone

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -19,6 +19,7 @@ import (
 
 	"gopkg.in/src-d/go-errors.v1"
 
+	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer/analyzererrors"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -3177,13 +3178,10 @@ var ScriptTests = []ScriptTest{
 		Name: "timezone default settings",
 		Assertions: []ScriptTestAssertion{
 			{
-				// To match MySQL's behavior, this should come from the operating system's timezone setting, but
-				// currently we default to UTC.
-				// TODO: When the value of @@system_time_zone is read, it should invoke time.Now() and return the
-				//       Zone() information. This should be done dynamically when @@system_time_zone is read, since
-				//       the system time_zone offset can change while the process is running (e.g. daylight savings).
-				Query:    `select @@system_time_zone;`,
-				Expected: []sql.Row{{"UTC"}},
+				// To match MySQL's behavior, this comes from the operating system's timezone setting
+				// TODO: the "global" shouldn't be necessary here, but GMS goes to session without it
+				Query:    `select @@global.system_time_zone;`,
+				Expected: []sql.Row{{gmstime.SystemTimezoneOffset()}},
 			},
 			{
 				// The default time_zone setting for MySQL is SYSTEM, which means timezone comes from @@system_time_zone

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -147,7 +147,7 @@ func (s *BaseSession) SetSessionVariable(ctx *Context, sysVarName string, value 
 		}
 	}
 
-	if !sysVar.Var.Dynamic {
+	if !sysVar.Var.Dynamic || sysVar.Var.ValueFunction != nil {
 		return ErrSystemVariableReadOnly.New(sysVarName)
 	}
 	return s.setSessVar(ctx, sysVar.Var, value)

--- a/sql/core.go
+++ b/sql/core.go
@@ -370,6 +370,11 @@ type SystemVariable struct {
 	// block.  NotifyChanged is not called when a new system variable is
 	// registered.
 	NotifyChanged func(SystemVariableScope, SystemVarValue)
+	// ValueFunction defines an optional function that is executed to provide
+	// the value of this system variable whenever it is requested. System variables
+	// that provide a ValueFunction should also set Dynamic to false, since they
+	// cannot be assigned a value and will return a read-only error if tried.
+	ValueFunction func() interface{}
 }
 
 // SystemVariableScope represents the scope of a system variable.

--- a/sql/core.go
+++ b/sql/core.go
@@ -374,7 +374,7 @@ type SystemVariable struct {
 	// the value of this system variable whenever it is requested. System variables
 	// that provide a ValueFunction should also set Dynamic to false, since they
 	// cannot be assigned a value and will return a read-only error if tried.
-	ValueFunction func() interface{}
+	ValueFunction func() (interface{}, error)
 }
 
 // SystemVariableScope represents the scope of a system variable.


### PR DESCRIPTION
The [`@@system_time_zone` global system variable](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_system_time_zone) is a read-only system variable that shows the timezone that the server is running in. MySQL and Golang both load the system timezone from the OS, typically using the `TZ` env var or `/etc/timezone`. This change exposes that system timezone information through the `@@system_time_zone` variable, which was previously hardcoded to `UTC`. 

Because timezone settings can change while the system is running (thanks daylight savings time!), we need to check with the runtime for the system timezone whenever it is requested. I gave `SystemVariable` the ability to include a function that gets executed to return the sys var value and moved the `uptime` sys var over to that, too. 