### PR TITLE
*plan.TableCountLookup short circuits count(*)

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -742,6 +742,46 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
+		Query:    "select count(*) from mytable",
+		Expected: []sql.Row{{3}},
+	},
+	{
+		Query:    `select count(*) as cnt from mytable`,
+		Expected: []sql.Row{{3}},
+	},
+	{
+		Query:    "select count(*) from xy",
+		Expected: []sql.Row{{4}},
+	},
+	{
+		Query:    "select count(*) from xy alias",
+		Expected: []sql.Row{{4}},
+	},
+	{
+		Query:    "select count(1) from mytable",
+		Expected: []sql.Row{{3}},
+	},
+	{
+		Query:    "select count(1) from xy",
+		Expected: []sql.Row{{4}},
+	},
+	{
+		Query:    "select count(1) from xy, uv",
+		Expected: []sql.Row{{16}},
+	},
+	{
+		Query:    "select * from (select count(*) from xy) dt",
+		Expected: []sql.Row{{4}},
+	},
+	{
+		Query:    "select (select count(*) from xy), (select count(*) from uv)",
+		Expected: []sql.Row{{4, 4}},
+	},
+	{
+		Query:    "select (select count(*) from xy), (select count(*) from uv), count(*) from ab",
+		Expected: []sql.Row{{4, 4, 4}},
+	},
+	{
 		Query:    "select i from mytable alias where i = 1 and s = 'first row'",
 		Expected: []sql.Row{{1}},
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -27,36 +27,36 @@ var PlanTests = []QueryPlanTest{
 	{
 		Query: `select count(*) from mytable`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mytable.count(1):0!null as count(*)]\n" +
-			" └─ table_count(mytable)\n" +
+			" ├─ columns: [mytable.count(*):0!null as count(*)]\n" +
+			" └─ table_count(mytable) as count(*)\n" +
 			"",
 	},
 	{
 		Query: `select count(*) as cnt from mytable`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mytable.count(1):0!null as cnt]\n" +
-			" └─ table_count(mytable)\n" +
+			" ├─ columns: [mytable.cnt:0!null as cnt]\n" +
+			" └─ table_count(mytable) as cnt\n" +
 			"",
 	},
 	{
 		Query: `select count(*) from xy`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [xy.count(1):0!null as count(*)]\n" +
-			" └─ table_count(xy)\n" +
+			" ├─ columns: [xy.count(*):0!null as count(*)]\n" +
+			" └─ table_count(xy) as count(*)\n" +
 			"",
 	},
 	{
 		Query: `select count(1) from mytable`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [mytable.count(1):0!null as count(1)]\n" +
-			" └─ table_count(mytable)\n" +
+			" └─ table_count(mytable) as count(1)\n" +
 			"",
 	},
 	{
 		Query: `select count(1) from xy`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [xy.count(1):0!null as count(1)]\n" +
-			" └─ table_count(xy)\n" +
+			" └─ table_count(xy) as count(1)\n" +
 			"",
 	},
 	{
@@ -82,8 +82,8 @@ var PlanTests = []QueryPlanTest{
 			" ├─ outerVisibility: false\n" +
 			" ├─ cacheable: true\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.count(1):0!null as count(*)]\n" +
-			"     └─ table_count(xy)\n" +
+			"     ├─ columns: [xy.count(*):0!null as count(*)]\n" +
+			"     └─ table_count(xy) as count(*)\n" +
 			"",
 	},
 	{
@@ -92,13 +92,13 @@ var PlanTests = []QueryPlanTest{
 			" ├─ columns: [Subquery\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [xy.count(1):1!null as count(*)]\n" +
-			" │       └─ table_count(xy)\n" +
+			" │       ├─ columns: [xy.count(*):1!null as count(*)]\n" +
+			" │       └─ table_count(xy) as count(*)\n" +
 			" │   as (select count(*) from xy), Subquery\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [uv.count(1):1!null as count(*)]\n" +
-			" │       └─ table_count(uv)\n" +
+			" │       ├─ columns: [uv.count(*):1!null as count(*)]\n" +
+			" │       └─ table_count(uv) as count(*)\n" +
 			" │   as (select count(*) from uv)]\n" +
 			" └─ Table\n" +
 			"     ├─ name: \n" +
@@ -111,13 +111,13 @@ var PlanTests = []QueryPlanTest{
 			" ├─ columns: [Subquery\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [xy.count(1):1!null as count(*)]\n" +
-			" │       └─ table_count(xy)\n" +
+			" │       ├─ columns: [xy.count(*):1!null as count(*)]\n" +
+			" │       └─ table_count(xy) as count(*)\n" +
 			" │   as (select count(*) from xy), Subquery\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [uv.count(1):1!null as count(*)]\n" +
-			" │       └─ table_count(uv)\n" +
+			" │       ├─ columns: [uv.count(*):1!null as count(*)]\n" +
+			" │       └─ table_count(uv) as count(*)\n" +
 			" │   as (select count(*) from uv), COUNT(1):0!null as count(*)]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
@@ -11329,8 +11329,8 @@ WHERE
 		Query: `
 	SELECT COUNT(*) FROM NOXN3`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [NOXN3.count(1):0!null as COUNT(*)]\n" +
-			" └─ table_count(NOXN3)\n" +
+			" ├─ columns: [NOXN3.COUNT(*):0!null as COUNT(*)]\n" +
+			" └─ table_count(NOXN3) as COUNT(*)\n" +
 			"",
 	},
 	{
@@ -15519,8 +15519,8 @@ ORDER BY id ASC`,
 		Query: `
 SELECT COUNT(*) FROM E2I7U`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [E2I7U.count(1):0!null as COUNT(*)]\n" +
-			" └─ table_count(E2I7U)\n" +
+			" ├─ columns: [E2I7U.COUNT(*):0!null as COUNT(*)]\n" +
+			" └─ table_count(E2I7U) as COUNT(*)\n" +
 			"",
 	},
 	{

--- a/sql/analyzer/expand_stars.go
+++ b/sql/analyzer/expand_stars.go
@@ -124,17 +124,52 @@ func replaceCountStar(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sco
 		return n, transform.SameTree, nil
 	}
 
-	return transform.NodeExprs(n, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-		if count, ok := e.(*aggregation.Count); ok {
-			if _, ok := count.Child.(*expression.Star); ok {
-				count, err := count.WithChildren(expression.NewLiteral(int64(1), types.Int64))
-				if err != nil {
-					return nil, transform.SameTree, err
+	return transform.Node(n, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
+		if agg, ok := n.(*plan.GroupBy); ok {
+			if len(agg.SelectedExprs) == 1 && len(agg.GroupByExprs) == 0 {
+				if alias, ok := agg.SelectedExprs[0].(*expression.Alias); ok {
+					if cnt, ok := alias.Child.(*aggregation.Count); ok {
+						switch cnt.Child.(type) {
+						case *expression.Star, *expression.Literal:
+							var rt *plan.ResolvedTable
+							switch c := agg.Child.(type) {
+							case *plan.ResolvedTable:
+								rt = c
+							case *plan.TableAlias:
+								if t, ok := c.Child.(*plan.ResolvedTable); ok {
+									rt = t
+								}
+							}
+							if rt != nil {
+								if statsTable, ok := rt.Table.(sql.StatisticsTable); ok {
+									cnt, err := statsTable.RowCount(ctx)
+									if err == nil {
+										return plan.NewProject(
+											[]sql.Expression{
+												expression.NewAlias(alias.Name(), expression.NewGetFieldWithTable(0, types.Int64, statsTable.Name(), "count(1)", false)),
+											},
+											plan.NewTableCount(statsTable, cnt),
+										), transform.SameTree, nil
+									}
+								}
+							}
+						}
+					}
 				}
-				return count, transform.NewTree, nil
 			}
 		}
+		return transform.NodeExprs(n, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+			if count, ok := e.(*aggregation.Count); ok {
+				if _, ok := count.Child.(*expression.Star); ok {
+					count, err := count.WithChildren(expression.NewLiteral(int64(1), types.Int64))
+					if err != nil {
+						return nil, transform.SameTree, err
+					}
+					return count, transform.NewTree, nil
+				}
+			}
 
-		return e, transform.SameTree, nil
+			return e, transform.SameTree, nil
+		})
 	})
 }

--- a/sql/analyzer/expand_stars.go
+++ b/sql/analyzer/expand_stars.go
@@ -146,9 +146,9 @@ func replaceCountStar(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sco
 									if err == nil {
 										return plan.NewProject(
 											[]sql.Expression{
-												expression.NewAlias(alias.Name(), expression.NewGetFieldWithTable(0, types.Int64, statsTable.Name(), "count(1)", false)),
+												expression.NewAlias(alias.Name(), expression.NewGetFieldWithTable(0, types.Int64, statsTable.Name(), alias.Name(), false)),
 											},
-											plan.NewTableCount(statsTable, cnt),
+											plan.NewTableCount(alias.Name(), statsTable, cnt),
 										), transform.SameTree, nil
 									}
 								}

--- a/sql/analyzer/tables.go
+++ b/sql/analyzer/tables.go
@@ -163,33 +163,6 @@ func getResolvedTable(node sql.Node) *plan.ResolvedTable {
 	return table
 }
 
-// Finds first ResolvedTable node that is a descendant of the node given
-func getSingleResolvedTable(node sql.Node) *plan.ResolvedTable {
-	var table *plan.ResolvedTable
-	transform.Inspect(node, func(node sql.Node) bool {
-		// plan.Inspect will get called on all children of a node even if one of the children's calls returns false. We
-		// only want the first ResolvedTable match.
-		if table != nil {
-			return false
-		}
-
-		switch n := node.(type) {
-		case *plan.JoinNode:
-			return false
-		case *plan.ResolvedTable:
-			if !plan.IsDualTable(n) {
-				table = n
-				return false
-			}
-		case *plan.IndexedTableAccess:
-			table = n.ResolvedTable
-			return false
-		}
-		return true
-	})
-	return table
-}
-
 // getTablesByName takes a node and returns all found resolved tables in a map.
 func getTablesByName(node sql.Node) map[string]*plan.ResolvedTable {
 	ret := make(map[string]*plan.ResolvedTable)

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -183,7 +183,7 @@ func (s *Subquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 func prependRowInPlan(row sql.Row) func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 	return func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		switch n := n.(type) {
-		case sql.Table, sql.Projector, *ValueDerivedTable:
+		case sql.Table, sql.Projector, *ValueDerivedTable, *TableCountLookup:
 			return &PrependNode{
 				UnaryNode: UnaryNode{Child: n},
 				Row:       row,

--- a/sql/plan/table_count.go
+++ b/sql/plan/table_count.go
@@ -1,0 +1,53 @@
+package plan
+
+import (
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// TableCountLookup short-circuits `select count(*) from table`
+// using the sql.StatisticsTable interface.
+type TableCountLookup struct {
+	table sql.StatisticsTable
+	cnt   uint64
+}
+
+func NewTableCount(table sql.StatisticsTable, cnt uint64) sql.Node {
+	return &TableCountLookup{table: table, cnt: cnt}
+}
+
+var _ sql.Node = (*TableCountLookup)(nil)
+
+func (t TableCountLookup) Count() uint64 {
+	return t.cnt
+}
+
+func (t TableCountLookup) Resolved() bool {
+	return true
+}
+
+func (t TableCountLookup) String() string {
+	return fmt.Sprintf("table_count(%s)", t.table.Name())
+}
+
+func (t TableCountLookup) Schema() sql.Schema {
+	return sql.Schema{{
+		Name:     "count(1)",
+		Type:     types.Int64,
+		Nullable: false,
+		Source:   t.table.Name(),
+	}}
+}
+
+func (t TableCountLookup) Children() []sql.Node {
+	return nil
+}
+
+func (t TableCountLookup) WithChildren(children ...sql.Node) (sql.Node, error) {
+	return t, nil
+}
+
+func (t TableCountLookup) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
+	return true
+}

--- a/sql/rowexec/node_builder.gen.go
+++ b/sql/rowexec/node_builder.gen.go
@@ -51,6 +51,8 @@ func (b *BaseBuilder) buildNodeExec(ctx *sql.Context, n sql.Node, row sql.Row) (
 		return b.buildPrepareQuery(ctx, n, row)
 	case *plan.ResolvedTable:
 		return b.buildResolvedTable(ctx, n, row)
+	case *plan.TableCountLookup:
+		return b.buildTableCount(ctx, n, row)
 	case *plan.ShowCreateTable:
 		return b.buildShowCreateTable(ctx, n, row)
 	case *plan.ShowIndexes:

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -730,3 +730,7 @@ func (b *BaseBuilder) buildResolvedTable(ctx *sql.Context, n *plan.ResolvedTable
 
 	return sql.NewSpanIter(span, sql.NewTableRowIter(ctx, n.Table, partitions)), nil
 }
+
+func (b *BaseBuilder) buildTableCount(_ *sql.Context, n *plan.TableCountLookup, _ sql.Row) (sql.RowIter, error) {
+	return sql.RowsToRowIter(sql.Row{int(n.Count())}), nil
+}


### PR DESCRIPTION
In many cases it is unnecessary to read an entire table to report count(*). We can use the RowCount() interface to jump to the answer.