### PR TITLE
Removed unused AutoIncrementGetter interface

### DIFF
--- a/enginetest/queries/fulltext_queries.go
+++ b/enginetest/queries/fulltext_queries.go
@@ -842,4 +842,20 @@ var FulltextTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Full-Text with autoincrement",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk BIGINT UNSIGNED NOT NULL AUTO_INCREMENT, v1 VARCHAR(200), PRIMARY KEY(pk), FULLTEXT idx (v1));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "INSERT INTO test (v1) VALUES ('abc'), ('def');",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 1}}},
+			},
+			{
+				Query:    "SELECT * FROM test;",
+				Expected: []sql.Row{{uint64(1), "abc"}, {uint64(2), "def"}},
+			},
+		},
+	},
 }

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -278,18 +278,6 @@ type AutoIncrementSetter interface {
 	Closer
 }
 
-// AutoIncrementGetter is implemented by tables that support AUTO_INCREMENT to return the next value that will be
-// inserted, given a particular insert value provided by the client.
-type AutoIncrementGetter interface {
-	GetNextAutoIncrementValue(ctx *Context, insertVal interface{}) (uint64, error)
-}
-
-// AutoIncrementEditor is an interface for tables that support changing the value of auto increment columns.
-type AutoIncrementEditor interface {
-	AutoIncrementSetter
-	AutoIncrementGetter
-}
-
 // ReplaceableTable allows rows to be replaced through a Delete (if applicable) then Insert.
 type ReplaceableTable interface {
 	Table


### PR DESCRIPTION
Related to https://github.com/dolthub/dolt/issues/6543.

The `AutoIncrementGetter` was moved from the editor to the table years ago, however the interface remained. I debated deleting this during my Full-Text implementation, however decided to leave it. Now, we've encountered an error with an integrator making use of the interface, so it has been removed here and the interface was moved into the integrator since it's an internal detail now.