### PR TITLE
Add CustomValidator interface

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -486,7 +486,7 @@ func checkResults(
 		}
 	}
 
-	// Special case for DOLT COMMIT HASHES
+	// Special case for custom values
 	for i, row := range widenedExpected {
 		for j, field := range row {
 			if cvv, isCustom := field.(CustomValueValidator); isCustom {

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -446,6 +446,7 @@ func runQueryPreparedWithCtx(
 
 // DoltCommitType is a special equality type when we expect to see a commit hash in the results
 type DoltCommitType string
+
 var DoltCommit DoltCommitType = "DOLT_COMMIT"
 var hashRegex = regexp.MustCompile(`^[0-9a-v]{32}$`)
 
@@ -492,7 +493,7 @@ func checkResults(
 		for j, field := range row {
 			if _, ok := field.(DoltCommitType); ok {
 				actual := widenedRows[i][j] // shouldn't panic, but fine if it does
-				hash := actual.(string) // might panic, but also fine if it does
+				hash := actual.(string)     // might panic, but also fine if it does
 				if !hashRegex.MatchString(hash) {
 					t.Errorf("Expected commit hash, got %v", actual)
 				}


### PR DESCRIPTION
In many places we expect to see a commit hash in our result.
Since the hashes take into account the system time when computing, it is difficult to predict what they will be.

This PR adds a new interface that can be implemented on the dolt side to check for commit hashes.