### PR TITLE
foreign key index match should be on prefix not subset

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -1441,7 +1441,7 @@ var ForeignKeyTests = []ScriptTest{
 			},
 			{
 				Query:    "ALTER TABLE child ADD CONSTRAINT fk3 FOREIGN KEY (a, b) REFERENCES parent (a, b);",
-				Expected: []sql.Row{{types.NewOkResult(0)}},
+				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
 			},
 			{
 				Query:    "ALTER TABLE child ADD CONSTRAINT fk4 FOREIGN KEY (b, a) REFERENCES parent (b, a);",
@@ -1450,30 +1450,16 @@ var ForeignKeyTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "Reordered foreign key columns match an index's prefix, INSERT values",
+		Name: "Reordered foreign key columns do not match",
 		SetUpScript: []string{
 			"DROP TABLE child;",
 			"DROP TABLE parent;",
 			"CREATE TABLE parent(pk DOUBLE PRIMARY KEY, v1 BIGINT, v2 BIGINT, INDEX(v1, v2, pk));",
-			"INSERT INTO parent VALUES (1, 1, 1), (2, 1, 2);",
-			"CREATE TABLE child(pk BIGINT PRIMARY KEY, v1 BIGINT, v2 BIGINT, CONSTRAINT fk_child FOREIGN KEY (v2, v1) REFERENCES parent(v2, v1));",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "INSERT INTO child VALUES (1, 1, 1);",
-				Expected: []sql.Row{{types.NewOkResult(1)}},
-			},
-			{
-				Query:       "INSERT INTO child VALUES (2, 2, 2);",
-				ExpectedErr: sql.ErrForeignKeyChildViolation,
-			},
-			{
-				Query:       "INSERT INTO child VALUES (3, 2, 1);",
-				ExpectedErr: sql.ErrForeignKeyChildViolation,
-			},
-			{
-				Query:    "INSERT INTO child VALUES (4, 1, 2);",
-				Expected: []sql.Row{{types.NewOkResult(1)}},
+				Query:    "CREATE TABLE child(pk BIGINT PRIMARY KEY, v1 BIGINT, v2 BIGINT, CONSTRAINT fk_child FOREIGN KEY (v2, v1) REFERENCES parent(v2, v1));",
+				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
 			},
 		},
 	},
@@ -1490,7 +1476,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:       "ALTER TABLE child ADD CONSTRAINT fk_child FOREIGN KEY (v2, v1) REFERENCES parent(v2, v1);",
-				ExpectedErr: sql.ErrForeignKeyChildViolation,
+				ExpectedErr: sql.ErrForeignKeyMissingReferenceIndex,
 			},
 		},
 	},

--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -1450,6 +1450,34 @@ var ForeignKeyTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Reordered foreign key columns do match",
+		SetUpScript: []string{
+			"DROP TABLE child;",
+			"DROP TABLE parent;",
+			"CREATE TABLE parent(fk1 int, fk2 int, primary key(fk1, fk2));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "CREATE TABLE child(id int unique, fk1 int, fk2 int, primary key(fk2, fk1, id), constraint `fk` foreign key(fk1, fk2) references parent (fk1, fk2));",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "Show create table child;",
+				Expected: []sql.Row{
+					{"child", "CREATE TABLE `child` (\n" +
+						"  `id` int NOT NULL,\n" +
+						"  `fk1` int NOT NULL,\n" +
+						"  `fk2` int NOT NULL,\n" +
+						"  PRIMARY KEY (`fk2`,`fk1`,`id`),\n" +
+						"  KEY `fk1fk2` (`fk1`,`fk2`),\n" +
+						"  UNIQUE KEY `id` (`id`),\n" +
+						"  CONSTRAINT `fk` FOREIGN KEY (`fk1`,`fk2`) REFERENCES `parent` (`fk1`,`fk2`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
 		Name: "Reordered foreign key columns do not match",
 		SetUpScript: []string{
 			"DROP TABLE child;",


### PR DESCRIPTION
Turns out the logic for using an existing secondary index for foreign keys was matching on a subset instead of a prefix.
For example:
```
fks> create table parent (fk1 int, fk2 int, primary key (fk1, fk2));
fks> create table child (id int unique, fk1 int, fk2, primary key (fk2, fk1, id), foreign key (fk1, fk2) references parent (fk1, fk2));
```

This should produce a child table that creates a new secondary index over the columns (fk1, fk2).
But, we don't do that and instead reference some other index (not sure what), causing errors when calling `dolt constraints verify --all`


This PR ensures that we only pick an existing secondary index as the underlying index for a foreign key if that index is a prefix for the foreign key.