### PR TITLE
Functional dependencies

### DIFF
--- a/sql/col_set.go
+++ b/sql/col_set.go
@@ -1,0 +1,99 @@
+package sql
+
+type ColumnId uint16
+
+type ColSet struct {
+	set FastIntSet
+}
+
+func NewColSet(vals ...ColumnId) ColSet {
+	var ret ColSet
+	for _, v := range vals {
+		ret.Add(v)
+	}
+	return ret
+}
+
+// We offset the ColumnIDs in the underlying FastIntSet by 1, so that the
+// internal set fast-path can be used for ColumnIDs in the range [1, 64] instead
+// of [0, 63]. ColumnId 0 is reserved as an unknown ColumnId, and a ColSet
+// should never contain it, so this shift allows us to make use of the set
+// fast-path in a few more cases.
+const offset = 1
+
+// setVal returns the value to store in the internal set for the given ColumnId.
+func setVal(col ColumnId) int {
+	return int(col - offset)
+}
+
+// retVal returns the ColumnId to return for the given value in the internal
+// set.
+func retVal(i int) ColumnId {
+	return ColumnId(i + offset)
+}
+
+// MakeColSet returns a set initialized with the given values.
+func MakeColSet(vals ...ColumnId) ColSet {
+	var res ColSet
+	for _, v := range vals {
+		res.Add(v)
+	}
+	return res
+}
+
+// Add adds a column to the set. No-op if the column is already in the set.
+func (s *ColSet) Add(col ColumnId) {
+	s.set.Add(setVal(col))
+}
+
+// Remove removes a column from the set. No-op if the column is not in the set.
+func (s *ColSet) Remove(col ColumnId) { s.set.Remove(setVal(col)) }
+
+// Contains returns true if the set contains the column.
+func (s ColSet) Contains(col ColumnId) bool { return s.set.Contains(setVal(col)) }
+
+// Empty returns true if the set is empty.
+func (s ColSet) Empty() bool { return s.set.Empty() }
+
+// Len returns the number of the columns in the set.
+func (s ColSet) Len() int { return s.set.Len() }
+
+// Next returns the first value in the set which is >= startVal. If there is no
+// such column, the second return value is false.
+func (s ColSet) Next(startVal ColumnId) (ColumnId, bool) {
+	c, ok := s.set.Next(setVal(startVal))
+	return retVal(c), ok
+}
+
+// ForEach calls a function for each column in the set (in increasing order).
+func (s ColSet) ForEach(f func(col ColumnId)) { s.set.ForEach(func(i int) { f(retVal(i)) }) }
+
+// Copy returns a copy of s which can be modified independently.
+func (s ColSet) Copy() ColSet { return ColSet{set: s.set.Copy()} }
+
+// UnionWith adds all the columns from rhs to this set.
+func (s *ColSet) UnionWith(rhs ColSet) { s.set.UnionWith(rhs.set) }
+
+// Union returns the union of s and rhs as a new set.
+func (s ColSet) Union(rhs ColSet) ColSet { return ColSet{set: s.set.Union(rhs.set)} }
+
+// IntersectionWith removes any columns not in rhs from this set.
+func (s *ColSet) IntersectionWith(rhs ColSet) { s.set.IntersectionWith(rhs.set) }
+
+// Intersection returns the intersection of s and rhs as a new set.
+func (s ColSet) Intersection(rhs ColSet) ColSet { return ColSet{set: s.set.Intersection(rhs.set)} }
+
+// DifferenceWith removes any elements in rhs from this set.
+func (s *ColSet) DifferenceWith(rhs ColSet) { s.set.DifferenceWith(rhs.set) }
+
+// Difference returns the elements of s that are not in rhs as a new set.
+func (s ColSet) Difference(rhs ColSet) ColSet { return ColSet{set: s.set.Difference(rhs.set)} }
+
+// Intersects returns true if s has any elements in common with rhs.
+func (s ColSet) Intersects(rhs ColSet) bool { return s.set.Intersects(rhs.set) }
+
+// Equals returns true if the two sets are identical.
+func (s ColSet) Equals(rhs ColSet) bool { return s.set.Equals(rhs.set) }
+
+// SubsetOf returns true if rhs contains all the elements in s.
+func (s ColSet) SubsetOf(rhs ColSet) bool { return s.set.SubsetOf(rhs.set) }

--- a/sql/func_deps.go
+++ b/sql/func_deps.go
@@ -1,5 +1,10 @@
 package sql
 
+import (
+	"fmt"
+	"strings"
+)
+
 // EquivSets maintains equivalency sets
 type EquivSets struct {
 	sets []ColSet
@@ -17,6 +22,36 @@ func (e *EquivSets) Add(cols ColSet) {
 			return
 		}
 	}
