### PR TITLE
James/table func alias

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -668,6 +668,10 @@ func TestTableFunctions(t *testing.T) {
 			Expected: []sql.Row{{0}, {1}, {2}, {3}, {4}},
 		},
 		{
+			Query:    "select seq.x from sequence_table('x', 5) as seq",
+			Expected: []sql.Row{{0}, {1}, {2}, {3}, {4}},
+		},
+		{
 			Query:    "select * from sequence_table('x', 5) join sequence_table('y', 5) on x = y",
 			Expected: []sql.Row{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}},
 		},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20230606164345-6cb0d80700b2
+	github.com/dolthub/vitess v0.0.0-20230608185654-e51c8f6e4427
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2
@@ -27,6 +27,7 @@ require (
 	golang.org/x/text v0.3.8
 	golang.org/x/tools v0.3.0
 	gopkg.in/src-d/go-errors.v1 v1.0.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -43,7 +44,6 @@ require (
 	google.golang.org/grpc v1.37.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 go 1.19

--- a/go.sum
+++ b/go.sum
@@ -59,12 +59,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72 h1:NfWmngMi1CYU
 github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72/go.mod h1:ZWUdY4iszqRQ8OcoXClkxiAVAoWoK3cq0Hvv4ddGRuM=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20230531182027-fe0363298c52 h1:MGNJQpIOGRxtcKEsmbuMXFhMIJdlfxeeBaDZjbI6ZAg=
-github.com/dolthub/vitess v0.0.0-20230531182027-fe0363298c52/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
-github.com/dolthub/vitess v0.0.0-20230605213213-cbc62ca5fb39 h1:T1oXYVAZrpANwuyStC/SZGw4cYmPFMwq6n6KvK4U6Mw=
-github.com/dolthub/vitess v0.0.0-20230605213213-cbc62ca5fb39/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
-github.com/dolthub/vitess v0.0.0-20230606164345-6cb0d80700b2 h1:KGlVqYOuu6iG6DJAK06mZQPeXB/ElYlOH5UsuqUNf0A=
-github.com/dolthub/vitess v0.0.0-20230606164345-6cb0d80700b2/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
+github.com/dolthub/vitess v0.0.0-20230608185654-e51c8f6e4427 h1:5p44kYKnRzWenEiKLps8V4MhFgUOHo4z0AlEKGiKgHk=
+github.com/dolthub/vitess v0.0.0-20230608185654-e51c8f6e4427/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/analyzer/aliases.go
+++ b/sql/analyzer/aliases.go
@@ -306,6 +306,9 @@ func disambiguateTableFunctions(ctx *sql.Context, a *Analyzer, n sql.Node, scope
 	return transform.Node(n, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		switch n := n.(type) {
 		case *expression.UnresolvedTableFunction:
+			if n.Alias != "" {
+				return plan.NewTableAlias(n.Alias, n), transform.NewTree, nil
+			}
 			i++
 			return plan.NewTableAlias(fmt.Sprintf("%s_%d", n.Name(), i), n), transform.NewTree, nil
 		default:

--- a/sql/expression/unresolved.go
+++ b/sql/expression/unresolved.go
@@ -115,6 +115,7 @@ var _ sql.TableFunction = (*UnresolvedTableFunction)(nil)
 // intended to be used.
 type UnresolvedTableFunction struct {
 	name      string
+	Alias     string
 	Arguments []sql.Expression
 	database  sql.Database
 }
@@ -124,9 +125,10 @@ var _ sql.CollationCoercible = (*UnresolvedTableFunction)(nil)
 var _ sql.RenameableNode = (*UnresolvedTableFunction)(nil)
 
 // NewUnresolvedTableFunction creates a new UnresolvedTableFunction node for a sql plan.
-func NewUnresolvedTableFunction(name string, arguments []sql.Expression) *UnresolvedTableFunction {
+func NewUnresolvedTableFunction(name, alias string, arguments []sql.Expression) *UnresolvedTableFunction {
 	return &UnresolvedTableFunction{
 		name:      name,
+		Alias:     alias,
 		Arguments: arguments,
 	}
 }

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -3480,7 +3480,7 @@ func tableExprToTable(
 			return nil, err
 		}
 
-		return expression.NewUnresolvedTableFunction(t.Name, exprs), nil
+		return expression.NewUnresolvedTableFunction(t.Name, t.Alias.String(), exprs), nil
 
 	case *sqlparser.JoinTableExpr:
 		return joinTableExpr(ctx, t)

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -365,7 +365,7 @@ func (b *PlanBuilder) buildTableFunc(inScope *scope, t *ast.TableFuncExpr) (outS
 		}
 	}
 
-	utf := expression.NewUnresolvedTableFunction(t.Name, args)
+	utf := expression.NewUnresolvedTableFunction(t.Name, t.Alias.String(), args)
 
 	tableFunction, err := b.cat.TableFunction(b.ctx, utf.Name())
 	if err != nil {


### PR DESCRIPTION
Added string field to `expression.UnresolvedTableFunction` to so an alias can be specified.
Changed `disambiguate_table_functions` to use provided aslias for `TableFunction`s instead of generated name when provided.

Companion PR: https://github.com/dolthub/vitess/pull/244