### PR TITLE
Reverting `@@system_time_zone` support for returning system timezone

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3178,6 +3178,9 @@ var ScriptTests = []ScriptTest{
 		Name: "timezone default settings",
 		Assertions: []ScriptTestAssertion{
 			{
+				// TODO: Skipping this test while we figure out why this change causes the mysql java
+				// connector integration test to fail.
+				Skip: true,
 				// To match MySQL's behavior, this comes from the operating system's timezone setting
 				// TODO: the "global" shouldn't be necessary here, but GMS goes to session without it
 				Query:    `select @@global.system_time_zone;`,

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -2485,9 +2484,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("system_time_zone"),
-		ValueFunction: func() (interface{}, error) {
-			return gmstime.SystemTimezoneOffset(), nil
-		},
+		Default:           "UTC",
 	},
 	"table_definition_cache": {
 		Name:              "table_definition_cache",


### PR DESCRIPTION
I'm not sure yet why this change causes Dolt's MySQL Connector J integ test to fail, but after testing commits yesterday and testing this fix this morning, this is definitely causing some problem. In CI, but not locally, the MySQL Connector J integ test is failing with a generic/empty `SQLException` each time, immediately after executing the first query. Dolt logs look fine, but there's obviously something happening that the MySQL Connector J can't deal with. I have a few more repro ideas that I'll follow up with, but wanted to get the GMS -> Dolt pipeline cleared up first.

Until then, this PR reverts `@@system_time_zone` from returning the actual timezone in use by the runtime and OS. 

This change was able to get the Dolt MySQL Connector integ suite passing again: https://github.com/dolthub/dolt/actions/runs/5059419161/jobs/9081665231