### PR TITLE
adding `version` and `version_comment` values

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4963,13 +4963,13 @@ Select * from (
 	{
 		Query: `SHOW VARIABLES WHERE Variable_name = 'version' || variable_name = 'autocommit'`,
 		Expected: []sql.Row{
-			{"autocommit", 1}, {"version", ""},
+			{"autocommit", 1}, {"version", "8.0.11"},
 		},
 	},
 	{
 		Query: `SHOW VARIABLES WHERE Variable_name > 'version' and variable_name like '%_%'`,
 		Expected: []sql.Row{
-			{"version_comment", ""}, {"version_compile_machine", ""}, {"version_compile_os", ""}, {"version_compile_zlib", ""}, {"wait_timeout", 28800}, {"windowing_use_high_precision", 1},
+			{"version_comment", "Dolt"}, {"version_compile_machine", ""}, {"version_compile_os", ""}, {"version_compile_zlib", ""}, {"wait_timeout", 28800}, {"windowing_use_high_precision", 1},
 		},
 	},
 	{

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -2786,7 +2786,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("version"),
-		Default:           "",
+		Default:           "8.0.11",
 	},
 	"version_comment": {
 		Name:              "version_comment",
@@ -2794,7 +2794,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("version_comment"),
-		Default:           "",
+		Default:           "MySQL Community Server - GPL",
 	},
 	"version_compile_machine": {
 		Name:              "version_compile_machine",

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -2794,7 +2794,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("version_comment"),
-		Default:           "MySQL Community Server - GPL",
+		Default:           "Dolt",
 	},
 	"version_compile_machine": {
 		Name:              "version_compile_machine",


### PR DESCRIPTION
`@@version` now returns `8.0.11`

`@@version_comment` now returns "Dolt"; in mysql, this appears to be dependent on OS / method of install
 - Some people get `MySQL Community Server - GPL`
 - Others get `Homebrew`

Fix for first part of: https://github.com/dolthub/dolt/issues/6179