### PR TITLE
Apply index optimization to `Offset` nodes and drop 0 `Offsets`

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -248,16 +248,16 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "trigger with signal and user var",
+			Name: "delete me",
 			SetUpScript: []string{
-				"create table auctions (ai int auto_increment, id varchar(32), data json, primary key (ai));",
+				"create table t (i int primary key);",
+				"insert into t values (1), (2), (3);",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    `select data from auctions order by ai desc limit 1;`,
+					Query:    "select * from t limit 0, 2",
 					Expected: []sql.Row{},
 				},
 			},
@@ -270,11 +270,35 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		engine.Analyzer.Debug = true
-		engine.Analyzer.Verbose = true
-
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
+	//t.Skip()
+	//var scripts = []queries.ScriptTest{
+	//	{
+	//		Name: "trigger with signal and user var",
+	//		SetUpScript: []string{
+	//			"create table auctions (ai int auto_increment, id varchar(32), data json, primary key (ai));",
+	//		},
+	//		Assertions: []queries.ScriptTestAssertion{
+	//			{
+	//				Query:    `select data from auctions order by ai desc limit 1;`,
+	//				Expected: []sql.Row{},
+	//			},
+	//		},
+	//	},
+	//}
+	//
+	//for _, test := range scripts {
+	//	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
+	//	engine, err := harness.NewEngine(t)
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//	engine.Analyzer.Debug = true
+	//	engine.Analyzer.Verbose = true
+	//
+	//	enginetest.TestScriptWithEngine(t, engine, harness, test)
+	//}
 }
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -248,16 +248,16 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "delete me",
+			Name: "trigger with signal and user var",
 			SetUpScript: []string{
-				"create table t (i int primary key);",
-				"insert into t values (1), (2), (3);",
+				"create table auctions (ai int auto_increment, id varchar(32), data json, primary key (ai));",
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "select * from t limit 0, 2",
+					Query:    `select data from auctions order by ai desc limit 1;`,
 					Expected: []sql.Row{},
 				},
 			},
@@ -270,35 +270,11 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+		engine.Analyzer.Debug = true
+		engine.Analyzer.Verbose = true
+
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
-	//t.Skip()
-	//var scripts = []queries.ScriptTest{
-	//	{
-	//		Name: "trigger with signal and user var",
-	//		SetUpScript: []string{
-	//			"create table auctions (ai int auto_increment, id varchar(32), data json, primary key (ai));",
-	//		},
-	//		Assertions: []queries.ScriptTestAssertion{
-	//			{
-	//				Query:    `select data from auctions order by ai desc limit 1;`,
-	//				Expected: []sql.Row{},
-	//			},
-	//		},
-	//	},
-	//}
-	//
-	//for _, test := range scripts {
-	//	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
-	//	engine, err := harness.NewEngine(t)
-	//	if err != nil {
-	//		panic(err)
-	//	}
-	//	engine.Analyzer.Debug = true
-	//	engine.Analyzer.Verbose = true
-	//
-	//	enginetest.TestScriptWithEngine(t, engine, harness, test)
-	//}
 }
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -8728,6 +8728,25 @@ WHERE keyless.c0 IN (
 			"             └─ columns: [pk1 pk2 c1]\n" +
 			"",
 	},
+	{
+		Query: `SELECT * FROM one_pk ORDER BY pk LIMIT 0, 10;`,
+		ExpectedPlan: "Limit(10)\n" +
+			" └─ IndexedTableAccess(one_pk)\n" +
+			"     ├─ index: [one_pk.pk]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     └─ columns: [pk c1 c2 c3 c4 c5]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM one_pk ORDER BY pk LIMIT 5, 10;`,
+		ExpectedPlan: "Limit(10)\n" +
+			" └─ Offset(5)\n" +
+			"     └─ IndexedTableAccess(one_pk)\n" +
+			"         ├─ index: [one_pk.pk]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
+			"",
+	},
 }
 
 // QueryPlanTODOs are queries where the query planner produces a correct (results) but suboptimal plan.

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -4733,20 +4733,21 @@ inner join pq on true
 			join datetime_table dt2 on dt1.date_col = date(date_sub(dt2.timestamp_col, interval 2 day))
 			order by 1 limit 3 offset 0`,
 		ExpectedPlan: "Limit(3)\n" +
-			" └─ Offset(0)\n" +
-			"     └─ TopN(Limit: [(3 + 0)]; dt1.i ASC)\n" +
-			"         └─ Project\n" +
-			"             ├─ columns: [dt1.i]\n" +
-			"             └─ LookupJoin\n" +
-			"                 ├─ (dt1.date_col = DATE(date_sub(dt2.timestamp_col,INTERVAL 2 DAY)))\n" +
-			"                 ├─ TableAlias(dt2)\n" +
-			"                 │   └─ Table\n" +
-			"                 │       ├─ name: datetime_table\n" +
-			"                 │       └─ columns: [timestamp_col]\n" +
-			"                 └─ TableAlias(dt1)\n" +
-			"                     └─ IndexedTableAccess(datetime_table)\n" +
-			"                         ├─ index: [datetime_table.date_col]\n" +
-			"                         └─ columns: [i date_col]\n" +
+			" └─ TopN(Limit: [3 (tinyint)]; dt1.i:0!null ASC nullsFirst)\n" +
+			"     └─ Project\n" +
+			"         ├─ columns: [dt1.i:1!null]\n" +
+			"         └─ LookupJoin\n" +
+			"             ├─ Eq\n" +
+			"             │   ├─ dt1.date_col:2\n" +
+			"             │   └─ DATE(date_sub(dt2.timestamp_col,INTERVAL 2 DAY))\n" +
+			"             ├─ TableAlias(dt2)\n" +
+			"             │   └─ Table\n" +
+			"             │       ├─ name: datetime_table\n" +
+			"             │       └─ columns: [timestamp_col]\n" +
+			"             └─ TableAlias(dt1)\n" +
+			"                 └─ IndexedTableAccess(datetime_table)\n" +
+			"                     ├─ index: [datetime_table.date_col]\n" +
+			"                     └─ columns: [i date_col]\n" +
 			"",
 	},
 	{

--- a/sql/analyzer/replace_pk_sort.go
+++ b/sql/analyzer/replace_pk_sort.go
@@ -100,7 +100,7 @@ func replacePkSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, sor
 		var err error
 		same := transform.SameTree
 		switch c := child.(type) {
-		case *plan.Project, *plan.TableAlias, *plan.ResolvedTable, *plan.Filter, *plan.Limit, *plan.Sort:
+		case *plan.Project, *plan.TableAlias, *plan.ResolvedTable, *plan.Filter, *plan.Limit, *plan.Offset, *plan.Sort:
 			newChildren[i], same, err = replacePkSortHelper(ctx, scope, child, sortNode)
 		default:
 			newChildren[i] = c


### PR DESCRIPTION
This PR applies the index sort optimization to plans that look like `LIMIT(OFFSET(SORT()))`.
Additionally, this PR drops `OFFSET` nodes that start at 0, as they don't change the output.

Fix for: https://github.com/dolthub/dolt/issues/6347