### PR TITLE
deduplicate (hash) intuple for and queries

### DIFF
--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -2211,7 +2211,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `SELECT * FROM comp_index_t1 WHERE (v1<=99 AND v2<>86) AND (v1>=21 AND v2>36);`,
 		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{[21, 99], (86, ∞), [NULL, ∞)}, {[21, 99], (36, 86), [NULL, ∞)}]\n" +
+			" ├─ static: [{[21, 99], (36, 86), [NULL, ∞)}, {[21, 99], (86, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
@@ -6044,7 +6044,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 20 AND 93) AND (v1=66 AND v2<>21 AND v3 BETWEEN 43 AND 94);`,
 		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{[66, 66], (21, ∞), [43, 94], [NULL, ∞)}, {[66, 66], (NULL, 21), [43, 94], [NULL, ∞)}]\n" +
+			" ├─ static: [{[66, 66], (NULL, 21), [43, 94], [NULL, ∞)}, {[66, 66], (21, ∞), [43, 94], [NULL, ∞)}]\n" +
 			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
@@ -11927,7 +11927,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `SELECT * FROM comp_index_t2 WHERE (v1 BETWEEN 9 AND 35 AND v4<=69 AND v2 BETWEEN 34 AND 53 AND v3<>28) AND (v1 BETWEEN 12 AND 48);`,
 		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{[12, 35], [34, 53], (28, ∞), (NULL, 69]}, {[12, 35], [34, 53], (NULL, 28), (NULL, 69]}]\n" +
+			" ├─ static: [{[12, 35], [34, 53], (NULL, 28), (NULL, 69]}, {[12, 35], [34, 53], (28, ∞), (NULL, 69]}]\n" +
 			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -2657,6 +2657,18 @@ Select * from (
 		},
 	},
 	{
+		Query: `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) or s in ('first row', 'first row', 'first row');`,
+		Expected: []sql.Row{
+			{1, "first row"},
+		},
+	},
+	{
+		Query: `SELECT * FROM mytable WHERE (i in (1, 1, 1, 1, 1) and s = 'first row') or s in ('first row', 'first row', 'first row');`,
+		Expected: []sql.Row{
+			{1, "first row"},
+		},
+	},
+	{
 		Query: `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) and s in ('first row', 'first row', 'first row');`,
 		Expected: []sql.Row{
 			{1, "first row"},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -2651,6 +2651,32 @@ Select * from (
 		Expected: []sql.Row{{1}, {1}, {1}},
 	},
 	{
+		Query:    `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) and s = 'first row'`,
+		Expected: []sql.Row{
+			{1, "first row"},
+		},
+	},
+	{
+		Query:    `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) and s in ('first row', 'first row', 'first row');`,
+		Expected: []sql.Row{
+			{1, "first row"},
+		},
+	},
+	{
+		Query:    `SELECT * FROM mytable WHERE i NOT in (1, 1, 1, 1, 1) and s != 'first row';`,
+		Expected: []sql.Row{
+			{2, "second row"},
+			{3, "third row"},
+		},
+	},
+	{
+		Query:    `SELECT * FROM mytable WHERE i NOT in (1, 1, 1, 1, 1) and s NOT in ('first row', 'first row', 'first row');`,
+		Expected: []sql.Row{
+			{2, "second row"},
+			{3, "third row"},
+		},
+	},
+	{
 		Query:    "SELECT * from mytable WHERE 4 IN (i + 2)",
 		Expected: []sql.Row{{2, "second row"}},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -2651,26 +2651,26 @@ Select * from (
 		Expected: []sql.Row{{1}, {1}, {1}},
 	},
 	{
-		Query:    `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) and s = 'first row'`,
+		Query: `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) and s = 'first row'`,
 		Expected: []sql.Row{
 			{1, "first row"},
 		},
 	},
 	{
-		Query:    `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) and s in ('first row', 'first row', 'first row');`,
+		Query: `SELECT * FROM mytable WHERE i in (1, 1, 1, 1, 1) and s in ('first row', 'first row', 'first row');`,
 		Expected: []sql.Row{
 			{1, "first row"},
 		},
 	},
 	{
-		Query:    `SELECT * FROM mytable WHERE i NOT in (1, 1, 1, 1, 1) and s != 'first row';`,
+		Query: `SELECT * FROM mytable WHERE i NOT in (1, 1, 1, 1, 1) and s != 'first row';`,
 		Expected: []sql.Row{
 			{2, "second row"},
 			{3, "third row"},
 		},
 	},
 	{
-		Query:    `SELECT * FROM mytable WHERE i NOT in (1, 1, 1, 1, 1) and s NOT in ('first row', 'first row', 'first row');`,
+		Query: `SELECT * FROM mytable WHERE i NOT in (1, 1, 1, 1, 1) and s NOT in ('first row', 'first row', 'first row');`,
 		Expected: []sql.Row{
 			{2, "second row"},
 			{3, "third row"},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -2183,7 +2183,7 @@ inner join pq on true
 			" │   └─ TUPLE(1 (tinyint), 2 (tinyint))\n" +
 			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
 			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
-			"     ├─ static: [{[2, 2], (NULL, 2]}, {[1, 1], (NULL, 2]}]\n" +
+			"     ├─ static: [{[1, 1], (NULL, 2]}, {[2, 2], (NULL, 2]}]\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
@@ -17654,7 +17654,7 @@ WHERE
 			"             │                       └─ TableAlias(umf)\n" +
 			"             │                           └─ IndexedTableAccess(NZKPM)\n" +
 			"             │                               ├─ index: [NZKPM.id]\n" +
-			"             │                               ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │                               ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
 			"             │                               └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
@@ -17926,7 +17926,7 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │           │   │   │       │                   └─ columns: [fgg57]\n" +
 			"             │           │   │   │       └─ IndexedTableAccess(NZKPM)\n" +
 			"             │           │   │   │           ├─ index: [NZKPM.id]\n" +
-			"             │           │   │   │           ├─ static: [{[2, 2]}, {[3, 3]}, {[1, 1]}]\n" +
+			"             │           │   │   │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
 			"             │           │   │   │           └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"             │           │   │   └─ TableAlias(TJ5D2)\n" +
 			"             │           │   │       └─ Table\n" +

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -268,13 +268,6 @@ func getIndexes(
 			if err != nil {
 				return nil, err
 			}
-			for name, idx := range indexes {
-				newRanges, err := sql.RemoveOverlappingRanges(idx.lookup.Ranges...)
-				if err != nil {
-					return nil, nil
-				}
-				indexes[name].lookup.Ranges = newRanges
-			}
 
 			// Merge this index if possible. If at any time we cannot merge the result, then we simply return nil. Returning
 			// an indexed lookup for only part of an expression leads to incorrect results, e.g. (col = 1 AND col = 2) can
@@ -287,6 +280,14 @@ func getIndexes(
 			if err != nil {
 				return nil, err
 			}
+		}
+
+		for name, idx := range result {
+			newRanges, err := sql.RemoveOverlappingRanges(idx.lookup.Ranges...)
+			if err != nil {
+				return nil, nil
+			}
+			result[name].lookup.Ranges = newRanges
 		}
 
 		return result, nil

--- a/sql/analyzer/indexes.go
+++ b/sql/analyzer/indexes.go
@@ -268,6 +268,13 @@ func getIndexes(
 			if err != nil {
 				return nil, err
 			}
+			for name, idx := range indexes {
+				newRanges, err := sql.RemoveOverlappingRanges(idx.lookup.Ranges...)
+				if err != nil {
+					return nil, nil
+				}
+				indexes[name].lookup.Ranges = newRanges
+			}
 
 			// Merge this index if possible. If at any time we cannot merge the result, then we simply return nil. Returning
 			// an indexed lookup for only part of an expression leads to incorrect results, e.g. (col = 1 AND col = 2) can


### PR DESCRIPTION
This PR was originally supposed to fix it: original fix: https://github.com/dolthub/go-mysql-server/pull/1677, but `AND` statements weren't covered.

fix for: https://github.com/dolthub/dolt/issues/6189
