### PR TITLE
Add extra filters to AntiJoin to guarentee correct behavior around NULLs.

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -250,18 +250,18 @@ var JoinPlanningTests = []struct {
 			},
 			{
 				q:     "select * from xy where x not in (select u from uv where u not in (select a from ab where a not in (select r from rs where r = 1))) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash, plan.JoinTypeLeftOuterHash, plan.JoinTypeLeftOuterMerge},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls, plan.JoinTypeLeftOuterHashExcludeNulls, plan.JoinTypeLeftOuterMerge},
 				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
 			},
 			{
 				q:     "select * from xy where x != (select r from rs where r = 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
 			},
 			{
 				// anti join will be cross-join-right, be passed non-nil parent row
 				q:     "select x,a from ab, (select * from xy where x != (select r from rs where r = 1) order by 1) sq where x = 2 and b = 2 order by 1,2;",
-				types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeCross, plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp:   []sql.Row{{2, 0}, {2, 1}, {2, 2}},
 			},
 			{
@@ -276,25 +276,25 @@ select * from uv where u > (
   order by 1 limit 1
 )
 order by 1;`,
-				types: []plan.JoinType{plan.JoinTypeSemi, plan.JoinTypeCross, plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeSemi, plan.JoinTypeCross, plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp:   []sql.Row{{1, 1}, {2, 2}, {3, 2}},
 			},
 			{
 				// cast prevents scope merging
 				q:     "select * from xy where x != (select cast(r as signed) from rs where r = 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
 			},
 			{
 				// order by will be discarded
 				q:     "select * from xy where x != (select r from rs where r = 1 order by 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
 			},
 			{
 				// limit prevents scope merging
 				q:     "select * from xy where x != (select r from rs where r = 1 limit 1) order by 1;",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp:   []sql.Row{{0, 2}, {2, 1}, {3, 3}},
 			},
 			{
@@ -665,7 +665,7 @@ where u in (select * from rec);`,
 		tests: []JoinPlanTest{
 			{
 				q:     "select /*+ HASH_JOIN(xy,scalarSubq0) */ * from xy where x not in (select a from empty_tbl) order by x",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp: []sql.Row{
 					{0, 2},
 					{1, 0},
@@ -675,7 +675,7 @@ where u in (select * from rec);`,
 			},
 			{
 				q:     "select /*+ HASH_JOIN(xy,scalarSubq0) */ * from xy where x not in (select v from uv) order by x",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp: []sql.Row{
 					{0, 2},
 					{3, 3},
@@ -683,7 +683,7 @@ where u in (select * from rec);`,
 			},
 			{
 				q:     "select /*+ HASH_JOIN(xy,scalarSubq0) */ * from xy where x not in (select v from uv where u = 2) order by x",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp: []sql.Row{
 					{0, 2},
 					{1, 0},
@@ -692,7 +692,7 @@ where u in (select * from rec);`,
 			},
 			{
 				q:     "select /*+ HASH_JOIN(xy,scalarSubq0) */ * from xy where x != (select v from uv where u = 2) order by x",
-				types: []plan.JoinType{plan.JoinTypeLeftOuterHash},
+				types: []plan.JoinType{plan.JoinTypeLeftOuterHashExcludeNulls},
 				exp: []sql.Row{
 					{0, 2},
 					{1, 0},

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -722,10 +722,6 @@ on w = 0;`,
 		Query:    `SELECT * from xy where y not in (SELECT b from ab_hasnull)`,
 		Expected: []sql.Row{},
 	},
-	{
-		Query:    `SELECT * from xy where null not in (SELECT b from ab)`,
-		Expected: []sql.Row{},
-	},
 }
 
 var JoinScriptTests = []ScriptTest{

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -722,6 +722,10 @@ on w = 0;`,
 		Query:    `SELECT * from xy where y not in (SELECT b from ab_hasnull)`,
 		Expected: []sql.Row{},
 	},
+	{
+		Query:    `SELECT * from xy where null not in (SELECT b from ab)`,
+		Expected: []sql.Row{},
+	},
 }
 
 var JoinScriptTests = []ScriptTest{

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -710,6 +710,22 @@ JSON_TABLE(
 on w = 0;`,
 		Expected: []sql.Row{{0}},
 	},
+	{
+		Query:    `SELECT * from xy_hasnull where y not in (SELECT b from ab_hasnull)`,
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    `SELECT * from xy_hasnull where y not in (SELECT b from ab)`,
+		Expected: []sql.Row{{1, 0}},
+	},
+	{
+		Query:    `SELECT * from xy where y not in (SELECT b from ab_hasnull)`,
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    `SELECT * from xy where null not in (SELECT b from ab)`,
+		Expected: []sql.Row{},
+	},
 }
 
 var JoinScriptTests = []ScriptTest{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -769,7 +769,7 @@ Select * from (
 			"     ├─ columns: [xy.x:0!null, xy.y:1]\n" +
 			"     └─ Filter\n" +
 			"         ├─ scalarSubq0.u:2!null IS NULL\n" +
-			"         └─ LeftOuterHashJoin\n" +
+			"         └─ LeftOuterHashJoinExcludeNulls\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ xy.x:0!null\n" +
 			"             │   └─ scalarSubq0.u:2!null\n" +

--- a/enginetest/scriptgen/setup/scripts/xy
+++ b/enginetest/scriptgen/setup/scripts/xy
@@ -23,6 +23,30 @@ create table rs (r int primary key, s int, index s_idx(s));
 ----
 
 exec
+CREATE table xy_hasnull (x int primary key, y int);
+----
+
+exec
+CREATE table ab_hasnull (a int primary key, b int);
+----
+
+exec
+insert into xy_hasnull values
+  (1,0),
+  (2,1),
+  (0,2),
+  (3,NULL);
+----
+
+exec
+insert into ab_hasnull values
+  (0,2),
+  (1,2),
+  (2,NULL),
+  (3,1);
+----
+
+exec
 insert into xy values
   (1,0),
   (2,1),

--- a/enginetest/scriptgen/setup/setup_data.sg.go
+++ b/enginetest/scriptgen/setup/setup_data.sg.go
@@ -2854,6 +2854,18 @@ var XyData = []SetupScript{{
 	`CREATE table pq (p int primary key, q int);`,
 	`CREATE table mn (m int primary key, n int);`,
 	`create table rs (r int primary key, s int, index s_idx(s));`,
+	`CREATE table xy_hasnull (x int primary key, y int);`,
+	`CREATE table ab_hasnull (a int primary key, b int);`,
+	`insert into xy_hasnull values
+  (1,0),
+  (2,1),
+  (0,2),
+  (3,NULL);`,
+	`insert into ab_hasnull values
+  (0,2),
+  (1,2),
+  (2,NULL),
+  (3,1);`,
 	`insert into xy values
   (1,0),
   (2,1),

--- a/sql/analyzer/apply_join.go
+++ b/sql/analyzer/apply_join.go
@@ -169,8 +169,8 @@ func transformJoinApply(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope,
 				if m.op.IsAnti() && rightF.IsNullable() {
 					// Due to a quirk of MySQL, `a NOT IN (NULL, ...)` is always false.
 					// We emulate this by adding an extra filter to any AntiJoins.
-					// This filter excludes any rows from the join where the right column is NULL.
-					filter = expression.JoinOr(filter, expression.NewIsNull(rightF))
+					// This filter excludes any rows from the join where either column is NULL.
+					filter = expression.JoinOr(filter, expression.NewIsNull(m.l), expression.NewIsNull(rightF))
 				}
 				filter, _, err = FixFieldIndexes(scope, a, condSch, filter)
 				if err != nil {

--- a/sql/analyzer/apply_join.go
+++ b/sql/analyzer/apply_join.go
@@ -172,7 +172,9 @@ func transformJoinApply(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope,
 				if c, ok := ret.(sql.CommentedNode); ok {
 					comment = c.Comment()
 				}
-				ret = plan.NewJoin(ret, newSubq, m.op, filter).WithComment(comment)
+				newJoin := plan.NewJoin(ret, newSubq, m.op, filter)
+				newJoin.RejectRowsWithNullCondition = true
+				ret = newJoin.WithComment(comment)
 			}
 
 			if len(newFilters) == 0 {

--- a/sql/analyzer/apply_join.go
+++ b/sql/analyzer/apply_join.go
@@ -158,12 +158,6 @@ func transformJoinApply(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope,
 				if err != nil {
 					return n, transform.SameTree, err
 				}
-				if m.op.IsAnti() && rightF.IsNullable() {
-					// Due to a quirk of MySQL, `a NOT IN (NULL, ...)` is always false.
-					// We emulate this by adding an extra filter to any AntiJoins.
-					// This filter excludes any rows from the join where either column is NULL.
-					filter = expression.JoinOr(filter, expression.NewIsNull(m.l), expression.NewIsNull(rightF))
-				}
 				filter, _, err = FixFieldIndexes(scope, a, condSch, filter)
 				if err != nil {
 					return n, transform.SameTree, err

--- a/sql/analyzer/apply_join.go
+++ b/sql/analyzer/apply_join.go
@@ -96,14 +96,6 @@ func transformJoinApply(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope,
 					sq, _ = e.Right.(*plan.Subquery)
 					l = e.Left
 
-					if l.IsNullable() {
-						newFilters = append(newFilters, e)
-						continue
-					}
-					if sq.Query.Schema()[0].Nullable {
-						newFilters = append(newFilters, e)
-						continue
-					}
 					joinF = expression.NewEquals(nil, nil)
 				case expression.Comparer:
 					sq, _ = e.Right().(*plan.Subquery)

--- a/sql/analyzer/apply_join.go
+++ b/sql/analyzer/apply_join.go
@@ -95,6 +95,15 @@ func transformJoinApply(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope,
 				case *plan.InSubquery:
 					sq, _ = e.Right.(*plan.Subquery)
 					l = e.Left
+
+					if l.IsNullable() {
+						newFilters = append(newFilters, e)
+						continue
+					}
+					if sq.Query.Schema()[0].Nullable {
+						newFilters = append(newFilters, e)
+						continue
+					}
 					joinF = expression.NewEquals(nil, nil)
 				case expression.Comparer:
 					sq, _ = e.Right().(*plan.Subquery)

--- a/sql/analyzer/apply_join.go
+++ b/sql/analyzer/apply_join.go
@@ -167,7 +167,6 @@ func transformJoinApply(ctx *sql.Context, a *Analyzer, n sql.Node, scope *Scope,
 					comment = c.Comment()
 				}
 				newJoin := plan.NewJoin(ret, newSubq, m.op, filter)
-				newJoin.RejectRowsWithNullCondition = true
 				ret = newJoin.WithComment(comment)
 			}
 

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -432,7 +432,7 @@ func convertAntiToLeftJoin(a *Analyzer, m *Memo) error {
 				relBase: &relBase{},
 				left:    anti.left,
 				right:   rightGrp,
-				op:      plan.JoinTypeLeftOuter,
+				op:      plan.JoinTypeLeftOuterExcludeNulls,
 				filter:  anti.filter,
 			},
 		}

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -27,35 +27,48 @@ import (
 type JoinType uint16
 
 const (
-	JoinTypeUnknown         JoinType = iota // UnknownJoin
-	JoinTypeCross                           // CrossJoin
-	JoinTypeInner                           // InnerJoin
-	JoinTypeSemi                            // SemiJoin
-	JoinTypeAnti                            // AntiJoin
-	JoinTypeRightSemi                       // RightSemiJoin
-	JoinTypeLeftOuter                       // LeftOuterJoin
-	JoinTypeFullOuter                       // FullOuterJoin
-	JoinTypeGroupBy                         // GroupByJoin
-	JoinTypeRightOuter                      // RightJoin
-	JoinTypeLookup                          // LookupJoin
-	JoinTypeLeftOuterLookup                 // LeftOuterLookupJoin
-	JoinTypeHash                            // HashJoin
-	JoinTypeLeftOuterHash                   // LeftOuterHashJoin
-	JoinTypeMerge                           // MergeJoin
-	JoinTypeLeftOuterMerge                  // LeftOuterMergeJoin
-	JoinTypeSemiHash                        // SemiHashJoin
-	JoinTypeAntiHash                        // AntiHashJoin
-	JoinTypeSemiLookup                      // SemiLookupJoin
-	JoinTypeAntiLookup                      // AntiLookupJoin
-	JoinTypeRightSemiLookup                 // RightSemiLookupJoin
-	JoinTypeSemiMerge                       // SemiMergeJoin
-	JoinTypeAntiMerge                       // AntiMergeJoin
-	JoinTypeNatural                         // NaturalJoin
+	JoinTypeUnknown                   JoinType = iota // UnknownJoin
+	JoinTypeCross                                     // CrossJoin
+	JoinTypeInner                                     // InnerJoin
+	JoinTypeSemi                                      // SemiJoin
+	JoinTypeAnti                                      // AntiJoin
+	JoinTypeRightSemi                                 // RightSemiJoin
+	JoinTypeLeftOuter                                 // LeftOuterJoin
+	JoinTypeLeftOuterExcludeNulls                     // LeftOuterJoinExcludingNulls
+	JoinTypeFullOuter                                 // FullOuterJoin
+	JoinTypeGroupBy                                   // GroupByJoin
+	JoinTypeRightOuter                                // RightJoin
+	JoinTypeLookup                                    // LookupJoin
+	JoinTypeLeftOuterLookup                           // LeftOuterLookupJoin
+	JoinTypeHash                                      // HashJoin
+	JoinTypeLeftOuterHash                             // LeftOuterHashJoin
+	JoinTypeLeftOuterHashExcludeNulls                 // LeftOuterHashJoinExcludeNulls
+	JoinTypeMerge                                     // MergeJoin
+	JoinTypeLeftOuterMerge                            // LeftOuterMergeJoin
+	JoinTypeSemiHash                                  // SemiHashJoin
+	JoinTypeAntiHash                                  // AntiHashJoin
+	JoinTypeSemiLookup                                // SemiLookupJoin
+	JoinTypeAntiLookup                                // AntiLookupJoin
+	JoinTypeRightSemiLookup                           // RightSemiLookupJoin
+	JoinTypeSemiMerge                                 // SemiMergeJoin
+	JoinTypeAntiMerge                                 // AntiMergeJoin
+	JoinTypeNatural                                   // NaturalJoin
 )
 
 func (i JoinType) IsLeftOuter() bool {
 	switch i {
-	case JoinTypeLeftOuter, JoinTypeLeftOuterLookup, JoinTypeLeftOuterHash, JoinTypeLeftOuterMerge:
+	case JoinTypeLeftOuter, JoinTypeLeftOuterExcludeNulls, JoinTypeLeftOuterLookup, JoinTypeLeftOuterHash, JoinTypeLeftOuterHashExcludeNulls, JoinTypeLeftOuterMerge:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsExcludeNulls returns whether a join operation has the behavior that if a condition evaluates to NULL,
+// that row is excluded from the result table.
+func (i JoinType) IsExcludeNulls() bool {
+	switch i {
+	case JoinTypeAnti, JoinTypeLeftOuterExcludeNulls, JoinTypeLeftOuterHashExcludeNulls:
 		return true
 	default:
 		return false
@@ -74,7 +87,7 @@ func (i JoinType) IsPhysical() bool {
 	switch i {
 	case JoinTypeLookup, JoinTypeLeftOuterLookup,
 		JoinTypeSemiLookup, JoinTypeRightSemiLookup, JoinTypeSemiMerge, JoinTypeSemiHash,
-		JoinTypeHash, JoinTypeLeftOuterHash,
+		JoinTypeHash, JoinTypeLeftOuterHash, JoinTypeLeftOuterHashExcludeNulls,
 		JoinTypeMerge, JoinTypeLeftOuterMerge,
 		JoinTypeAntiLookup, JoinTypeAntiMerge, JoinTypeAntiHash:
 		return true
@@ -111,7 +124,7 @@ func (i JoinType) IsMerge() bool {
 
 func (i JoinType) IsHash() bool {
 	switch i {
-	case JoinTypeHash, JoinTypeSemiHash, JoinTypeAntiHash, JoinTypeLeftOuterHash:
+	case JoinTypeHash, JoinTypeSemiHash, JoinTypeAntiHash, JoinTypeLeftOuterHash, JoinTypeLeftOuterHashExcludeNulls:
 		return true
 	default:
 		return false
@@ -182,6 +195,8 @@ func (i JoinType) AsHash() JoinType {
 		return JoinTypeHash
 	case JoinTypeLeftOuter:
 		return JoinTypeLeftOuterHash
+	case JoinTypeLeftOuterExcludeNulls:
+		return JoinTypeLeftOuterHashExcludeNulls
 	case JoinTypeSemi:
 		return JoinTypeSemiHash
 	case JoinTypeAnti:
@@ -195,7 +210,7 @@ func (i JoinType) AsMerge() JoinType {
 	switch i {
 	case JoinTypeInner:
 		return JoinTypeMerge
-	case JoinTypeLeftOuter:
+	case JoinTypeLeftOuter, JoinTypeLeftOuterExcludeNulls:
 		return JoinTypeLeftOuterMerge
 	case JoinTypeSemi:
 		return JoinTypeSemiMerge
@@ -210,7 +225,7 @@ func (i JoinType) AsLookup() JoinType {
 	switch i {
 	case JoinTypeInner:
 		return JoinTypeLookup
-	case JoinTypeLeftOuter:
+	case JoinTypeLeftOuter, JoinTypeLeftOuterExcludeNulls:
 		return JoinTypeLeftOuterLookup
 	case JoinTypeSemi:
 		return JoinTypeSemiLookup

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -230,6 +230,9 @@ type JoinNode struct {
 	Op         JoinType
 	CommentStr string
 	ScopeLen   int
+	// If RejectRowsWithNullCondition is true, then the results will filter any row from the left child that
+	// was compared against a row on the right table and returned NULL. This only makes sense for outer joins.
+	RejectRowsWithNullCondition bool
 }
 
 var _ sql.Node = (*JoinNode)(nil)

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -245,9 +245,6 @@ type JoinNode struct {
 	Op         JoinType
 	CommentStr string
 	ScopeLen   int
-	// If RejectRowsWithNullCondition is true, then the results will filter any row from the left child that
-	// was compared against a row on the right table and returned NULL. This only makes sense for outer joins.
-	RejectRowsWithNullCondition bool
 }
 
 var _ sql.Node = (*JoinNode)(nil)

--- a/sql/plan/jointype_string.go
+++ b/sql/plan/jointype_string.go
@@ -2,9 +2,7 @@
 
 package plan
 
-import (
-	"strconv"
-)
+import "strconv"
 
 func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
@@ -17,28 +15,30 @@ func _() {
 	_ = x[JoinTypeAnti-4]
 	_ = x[JoinTypeRightSemi-5]
 	_ = x[JoinTypeLeftOuter-6]
-	_ = x[JoinTypeFullOuter-7]
-	_ = x[JoinTypeGroupBy-8]
-	_ = x[JoinTypeRightOuter-9]
-	_ = x[JoinTypeLookup-10]
-	_ = x[JoinTypeLeftOuterLookup-11]
-	_ = x[JoinTypeHash-12]
-	_ = x[JoinTypeLeftOuterHash-13]
-	_ = x[JoinTypeMerge-14]
-	_ = x[JoinTypeLeftOuterMerge-15]
-	_ = x[JoinTypeSemiHash-16]
-	_ = x[JoinTypeAntiHash-17]
-	_ = x[JoinTypeSemiLookup-18]
-	_ = x[JoinTypeAntiLookup-19]
-	_ = x[JoinTypeRightSemiLookup-20]
-	_ = x[JoinTypeSemiMerge-21]
-	_ = x[JoinTypeAntiMerge-22]
-	_ = x[JoinTypeNatural-23]
+	_ = x[JoinTypeLeftOuterExcludeNulls-7]
+	_ = x[JoinTypeFullOuter-8]
+	_ = x[JoinTypeGroupBy-9]
+	_ = x[JoinTypeRightOuter-10]
+	_ = x[JoinTypeLookup-11]
+	_ = x[JoinTypeLeftOuterLookup-12]
+	_ = x[JoinTypeHash-13]
+	_ = x[JoinTypeLeftOuterHash-14]
+	_ = x[JoinTypeLeftOuterHashExcludeNulls-15]
+	_ = x[JoinTypeMerge-16]
+	_ = x[JoinTypeLeftOuterMerge-17]
+	_ = x[JoinTypeSemiHash-18]
+	_ = x[JoinTypeAntiHash-19]
+	_ = x[JoinTypeSemiLookup-20]
+	_ = x[JoinTypeAntiLookup-21]
+	_ = x[JoinTypeRightSemiLookup-22]
+	_ = x[JoinTypeSemiMerge-23]
+	_ = x[JoinTypeAntiMerge-24]
+	_ = x[JoinTypeNatural-25]
 }
 
-const _JoinType_name = "UnknownJoinCrossJoinInnerJoinSemiJoinAntiJoinRightSemiJoinLeftOuterJoinFullOuterJoinGroupByJoinRightJoinLookupJoinLeftOuterLookupJoinHashJoinLeftOuterHashJoinMergeJoinLeftOuterMergeJoinSemiHashJoinAntiHashJoinSemiLookupJoinAntiLookupJoinRightSemiLookupJoinSemiMergeJoinAntiMergeJoinNaturalJoin"
+const _JoinType_name = "UnknownJoinCrossJoinInnerJoinSemiJoinAntiJoinRightSemiJoinLeftOuterJoinLeftOuterJoinExcludingNullsFullOuterJoinGroupByJoinRightJoinLookupJoinLeftOuterLookupJoinHashJoinLeftOuterHashJoinLeftOuterHashJoinExcludeNullsMergeJoinLeftOuterMergeJoinSemiHashJoinAntiHashJoinSemiLookupJoinAntiLookupJoinRightSemiLookupJoinSemiMergeJoinAntiMergeJoinNaturalJoin"
 
-var _JoinType_index = [...]uint16{0, 11, 20, 29, 37, 45, 58, 71, 84, 95, 104, 114, 133, 141, 158, 167, 185, 197, 209, 223, 237, 256, 269, 282, 293}
+var _JoinType_index = [...]uint16{0, 11, 20, 29, 37, 45, 58, 71, 98, 111, 122, 131, 141, 160, 168, 185, 214, 223, 241, 253, 265, 279, 293, 312, 325, 338, 349}
 
 func (i JoinType) String() string {
 	if i >= JoinType(len(_JoinType_index)-1) {

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -52,15 +52,14 @@ func newJoinIter(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinNode, row 
 		return nil, err
 	}
 	return sql.NewSpanIter(span, &joinIter{
-		parentRow:                   row,
-		primary:                     l,
-		secondaryProvider:           j.Right(),
-		cond:                        j.Filter,
-		joinType:                    j.Op,
-		rowSize:                     len(row) + len(j.Left().Schema()) + len(j.Right().Schema()),
-		scopeLen:                    j.ScopeLen,
-		b:                           b,
-		rejectRowsWithNullCondition: j.RejectRowsWithNullCondition,
+		parentRow:         row,
+		primary:           l,
+		secondaryProvider: j.Right(),
+		cond:              j.Filter,
+		joinType:          j.Op,
+		rowSize:           len(row) + len(j.Left().Schema()) + len(j.Right().Schema()),
+		scopeLen:          j.ScopeLen,
+		b:                 b,
 	}), nil
 }
 
@@ -79,10 +78,6 @@ type joinIter struct {
 	rowSize    int
 	scopeLen   int
 	b          sql.NodeExecBuilder
-
-	// If RejectRowsWithNullCondition is true, then the results will filter any row from the left child that
-	// was compared against a row on the right table and returned NULL. This only makes sense for outer joins.
-	rejectRowsWithNullCondition bool
 }
 
 func (i *joinIter) loadPrimary(ctx *sql.Context) error {
@@ -234,16 +229,15 @@ func newExistsIter(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinNode, ro
 		return nil, err
 	}
 	return &existsIter{
-		parentRow:                   row,
-		typ:                         j.Op,
-		primary:                     leftIter,
-		secondaryProvider:           j.Right(),
-		cond:                        j.Filter,
-		scopeLen:                    j.ScopeLen,
-		rowSize:                     len(row) + len(j.Left().Schema()) + len(j.Right().Schema()),
-		nullRej:                     !(j.Filter != nil && plan.IsNullRejecting(j.Filter)),
-		b:                           b,
-		rejectRowsWithNullCondition: j.RejectRowsWithNullCondition,
+		parentRow:         row,
+		typ:               j.Op,
+		primary:           leftIter,
+		secondaryProvider: j.Right(),
+		cond:              j.Filter,
+		scopeLen:          j.ScopeLen,
+		rowSize:           len(row) + len(j.Left().Schema()) + len(j.Right().Schema()),
+		nullRej:           !(j.Filter != nil && plan.IsNullRejecting(j.Filter)),
+		b:                 b,
 	}, nil
 }
 
@@ -260,10 +254,6 @@ type existsIter struct {
 	rowSize   int
 	nullRej   bool
 	b         sql.NodeExecBuilder
-
-	// If RejectRowsWithNullCondition is true, then the results will filter any row from the left child that
-	// was compared against a row on the right table and returned NULL.
-	rejectRowsWithNullCondition bool
 }
 
 type existsState uint8

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -334,7 +334,7 @@ func (i *existsIter) Next(ctx *sql.Context) (sql.Row, error) {
 				return nil, err
 			}
 
-			if res == nil && i.rejectRowsWithNullCondition {
+			if res == nil && i.typ.IsExcludeNulls() {
 				nextState = esRejectNull
 				continue
 			}

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -164,7 +164,12 @@ func (i *joinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, err
 		}
 
-		if res == nil && i.rejectRowsWithNullCondition {
+		if res == nil && i.joinType.IsExcludeNulls() {
+			err = i.secondary.Close(ctx)
+			i.secondary = nil
+			if err != nil {
+				return nil, err
+			}
 			i.primaryRow = nil
 			continue
 		}


### PR DESCRIPTION
This is a correctness fix: generating AntiJoins is not currently equivalent to MySql if either column being used in the `not in` expression contains NULL.

This will break a lot of regression tests. If this doesn't break Turbine's tests, we should submit this while we work on a fix.