### PR TITLE
Bug fix: The result schema of `SELECT INTO` should always be an empty schema

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -662,7 +662,6 @@ var ScriptTests = []ScriptTest{
 	{
 		Name: "Test cases on select into statement",
 		SetUpScript: []string{
-			"SELECT 1 INTO @abc",
 			"SELECT * FROM (VALUES ROW(22,44,88)) AS t INTO @x,@y,@z",
 			"CREATE TABLE tab1 (id int primary key, v1 int)",
 			"INSERT INTO tab1 VALUES (1, 1), (2, 3), (3, 6)",
@@ -675,6 +674,13 @@ var ScriptTests = []ScriptTest{
 			"SELECT id FROM tab1 WHERE id > 3 UNION select s FROM tab2 WHERE s < 'f' INTO @mustSingleVar",
 		},
 		Assertions: []ScriptTestAssertion{
+			{
+				// SELECT INTO has an empty result schema
+				// https://github.com/dolthub/dolt/issues/6105
+				Query:           `SELECT 1 INTO @abc`,
+				Expected:        []sql.Row{{}},
+				ExpectedColumns: nil,
+			},
 			{
 				Query:    `SELECT @abc`,
 				Expected: []sql.Row{{int8(1)}},

--- a/sql/plan/into.go
+++ b/sql/plan/into.go
@@ -38,6 +38,13 @@ func NewInto(child sql.Node, variables []sql.Expression) *Into {
 	}
 }
 
+// Schema implements the Node interface.
+func (i *Into) Schema() sql.Schema {
+	// SELECT INTO does not return results directly (only through SQL vars or files),
+	// so it's result schema is always empty.
+	return nil
+}
+
 func (i *Into) String() string {
 	p := sql.NewTreePrinter()
 	var vars = make([]string, len(i.IntoVars))


### PR DESCRIPTION
`SELECT INTO` currently returns it's child node's schema as its result schema, but it doesn't actually return row data in that schema. This causes a problem over a SQL connection when clients see a result schema and then see row data that doesn't match that schema. This causes clients to freak out and close the connection from their side. Since `SELECT INTO` always sends its results to a file or SQL vars (and NOT over the SQL connection), its result schema should always be the empty schema. 

Fixes: https://github.com/dolthub/dolt/issues/6105