### PR TITLE
Fix panic when selecting unsigned number columns via driver

### DIFF
--- a/driver/e2e_test.go
+++ b/driver/e2e_test.go
@@ -14,6 +14,7 @@ func TestQuery(t *testing.T) {
 	mtb, records := personMemTable("db", "person")
 	db := sqlOpen(t, mtb, t.Name()+"?jsonAs=object")
 
+	var id uint64
 	var name, email string
 	var numbers []any
 	var created time.Time
@@ -24,12 +25,12 @@ func TestQuery(t *testing.T) {
 		Pointers    Pointers
 		Expect      Records
 	}{
-		{"Select All", "SELECT * FROM db.person", []any{&name, &email, &numbers, &created}, records},
-		{"Select First", "SELECT * FROM db.person LIMIT 1", []any{&name, &email, &numbers, &created}, records.Rows(0)},
-		{"Select Name", "SELECT name FROM db.person", []any{&name}, records.Columns(0)},
+		{"Select All", "SELECT * FROM db.person", []any{&id, &name, &email, &numbers, &created}, records},
+		{"Select First", "SELECT * FROM db.person LIMIT 1", []any{&id, &name, &email, &numbers, &created}, records.Rows(0)},
+		{"Select Name", "SELECT name FROM db.person", []any{&name}, records.Columns(1)},
 		{"Select Count", "SELECT COUNT(1) FROM db.person", []any{&count}, Records{{len(records)}}},
 
-		{"Insert", `INSERT INTO db.person VALUES ('foo', 'bar', '["baz"]', NOW())`, []any{}, Records{}},
+		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', NOW())`, []any{}, Records{}},
 		{"Select Inserted", "SELECT name, email, phone_numbers FROM db.person WHERE name = 'foo'", []any{&name, &email, &numbers}, Records{{"foo", "bar", []any{"baz"}}}},
 
 		{"Update", "UPDATE db.person SET name = 'asdf' WHERE name = 'foo'", []any{}, Records{}},
@@ -82,7 +83,7 @@ func TestExec(t *testing.T) {
 		Name, Statement string
 		RowsAffected    int
 	}{
-		{"Insert", `INSERT INTO db.person VALUES ('asdf', 'qwer', '["zxcv"]', NOW())`, 1},
+		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('asdf', 'qwer', '["zxcv"]', NOW())`, 1},
 		{"Update", "UPDATE db.person SET name = 'foo' WHERE name = 'asdf'", 1},
 		{"Delete", "DELETE FROM db.person WHERE name = 'foo'", 1},
 		{"Delete All", "DELETE FROM db.person WHERE LENGTH(name) < 100", len(records)},

--- a/driver/fixtures_test.go
+++ b/driver/fixtures_test.go
@@ -47,16 +47,17 @@ func (f *memTable) Resolve(name string, _ *driver.Options) (string, sql.Database
 func personMemTable(database, table string) (*memTable, Records) {
 	type J = types.JSONDocument
 	records := Records{
-		[]any{"John Doe", "john@doe.com", J{Val: []any{"555-555-555"}}, time.Now()},
-		[]any{"John Doe", "johnalt@doe.com", J{Val: []any{}}, time.Now()},
-		[]any{"Jane Doe", "jane@doe.com", J{Val: []any{}}, time.Now()},
-		[]any{"Evil Bob", "evilbob@gmail.com", J{Val: []any{"555-666-555", "666-666-666"}}, time.Now()},
+		[]any{uint64(1), "John Doe", "john@doe.com", J{Val: []any{"555-555-555"}}, time.Now()},
+		[]any{uint64(2), "John Doe", "johnalt@doe.com", J{Val: []any{}}, time.Now()},
+		[]any{uint64(3), "Jane Doe", "jane@doe.com", J{Val: []any{}}, time.Now()},
+		[]any{uint64(4), "Evil Bob", "evilbob@gmail.com", J{Val: []any{"555-666-555", "666-666-666"}}, time.Now()},
 	}
 
 	mtb := &memTable{
 		DatabaseName: database,
 		TableName:    table,
 		Schema: sql.Schema{
+			{Name: "id", Type: types.Uint64, Nullable: false, Source: table, AutoIncrement: true},
 			{Name: "name", Type: types.Text, Nullable: false, Source: table},
 			{Name: "email", Type: types.Text, Nullable: false, Source: table},
 			{Name: "phone_numbers", Type: types.JSON, Nullable: false, Source: table},

--- a/driver/rows.go
+++ b/driver/rows.go
@@ -89,8 +89,10 @@ func (r *Rows) convert(col int, v driver.Value) interface{} {
 		query.Type_FLOAT32, query.Type_FLOAT64:
 		rv := reflect.ValueOf(v)
 		switch rv.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			return rv.Int()
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return rv.Uint()
 		case reflect.Float32, reflect.Float64:
 			return rv.Float()
 		case reflect.String:


### PR DESCRIPTION
Calling the [`reflect.Value.Int()`](https://pkg.go.dev/reflect#Value.Int) on an unsigned typed value will panic.
The [`reflect.Value.Uint()`](https://pkg.go.dev/reflect#Value.Uint) must be used.