### PR TITLE
Fix TargetSchema.Resolved() to check targetSchema column default expressions

### DIFF
--- a/sql/plan/alter_default.go
+++ b/sql/plan/alter_default.go
@@ -64,6 +64,11 @@ func (d *AlterDefaultSet) String() string {
 	return fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s", d.Table.String(), d.ColumnName, d.Default.String())
 }
 
+// Resolved implements the sql.Node interface.
+func (d *AlterDefaultDrop) Resolved() bool {
+	return d.ddlNode.Resolved() && d.Table.Resolved() && d.targetSchema.Resolved()
+}
+
 // RowIter implements the sql.Node interface.
 func (d *AlterDefaultSet) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
 	// Grab the table fresh from the database.
@@ -123,7 +128,7 @@ func (d *AlterDefaultSet) CollationCoercibility(ctx *sql.Context) (collation sql
 
 // Resolved implements the sql.Node interface.
 func (d *AlterDefaultSet) Resolved() bool {
-	return d.Table.Resolved() && d.ddlNode.Resolved() && d.Default.Resolved()
+	return d.ddlNode.Resolved() && d.Table.Resolved() && d.Default.Resolved() && d.targetSchema.Resolved()
 }
 
 func (d *AlterDefaultSet) Expressions() []sql.Expression {

--- a/sql/plan/alter_index.go
+++ b/sql/plan/alter_index.go
@@ -257,7 +257,7 @@ func (p AlterIndex) String() string {
 }
 
 func (p *AlterIndex) Resolved() bool {
-	return p.Table.Resolved() && p.ddlNode.Resolved()
+	return p.Table.Resolved() && p.ddlNode.Resolved() && p.targetSchema.Resolved()
 }
 
 // Children implements the sql.Node interface.

--- a/sql/plan/alter_pk.go
+++ b/sql/plan/alter_pk.go
@@ -67,13 +67,7 @@ func NewAlterDropPk(db sql.Database, table sql.Node) *AlterPK {
 }
 
 func (a *AlterPK) Resolved() bool {
-	for _, expr := range a.Expressions() {
-		if expr.Resolved() == false {
-			return false
-		}
-	}
-
-	return a.Table.Resolved() && a.ddlNode.Resolved()
+	return a.Table.Resolved() && a.ddlNode.Resolved() && a.targetSchema.Resolved()
 }
 
 func (a *AlterPK) String() string {

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -303,17 +303,7 @@ func (a AddColumn) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
 
 // Resolved implements the Resolvable interface.
 func (a *AddColumn) Resolved() bool {
-	if !(a.ddlNode.Resolved() && a.Table.Resolved() && a.column.Default.Resolved()) {
-		return false
-	}
-
-	for _, col := range a.targetSch {
-		if !col.Default.Resolved() {
-			return false
-		}
-	}
-
-	return true
+	return a.ddlNode.Resolved() && a.Table.Resolved() && a.column.Default.Resolved() && a.targetSch.Resolved()
 }
 
 // WithTargetSchema implements sql.SchemaTarget
@@ -544,17 +534,7 @@ func (d *DropColumn) Schema() sql.Schema {
 }
 
 func (d *DropColumn) Resolved() bool {
-	if !d.Table.Resolved() && !d.ddlNode.Resolved() {
-		return false
-	}
-
-	for _, col := range d.targetSchema {
-		if !col.Default.Resolved() {
-			return false
-		}
-	}
-
-	return true
+	return d.Table.Resolved() && d.ddlNode.Resolved() && d.targetSchema.Resolved()
 }
 
 func (d *DropColumn) Children() []sql.Node {
@@ -667,17 +647,7 @@ func (r *RenameColumn) DebugString() string {
 }
 
 func (r *RenameColumn) Resolved() bool {
-	if !r.Table.Resolved() && r.ddlNode.Resolved() {
-		return false
-	}
-
-	for _, col := range r.targetSchema {
-		if !col.Default.Resolved() {
-			return false
-		}
-	}
-
-	return true
+	return r.Table.Resolved() && r.ddlNode.Resolved() && r.targetSchema.Resolved()
 }
 
 func (r *RenameColumn) Schema() sql.Schema {
@@ -838,17 +808,7 @@ func (m ModifyColumn) WithExpressions(exprs ...sql.Expression) (sql.Node, error)
 
 // Resolved implements the Resolvable interface.
 func (m *ModifyColumn) Resolved() bool {
-	if !(m.Table.Resolved() && m.column.Default.Resolved() && m.ddlNode.Resolved()) {
-		return false
-	}
-
-	for _, col := range m.targetSchema {
-		if !col.Default.Resolved() {
-			return false
-		}
-	}
-
-	return true
+	return m.Table.Resolved() && m.column.Default.Resolved() && m.ddlNode.Resolved() && m.targetSchema.Resolved()
 }
 
 func (m *ModifyColumn) ValidateDefaultPosition(tblSch sql.Schema) error {

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -223,14 +223,8 @@ func (c *CreateTable) PkSchema() sql.PrimaryKeySchema {
 
 // Resolved implements the Resolvable interface.
 func (c *CreateTable) Resolved() bool {
-	if !c.ddlNode.Resolved() {
+	if !c.ddlNode.Resolved() || !c.CreateSchema.Schema.Resolved() {
 		return false
-	}
-
-	for _, col := range c.CreateSchema.Schema {
-		if !col.Default.Resolved() {
-			return false
-		}
 	}
 
 	for _, chDef := range c.ChDefs {

--- a/sql/plan/show_create_table.go
+++ b/sql/plan/show_create_table.go
@@ -59,17 +59,7 @@ func NewShowCreateTableWithAsOf(table sql.Node, isView bool, asOf sql.Expression
 
 // Resolved implements the Resolvable interface.
 func (sc *ShowCreateTable) Resolved() bool {
-	if !sc.Child.Resolved() {
-		return false
-	}
-
-	for _, col := range sc.targetSchema {
-		if !col.Default.Resolved() {
-			return false
-		}
-	}
-
-	return true
+	return sc.Child.Resolved() && sc.targetSchema.Resolved()
 }
 
 func (sc ShowCreateTable) WithChildren(children ...sql.Node) (sql.Node, error) {

--- a/sql/plan/showcolumns.go
+++ b/sql/plan/showcolumns.go
@@ -74,17 +74,7 @@ func (s *ShowColumns) Schema() sql.Schema {
 
 // Resolved implements the sql.Node interface.
 func (s *ShowColumns) Resolved() bool {
-	if !s.Child.Resolved() {
-		return false
-	}
-
-	for _, col := range s.targetSchema {
-		if !col.Default.Resolved() {
-			return false
-		}
-	}
-
-	return true
+	return s.Child.Resolved() && s.targetSchema.Resolved()
 }
 
 func (s *ShowColumns) Expressions() []sql.Expression {

--- a/sql/schemas.go
+++ b/sql/schemas.go
@@ -118,6 +118,20 @@ func (s Schema) HasAutoIncrement() bool {
 	return false
 }
 
+// Resolved returns true if this schema is fully resolved. Currently, the only piece of a schema that needs
+// to be resolved are any column default value expressions.
+func (s Schema) Resolved() bool {
+	for _, c := range s {
+		if c.Default != nil {
+			if !c.Default.Resolved() {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
 func IsKeyless(s Schema) bool {
 	for _, c := range s {
 		if c.PrimaryKey {


### PR DESCRIPTION
A couple `SchemaTarget` implementations weren't checking if the `targetSchema` was resolved as part of the `Resolved()` method. Added tests, audited the other implementations, and simplified the logic to use a new method on `Schema` to check that column default expressions are resolved. 

Fixes: https://github.com/dolthub/dolt/issues/6206

Dolt CI Run: https://github.com/dolthub/dolt/pull/6213