### PR TITLE
fix panic for group by binary type

### DIFF
--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -95,21 +95,21 @@ var OrderByGroupByScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "select binary s from t group by binary s order by binary s",
+				Query: "select binary s from t group by binary s order by binary s",
 				Expected: []sql.Row{
 					{[]uint8("abc")},
 					{[]uint8("def")},
 				},
 			},
 			{
-				Query:    "select count(b), b from t1 group by b order by b",
+				Query: "select count(b), b from t1 group by b order by b",
 				Expected: []sql.Row{
 					{3, []uint8("abc")},
 					{2, []uint8("def")},
 				},
 			},
 			{
-				Query:    "select binary s from t group by binary s order by s",
+				Query: "select binary s from t group by binary s order by s",
 				Expected: []sql.Row{
 					{[]uint8("abc")},
 					{[]uint8("def")},

--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -86,6 +86,40 @@ var OrderByGroupByScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Group by BINARY: https://github.com/dolthub/dolt/issues/6179",
+		SetUpScript: []string{
+			"create table t (s varchar(100));",
+			"insert into t values ('abc'), ('def');",
+			"create table t1 (b binary(3));",
+			"insert into t1 values ('abc'), ('abc'), ('def'), ('abc'), ('def');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select binary s from t group by binary s order by binary s",
+				Expected: []sql.Row{
+					{[]uint8("abc")},
+					{[]uint8("def")},
+				},
+			},
+			{
+				Query:    "select count(b), b from t1 group by b order by b",
+				Expected: []sql.Row{
+					{3, []uint8("abc")},
+					{2, []uint8("def")},
+				},
+			},
+			// These should work without the order by, but we don't implement functional dependencies correctly
+			{
+				Query:    "select binary s from t group by binary s order by s",
+				Skip: true,
+				Expected: []sql.Row{
+					{[]uint8("abc")},
+					{[]uint8("def")},
+				},
+			},
+		},
+	},
+	{
 		Name: "https://github.com/dolthub/dolt/issues/3016",
 		SetUpScript: []string{
 			"CREATE TABLE `users` (`id` int NOT NULL AUTO_INCREMENT,  `username` varchar(255) NOT NULL,  PRIMARY KEY (`id`));",

--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -108,10 +108,8 @@ var OrderByGroupByScriptTests = []ScriptTest{
 					{2, []uint8("def")},
 				},
 			},
-			// These should work without the order by, but we don't implement functional dependencies correctly
 			{
 				Query:    "select binary s from t group by binary s order by s",
-				Skip: true,
 				Expected: []sql.Row{
 					{[]uint8("abc")},
 					{[]uint8("def")},

--- a/sql/analyzer/resolve_columns.go
+++ b/sql/analyzer/resolve_columns.go
@@ -344,7 +344,7 @@ func identifyGroupingAliasReferences(groupBy *plan.GroupBy) (*plan.GroupBy, tran
 			return e, transform.SameTree, nil
 		}
 
-		if stringContains(projectedAliases, strings.ToLower(uc.Name())) {
+		if stringContains(projectedAliases, uc.Name()) {
 			return expression.NewAliasReference(uc.Name()), transform.NewTree, nil
 		}
 

--- a/sql/analyzer/resolve_orderby.go
+++ b/sql/analyzer/resolve_orderby.go
@@ -64,8 +64,7 @@ func pushdownSort(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, 
 
 			for _, n := range ns {
 				col := tableColFromNameable(n)
-				name := strings.ToLower(n.Name())
-				if col.Table() == "" && stringContains(childAliases, name) {
+				if col.Table() == "" && stringContains(childAliases, n.Name()) {
 					colsFromChild = append(colsFromChild, n.Name())
 				} else if !tableColsContains(schemaCols, col) {
 					missingCols = append(missingCols, col)

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -296,7 +296,7 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 
 		var groupBys []string
 		for _, expr := range gb.GroupByExprs {
-			groupBys = append(groupBys, expr.String())
+			groupBys = append(groupBys, strings.ToLower(expr.String()))
 		}
 
 		for _, expr := range gb.SelectedExprs {
@@ -320,7 +320,7 @@ func expressionReferencesOnlyGroupBys(groupBys []string, expr sql.Expression) bo
 		case nil, sql.Aggregation, *expression.Literal:
 			return false
 		case *expression.Alias, sql.FunctionExpression:
-			if stringContains(groupBys, expr.String()) {
+			if stringContains(groupBys, strings.ToLower(expr.String())) {
 				return false
 			}
 			return true
@@ -328,8 +328,8 @@ func expressionReferencesOnlyGroupBys(groupBys []string, expr sql.Expression) bo
 		// Each part of the SelectExpr must refer to the aggregated columns in some way
 		// TODO: this isn't complete, it's overly restrictive. Dependant columns are fine to reference.
 		default:
-			if stringContains(groupBys, expr.String()) {
-				return true
+			if stringContains(groupBys, strings.ToLower(expr.String())) {
+				return false
 			}
 
 			if len(expr.Children()) == 0 {

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -296,7 +296,7 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 
 		var groupBys []string
 		for _, expr := range gb.GroupByExprs {
-			groupBys = append(groupBys, strings.ToLower(expr.String()))
+			groupBys = append(groupBys, expr.String())
 		}
 
 		for _, expr := range gb.SelectedExprs {
@@ -320,7 +320,7 @@ func expressionReferencesOnlyGroupBys(groupBys []string, expr sql.Expression) bo
 		case nil, sql.Aggregation, *expression.Literal:
 			return false
 		case *expression.Alias, sql.FunctionExpression:
-			if stringContains(groupBys, strings.ToLower(expr.String())) {
+			if stringContains(groupBys, expr.String()) {
 				return false
 			}
 			return true
@@ -328,7 +328,7 @@ func expressionReferencesOnlyGroupBys(groupBys []string, expr sql.Expression) bo
 		// Each part of the SelectExpr must refer to the aggregated columns in some way
 		// TODO: this isn't complete, it's overly restrictive. Dependant columns are fine to reference.
 		default:
-			if stringContains(groupBys, strings.ToLower(expr.String())) {
+			if stringContains(groupBys, expr.String()) {
 				return false
 			}
 
@@ -659,8 +659,9 @@ func validateSubqueryColumns(ctx *sql.Context, a *Analyzer, n sql.Node, scope *p
 }
 
 func stringContains(strs []string, target string) bool {
+	lowerTarget := strings.ToLower(target)
 	for _, s := range strs {
-		if s == target {
+		if lowerTarget == strings.ToLower(s) {
 			return true
 		}
 	}

--- a/sql/rowexec/agg.go
+++ b/sql/rowexec/agg.go
@@ -17,6 +17,7 @@ package rowexec
 import (
 	"errors"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"io"
 
 	"github.com/cespare/xxhash"
@@ -248,7 +249,10 @@ func groupingKey(
 
 		t, isStringType := expr.Type().(sql.StringType)
 		if isStringType && v != nil {
-			err = t.Collation().WriteWeightString(hash, v.(string))
+			v, err = types.ConvertToString(v, t)
+			if err == nil {
+				err = t.Collation().WriteWeightString(hash, v.(string))
+			}
 		} else {
 			_, err = fmt.Fprintf(hash, "%v", v)
 		}

--- a/sql/rowexec/agg.go
+++ b/sql/rowexec/agg.go
@@ -17,13 +17,13 @@ package rowexec
 import (
 	"errors"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/types"
 	"io"
 
 	"github.com/cespare/xxhash"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 type groupByIter struct {


### PR DESCRIPTION
We made a bad type assertion for `sql.StringType`.
Additionally, this fixes a issue where `UnaryExpressions` with `GetFields` would incorrectly throw a functional dependency error with `ONLY_FULL_GROUP_BY` enabled.

Fix for second part of: https://github.com/dolthub/dolt/issues/6179