### PR TITLE
Ignore FULLTEXT in CREATE TABLE

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8590,10 +8590,6 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: sql.ErrUnsupportedFeature,
 	},
 	{
-		Query:       `CREATE TABLE test (pk int primary key, body text, FULLTEXT KEY idx_body (body))`,
-		ExpectedErr: sql.ErrUnsupportedFeature,
-	},
-	{
 		Query:       `CREATE FULLTEXT INDEX idx ON opening_lines(opening_line)`,
 		ExpectedErr: sql.ErrUnsupportedFeature,
 	},

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/text v0.3.8
 	golang.org/x/tools v0.3.0
 	gopkg.in/src-d/go-errors.v1 v1.0.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -43,7 +44,6 @@ require (
 	google.golang.org/grpc v1.37.0 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 go 1.19

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,6 @@ github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72 h1:NfWmngMi1CYU
 github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72/go.mod h1:ZWUdY4iszqRQ8OcoXClkxiAVAoWoK3cq0Hvv4ddGRuM=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20230531182027-fe0363298c52 h1:MGNJQpIOGRxtcKEsmbuMXFhMIJdlfxeeBaDZjbI6ZAg=
-github.com/dolthub/vitess v0.0.0-20230531182027-fe0363298c52/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
-github.com/dolthub/vitess v0.0.0-20230605213213-cbc62ca5fb39 h1:T1oXYVAZrpANwuyStC/SZGw4cYmPFMwq6n6KvK4U6Mw=
-github.com/dolthub/vitess v0.0.0-20230605213213-cbc62ca5fb39/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
 github.com/dolthub/vitess v0.0.0-20230606164345-6cb0d80700b2 h1:KGlVqYOuu6iG6DJAK06mZQPeXB/ElYlOH5UsuqUNf0A=
 github.com/dolthub/vitess v0.0.0-20230606164345-6cb0d80700b2/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -2511,7 +2511,8 @@ func ConvertIndexDefs(ctx *sql.Context, spec *sqlparser.TableSpec) (idxDefs []*p
 			constraint = sql.IndexConstraint_Spatial
 		} else if idxDef.Info.Fulltext {
 			// TODO: We do not support FULLTEXT indexes or keys
-			return nil, sql.ErrUnsupportedFeature.New("fulltext keys are unsupported")
+			ctx.Warn(1214, "ignoring fulltext index as they have not yet been implemented")
+			continue
 		}
 
 		columns, err := gatherIndexColumns(idxDef.Columns)
@@ -2536,7 +2537,9 @@ func ConvertIndexDefs(ctx *sql.Context, spec *sqlparser.TableSpec) (idxDefs []*p
 
 	for _, colDef := range spec.Columns {
 		if colDef.Type.KeyOpt == colKeyFulltextKey {
-			return nil, sql.ErrUnsupportedFeature.New("fulltext keys are unsupported")
+			// TODO: We do not support FULLTEXT indexes or keys
+			ctx.Warn(1214, "ignoring fulltext index as they have not yet been implemented")
+			continue
 		}
 		if colDef.Type.KeyOpt == colKeyUnique || colDef.Type.KeyOpt == colKeyUniqueKey {
 			idxDefs = append(idxDefs, &plan.IndexDefinition{

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -5229,7 +5229,6 @@ var fixturesErrors = map[string]*errors.Kind{
 	`KILL CONNECTION 4294967296`:                                sql.ErrUnsupportedFeature,
 	`DROP TABLE IF EXISTS curdb.foo, otherdb.bar`:               sql.ErrUnsupportedFeature,
 	`DROP TABLE curdb.t1, t2`:                                   sql.ErrUnsupportedFeature,
-	`CREATE TABLE test (i int fulltext key)`:                    sql.ErrUnsupportedFeature,
 }
 
 func TestParseOne(t *testing.T) {


### PR DESCRIPTION
This change allows us to ignore any FULLTEXT keys when using `CREATE TABLE`. This should unblock customers who just need their statements to parse, but don't actually need the functionality of FULLTEXT. We still error when trying to manually add a FULLTEXT index using `ALTER` or `CREATE INDEX`. Since this isn't really "correct" behavior, I did not add any tests.