### PR TITLE
Support load data ignore/replace

### DIFF
--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2183,7 +2183,7 @@ func convertAlterTable(ctx *sql.Context, ddl *sqlparser.DDL) (sql.Node, error) {
 				if commentVal := column.Type.Comment; commentVal != nil {
 					comment = commentVal.String()
 				}
-				columns := []sql.IndexColumn{sql.IndexColumn{Name: column.Name.String()}}
+				columns := []sql.IndexColumn{{Name: column.Name.String()}}
 				if isUnique {
 					alteredTable, err = plan.NewAlterCreateIndex(sql.UnresolvedDatabase(ddl.Table.Qualifier.String()), alteredTable, column.Name.String(), sql.IndexUsing_BTree, sql.IndexConstraint_Unique, columns, comment), nil
 					if err != nil {
@@ -2815,9 +2815,9 @@ func convertLoad(ctx *sql.Context, d *sqlparser.Load) (sql.Node, error) {
 		}
 	}
 
-	ld := plan.NewLoadData(bool(d.Local), d.Infile, unresolvedTable, columnsToStrings(d.Columns), d.Fields, d.Lines, ignoreNumVal)
+	ld := plan.NewLoadData(bool(d.Local), d.Infile, unresolvedTable, columnsToStrings(d.Columns), d.Fields, d.Lines, ignoreNumVal, d.IgnoreOrReplace)
 
-	return plan.NewInsertInto(sql.UnresolvedDatabase(d.Table.Qualifier.String()), tableNameToUnresolvedTable(d.Table), ld, false, ld.ColumnNames, nil, false), nil
+	return plan.NewInsertInto(sql.UnresolvedDatabase(d.Table.Qualifier.String()), tableNameToUnresolvedTable(d.Table), ld, ld.IsReplace, ld.ColumnNames, nil, ld.IsIgnore), nil
 }
 
 func getPkOrdinals(ts *sqlparser.TableSpec) []int {

--- a/sql/plan/load_data.go
+++ b/sql/plan/load_data.go
@@ -32,6 +32,8 @@ type LoadData struct {
 	Fields                  *sqlparser.Fields
 	Lines                   *sqlparser.Lines
 	IgnoreNum               int64
+	IsIgnore                bool
+	IsReplace               bool
 	FieldsTerminatedByDelim string
 	FieldsEnclosedByDelim   string
 	FieldsOptionallyDelim   bool
@@ -158,7 +160,9 @@ func (*LoadData) CollationCoercibility(ctx *sql.Context) (collation sql.Collatio
 	return sql.Collation_binary, 7
 }
 
-func NewLoadData(local bool, file string, destination sql.Node, cols []string, fields *sqlparser.Fields, lines *sqlparser.Lines, ignoreNum int64) *LoadData {
+func NewLoadData(local bool, file string, destination sql.Node, cols []string, fields *sqlparser.Fields, lines *sqlparser.Lines, ignoreNum int64, ignoreOrReplace string) *LoadData {
+	isReplace := ignoreOrReplace == sqlparser.ReplaceStr
+	isIgnore := ignoreOrReplace == sqlparser.IgnoreStr || (local && !isReplace)
 	return &LoadData{
 		Local:                   local,
 		File:                    file,
@@ -167,6 +171,8 @@ func NewLoadData(local bool, file string, destination sql.Node, cols []string, f
 		Fields:                  fields,
 		Lines:                   lines,
 		IgnoreNum:               ignoreNum,
+		IsIgnore:                isIgnore,
+		IsReplace:               isReplace,
 		LinesStartingByDelim:    defaultLinesStartingByDelim,
 		LinesTerminatedByDelim:  defaultLinesTerminatedByDelim,
 		FieldsEnclosedByDelim:   defaultFieldsEnclosedByDelim,


### PR DESCRIPTION
Vitess PR: https://github.com/dolthub/vitess/pull/243

Here are the docs for load data with ignore/replace modifiers: https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-error-handling

This also changes `LOCAL` to have the same effect as `IGNORE` to match mysql