### PR TITLE
Reworked implicit PK handling for referenced foreign keys

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -1884,7 +1884,7 @@ var ForeignKeyTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "foreign key prefix matches primary key",
+		Name: "Referenced index includes implicit primary key columns",
 		SetUpScript: []string{
 			"create table parent1 (fk1 int, pk1 int, pk2 int, pk3 int, primary key(pk1, pk2, pk3), index (fk1, pk2));",
 			"insert into parent1 values (0, 1, 2, 3);",
@@ -1943,7 +1943,6 @@ var ForeignKeyTests = []ScriptTest{
 				Query:       "insert into child1 values (0, 99, 99, 99);",
 				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
-
 			{
 				Query: "alter table child2 add constraint fk2 foreign key (fk1, pk2, pk1) references parent1 (fk1, pk2, pk1);",
 				Expected: []sql.Row{
@@ -1980,7 +1979,6 @@ var ForeignKeyTests = []ScriptTest{
 				Query:       "insert into child2 values (0, 99, 2, 99);",
 				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
-
 			{
 				Query: "alter table child3 add constraint fk3 foreign key (fk1, pk2, pk1, pk3) references parent1 (fk1, pk2, pk1, pk3);",
 				Expected: []sql.Row{
@@ -2011,9 +2009,7 @@ var ForeignKeyTests = []ScriptTest{
 				Query:       "insert into child3 values (0, 1, 2, 99);",
 				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
-
-			// although idx4 would be a valid index, it is not used for the foreign key fk4
-			{
+			{ // although idx4 would be a valid index, it is not used for the foreign key fk4
 				Query: "alter table child4 add constraint fk4 foreign key (fk1, pk2, pk1, pk3) references parent1 (fk1, pk2, pk1, pk3);",
 				Expected: []sql.Row{
 					{types.NewOkResult(0)},
@@ -2034,8 +2030,7 @@ var ForeignKeyTests = []ScriptTest{
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
-			// idx4 satisfies the foreign key fk5
-			{
+			{ // idx4 satisfies the foreign key fk5
 				Query: "alter table child4 add constraint fk5 foreign key (fk1) references parent1 (fk1);",
 				Expected: []sql.Row{
 					{types.NewOkResult(0)},

--- a/sql/expression/filter-range.go
+++ b/sql/expression/filter-range.go
@@ -34,8 +34,8 @@ func NewRangeFilterExpr(exprs []sql.Expression, ranges []sql.Range) (sql.Express
 
 	var rangeCollectionExpr sql.Expression
 	for rangIdx, rang := range ranges {
-		if len(rang) > len(exprs) {
-			return nil, fmt.Errorf("expected different key count: exprs(%d) != (ranges[%d])(%d)", len(exprs), rangIdx, len(rang))
+		if len(exprs) < len(rang) {
+			return nil, fmt.Errorf("expected different key count: exprs(%d) < (ranges[%d])(%d)", len(exprs), rangIdx, len(rang))
 		}
 		var rangeExpr sql.Expression
 		for i, rce := range rang {

--- a/sql/index.go
+++ b/sql/index.go
@@ -85,6 +85,21 @@ type Index interface {
 	PrefixLengths() []uint16
 }
 
+// ExtendedIndex is an extension of Index, that allows access to appended primary keys. MySQL internally represents an
+// index as the collection of all explicitly referenced columns, while appending any unreferenced primary keys to the
+// end (in order of their declaration). For full MySQL compatibility, integrators are encouraged to mimic this, however
+// not all implementations may define their indexes (on tables with primary keys) in this way, therefore this interface
+// is optional.
+type ExtendedIndex interface {
+	Index
+	// ExtendedExpressions returns the same result as Expressions, but appends any primary keys that are implicitly in
+	// the index. The appended primary keys are in declaration order.
+	ExtendedExpressions() []string
+	// ExtendedColumnExpressionTypes returns the same result as ColumnExpressionTypes, but appends the type of any
+	// primary keys that are implicitly in the index. The appended primary keys are in declaration order.
+	ExtendedColumnExpressionTypes() []ColumnExpressionType
+}
+
 // IndexLookup is the implementation-specific definition of an index lookup. The IndexLookup must contain all necessary
 // information to retrieve exactly the rows in the table as specified by the ranges given to their parent index.
 // Implementors are responsible for all semantics of correctly returning rows that match an index lookup.

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -183,26 +183,15 @@ func ResolveForeignKey(ctx *sql.Context, tbl sql.ForeignKeyTable, refTbl sql.For
 		}
 
 		// Ensure that a suitable index exists on the referenced table, and check the declaring table for a suitable index.
-		refTblIndex, ok, err := FindIndexWithPrefix(ctx, refTbl, fkDef.ParentColumns)
+		refTblIndex, ok, err := FindIndexWithPrefix(ctx, refTbl, fkDef.ParentColumns, true)
 		if err != nil {
 			return err
 		}
 		if !ok {
 			return sql.ErrForeignKeyMissingReferenceIndex.New(fkDef.Name, fkDef.ParentTable)
 		}
-		var refTblPk sql.Index
-		if idxs, err := refTbl.GetIndexes(ctx); err != nil {
-			return err
-		} else {
-			for _, idx := range idxs {
-				if idx.ID() == "PRIMARY" {
-					refTblPk = idx
-					break
-				}
-			}
-		}
 
-		indexPositions, appendTypes, err := FindForeignKeyColMapping(ctx, fkDef.Name, tbl, fkDef.Columns, fkDef.ParentColumns, refTblIndex, refTblPk)
+		indexPositions, appendTypes, err := FindForeignKeyColMapping(ctx, fkDef.Name, tbl, fkDef.Columns, fkDef.ParentColumns, refTblIndex)
 		if err != nil {
 			return err
 		}
@@ -246,11 +235,7 @@ func ResolveForeignKey(ctx *sql.Context, tbl sql.ForeignKeyTable, refTbl sql.For
 		}
 	}
 
-	// child table requires strict prefix
-	idx, ok, err := FindIndexWithPrefix(ctx, tbl, fkDef.Columns)
-	if ok && len(idx.Expressions()) < len(fkDef.Columns) {
-		ok = false
-	}
+	_, ok, err := FindIndexWithPrefix(ctx, tbl, fkDef.Columns, false)
 	if err != nil {
 		return err
 	}
@@ -389,7 +374,7 @@ func FindForeignKeyColMapping(
 	localTbl sql.ForeignKeyTable,
 	localFKCols []string,
 	destFKCols []string,
-	index, pkIndex sql.Index,
+	index sql.Index,
 ) ([]int, []sql.Type, error) {
 	localFKCols = lowercaseSlice(localFKCols)
 	destFKCols = lowercaseSlice(destFKCols)
@@ -405,8 +390,13 @@ func FindForeignKeyColMapping(
 	var appendTypes []sql.Type
 	indexTypeMap := make(map[string]sql.Type)
 	indexColMap := make(map[string]int)
-	indexColExprTypes := index.ColumnExpressionTypes()
-	for i, indexCol := range indexColExprTypes {
+	var columnExpressionTypes []sql.ColumnExpressionType
+	if extendedIndex, ok := index.(sql.ExtendedIndex); ok {
+		columnExpressionTypes = extendedIndex.ExtendedColumnExpressionTypes()
+	} else {
+		columnExpressionTypes = index.ColumnExpressionTypes()
+	}
+	for i, indexCol := range columnExpressionTypes {
 		indexColName := strings.ToLower(indexCol.Expression)
 		indexTypeMap[indexColName] = indexCol.Type
 		indexColMap[indexColName] = i
@@ -414,23 +404,6 @@ func FindForeignKeyColMapping(
 			appendTypes = append(appendTypes, indexCol.Type)
 		}
 	}
-	// TODO: concat primary key? not always??
-	if pkIndex != nil {
-		i := len(indexColExprTypes)
-		for _, indexCol := range pkIndex.ColumnExpressionTypes() {
-			indexColName := strings.ToLower(indexCol.Expression)
-			if _, ok := indexColMap[indexColName]; ok {
-				continue
-			}
-			indexTypeMap[indexColName] = indexCol.Type
-			indexColMap[indexColName] = i
-			if i >= len(destFKCols) {
-				appendTypes = append(appendTypes, indexCol.Type)
-			}
-			i++
-		}
-	}
-
 	indexPositions := make([]int, len(destFKCols))
 
 	for fkIdx, colName := range localFKCols {
@@ -470,7 +443,11 @@ func FindForeignKeyColMapping(
 // prefix. For example, the slices [col1, col2] and [col2, col1] will match the same index, as their ordering does not
 // matter. The index [col1, col2, col3] would match, but the index [col1, col3] would not match as it is missing "col2".
 // Prefix columns are case-insensitive.
-func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexAddressableTable, prefixCols []string, ignoredIndexes ...string) (sql.Index, bool, error) {
+//
+// If `useExtendedIndexes` is true, then this will include any implicit primary keys that were not explicitly defined on
+// the index. Some operations only consider explicitly indexed columns, while others also consider any implicit primary
+// keys as well, therefore this is a boolean to control the desired behavior.
+func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexAddressableTable, prefixCols []string, useExtendedIndexes bool, ignoredIndexes ...string) (sql.Index, bool, error) {
 	type idxWithLen struct {
 		sql.Index
 		colLen int
@@ -485,12 +462,12 @@ func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexAddressableTable, prefix
 	if err != nil {
 		return nil, false, err
 	}
-	// ignore indexes with prefix lengths; they are unsupported in MySQL
+	// Ignore indexes with prefix lengths; they are unsupported in MySQL
 	// https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html#:~:text=Index%20prefixes%20on%20foreign%20key%20columns%20are%20not%20supported.
-	// ignore spatial indexes; MySQL will not pick them as the underlying secondary index for foreign keys
+	// Ignore spatial indexes; MySQL will not pick them as the underlying secondary index for foreign keys
 	for _, idx := range indexes {
 		if len(idx.PrefixLengths()) > 0 || idx.IsSpatial() {
-			ignoredIndexesMap[idx.ID()] = struct{}{}
+			ignoredIndexesMap[strings.ToLower(idx.ID())] = struct{}{}
 		}
 	}
 	tblName := strings.ToLower(tbl.Name())
@@ -498,23 +475,19 @@ func FindIndexWithPrefix(ctx *sql.Context, tbl sql.IndexAddressableTable, prefix
 	for i, prefixCol := range prefixCols {
 		exprCols[i] = tblName + "." + strings.ToLower(prefixCol)
 	}
-
-	var primaryIdxExprs []string
-	for _, idx := range indexes {
-		if idx.ID() == "PRIMARY" {
-			primaryIdxExprs = lowercaseSlice(idx.Expressions())
-			break
-		}
-	}
-
 	colLen := len(exprCols)
 	var indexesWithLen []idxWithLen
 	for _, idx := range indexes {
 		if _, ok := ignoredIndexesMap[strings.ToLower(idx.ID())]; ok {
 			continue
 		}
-		indexExprs := lowercaseSlice(idx.Expressions())
-		if ok := exprsAreIndexPrefix(exprCols, indexExprs, primaryIdxExprs); ok {
+		var indexExprs []string
+		if extendedIdx, ok := idx.(sql.ExtendedIndex); ok && useExtendedIndexes {
+			indexExprs = lowercaseSlice(extendedIdx.ExtendedExpressions())
+		} else {
+			indexExprs = lowercaseSlice(idx.Expressions())
+		}
+		if ok := exprsAreIndexPrefix(exprCols, indexExprs); ok {
 			indexesWithLen = append(indexesWithLen, idxWithLen{idx, len(indexExprs)})
 		}
 	}
@@ -569,18 +542,7 @@ func foreignKeyComparableTypes(ctx *sql.Context, type1 sql.Type, type2 sql.Type)
 }
 
 // exprsAreIndexPrefix returns whether the given expressions are a prefix of the given index expressions
-func exprsAreIndexPrefix(exprs, indexExprs, primaryIndexExprs []string) bool {
-	indexExprsMap := make(map[string]struct{})
-	for _, e := range indexExprs {
-		indexExprsMap[e] = struct{}{}
-	}
-
-	for _, e := range primaryIndexExprs {
-		if _, ok := indexExprsMap[e]; !ok {
-			indexExprs = append(indexExprs, e)
-		}
-	}
-
+func exprsAreIndexPrefix(exprs, indexExprs []string) bool {
 	if len(exprs) > len(indexExprs) {
 		return false
 	}

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -1816,7 +1816,7 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 				return err
 			}
 			for _, fk := range fks {
-				_, ok, err := plan.FindIndexWithPrefix(ctx, fkTable, fk.Columns, n.IndexName)
+				_, ok, err := plan.FindIndexWithPrefix(ctx, fkTable, fk.Columns, false, n.IndexName)
 				if err != nil {
 					return err
 				}
@@ -1830,7 +1830,7 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 				return err
 			}
 			for _, parentFk := range parentFks {
-				_, ok, err := plan.FindIndexWithPrefix(ctx, fkTable, parentFk.ParentColumns, n.IndexName)
+				_, ok, err := plan.FindIndexWithPrefix(ctx, fkTable, parentFk.ParentColumns, true, n.IndexName)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Builds on https://github.com/dolthub/go-mysql-server/pull/1798, introduces an interface which exposes internal (and implicit) primary keys on indexes. Not all integrators will have the functionality, so it's an optional interface to expand compatibility. Also quite a bit simpler.