### PR TITLE
Add support for JSON `->` and `->>` operators

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -333,6 +333,35 @@ var JsonScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "JSON -> and ->> operator support",
+		SetUpScript: []string{
+			"create table t (pk int primary key, col1 JSON);",
+			`insert into t values (1, JSON_OBJECT('key1', 1, 'key2', '"abc"'));`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    `select col1->'$.key1' from t;`,
+				Expected: []sql.Row{{types.JSONDocument{Val: 1}}},
+			},
+			{
+				Query:    `select col1->>'$.key2' from t;`,
+				Expected: []sql.Row{{"abc"}},
+			},
+			{
+				Query:    `select * from t where col1->'$.key1' = 1;`,
+				Expected: []sql.Row{{1, types.JSONDocument{Val: map[string]interface{}{"key1": 1, "key2": "\"abc\""}}}},
+			},
+			{
+				Query:    `select * from t where col1->>'$.key2' = 'abc';`,
+				Expected: []sql.Row{{1, types.JSONDocument{Val: map[string]interface{}{"key1": 1, "key2": "\"abc\""}}}},
+			},
+			{
+				Query:    `select * from t where col1->>'$.key2' = 'def';`,
+				Expected: []sql.Row{},
+			},
+		},
+	},
 	// from https://dev.mysql.com/doc/refman/8.0/en/json.html#json-converting-between-types:~:text=information%20and%20examples.-,Comparison%20and%20Ordering%20of%20JSON%20Values,-JSON%20values%20can
 	{
 		Name: "json is ordered correctly",

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -345,7 +345,7 @@ var JsonScripts = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    `select col1->'$.key1' from t;`,
-				Expected: []sql.Row{{types.JSONDocument{Val: 1}}, {types.JSONDocument{Val: 100}}},
+				Expected: []sql.Row{{types.MustJSON("1")}, {types.MustJSON("100")}},
 			},
 			{
 				Query:    `select col1->>'$.key2' from t;`,
@@ -353,11 +353,11 @@ var JsonScripts = []ScriptTest{
 			},
 			{
 				Query:    `select pk, col1 from t where col1->'$.key1' = 1;`,
-				Expected: []sql.Row{{1, types.JSONDocument{Val: map[string]interface{}{"key1": 1, "key2": "\"abc\""}}}},
+				Expected: []sql.Row{{1, types.MustJSON(`{"key1":1, "key2":"\"abc\""}`)}},
 			},
 			{
 				Query:    `select pk, col1 from t where col1->>'$.key2' = 'abc';`,
-				Expected: []sql.Row{{1, types.JSONDocument{Val: map[string]interface{}{"key1": 1, "key2": "\"abc\""}}}},
+				Expected: []sql.Row{{1, types.MustJSON(`{"key1":1, "key2":"\"abc\""}`)}},
 			},
 			{
 				Query:    `select * from t where col1->>'$.key2' = 'def';`,
@@ -365,11 +365,11 @@ var JsonScripts = []ScriptTest{
 			},
 			{
 				Query:    `SELECT col2->"$[3]", col2->>"$[3]" FROM t;`,
-				Expected: []sql.Row{{types.JSONDocument{Val: 17}, "17"}, {types.JSONDocument{Val: 17}, "17"}},
+				Expected: []sql.Row{{types.MustJSON("17"), "17"}, {types.MustJSON("17"), "17"}},
 			},
 			{
 				Query:    `SELECT col2->"$[4]", col2->>"$[4]" FROM t where pk=1;`,
-				Expected: []sql.Row{{types.JSONDocument{Val: "z"}, "z"}},
+				Expected: []sql.Row{{types.MustJSON("\"z\""), "z"}},
 			},
 			{
 				// TODO: JSON_Extract doesn't seem able to handle a JSON path expression that references a nested array

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -336,29 +336,45 @@ var JsonScripts = []ScriptTest{
 	{
 		Name: "JSON -> and ->> operator support",
 		SetUpScript: []string{
-			"create table t (pk int primary key, col1 JSON);",
-			`insert into t values (1, JSON_OBJECT('key1', 1, 'key2', '"abc"'));`,
+			"create table t (pk int primary key, col1 JSON, col2 JSON);",
+			`insert into t values (1, JSON_OBJECT('key1', 1, 'key2', '"abc"'), JSON_ARRAY(3,10,5,17,"z"));`,
+			`insert into t values (2, JSON_OBJECT('key1', 100, 'key2', '"ghi"'), JSON_ARRAY(3,10,5,17,JSON_ARRAY(22,"y",66)));`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    `select col1->'$.key1' from t;`,
-				Expected: []sql.Row{{types.JSONDocument{Val: 1}}},
+				Expected: []sql.Row{{types.JSONDocument{Val: 1}}, {types.JSONDocument{Val: 100}}},
 			},
 			{
 				Query:    `select col1->>'$.key2' from t;`,
-				Expected: []sql.Row{{"abc"}},
+				Expected: []sql.Row{{"abc"}, {"ghi"}},
 			},
 			{
-				Query:    `select * from t where col1->'$.key1' = 1;`,
+				Query:    `select pk, col1 from t where col1->'$.key1' = 1;`,
 				Expected: []sql.Row{{1, types.JSONDocument{Val: map[string]interface{}{"key1": 1, "key2": "\"abc\""}}}},
 			},
 			{
-				Query:    `select * from t where col1->>'$.key2' = 'abc';`,
+				Query:    `select pk, col1 from t where col1->>'$.key2' = 'abc';`,
 				Expected: []sql.Row{{1, types.JSONDocument{Val: map[string]interface{}{"key1": 1, "key2": "\"abc\""}}}},
 			},
 			{
 				Query:    `select * from t where col1->>'$.key2' = 'def';`,
 				Expected: []sql.Row{},
+			},
+			{
+				Query:    `SELECT col2->"$[3]", col2->>"$[3]" FROM t;`,
+				Expected: []sql.Row{{types.JSONDocument{Val: 17}, "17"}, {types.JSONDocument{Val: 17}, "17"}},
+			},
+			{
+				Query:    `SELECT col2->"$[4]", col2->>"$[4]" FROM t where pk=1;`,
+				Expected: []sql.Row{{types.JSONDocument{Val: "z"}, "z"}},
+			},
+			{
+				// TODO: JSON_Extract doesn't seem able to handle a JSON path expression that references a nested array
+				//       This errors with "object is not Slice"
+				Skip:     true,
+				Query:    `SELECT col2->>"$[3]", col2->>"$[4][0]" FROM t;`,
+				Expected: []sql.Row{{17, 44}, {17, "y"}},
 			},
 		},
 	},

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -339,6 +339,8 @@ var JsonScripts = []ScriptTest{
 			"create table t (pk int primary key, col1 JSON, col2 JSON);",
 			`insert into t values (1, JSON_OBJECT('key1', 1, 'key2', '"abc"'), JSON_ARRAY(3,10,5,17,"z"));`,
 			`insert into t values (2, JSON_OBJECT('key1', 100, 'key2', '"ghi"'), JSON_ARRAY(3,10,5,17,JSON_ARRAY(22,"y",66)));`,
+			`CREATE TABLE t2 (i INT PRIMARY KEY, j JSON);`,
+			`INSERT INTO t2 VALUES (0, '{"a": "123", "outer": {"inner": 456}}');`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -375,6 +377,10 @@ var JsonScripts = []ScriptTest{
 				Skip:     true,
 				Query:    `SELECT col2->>"$[3]", col2->>"$[4][0]" FROM t;`,
 				Expected: []sql.Row{{17, 44}, {17, "y"}},
+			},
+			{
+				Query:    `SELECT k->"$.inner" from (SELECT j->"$.outer" AS k FROM t2) sq;`,
+				Expected: []sql.Row{{types.MustJSON("456")}},
 			},
 		},
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25,6 +25,34 @@ type QueryPlanTest struct {
 // in testgen_test.go.
 var PlanTests = []QueryPlanTest{
 	{
+		Query: `SELECT col1->'$.key1' from (SELECT JSON_OBJECT('key1', 1, 'key2', 'abc')) as dt(col1);`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [json_extract(dt.col1, '$.key1') as col1->'$.key1']\n" +
+			" └─ SubqueryAlias\n" +
+			"     ├─ name: dt\n" +
+			"     ├─ outerVisibility: false\n" +
+			"     ├─ cacheable: true\n" +
+			"     └─ Project\n" +
+			"         ├─ columns: [json_object('key1',1,'key2','abc') as JSON_OBJECT('key1', 1, 'key2', 'abc')]\n" +
+			"         └─ Table\n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n",
+	},
+	{
+		Query: `SELECT col1->>'$.key1' from (SELECT JSON_OBJECT('key1', 1, 'key2', 'abc')) as dt(col1);`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [json_unquote(json_extract(dt.col1, '$.key1')) as col1->>'$.key1']\n" +
+			" └─ SubqueryAlias\n" +
+			"     ├─ name: dt\n" +
+			"     ├─ outerVisibility: false\n" +
+			"     ├─ cacheable: true\n" +
+			"     └─ Project\n" +
+			"         ├─ columns: [json_object('key1',1,'key2','abc') as JSON_OBJECT('key1', 1, 'key2', 'abc')]\n" +
+			"         └─ Table\n" +
+			"             ├─ name: \n" +
+			"             └─ columns: []\n",
+	},
+	{
 		Query: `
 Select x
 from (select * from xy) sq1

--- a/sql/expression/function/json_extract.go
+++ b/sql/expression/function/json_extract.go
@@ -53,11 +53,6 @@ func (j *JSONExtract) Description() string {
 	return "returns data from JSON document"
 }
 
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONExtract) IsUnsupported() bool {
-	return true
-}
-
 // Resolved implements the sql.Expression interface.
 func (j *JSONExtract) Resolved() bool {
 	for _, p := range j.Paths {

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -4613,9 +4613,8 @@ func binaryExprToExpression(ctx *sql.Context, be *sqlparser.BinaryExpr) (sql.Exp
 
 		if operator == sqlparser.JSONUnquoteExtractOp {
 			return function.NewJSONUnquote(jsonExtract), nil
-		} else {
-			return jsonExtract, nil
 		}
+		return jsonExtract, nil
 
 	default:
 		return nil, sql.ErrUnsupportedFeature.New(be.Operator)

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -4557,7 +4557,18 @@ func unaryExprToExpression(ctx *sql.Context, e *sqlparser.UnaryExpr) (sql.Expres
 }
 
 func binaryExprToExpression(ctx *sql.Context, be *sqlparser.BinaryExpr) (sql.Expression, error) {
-	switch strings.ToLower(be.Operator) {
+	l, err := ExprToExpression(ctx, be.Left)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := ExprToExpression(ctx, be.Right)
+	if err != nil {
+		return nil, err
+	}
+
+	operator := strings.ToLower(be.Operator)
+	switch operator {
 	case
 		sqlparser.PlusStr,
 		sqlparser.MinusStr,
@@ -4571,16 +4582,6 @@ func binaryExprToExpression(ctx *sql.Context, be *sqlparser.BinaryExpr) (sql.Exp
 		sqlparser.IntDivStr,
 		sqlparser.ModStr:
 
-		l, err := ExprToExpression(ctx, be.Left)
-		if err != nil {
-			return nil, err
-		}
-
-		r, err := ExprToExpression(ctx, be.Right)
-		if err != nil {
-			return nil, err
-		}
-
 		_, lok := l.(*expression.Interval)
 		_, rok := r.(*expression.Interval)
 		if lok && be.Operator == "-" {
@@ -4591,7 +4592,7 @@ func binaryExprToExpression(ctx *sql.Context, be *sqlparser.BinaryExpr) (sql.Exp
 			return nil, sql.ErrUnsupportedSyntax.New("intervals cannot be added or subtracted from other intervals")
 		}
 
-		switch strings.ToLower(be.Operator) {
+		switch operator {
 		case sqlparser.DivStr:
 			return expression.NewDiv(l, r), nil
 		case sqlparser.ModStr:
@@ -4603,10 +4604,18 @@ func binaryExprToExpression(ctx *sql.Context, be *sqlparser.BinaryExpr) (sql.Exp
 		default:
 			return expression.NewArithmetic(l, r, be.Operator), nil
 		}
-	case
-		sqlparser.JSONExtractOp,
-		sqlparser.JSONUnquoteExtractOp:
-		return nil, sql.ErrUnsupportedFeature.New(fmt.Sprintf("(%s) JSON operators not supported", be.Operator))
+
+	case sqlparser.JSONExtractOp, sqlparser.JSONUnquoteExtractOp:
+		jsonExtract, err := function.NewJSONExtract(l, r)
+		if err != nil {
+			return nil, err
+		}
+
+		if operator == sqlparser.JSONUnquoteExtractOp {
+			return function.NewJSONUnquote(jsonExtract), nil
+		} else {
+			return jsonExtract, nil
+		}
 
 	default:
 		return nil, sql.ErrUnsupportedFeature.New(be.Operator)

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -356,9 +356,8 @@ func (b *PlanBuilder) buildBinaryScalar(inScope *scope, be *ast.BinaryExpr) sql.
 
 		if operator == ast.JSONUnquoteExtractOp {
 			return function.NewJSONUnquote(jsonExtract)
-		} else {
-			return jsonExtract
 		}
+		return jsonExtract
 
 	default:
 		err := sql.ErrUnsupportedFeature.New(be.Operator)
@@ -602,9 +601,8 @@ func (b *PlanBuilder) binaryExprToExpression(inScope *scope, be *ast.BinaryExpr)
 
 		if operator == ast.JSONUnquoteExtractOp {
 			return function.NewJSONUnquote(jsonExtract), nil
-		} else {
-			return jsonExtract, nil
 		}
+		return jsonExtract, nil
 
 	default:
 		return nil, sql.ErrUnsupportedFeature.New(be.Operator)

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -304,7 +304,11 @@ func (b *PlanBuilder) buildUnaryScalar(inScope *scope, e *ast.UnaryExpr) sql.Exp
 }
 
 func (b *PlanBuilder) buildBinaryScalar(inScope *scope, be *ast.BinaryExpr) sql.Expression {
-	switch strings.ToLower(be.Operator) {
+	l := b.buildScalar(inScope, be.Left)
+	r := b.buildScalar(inScope, be.Right)
+
+	operator := strings.ToLower(be.Operator)
+	switch operator {
 	case
 		ast.PlusStr,
 		ast.MinusStr,
@@ -317,10 +321,6 @@ func (b *PlanBuilder) buildBinaryScalar(inScope *scope, be *ast.BinaryExpr) sql.
 		ast.BitXorStr,
 		ast.IntDivStr,
 		ast.ModStr:
-
-		l := b.buildScalar(inScope, be.Left)
-
-		r := b.buildScalar(inScope, be.Right)
 
 		_, lok := l.(*expression.Interval)
 		_, rok := r.(*expression.Interval)
@@ -347,11 +347,18 @@ func (b *PlanBuilder) buildBinaryScalar(inScope *scope, be *ast.BinaryExpr) sql.
 		default:
 			return expression.NewArithmetic(l, r, be.Operator)
 		}
-	case
-		ast.JSONExtractOp,
-		ast.JSONUnquoteExtractOp:
-		err := sql.ErrUnsupportedFeature.New(fmt.Sprintf("(%s) JSON operators not supported", be.Operator))
-		b.handleErr(err)
+
+	case ast.JSONExtractOp, ast.JSONUnquoteExtractOp:
+		jsonExtract, err := function.NewJSONExtract(l, r)
+		if err != nil {
+			b.handleErr(err)
+		}
+
+		if operator == ast.JSONUnquoteExtractOp {
+			return function.NewJSONUnquote(jsonExtract)
+		} else {
+			return jsonExtract
+		}
 
 	default:
 		err := sql.ErrUnsupportedFeature.New(be.Operator)
@@ -546,7 +553,11 @@ func (b *PlanBuilder) buildIsExprToExpression(inScope *scope, c *ast.IsExpr) sql
 }
 
 func (b *PlanBuilder) binaryExprToExpression(inScope *scope, be *ast.BinaryExpr) (sql.Expression, error) {
-	switch strings.ToLower(be.Operator) {
+	l := b.buildScalar(inScope, be.Left)
+	r := b.buildScalar(inScope, be.Right)
+
+	operator := strings.ToLower(be.Operator)
+	switch operator {
 	case
 		ast.PlusStr,
 		ast.MinusStr,
@@ -560,9 +571,6 @@ func (b *PlanBuilder) binaryExprToExpression(inScope *scope, be *ast.BinaryExpr)
 		ast.IntDivStr,
 		ast.ModStr:
 
-		l := b.buildScalar(inScope, be.Left)
-		r := b.buildScalar(inScope, be.Right)
-
 		_, lok := l.(*expression.Interval)
 		_, rok := r.(*expression.Interval)
 		if lok && be.Operator == "-" {
@@ -573,7 +581,7 @@ func (b *PlanBuilder) binaryExprToExpression(inScope *scope, be *ast.BinaryExpr)
 			return nil, sql.ErrUnsupportedSyntax.New("intervals cannot be added or subtracted from other intervals")
 		}
 
-		switch strings.ToLower(be.Operator) {
+		switch operator {
 		case ast.DivStr:
 			return expression.NewDiv(l, r), nil
 		case ast.ModStr:
@@ -585,10 +593,18 @@ func (b *PlanBuilder) binaryExprToExpression(inScope *scope, be *ast.BinaryExpr)
 		default:
 			return expression.NewArithmetic(l, r, be.Operator), nil
 		}
-	case
-		ast.JSONExtractOp,
-		ast.JSONUnquoteExtractOp:
-		return nil, sql.ErrUnsupportedFeature.New(fmt.Sprintf("(%s) JSON operators not supported", be.Operator))
+
+	case ast.JSONExtractOp, ast.JSONUnquoteExtractOp:
+		jsonExtract, err := function.NewJSONExtract(l, r)
+		if err != nil {
+			return nil, err
+		}
+
+		if operator == ast.JSONUnquoteExtractOp {
+			return function.NewJSONUnquote(jsonExtract), nil
+		} else {
+			return jsonExtract, nil
+		}
 
 	default:
 		return nil, sql.ErrUnsupportedFeature.New(be.Operator)


### PR DESCRIPTION
[MySQL `column->path` Documentation](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_json-column-path)
[MySQL `column->>path` Documentation](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_json-inline-path)

Fixes: https://github.com/dolthub/dolt/issues/5662