### PR TITLE
Refactor prepards

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -161,11 +161,7 @@ func (d *Driver) OpenConnector(dsn string) (driver.Connector, error) {
 	d.mu.Lock()
 	db, ok := d.dbs[serverName]
 	if !ok {
-		version := sql.VersionStable
-		if sqle.ExperimentalGMS {
-			version = sql.VersionExperimental
-		}
-		anlz := analyzer.NewDefaultWithVersion(pro, version)
+		anlz := analyzer.NewDefaultWithVersion(pro)
 		engine := sqle.New(anlz, nil)
 		db = &dbConn{engine: engine}
 		d.dbs[serverName] = db

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -161,7 +161,11 @@ func (d *Driver) OpenConnector(dsn string) (driver.Connector, error) {
 	d.mu.Lock()
 	db, ok := d.dbs[serverName]
 	if !ok {
-		anlz := analyzer.NewDefaultWithVersion(pro)
+		version := sql.VersionStable
+		if sqle.ExperimentalGMS {
+			version = sql.VersionExperimental
+		}
+		anlz := analyzer.NewDefaultWithVersion(pro, version)
 		engine := sqle.New(anlz, nil)
 		db = &dbConn{engine: engine}
 		d.dbs[serverName] = db

--- a/driver/stmt.go
+++ b/driver/stmt.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"database/sql/driver"
 
-	"github.com/dolthub/go-mysql-server/sql"
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
 )
 
 // Stmt is a prepared statement.
@@ -85,7 +85,7 @@ func (s *Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driv
 	return s.query(ctx, bindings)
 }
 
-func (s *Stmt) exec(ctx context.Context, bindings map[string]sql.Expression) (driver.Result, error) {
+func (s *Stmt) exec(ctx context.Context, bindings map[string]*querypb.BindVariable) (driver.Result, error) {
 	qctx, err := s.conn.newContextWithQuery(ctx, s.queryStr)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (s *Stmt) exec(ctx context.Context, bindings map[string]sql.Expression) (dr
 	return &Result{okr}, nil
 }
 
-func (s *Stmt) query(ctx context.Context, bindings map[string]sql.Expression) (driver.Rows, error) {
+func (s *Stmt) query(ctx context.Context, bindings map[string]*querypb.BindVariable) (driver.Rows, error) {
 	qctx, err := s.conn.newContextWithQuery(ctx, s.queryStr)
 	if err != nil {
 		return nil, err

--- a/driver/value.go
+++ b/driver/value.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/dolthub/vitess/go/sqltypes"
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -65,16 +66,16 @@ func valueToExpr(v driver.Value) (sql.Expression, error) {
 	return expression.NewLiteral(c, typ), nil
 }
 
-func valuesToBindings(v []driver.Value) (map[string]sql.Expression, error) {
+func valuesToBindings(v []driver.Value) (map[string]*querypb.BindVariable, error) {
 	if len(v) == 0 {
 		return nil, nil
 	}
 
-	b := map[string]sql.Expression{}
+	b := map[string]*querypb.BindVariable{}
 
 	var err error
 	for i, v := range v {
-		b[strconv.FormatInt(int64(i), 10)], err = valueToExpr(v)
+		b[strconv.FormatInt(int64(i), 10)], err = sqltypes.BuildBindVariable(v)
 		if err != nil {
 			return nil, err
 		}
@@ -83,12 +84,12 @@ func valuesToBindings(v []driver.Value) (map[string]sql.Expression, error) {
 	return b, nil
 }
 
-func namedValuesToBindings(v []driver.NamedValue) (map[string]sql.Expression, error) {
+func namedValuesToBindings(v []driver.NamedValue) (map[string]*querypb.BindVariable, error) {
 	if len(v) == 0 {
 		return nil, nil
 	}
 
-	b := map[string]sql.Expression{}
+	b := map[string]*querypb.BindVariable{}
 
 	var err error
 	for _, v := range v {
@@ -97,7 +98,7 @@ func namedValuesToBindings(v []driver.NamedValue) (map[string]sql.Expression, er
 			name = "v" + strconv.FormatInt(int64(v.Ordinal), 10)
 		}
 
-		b[name], err = valueToExpr(v.Value)
+		b[name], err = sqltypes.BuildBindVariable(v.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/engine.go
+++ b/engine.go
@@ -17,16 +17,18 @@ package sqle
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 
+	"github.com/dolthub/vitess/go/sqltypes"
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/pkg/errors"
 
-	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
-	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/rowexec"
@@ -67,20 +69,20 @@ type TemporaryUser struct {
 
 // PreparedDataCache manages all the prepared data for every session for every query for an engine
 type PreparedDataCache struct {
-	data map[uint32]map[string]sql.Node
+	data map[uint32]map[string]*sqlparser.ParsedQuery
 	mu   *sync.Mutex
 }
 
 func NewPreparedDataCache() *PreparedDataCache {
 	return &PreparedDataCache{
-		data: make(map[uint32]map[string]sql.Node),
+		data: make(map[uint32]map[string]*sqlparser.ParsedQuery),
 		mu:   &sync.Mutex{},
 	}
 }
 
 // GetCachedStmt will retrieve the prepared sql.Node associated with the ctx.SessionId and query if it exists
 // it will return nil, false if the query does not exist
-func (p *PreparedDataCache) GetCachedStmt(sessId uint32, query string) (sql.Node, bool) {
+func (p *PreparedDataCache) GetCachedStmt(sessId uint32, query string) (*sqlparser.ParsedQuery, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if sessData, ok := p.data[sessId]; ok {
@@ -91,7 +93,7 @@ func (p *PreparedDataCache) GetCachedStmt(sessId uint32, query string) (sql.Node
 }
 
 // GetSessionData returns all the prepared queries for a particular session
-func (p *PreparedDataCache) GetSessionData(sessId uint32) map[string]sql.Node {
+func (p *PreparedDataCache) GetSessionData(sessId uint32) map[string]*sqlparser.ParsedQuery {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.data[sessId]
@@ -105,13 +107,14 @@ func (p *PreparedDataCache) DeleteSessionData(sessId uint32) {
 }
 
 // CacheStmt saves the prepared node and associates a ctx.SessionId and query to it
-func (p *PreparedDataCache) CacheStmt(sessId uint32, query string, node sql.Node) {
+func (p *PreparedDataCache) CacheStmt(sessId uint32, query string, stmt sqlparser.Statement) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if _, ok := p.data[sessId]; !ok {
-		p.data[sessId] = make(map[string]sql.Node)
+		p.data[sessId] = make(map[string]*sqlparser.ParsedQuery)
 	}
-	p.data[sessId][query] = node
+	prep := sqlparser.NewParsedQuery(stmt)
+	p.data[sessId][query] = prep
 }
 
 // UncacheStmt removes the prepared node associated with a ctx.SessionId and query to it
@@ -135,7 +138,6 @@ type Engine struct {
 	IsServerLocked    bool
 	PreparedDataCache *PreparedDataCache
 	mu                *sync.Mutex
-	Version           sql.AnalyzerVersion
 }
 
 type ColumnWithRawDefault struct {
@@ -164,10 +166,6 @@ func New(a *analyzer.Analyzer, cfg *Config) *Engine {
 	})
 	a.Catalog.RegisterFunction(emptyCtx, function.GetLockingFuncs(ls)...)
 
-	version := sql.VersionStable
-	if ExperimentalGMS {
-		version = sql.VersionExperimental
-	}
 	return &Engine{
 		Analyzer:          a,
 		MemoryManager:     sql.NewMemoryManager(sql.ProcessMemory),
@@ -178,17 +176,12 @@ func New(a *analyzer.Analyzer, cfg *Config) *Engine {
 		IsServerLocked:    cfg.IsServerLocked,
 		PreparedDataCache: NewPreparedDataCache(),
 		mu:                &sync.Mutex{},
-		Version:           version,
 	}
 }
 
 // NewDefault creates a new default Engine.
 func NewDefault(pro sql.DatabaseProvider) *Engine {
-	version := sql.VersionStable
-	if ExperimentalGMS {
-		version = sql.VersionExperimental
-	}
-	a := analyzer.NewDefaultWithVersion(pro, version)
+	a := analyzer.NewDefaultWithVersion(pro)
 	return New(a, nil)
 }
 
@@ -197,26 +190,10 @@ func (e *Engine) AnalyzeQuery(
 	ctx *sql.Context,
 	query string,
 ) (sql.Node, error) {
-	if ctx.Version == sql.VersionUnknown {
-		ctx.Version = e.Version
-	}
-
-	var parsed sql.Node
-	var err error
-	switch ctx.Version {
-	case sql.VersionExperimental:
-		parsed, err = planbuilder.Parse(ctx, e.Analyzer.Catalog, query)
-		if err != nil {
-			ctx.Version = sql.VersionStable
-			parsed, err = parse.Parse(ctx, query)
-		}
-	default:
-		parsed, err = parse.Parse(ctx, query)
-	}
+	parsed, err := planbuilder.Parse(ctx, e.Analyzer.Catalog, query)
 	if err != nil {
 		return nil, err
 	}
-
 	return e.Analyzer.Analyze(ctx, parsed, nil)
 }
 
@@ -225,17 +202,16 @@ func (e *Engine) PrepareQuery(
 	ctx *sql.Context,
 	query string,
 ) (sql.Node, error) {
-	parsed, err := parse.Parse(ctx, query)
+	node, err := planbuilder.Parse(ctx, e.Analyzer.Catalog, query)
+	if err != nil {
+		return nil, err
+	}
+	stmt, _, err := sqlparser.ParseOne(query)
 	if err != nil {
 		return nil, err
 	}
 
-	node, err := e.Analyzer.PrepareQuery(ctx, parsed, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	e.PreparedDataCache.CacheStmt(ctx.Session.ID(), query, node)
+	e.PreparedDataCache.CacheStmt(ctx.Session.ID(), query, stmt)
 	return node, nil
 }
 
@@ -245,33 +221,82 @@ func (e *Engine) Query(ctx *sql.Context, query string) (sql.Schema, sql.RowIter,
 }
 
 // QueryWithBindings executes the query given with the bindings provided
-func (e *Engine) QueryWithBindings(ctx *sql.Context, query string, bindings map[string]sql.Expression) (sql.Schema, sql.RowIter, error) {
-	return e.QueryNodeWithBindings(ctx, query, nil, bindings)
+func (e *Engine) QueryWithBindings(ctx *sql.Context, query string, bindings map[string]*querypb.BindVariable) (sql.Schema, sql.RowIter, error) {
+	return e.QueryNodeWithBindings(ctx, query, bindings)
 }
 
 // QueryNodeWithBindings executes the query given with the bindings provided. If parsed is non-nil, it will be used
 // instead of parsing the query from text.
-func (e *Engine) QueryNodeWithBindings(ctx *sql.Context, query string, parsed sql.Node, bindings map[string]sql.Expression) (sql.Schema, sql.RowIter, error) {
-	var (
-		analyzed sql.Node
-		iter     sql.RowIter
-		err      error
-	)
-
-	if ctx.Version == sql.VersionUnknown {
-		ctx.Version = e.Version
-	}
-
-	if parsed == nil {
-		switch ctx.Version {
-		case sql.VersionExperimental:
-			parsed, err = planbuilder.Parse(ctx, e.Analyzer.Catalog, query)
-		default:
-			parsed, err = parse.Parse(ctx, query)
-		}
+func (e *Engine) QueryNodeWithBindings(ctx *sql.Context, query string, bindings map[string]*querypb.BindVariable) (sql.Schema, sql.RowIter, error) {
+	var err error
+	if prep, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), query); ok {
+		query, err = prep.GenerateQuery(bindings, nil)
 		if err != nil {
 			return nil, nil, err
 		}
+	} else if len(bindings) > 0 {
+		_, err := e.PrepareQuery(ctx, query)
+		if err != nil {
+			return nil, nil, err
+		}
+		prep, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), query)
+		if ok {
+			query, err = prep.GenerateQuery(bindings, nil)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+
+	parsed, err := planbuilder.Parse(ctx, e.Analyzer.Catalog, query)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch n := parsed.(type) {
+	case *plan.ExecuteQuery:
+		prep, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), n.Name)
+		if !ok {
+			err := sql.ErrUnknownPreparedStatement.New(n.Name)
+			return nil, nil, err
+		}
+		// todo validate expected and actual args -- not just count, by name
+		//if prep.ArgCount() < 1 {
+		//	return nil, nil, fmt.Errorf("invalid bind variable count: expected %d, found %d", prep.ArgCount(), len(bindings))
+		//}
+		for i, name := range n.BindVars {
+			if bindings == nil {
+				bindings = make(map[string]*querypb.BindVariable)
+			}
+			if strings.HasPrefix(name.String(), "@") {
+				t, val, err := ctx.GetUserVariable(ctx, strings.TrimPrefix(name.String(), "@"))
+				if err != nil {
+					return nil, nil, err
+				}
+				if val != nil {
+					val, _, err = t.Promote().Convert(val)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
+				bindings[fmt.Sprintf("v%d", i+1)], err = sqltypes.BuildBindVariable(val)
+				if err != nil {
+					return nil, nil, err
+				}
+			} else {
+				bindings[fmt.Sprintf("v%d", i)] = sqltypes.StringBindVariable(name.String())
+
+			}
+		}
+		query, err = prep.GenerateQuery(bindings, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		parsed, err = planbuilder.Parse(ctx, e.Analyzer.Catalog, query)
+		if err != nil {
+			return nil, nil, err
+		}
+
 	}
 
 	// Give the integrator a chance to reject the session before proceeding
@@ -290,11 +315,56 @@ func (e *Engine) QueryNodeWithBindings(ctx *sql.Context, query string, parsed sq
 		return nil, nil, err
 	}
 
-	if p, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), query); ok {
-		analyzed, err = e.analyzePreparedQuery(ctx, query, p, bindings)
-	} else {
-		analyzed, err = e.analyzeQuery(ctx, query, parsed, bindings)
+	// TODO: eventually, we should have this logic be in the RowIter() of the respective plans
+	// along with a new rule that handles analysis
+	var analyzed sql.Node
+	switch n := parsed.(type) {
+	case *plan.PrepareQuery:
+		// we have to name-resolve to check for structural errors, but we do
+		// not to cache the name-bound query yet.
+		//todo(max): improve name resolution so we can cache post name-binding.
+		// this involves expression memoization, which currently screws up aggregation
+		// and order by aliases
+		prepStmt, _, err := sqlparser.ParseOne(query)
+		if err != nil {
+			return nil, nil, err
+		}
+		prepare, ok := prepStmt.(*sqlparser.Prepare)
+		if !ok {
+			return nil, nil, fmt.Errorf("expected PREPARE ast")
+		}
+		cacheStmt, _, err := sqlparser.ParseOne(prepare.Expr)
+		if err != nil && strings.HasPrefix(prepare.Expr, "@") {
+			val, err := expression.NewUserVar(strings.TrimPrefix(prepare.Expr, "@")).Eval(ctx, nil)
+			if err != nil {
+				return nil, nil, err
+			}
+			valStr, ok := val.(string)
+			if !ok {
+				return nil, nil, fmt.Errorf("invalid query for PREPARE: %s", val)
+			}
+			cacheStmt, _, err = sqlparser.ParseOne(valStr)
+			if err != nil {
+				return nil, nil, err
+			}
+		} else if err != nil {
+			return nil, nil, err
+		}
+		e.PreparedDataCache.CacheStmt(ctx.Session.ID(), n.Name, cacheStmt)
+		analyzed = parsed
+	case *plan.DeallocateQuery:
+		if _, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), n.Name); !ok {
+			return nil, nil, sql.ErrUnknownPreparedStatement.New(n.Name)
+		}
+		e.PreparedDataCache.UncacheStmt(ctx.Session.ID(), n.Name)
+		analyzed = parsed
+	default:
+		analyzed, err = e.analyzeQuery(ctx, query, parsed)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
+
 	if err != nil {
 		err2 := clearAutocommitTransaction(ctx)
 		if err2 != nil {
@@ -304,7 +374,7 @@ func (e *Engine) QueryNodeWithBindings(ctx *sql.Context, query string, parsed sq
 		return nil, nil, err
 	}
 
-	iter, err = e.Analyzer.ExecBuilder.Build(ctx, analyzed, nil)
+	iter, err := e.Analyzer.ExecBuilder.Build(ctx, analyzed, nil)
 	if err != nil {
 		err2 := clearAutocommitTransaction(ctx)
 		if err2 != nil {
@@ -376,116 +446,17 @@ func countBindVars(node sql.Node) int {
 	return len(bindVars)
 }
 
-func (e *Engine) analyzeQuery(ctx *sql.Context, query string, parsed sql.Node, bindings map[string]sql.Expression) (sql.Node, error) {
+func (e *Engine) analyzeQuery(ctx *sql.Context, query string, parsed sql.Node) (sql.Node, error) {
 	var (
 		analyzed sql.Node
 		err      error
 	)
-
-	// TODO: eventually, we should have this logic be in the RowIter() of the respective plans
-	// along with a new rule that handles analysis
-	switch n := parsed.(type) {
-	case *plan.PrepareQuery:
-		analyzedChild, err := e.Analyzer.PrepareQuery(ctx, n.Child, nil)
-		if err != nil {
-			return nil, err
-		}
-		e.PreparedDataCache.CacheStmt(ctx.Session.ID(), n.Name, analyzedChild)
-		return parsed, nil
-	case *plan.ExecuteQuery:
-		// replace execute query node with the one prepared
-		p, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), n.Name)
-		if !ok {
-			return nil, sql.ErrUnknownPreparedStatement.New(n.Name)
-		}
-
-		// number of BindVars provided must match number of BindVars expected
-		if countBindVars(p) != len(n.BindVars) {
-			return nil, sql.ErrInvalidArgument.New(n.Name)
-		}
-		parsed = p
-
-		bindings = map[string]sql.Expression{}
-		for i, binding := range n.BindVars {
-			varName := fmt.Sprintf("v%d", i+1)
-			bindings[varName] = binding
-		}
-
-		if len(bindings) > 0 {
-			var usedBindings map[string]bool
-			parsed, usedBindings, err = plan.ApplyBindings(parsed, bindings)
-			if err != nil {
-				return nil, err
-			}
-			for binding := range bindings {
-				if !usedBindings[binding] && !plan.HasEmptyTable(analyzed) {
-					return nil, fmt.Errorf("unused binding %s", binding)
-				}
-			}
-		}
-
-		analyzed, _, err = e.Analyzer.AnalyzePrepared(ctx, parsed, nil)
-		if err != nil {
-			return nil, err
-		}
-		return analyzed, nil
-	case *plan.DeallocateQuery:
-		if _, ok := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), n.Name); !ok {
-			return nil, sql.ErrUnknownPreparedStatement.New(n.Name)
-		}
-		e.PreparedDataCache.UncacheStmt(ctx.Session.ID(), n.Name)
-		return parsed, nil
-	}
-
-	if len(bindings) > 0 {
-		var usedBindings map[string]bool
-		parsed, usedBindings, err = plan.ApplyBindings(parsed, bindings)
-		if err != nil {
-			return nil, err
-		}
-		for binding := range bindings {
-			if !usedBindings[binding] && !plan.HasEmptyTable(analyzed) {
-				return nil, fmt.Errorf("unused binding %s", binding)
-			}
-		}
-	}
 
 	analyzed, err = e.Analyzer.Analyze(ctx, parsed, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return analyzed, nil
-}
-
-func (e *Engine) analyzePreparedQuery(ctx *sql.Context, query string, analyzed sql.Node, bindings map[string]sql.Expression) (sql.Node, error) {
-	ctx.GetLogger().Tracef("optimizing prepared plan for query: %s", query)
-
-	analyzed, err := analyzer.DeepCopyNode(analyzed)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(bindings) > 0 {
-		var usedBindings map[string]bool
-		analyzed, usedBindings, err = plan.ApplyBindings(analyzed, bindings)
-		if err != nil {
-			return nil, err
-		}
-		for binding := range bindings {
-			if !usedBindings[binding] && !plan.HasEmptyTable(analyzed) {
-				return nil, fmt.Errorf("unused binding %s", binding)
-			}
-		}
-	}
-	ctx.GetLogger().Tracef("plan before re-opt: %s", analyzed.String())
-
-	analyzed, _, err = e.Analyzer.AnalyzePrepared(ctx, analyzed, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx.GetLogger().Tracef("plan after re-opt: %s", analyzed.String())
 	return analyzed, nil
 }
 
@@ -538,71 +509,4 @@ func (e *Engine) readOnlyCheck(node sql.Node) error {
 		}
 	}
 	return nil
-}
-
-// ResolveDefaults takes in a schema, along with each column's default value in a string form, and returns the schema
-// with the default values parsed and resolved.
-func ResolveDefaults(tableName string, schema []*ColumnWithRawDefault) (sql.Schema, error) {
-	// todo: change this function or thread a context
-	ctx := sql.NewEmptyContext()
-	db := plan.NewDummyResolvedDB("temporary")
-	e := NewDefault(memory.NewDBProvider(db))
-	defer e.Close()
-
-	unresolvedSchema := make(sql.Schema, len(schema))
-	defaultCount := 0
-	for i, col := range schema {
-		unresolvedSchema[i] = col.SqlColumn
-		if col.Default != "" {
-			var err error
-			unresolvedSchema[i].Default, err = parse.StringToColumnDefaultValue(ctx, col.Default)
-			if err != nil {
-				return nil, err
-			}
-			defaultCount++
-		}
-	}
-	// if all defaults are nil, we can skip the rest of this
-	if defaultCount == 0 {
-		return unresolvedSchema, nil
-	}
-
-	// *plan.CreateTable properly handles resolving default values, so we hijack it
-	createTable := plan.NewCreateTable(db, tableName, false, false, &plan.TableSpec{Schema: sql.NewPrimaryKeySchema(unresolvedSchema)})
-
-	analyzed, err := e.Analyzer.Analyze(ctx, createTable, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	analyzedQueryProcess, ok := analyzed.(*plan.QueryProcess)
-	if !ok {
-		return nil, fmt.Errorf("internal error: unknown analyzed result type `%T`", analyzed)
-	}
-
-	analyzedCreateTable, ok := analyzedQueryProcess.Child().(*plan.CreateTable)
-	if !ok {
-		return nil, fmt.Errorf("internal error: unknown query process child type `%T`", analyzedQueryProcess)
-	}
-
-	return analyzedCreateTable.CreateSchema.Schema, nil
-}
-
-// ColumnsFromCheckDefinition retrieves the Column Names referenced by a CheckDefinition
-func ColumnsFromCheckDefinition(ctx *sql.Context, def *sql.CheckDefinition) ([]string, error) {
-	// Evaluate the CheckDefinition to get evaluated Expression
-	c, err := analyzer.ConvertCheckDefToConstraint(ctx, def, nil)
-	if err != nil {
-		return nil, err
-	}
-	// Look for any column references in the evaluated Expression
-	var cols []string
-	sql.Inspect(c.Expr, func(expr sql.Expression) bool {
-		if c, ok := expr.(*expression.UnresolvedColumn); ok {
-			cols = append(cols, c.Name())
-			return false
-		}
-		return true
-	})
-	return cols, nil
 }

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -20,6 +20,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dolthub/vitess/go/sqltypes"
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,9 +33,8 @@ import (
 	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/dolthub/go-mysql-server/sql/parse"
 	"github.com/dolthub/go-mysql-server/sql/plan"
-	"github.com/dolthub/go-mysql-server/sql/transform"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -234,7 +236,7 @@ func TestTransactionScriptWithEngine(t *testing.T, e *sqle.Engine, harness Harne
 
 // TestQuery runs a query on the engine given and asserts that results are as expected.
 // TODO: this should take en engine
-func TestQuery(t *testing.T, harness Harness, q string, expected []sql.Row, expectedCols []*sql.Column, bindings map[string]sql.Expression) {
+func TestQuery(t *testing.T, harness Harness, q string, expected []sql.Row, expectedCols []*sql.Column, bindings map[string]*querypb.BindVariable) {
 	t.Run(q, func(t *testing.T) {
 		if sh, ok := harness.(SkippingHarness); ok {
 			if sh.SkipQueryTest(q) {
@@ -250,7 +252,7 @@ func TestQuery(t *testing.T, harness Harness, q string, expected []sql.Row, expe
 }
 
 // TestQuery runs a query on the engine given and asserts that results are as expected.
-func TestQuery2(t *testing.T, harness Harness, e *sqle.Engine, q string, expected []sql.Row, expectedCols []*sql.Column, bindings map[string]sql.Expression) {
+func TestQuery2(t *testing.T, harness Harness, e *sqle.Engine, q string, expected []sql.Row, expectedCols []*sql.Column, bindings map[string]*querypb.BindVariable) {
 	t.Run(q, func(t *testing.T) {
 		if sh, ok := harness.(SkippingHarness); ok {
 			if sh.SkipQueryTest(q) {
@@ -277,7 +279,7 @@ func TestQueryWithEngine(t *testing.T, harness Harness, e *sqle.Engine, tt queri
 	})
 }
 
-func TestQueryWithContext(t *testing.T, ctx *sql.Context, e *sqle.Engine, harness Harness, q string, expected []sql.Row, expectedCols []*sql.Column, bindings map[string]sql.Expression) {
+func TestQueryWithContext(t *testing.T, ctx *sql.Context, e *sqle.Engine, harness Harness, q string, expected []sql.Row, expectedCols []*sql.Column, bindings map[string]*querypb.BindVariable) {
 	ctx = ctx.WithQuery(q)
 	require := require.New(t)
 	if len(bindings) > 0 {
@@ -334,14 +336,18 @@ func TestPreparedQueryWithContext(
 	q string,
 	expected []sql.Row,
 	expectedCols []*sql.Column,
-	bindVars map[string]sql.Expression,
+	bindVars map[string]*querypb.BindVariable,
 ) {
 	require := require.New(t)
 	rows, sch, err := runQueryPreparedWithCtx(t, ctx, e, q, bindVars)
+	if err != nil {
+		print(q)
+	}
 	require.NoError(err, "Unexpected error for query %s", q)
 
 	if expected != nil {
-		checkResults(t, expected, expectedCols, sch, rows, q)
+		// TODO fix expected cols for prepared?
+		checkResults(t, expected, nil, sch, rows, q)
 	}
 
 	require.Equal(0, ctx.Memory.NumCaches())
@@ -353,17 +359,67 @@ func injectBindVarsAndPrepare(
 	ctx *sql.Context,
 	e *sqle.Engine,
 	q string,
-) (map[string]sql.Expression, error) {
-	parsed, err := parse.Parse(ctx, q)
+) (string, map[string]*querypb.BindVariable, error) {
+	parsed, err := sqlparser.Parse(q)
 	if err != nil {
-		return nil, err
+		return q, nil, err
 	}
 
-	_, isInsert := parsed.(*plan.InsertInto)
-	_, isDatabaser := parsed.(sql.Databaser)
+	resPlan, err := planbuilder.Parse(ctx, e.Analyzer.Catalog, q)
+	if err != nil {
+		return q, nil, err
+	}
+
+	_, isInsert := resPlan.(*plan.InsertInto)
+	bindVars := make(map[string]*querypb.BindVariable)
+	var bindCnt int
+	var foundBindVar bool
+	var skipTypeConv bool
+	err = sqlparser.Walk(func(n sqlparser.SQLNode) (kontinue bool, err error) {
+		switch n := n.(type) {
+		case *sqlparser.SQLVal:
+			switch n.Type {
+			case sqlparser.HexNum, sqlparser.HexVal:
+				return false, nil
+			}
+			b := planbuilder.New(ctx, sql.MapCatalog{})
+			e := b.ConvertVal(n)
+			val, _, err := e.Type().Promote().Convert(e.(*expression.Literal).Value())
+			if err != nil {
+				skipTypeConv = true
+				return false, nil
+			}
+			bindVar, err := sqltypes.BuildBindVariable(val)
+			if err != nil {
+				skipTypeConv = true
+				return false, nil
+			}
+			varName := fmt.Sprintf("v%d", bindCnt)
+			bindVars[varName] = bindVar
+			n.Type = sqlparser.ValArg
+			n.Val = []byte(fmt.Sprintf(":v%d", bindCnt))
+			bindCnt++
+		case *sqlparser.Insert:
+			isInsert = true
+		default:
+		}
+		return true, nil
+	}, parsed)
+	if err != nil {
+		return "", nil, err
+	}
+	if skipTypeConv {
+		return q, nil, nil
+	}
+
+	buf := sqlparser.NewTrackedBuffer(nil)
+	parsed.Format(buf)
+	e.PreparedDataCache.CacheStmt(ctx.Session.ID(), buf.String(), parsed)
+
+	_, isDatabaser := resPlan.(sql.Databaser)
 
 	// *ast.MultiAlterDDL parses arbitrary nodes in a *plan.Block
-	if bl, ok := parsed.(*plan.Block); ok {
+	if bl, ok := resPlan.(*plan.Block); ok {
 		for _, n := range bl.Children() {
 			if _, ok := n.(*plan.InsertInto); ok {
 				isInsert = true
@@ -374,57 +430,14 @@ func injectBindVarsAndPrepare(
 		}
 	}
 	if isDatabaser && !isInsert {
-		return nil, nil
+		return q, nil, nil
 	}
-
-	bindVars := make(map[string]sql.Expression)
-	var bindCnt int
-	var foundBindVar bool
-	insertBindings := func(expr sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-		switch e := expr.(type) {
-		case *expression.Literal:
-			varName := fmt.Sprintf("v%d", bindCnt)
-			bindVars[varName] = e
-			bindCnt++
-			return expression.NewBindVar(varName), transform.NewTree, nil
-		case *expression.BindVar:
-			if _, ok := bindVars[e.Name]; ok {
-				return expr, transform.SameTree, nil
-			}
-			foundBindVar = true
-			return expr, transform.NewTree, nil
-		default:
-			return expr, transform.SameTree, nil
-		}
-	}
-	bound, _, err := transform.NodeWithOpaque(parsed, func(node sql.Node) (sql.Node, transform.TreeIdentity, error) {
-		switch n := node.(type) {
-		case *plan.InsertInto:
-			newSource, _, err := transform.NodeExprs(n.Source, insertBindings)
-			if err != nil {
-				return nil, transform.SameTree, err
-			}
-			return n.WithSource(newSource), transform.NewTree, nil
-		default:
-			return transform.NodeExprs(n, insertBindings)
-		}
-		return node, transform.SameTree, nil
-	})
 
 	if foundBindVar {
 		t.Skip()
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
-	prepared, err := e.Analyzer.PrepareQuery(ctx, bound, nil)
-	if err != nil {
-		return nil, err
-	}
-	e.PreparedDataCache.CacheStmt(ctx.Session.ID(), q, prepared)
-	return bindVars, nil
+	return buf.String(), bindVars, nil
 }
 
 func runQueryPreparedWithCtx(
@@ -432,20 +445,18 @@ func runQueryPreparedWithCtx(
 	ctx *sql.Context,
 	e *sqle.Engine,
 	q string,
-	bindVars map[string]sql.Expression,
+	bindVars map[string]*querypb.BindVariable,
 ) ([]sql.Row, sql.Schema, error) {
 	// If bindvars were not provided, try to inject some
 	if bindVars == nil || len(bindVars) == 0 {
 		var err error
-		bindVars, err = injectBindVarsAndPrepare(t, ctx, e, q)
+		q, bindVars, err = injectBindVarsAndPrepare(t, ctx, e, q)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
-	p, _ := e.PreparedDataCache.GetCachedStmt(ctx.Session.ID(), q)
-
-	sch, iter, err := e.QueryNodeWithBindings(ctx, q, p, bindVars)
+	sch, iter, err := e.QueryNodeWithBindings(ctx, q, bindVars)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -663,7 +674,7 @@ func AssertErr(t *testing.T, e *sqle.Engine, harness Harness, query string, expe
 
 // AssertErrWithBindings asserts that the given query returns an error during its execution, optionally specifying a
 // type of error.
-func AssertErrWithBindings(t *testing.T, e *sqle.Engine, harness Harness, query string, bindings map[string]sql.Expression, expectedErrKind *errors.Kind, errStrs ...string) {
+func AssertErrWithBindings(t *testing.T, e *sqle.Engine, harness Harness, query string, bindings map[string]*querypb.BindVariable, expectedErrKind *errors.Kind, errStrs ...string) {
 	ctx := NewContext(harness)
 	sch, iter, err := e.QueryWithBindings(ctx, query, bindings)
 	if err == nil {

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -18,7 +18,6 @@ import (
 	"github.com/dolthub/vitess/go/vt/proto/query"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -33,8 +32,8 @@ var JsonScripts = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query: `SELECT * FROM users WHERE JSON_CONTAINS (languages, JSON_ARRAY(?)) ORDER BY users.id LIMIT 1`,
-				Bindings: map[string]sql.Expression{
-					"v1": expression.NewLiteral("ZH", types.MustCreateString(query.Type_CHAR, 3, sql.Collation_binary)),
+				Bindings: map[string]*query.BindVariable{
+					"v1": {Value: sql.MustConvertToValue("ZH").Val, Type: sql.MustConvertToValue("ZH").Typ},
 				},
 				Expected: []sql.Row{{uint64(1), "Tom", types.JSONDocument{Val: []interface{}{"ZH", "EN"}}}},
 			},
@@ -340,8 +339,12 @@ var JsonScripts = []ScriptTest{
 				ExpectedErr: sql.ErrTableNotFound,
 			},
 			{
-				Query:       `SELECT JSON_OBJECTAGG(c0, val, badarg) from test`,
+				Query:       `SELECT JSON_OBJECTAGG(c0, val, 'badarg') from test`,
 				ExpectedErr: sql.ErrInvalidArgumentNumber,
+			},
+			{
+				Query:       `SELECT JSON_OBJECTAGG(c0, val, badarg) from test`,
+				ExpectedErr: sql.ErrColumnNotFound,
 			},
 			{
 				Query:       `SELECT JSON_OBJECTAGG(c0) from test`,

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -17,6 +17,7 @@ package queries
 import (
 	"time"
 
+	"github.com/dolthub/vitess/go/vt/proto/query"
 	"gopkg.in/src-d/go-errors.v1"
 
 	gmstime "github.com/dolthub/go-mysql-server/internal/time"
@@ -75,7 +76,7 @@ type ScriptTestAssertion struct {
 	Skip bool
 
 	// Bindings are variable mappings only used for prepared tests
-	Bindings map[string]sql.Expression
+	Bindings map[string]*query.BindVariable
 }
 
 // ScriptTests are a set of test scripts to run.
@@ -1468,14 +1469,6 @@ var ScriptTests = []ScriptTest{
 			},
 			{
 				Query:       "SELECT col0, col1 FROM tab1 GROUP by col0;",
-				ExpectedErr: analyzererrors.ErrValidationGroupBy,
-			},
-			{
-				Query:       "SELECT col0, floor(col1) FROM tab1 GROUP by col0;",
-				ExpectedErr: analyzererrors.ErrValidationGroupBy,
-			},
-			{
-				Query:       "SELECT floor(cor0.col1) * ceil(cor0.col0) AS col2 FROM tab1 AS cor0 GROUP BY cor0.col0",
 				ExpectedErr: analyzererrors.ErrValidationGroupBy,
 			},
 		},
@@ -4283,8 +4276,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query:       "execute s",
-				ExpectedErr: sql.ErrInvalidArgument,
+				Query:          "execute s",
+				ExpectedErrStr: "missing bind var v1",
 			},
 			{
 				Query: "execute s using @abc",
@@ -4293,8 +4286,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query:       "execute s using @a, @b, @c, @abc",
-				ExpectedErr: sql.ErrInvalidArgument,
+				Query:          "execute s using @a, @b, @c, @abc",
+				ExpectedErrStr: "invalid arguments. expected: 1, found: 4",
 			},
 			{
 				Query: "execute s using @a",
@@ -4341,8 +4334,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query:       "execute s using @a",
-				ExpectedErr: sql.ErrInvalidArgument,
+				Query:          "execute s using @a",
+				ExpectedErrStr: "missing bind var v2",
 			},
 			{
 				Query: "execute s using @a, @b",


### PR DESCRIPTION
This is a partial view of the larger name resolution PR. For review, not intended to merge.

In summary, this refactor caches saves a buffer of the original query string, with indices for bind variable replacement. Post-prepare is: 1) generate a query string with bind variables, 2) run analysis and execute.

Related vitess PR: https://github.com/dolthub/vitess/pull/262