### PR TITLE
fix expected schema for `sum(literal)`

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -1053,9 +1053,9 @@ SELECT SUM(x) FROM xy WHERE x IN (
 			{
 				Query: "select sum(x.i) + y.i from mytable as x, mytable as y where x.i = y.i GROUP BY x.i",
 				Expected: []sql.Row{
-					{int64(2)},
-					{int64(4)},
-					{int64(6)},
+					{float64(2)},
+					{float64(4)},
+					{float64(6)},
 				},
 			},
 			{

--- a/enginetest/queries/column_alias_queries.go
+++ b/enginetest/queries/column_alias_queries.go
@@ -99,7 +99,7 @@ var ColumnAliasQueries = []ScriptTest{
 					},
 					{
 						Name: "COL2",
-						Type: types.Int64,
+						Type: types.Float64,
 					},
 				},
 				Expected: []sql.Row{
@@ -128,7 +128,7 @@ var ColumnAliasQueries = []ScriptTest{
 					},
 					{
 						Name: "coL2",
-						Type: types.Int64,
+						Type: types.Float64,
 					},
 				},
 				Expected: []sql.Row{
@@ -147,7 +147,7 @@ var ColumnAliasQueries = []ScriptTest{
 					},
 					{
 						Name: "TimeStamp",
-						Type: types.Int64,
+						Type: types.Float64,
 					},
 				},
 				Expected: []sql.Row{

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1881,7 +1881,7 @@ END;`,
 			{
 				Query: "CALL computeSummary('i am not used');",
 				Expected: []sql.Row{
-					{"0.5000", 4},
+					{float64(0.5), 4},
 				},
 			},
 		},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1055,15 +1055,15 @@ Select * from (
 	{
 		Query: "SELECT pk DIV 2, SUM(c3) + sum(c3) as sum FROM one_pk GROUP BY 1 ORDER BY 1",
 		Expected: []sql.Row{
-			{int64(0), int64(28)},
-			{int64(1), int64(108)},
+			{int64(0), float64(28)},
+			{int64(1), float64(108)},
 		},
 	},
 	{
 		Query: "SELECT pk DIV 2, SUM(c3) + min(c3) as sum_and_min FROM one_pk GROUP BY 1 ORDER BY 1",
 		Expected: []sql.Row{
-			{int64(0), int64(16)},
-			{int64(1), int64(76)},
+			{int64(0), float64(16)},
+			{int64(1), float64(76)},
 		},
 		ExpectedColumns: sql.Schema{
 			{
@@ -1072,15 +1072,15 @@ Select * from (
 			},
 			{
 				Name: "sum_and_min",
-				Type: types.Int64,
+				Type: types.Float64,
 			},
 		},
 	},
 	{
 		Query: "SELECT pk DIV 2, SUM(`c3`) +    min( c3 ) FROM one_pk GROUP BY 1 ORDER BY 1",
 		Expected: []sql.Row{
-			{int64(0), int64(16)},
-			{int64(1), int64(76)},
+			{int64(0), float64(16)},
+			{int64(1), float64(76)},
 		},
 		ExpectedColumns: sql.Schema{
 			{
@@ -1089,7 +1089,7 @@ Select * from (
 			},
 			{
 				Name: "SUM(`c3`) +    min( c3 )",
-				Type: types.Int64,
+				Type: types.Float64,
 			},
 		},
 	},
@@ -4700,9 +4700,9 @@ Select * from (
 	{
 		Query: "SELECT SUM(i) + 1, i FROM mytable GROUP BY i ORDER BY i",
 		Expected: []sql.Row{
-			{int64(2), int64(1)},
-			{int64(3), int64(2)},
-			{int64(4), int64(3)},
+			{float64(2), int64(1)},
+			{float64(3), int64(2)},
+			{float64(4), int64(3)},
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -742,6 +742,22 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
+		Query:    "select count(1)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "select count(100)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "select sum(1)",
+		Expected: []sql.Row{{float64(1)}},
+	},
+	{
+		Query:    "select sum(100)",
+		Expected: []sql.Row{{float64(100)}},
+	},
+	{
 		Query:    "select count(*) from mytable",
 		Expected: []sql.Row{{3}},
 	},
@@ -772,6 +788,22 @@ var QueryTests = []QueryTest{
 	{
 		Query:    "select count(1) from xy, uv",
 		Expected: []sql.Row{{16}},
+	},
+	{
+		Query:    "select count('abc') from xy, uv",
+		Expected: []sql.Row{{16}},
+	},
+	{
+		Query:    "select sum('abc') from mytable",
+		Expected: []sql.Row{{float64(0)}},
+	},
+	{
+		Query:    "select sum(10) from mytable",
+		Expected: []sql.Row{{float64(30)}},
+	},
+	{
+		Query:    "select sum(1) from emptytable",
+		Expected: []sql.Row{{nil}},
 	},
 	{
 		Query:    "select * from (select count(*) from xy) dt",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1408,7 +1408,7 @@ var ScriptTests = []ScriptTest{
 			},
 			{
 				Query:    "SELECT SUM( DISTINCT + col1 ) * - 22 - - ( - COUNT( * ) ) col0 FROM tab1 AS cor0",
-				Expected: []sql.Row{{int64(-1455)}},
+				Expected: []sql.Row{{float64(-1455)}},
 			},
 			{
 				Query:    "SELECT MIN (DISTINCT col1) from tab1 GROUP BY col0 ORDER BY col0",

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -175,6 +175,19 @@ func TestHandlerOutput(t *testing.T) {
 		require.Equal(t, sqltypes.Float64, result.Rows[0][0].Type())
 		require.Equal(t, []byte("1010"), result.Rows[0][0].ToBytes())
 	})
+
+	t.Run("avg aggregation type is correct", func(t *testing.T) {
+		handler.ComInitDB(dummyConn, "test")
+		var result *sqltypes.Result
+		err := handler.ComQuery(dummyConn, "select avg(1) from test", func(res *sqltypes.Result, more bool) error {
+			result = res
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(result.Rows))
+		require.Equal(t, sqltypes.Float64, result.Rows[0][0].Type())
+		require.Equal(t, []byte("1"), result.Rows[0][0].ToBytes())
+	})
 }
 
 func TestHandlerComPrepare(t *testing.T) {

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -162,6 +162,19 @@ func TestHandlerOutput(t *testing.T) {
 
 		})
 	}
+
+	t.Run("sum aggregation type is correct", func(t *testing.T) {
+		handler.ComInitDB(dummyConn, "test")
+		var result *sqltypes.Result
+		err := handler.ComQuery(dummyConn, "select sum(1) from test", func(res *sqltypes.Result, more bool) error {
+			result = res
+			return nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(result.Rows))
+		require.Equal(t, sqltypes.Float64, result.Rows[0][0].Type())
+		require.Equal(t, []byte("1010"), result.Rows[0][0].ToBytes())
+	})
 }
 
 func TestHandlerComPrepare(t *testing.T) {

--- a/sql/analyzer/aggregations.go
+++ b/sql/analyzer/aggregations.go
@@ -99,9 +99,11 @@ func replaceAggregatesWithGetFieldProjections(_ *sql.Context, scope *plan.Scope,
 				newAggregates = append(newAggregates, e)
 				aggPassthrough[e.String()] = struct{}{}
 				typ := e.Type()
-				// special case for sum, which should always return a float64
-				if _, ok := e.(*aggregation.Sum); ok {
+				switch e.(type) {
+				case *aggregation.Sum, *aggregation.Avg:
 					typ = types.Float64
+				case *aggregation.Count:
+					typ = types.Int64
 				}
 				return expression.NewGetField(scopeLen+len(newAggregates)-1, typ, e.String(), e.IsNullable()), transform.NewTree, nil
 			default:

--- a/sql/analyzer/aggregations.go
+++ b/sql/analyzer/aggregations.go
@@ -17,8 +17,10 @@ package analyzer
 import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // flattenAggregationExpressions flattens any complex aggregate or window expressions in a GroupBy or Window node and
@@ -96,9 +98,12 @@ func replaceAggregatesWithGetFieldProjections(_ *sql.Context, scope *plan.Scope,
 			case sql.Aggregation, sql.WindowAggregation:
 				newAggregates = append(newAggregates, e)
 				aggPassthrough[e.String()] = struct{}{}
-				return expression.NewGetField(
-					scopeLen+len(newAggregates)-1, e.Type(), e.String(), e.IsNullable(),
-				), transform.NewTree, nil
+				typ := e.Type()
+				// special case for sum, which should always return a float64
+				if _, ok := e.(*aggregation.Sum); ok {
+					typ = types.Float64
+				}
+				return expression.NewGetField(scopeLen+len(newAggregates)-1, typ, e.String(), e.IsNullable()), transform.NewTree, nil
 			default:
 				return e, transform.SameTree, nil
 			}

--- a/sql/analyzer/aggregations_test.go
+++ b/sql/analyzer/aggregations_test.go
@@ -63,7 +63,7 @@ func TestFlattenAggregationExprs(t *testing.T) {
 			expected: plan.NewProject(
 				[]sql.Expression{
 					expression.NewArithmetic(
-						expression.NewGetField(0, types.Int64, "SUM(foo.a)", false),
+						expression.NewGetField(0, types.Float64, "SUM(foo.a)", false),
 						expression.NewLiteral(int64(1), types.Int64),
 						"+",
 					),
@@ -103,7 +103,7 @@ func TestFlattenAggregationExprs(t *testing.T) {
 				[]sql.Expression{
 					expression.NewAlias("x",
 						expression.NewArithmetic(
-							expression.NewGetField(0, types.Int64, "SUM(foo.a)", false),
+							expression.NewGetField(0, types.Float64, "SUM(foo.a)", false),
 							expression.NewLiteral(int64(1), types.Int64),
 							"+",
 						)),
@@ -144,7 +144,7 @@ func TestFlattenAggregationExprs(t *testing.T) {
 			expected: plan.NewProject(
 				[]sql.Expression{
 					expression.NewDiv(
-						expression.NewGetField(0, types.Int64, "SUM(foo.a)", false),
+						expression.NewGetField(0, types.Float64, "SUM(foo.a)", false),
 						expression.NewGetField(1, types.Int64, "COUNT(foo.a)", false),
 					),
 					expression.NewGetFieldWithTable(2, types.Int64, "foo", "b", false),
@@ -188,7 +188,7 @@ func TestFlattenAggregationExprs(t *testing.T) {
 			expected: plan.NewProject(
 				[]sql.Expression{
 					expression.NewArithmetic(
-						expression.NewGetField(0, types.Int64, "SUM(foo.a)", false),
+						expression.NewGetField(0, types.Float64, "SUM(foo.a)", false),
 						expression.NewGetFieldWithTable(1, types.Int64, "bar", "a", false),
 						"+",
 					),

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -274,21 +274,26 @@ func (b *PlanBuilder) buildAggregateFunc(inScope *scope, name string, e *ast.Fun
 		}
 	}
 
+	aggType := agg.Type()
+	if name == "avg" || name == "sum" {
+		aggType = types.Float64
+	}
+
 	aggName := strings.ToLower(agg.String())
 	if id, ok := gb.outScope.getExpr(aggName); ok {
 		// TODO check agg scope output, see if we've already computed
 		// if so use reference here
-		gf := expression.NewGetFieldWithTable(int(id), agg.Type(), "", agg.String(), agg.IsNullable())
+		gf := expression.NewGetFieldWithTable(int(id), aggType, "", agg.String(), agg.IsNullable())
 		return gf
 	}
 
-	col := scopeColumn{col: aggName, scalar: agg, typ: agg.Type(), nullable: agg.IsNullable()}
+	col := scopeColumn{col: aggName, scalar: agg, typ: aggType, nullable: agg.IsNullable()}
 	id := gb.outScope.newColumn(col)
 	gb.addAggStr(agg)
 
 	//TODO we need to return a reference here, so that top-level
 	// projection references the group by output.
-	return expression.NewGetFieldWithTable(int(id), agg.Type(), "", agg.String(), agg.IsNullable())
+	return expression.NewGetFieldWithTable(int(id), aggType, "", agg.String(), agg.IsNullable())
 }
 
 func isAggregateFunc(name string) bool {


### PR DESCRIPTION
The code path we take when print rows to shell is different than spooling from server.

In the sql case, we ignore the schema we get from analysis.
In the server case, we actually read the schema, and ensure that the rows are of that type.

When doing `sum(literal)`, we use the type of the literal. In this issue, the literal was `1`, so an `INT8`, which caps out at `127`.
`sum()` is always supposed to return a float64, so I made a change to do that.

I checked by starting mysql with `--column-type-info` option, and it does appear that any columns coming from `sum()` has a `DECIMAL` type.

Fix for: https://github.com/dolthub/dolt/issues/6120

