### PR TITLE
Render enum/set variables as strings after they are set

### DIFF
--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -276,6 +276,20 @@ var VariableQueries = []ScriptTest{
 			{"ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,STRICT_ALL_TABLES,STRICT_TRANS_TABLES,TRADITIONAL"},
 		},
 	},
+	{
+		Name: "show variables renders enums after set",
+		SetUpScript: []string{
+			`set @@sql_mode='ONLY_FULL_GROUP_BY';`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:		`SHOW VARIABLES LIKE '%sql_mode%'`,
+				Expected:   []sql.Row{
+					{"sql_mode", `ONLY_FULL_GROUP_BY`},
+				},
+			},
+		},
+	},
 	// User variables
 	{
 		Name: "set user var",

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -285,7 +285,7 @@ var VariableQueries = []ScriptTest{
 			{
 				Query: `SHOW VARIABLES LIKE '%sql_mode%'`,
 				Expected: []sql.Row{
-					{"sql_mode", `ONLY_FULL_GROUP_BY`},
+					{"sql_mode", "ONLY_FULL_GROUP_BY"},
 				},
 			},
 		},

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -283,8 +283,8 @@ var VariableQueries = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:		`SHOW VARIABLES LIKE '%sql_mode%'`,
-				Expected:   []sql.Row{
+				Query: `SHOW VARIABLES LIKE '%sql_mode%'`,
+				Expected: []sql.Row{
 					{"sql_mode", `ONLY_FULL_GROUP_BY`},
 				},
 			},

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -124,8 +124,9 @@ func (s *BaseSession) GetAllSessionVariables() map[string]interface{} {
 	for k, v := range s.systemVars {
 		if sysType, ok := v.Var.Type.(SetType); ok {
 			if sv, ok := v.Val.(uint64); ok {
-				x, _ := sysType.BitsToString(sv)
-				m[k] = x
+				if svStr, err := sysType.BitsToString(sv); err == nil {
+					m[k] = svStr
+				}
 				continue
 			}
 		}

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -122,6 +122,13 @@ func (s *BaseSession) GetAllSessionVariables() map[string]interface{} {
 	defer s.mu.RUnlock()
 
 	for k, v := range s.systemVars {
+		if sysType, ok := v.Var.Type.(SetType); ok {
+			if sv, ok := v.Val.(uint64); ok {
+				x, _ := sysType.BitsToString(sv)
+				m[k] = x
+				continue
+			}
+		}
 		m[k] = v.Val
 	}
 	return m
@@ -164,7 +171,7 @@ func (s *BaseSession) InitSessionVariable(ctx *Context, sysVarName string, value
 	if ok && val.Val != sysVar.Default {
 		return ErrSystemVariableReinitialized.New(sysVarName)
 	}
-
+	
 	return s.setSessVar(ctx, sysVar, value)
 }
 

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -171,7 +171,7 @@ func (s *BaseSession) InitSessionVariable(ctx *Context, sysVarName string, value
 	if ok && val.Val != sysVar.Default {
 		return ErrSystemVariableReinitialized.New(sysVarName)
 	}
-	
+
 	return s.setSessVar(ctx, sysVar, value)
 }
 


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6370
Ensure that when getting all session variables, if any of them is of an enum/set type, we convert them back to their string value. The SET command would amend the value in the session variables map to its numerical representation, which we need to translate back.

