### PR TITLE
Stubbing out new Handler function to prep for supporting `ANSI_QUOTES` SQL mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20230718053226-42bab255733a
+	github.com/dolthub/vitess v0.0.0-20230724231239-57b7c816dc1e
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/dolthub/vitess v0.0.0-20230710224128-865ffe81a2e7 h1:mo+N0F7iFQP+n1LR
 github.com/dolthub/vitess v0.0.0-20230710224128-865ffe81a2e7/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
 github.com/dolthub/vitess v0.0.0-20230718053226-42bab255733a h1:HZrszGMumqm3pxeNuZUO7sdbNz9/BOvR3nVNCpLQl4s=
 github.com/dolthub/vitess v0.0.0-20230718053226-42bab255733a/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
+github.com/dolthub/vitess v0.0.0-20230724231239-57b7c816dc1e h1:hYL15UyksJZ15CPSFi30wyb1a7HsH06T7iPzulErLxI=
+github.com/dolthub/vitess v0.0.0-20230724231239-57b7c816dc1e/go.mod h1:IyoysiiOzrIs7QsEHC+yVF0yRQ6W70GXyCXqtI2vVTs=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/server/golden/proxy.go
+++ b/server/golden/proxy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	mysql2 "github.com/go-sql-driver/mysql"
 	"github.com/gocraft/dbr/v2"
 	"github.com/sirupsen/logrus"
@@ -198,6 +199,10 @@ func (h MySqlProxy) ComQuery(
 		conn.Errorf("Failed to process MySQL results: %s", err)
 	}
 	return err
+}
+
+func (h MySqlProxy) ParserOptionsForConnection(c *mysql.Conn) (sqlparser.ParserOptions, error) {
+	return sqlparser.ParserOptions{}, nil
 }
 
 func (h MySqlProxy) processQuery(

--- a/server/golden/validator.go
+++ b/server/golden/validator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -149,6 +150,10 @@ func (v Validator) ComQuery(
 // or after the last ComQuery call completes.
 func (v Validator) WarningCount(c *mysql.Conn) uint16 {
 	return 0
+}
+
+func (v Validator) ParserOptionsForConnection(c *mysql.Conn) (sqlparser.ParserOptions, error) {
+	return sqlparser.ParserOptions{}, nil
 }
 
 func (v Validator) getLogger(c *mysql.Conn) *logrus.Entry {

--- a/server/handler.go
+++ b/server/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dolthub/vitess/go/netutil"
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/go-kit/kit/metrics/discard"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
@@ -127,6 +128,10 @@ func (h *Handler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, call
 
 func (h *Handler) ComResetConnection(c *mysql.Conn) {
 	// TODO: handle reset logic
+}
+
+func (h *Handler) ParserOptionsForConnection(c *mysql.Conn) (sqlparser.ParserOptions, error) {
+	return sqlparser.ParserOptions{}, nil
 }
 
 // ConnectionClosed reports that a connection has been closed.


### PR DESCRIPTION
PR https://github.com/dolthub/vitess/pull/256 adds support at the Vitess layer for parsing SQL statements using `ANSI_QUOTES` SQL mode, where double quotes are used as identifier quotes, and not string literal quotes. This change updates the implementations of `mysql.Handler` for the new function needed to parse prepared statement commands with `ANSI_QUOTES` mode. A future PR will enable the ability to turn on the `ANSI_QUOTES` support in Vitess. 