### PR TITLE
Use EvaluateCondition for conditions in join statements

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -745,6 +745,36 @@ var JoinScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Join with truthy condition",
+		SetUpScript: []string{
+			"CREATE TABLE `a` (aa int);",
+			"INSERT INTO `a` VALUES (1), (2);",
+
+			"CREATE TABLE `b` (bb int);",
+			"INSERT INTO `b` VALUES (1), (2);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT * FROM a LEFT JOIN b ON 1;",
+				Expected: []sql.Row{
+					{1, 2},
+					{1, 1},
+					{2, 2},
+					{2, 1},
+				},
+			},
+			{
+				Query: "SELECT * FROM a RIGHT JOIN b ON 8+9;",
+				Expected: []sql.Row{
+					{1, 2},
+					{1, 1},
+					{2, 2},
+					{2, 1},
+				},
+			},
+		},
+	},
 }
 
 var SkippedJoinQueryTests = []QueryTest{

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -830,7 +830,7 @@ func (i *lateralJoinIterator) Next(ctx *sql.Context) (sql.Row, error) {
 		if i.cond != nil {
 			if res, err := sql.EvaluateCondition(ctx, i.cond, row); err != nil {
 				return nil, err
-			} else if sql.IsFalse(res) {
+			} else if !sql.IsTrue(res) {
 				continue
 			}
 		}

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -153,8 +153,7 @@ func (i *joinIter) Next(ctx *sql.Context) (sql.Row, error) {
 		}
 
 		row := i.buildRow(primary, secondary)
-		res, err := i.cond.Eval(ctx, row)
-		matches := res == true
+		res, err := sql.EvaluateCondition(ctx, i.cond, row)
 		if err != nil {
 			return nil, err
 		}
@@ -169,7 +168,7 @@ func (i *joinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			continue
 		}
 
-		if !matches {
+		if !sql.IsTrue(res) {
 			continue
 		}
 
@@ -182,16 +181,6 @@ func (i *joinIter) removeParentRow(r sql.Row) sql.Row {
 	copy(r[i.scopeLen:], r[len(i.parentRow):])
 	r = r[:len(r)-len(i.parentRow)+i.scopeLen]
 	return r
-}
-
-func conditionIsTrue(ctx *sql.Context, row sql.Row, cond sql.Expression) (bool, error) {
-	v, err := cond.Eval(ctx, row)
-	if err != nil {
-		return false, err
-	}
-
-	// Expressions containing nil evaluate to nil, not false
-	return v == true, nil
 }
 
 // buildRow builds the result set row using the rows from the primary and secondary tables
@@ -269,7 +258,6 @@ const (
 
 func (i *existsIter) Next(ctx *sql.Context) (sql.Row, error) {
 	var row sql.Row
-	var matches bool
 	var right sql.Row
 	var left sql.Row
 	var rIter sql.RowIter
@@ -328,8 +316,7 @@ func (i *existsIter) Next(ctx *sql.Context) (sql.Row, error) {
 			}
 		case esCompare:
 			row = i.buildRow(left, right)
-			res, err := i.cond.Eval(ctx, row)
-			matches = res == true
+			res, err := sql.EvaluateCondition(ctx, i.cond, row)
 			if err != nil {
 				return nil, err
 			}
@@ -339,7 +326,7 @@ func (i *existsIter) Next(ctx *sql.Context) (sql.Row, error) {
 				continue
 			}
 
-			if !matches {
+			if !sql.IsTrue(res) {
 				nextState = esIncRight
 			} else {
 				err = rIter.Close(ctx)
@@ -476,11 +463,11 @@ func (i *fullJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 		}
 
 		row := i.buildRow(i.leftRow, rightRow)
-		matches, err := conditionIsTrue(ctx, row, i.cond)
+		matches, err := sql.EvaluateCondition(ctx, i.cond, row)
 		if err != nil {
 			return nil, err
 		}
-		if !matches {
+		if !sql.IsTrue(matches) {
 			continue
 		}
 		rkey, err := sql.HashOf(rightRow)
@@ -841,9 +828,9 @@ func (i *lateralJoinIterator) Next(ctx *sql.Context) (sql.Row, error) {
 		row := i.buildRow(i.lRow, i.rRow)
 		i.rRow = nil
 		if i.cond != nil {
-			if res, err := i.cond.Eval(ctx, row); err != nil {
+			if res, err := sql.EvaluateCondition(ctx, i.cond, row); err != nil {
 				return nil, err
-			} else if res == false {
+			} else if sql.IsFalse(res) {
 				continue
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6412
Use the given EvaluateCondition util function to determine whether a join condition is satisfied, which accounts for truthy integer values as mentioned in the linked issue.
