### PR TITLE
have `plan.EmptyTable` implement `sql.DeletableTable`

### DIFF
--- a/sql/plan/empty_table.go
+++ b/sql/plan/empty_table.go
@@ -31,12 +31,18 @@ func NewEmptyTableWithSchema(schema sql.Schema) sql.Node {
 var _ sql.Node = (*EmptyTable)(nil)
 var _ sql.CollationCoercible = (*EmptyTable)(nil)
 var _ sql.UpdatableTable = (*EmptyTable)(nil)
+var _ sql.DeletableTable = (*EmptyTable)(nil)
 
 type EmptyTable struct {
 	schema sql.Schema
 }
 
-func (e *EmptyTable) Name() string       { return "__emptytable" }
+func (e *EmptyTable) Name() string {
+	if len(e.schema) == 0 {
+		return "__emptytable"
+	}
+	return e.schema[0].Source
+}
 func (e *EmptyTable) Schema() sql.Schema { return e.schema }
 func (*EmptyTable) Children() []sql.Node { return nil }
 func (*EmptyTable) Resolved() bool       { return true }
@@ -84,6 +90,11 @@ func (e *EmptyTable) Partitions(_ *sql.Context) (sql.PartitionIter, error) {
 // PartitionRows implements the sql.UpdatableTable interface.
 func (e *EmptyTable) PartitionRows(_ *sql.Context, _ sql.Partition) (sql.RowIter, error) {
 	return &emptyTableIter{}, nil
+}
+
+// Deleter implements the sql.DeletableTable interface.
+func (e *EmptyTable) Deleter(context *sql.Context) sql.RowDeleter {
+	return &emptyTableDeleter{}
 }
 
 type emptyTableUpdater struct{}
@@ -140,3 +151,25 @@ func (e *emptyTablePartitionIter) Close(_ *sql.Context) error {
 func (e *emptyTablePartitionIter) Next(_ *sql.Context) (sql.Partition, error) {
 	return nil, io.EOF
 }
+
+type emptyTableDeleter struct{}
+var _ sql.RowDeleter = (*emptyTableDeleter)(nil)
+
+func (e *emptyTableDeleter) StatementBegin(_ *sql.Context) {}
+
+func (e *emptyTableDeleter) DiscardChanges(_ *sql.Context, _ error) error {
+	return nil
+}
+
+func (e *emptyTableDeleter) StatementComplete(_ *sql.Context) error {
+	return nil
+}
+
+func (e *emptyTableDeleter) Delete(_ *sql.Context, _ sql.Row) error {
+	return nil
+}
+
+func (e *emptyTableDeleter) Close(_ *sql.Context) error {
+	return nil
+}
+

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -85,10 +85,6 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 func (b *BaseBuilder) buildDeleteFrom(ctx *sql.Context, n *plan.DeleteFrom, row sql.Row) (sql.RowIter, error) {
 	// If an empty table is passed in (potentially from a bad filter) return an empty row iter.
 	// Note: emptyTable could also implement sql.DetetableTable
-	// TODO: this doesn't always work because of exchange
-	//if _, ok := n.Child.(*plan.EmptyTable); ok {
-	//	return sql.RowsToRowIter(), nil
-	//}
 
 	iter, err := b.buildNodeExec(ctx, n.Child, row)
 	if err != nil {

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -83,9 +83,6 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 }
 
 func (b *BaseBuilder) buildDeleteFrom(ctx *sql.Context, n *plan.DeleteFrom, row sql.Row) (sql.RowIter, error) {
-	// If an empty table is passed in (potentially from a bad filter) return an empty row iter.
-	// Note: emptyTable could also implement sql.DetetableTable
-
 	iter, err := b.buildNodeExec(ctx, n.Child, row)
 	if err != nil {
 		return nil, err

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -85,9 +85,10 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 func (b *BaseBuilder) buildDeleteFrom(ctx *sql.Context, n *plan.DeleteFrom, row sql.Row) (sql.RowIter, error) {
 	// If an empty table is passed in (potentially from a bad filter) return an empty row iter.
 	// Note: emptyTable could also implement sql.DetetableTable
-	if _, ok := n.Child.(*plan.EmptyTable); ok {
-		return sql.RowsToRowIter(), nil
-	}
+	// TODO: this doesn't always work because of exchange
+	//if _, ok := n.Child.(*plan.EmptyTable); ok {
+	//	return sql.RowsToRowIter(), nil
+	//}
 
 	iter, err := b.buildNodeExec(ctx, n.Child, row)
 	if err != nil {


### PR DESCRIPTION
We throw an error when trying to delete from EmptyTable.
This error is partially caused by https://github.com/dolthub/go-mysql-server/pull/1885

The error didn't show up in GMS as there are Exchange nodes that appear in dolt side that don't appear here.