### PR TITLE
update cached table count in prepared statements

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4090,6 +4090,33 @@ var CreateCheckConstraintsScripts = []ScriptTest{
 
 var PreparedScriptTests = []ScriptTest{
 	{
+		Name: "table_count optimization refreshes result",
+		SetUpScript: []string{
+			"create table a (a int primary key);",
+			"insert into a values (0), (1), (2);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "prepare cnt from 'select count(*) from a';",
+				Expected: []sql.Row{{types.OkResult{Info: plan.PrepareInfo{}}}},
+			},
+			{
+				Query:    "execute cnt",
+				Expected: []sql.Row{{3}},
+			},
+			{
+				Query: "insert into a values (3), (4)",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 2}},
+				},
+			},
+			{
+				Query:    "execute cnt",
+				Expected: []sql.Row{{5}},
+			},
+		},
+	},
+	{
 		Name:        "bad prepare",
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{

--- a/sql/analyzer/expand_stars.go
+++ b/sql/analyzer/expand_stars.go
@@ -148,7 +148,7 @@ func replaceCountStar(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sco
 											[]sql.Expression{
 												expression.NewAlias(alias.Name(), expression.NewGetFieldWithTable(0, types.Int64, statsTable.Name(), alias.Name(), false)),
 											},
-											plan.NewTableCount(alias.Name(), statsTable, cnt),
+											plan.NewTableCount(alias.Name(), rt.Database, statsTable, cnt),
 										), transform.SameTree, nil
 									}
 								}

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -272,6 +272,28 @@ func reresolveTables(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 			}
 			new := transferProjections(ctx, from, to.(*plan.ResolvedTable))
 			return new, transform.NewTree, nil
+		case *plan.TableCountLookup:
+			new, err := resolveTable(ctx, plan.NewUnresolvedTableWithDatabase(n.Table().Name(), n.Db()), a)
+			if err != nil {
+				return nil, transform.SameTree, err
+			}
+			rt, ok := new.(*plan.ResolvedTable)
+			if !ok {
+				return n, transform.SameTree, fmt.Errorf("unable to re-resolve prepared *plan.TableCountLookup")
+			}
+			statsTable, ok := rt.Table.(sql.StatisticsTable)
+			if !ok {
+				return n, transform.SameTree, fmt.Errorf("unable to re-resolve prepared *plan.TableCountLookup")
+			}
+
+			cnt, err := statsTable.RowCount(ctx)
+			if err != nil {
+				return n, transform.SameTree, err
+			}
+
+			log.Printf("new count %d", cnt)
+
+			return plan.NewTableCount(n.Name(), n.Db(), statsTable, cnt), transform.NewTree, nil
 		default:
 		}
 		if err != nil {

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -279,11 +279,11 @@ func reresolveTables(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 			}
 			rt, ok := new.(*plan.ResolvedTable)
 			if !ok {
-				return n, transform.SameTree, fmt.Errorf("unable to re-resolve prepared *plan.TableCountLookup")
+				return n, transform.SameTree, fmt.Errorf("unable to re-resolve prepared *plan.TableCountLookup; expected *plan.ResolvedTable, found: %T", new)
 			}
 			statsTable, ok := rt.Table.(sql.StatisticsTable)
 			if !ok {
-				return n, transform.SameTree, fmt.Errorf("unable to re-resolve prepared *plan.TableCountLookup")
+				return n, transform.SameTree, fmt.Errorf("unable to re-resolve prepared *plan.TableCountLookup; expected sql.StatisticsTable, found: %T", new)
 			}
 
 			cnt, err := statsTable.RowCount(ctx)

--- a/sql/analyzer/resolve_tables.go
+++ b/sql/analyzer/resolve_tables.go
@@ -291,8 +291,6 @@ func reresolveTables(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 				return n, transform.SameTree, err
 			}
 
-			log.Printf("new count %d", cnt)
-
 			return plan.NewTableCount(n.Name(), n.Db(), statsTable, cnt), transform.NewTree, nil
 		default:
 		}

--- a/sql/plan/table_count.go
+++ b/sql/plan/table_count.go
@@ -11,15 +11,20 @@ import (
 // using the sql.StatisticsTable interface.
 type TableCountLookup struct {
 	aliasName string
+	db        sql.Database
 	table     sql.StatisticsTable
 	cnt       uint64
 }
 
-func NewTableCount(aliasName string, table sql.StatisticsTable, cnt uint64) sql.Node {
-	return &TableCountLookup{aliasName: aliasName, table: table, cnt: cnt}
+func NewTableCount(aliasName string, db sql.Database, table sql.StatisticsTable, cnt uint64) sql.Node {
+	return &TableCountLookup{aliasName: aliasName, db: db, table: table, cnt: cnt}
 }
 
 var _ sql.Node = (*TableCountLookup)(nil)
+
+func (t TableCountLookup) Name() string {
+	return t.aliasName
+}
 
 func (t TableCountLookup) Count() uint64 {
 	return t.cnt
@@ -27,6 +32,14 @@ func (t TableCountLookup) Count() uint64 {
 
 func (t TableCountLookup) Resolved() bool {
 	return true
+}
+
+func (t TableCountLookup) Table() sql.Table {
+	return t.table
+}
+
+func (t TableCountLookup) Db() sql.Database {
+	return t.db
 }
 
 func (t TableCountLookup) String() string {


### PR DESCRIPTION
Prepared statements were caching table counts. We need to update the table count when finalizing prepared statements to bring table count up to date with any intermediate edits.