### PR TITLE
`IntDiv.Type()` should always return either `uint64` or `int64`

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3293,9 +3293,9 @@ Select * from (
 	{
 		Query: "SELECT unix_timestamp(timestamp_col) div 60 * 60 as timestamp_col, avg(i) from datetime_table group by 1 order by unix_timestamp(timestamp_col) div 60 * 60",
 		Expected: []sql.Row{
-			{"1577966400", 1.0},
-			{"1578225600", 2.0},
-			{"1578398400", 3.0}},
+			{int64(1577966400), 1.0},
+			{int64(1578225600), 2.0},
+			{int64(1578398400), 3.0}},
 		SkipPrepared: true,
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1591,10 +1591,10 @@ var ScriptTests = []ScriptTest{
 				Query: `SELECT UNIX_TIMESTAMP(time) DIV 60 * 60 AS "time", avg(value) AS "value"
 				FROM test GROUP BY 1 ORDER BY UNIX_TIMESTAMP(test.time) DIV 60 * 60`,
 				Expected: []sql.Row{
-					{"1625133600", 4.0},
-					{"1625220000", 3.0},
-					{"1625306400", 2.0},
-					{"1625392800", 1.0},
+					{int64(1625133600), 4.0},
+					{int64(1625220000), 3.0},
+					{int64(1625306400), 2.0},
+					{int64(1625392800), 1.0},
 				},
 			},
 		},


### PR DESCRIPTION
Previously, our `IntDiv.convertLeftRight()` used `IntDiv.Type()` to determine the larger type between `IntDiv.Left.Type()` and `IntDiv.Right.Type()` to avoid precision loss when doing internal calculations. Now, that logic is moved from `IntDiv.Type()` to `IntDiv.convertLeftRight()`, and `IntDiv.Type()` can only return `uint64` or `int64`.

This should fix the sql correctness regression from https://github.com/dolthub/go-mysql-server/pull/1834