### PR TITLE
Small aggregation perf improvements

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -928,7 +928,7 @@ func evalJoinTypeTest(t *testing.T, harness Harness, e *sqle.Engine, tt JoinPlan
 
 func evalJoinCorrectness(t *testing.T, harness Harness, e *sqle.Engine, name, q string, exp []sql.Row, skipOld bool) {
 	t.Run(name, func(t *testing.T) {
-		if vh, ok := harness.(VersionedHarness); ok && vh.Version() == sql.VersionStable && skipOld {
+		if vh, ok := harness.(VersionedHarness); (ok && vh.Version() == sql.VersionStable && skipOld) || (!ok && skipOld) {
 			t.Skip()
 		}
 
@@ -980,7 +980,7 @@ func collectJoinTypes(n sql.Node) []plan.JoinType {
 
 func evalJoinOrder(t *testing.T, harness Harness, e *sqle.Engine, q string, exp []string, skipOld bool) {
 	t.Run(q+" join order", func(t *testing.T) {
-		if vh, ok := harness.(VersionedHarness); ok && vh.Version() == sql.VersionStable && skipOld {
+		if vh, ok := harness.(VersionedHarness); (ok && vh.Version() == sql.VersionStable && skipOld) || (!ok && skipOld) {
 			t.Skip()
 		}
 
@@ -1037,7 +1037,7 @@ func TestJoinPlanningPrepared(t *testing.T, harness Harness) {
 
 func evalJoinTypeTestPrepared(t *testing.T, harness Harness, e *sqle.Engine, tt JoinPlanTest, skipOld bool) {
 	t.Run(tt.q+" join types", func(t *testing.T) {
-		if vh, ok := harness.(VersionedHarness); ok && vh.Version() == sql.VersionStable && skipOld {
+		if vh, ok := harness.(VersionedHarness); (ok && vh.Version() == sql.VersionStable && skipOld) || (!ok && skipOld) {
 			t.Skip()
 		}
 
@@ -1077,7 +1077,7 @@ func evalJoinTypeTestPrepared(t *testing.T, harness Harness, e *sqle.Engine, tt 
 
 func evalJoinCorrectnessPrepared(t *testing.T, harness Harness, e *sqle.Engine, name, q string, exp []sql.Row, skipOld bool) {
 	t.Run(q, func(t *testing.T) {
-		if vh, ok := harness.(VersionedHarness); ok && vh.Version() == sql.VersionStable && skipOld {
+		if vh, ok := harness.(VersionedHarness); (ok && vh.Version() == sql.VersionStable && skipOld) || (!ok && skipOld) {
 			t.Skip()
 		}
 
@@ -1104,7 +1104,7 @@ func evalJoinCorrectnessPrepared(t *testing.T, harness Harness, e *sqle.Engine, 
 
 func evalJoinOrderPrepared(t *testing.T, harness Harness, e *sqle.Engine, q string, exp []string, skipOld bool) {
 	t.Run(q+" join order", func(t *testing.T) {
-		if vh, ok := harness.(VersionedHarness); ok && vh.Version() == sql.VersionStable && skipOld {
+		if vh, ok := harness.(VersionedHarness); (ok && vh.Version() == sql.VersionStable && skipOld) || (!ok && skipOld) {
 			t.Skip()
 		}
 

--- a/sql/cache.go
+++ b/sql/cache.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cespare/xxhash"
 
 	lru "github.com/hashicorp/golang-lru"
-	errors "gopkg.in/src-d/go-errors.v1"
 )
 
 // HashOf returns a hash of the given value to be used as key in a cache.
@@ -37,7 +36,7 @@ func HashOf(v Row) (uint64, error) {
 }
 
 // ErrKeyNotFound is returned when the key could not be found in the cache.
-var ErrKeyNotFound = errors.NewKind("memory: key %d not found in cache")
+var ErrKeyNotFound = fmt.Errorf("memory: key not found in cache")
 
 type lruCache struct {
 	memory   Freeable
@@ -65,7 +64,7 @@ func (l *lruCache) Put(k uint64, v interface{}) error {
 func (l *lruCache) Get(k uint64) (interface{}, error) {
 	v, ok := l.cache.Get(k)
 	if !ok {
-		return nil, ErrKeyNotFound.New(k)
+		return nil, ErrKeyNotFound
 	}
 
 	return v, nil
@@ -133,7 +132,7 @@ func (m mapCache) Put(u uint64, i interface{}) error {
 func (m mapCache) Get(u uint64) (interface{}, error) {
 	v, ok := m.cache[u]
 	if !ok {
-		return nil, ErrKeyNotFound.New(u)
+		return nil, ErrKeyNotFound
 	}
 	return v, nil
 }
@@ -173,7 +172,7 @@ func (h *historyCache) Put(k uint64, v interface{}) error {
 func (h *historyCache) Get(k uint64) (interface{}, error) {
 	v, ok := h.cache[k]
 	if !ok {
-		return nil, ErrKeyNotFound.New(k)
+		return nil, ErrKeyNotFound
 	}
 	return v, nil
 }

--- a/sql/cache_test.go
+++ b/sql/cache_test.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,14 +34,14 @@ func TestLRUCache(t *testing.T) {
 
 		_, err = cache.Get(2)
 		require.Error(err)
-		require.True(ErrKeyNotFound.Is(err))
+		require.True(errors.Is(err, ErrKeyNotFound))
 
 		// Free the cache and check previous entry disappeared.
 		cache.Free()
 
 		_, err = cache.Get(1)
 		require.Error(err)
-		require.True(ErrKeyNotFound.Is(err))
+		require.True(errors.Is(err, ErrKeyNotFound))
 
 		cache.Dispose()
 		require.Panics(func() {
@@ -55,7 +56,7 @@ func TestLRUCache(t *testing.T) {
 		require.NoError(cache.Put(1, "foo"))
 		_, err := cache.Get(1)
 		require.Error(err)
-		require.True(ErrKeyNotFound.Is(err))
+		require.True(errors.Is(err, ErrKeyNotFound))
 	})
 
 	t.Run("free required to add entry", func(t *testing.T) {
@@ -94,7 +95,7 @@ func TestHistoryCache(t *testing.T) {
 
 		_, err = cache.Get(2)
 		require.Error(err)
-		require.True(ErrKeyNotFound.Is(err))
+		require.True(errors.Is(err, ErrKeyNotFound))
 
 		cache.Dispose()
 		require.Panics(func() {

--- a/sql/rowexec/agg.go
+++ b/sql/rowexec/agg.go
@@ -15,6 +15,7 @@
 package rowexec
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -162,7 +163,7 @@ func (i *groupByGroupingIter) compute(ctx *sql.Context) error {
 		}
 
 		b, err := i.get(key)
-		if sql.ErrKeyNotFound.Is(err) {
+		if errors.Is(err, sql.ErrKeyNotFound) {
 			b = make([]sql.AggregationBuffer, len(i.selectedExprs))
 			for j, a := range i.selectedExprs {
 				b[j], err = newAggregationBuffer(a)

--- a/sql/rowexec/update.go
+++ b/sql/rowexec/update.go
@@ -15,6 +15,7 @@
 package rowexec
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -209,7 +210,7 @@ func (u *updateJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			}
 
 			_, err = cache.Get(hash)
-			if sql.ErrKeyNotFound.Is(err) {
+			if errors.Is(err, sql.ErrKeyNotFound) {
 				cache.Put(hash, struct{}{})
 				continue
 			} else if err != nil {


### PR DESCRIPTION
- We used to make a new error object for every `cache.Get()` miss. Use shared object instead.
- Add reuse pool for collation weight buffers rather than making thousands of `[4]byte`.

before:
<img width="1344" alt="image" src="https://github.com/dolthub/go-mysql-server/assets/18337807/5dc864f1-d5c2-4d1f-85d0-283fb19ce3c2">

after:
<img width="986" alt="image" src="https://github.com/dolthub/go-mysql-server/assets/18337807/6917c1a0-97b9-4ed0-a328-58ad00513e31">
