### PR TITLE
No parallelism for children of ordered distinct

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -420,6 +420,15 @@ func TestIndexQueryPlans(t *testing.T) {
 	}
 }
 
+func TestParallelismQueries(t *testing.T) {
+	enginetest.TestParallelismQueries(t, enginetest.NewMemoryHarness("default", 2, testNumPartitions, true, nil))
+}
+
+func TestParallelismQueries_Experimental(t *testing.T) {
+	t.Skip("parallelism + experimental harness hard to construct")
+	enginetest.TestParallelismQueries(t, enginetest.NewMemoryHarness("default", 2, testNumPartitions, true, nil).WithVersion(sql.VersionExperimental))
+}
+
 func TestQueryErrors(t *testing.T) {
 	enginetest.TestQueryErrors(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/enginetest/parallelism.go
+++ b/enginetest/parallelism.go
@@ -1,0 +1,61 @@
+package enginetest
+
+import (
+	"fmt"
+	"testing"
+
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParallelismQueries(t *testing.T, harness Harness) {
+	harness.Setup(setup.XySetup...)
+	e := mustNewEngine(t, harness)
+	defer e.Close()
+	for _, tt := range queries.ParallelismTests {
+		t.Run(tt.Query, func(t *testing.T) {
+			evalParallelismTest(t, harness, e, tt.Query, tt.Parallel)
+		})
+	}
+}
+
+func evalParallelismTest(t *testing.T, harness Harness, e *sqle.Engine, query string, parallel bool) {
+	ctx := NewContext(harness)
+	ctx = ctx.WithQuery(query)
+	a, err := e.AnalyzeQuery(ctx, query)
+	require.NoError(t, err)
+	require.Equal(t, parallel, findExchange(a), fmt.Sprintf("expected exchange: %t\nplan:\n%s", parallel, sql.DebugString(a)))
+}
+
+func findExchange(n sql.Node) bool {
+	return transform.InspectUp(n, func(n sql.Node) bool {
+		if n == nil {
+			return false
+		}
+		_, ok := n.(*plan.Exchange)
+		if ok {
+			return true
+		}
+
+		if ex, ok := n.(sql.Expressioner); ok {
+			for _, e := range ex.Expressions() {
+				found := transform.InspectExpr(e, func(e sql.Expression) bool {
+					sq, ok := e.(*plan.Subquery)
+					if !ok {
+						return false
+					}
+					return findExchange(sq.Query)
+				})
+				if found {
+					return true
+				}
+			}
+		}
+		return false
+	})
+}

--- a/enginetest/parallelism.go
+++ b/enginetest/parallelism.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/enginetest/queries"
 	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
-	"github.com/stretchr/testify/require"
 )
 
 func TestParallelismQueries(t *testing.T, harness Harness) {

--- a/enginetest/queries/parallelism.go
+++ b/enginetest/queries/parallelism.go
@@ -1,0 +1,13 @@
+package queries
+
+type ParallelismTest struct {
+	Query    string
+	Parallel bool
+}
+
+var ParallelismTests = []ParallelismTest{
+	{
+		Query:    "SELECT /*+ JOIN_ORDER(xy,scalarSubq0) LOOKUP_JOIN(xy,scalarSubq0) */ count(*) from xy where y in (select distinct v from uv)",
+		Parallel: false,
+	},
+}


### PR DESCRIPTION
We permitted parallelism into an OrderedDistinct node, which is a specialized Distinct node that expects results sorted on a specific index key. This change prevents parallelizing children of OrderedDistinct.