### PR TITLE
Use SO_REUSEADDR and SO_REUSEPORT options when creating the sql server on Unix

### DIFF
--- a/server/listener.go
+++ b/server/listener.go
@@ -53,7 +53,7 @@ type Listener struct {
 // For unix socket connection, 'unixSocketPath' takes a path for the unix socket file.
 // If 'unixSocketPath' is empty, no need to create the second listener.
 func NewListener(protocol, address string, unixSocketPath string) (*Listener, error) {
-	netl, err := net.Listen(protocol, address)
+	netl, err := newNetListener(protocol, address)
 	if err != nil {
 		return nil, err
 	}

--- a/server/net_listener_unix.go
+++ b/server/net_listener_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package server
+
+import (
+	"context"
+	"golang.org/x/sys/unix"
+	"net"
+	"syscall"
+)
+
+func newNetListener(protocol, address string) (net.Listener, error) {
+	lc := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			var socketErr error
+			err := c.Control(func(fd uintptr) {
+				err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+				if err != nil {
+					socketErr = err
+				}
+
+				err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+				if err != nil {
+					socketErr = err
+				}
+			})
+			if err != nil {
+				return err
+			}
+			return socketErr
+		},
+	}
+	return lc.Listen(context.Background(), protocol, address)
+}

--- a/server/net_listener_unix.go
+++ b/server/net_listener_unix.go
@@ -9,6 +9,10 @@ import (
 	"syscall"
 )
 
+// Very rarely in our CI, the server fails to bind to the port with the error: "port already in use."
+// This is odd because the server already confirms that the port is not in use before connecting.
+// Using the SO_REUSEADDR and SO_REUSEPORT options prevents this spurious failure.
+// This is safe to do because we have already checked that the
 func newNetListener(protocol, address string) (net.Listener, error) {
 	lc := net.ListenConfig{
 		Control: func(network, address string, c syscall.RawConn) error {

--- a/server/net_listener_unix.go
+++ b/server/net_listener_unix.go
@@ -4,9 +4,10 @@ package server
 
 import (
 	"context"
-	"golang.org/x/sys/unix"
 	"net"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // Very rarely in our CI, the server fails to bind to the port with the error: "port already in use."

--- a/server/net_listener_windows.go
+++ b/server/net_listener_windows.go
@@ -1,0 +1,7 @@
+package server
+
+import "net"
+
+func newNetListener(protocol, address string) (net.Listener, error) {
+	return net.Listen(protocol, address)
+}


### PR DESCRIPTION
This prevents a transient error we've been seeing where the server sometimes fails to start, and the OS claims `port already in use`, even though we've already confirmed that the port is not in use prior to running `dolt sql-server`.