### PR TITLE
[no-release-notes] Fixing test to always expect the correct date and not shift value to UTC timezone

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5767,6 +5767,9 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 		TestQueryWithContext(t, ctx, e, harness, "CREATE TABLE t11(pk BIGINT PRIMARY KEY, v1 DATE DEFAULT (NOW()), v2 VARCHAR(20) DEFAULT (CURRENT_TIMESTAMP()))", []sql.Row{{types.NewOkResult(0)}}, nil, nil)
 
 		now := time.Now()
+		expectedDate := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		expectedDatetimeString := now.Truncate(time.Second).Format(sql.TimestampDatetimeLayout)
+
 		sql.RunWithNowFunc(func() time.Time {
 			return now
 		}, func() error {
@@ -5775,7 +5778,8 @@ func TestColumnDefaults(t *testing.T, harness Harness) {
 		})
 
 		// TODO: the string conversion does not transform to UTC like other NOW() calls, fix this
-		TestQueryWithContext(t, ctx, e, harness, "select * from t11 order by 1", []sql.Row{{1, now.UTC().Truncate(time.Hour * 24), now.Truncate(time.Second).Format(sql.TimestampDatetimeLayout)}}, nil, nil)
+		TestQueryWithContext(t, ctx, e, harness, "select * from t11 order by 1",
+			[]sql.Row{{1, expectedDate, expectedDatetimeString}}, nil, nil)
 	})
 
 	t.Run("REPLACE INTO with default expression", func(t *testing.T) {


### PR DESCRIPTION
This fixes the test that was failing when past 5pm in PDT timezone because of UTC shift that no longer needs to happen. I pushed my local clock to 11pm to repro the failure and verify the fix. 