### PR TITLE
Fix bug in OrderedDistinct over Projection

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -168,6 +168,28 @@ var joinOpTests = []struct {
 		},
 	},
 	{
+		name: "ordered distinct",
+		setup: [][]string{
+			setup.MydbData[0],
+			{
+				"create table uv (u int primary key, v int);",
+				"insert into uv values (1,1),(2,2),(3,1),(4,2);",
+				"create table xy (x int primary key, y int);",
+				"insert into xy values (1,1),(2,2);",
+			},
+		},
+		tests: []JoinOpTests{
+			{
+				Query:    `select /*+ JOIN_ORDER(scalarSubq0,xy) */ count(*) from xy where y in (select distinct v from uv);`,
+				Expected: []sql.Row{{2}},
+			},
+			{
+				Query:    `SELECT /*+ JOIN_ORDER(scalarSubq0,xy) */ count(*) from xy where y in (select distinct u from uv);`,
+				Expected: []sql.Row{{2}},
+			},
+		},
+	},
+	{
 		name: "4-way join tests",
 		setup: [][]string{
 			setup.MydbData[0],

--- a/enginetest/queries/parallelism.go
+++ b/enginetest/queries/parallelism.go
@@ -7,7 +7,11 @@ type ParallelismTest struct {
 
 var ParallelismTests = []ParallelismTest{
 	{
-		Query:    "SELECT /*+ JOIN_ORDER(xy,scalarSubq0) LOOKUP_JOIN(xy,scalarSubq0) */ count(*) from xy where y in (select distinct v from uv)",
+		Query:    "SELECT /*+ JOIN_ORDER(scalarSubq0,xy) LOOKUP_JOIN(xy,scalarSubq0) */ count(*) from xy where y in (select distinct v from uv)",
+		Parallel: true,
+	},
+	{
+		Query:    "SELECT /*+ JOIN_ORDER(scalarSubq0,xy) LOOKUP_JOIN(xy,scalarSubq0) */ count(*) from xy where y in (select distinct u from uv)",
 		Parallel: false,
 	},
 }

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25,6 +25,56 @@ type QueryPlanTest struct {
 // in testgen_test.go.
 var PlanTests = []QueryPlanTest{
 	{
+		Query: `select /*+ JOIN_ORDER(scalarSubq0,xy) */ count(*) from xy where y in (select distinct v from uv);`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [COUNT(1):0!null as count(*)]\n" +
+			" └─ GroupBy\n" +
+			"     ├─ select: COUNT(1 (bigint))\n" +
+			"     ├─ group: \n" +
+			"     └─ Project\n" +
+			"         ├─ columns: [xy.x:1!null, xy.y:2]\n" +
+			"         └─ LookupJoin\n" +
+			"             ├─ Eq\n" +
+			"             │   ├─ xy.y:2\n" +
+			"             │   └─ scalarSubq0.v:0\n" +
+			"             ├─ Distinct\n" +
+			"             │   └─ Project\n" +
+			"             │       ├─ columns: [scalarSubq0.v:1]\n" +
+			"             │       └─ TableAlias(scalarSubq0)\n" +
+			"             │           └─ Table\n" +
+			"             │               ├─ name: uv\n" +
+			"             │               └─ columns: [u v]\n" +
+			"             └─ IndexedTableAccess(xy)\n" +
+			"                 ├─ index: [xy.y]\n" +
+			"                 └─ columns: [x y]\n" +
+			"",
+	},
+	{
+		Query: `SELECT /*+ JOIN_ORDER(scalarSubq0,xy) */ count(*) from xy where y in (select distinct u from uv);`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [COUNT(1):0!null as count(*)]\n" +
+			" └─ GroupBy\n" +
+			"     ├─ select: COUNT(1 (bigint))\n" +
+			"     ├─ group: \n" +
+			"     └─ Project\n" +
+			"         ├─ columns: [xy.x:1!null, xy.y:2]\n" +
+			"         └─ LookupJoin\n" +
+			"             ├─ Eq\n" +
+			"             │   ├─ xy.y:2\n" +
+			"             │   └─ scalarSubq0.u:0!null\n" +
+			"             ├─ OrderedDistinct\n" +
+			"             │   └─ Project\n" +
+			"             │       ├─ columns: [scalarSubq0.u:0!null]\n" +
+			"             │       └─ TableAlias(scalarSubq0)\n" +
+			"             │           └─ Table\n" +
+			"             │               ├─ name: uv\n" +
+			"             │               └─ columns: [u v]\n" +
+			"             └─ IndexedTableAccess(xy)\n" +
+			"                 ├─ index: [xy.y]\n" +
+			"                 └─ columns: [x y]\n" +
+			"",
+	},
+	{
 		Query: `select count(*) from mytable`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [mytable.count(*):0!null as count(*)]\n" +
@@ -15943,7 +15993,7 @@ ORDER BY cla.FTQLQ ASC`,
 			"                 │               │       │       ├─ index: [THNTS.id]\n" +
 			"                 │               │       │       ├─ static: [{[NULL, ∞)}]\n" +
 			"                 │               │       │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
-			"                 │               │       └─ OrderedDistinct\n" +
+			"                 │               │       └─ Distinct\n" +
 			"                 │               │           └─ TableAlias(scalarSubq1)\n" +
 			"                 │               │               └─ IndexedTableAccess(HGMQ6)\n" +
 			"                 │               │                   ├─ index: [HGMQ6.GXLUB]\n" +
@@ -15953,7 +16003,7 @@ ORDER BY cla.FTQLQ ASC`,
 			"                 │                   ├─ left-key: TUPLE(scalarSubq0.id:0!null)\n" +
 			"                 │                   ├─ right-key: TUPLE(scalarSubq2.GXLUB:0!null)\n" +
 			"                 │                   └─ CachedResults\n" +
-			"                 │                       └─ OrderedDistinct\n" +
+			"                 │                       └─ Distinct\n" +
 			"                 │                           └─ TableAlias(scalarSubq2)\n" +
 			"                 │                               └─ Table\n" +
 			"                 │                                   ├─ name: AMYXQ\n" +
@@ -16043,7 +16093,7 @@ ORDER BY cla.FTQLQ ASC`,
 			"                 │               │       ├─ index: [THNTS.id]\n" +
 			"                 │               │       ├─ static: [{[NULL, ∞)}]\n" +
 			"                 │               │       └─ columns: [id nfryn ixuxu fhcyt]\n" +
-			"                 │               └─ OrderedDistinct\n" +
+			"                 │               └─ Distinct\n" +
 			"                 │                   └─ TableAlias(scalarSubq1)\n" +
 			"                 │                       └─ IndexedTableAccess(AMYXQ)\n" +
 			"                 │                           ├─ index: [AMYXQ.GXLUB]\n" +

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -419,7 +419,7 @@ func sortedInputs(rel RelExpr) bool {
 			// i -> output idx (distinct)
 			// j -> input idx
 			// want to find matches for all i where j_i <= j_i+1
-			if strings.EqualFold(outputs[i].Source, inputs[j].Source) &&
+			if strings.EqualFold(outputs[i].Name, inputs[j].Name) &&
 				strings.EqualFold(outputs[i].Source, inputs[j].Source) {
 				i++
 			} else {


### PR DESCRIPTION
A mistype was checking the table name twice for column equality, rather than table and column name. The bug led to using OrderedDistinct in inappropriate cases.