### PR TITLE
Improvements to `CAST` and `CONVERT` functions

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4425,6 +4425,14 @@ Select * from (
 		},
 	},
 	{
+		Query:    "SELECT CAST(-3 AS DOUBLE) FROM dual",
+		Expected: []sql.Row{{-3.0}},
+	},
+	{
+		Query:    `SELECT CONVERT("-3.9876", FLOAT) FROM dual`,
+		Expected: []sql.Row{{float32(-3.9876)}},
+	},
+	{
 		Query: "SELECT CONVERT(-3, UNSIGNED) FROM mytable",
 		Expected: []sql.Row{
 			{uint64(18446744073709551613)},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4433,6 +4433,22 @@ Select * from (
 		Expected: []sql.Row{{float32(-3.9876)}},
 	},
 	{
+		Query:    "SELECT CAST(10.56789 as CHAR(3));",
+		Expected: []sql.Row{{"10."}},
+	},
+	{
+		Query:    `SELECT CONVERT(10.12345, DECIMAL(4,2))`,
+		Expected: []sql.Row{{"10.12"}},
+	},
+	{
+		// In enginetests, the SQL wire conversion logic isn't used, which is what expands the DECIMAL(4,2) value
+		// from "10" to "10.00" to exactly match MySQL's result. So, here we see just "10", but through sql-server
+		// we'll see the correct "10.00" value. Ideally, the enginetests (and dolt sql) would also execute the
+		// SQL wire conversion logic so that we don't have this inconsistency.
+		Query:    `SELECT CONVERT(10, DECIMAL(4,2))`,
+		Expected: []sql.Row{{"10"}},
+	},
+	{
 		Query: "SELECT CONVERT(-3, UNSIGNED) FROM mytable",
 		Expected: []sql.Row{
 			{uint64(18446744073709551613)},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4437,6 +4437,14 @@ Select * from (
 		Expected: []sql.Row{{"10."}},
 	},
 	{
+		Query:    "SELECT CAST(10.56789 as CHAR(30));",
+		Expected: []sql.Row{{"10.56789"}},
+	},
+	{
+		Query:    "SELECT CAST('abcdef' as BINARY(30));",
+		Expected: []sql.Row{{[]byte("abcdef")}},
+	},
+	{
 		Query:    `SELECT CONVERT(10.12345, DECIMAL(4,2))`,
 		Expected: []sql.Row{{"10.12"}},
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -479,6 +479,8 @@ Select * from (
 			"     └─ Project\n" +
 			"         ├─ columns: [convert\n" +
 			"         │   ├─ type: signed\n" +
+			"         │   ├─ typeLength: 0\n" +
+			"         │   ├─ typeScale: 0\n" +
 			"         │   └─ xy.x:0!null\n" +
 			"         │   as x]\n" +
 			"         └─ Project\n" +
@@ -554,6 +556,8 @@ Select * from (
 			"     └─ Project\n" +
 			"         ├─ columns: [convert\n" +
 			"         │   ├─ type: signed\n" +
+			"         │   ├─ typeLength: 0\n" +
+			"         │   ├─ typeScale: 0\n" +
 			"         │   └─ xy.x:0!null\n" +
 			"         │   as x]\n" +
 			"         └─ Project\n" +
@@ -2634,6 +2638,8 @@ inner join pq on true
 			"                 │   │   └─ Eq\n" +
 			"                 │   │       ├─ convert\n" +
 			"                 │   │       │   ├─ type: signed\n" +
+			"                 │   │       │   ├─ typeLength: 0\n" +
+			"                 │   │       │   ├─ typeScale: 0\n" +
 			"                 │   │       │   └─ othertable.s2:0!null\n" +
 			"                 │   │       └─ 0 (tinyint)\n" +
 			"                 │   └─ IndexedTableAccess(othertable)\n" +
@@ -3263,6 +3269,8 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ convert\n" +
 			" │   │   ├─ type: char\n" +
+			" │   │   ├─ typeLength: 0\n" +
+			" │   │   ├─ typeScale: 0\n" +
 			" │   │   └─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(a (longtext), b (longtext))\n" +
 			" └─ Table\n" +
@@ -3276,6 +3284,8 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ convert\n" +
 			" │   │   ├─ type: char\n" +
+			" │   │   ├─ typeLength: 0\n" +
+			" │   │   ├─ typeScale: 0\n" +
 			" │   │   └─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(1 (longtext), 2 (longtext))\n" +
 			" └─ Table\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -479,8 +479,6 @@ Select * from (
 			"     └─ Project\n" +
 			"         ├─ columns: [convert\n" +
 			"         │   ├─ type: signed\n" +
-			"         │   ├─ typeLength: 0\n" +
-			"         │   ├─ typeScale: 0\n" +
 			"         │   └─ xy.x:0!null\n" +
 			"         │   as x]\n" +
 			"         └─ Project\n" +
@@ -556,8 +554,6 @@ Select * from (
 			"     └─ Project\n" +
 			"         ├─ columns: [convert\n" +
 			"         │   ├─ type: signed\n" +
-			"         │   ├─ typeLength: 0\n" +
-			"         │   ├─ typeScale: 0\n" +
 			"         │   └─ xy.x:0!null\n" +
 			"         │   as x]\n" +
 			"         └─ Project\n" +
@@ -2638,8 +2634,6 @@ inner join pq on true
 			"                 │   │   └─ Eq\n" +
 			"                 │   │       ├─ convert\n" +
 			"                 │   │       │   ├─ type: signed\n" +
-			"                 │   │       │   ├─ typeLength: 0\n" +
-			"                 │   │       │   ├─ typeScale: 0\n" +
 			"                 │   │       │   └─ othertable.s2:0!null\n" +
 			"                 │   │       └─ 0 (tinyint)\n" +
 			"                 │   └─ IndexedTableAccess(othertable)\n" +
@@ -3269,8 +3263,6 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ convert\n" +
 			" │   │   ├─ type: char\n" +
-			" │   │   ├─ typeLength: 0\n" +
-			" │   │   ├─ typeScale: 0\n" +
 			" │   │   └─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(a (longtext), b (longtext))\n" +
 			" └─ Table\n" +
@@ -3284,8 +3276,6 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ convert\n" +
 			" │   │   ├─ type: char\n" +
-			" │   │   ├─ typeLength: 0\n" +
-			" │   │   ├─ typeScale: 0\n" +
 			" │   │   └─ mytable.i:0!null\n" +
 			" │   └─ TUPLE(1 (longtext), 2 (longtext))\n" +
 			" └─ Table\n" +

--- a/sql/expression/binary.go
+++ b/sql/expression/binary.go
@@ -52,12 +52,12 @@ func (*Binary) CollationCoercibility(ctx *sql.Context) (collation sql.CollationI
 }
 
 func (b *Binary) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	expr, err := b.Child.Eval(ctx, row)
+	val, err := b.Child.Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
 
-	return convertValue(expr, ConvertToBinary, b.Child.Type())
+	return convertValue(val, ConvertToBinary, b.Child.Type(), 0, 0)
 }
 
 func (b *Binary) WithChildren(children ...sql.Expression) (sql.Expression, error) {

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -232,12 +232,12 @@ func (c *comparison) castLeftAndRight(left, right interface{}) (interface{}, int
 }
 
 func convertLeftAndRight(left, right interface{}, convertTo string) (interface{}, interface{}, error) {
-	l, err := convertValue(left, convertTo, nil)
+	l, err := convertValue(left, convertTo, nil, 0, 0)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	r, err := convertValue(right, convertTo, nil)
+	r, err := convertValue(right, convertTo, nil, 0, 0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -183,10 +183,18 @@ func (c *Convert) DebugString() string {
 	_ = pr.WriteNode("convert")
 	children := []string{
 		fmt.Sprintf("type: %v", c.castToType),
-		fmt.Sprintf("typeLength: %v", c.typeLength),
-		fmt.Sprintf("typeScale: %v", c.typeScale),
-		fmt.Sprintf(sql.DebugString(c.Child)),
 	}
+
+	if c.typeLength > 0 {
+		children = append(children, fmt.Sprintf("typeLength: %v", c.typeLength))
+	}
+
+	if c.typeScale > 0 {
+		children = append(children, fmt.Sprintf("typeScale: %v", c.typeScale))
+	}
+
+	children = append(children, fmt.Sprintf(sql.DebugString(c.Child)))
+
 	_ = pr.WriteChildren(children...)
 	return pr.String()
 }

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -196,7 +196,7 @@ func (c *Convert) WithChildren(children ...sql.Expression) (sql.Expression, erro
 	if len(children) != 1 {
 		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
 	}
-	return NewConvert(children[0], c.castToType), nil
+	return NewConvertWithLengthAndScale(children[0], c.castToType, c.typeLength, c.typeScale), nil
 }
 
 // Eval implements the Expression interface.

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -43,6 +43,8 @@ const (
 	ConvertToDatetime = "datetime"
 	// ConvertToDecimal is a conversion to decimal.
 	ConvertToDecimal = "decimal"
+	// ConvertToFloat is a conversion to float.
+	ConvertToFloat = "float"
 	// ConvertToDouble is a conversion to double.
 	ConvertToDouble = "double"
 	// ConvertToJSON is a conversion to json.
@@ -99,6 +101,8 @@ func (c *Convert) Type() sql.Type {
 	case ConvertToDecimal:
 		//TODO: these values are completely arbitrary, we need to get the given precision/scale and store it
 		return types.MustCreateDecimalType(65, 10)
+	case ConvertToFloat:
+		return types.Float32
 	case ConvertToDouble, ConvertToReal:
 		return types.Float64
 	case ConvertToJSON:
@@ -127,7 +131,7 @@ func (c *Convert) CollationCoercibility(ctx *sql.Context) (collation sql.Collati
 		return sql.Collation_binary, 5
 	case ConvertToDecimal:
 		return sql.Collation_binary, 5
-	case ConvertToDouble, ConvertToReal:
+	case ConvertToDouble, ConvertToReal, ConvertToFloat:
 		return sql.Collation_binary, 5
 	case ConvertToJSON:
 		return ctx.GetCharacterSet().BinaryCollation(), 2
@@ -249,6 +253,16 @@ func convertValue(val interface{}, castTo string, originType sql.Type) (interfac
 		d, _, err := types.InternalDecimalType.Convert(value)
 		if err != nil {
 			return "0", nil
+		}
+		return d, nil
+	case ConvertToFloat:
+		value, err := convertHexBlobToDecimalForNumericContext(val, originType)
+		if err != nil {
+			return nil, err
+		}
+		d, _, err := types.Float32.Convert(value)
+		if err != nil {
+			return types.Float32.Zero(), nil
 		}
 		return d, nil
 	case ConvertToDouble, ConvertToReal:

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -375,7 +375,7 @@ func createConvertedDecimalType(length, scale int) sql.DecimalType {
 		}
 		return dt
 	}
-	return types.MustCreateDecimalType(65, 10)
+	return types.InternalDecimalType
 }
 
 // convertHexBlobToDecimalForNumericContext converts byte array value to unsigned int value if originType is BLOB type.

--- a/sql/expression/convert_test.go
+++ b/sql/expression/convert_test.go
@@ -121,6 +121,15 @@ func TestConvert(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:        "convert int to string with length constraint larger than value",
+			row:         nil,
+			expression:  NewLiteral(-3, types.Int32),
+			castTo:      ConvertToChar,
+			typeLength:  10,
+			expected:    "-3",
+			expectedErr: false,
+		},
+		{
 			name:        "impossible conversion string to unsigned",
 			row:         nil,
 			expression:  NewLiteral("hello", types.LongText),
@@ -200,6 +209,15 @@ func TestConvert(t *testing.T) {
 			typeLength:  4,
 			expression:  NewLiteral(10.56789, types.Float32),
 			expected:    "10.5",
+			expectedErr: false,
+		},
+		{
+			name:        "float to char with length restriction larger than value",
+			row:         nil,
+			castTo:      ConvertToChar,
+			typeLength:  40,
+			expression:  NewLiteral(10.56789, types.Float32),
+			expected:    "10.56789",
 			expectedErr: false,
 		},
 		{

--- a/sql/expression/convert_test.go
+++ b/sql/expression/convert_test.go
@@ -51,6 +51,22 @@ func TestConvert(t *testing.T) {
 			expectedErr: false,
 		},
 		{
+			name:        "convert int32 to float",
+			row:         nil,
+			expression:  NewLiteral(int32(-5), types.Int32),
+			castTo:      ConvertToFloat,
+			expected:    float32(-5.0),
+			expectedErr: false,
+		},
+		{
+			name:        "convert int32 to double",
+			row:         nil,
+			expression:  NewLiteral(int32(-5), types.Int32),
+			castTo:      ConvertToDouble,
+			expected:    -5.0,
+			expectedErr: false,
+		},
+		{
 			name:        "convert string to signed",
 			row:         nil,
 			expression:  NewLiteral("-3", types.LongText),
@@ -61,9 +77,17 @@ func TestConvert(t *testing.T) {
 		{
 			name:        "convert string to unsigned",
 			row:         nil,
-			expression:  NewLiteral("-3", types.Int32),
+			expression:  NewLiteral("-3", types.LongText),
 			castTo:      ConvertToUnsigned,
 			expected:    uint64(18446744073709551613),
+			expectedErr: false,
+		},
+		{
+			name:        "convert string to double",
+			row:         nil,
+			expression:  NewLiteral("-3.123", types.LongText),
+			castTo:      ConvertToDouble,
+			expected:    -3.123,
 			expectedErr: false,
 		},
 		{
@@ -88,6 +112,14 @@ func TestConvert(t *testing.T) {
 			castTo:      ConvertToSigned,
 			expression:  NewLiteral("A", types.LongText),
 			expected:    int64(0),
+			expectedErr: false,
+		},
+		{
+			name:        "impossible conversion string to double",
+			row:         nil,
+			castTo:      ConvertToDouble,
+			expression:  NewLiteral("A", types.LongText),
+			expected:    0.0,
 			expectedErr: false,
 		},
 		{

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -4100,7 +4100,23 @@ func ExprToExpression(ctx *sql.Context, e sqlparser.Expr) (sql.Expression, error
 			return nil, err
 		}
 
-		return expression.NewConvert(expr, v.Type.Type), nil
+		typeLength := 0
+		if v.Type.Length != nil {
+			typeLength, err = strconv.Atoi(v.Type.Length.String())
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		typeScale := 0
+		if v.Type.Scale != nil {
+			typeScale, err = strconv.Atoi(v.Type.Scale.String())
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return expression.NewConvertWithLengthAndScale(expr, v.Type.Type, typeLength, typeScale), nil
 	case *sqlparser.RangeCond:
 		val, err := ExprToExpression(ctx, v.Left)
 		if err != nil {

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -297,7 +297,7 @@ func (t DecimalType_) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltype
 	}
 
 	// decimal type value for valid table column should use scale defined by the column.
-	// if the value is not part of valid table column, the result value should used its
+	// if the value is not part of valid table column, the result value should use its
 	// own precision and scale.
 	var val []byte
 	if t.definesColumn {


### PR DESCRIPTION
This PR adds support for casting/converting to `FLOAT` and `DOUBLE` types with the `CAST` and `CONVERT` functions. It also adds support for length (aka precision) and scale type constraints (e.g. `CAST(1.2345 AS DECIMAL(3,2))`).

Parser support for `DOUBLE` and `FLOAT` with `CAST` and `CONVERT`: https://github.com/dolthub/vitess/pull/249

Fixes: https://github.com/dolthub/dolt/issues/5835