### PR TITLE
Don't parse queries twice

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -461,7 +461,7 @@ func runQueryPreparedWithCtx(
 		}
 	}
 
-	sch, iter, err := e.QueryNodeWithBindings(ctx, q, bindVars)
+	sch, iter, err := e.QueryNodeWithBindings(ctx, q, nil, bindVars)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/handler.go
+++ b/server/handler.go
@@ -215,8 +215,9 @@ func (h *Handler) doQuery(
 
 	var remainder string
 	var prequery string
+	var parsed sqlparser.Statement
 	if mode == MultiStmtModeOn {
-		_, prequery, remainder, err = planbuilder.ParseOne(ctx, h.e.Analyzer.Catalog, query)
+		parsed, prequery, remainder, err = planbuilder.ParseOnly(ctx, query, true)
 		if prequery != "" {
 			query = prequery
 		}
@@ -259,7 +260,7 @@ func (h *Handler) doQuery(
 		}
 	}()
 
-	schema, rowIter, err := h.e.QueryNodeWithBindings(ctx, query, bindings)
+	schema, rowIter, err := h.e.QueryNodeWithBindings(ctx, query, parsed, bindings)
 	if err != nil {
 		ctx.GetLogger().WithError(err).Warn("error running query")
 		return remainder, err


### PR DESCRIPTION
Local profile for `oltp_point_select` (query with smallest time spent in execution) is 5-15% speedup. Impact on queries with longer-runtime will be smaller, proportional to the fraction of time spent in analysis vs execution.

results here: https://github.com/dolthub/dolt/pull/6547#issuecomment-1686795603