### PR TITLE
Left pad odd length hex strings

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3958,6 +3958,10 @@ Select * from (
 		Expected: []sql.Row{{uint64(65), uint64(65)}},
 	},
 	{
+		Query:	  "SELECT 0x12345;",
+		Expected: []sql.Row{{[]uint8{0x1, 0x23, 0x45}}},
+	},
+	{
 		Query:    "SELECT i FROM mytable WHERE i BETWEEN 1 AND 2",
 		Expected: []sql.Row{{int64(1)}, {int64(2)}},
 	},

--- a/sql/parse/parse.go
+++ b/sql/parse/parse.go
@@ -4383,13 +4383,16 @@ func convertVal(ctx *sql.Context, v *sqlparser.SQLVal) (sql.Expression, error) {
 			v = strings.Trim(v[1:], "'")
 		}
 
-		valBytes := []byte(v)
-		dst := make([]byte, hex.DecodedLen(len(valBytes)))
-		_, err := hex.Decode(dst, valBytes)
+		// pad string to even length
+		if len(v) % 2 == 1 {
+			v = "0" + v;
+		}
+
+		val, err := hex.DecodeString(v)
 		if err != nil {
 			return nil, err
 		}
-		return expression.NewLiteral(dst, types.LongBlob), nil
+		return expression.NewLiteral(val, types.LongBlob), nil
 	case sqlparser.HexVal:
 		//TODO: binary collation?
 		val, err := v.HexDecode()

--- a/sql/parse/parse_test.go
+++ b/sql/parse/parse_test.go
@@ -2391,6 +2391,17 @@ CREATE TABLE t2
 			),
 		},
 		{
+			input: `SELECT 0x12345`,
+			plan: plan.NewProject(
+				[]sql.Expression{
+					expression.NewAlias("0x12345",
+						expression.NewLiteral([]byte{1, 35, 69}, types.LongBlob),
+					),
+				},
+				plan.NewResolvedDualTable(),
+			),
+		},
+		{
 			input: `SELECT X'41'`,
 			plan: plan.NewProject(
 				[]sql.Expression{


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6351
If hex string v is of odd length, prepend an "0" before passing it to Go's DecodeString.
I've changed the implementation to use DecodeString, but if keeping this as a byte array is preferred, I'll switch back.
