### PR TITLE
Allow timestamps when encoding json

### DIFF
--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"time"
 )
 
 var isEscaped = [256]bool{}
@@ -304,6 +305,12 @@ func writeMarshalledValue(writer io.Writer, val interface{}) error {
 
 	case nil:
 		writer.Write([]byte("null"))
+		return nil
+
+	case time.Time:
+		writer.Write([]byte{'"'})
+		writer.Write([]byte(val.Format(time.RFC3339)))
+		writer.Write([]byte{'"'})
 		return nil
 
 	default:

--- a/sql/types/json_encode_test.go
+++ b/sql/types/json_encode_test.go
@@ -1,6 +1,9 @@
 package types
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestMarshalToMySqlString(t *testing.T) {
 	tests := []struct {
@@ -63,6 +66,14 @@ func TestMarshalToMySqlString(t *testing.T) {
 				"baz": "qux",
 			},
 			expected: `{"baz": "qux", "foo": "bar"}`,
+		},
+		{
+			name: "map of timestamps",
+			val: map[string]interface{}{
+				"a": time.Date(2023, 1, 2, 3, 4, 5, 6, time.UTC),
+				"b": time.Date(2023, 6, 5, 4, 3, 2, 1, time.UTC),
+			},
+			expected: `{"a": "2023-01-02T03:04:05Z", "b": "2023-06-05T04:03:02Z"}`,
 		},
 		{
 			name: "string formatting",


### PR DESCRIPTION
As reported on discord, Nautobot, through DJango, puts time stamp data into a json object. This fails because:

```
db> select JSON_OBJECT("a", Now());
unsupported type: time.Time
```

This change enables the encoding of a time stamp into a string.