### PR TITLE
Fixed collation display in SHOW CREATE TABLE

### DIFF
--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -423,6 +423,105 @@ var AlterTableScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "ALTER TABLE does not change column collations",
+		SetUpScript: []string{
+			"CREATE TABLE test1 (v1 VARCHAR(200), v2 ENUM('a'), v3 SET('a'));",
+			"CREATE TABLE test2 (v1 VARCHAR(200), v2 ENUM('a'), v3 SET('a')) COLLATE=utf8mb4_general_ci;",
+			"CREATE TABLE test3 (v1 VARCHAR(200) COLLATE utf8mb4_general_ci, v2 ENUM('a'), v3 SET('a') CHARACTER SET utf8mb3) COLLATE=utf8mb4_general_ci",
+			"CREATE TABLE test4 (v1 VARCHAR(200) COLLATE utf8mb4_0900_ai_ci, v2 ENUM('a') COLLATE utf8mb4_general_ci, v3 SET('a') COLLATE utf8mb4_unicode_ci) COLLATE=utf8mb4_bin;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SHOW CREATE TABLE test1",
+				Expected: []sql.Row{{"test1",
+					"CREATE TABLE `test1` (\n" +
+						"  `v1` varchar(200),\n" +
+						"  `v2` enum('a'),\n" +
+						"  `v3` set('a')\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query: "SHOW CREATE TABLE test2",
+				Expected: []sql.Row{{"test2",
+					"CREATE TABLE `test2` (\n" +
+						"  `v1` varchar(200),\n" +
+						"  `v2` enum('a'),\n" +
+						"  `v3` set('a')\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"}},
+			},
+			{
+				Query: "SHOW CREATE TABLE test3",
+				Expected: []sql.Row{{"test3",
+					"CREATE TABLE `test3` (\n" +
+						"  `v1` varchar(200),\n" +
+						"  `v2` enum('a'),\n" +
+						"  `v3` set('a') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"}},
+			},
+			{
+				Query: "SHOW CREATE TABLE test4",
+				Expected: []sql.Row{{"test4",
+					"CREATE TABLE `test4` (\n" +
+						"  `v1` varchar(200) COLLATE utf8mb4_0900_ai_ci,\n" +
+						"  `v2` enum('a') COLLATE utf8mb4_general_ci,\n" +
+						"  `v3` set('a') COLLATE utf8mb4_unicode_ci\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"}},
+			},
+			{
+				Query:    "ALTER TABLE test1 COLLATE utf8mb4_general_ci;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "ALTER TABLE test2 COLLATE utf8mb4_0900_bin;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "ALTER TABLE test3 COLLATE utf8mb4_0900_bin;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "ALTER TABLE test4 COLLATE utf8mb4_unicode_ci;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "SHOW CREATE TABLE test1",
+				Expected: []sql.Row{{"test1",
+					"CREATE TABLE `test1` (\n" +
+						"  `v1` varchar(200) COLLATE utf8mb4_0900_bin,\n" +
+						"  `v2` enum('a') COLLATE utf8mb4_0900_bin,\n" +
+						"  `v3` set('a') COLLATE utf8mb4_0900_bin\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"}},
+			},
+			{
+				Query: "SHOW CREATE TABLE test2",
+				Expected: []sql.Row{{"test2",
+					"CREATE TABLE `test2` (\n" +
+						"  `v1` varchar(200) COLLATE utf8mb4_general_ci,\n" +
+						"  `v2` enum('a') COLLATE utf8mb4_general_ci,\n" +
+						"  `v3` set('a') COLLATE utf8mb4_general_ci\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query: "SHOW CREATE TABLE test3",
+				Expected: []sql.Row{{"test3",
+					"CREATE TABLE `test3` (\n" +
+						"  `v1` varchar(200) COLLATE utf8mb4_general_ci,\n" +
+						"  `v2` enum('a') COLLATE utf8mb4_general_ci,\n" +
+						"  `v3` set('a') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query: "SHOW CREATE TABLE test4",
+				Expected: []sql.Row{{"test4",
+					"CREATE TABLE `test4` (\n" +
+						"  `v1` varchar(200) COLLATE utf8mb4_0900_ai_ci,\n" +
+						"  `v2` enum('a') COLLATE utf8mb4_general_ci,\n" +
+						"  `v3` set('a')\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"}},
+			},
+		},
+	},
 }
 
 var AlterTableAddAutoIncrementScripts = []ScriptTest{

--- a/enginetest/queries/charset_collation_engine.go
+++ b/enginetest/queries/charset_collation_engine.go
@@ -306,19 +306,19 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			{
 				Query: "SHOW CREATE TABLE test1;",
 				Expected: []sql.Row{
-					{"test1", "CREATE TABLE `test1` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255) CHARACTER SET utf16 COLLATE utf16_unicode_ci,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf16 COLLATE=utf16_unicode_ci"},
+					{"test1", "CREATE TABLE `test1` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf16 COLLATE=utf16_unicode_ci"},
 				},
 			},
 			{
 				Query: "SHOW CREATE TABLE test2;",
 				Expected: []sql.Row{
-					{"test2", "CREATE TABLE `test2` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(100) COLLATE utf8mb4_unicode_ci,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
+					{"test2", "CREATE TABLE `test2` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(100),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
 				},
 			},
 			{
 				Query: "SHOW CREATE TABLE test3;",
 				Expected: []sql.Row{
-					{"test3", "CREATE TABLE `test3` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255) COLLATE utf8mb4_unicode_ci,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
+					{"test3", "CREATE TABLE `test3` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
 				},
 			},
 			{
@@ -336,7 +336,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			{
 				Query: "SHOW CREATE TABLE test3;",
 				Expected: []sql.Row{
-					{"test3", "CREATE TABLE `test3` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255) COLLATE utf8mb4_unicode_ci,\n  `v2` varchar(255) COLLATE utf8mb4_unicode_ci,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
+					{"test3", "CREATE TABLE `test3` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(255),\n  `v2` varchar(255),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
 				},
 			},
 			{
@@ -348,7 +348,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			{
 				Query: "SHOW CREATE TABLE test2;",
 				Expected: []sql.Row{
-					{"test2", "CREATE TABLE `test2` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(220) COLLATE utf8mb4_unicode_ci,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
+					{"test2", "CREATE TABLE `test2` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(220),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci"},
 				},
 			},
 			{
@@ -388,7 +388,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			{
 				Query: "SHOW CREATE TABLE test2;",
 				Expected: []sql.Row{
-					{"test2", "CREATE TABLE `test2` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(220) COLLATE utf8mb4_unicode_ci,\n  `v2` varchar(255) COLLATE utf8mb4_bin,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"},
+					{"test2", "CREATE TABLE `test2` (\n  `pk` bigint NOT NULL,\n  `v1` varchar(220) COLLATE utf8mb4_unicode_ci,\n  `v2` varchar(255),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"},
 				},
 			},
 		},

--- a/enginetest/queries/charset_collation_wire.go
+++ b/enginetest/queries/charset_collation_wire.go
@@ -1271,19 +1271,19 @@ var DatabaseCollationWireTests = []CharsetCollationWireTest{
 			{
 				Query: "SHOW CREATE TABLE test_a;",
 				Expected: []sql.Row{
-					{"test_a", "CREATE TABLE `test_a` (\n  `pk` varchar(20) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"},
+					{"test_a", "CREATE TABLE `test_a` (\n  `pk` varchar(20) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"},
 				},
 			},
 			{
 				Query: "SHOW CREATE TABLE test_b;",
 				Expected: []sql.Row{
-					{"test_b", "CREATE TABLE `test_b` (\n  `pk` varchar(20) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci"},
+					{"test_b", "CREATE TABLE `test_b` (\n  `pk` varchar(20) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_unicode_ci"},
 				},
 			},
 			{
 				Query: "SHOW CREATE TABLE test_c;",
 				Expected: []sql.Row{
-					{"test_c", "CREATE TABLE `test_c` (\n  `pk` varchar(20) CHARACTER SET utf8mb3 COLLATE utf8mb3_unicode_ci NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"},
+					{"test_c", "CREATE TABLE `test_c` (\n  `pk` varchar(20) COLLATE utf8mb3_unicode_ci NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"},
 				},
 			},
 			{
@@ -1299,7 +1299,7 @@ var DatabaseCollationWireTests = []CharsetCollationWireTest{
 			{
 				Query: "SHOW CREATE TABLE test_d;",
 				Expected: []sql.Row{
-					{"test_d", "CREATE TABLE `test_d` (\n  `pk` varchar(20) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci"},
+					{"test_d", "CREATE TABLE `test_d` (\n  `pk` varchar(20) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_general_ci"},
 				},
 			},
 			{

--- a/enginetest/queries/mysql_db_queries.go
+++ b/enginetest/queries/mysql_db_queries.go
@@ -22,15 +22,15 @@ var MySqlDbTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "show create table mysql.help_topic;",
-				Expected: []sql.Row{{"help_topic", "CREATE TABLE `help_topic` (\n  `help_topic_id` bigint unsigned NOT NULL,\n  `name` char(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  `help_category_id` tinyint unsigned NOT NULL,\n  `description` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  `example` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  `url` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  PRIMARY KEY (`help_topic_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"}},
+				Expected: []sql.Row{{"help_topic", "CREATE TABLE `help_topic` (\n  `help_topic_id` bigint unsigned NOT NULL,\n  `name` char(64) COLLATE utf8mb3_general_ci NOT NULL,\n  `help_category_id` tinyint unsigned NOT NULL,\n  `description` text COLLATE utf8mb3_general_ci NOT NULL,\n  `example` text COLLATE utf8mb3_general_ci NOT NULL,\n  `url` text COLLATE utf8mb3_general_ci NOT NULL,\n  PRIMARY KEY (`help_topic_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"}},
 			},
 			{
 				Query:    "show create table mysql.help_category;",
-				Expected: []sql.Row{{"help_category", "CREATE TABLE `help_category` (\n  `help_category_id` tinyint unsigned NOT NULL,\n  `name` char(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  `parent_category_id` tinyint unsigned NOT NULL,\n  `url` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  PRIMARY KEY (`help_category_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"}},
+				Expected: []sql.Row{{"help_category", "CREATE TABLE `help_category` (\n  `help_category_id` tinyint unsigned NOT NULL,\n  `name` char(64) COLLATE utf8mb3_general_ci NOT NULL,\n  `parent_category_id` tinyint unsigned NOT NULL,\n  `url` text COLLATE utf8mb3_general_ci NOT NULL,\n  PRIMARY KEY (`help_category_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"}},
 			},
 			{
 				Query:    "show create table mysql.help_keyword;",
-				Expected: []sql.Row{{"help_keyword", "CREATE TABLE `help_keyword` (\n  `help_keyword_id` bigint unsigned NOT NULL,\n  `name` char(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL,\n  PRIMARY KEY (`help_keyword_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"}},
+				Expected: []sql.Row{{"help_keyword", "CREATE TABLE `help_keyword` (\n  `help_keyword_id` bigint unsigned NOT NULL,\n  `name` char(64) COLLATE utf8mb3_general_ci NOT NULL,\n  PRIMARY KEY (`help_keyword_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_bin"}},
 			},
 			{
 				Query:    "show create table mysql.help_relation;",

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10197,7 +10197,7 @@ var IndexPrefixQueries = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "show create table t",
-				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` varchar(10) COLLATE utf8mb4_0900_ai_ci,\n  `v2` varchar(10) COLLATE utf8mb4_0900_ai_ci,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1v2` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"}},
+				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` varchar(10),\n  `v2` varchar(10),\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1v2` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"}},
 			},
 			{
 				Query:    "insert into t values (0, 'a', 'a'), (1, 'ab','ab'), (2, 'abc', 'abc'), (3, 'abcde', 'abcde')",

--- a/sql/collations.go
+++ b/sql/collations.go
@@ -955,6 +955,11 @@ func (ci *CollationsIterator) Next() (Collation, bool) {
 
 // TypeWithCollation is implemented on all types that may return a collation.
 type TypeWithCollation interface {
+	// Collation returns the collation belonging to this type.
 	Collation() CollationID
+	// WithNewCollation returns a replica of this type, except with the given collation replacing the existing collation.
 	WithNewCollation(collation CollationID) (Type, error)
+	// StringWithTableCollation converts this type to a string, however it uses the given table collation to determine
+	// whether to include the character set and/or collation information.
+	StringWithTableCollation(tableCollation CollationID) string
 }

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -340,6 +340,7 @@ func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, tab
 	}
 
 	// Statement creation parts for each column
+	tableCollation := table.Collation()
 	for i, col := range schema {
 		var colDefaultStr string
 		// TODO: The columns that are rendered in defaults should be backticked
@@ -359,7 +360,7 @@ func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, tab
 			pkOrdinals = append(pkOrdinals, i)
 		}
 
-		colStmts[i] = sql.GenerateCreateTableColumnDefinition(col, colDefaultStr)
+		colStmts[i] = sql.GenerateCreateTableColumnDefinition(col, colDefaultStr, tableCollation)
 	}
 
 	for _, i := range pkOrdinals {

--- a/sql/sqlfmt.go
+++ b/sql/sqlfmt.go
@@ -38,8 +38,14 @@ func GenerateCreateTableStatement(tblName string, colStmts []string, tblCharsetN
 
 // GenerateCreateTableColumnDefinition returns column definition string for 'CREATE TABLE' statement for given column.
 // This part comes first in the 'CREATE TABLE' statement.
-func GenerateCreateTableColumnDefinition(col *Column, colDefault string) string {
-	stmt := fmt.Sprintf("  %s %s", QuoteIdentifier(col.Name), col.Type.String())
+func GenerateCreateTableColumnDefinition(col *Column, colDefault string, tableCollation CollationID) string {
+	var colTypeString string
+	if collationType, ok := col.Type.(TypeWithCollation); ok {
+		colTypeString = collationType.StringWithTableCollation(tableCollation)
+	} else {
+		colTypeString = col.Type.String()
+	}
+	stmt := fmt.Sprintf("  %s %s", QuoteIdentifier(col.Name), colTypeString)
 	if !col.Nullable {
 		stmt = fmt.Sprintf("%s NOT NULL", stmt)
 	}

--- a/sql/types/enum.go
+++ b/sql/types/enum.go
@@ -258,14 +258,7 @@ func (t EnumType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 
 // String implements Type interface.
 func (t EnumType) String() string {
-	s := fmt.Sprintf("enum('%v')", strings.Join(t.indexToVal, `','`))
-	if t.CharacterSet() != sql.Collation_Default.CharacterSet() {
-		s += " CHARACTER SET " + t.CharacterSet().String()
-	}
-	if !t.collation.Equals(sql.Collation_Default) {
-		s += " COLLATE " + t.collation.String()
-	}
-	return s
+	return t.StringWithTableCollation(sql.Collation_Default)
 }
 
 // Type implements Type interface.
@@ -339,7 +332,19 @@ func (t EnumType) Values() []string {
 	return vals
 }
 
-// WithNewCollation implements TypeWithCollation interface.
+// WithNewCollation implements sql.TypeWithCollation interface.
 func (t EnumType) WithNewCollation(collation sql.CollationID) (sql.Type, error) {
 	return CreateEnumType(t.indexToVal, collation)
+}
+
+// StringWithTableCollation implements sql.TypeWithCollation interface.
+func (t EnumType) StringWithTableCollation(tableCollation sql.CollationID) string {
+	s := fmt.Sprintf("enum('%v')", strings.Join(t.indexToVal, `','`))
+	if t.CharacterSet() != tableCollation.CharacterSet() {
+		s += " CHARACTER SET " + t.CharacterSet().String()
+	}
+	if t.collation != tableCollation {
+		s += " COLLATE " + t.collation.String()
+	}
+	return s
 }

--- a/sql/types/set.go
+++ b/sql/types/set.go
@@ -249,14 +249,7 @@ func (t SetType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Val
 
 // String implements Type interface.
 func (t SetType) String() string {
-	s := fmt.Sprintf("set('%v')", strings.Join(t.Values(), `','`))
-	if t.CharacterSet() != sql.Collation_Default.CharacterSet() {
-		s += " CHARACTER SET " + t.CharacterSet().String()
-	}
-	if !t.collation.Equals(sql.Collation_Default) {
-		s += " COLLATE " + t.collation.String()
-	}
-	return s
+	return t.StringWithTableCollation(sql.Collation_Default)
 }
 
 // Type implements Type interface.
@@ -310,9 +303,21 @@ func (t SetType) Values() []string {
 	return valArray
 }
 
-// WithNewCollation implements TypeWithCollation interface.
+// WithNewCollation implements sql.TypeWithCollation interface.
 func (t SetType) WithNewCollation(collation sql.CollationID) (sql.Type, error) {
 	return CreateSetType(t.Values(), collation)
+}
+
+// StringWithTableCollation implements sql.TypeWithCollation interface.
+func (t SetType) StringWithTableCollation(tableCollation sql.CollationID) string {
+	s := fmt.Sprintf("set('%v')", strings.Join(t.Values(), `','`))
+	if t.CharacterSet() != tableCollation.CharacterSet() {
+		s += " CHARACTER SET " + t.CharacterSet().String()
+	}
+	if t.collation != tableCollation {
+		s += " COLLATE " + t.collation.String()
+	}
+	return s
 }
 
 // allValuesBitField returns a bit field that references every value that the set contains.

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -506,6 +506,42 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 
 // String implements Type interface.
 func (t StringType) String() string {
+	return t.StringWithTableCollation(sql.Collation_Default)
+}
+
+// Type implements Type interface.
+func (t StringType) Type() query.Type {
+	return t.baseType
+}
+
+// ValueType implements Type interface.
+func (t StringType) ValueType() reflect.Type {
+	if IsBinaryType(t) {
+		return byteValueType
+	}
+	return stringValueType
+}
+
+// Zero implements Type interface.
+func (t StringType) Zero() interface{} {
+	return ""
+}
+
+// CollationCoercibility implements sql.CollationCoercible interface.
+func (t StringType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return t.collation, 4
+}
+
+func (t StringType) CharacterSet() sql.CharacterSetID {
+	return t.collation.CharacterSet()
+}
+
+func (t StringType) Collation() sql.CollationID {
+	return t.collation
+}
+
+// StringWithTableCollation implements sql.TypeWithCollation interface.
+func (t StringType) StringWithTableCollation(tableCollation sql.CollationID) string {
 	var s string
 
 	switch t.baseType {
@@ -540,46 +576,15 @@ func (t StringType) String() string {
 	}
 
 	if t.CharacterSet() != sql.CharacterSet_binary {
-		if t.CharacterSet() != sql.Collation_Default.CharacterSet() {
+		if t.CharacterSet() != tableCollation.CharacterSet() {
 			s += " CHARACTER SET " + t.CharacterSet().String()
 		}
-		if t.collation != sql.Collation_Default {
+		if t.collation != tableCollation {
 			s += " COLLATE " + t.collation.Name()
 		}
 	}
 
 	return s
-}
-
-// Type implements Type interface.
-func (t StringType) Type() query.Type {
-	return t.baseType
-}
-
-// ValueType implements Type interface.
-func (t StringType) ValueType() reflect.Type {
-	if IsBinaryType(t) {
-		return byteValueType
-	}
-	return stringValueType
-}
-
-// Zero implements Type interface.
-func (t StringType) Zero() interface{} {
-	return ""
-}
-
-// CollationCoercibility implements sql.CollationCoercible interface.
-func (t StringType) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
-	return t.collation, 4
-}
-
-func (t StringType) CharacterSet() sql.CharacterSetID {
-	return t.collation.CharacterSet()
-}
-
-func (t StringType) Collation() sql.CollationID {
-	return t.collation
 }
 
 // WithNewCollation implements TypeWithCollation interface.


### PR DESCRIPTION
Originally, we didn't display the collation in `SHOW CREATE TABLE` when the collation was the default collation. Now, it doesn't display it if it's the same as the table collation, which mimics MySQL's behavior.