### PR TITLE
Add "Sliding Range Join" execution plan 

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -915,6 +915,38 @@ join uv d on d.u = c.x`,
 			},
 		},
 	},
+	{
+		name: "simple range join",
+		setup: []string{
+			"create table vals (val int primary key)",
+			"create table ranges (min int primary key, max int, unique key(min,max))",
+			"insert into vals values (0), (1), (2), (3), (4), (5), (6)",
+			"insert into ranges values (0,2), (1,3), (2,4), (3,5), (4,6)",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select * from vals join ranges on val between min and max",
+				types: []plan.JoinType{plan.JoinTypeSlidingRange},
+				exp: []sql.Row{
+					{0, 0, 2},
+					{1, 0, 2},
+					{1, 1, 3},
+					{2, 0, 2},
+					{2, 1, 3},
+					{2, 2, 4},
+					{3, 1, 3},
+					{3, 2, 4},
+					{3, 3, 5},
+					{4, 2, 4},
+					{4, 3, 5},
+					{4, 4, 6},
+					{5, 3, 5},
+					{5, 4, 6},
+					{6, 4, 6},
+				},
+			},
+		},
+	},
 }
 
 func TestJoinPlanning(t *testing.T, harness Harness) {

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -162,6 +162,16 @@ func TestJoinOpsPrepared(t *testing.T) {
 	enginetest.TestJoinOpsPrepared(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
 }
 
+// TestJoinOps runs range-join-specific tests for merge
+func TestRangeJoinOps(t *testing.T) {
+	enginetest.TestRangeJoinOps(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
+}
+
+// TestJoinOpsPrepared runs prepared range-join-specific tests for merge
+func TestRangeJoinOpsPrepared(t *testing.T) {
+	enginetest.TestRangeJoinOpsPrepared(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))
+}
+
 // TestJSONTableQueries runs the canonical test queries against a single threaded index enabled harness.
 func TestJSONTableQueries(t *testing.T) {
 	enginetest.TestJSONTableQueries(t, enginetest.NewMemoryHarness("simple", 1, testNumPartitions, true, nil))

--- a/enginetest/range_join_op_tests.go
+++ b/enginetest/range_join_op_tests.go
@@ -1,0 +1,128 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package enginetest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql/memo"
+
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+var biasedrangeCosters = map[string]memo.Coster{
+	"inner":        memo.NewInnerBiasedCoster(),
+	"lookup":       memo.NewLookupBiasedCoster(),
+	"hash":         memo.NewHashBiasedCoster(),
+	"merge":        memo.NewMergeBiasedCoster(),
+	"partial":      memo.NewPartialBiasedCoster(),
+	"slidingRange": memo.NewSlidingRangeBiasedCoster(),
+}
+
+func TestRangeJoinOps(t *testing.T, harness Harness) {
+	for _, tt := range rangeJoinOpTests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := mustNewEngine(t, harness)
+			defer e.Close()
+			for _, setup := range tt.setup {
+				for _, statement := range setup {
+					if sh, ok := harness.(SkippingHarness); ok {
+						if sh.SkipQueryTest(statement) {
+							t.Skip()
+						}
+					}
+					ctx := NewContext(harness)
+					RunQueryWithContext(t, e, harness, ctx, statement)
+				}
+			}
+			for k, c := range biasedrangeCosters {
+				e.Analyzer.Coster = c
+				for _, tt := range tt.tests {
+					evalJoinCorrectness(t, harness, e, fmt.Sprintf("%s join: %s", k, tt.Query), tt.Query, tt.Expected, tt.Skip)
+				}
+			}
+		})
+	}
+}
+
+func TestRangeJoinOpsPrepared(t *testing.T, harness Harness) {
+	for _, tt := range joinOpTests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := mustNewEngine(t, harness)
+			defer e.Close()
+			for _, setup := range tt.setup {
+				for _, statement := range setup {
+					if sh, ok := harness.(SkippingHarness); ok {
+						if sh.SkipQueryTest(statement) {
+							t.Skip()
+						}
+					}
+					ctx := NewContext(harness)
+					RunQueryWithContext(t, e, harness, ctx, statement)
+				}
+			}
+
+			for k, c := range biasedrangeCosters {
+				e.Analyzer.Coster = c
+				for _, tt := range tt.tests {
+					evalJoinCorrectnessPrepared(t, harness, e, fmt.Sprintf("%s join: %s", k, tt.Query), tt.Query, tt.Expected, tt.Skip)
+				}
+			}
+		})
+	}
+}
+
+var rangeJoinOpTests = []struct {
+	name  string
+	setup [][]string
+	tests []JoinOpTests
+}{
+	{
+		name: "simple range join",
+		setup: [][]string{
+			setup.MydbData[0],
+			{
+				"create table vals (val int primary key)",
+				"create table ranges (min int primary key, max int, unique key(min,max))",
+				"insert into vals values (0), (1), (2), (3), (4), (5), (6)",
+				"insert into ranges values (0,2), (1,3), (2,4), (3,5), (4,6)",
+			},
+		},
+		tests: []JoinOpTests{
+			{
+				Query: "select * from vals join ranges on val between min and max",
+				Expected: []sql.Row{
+					{0, 0, 2},
+					{1, 0, 2},
+					{1, 1, 3},
+					{2, 0, 2},
+					{2, 1, 3},
+					{2, 2, 4},
+					{3, 1, 3},
+					{3, 2, 4},
+					{3, 3, 5},
+					{4, 2, 4},
+					{4, 3, 5},
+					{4, 4, 6},
+					{5, 3, 5},
+					{5, 4, 6},
+					{6, 4, 6},
+				},
+			},
+		},
+	},
+}

--- a/optgen/cmd/source/memo.yaml
+++ b/optgen/cmd/source/memo.yaml
@@ -13,6 +13,10 @@ exprs:
   join: true
   attrs:
   - [lookup, "*Lookup"]
+- name: "SlidingRangeJoin"
+  join: true
+  attrs:
+    - [slidingRange, "*SlidingRange"]
 - name: "ConcatJoin"
   join: true
   attrs:

--- a/optgen/cmd/source/memo.yaml
+++ b/optgen/cmd/source/memo.yaml
@@ -122,6 +122,12 @@ exprs:
   scalar: true
   attrs:
   - [values, "[]*ExprGroup"]
+- name: "Between"
+  scalar: true
+  attrs:
+  - [Value, "*ExprGroup"]
+  - [Min, "*ExprGroup"]
+  - [Max, "*ExprGroup"]
 - name: "Hidden"
   scalar: true
   attrs:

--- a/optgen/cmd/support/memo_gen.go
+++ b/optgen/cmd/support/memo_gen.go
@@ -221,6 +221,8 @@ func (g *MemoGen) genFormatters(defines []ExprDef) {
 				fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s: '%%s.%%s'\", r.Gf.Table(), r.Gf.Name())\n", loweredName)
 			case "Bindvar":
 				fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s: %%s\", r.Name)\n", loweredName)
+			case "Between":
+				fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s: %%d, %%d, %%d\", r.Value.Id, r.Min.Id, r.Max.Id)\n", loweredName)
 			case "Hidden":
 				fmt.Fprintf(g.w, "    return fmt.Sprintf(\"%s: %%s\", r.E)\n", loweredName)
 			case "Tuple":

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -195,6 +195,10 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *plan.Sco
 	if err != nil {
 		return nil, err
 	}
+	err = addSlidingRangeJoin(m)
+	if err != nil {
+		return nil, err
+	}
 
 	hints := memo.ExtractJoinHint(n)
 	for _, h := range hints {
@@ -642,6 +646,57 @@ func addHashJoins(m *memo.Memo) error {
 		rel.Op = rel.Op.AsHash()
 		e.Group().Prepend(rel)
 		return nil
+	})
+}
+
+func addSlidingRangeJoin(m *memo.Memo) error {
+	return memo.DfsRel(m.Root(), func(e memo.RelExpr) error {
+		switch e.(type) {
+		case *memo.InnerJoin, *memo.LeftJoin:
+		default:
+			return nil
+		}
+
+		join := e.(memo.JoinRel).JoinPrivate()
+		if len(join.Filter) != 1 {
+			return nil
+		}
+
+		filter := join.Filter[0]
+
+		switch f := filter.(type) {
+		case *memo.Between:
+			if !(satisfiesScalarRefs(f.Value.Scalar, join.Left) &&
+				satisfiesScalarRefs(f.Min.Scalar, join.Right) &&
+				satisfiesScalarRefs(f.Max.Scalar, join.Right)) {
+				return nil
+			}
+			// TODO: Is this safe? If the expression references multiple columns, does this reference one
+			// arbitrarily?
+			valueColRef := getColumnRefFromScalar(f.Value.Scalar)
+			minColRef := getColumnRefFromScalar(f.Min.Scalar)
+			maxColRef := getColumnRefFromScalar(f.Max.Scalar)
+			if valueColRef == nil || minColRef == nil || maxColRef == nil {
+				return nil
+			}
+
+			rel := &memo.SlidingRangeJoin{
+				JoinBase: join.Copy(),
+			}
+			rel.SlidingRange = &memo.SlidingRange{
+				ValueCol:  valueColRef,
+				MinColRef: minColRef,
+				MaxColRef: maxColRef,
+				Parent:    rel.JoinBase,
+			}
+			rel.Op = rel.Op.AsSlidingRange()
+			e.Group().Prepend(rel)
+
+			return nil
+		default:
+			return nil
+		}
+
 	})
 }
 

--- a/sql/memo/coster.go
+++ b/sql/memo/coster.go
@@ -71,6 +71,8 @@ func (c *coster) costRel(ctx *sql.Context, n RelExpr, s sql.StatsReader) (float6
 		return c.costMergeJoin(ctx, n, s)
 	case *LookupJoin:
 		return c.costLookupJoin(ctx, n, s)
+	case *SlidingRangeJoin:
+		return c.costSlidingRangeJoin(ctx, n, s)
 	case *SemiJoin:
 		return c.costSemiJoin(ctx, n, s)
 	case *AntiJoin:
@@ -181,6 +183,11 @@ func (c *coster) costLookupJoin(_ *sql.Context, n *LookupJoin, _ sql.StatsReader
 		return l*(cpuCostFactor+randIOCostFactor) - r*seqIOCostFactor, nil
 	}
 	return l*r*sel*(cpuCostFactor+randIOCostFactor) - r*seqIOCostFactor, nil
+}
+
+func (c *coster) costSlidingRangeJoin(_ *sql.Context, n *SlidingRangeJoin, _ sql.StatsReader) (float64, error) {
+	// For now always favor sliding range.
+	return 0, nil
 }
 
 func (c *coster) costConcatJoin(_ *sql.Context, n *ConcatJoin, _ sql.StatsReader) (float64, error) {

--- a/sql/memo/coster.go
+++ b/sql/memo/coster.go
@@ -498,3 +498,20 @@ func (c *partialBiasedCoster) EstimateCost(ctx *sql.Context, r RelExpr, s sql.St
 		return c.costRel(ctx, r, s)
 	}
 }
+
+type slidingRangeBiasedCoster struct {
+	*coster
+}
+
+func NewSlidingRangeBiasedCoster() Coster {
+	return &slidingRangeBiasedCoster{coster: &coster{}}
+}
+
+func (c *slidingRangeBiasedCoster) EstimateCost(ctx *sql.Context, r RelExpr, s sql.StatsReader) (float64, error) {
+	switch r.(type) {
+	case *SlidingRangeJoin:
+		return -biasFactor, nil
+	default:
+		return c.costRel(ctx, r, s)
+	}
+}

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -549,6 +549,22 @@ func (b *ExecBuilder) buildTuple(e *Tuple, sch sql.Schema) (sql.Expression, erro
 	return expression.NewTuple(values...), nil
 }
 
+func (b *ExecBuilder) buildBetween(e *Between, sch sql.Schema) (sql.Expression, error) {
+	value, err := b.buildScalar(e.Value.Scalar, sch)
+	if err != nil {
+		return nil, err
+	}
+	min, err := b.buildScalar(e.Min.Scalar, sch)
+	if err != nil {
+		return nil, err
+	}
+	max, err := b.buildScalar(e.Max.Scalar, sch)
+	if err != nil {
+		return nil, err
+	}
+	return expression.NewBetween(value, min, max), nil
+}
+
 func (b *ExecBuilder) buildHidden(e *Hidden, sch sql.Schema) (sql.Expression, error) {
 	ret, _, err := fixidx.FixFieldIndexes(e.g.m.scope, nil, sch, e.E)
 	return ret, err

--- a/sql/memo/interner.go
+++ b/sql/memo/interner.go
@@ -41,6 +41,7 @@ const (
 	ScalarExprBindvar
 	ScalarExprIsNull
 	ScalarExprTuple
+	ScalarExprBetween
 	ScalarExprHidden
 )
 
@@ -84,6 +85,8 @@ func internExpr(e ScalarExpr) uint64 {
 		for _, c := range e.Values {
 			h.Write([]byte(fmt.Sprintf("%d", internExpr(c.Scalar))))
 		}
+	case *Between:
+		h.Write([]byte(fmt.Sprintf("%d%d%d%d", e.ExprId(), internExpr(e.Value.Scalar), internExpr(e.Min.Scalar), internExpr(e.Max.Scalar))))
 	case *Regexp:
 		h.Write([]byte(fmt.Sprintf("%d%d%d", e.ExprId(), internExpr(e.Left.Scalar), internExpr(e.Right.Scalar))))
 	case *Not:

--- a/sql/memo/memo.og.go
+++ b/sql/memo/memo.og.go
@@ -102,6 +102,22 @@ func (r *LookupJoin) JoinPrivate() *JoinBase {
 	return r.JoinBase
 }
 
+type SlidingRangeJoin struct {
+	*JoinBase
+	SlidingRange *SlidingRange
+}
+
+var _ RelExpr = (*SlidingRangeJoin)(nil)
+var _ JoinRel = (*SlidingRangeJoin)(nil)
+
+func (r *SlidingRangeJoin) String() string {
+	return FormatExpr(r)
+}
+
+func (r *SlidingRangeJoin) JoinPrivate() *JoinBase {
+	return r.JoinBase
+}
+
 type ConcatJoin struct {
 	*JoinBase
 	Concat []*Lookup
@@ -886,6 +902,8 @@ func FormatExpr(r exprType) string {
 		return fmt.Sprintf("antijoin %d %d", r.Left.Id, r.Right.Id)
 	case *LookupJoin:
 		return fmt.Sprintf("lookupjoin %d %d", r.Left.Id, r.Right.Id)
+	case *SlidingRangeJoin:
+		return fmt.Sprintf("slidingrangejoin %d %d", r.Left.Id, r.Right.Id)
 	case *ConcatJoin:
 		return fmt.Sprintf("concatjoin %d %d", r.Left.Id, r.Right.Id)
 	case *HashJoin:
@@ -982,6 +1000,8 @@ func buildRelExpr(b *ExecBuilder, r RelExpr, input sql.Schema, children ...sql.N
 		result, err = b.buildAntiJoin(r, input, children...)
 	case *LookupJoin:
 		result, err = b.buildLookupJoin(r, input, children...)
+	case *SlidingRangeJoin:
+		result, err = b.buildSlidingRangeJoin(r, input, children...)
 	case *ConcatJoin:
 		result, err = b.buildConcatJoin(r, input, children...)
 	case *HashJoin:

--- a/sql/memo/memo.og.go
+++ b/sql/memo/memo.og.go
@@ -830,6 +830,27 @@ func (r *Tuple) Children() []*ExprGroup {
 	return nil
 }
 
+type Between struct {
+	*scalarBase
+	Value *ExprGroup
+	Min   *ExprGroup
+	Max   *ExprGroup
+}
+
+var _ ScalarExpr = (*Between)(nil)
+
+func (r *Between) ExprId() ScalarExprId {
+	return ScalarExprBetween
+}
+
+func (r *Between) String() string {
+	return FormatExpr(r)
+}
+
+func (r *Between) Children() []*ExprGroup {
+	return nil
+}
+
 type Hidden struct {
 	*scalarBase
 	E      sql.Expression
@@ -935,6 +956,8 @@ func FormatExpr(r exprType) string {
 			vals[i] = fmt.Sprintf("%d", v.Id)
 		}
 		return fmt.Sprintf("tuple: %s", strings.Join(vals, " "))
+	case *Between:
+		return fmt.Sprintf("between: %d, %d, %d", r.Value.Id, r.Min.Id, r.Max.Id)
 	case *Hidden:
 		return fmt.Sprintf("hidden: %s", r.E)
 	default:
@@ -1040,6 +1063,8 @@ func buildScalarExpr(b *ExecBuilder, r ScalarExpr, sch sql.Schema) (sql.Expressi
 		return b.buildIsNull(r, sch)
 	case *Tuple:
 		return b.buildTuple(r, sch)
+	case *Between:
+		return b.buildBetween(r, sch)
 	case *Hidden:
 		return b.buildHidden(r, sch)
 	default:

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -45,6 +45,8 @@ const (
 	JoinTypeLeftOuterHashExcludeNulls                 // LeftOuterHashJoinExcludeNulls
 	JoinTypeMerge                                     // MergeJoin
 	JoinTypeLeftOuterMerge                            // LeftOuterMergeJoin
+	JoinTypeSlidingRange                              // SlidingRangeJoin
+	JoinTypeLeftOuterSlidingRange                     // LeftOuterSlidingRangeJoin
 	JoinTypeSemiHash                                  // SemiHashJoin
 	JoinTypeAntiHash                                  // AntiHashJoin
 	JoinTypeSemiLookup                                // SemiLookupJoin
@@ -56,7 +58,7 @@ const (
 
 func (i JoinType) IsLeftOuter() bool {
 	switch i {
-	case JoinTypeLeftOuter, JoinTypeLeftOuterExcludeNulls, JoinTypeLeftOuterLookup, JoinTypeLeftOuterHash, JoinTypeLeftOuterHashExcludeNulls, JoinTypeLeftOuterMerge:
+	case JoinTypeLeftOuter, JoinTypeLeftOuterExcludeNulls, JoinTypeLeftOuterLookup, JoinTypeLeftOuterHash, JoinTypeLeftOuterHashExcludeNulls, JoinTypeLeftOuterMerge, JoinTypeLeftOuterSlidingRange:
 		return true
 	default:
 		return false
@@ -88,7 +90,7 @@ func (i JoinType) IsPhysical() bool {
 		JoinTypeSemiLookup, JoinTypeSemiMerge, JoinTypeSemiHash,
 		JoinTypeHash, JoinTypeLeftOuterHash, JoinTypeLeftOuterHashExcludeNulls,
 		JoinTypeMerge, JoinTypeLeftOuterMerge,
-		JoinTypeAntiLookup, JoinTypeAntiMerge, JoinTypeAntiHash:
+		JoinTypeAntiLookup, JoinTypeAntiMerge, JoinTypeAntiHash, JoinTypeSlidingRange, JoinTypeLeftOuterSlidingRange:
 		return true
 	default:
 		return false
@@ -190,6 +192,17 @@ func (i JoinType) AsHash() JoinType {
 		return JoinTypeAntiHash
 	case JoinTypeCross:
 		return JoinTypeCrossHash
+	default:
+		return i
+	}
+}
+
+func (i JoinType) AsSlidingRange() JoinType {
+	switch i {
+	case JoinTypeInner:
+		return JoinTypeSlidingRange
+	case JoinTypeLeftOuter:
+		return JoinTypeLeftOuterSlidingRange
 	default:
 		return i
 	}

--- a/sql/plan/jointype_string.go
+++ b/sql/plan/jointype_string.go
@@ -26,18 +26,20 @@ func _() {
 	_ = x[JoinTypeLeftOuterHashExcludeNulls-15]
 	_ = x[JoinTypeMerge-16]
 	_ = x[JoinTypeLeftOuterMerge-17]
-	_ = x[JoinTypeSemiHash-18]
-	_ = x[JoinTypeAntiHash-19]
-	_ = x[JoinTypeSemiLookup-20]
-	_ = x[JoinTypeAntiLookup-21]
-	_ = x[JoinTypeSemiMerge-22]
-	_ = x[JoinTypeAntiMerge-23]
-	_ = x[JoinTypeNatural-24]
+	_ = x[JoinTypeSlidingRange-18]
+	_ = x[JoinTypeLeftOuterSlidingRange-19]
+	_ = x[JoinTypeSemiHash-20]
+	_ = x[JoinTypeAntiHash-21]
+	_ = x[JoinTypeSemiLookup-22]
+	_ = x[JoinTypeAntiLookup-23]
+	_ = x[JoinTypeSemiMerge-24]
+	_ = x[JoinTypeAntiMerge-25]
+	_ = x[JoinTypeNatural-26]
 }
 
-const _JoinType_name = "UnknownJoinCrossJoinCrossHashJoinInnerJoinSemiJoinAntiJoinLeftOuterJoinLeftOuterJoinExcludingNullsFullOuterJoinGroupByJoinRightJoinLookupJoinLeftOuterLookupJoinHashJoinLeftOuterHashJoinLeftOuterHashJoinExcludeNullsMergeJoinLeftOuterMergeJoinSemiHashJoinAntiHashJoinSemiLookupJoinAntiLookupJoinSemiMergeJoinAntiMergeJoinNaturalJoin"
+const _JoinType_name = "UnknownJoinCrossJoinCrossHashJoinInnerJoinSemiJoinAntiJoinLeftOuterJoinLeftOuterJoinExcludingNullsFullOuterJoinGroupByJoinRightJoinLookupJoinLeftOuterLookupJoinHashJoinLeftOuterHashJoinLeftOuterHashJoinExcludeNullsMergeJoinLeftOuterMergeJoinSlidingRangeJoinLeftOuterSlidingRangeJoinSemiHashJoinAntiHashJoinSemiLookupJoinAntiLookupJoinSemiMergeJoinAntiMergeJoinNaturalJoin"
 
-var _JoinType_index = [...]uint16{0, 11, 20, 33, 42, 50, 58, 71, 98, 111, 122, 131, 141, 160, 168, 185, 214, 223, 241, 253, 265, 279, 293, 306, 319, 330}
+var _JoinType_index = [...]uint16{0, 11, 20, 33, 42, 50, 58, 71, 98, 111, 122, 131, 141, 160, 168, 185, 214, 223, 241, 257, 282, 294, 306, 320, 334, 347, 360, 371}
 
 func (i JoinType) String() string {
 	if i >= JoinType(len(_JoinType_index)-1) {

--- a/sql/plan/sliding_range.go
+++ b/sql/plan/sliding_range.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// SlidingRange is a Node that wraps a table with min and max range columns. When used as a secondary provider in Join
+// operations, it can efficiently compute the rows whose ranges bound the value from the other table. When the ranges
+// don't overlap, the amortized complexity is O(1) for each result row.
+type SlidingRange struct {
+	UnaryNode
+	childRowIter     sql.RowIter
+	activeRanges     priorityQueue
+	pendingRow       sql.Row
+	valueColumnIndex int
+	minColumnIndex   int
+	maxColumnIndex   int
+	comparisonType   sql.Type
+}
+
+type priorityQueue struct {
+	slidingRange *SlidingRange
+	rows         []sql.Row
+	err          error
+}
+
+var _ sql.Node = (*SlidingRange)(nil)
+
+func NewSlidingRange(child sql.Node, lhsSchema sql.Schema, rhsSchema sql.Schema, value, min, max string) (*SlidingRange, error) {
+	// TODO: This doesn't appear to actually use the passed in indexes.
+	maxColumnIndex := rhsSchema.IndexOfColName(max)
+	newSr := &SlidingRange{
+		activeRanges:     priorityQueue{},
+		pendingRow:       nil,
+		valueColumnIndex: lhsSchema.IndexOfColName(value),
+		minColumnIndex:   rhsSchema.IndexOfColName(min),
+		maxColumnIndex:   maxColumnIndex,
+		comparisonType:   rhsSchema[maxColumnIndex].Type,
+	}
+	newSr.Child = child
+	newSr.activeRanges.slidingRange = newSr
+	return newSr, nil
+}
+
+func (s *SlidingRange) String() string {
+	return s.Child.String()
+}
+
+func (s *SlidingRange) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, fmt.Errorf("ds")
+	}
+
+	s2 := *s
+	s2.UnaryNode = UnaryNode{Child: children[0]}
+	return &s2, nil
+}
+
+func (s *SlidingRange) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
+	return s.Child.CheckPrivileges(ctx, opChecker)
+}
+
+var _ sql.Node = (*SlidingRange)(nil)

--- a/sql/plan/sliding_range.go
+++ b/sql/plan/sliding_range.go
@@ -15,8 +15,11 @@
 package plan
 
 import (
+	"container/heap"
+	"errors"
 	"fmt"
 	"github.com/dolthub/go-mysql-server/sql"
+	"io"
 )
 
 // SlidingRange is a Node that wraps a table with min and max range columns. When used as a secondary provider in Join
@@ -76,3 +79,100 @@ func (s *SlidingRange) CheckPrivileges(ctx *sql.Context, opChecker sql.Privilege
 }
 
 var _ sql.Node = (*SlidingRange)(nil)
+
+func (s *SlidingRange) Initialize(ctx *sql.Context, childRowIter sql.RowIter) (err error) {
+	s.childRowIter = childRowIter
+	s.activeRanges = priorityQueue{
+		slidingRange: s,
+		rows:         nil,
+		err:          nil,
+	}
+	s.pendingRow, err = childRowIter.Next(ctx)
+	return err
+}
+
+func (s *SlidingRange) IsInitialized() bool {
+	return s.childRowIter != nil
+}
+
+func (s *SlidingRange) AcceptRow(ctx *sql.Context, row sql.Row) (sql.RowIter, error) {
+	// Remove rows from the heap if we've advanced beyond their max value.
+	for s.activeRanges.Len() > 0 {
+		maxValue := s.activeRanges.Peek()
+		compareResult, err := s.comparisonType.Compare(row[s.valueColumnIndex], maxValue)
+		if err != nil {
+			return nil, err
+		}
+		if compareResult > 0 {
+			heap.Pop(&s.activeRanges)
+		} else {
+			break
+		}
+	}
+
+	// Advance the child iterator until we encounter a row whose min value is beyond the range.
+	for s.pendingRow != nil {
+		minValue := s.pendingRow[s.minColumnIndex]
+		compareResult, err := s.comparisonType.Compare(row[s.valueColumnIndex], minValue)
+		if err != nil {
+			return nil, err
+		}
+
+		if compareResult < 0 {
+			break
+		} else {
+			heap.Push(&s.activeRanges, s.pendingRow)
+		}
+
+		s.pendingRow, err = s.childRowIter.Next(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				// We've already imported every range into the priority queue.
+				s.pendingRow = nil
+				break
+			}
+			return nil, err
+		}
+	}
+
+	// Every active row must match the accepted row.
+	return sql.RowsToRowIter(s.activeRanges.rows...), nil
+}
+
+func (pq priorityQueue) Len() int { return len(pq.rows) }
+
+func (pq *priorityQueue) Less(i, j int) bool {
+	lhs := pq.rows[i][pq.slidingRange.maxColumnIndex]
+	rhs := pq.rows[j][pq.slidingRange.maxColumnIndex]
+	// compareResult will be 0 if lhs==rhs, -1 if lhs < rhs, and +1 if lhs > rhs.
+	compareResult, err := pq.SortedType().Compare(lhs, rhs)
+	if pq.err == nil && err != nil {
+		pq.err = err
+	}
+	return compareResult < 0
+}
+
+func (pq *priorityQueue) Swap(i, j int) {
+	pq.rows[i], pq.rows[j] = pq.rows[j], pq.rows[i]
+}
+
+func (pq *priorityQueue) Push(x any) {
+	item := x.(sql.Row)
+	pq.rows = append(pq.rows, item)
+}
+
+func (pq *priorityQueue) Pop() any {
+	n := len(pq.rows)
+	x := pq.rows[n-1]
+	pq.rows = pq.rows[0 : n-1]
+	return x
+}
+
+func (pq *priorityQueue) Peek() interface{} {
+	n := len(pq.rows)
+	return pq.rows[n-1][pq.slidingRange.maxColumnIndex]
+}
+
+func (pq *priorityQueue) SortedType() sql.Type {
+	return pq.slidingRange.comparisonType
+}

--- a/sql/plan/sliding_range.go
+++ b/sql/plan/sliding_range.go
@@ -18,8 +18,9 @@ import (
 	"container/heap"
 	"errors"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql"
 	"io"
+
+	"github.com/dolthub/go-mysql-server/sql"
 )
 
 // SlidingRange is a Node that wraps a table with min and max range columns. When used as a secondary provider in Join

--- a/sql/rowexec/node_builder.gen.go
+++ b/sql/rowexec/node_builder.gen.go
@@ -360,6 +360,8 @@ func (b *BaseBuilder) buildNodeExec(ctx *sql.Context, n sql.Node, row sql.Row) (
 		return n.RowIter(ctx, row)
 	case *plan.CreateSpatialRefSys:
 		return b.buildCreateSpatialRefSys(ctx, n, row)
+	case *plan.SlidingRange:
+		return b.buildSlidingRange(ctx, n, row)
 	default:
 		return nil, fmt.Errorf("exec builder found unknown Node type %T", n)
 	}


### PR DESCRIPTION
This is the draft implementation of the "Sliding Range Join" execution plan. This allows for more performant joins when the join condition checks that the column on one table is within a range specified by two columns on the other table.

TODO: Elaborate in this description before making this PR not a draft.