### PR TITLE
Bug fix: Prevent panic when reading non-existent user and system vars

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -401,6 +401,9 @@ func (e *Engine) QueryNodeWithBindings(ctx *sql.Context, query string, parsed sq
 			return nil, nil, err
 		}
 		bound, err = b.BindOnly(parsed, query)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	switch n := bound.(type) {

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -195,7 +195,10 @@ func (b *Builder) buildSysVar(colName *ast.ColName, scopeHint ast.SetScope) (sql
 		if err != nil {
 			b.handleErr(err)
 		}
-		return expression.NewUserVarWithType(varName, t), scope, true
+		if t != nil {
+			return expression.NewUserVarWithType(varName, t), scope, true
+		}
+		return expression.NewUserVar(varName), scope, true
 	case ast.SetScope_Persist:
 		return expression.NewSystemVar(varName, sql.SystemVariableScope_Persist), scope, true
 	case ast.SetScope_PersistOnly:


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6546

We have enginetests that cover both of these queries, but because we don't run them with the full wire request/response processing code, we didn't catch these bugs during testing. Happy to add more tests here if there are suggestions, but I think the right way to test both of these is to get our existing test suite running over a SQL server connection, instead of just using the internal interfaces to the engine (i.e. https://github.com/dolthub/dolt/issues/3646), which Zach started on last week. 