### PR TITLE
Fix ErrBinaryCollation in queries with []byte argument

### DIFF
--- a/driver/e2e_test.go
+++ b/driver/e2e_test.go
@@ -19,27 +19,31 @@ func TestQuery(t *testing.T) {
 	var numbers []any
 	var created time.Time
 	var count int
+	var blob []byte
 
 	cases := []struct {
 		Name, Query string
+		Args        []any
 		Pointers    Pointers
 		Expect      Records
 	}{
-		{"Select All", "SELECT * FROM db.person", []any{&id, &name, &email, &numbers, &created}, records},
-		{"Select First", "SELECT * FROM db.person LIMIT 1", []any{&id, &name, &email, &numbers, &created}, records.Rows(0)},
-		{"Select Name", "SELECT name FROM db.person", []any{&name}, records.Columns(1)},
-		{"Select Count", "SELECT COUNT(1) FROM db.person", []any{&count}, Records{{len(records)}}},
+		{"Select All", "SELECT * FROM db.person", nil, []any{&id, &name, &email, &numbers, &created}, records},
+		{"Select First", "SELECT * FROM db.person LIMIT 1", nil, []any{&id, &name, &email, &numbers, &created}, records.Rows(0)},
+		{"Select Name", "SELECT name FROM db.person", nil, []any{&name}, records.Columns(1)},
+		{"Select Count", "SELECT COUNT(1) FROM db.person", nil, []any{&count}, Records{{len(records)}}},
 
-		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', NOW())`, []any{}, Records{}},
-		{"Select Inserted", "SELECT name, email, phone_numbers FROM db.person WHERE name = 'foo'", []any{&name, &email, &numbers}, Records{{"foo", "bar", []any{"baz"}}}},
+		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', NOW())`, nil, []any{}, Records{}},
+		{"Select Inserted", "SELECT name, email, phone_numbers FROM db.person WHERE name = 'foo'", nil, []any{&name, &email, &numbers}, Records{{"foo", "bar", []any{"baz"}}}},
 
-		{"Update", "UPDATE db.person SET name = 'asdf' WHERE name = 'foo'", []any{}, Records{}},
-		{"Delete", "DELETE FROM db.person WHERE name = 'asdf'", []any{}, Records{}},
+		{"Update", "UPDATE db.person SET name = 'asdf' WHERE name = 'foo'", nil, []any{}, Records{}},
+		{"Delete", "DELETE FROM db.person WHERE name = 'asdf'", nil, []any{}, Records{}},
+
+		{"Select Binary Args", `SELECT ?`, []any{[]byte{1, 2, 3}}, []any{&blob}, Records{{[]byte{1, 2, 3}}}},
 	}
 
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
-			rows, err := db.Query(c.Query)
+			rows, err := db.Query(c.Query, c.Args...)
 			require.NoError(t, err, "Query")
 
 			var i int

--- a/driver/value.go
+++ b/driver/value.go
@@ -46,7 +46,7 @@ func valueToExpr(v driver.Value) (sql.Expression, error) {
 	case bool:
 		typ = types.Boolean
 	case []byte:
-		typ, err = types.CreateStringWithDefaults(sqltypes.Blob, int64(len(v)))
+		typ, err = types.CreateBinary(sqltypes.Blob, int64(len(v)))
 	case string:
 		typ, err = types.CreateStringWithDefaults(sqltypes.Text, int64(len(v)))
 	case time.Time:

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -46,7 +46,7 @@ var (
 	// ErrLengthTooLarge is thrown when a string's length is too large given the other parameters.
 	ErrLengthTooLarge    = errors.NewKind("length is %v but max allowed is %v")
 	ErrLengthBeyondLimit = errors.NewKind("string '%v' is too large for column '%v'")
-	ErrBinaryCollation   = errors.NewKind("binary types must have the binary collation")
+	ErrBinaryCollation   = errors.NewKind("binary types must have the binary collation: %v")
 
 	TinyText   = MustCreateStringWithDefaults(sqltypes.Text, TinyTextBlobMax)
 	Text       = MustCreateStringWithDefaults(sqltypes.Text, TextBlobMax)
@@ -99,7 +99,7 @@ func CreateString(baseType query.Type, length int64, collation sql.CollationID) 
 	switch baseType {
 	case sqltypes.Binary, sqltypes.VarBinary, sqltypes.Blob:
 		if collation != sql.Collation_binary {
-			return nil, ErrBinaryCollation.New(collation.Name, sql.Collation_binary)
+			return nil, ErrBinaryCollation.New(collation.Name())
 		}
 	}
 


### PR DESCRIPTION
Binding arguments of type `[]byte` have been converted to string literals with the default collation (utf8mb4_0900_bin) by `types.CreateStringWithDefaults()`.
I think `types.CreateBinary()` should be used, which generates literals with binary collation.