+	e.sets = append(e.sets, cols)
+}
+
+func (e *EquivSets) Len() int {
+	if e == nil {
+		return 0
+	}
+	return len(e.sets)
+}
+
+func (e *EquivSets) Sets() []ColSet {
+	if e == nil {
+		return nil
+	}
+	return e.sets
+}
+
+func (e *EquivSets) String() string {
+	if e == nil {
+		return "equiv()"
+	}
+	b := strings.Builder{}
+	sep := ""
+	for i, set := range e.sets {
+		b.WriteString(fmt.Sprintf("%sequiv%s", sep, set))
+		if i == 0 {
+			sep = "; "
+		}
+	}
+	return b.String()
 }
 
 func (e *EquivSets) simplifyFromEditedSet(j int) {
@@ -39,6 +74,10 @@ type Key struct {
 	// nullability is implicit, pass in SetNotNullCols
 }
 
+func (k *Key) Empty() bool {
+	return k.cols.Len() == 0
+}
+
 // FuncDepsSet encodes functional dependencies for a relational
 // expression. Common uses for functional dependencies:
 // - Do a set of equality columns comprise a strict key? (lookup joins)
@@ -59,6 +98,62 @@ type FuncDepsSet struct {
 	equivs *EquivSets
 	// first key is the lead key
 	keys []Key
+}
+
+func (f *FuncDepsSet) StrictKey() (ColSet, bool) {
+	if len(f.keys) == 0 || !f.keys[0].strict {
+		return ColSet{}, false
+	}
+	return f.keys[0].cols, true
+}
+
+func (f *FuncDepsSet) LaxKey() (ColSet, bool) {
+	if len(f.keys) == 0 || f.keys[0].strict {
+		return ColSet{}, false
+	}
+	return f.keys[0].cols, true
+}
+
+func (f *FuncDepsSet) String() string {
+	b := strings.Builder{}
+	if len(f.keys) > 0 {
+		key := f.keys[0]
+		lax := ""
+		if !key.strict {
+			lax = "lax-"
+		}
+		b.WriteString(fmt.Sprintf("%skey%s", lax, key.cols))
+	}
+	if !f.consts.Empty() {
+		b.WriteString(fmt.Sprintf("; constant%s", f.consts))
+	}
+	if f.equivs.Len() > 0 {
+		b.WriteString(fmt.Sprintf("; %s", f.equivs))
+	}
+	if len(f.keys) < 2 {
+		return b.String()
+	}
+	for _, k := range f.keys[1:] {
+		if k.strict {
+			b.WriteString(fmt.Sprintf("; key%s", k.cols))
+		} else {
+			b.WriteString(fmt.Sprintf("; lax-key%s", k.cols))
+		}
+	}
+	return b.String()
+}
+
+func (f *FuncDepsSet) Constants() ColSet {
+	return f.consts
+}
+
+func (f *FuncDepsSet) EquivalenceClosure(cols ColSet) ColSet {
+	for _, set := range f.equivs.Sets() {
+		if set.Intersects(cols) {
+			cols = cols.Union(set)
+		}
+	}
+	return cols
 }
 
 // Questions to answer:
@@ -84,7 +179,7 @@ type FuncDepsSet struct {
 // - Add constant from column
 //   - fixup keys
 
-func (f *FuncDepsSet) AddNullable(cols ColSet) {
+func (f *FuncDepsSet) AddNotNullable(cols ColSet) {
 	// must be called first
 	cols = f.simplifyCols(cols)
 	f.notNull = f.notNull.Union(cols)
@@ -98,13 +193,29 @@ func (f *FuncDepsSet) AddConstants(cols ColSet) {
 
 func (f *FuncDepsSet) AddEquiv(i, j ColumnId) {
 	cols := NewColSet(i, j)
+	if f.equivs == nil {
+		f.equivs = &EquivSets{}
+	}
+	f.AddEquivSet(cols)
+}
+
+func (f *FuncDepsSet) AddEquivSet(cols ColSet) {
 	f.equivs.Add(cols)
 
-	for _, set := range f.equivs.sets {
+	for _, set := range f.equivs.Sets() {
 		// if one col in equiv set is constant, rest are too
 		if set.Intersects(f.consts) {
 			f.AddConstants(set)
 		}
+	}
+}
+
+func (f *FuncDepsSet) AddKey(k Key) {
+	switch k.strict {
+	case true:
+		f.AddStrictKey(k.cols)
+	case false:
+		f.AddLaxKey(k.cols)
 	}
 }
 
@@ -158,10 +269,11 @@ func (f *FuncDepsSet) simplifyCols(key ColSet) ColSet {
 	// i.e. check if removedCol is in closure of rest of set
 	ret := key.Copy()
 	var plucked ColSet
-	for i, ok := key.Next(0); ok; i, ok = key.Next(i) {
+	for i, ok := key.Next(1); ok; i, ok = key.Next(i + 1) {
 		ret.Remove(i)
 		plucked.Add(i)
-		if !f.inClosureOf(plucked, ret) {
+		notConst := f.consts.Intersection(plucked).Empty()
+		if notConst && !f.inClosureOf(plucked, ret) {
 			// plucked is novel
 			ret.Add(i)
 		}
@@ -174,7 +286,7 @@ func (f *FuncDepsSet) inClosureOf(cols1, cols2 ColSet) bool {
 	if cols1.SubsetOf(cols2) {
 		return true
 	}
-	for _, set := range f.equivs.sets {
+	for _, set := range f.equivs.Sets() {
 		if set.Intersects(cols2) {
 			cols2 = cols2.Union(set)
 		}
@@ -183,4 +295,141 @@ func (f *FuncDepsSet) inClosureOf(cols1, cols2 ColSet) bool {
 		return true
 	}
 	return false
+}
+
+// NewCrossJoinFDs makes functional dependencies for a cross join
+// between two relations.
+func NewCrossJoinFDs(left, right *FuncDepsSet) *FuncDepsSet {
+	ret := &FuncDepsSet{}
+	ret.AddNotNullable(left.notNull)
+	ret.AddNotNullable(right.notNull)
+	ret.AddConstants(left.consts)
+	ret.AddConstants(right.consts)
+	// no equiv in cross join
+	// concatenate lead key, append others
+	var lKey, rKey Key
+	if len(left.keys) > 0 {
+		lKey = left.keys[0]
+		left.keys = left.keys[1:]
+	}
+	if len(right.keys) > 0 {
+		rKey = right.keys[0]
+		right.keys = right.keys[1:]
+	}
+	var jKey Key
+	if lKey.Empty() && rKey.Empty() {
+		return ret
+	} else if lKey.Empty() {
+		jKey = rKey
+	} else if rKey.Empty() {
+		jKey = lKey
+	} else {
+		jKey.cols = lKey.cols.Union(rKey.cols)
+		jKey.strict = lKey.strict && rKey.strict
+	}
+	ret.keys = append(ret.keys, jKey)
+	ret.keys = append(ret.keys, left.keys...)
+	ret.keys = append(ret.keys, right.keys...)
+	return ret
+}
+
+// NewInnerJoinFDs makes functional dependencies for an inner join
+// between two relations.
+func NewInnerJoinFDs(left, right *FuncDepsSet, filters [][2]ColumnId) *FuncDepsSet {
+	ret := &FuncDepsSet{}
+	ret.AddNotNullable(left.notNull)
+	ret.AddNotNullable(right.notNull)
+	ret.AddConstants(left.consts)
+	ret.AddConstants(right.consts)
+	for _, f := range filters {
+		ret.AddEquiv(f[0], f[1])
+	}
+	// concatenate lead key, append others
+	var lKey, rKey Key
+	if len(left.keys) > 0 {
+		lKey = left.keys[0]
+		left.keys = left.keys[1:]
+	}
+	if len(right.keys) > 0 {
+		rKey = right.keys[0]
+		right.keys = right.keys[1:]
+	}
+	var jKey Key
+	if lKey.Empty() && rKey.Empty() {
+		return ret
+	} else if lKey.Empty() {
+		jKey = rKey
+	} else if rKey.Empty() {
+		jKey = lKey
+	} else {
+		jKey.cols = lKey.cols.Union(rKey.cols)
+		jKey.strict = lKey.strict && rKey.strict
+	}
+	ret.AddKey(jKey)
+	for _, k := range left.keys {
+		ret.AddKey(k)
+	}
+	for _, k := range right.keys {
+		ret.AddKey(k)
+	}
+	return ret
+}
+
+// NewProjectFDs returns a new functional dependency set projecting
+// a subset of cols.
+func NewProjectFDs(fds *FuncDepsSet, cols ColSet, distinct bool) *FuncDepsSet {
+	ret := &FuncDepsSet{}
+	ret.AddNotNullable(fds.notNull)
+
+	if keptConst := fds.consts.Intersection(cols); !keptConst.Empty() {
+		ret.AddConstants(keptConst)
+	}
+
+	if distinct {
+		ret.AddStrictKey(cols)
+	}
+
+	// mapping deleted->equiv helps us keep keys whose removed cols
+	// have projected equivalents
+	equivMapping := make(map[ColumnId]ColumnId)
+	for _, set := range fds.equivs.Sets() {
+		if set.SubsetOf(cols) {
+			if ret.equivs == nil {
+				ret.equivs = &EquivSets{}
+			}
+			ret.AddEquivSet(set)
+		} else {
+			toKeep := set.Intersection(cols)
+			if toKeep.Empty() {
+				continue
+			}
+			if toRemove := set.Difference(cols); !toRemove.Empty() {
+				for i, ok := toRemove.Next(1); ok; i, ok = toRemove.Next(i + 1) {
+					equivMapping[i], _ = toKeep.Next(1)
+				}
+			}
+		}
+	}
+
+	for _, key := range fds.keys {
+		if key.cols.SubsetOf(cols) {
+			continue
+		}
+		toRemove := key.cols.Difference(cols)
+		newKey := key.cols.Intersection(cols)
+		allOk := true
+		var replace ColumnId
+		for i, ok := toRemove.Next(1); ok; i, ok = toRemove.Next(i + 1) {
+			replace, allOk = equivMapping[i]
+			if !allOk {
+				break
+			}
+			newKey.Add(replace)
+		}
+		if allOk {
+			ret.AddKey(Key{strict: key.strict, cols: newKey})
+		}
+	}
+
+	return ret
 }

--- a/sql/func_deps.go
+++ b/sql/func_deps.go
@@ -1,0 +1,186 @@
+package sql
+
+// EquivSets maintains equivalency sets
+type EquivSets struct {
+	sets []ColSet
+}
+
+func (e *EquivSets) Add(cols ColSet) {
+	for i := range e.sets {
+		set := e.sets[i]
+		if cols.SubsetOf(set) {
+			return
+		} else if set.Intersects(cols) {
+			set = set.Union(cols)
+			e.sets[i] = set
+			e.simplifyFromEditedSet(i)
+			return
+		}
+	}
+}
+
+func (e *EquivSets) simplifyFromEditedSet(j int) {
+	target := e.sets[j]
+	for i := j + 1; i < len(e.sets); i++ {
+		set := e.sets[i]
+		if set.Intersects(target) {
+			target = target.Union(set)
+			e.sets[j] = target
+			e.sets[i] = e.sets[len(e.sets)-1]
+			e.sets = e.sets[:len(e.sets)-1]
+		}
+	}
+}
+
+// Key maintains a strict or lax dependency
+type Key struct {
+	strict bool
+	cols   ColSet
+	// nullability is implicit, pass in SetNotNullCols
+}
+
+// FuncDepsSet encodes functional dependencies for a relational
+// expression. Common uses for functional dependencies:
+// - Do a set of equality columns comprise a strict key? (lookup joins)
+// - Is there a strict key for a relation? (decorrelate scopes)
+// - What are the set of equivalent filters? (join planning)
+//
+// This object expects fields to be set in the following order:
+// - notNull: what columns are non-nullable?
+// - consts: what columns are constant?
+// - equivs: transitive closure of column equivalence
+// - keys: primary and secondary keys, simplified
+type FuncDepsSet struct {
+	// non-null columns for relation
+	notNull ColSet
+	// tracks in-scope constants
+	consts ColSet
+	// tracks in-scope equivalent closure
+	equivs *EquivSets
+	// first key is the lead key
+	keys []Key
+}
+
+// Questions to answer:
+// - what columns are equivalent (building memo and spot filter)
+// - are filters redundant
+// - do the set of columns comprise a key? (do eq cols comprise index lookup)
+// - what is a strict key for the relation (subq decorrelation)
+
+// how to use constants for index lookup?
+
+// tagging expressions in join tree
+// - tables add colIds
+// - filters represented by colIds and converted back w/ indexing?
+
+// not null cols -- relProps collect non-null, set in FDs as one of last steps
+// would be really nice to be given nullability beforehand
+
+//todo
+// - Add strict key, lax key from table
+// - Add equivs from filter
+//   - strict key, lax key
+//   - fixup keys
+// - Add constant from column
+//   - fixup keys
+
+func (f *FuncDepsSet) AddNullable(cols ColSet) {
+	// must be called first
+	cols = f.simplifyCols(cols)
+	f.notNull = f.notNull.Union(cols)
+}
+
+func (f *FuncDepsSet) AddConstants(cols ColSet) {
+	// compute closure of all constants
+	// must be called after
+	f.consts = f.consts.Union(cols)
+}
+
+func (f *FuncDepsSet) AddEquiv(i, j ColumnId) {
+	cols := NewColSet(i, j)
+	f.equivs.Add(cols)
+
+	for _, set := range f.equivs.sets {
+		// if one col in equiv set is constant, rest are too
+		if set.Intersects(f.consts) {
+			f.AddConstants(set)
+		}
+	}
+}
+
+func (f *FuncDepsSet) AddStrictKey(cols ColSet) {
+	// simplify colSet
+	// add the key
+	// try to simplify the current best key
+	// update the best key (strict > lax, shorter better)
+	cols = f.simplifyCols(cols)
+	f.keys = append(f.keys, Key{cols: cols, strict: true})
+
+	if len(f.keys) > 1 {
+		lead := f.keys[0]
+		lead.cols = f.simplifyCols(lead.cols)
+		if !lead.strict || lead.strict && lead.cols.Len() > cols.Len() {
+			// strict > lax
+			// short > long
+			f.keys[0], f.keys[len(f.keys)-1] = f.keys[len(f.keys)-1], lead
+		}
+	}
+}
+
+func (f *FuncDepsSet) AddLaxKey(cols ColSet) {
+	// if all cols are not null, make strict
+	// simplifyColset
+	// add key
+	// would need not nulls to convert to strict key
+	// update best key
+	nullableCols := f.notNull.Difference(cols)
+	if nullableCols.Empty() {
+		f.AddStrictKey(cols)
+	}
+
+	cols = f.simplifyCols(cols)
+	f.keys = append(f.keys, Key{cols: cols, strict: false})
+	if len(f.keys) > 1 && !f.keys[0].strict {
+		// only try to improve if lax key
+		lead := f.keys[0]
+		lead.cols = f.simplifyCols(lead.cols)
+		if lead.cols.Len() > cols.Len() {
+			f.keys[0], f.keys[len(f.keys)-1] = f.keys[len(f.keys)-1], lead
+		}
+	}
+}
+
+// simplifyCols uses equivalence and constant sets to minimize
+// a key set
+func (f *FuncDepsSet) simplifyCols(key ColSet) ColSet {
+	// for each column, attempt to remove and verify
+	// the remaining set does not determine it
+	// i.e. check if removedCol is in closure of rest of set
+	ret := key.Copy()
+	var plucked ColSet
+	for i, ok := key.Next(0); ok; i, ok = key.Next(i) {
+		ret.Remove(i)
+		plucked.Add(i)
+		if !f.inClosureOf(plucked, ret) {
+			// plucked is novel
+			ret.Add(i)
+		}
+		plucked.Remove(i)
+	}
+	return ret
+}
+
+func (f *FuncDepsSet) inClosureOf(cols1, cols2 ColSet) bool {
+	if cols1.SubsetOf(cols2) {
+		return true
+	}
+	for _, set := range f.equivs.sets {
+		if set.Intersects(cols2) {
+			cols2 = cols2.Union(set)
+		}
+	}
+	if cols1.SubsetOf(cols2) {
+		return true
+	}
+	return false
+}

--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -1,6 +1,9 @@
 package sql
 
-import "testing"
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
 // tables: customer, warehouse
 // warehouse: id
@@ -49,6 +52,118 @@ type testFdOp struct {
 	args []ColumnId
 }
 
-func TestFuncDeps(t *testing.T) {
+func TestFuncDeps_A(t *testing.T) {
+	// create table customer (id primary key, wid int not null, did int not null, first varchar(10), last varchar(10))
+	// create table warehouse (id primary key)
+	cust := &FuncDepsSet{}
+	cust.AddNotNullable(cols(1, 2, 3))
+	// w.id = 1, c.did = 2, c.id = 2327
+	cust.AddConstants(cols(1, 3))
+	cust.AddStrictKey(cols(1))
+	cust.AddLaxKey(cols(2, 3))
 
+	ware := &FuncDepsSet{}
+	ware.AddConstants(cols(6))
+	ware.AddNotNullable(cols(6))
+	ware.AddStrictKey(cols(6))
+
+	// c.wid = w.id
+	ware.AddEquiv(2, 6)
+}
+
+func TestFuncDeps_CrossJoin(t *testing.T) {
+	// create table abcde (a primary key, b int, c int not null, d int not null, e int not null)
+	// create table mnpq (m primary key, n int, p int not null, q int not null)
+	abcde := &FuncDepsSet{}
+	abcde.AddNotNullable(cols(1))
+	abcde.AddStrictKey(cols(1))
+	abcde.AddLaxKey(cols(2, 3))
+
+	mnpq := &FuncDepsSet{}
+	mnpq.AddNotNullable(cols(6, 7))
+	mnpq.AddStrictKey(cols(6, 7))
+
+	join := NewCrossJoinFDs(abcde, mnpq)
+	assert.Equal(t, "key(1,6,7); lax-key(2,3)", join.String())
+
+}
+
+func TestFuncDeps_InnerJoin(t *testing.T) {
+	t.Run("abcde X mnpq", func(t *testing.T) {
+		// abcde JOIN mnpq ON a = m WHERE n = 2
+		abcde := &FuncDepsSet{}
+		abcde.AddNotNullable(cols(1))
+		abcde.AddStrictKey(cols(1))
+		abcde.AddLaxKey(cols(2, 3))
+
+		mnpq := &FuncDepsSet{}
+		mnpq.AddNotNullable(cols(6, 7))
+		mnpq.AddConstants(cols(7))
+		mnpq.AddStrictKey(cols(6, 7))
+
+		join := NewInnerJoinFDs(abcde, mnpq, [][2]ColumnId{{1, 6}})
+		assert.Equal(t, "key(6); constant(7); equiv(1,6); lax-key(2,3)", join.String())
+	})
+
+	t.Run("ware X cust", func(t *testing.T) {
+		// create table customer (id primary key, did not null, wid int not null, first varchar(10), last varchar(10))
+		// create table warehouse (id primary key)
+
+		// c.wid = w.id
+		// SELECT * from cust join ware
+		// ON c_w_id = w_id AND
+		// WHERE w_id = 1 AND c_d_id = 2 AND c_id = 2327
+
+		cust := &FuncDepsSet{}
+		cust.AddNotNullable(cols(1, 2, 3))
+		cust.AddConstants(cols(1, 2))
+		cust.AddStrictKey(cols(3, 2, 1))
+		cust.AddLaxKey(cols(3, 2, 4, 5))
+
+		ware := &FuncDepsSet{}
+		ware.AddNotNullable(cols(6))
+		ware.AddConstants(cols(6))
+		ware.AddStrictKey(cols(6))
+
+		join := NewInnerJoinFDs(cust, ware, [][2]ColumnId{{3, 6}})
+		assert.Equal(t, "key(); constant(1-3,6); equiv(3,6); lax-key(4,5)", join.String())
+	})
+}
+
+func TestFuncDeps_Project(t *testing.T) {
+	t.Run("project const via equiv", func(t *testing.T) {
+		{
+			// a == b, a const, proj(b) => maintian const(b)
+			fds := &FuncDepsSet{}
+			fds.AddConstants(cols(1))
+			fds.AddEquiv(1, 2)
+			proj := NewProjectFDs(fds, cols(2), false)
+			assert.Equal(t, "(2)", proj.Constants().String())
+		}
+	})
+	t.Run("project pk via equiv", func(t *testing.T) {
+		{
+			// pk(a,b), a == c, prok(b,c) => maintain pk(c,b)
+			fds := &FuncDepsSet{}
+			fds.AddEquiv(1, 3)
+			fds.AddStrictKey(cols(1, 2))
+			proj := NewProjectFDs(fds, cols(2, 3), false)
+			assert.Equal(t, "key(2,3)", proj.String())
+		}
+
+	})
+	t.Run("distinct project adds strict key", func(t *testing.T) {
+
+	})
+	t.Run("columns preserved", func(t *testing.T) {
+		// a == b, b == c, proj(a,c) maintains a == c
+	})
+}
+
+func TestFuncDeps_LeftJoin(t *testing.T) {
+
+}
+
+func cols(vals ...ColumnId) ColSet {
+	return NewColSet(vals...)
 }

--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -6,42 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// tables: customer, warehouse
-// warehouse: id
-// customer: id, wid, did
-//
-// select * from customer c
-// join warehouse w
-// on w.id = c.wid
-// where
-//   w.id = 1 and
-//   c.did = 2 and
-//   c.id = 2327
-//
-// need:
-//  - add table -> pk
-//  - add constant filter
-//  - is not null filters
-//  - join condition
-//
-// add warehouse (keys)
-//  - (id)
-// add customer (keys)
-//  - (wid, did, id)
-//  - (wid, did, lastname, firstname)
-// add join (join conditions)
-//  - w.id = c.wid
-// add constant (remove determinants)
-//  - c.id = 2327 => (customer pk to (wid, did))
-//  - c.did = 2 => (customer pk to (wid))
-//  - w.id = 1 => (equivalence => c.wid = 1), warehouse pk to ())
-//  - (eq) c.wid = 1 => (customer pk to ())
-//
-// prereq:
-//  - columnId in memo
-
-type testFdProp uint16
-
 func TestFuncDeps_Project(t *testing.T) {
 	t.Run("project const via equiv", func(t *testing.T) {
 		{
@@ -96,18 +60,33 @@ func TestFuncDeps_Project(t *testing.T) {
 func TestFuncDeps_CrossJoin(t *testing.T) {
 	// create table abcde (a primary key, b int, c int not null, d int not null, e int not null)
 	// create table mnpq (m primary key, n int, p int not null, q int not null)
-	abcde := &FuncDepsSet{}
-	abcde.AddNotNullable(cols(1))
-	abcde.AddStrictKey(cols(1))
-	abcde.AddLaxKey(cols(2, 3))
+	t.Run("cross product", func(t *testing.T) {
+		abcde := &FuncDepsSet{}
+		abcde.AddNotNullable(cols(1))
+		abcde.AddStrictKey(cols(1))
+		abcde.AddLaxKey(cols(2, 3))
 
-	mnpq := &FuncDepsSet{}
-	mnpq.AddNotNullable(cols(6, 7))
-	mnpq.AddStrictKey(cols(6, 7))
+		mnpq := &FuncDepsSet{}
+		mnpq.AddNotNullable(cols(6, 7))
+		mnpq.AddStrictKey(cols(6, 7))
 
-	join := NewCrossJoinFDs(abcde, mnpq)
-	assert.Equal(t, "key(1,6,7); lax-fd(2,3)", join.String())
+		join := NewCrossJoinFDs(abcde, mnpq)
+		assert.Equal(t, "key(1,6,7); lax-fd(2,3)", join.String())
+	})
+	t.Run("cross product one-sided equiv", func(t *testing.T) {
+		abcde := &FuncDepsSet{}
+		abcde.AddNotNullable(cols(1))
+		abcde.AddEquiv(1, 5)
+		abcde.AddStrictKey(cols(1))
+		abcde.AddLaxKey(cols(2, 3))
 
+		mnpq := &FuncDepsSet{}
+		mnpq.AddNotNullable(cols(6, 7))
+		mnpq.AddStrictKey(cols(6, 7))
+
+		join := NewCrossJoinFDs(abcde, mnpq)
+		assert.Equal(t, "key(1,6,7); equiv(1,5); lax-fd(2,3)", join.String())
+	})
 }
 
 func TestFuncDeps_InnerJoin(t *testing.T) {
@@ -153,8 +132,7 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 }
 
 func TestFuncDeps_LeftJoin(t *testing.T) {
-	t.Run("left join w filter", func(t *testing.T) {
-		//   SELECT * FROM abcde LEFT OUTER JOIN mnpq ON a = m and a = n
+	t.Run("preserved-side constants kept", func(t *testing.T) {
 		abcde := &FuncDepsSet{all: cols(1, 2, 3, 4, 5)}
 		abcde.AddNotNullable(cols(1))
 		abcde.AddStrictKey(cols(1))
@@ -162,12 +140,54 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 
 		mnpq := &FuncDepsSet{all: cols(6, 7, 8, 9)}
 		mnpq.AddNotNullable(cols(6, 7))
-		mnpq.AddConstants(cols(7))
+		mnpq.AddConstants(cols(8, 9))
 		mnpq.AddStrictKey(cols(6, 7))
 
-		//join := NewLeftJoinFDs(abcde, mnpq, [][2]ColumnId{{1,6},{1,7}})
+		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
+		assert.Equal(t, "key(1,6,7); constant(8,9); fd(6,7); fd(1); lax-fd(2,3); fd(6,7)", join.String())
+	})
+	t.Run("preserved-side equiv constants kept", func(t *testing.T) {
+		abcde := &FuncDepsSet{all: cols(1, 2, 3, 4, 5)}
+		abcde.AddNotNullable(cols(1))
+		abcde.AddStrictKey(cols(1))
+		abcde.AddLaxKey(cols(2, 3))
+
+		mnpq := &FuncDepsSet{all: cols(6, 7, 8, 9)}
+		mnpq.AddNotNullable(cols(6, 7))
+		mnpq.AddEquiv(8, 9)
+		mnpq.AddConstants(cols(8))
+		mnpq.AddStrictKey(cols(6, 7))
+
+		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
+		assert.Equal(t, "key(1,6,7); constant(8,9); equiv(8,9); fd(6,7); fd(1); lax-fd(2,3); fd(6,7)", join.String())
+	})
+	t.Run("preserved-side key constants kept", func(t *testing.T) {
+		abcde := &FuncDepsSet{all: cols(1, 2, 3, 4, 5)}
+		abcde.AddNotNullable(cols(1))
+		abcde.AddStrictKey(cols(1))
+		abcde.AddLaxKey(cols(2, 3))
+
+		mnpq := &FuncDepsSet{all: cols(6, 7, 8, 9)}
+		mnpq.AddNotNullable(cols(6, 7))
+		mnpq.AddConstants(cols(6, 8, 9))
+		mnpq.AddStrictKey(cols(6, 7))
+
+		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
+		assert.Equal(t, "key(1,7); constant(6,8,9); fd(7); fd(1); lax-fd(2,3); fd(7)", join.String())
 	})
 	t.Run("null-project side constants removed", func(t *testing.T) {
+		abcde := &FuncDepsSet{all: cols(1, 2, 3, 4, 5)}
+		abcde.AddNotNullable(cols(1))
+		abcde.AddStrictKey(cols(1))
+		abcde.AddConstants(cols(3, 4))
+		abcde.AddLaxKey(cols(2, 3))
+
+		mnpq := &FuncDepsSet{all: cols(6, 7, 8, 9)}
+		mnpq.AddNotNullable(cols(6, 7))
+		mnpq.AddStrictKey(cols(6, 7))
+
+		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
+		assert.Equal(t, "key(1,6,7); fd(6,7); fd(1); lax-fd(2); fd(6,7)", join.String())
 	})
 	t.Run("equiv on both sides", func(t *testing.T) {
 		abcde := &FuncDepsSet{all: cols(1, 2, 3, 4, 5)}
@@ -211,10 +231,6 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 6}, {1, 2}})
 		assert.Equal(t, "key(6,7); fd(1); lax-fd(2,3); fd(6,7)", join.String())
-	})
-	t.Run("project const via equiv", func(t *testing.T) {
-		//   SELECT * FROM (SELECT * FROM abcde WHERE b=1) FULL JOIN mnpq ON True
-		//   SELECT * FROM abcde LEFT OUTER JOIN (SELECT *, p+q FROM mnpq) ON True
 	})
 }
 

--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -1,0 +1,54 @@
+package sql
+
+import "testing"
+
+// tables: customer, warehouse
+// warehouse: id
+// customer: id, wid, did
+//
+// select * from customer c
+// join warehouse w
+// on w.id = c.wid
+// where
+//   w.id = 1 and
+//   c.did = 2 and
+//   c.id = 2327
+//
+// need:
+//  - add table -> pk
+//  - add constant filter
+//  - is not null filters
+//  - join condition
+//
+// add warehouse (keys)
+//  - (id)
+// add customer (keys)
+//  - (wid, did, id)
+//  - (wid, did, lastname, firstname)
+// add join (join conditions)
+//  - w.id = c.wid
+// add constant (remove determinants)
+//  - c.id = 2327 => (customer pk to (wid, did))
+//  - c.did = 2 => (customer pk to (wid))
+//  - w.id = 1 => (equivalence => c.wid = 1), warehouse pk to ())
+//  - (eq) c.wid = 1 => (customer pk to ())
+//
+// prereq:
+//  - columnId in memo
+
+type testFdProp uint16
+
+const (
+	fdTablescan testFdProp = iota + 1
+	fdInnerJoin
+	fdEq
+)
+
+type testFdOp struct {
+	prop testFdProp
+	args []ColumnId
+}
+
+func TestFuncDeps(t *testing.T) {
+
+}


### PR DESCRIPTION
Functional dependencies track 1) key uniqueness, constant propagation, column equivalence, nullability sets.

This information is built bottom-up from tables scans through projections, and is used to answer certain questions about relational nodes:

1) What is the equivalence closure for a join condition?
2) Are a set of filters redundant?
3) Do a set of index expressions comprise a strict key for a LOOKUP_JOIN?
4) Does a subquery decorrelation scope have a strict/null-safe key for an ANTI_JOIN?
5) Are the grouping columns a strict key of the table (only_full_group_by is unnecessary)
6) Is the relation sorted on a given column set? (is a Sort already enforced)
7) Is a relation constant? (Max1Row)

Questions (1) and (3) contribute towards fixing this issue: https://github.com/dolthub/dolt/issues/5993. Question (2) contributes to filter pruning. Question (4) is relevant for this issue: https://github.com/dolthub/dolt/issues/5954.

This master's thesis explains how to build the derivation graph starting at page 113: https://cs.uwaterloo.ca/research/tr/2000/11/CS-2000-11.thesis.pdf. The graph is composed of `(determinant) -> (dependent)` relationships on columns to track these properties. They color edges and nodes to differentiate constant, nullability, equivalence attributes. Any set of of columns uniquely determines the value of constants, so they have empty determinants: `() -> (colSet)`. We differentiate strict keys (set of columns unique and non-nullable index) from lax keys (index that maybe be non-unique or nullable).

Cockroach implemented a version that uses flattened to/from sets rather than individual nodes for determinant/dependents, and makes optimizations for quickly computing candidate keys: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/opt/props/func_dep.go.

My encoding is a little different. First, I assume that attributes trickle down from nullability -> constant -> equivalence -> functional dependencies. An FD built in this order simplifies the upstream additions in a way that avoids having to recompute dependency closures (ex: nullability, constant, and equiv columns don't recompute keys). Second, I assume FDs will be limited to primary and secondary key indexes; keys will have either strict or lax determinants, and the dependents are always assumed to be the rest of the table. So far this drops LEFT_JOIN right-equivalence relations that translate to lax-keys after the join, which could opportunistically be converted back to strict keys by downstream operators. If this was a mistake we can undo that, add back in dependent column sets.

We need to support a handful of operators to use FDs in the join memo:
- Table scan
- Cross join
- Inner join
- Left join
- Project (Distinct)
- Filter

Missing:
- Full outer join
- Synthesized columns

Additionally:
- the memo needs to embed equal filters in a format with expression ids
- join reordering should compute equivalence closures for join edges
- join selection should use functional dependencies to check if lookup expressions are valid

Missing practical considerations:
- when we determine a lookup expression comprises a strict key for a table, we need a way to backfill constants and equivalences used to make that decision
- filters should maybe be represented in memo selection nodes to support redundancy elimination