### PR TITLE
Hoist subquery filters bug

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -179,6 +179,14 @@ var joinOpTests = []struct {
 		},
 		tests: []JoinOpTests{
 			{
+				Query: `SELECT xy.x, xy.y
+					FROM xy
+					WHERE EXISTS (
+					SELECT 1 FROM uv WHERE xy.x = uv.v AND (EXISTS (
+					SELECT 1 FROM ab WHERE uv.u = ab.b)))`,
+				Expected: []sql.Row{{1, 0}, {2, 1}},
+			},
+			{
 				// natural join w/ inner join
 				Query: "select * from mytable t1 natural join mytable t2 join othertable t3 on t2.i = t3.i2;",
 				Expected: []sql.Row{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -249,7 +249,7 @@ Select * from (
 	},
 	{
 		Query: `select * from uv where not exists (select * from xy where not exists (select * from xy where not(u = 1)))`,
-		ExpectedPlan: "Filter\n" +
+		ExpectedPlan: "AntiJoin\n" +
 			" ├─ NOT\n" +
 			" │   └─ AND\n" +
 			" │       ├─ EXISTS Subquery\n" +
@@ -258,19 +258,15 @@ Select * from (
 			" │       │       ├─ name: xy\n" +
 			" │       │       └─ columns: [x y]\n" +
 			" │       └─ NOT\n" +
-			" │           └─ AND\n" +
-			" │               ├─ EXISTS Subquery\n" +
-			" │               │   ├─ cacheable: true\n" +
-			" │               │   └─ Table\n" +
-			" │               │       ├─ name: xy\n" +
-			" │               │       └─ columns: [x y]\n" +
-			" │               └─ NOT\n" +
-			" │                   └─ Eq\n" +
-			" │                       ├─ uv.u:0!null\n" +
-			" │                       └─ 1 (tinyint)\n" +
+			" │           └─ Eq\n" +
+			" │               ├─ uv.u:0!null\n" +
+			" │               └─ 1 (tinyint)\n" +
+			" ├─ Table\n" +
+			" │   ├─ name: uv\n" +
+			" │   └─ columns: [u v]\n" +
 			" └─ Table\n" +
-			"     ├─ name: uv\n" +
-			"     └─ columns: [u v]\n" +
+			"     ├─ name: xy\n" +
+			"     └─ columns: [x y]\n" +
 			"",
 	},
 	{

--- a/sql/analyzer/hoist_filters.go
+++ b/sql/analyzer/hoist_filters.go
@@ -159,9 +159,7 @@ func recurseSubqueryForOuterFilters(n sql.Node, a *Analyzer, scope *Scope) (sql.
 // exprRefsTableSet returns |foundRef| if the expression directly
 // references a table in the table set, and |foundAlias| if the expression
 // references an alias that is scope-ambiguous.
-func exprRefsTableSet(e sql.Expression, tables TableAliases) (bool, bool) {
-	var foundRef bool
-	var foundAlias bool
+func exprRefsTableSet(e sql.Expression, tables TableAliases) (foundRef, foundAlias bool) {
 	transform.InspectExpr(e, func(e sql.Expression) bool {
 		switch e := e.(type) {
 		case *expression.GetField:
@@ -181,5 +179,5 @@ func exprRefsTableSet(e sql.Expression, tables TableAliases) (bool, bool) {
 		}
 		return foundRef && foundAlias
 	})
-	return foundRef, foundAlias
+	return
 }

--- a/sql/analyzer/hoist_filters.go
+++ b/sql/analyzer/hoist_filters.go
@@ -122,8 +122,6 @@ func recurseSubqueryForOuterFilters(n sql.Node, a *Analyzer, scope *Scope) (sql.
 			}
 
 			// (2) evaluate if expression hoistable
-			var innerRef bool
-			var maybeAlias bool
 			if inScope == nil {
 				var err error
 				inScope, err = getTableAliases(n, nil)
@@ -131,23 +129,10 @@ func recurseSubqueryForOuterFilters(n sql.Node, a *Analyzer, scope *Scope) (sql.
 					return n, transform.SameTree, err
 				}
 			}
-			transform.InspectExpr(e, func(e sql.Expression) bool {
-				gf, _ := e.(*expression.GetField)
-				if gf == nil {
-					return false
-				}
-				tName := strings.ToLower(gf.Table())
-				if tName == "" {
-					maybeAlias = true
-				} else if _, ok := inScope[tName]; ok {
-					innerRef = true
-				}
-
-				return innerRef && maybeAlias
-			})
+			foundRef, foundAlias := exprRefsTableSet(e, inScope)
 
 			// (3) bucket filter into parent or current scope
-			if !innerRef && !maybeAlias {
+			if !foundRef && !foundAlias {
 				// belongs in outer scope
 				hoistFilters = append(hoistFilters, e)
 			} else {
@@ -169,4 +154,32 @@ func recurseSubqueryForOuterFilters(n sql.Node, a *Analyzer, scope *Scope) (sql.
 		return ret, transform.NewTree, nil
 	})
 	return ret, same, hoistFilters, err
+}
+
+// exprRefsTableSet returns |foundRef| if the expression directly
+// references a table in the table set, and |foundAlias| if the expression
+// references an alias that is scope-ambiguous.
+func exprRefsTableSet(e sql.Expression, tables TableAliases) (bool, bool) {
+	var foundRef bool
+	var foundAlias bool
+	transform.InspectExpr(e, func(e sql.Expression) bool {
+		switch e := e.(type) {
+		case *expression.GetField:
+			tName := strings.ToLower(e.Table())
+			if tName == "" {
+				foundAlias = true
+			} else if _, ok := tables[tName]; ok {
+				foundRef = true
+			}
+		case *plan.Subquery:
+			transform.InspectExpressions(e.Query, func(e sql.Expression) bool {
+				subqRef, subqAlias := exprRefsTableSet(e, tables)
+				foundRef = foundRef || subqRef
+				foundAlias = foundAlias || subqAlias
+				return foundRef && foundAlias
+			})
+		}
+		return foundRef && foundAlias
+	})
+	return foundRef, foundAlias
 }

--- a/sql/analyzer/hoist_select_exists.go
+++ b/sql/analyzer/hoist_select_exists.go
@@ -184,7 +184,6 @@ func hoistExistSubqueries(scope *Scope, a *Analyzer, filter *plan.Filter, scopeL
 		default:
 			return filter, transform.SameTree, fmt.Errorf("hoistSelectExists failed on unexpected join type")
 		}
-
 	}
 
 	if same {


### PR DESCRIPTION
Hoist filters is supposed to move filters that do not reference tables in the current sope upwards. We did not descend subqueries when checking for that condition, mistakenly hoisting filters in some cases.

Re: https://github.com/dolthub/dolt/issues/6089