### PR TITLE
avoid scientific notation for floats/decimals

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4437,6 +4437,10 @@ Select * from (
 		Expected: []sql.Row{{"10.12"}},
 	},
 	{
+		Query:    `SELECT CONVERT(1234567893.1234567893, DECIMAL(20,10))`,
+		Expected: []sql.Row{{"1234567893.1234567893"}},
+	},
+	{
 		// In enginetests, the SQL wire conversion logic isn't used, which is what expands the DECIMAL(4,2) value
 		// from "10" to "10.00" to exactly match MySQL's result. So, here we see just "10", but through sql-server
 		// we'll see the correct "10.00" value. Ideally, the enginetests (and dolt sql) would also execute the

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -4346,7 +4346,7 @@ func convertVal(ctx *sql.Context, v *sqlparser.SQLVal) (sql.Expression, error) {
 		// use the value as string format to keep precision and scale as defined for DECIMAL data type to avoid rounded up float64 value
 		if ps := strings.Split(string(v.Val), "."); len(ps) == 2 {
 			ogVal := string(v.Val)
-			floatVal := fmt.Sprintf("%v", val)
+			floatVal := strconv.FormatFloat(val, 'f', -1, 64)
 			if len(ogVal) >= len(floatVal) && ogVal != floatVal {
 				p, s := expression.GetDecimalPrecisionAndScale(ogVal)
 				dt, err := types.CreateDecimalType(p, s)

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -710,7 +710,7 @@ func (b *PlanBuilder) convertVal(ctx *sql.Context, v *ast.SQLVal) sql.Expression
 		// use the value as string format to keep precision and scale as defined for DECIMAL data type to avoid rounded up float64 value
 		if ps := strings.Split(string(v.Val), "."); len(ps) == 2 {
 			ogVal := string(v.Val)
-			floatVal := fmt.Sprintf("%v", val)
+			floatVal := strconv.FormatFloat(val, 'f', -1, 64)
 			if len(ogVal) >= len(floatVal) && ogVal != floatVal {
 				p, s := expression.GetDecimalPrecisionAndScale(ogVal)
 				dt, err := types.CreateDecimalType(p, s)


### PR DESCRIPTION
We use some string comparison logic to find precision loss and determine if something should be float/decimal type.
When printing very large floats, the `%v` format option in the `fmt` packages defaults to scientific notation, so like `1.234e567`.
This does not work well with our (hacky) string code.

The `%f` option doesn't work very well, as it likes to append `.00000`.
It appears `strconv.FormatFloat` does what we want, so I just picked that.

fmt package docs: https://pkg.go.dev/fmt
Format Float docs: https://pkg.go.dev/strconv#FormatFloat

fix for: https://github.com/dolthub/dolt/issues/6322