### PR TITLE
Allow AntiHashJoins to distinguish between empty and non-empty secondary tables.

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -1402,6 +1402,30 @@ SELECT SUM(x) FROM xy WHERE x IN (
 			},
 		}},
 	},
+	{
+		name: "where x not in (...)",
+		setup: [][]string{
+			setup.XyData[0],
+		},
+		tests: []JoinOpTests{
+			{
+				Query:    `SELECT * from xy_hasnull where y not in (SELECT b from ab_hasnull)`,
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    `SELECT * from xy_hasnull where y not in (SELECT b from ab)`,
+				Expected: []sql.Row{{1, 0}},
+			},
+			{
+				Query:    `SELECT * from xy where y not in (SELECT b from ab_hasnull)`,
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    `SELECT * from xy where null not in (SELECT b from ab)`,
+				Expected: []sql.Row{},
+			},
+		},
+	},
 }
 
 var rangeJoinOpTests = []JoinOpTests{

--- a/enginetest/scriptgen/setup/scripts/xy
+++ b/enginetest/scriptgen/setup/scripts/xy
@@ -100,7 +100,15 @@ update information_schema.statistics set cardinality = 1000 where table_name = '
 ----
 
 exec
+update information_schema.statistics set cardinality = 1000 where table_name = 'ab_hasnull';
+----
+
+exec
 update information_schema.statistics set cardinality = 1000 where table_name = 'xy';
+----
+
+exec
+update information_schema.statistics set cardinality = 1000 where table_name = 'xy_hasnull';
 ----
 
 exec

--- a/enginetest/scriptgen/setup/setup_data.sg.go
+++ b/enginetest/scriptgen/setup/setup_data.sg.go
@@ -2938,6 +2938,8 @@ var XyData = []SetupScript{{
   (4,4),
   (5,4);`,
 	`update information_schema.statistics set cardinality = 1000 where table_name = 'ab';`,
+	`update information_schema.statistics set cardinality = 1000 where table_name = 'ab_hasnull';`,
 	`update information_schema.statistics set cardinality = 1000 where table_name = 'xy';`,
+	`update information_schema.statistics set cardinality = 1000 where table_name = 'xy_hasnull';`,
 	`update information_schema.statistics set cardinality = 1000 where table_name = 'rs'`,
 }}

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -287,7 +287,7 @@ func (b *ExecBuilder) buildHashJoin(j *HashJoin, input sql.Schema, children ...s
 	}
 
 	cr := plan.NewCachedResults(children[1])
-	outer := plan.NewHashLookup(cr, rightEntryKey, leftProbeKey)
+	outer := plan.NewHashLookup(cr, rightEntryKey, leftProbeKey, j.Op)
 	inner := children[0]
 	return plan.NewJoin(inner, outer, j.Op, filters).WithScopeLen(j.g.m.scopeLen), nil
 }

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -30,12 +30,13 @@ import (
 // available, it fulfills the RowIter call by performing a hash lookup
 // on the projected results. If cached results are not available, it
 // simply delegates to the child.
-func NewHashLookup(n *CachedResults, rightEntryKey sql.Expression, leftProbeKey sql.Expression) *HashLookup {
+func NewHashLookup(n *CachedResults, rightEntryKey sql.Expression, leftProbeKey sql.Expression, joinType JoinType) *HashLookup {
 	return &HashLookup{
 		UnaryNode:     UnaryNode{n},
 		RightEntryKey: rightEntryKey,
 		LeftProbeKey:  leftProbeKey,
 		Mutex:         new(sync.Mutex),
+		JoinType:      joinType,
 	}
 }
 
@@ -45,6 +46,7 @@ type HashLookup struct {
 	LeftProbeKey  sql.Expression
 	Mutex         *sync.Mutex
 	Lookup        map[interface{}][]sql.Row
+	JoinType      JoinType
 }
 
 var _ sql.Node = (*HashLookup)(nil)

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -74,7 +74,7 @@ func (i JoinType) IsLeftOuter() bool {
 // that row is excluded from the result table.
 func (i JoinType) IsExcludeNulls() bool {
 	switch i {
-	case JoinTypeAnti, JoinTypeLeftOuterExcludeNulls, JoinTypeLeftOuterHashExcludeNulls:
+	case JoinTypeAnti, JoinTypeAntiHash, JoinTypeAntiLookup, JoinTypeAntiMerge, JoinTypeLeftOuterExcludeNulls, JoinTypeLeftOuterHashExcludeNulls:
 		return true
 	default:
 		return false

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -227,6 +227,19 @@ func (b *BaseBuilder) buildHashLookup(ctx *sql.Context, n *plan.HashLookup, row 
 		if err != nil {
 			return nil, err
 		}
+		if n.JoinType.IsExcludeNulls() {
+			// Some joins care if any of their filter comparisons have a NULL result.
+			// For these joins, we need to distinguish between an empty and non-empty secondary table.
+			// Thus, if there are any rows in the lookup, we must return at least one.
+			if len(n.Lookup[key]) > 0 {
+				return sql.RowsToRowIter(n.Lookup[key]...), nil
+			}
+			for k := range n.Lookup {
+				if len(n.Lookup[k]) > 0 {
+					return sql.RowsToRowIter(n.Lookup[k]...), nil
+				}
+			}
+		}
 		return sql.RowsToRowIter(n.Lookup[key]...), nil
 	}
 	return b.buildNodeExec(ctx, n.Child, row)


### PR DESCRIPTION
`AntiHashJoin` and `LeftOuterHashExcludeNullsJoin` should always evaluate at least one secondary row if the secondary table is nonempty. This guarentees the same behavior as MySQL for `where x not in (...)` expressions when x is nullable.

Some joins (AntiJoins and some joins converted from AntiJoins) have an "excludes NULL" property, which means that if a filter condition on the join evaluates to NULL, the corresponding primary row can't be included in the result set.

This means that if the primary row has a NULL value used in a filter, we need to know whether or not the secondary table has at least one row. Using a HashJoin makes that impossible without special handling.

We had a test designed to catch this, but the test wasn't actually using a HashJoin, so this was missed. This PR also fixes the test to use a hash join.