### PR TITLE
update `information_schema.processlist` to correctly display status of processes and databases

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -286,9 +286,6 @@ func TestInfoSchema(t *testing.T, h Harness) {
 			{uint64(1), "root", "localhost", "NULL", "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"},
 			{uint64(2), "root", "localhost", "NULL", "Sleep", 0, "", ""},
 		}, nil, nil)
-
-
-		//TestQueryWithContext(t, ctx, e, h, "SELECT * FROM information_schema.processlist", []sql.Row{{uint64(1), "root", "localhost", "NULL", "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"}}, nil, nil)
 	})
 
 	for _, tt := range queries.SkippedInfoSchemaQueries {

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -274,7 +274,21 @@ func TestInfoSchema(t *testing.T, h Harness) {
 		ctx, err := p.BeginQuery(ctx, "SELECT foo")
 		require.NoError(t, err)
 
-		TestQueryWithContext(t, ctx, e, h, "SELECT * FROM information_schema.processlist", []sql.Row{{uint64(1), "root", "localhost", "NULL", "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"}}, nil, nil)
+		p.AddConnection(2, "otherhost")
+		sess = sql.NewBaseSessionWithClientServer("localhost", sql.Client{Address: "localhost", User: "root"}, 2)
+		p.ConnectionReady(sess)
+		ctx2 := sql.NewContext(context.Background(), sql.WithPid(2), sql.WithSession(sess))
+		ctx2, err = p.BeginQuery(ctx2, "SELECT bar")
+		require.NoError(t, err)
+		p.EndQuery(ctx2)
+
+		TestQueryWithContext(t, ctx, e, h, "SELECT * FROM information_schema.processlist ORDER BY id", []sql.Row{
+			{uint64(1), "root", "localhost", "NULL", "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"},
+			{uint64(2), "root", "localhost", "NULL", "Sleep", 0, "", ""},
+		}, nil, nil)
+
+
+		//TestQueryWithContext(t, ctx, e, h, "SELECT * FROM information_schema.processlist", []sql.Row{{uint64(1), "root", "localhost", "NULL", "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"}}, nil, nil)
 	})
 
 	for _, tt := range queries.SkippedInfoSchemaQueries {

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -284,7 +284,7 @@ func TestInfoSchema(t *testing.T, h Harness) {
 		p.EndQuery(ctx2)
 
 		TestQueryWithContext(t, ctx, e, h, "SELECT * FROM information_schema.processlist ORDER BY id", []sql.Row{
-			{uint64(1), "root", "localhost", "NULL", "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"},
+			{uint64(1), "root", "localhost", nil, "Query", 0, "processlist(processlist (0/? partitions))", "SELECT foo"},
 			{uint64(2), "root", "otherhost", "otherdb", "Sleep", 0, "", ""},
 		}, nil, nil)
 	})

--- a/processlist.go
+++ b/processlist.go
@@ -80,6 +80,7 @@ func (pl *ProcessList) ConnectionReady(sess sql.Session) {
 		Host:       sess.Client().Address,
 		User:       sess.Client().User,
 		StartedAt:  time.Now(),
+		Database:   sess.GetCurrentDatabase(),
 	}
 }
 

--- a/processlist_test.go
+++ b/processlist_test.go
@@ -32,6 +32,7 @@ func TestProcessList(t *testing.T) {
 	p := NewProcessList()
 	p.AddConnection(1, clientHostOne)
 	sess := sql.NewBaseSessionWithClientServer("0.0.0.0:3306", sql.Client{Address: clientHostOne, User: "foo"}, 1)
+	sess.SetCurrentDatabase("test_db")
 	p.ConnectionReady(sess)
 	ctx := sql.NewContext(context.Background(), sql.WithPid(1), sql.WithSession(sess))
 	ctx, err := p.BeginQuery(ctx, "SELECT foo")
@@ -55,6 +56,7 @@ func TestProcessList(t *testing.T) {
 		Query:     "SELECT foo",
 		Command:   sql.ProcessCommandQuery,
 		StartedAt: p.procs[1].StartedAt,
+		Database:  "test_db",
 	}
 	require.NotNil(p.procs[1].Kill)
 	p.procs[1].Kill = nil

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1073,9 +1073,9 @@ func processListRowIter(ctx *Context, c Catalog) (RowIter, error) {
 		}
 		sort.Strings(status)
 
-		db := proc.Database
-		if db == "" {
-			db = "NULL"
+		var db interface{}
+		if proc.Database != "" {
+			db = proc.Database
 		}
 
 		rows[i] = Row{

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1063,11 +1063,6 @@ func processListRowIter(ctx *Context, c Catalog) (RowIter, error) {
 	processes := ctx.ProcessList.Processes()
 	var rows = make([]Row, len(processes))
 
-	db := ctx.GetCurrentDatabase()
-	if db == "" {
-		db = "NULL"
-	}
-
 	for i, proc := range processes {
 		var status []string
 		for name, progress := range proc.Progress {
@@ -1077,15 +1072,21 @@ func processListRowIter(ctx *Context, c Catalog) (RowIter, error) {
 			status = []string{"running"}
 		}
 		sort.Strings(status)
+
+		db := proc.Database
+		if db == "" {
+			db = "NULL"
+		}
+
 		rows[i] = Row{
-			uint64(proc.Connection),      // id
-			proc.User,                    // user
-			ctx.Session.Client().Address, // host
-			db,                           // db
-			string(proc.Command),         // command
-			int32(proc.Seconds()),        // time
-			strings.Join(status, ", "),   // state
-			proc.Query,                   // info
+			uint64(proc.Connection),        // id
+			proc.User,                      // user
+			proc.Host,                      // host
+			db,                             // db
+			string(proc.Command),           // command
+			int32(proc.Seconds()),          // time
+			strings.Join(status, ", "), // state
+			proc.Query,                     // info
 		}
 	}
 

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1073,7 +1073,7 @@ func processListRowIter(ctx *Context, c Catalog) (RowIter, error) {
 		for name, progress := range proc.Progress {
 			status = append(status, fmt.Sprintf("%s(%s)", name, progress))
 		}
-		if len(status) == 0 {
+		if len(status) == 0 && proc.Command == ProcessCommandQuery {
 			status = []string{"running"}
 		}
 		sort.Strings(status)
@@ -1082,7 +1082,7 @@ func processListRowIter(ctx *Context, c Catalog) (RowIter, error) {
 			proc.User,                    // user
 			ctx.Session.Client().Address, // host
 			db,                           // db
-			"Query",                      // command
+			string(proc.Command),         // command
 			int32(proc.Seconds()),        // time
 			strings.Join(status, ", "),   // state
 			proc.Query,                   // info

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -1079,14 +1079,14 @@ func processListRowIter(ctx *Context, c Catalog) (RowIter, error) {
 		}
 
 		rows[i] = Row{
-			uint64(proc.Connection),        // id
-			proc.User,                      // user
-			proc.Host,                      // host
-			db,                             // db
-			string(proc.Command),           // command
-			int32(proc.Seconds()),          // time
+			uint64(proc.Connection),    // id
+			proc.User,                  // user
+			proc.Host,                  // host
+			db,                         // db
+			string(proc.Command),       // command
+			int32(proc.Seconds()),      // time
 			strings.Join(status, ", "), // state
-			proc.Query,                     // info
+			proc.Query,                 // info
 		}
 	}
 


### PR DESCRIPTION
We used to hardcode `"Query"`, now we reference `process.Command`
Additionally, we now get the database from the current session and use that variable.

fix for: https://github.com/dolthub/dolt/issues/6023