### PR TITLE
Join aggregation projections subject to dropped refs

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -12193,13 +12193,14 @@ WHERE
 	   E2I7U TYMVL ON (sn.FFTBJ = TYMVL.id)
 	ORDER BY M6T2N ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [(row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N, s7egw.TW55N:1!null as FJVD7, tymvl.TW55N:31!null as KBXXJ, sn.NUMK2:2!null, sn.LETOE:3!null, sn.id:4!null as XLFIA]\n" +
+			" ├─ columns: [(row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N, s7egw.TW55N:1!null as FJVD7, tymvl.TW55N:2!null as KBXXJ, sn.NUMK2:3!null, sn.LETOE:4!null, sn.id:5!null as XLFIA]\n" +
 			" └─ Sort((row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [row_number() over ( order by sn.id asc):0!null, s7egw.TW55N:1!null, sn.NUMK2:2!null, sn.LETOE:3!null, sn.id:4!null, (row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N, s7egw.TW55N:1!null as FJVD7, tymvl.TW55N:31!null as KBXXJ, sn.id:4!null as XLFIA]\n" +
+			"         ├─ columns: [row_number() over ( order by sn.id asc):0!null, s7egw.TW55N:1!null, tymvl.TW55N:2!null, sn.NUMK2:3!null, sn.LETOE:4!null, sn.id:5!null, (row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N, s7egw.TW55N:1!null as FJVD7, tymvl.TW55N:2!null as KBXXJ, sn.id:5!null as XLFIA]\n" +
 			"         └─ Window\n" +
 			"             ├─ row_number() over ( order by sn.id ASC)\n" +
 			"             ├─ s7egw.TW55N:8!null\n" +
+			"             ├─ tymvl.TW55N:1!null\n" +
 			"             ├─ sn.NUMK2:5!null\n" +
 			"             ├─ sn.LETOE:6!null\n" +
 			"             ├─ sn.id:2!null\n" +

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -191,7 +191,7 @@ func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []s
 		transform.InspectExpr(col.scalar, func(e sql.Expression) bool {
 			switch e := e.(type) {
 			case *expression.GetField:
-				colName := strings.ToLower(e.Name())
+				colName := strings.ToLower(e.String())
 				if !selectStr[colName] {
 					selectExprs = append(selectExprs, e)
 					selectGfs = append(selectGfs, e)
@@ -204,7 +204,7 @@ func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []s
 	}
 	for _, e := range fromScope.extraCols {
 		// accessory cols used by ORDER_BY, HAVING
-		if !selectStr[e.col] {
+		if !selectStr[e.String()] {
 			selectExprs = append(selectExprs, e.scalarGf())
 			selectGfs = append(selectGfs, e.scalarGf())
 

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -208,7 +208,7 @@ func (b *Builder) buildAggregation(fromScope, projScope *scope, groupingCols []s
 			selectExprs = append(selectExprs, e.scalarGf())
 			selectGfs = append(selectGfs, e.scalarGf())
 
-			selectStr[e.col] = true
+			selectStr[e.String()] = true
 		}
 	}
 	gb := plan.NewGroupBy(selectExprs, groupingCols, fromScope.node)
@@ -501,11 +501,11 @@ func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {
 		transform.InspectExpr(col.scalar, func(e sql.Expression) bool {
 			switch e := e.(type) {
 			case *expression.GetField:
-				colName := strings.ToLower(e.Name())
+				colName := strings.ToLower(e.String())
 				if !selectStr[colName] {
 					selectExprs = append(selectExprs, e)
-					selectStr[colName] = true
 					selectGfs = append(selectGfs, e)
+					selectStr[colName] = true
 				}
 			default:
 			}
@@ -514,10 +514,10 @@ func (b *Builder) buildWindow(fromScope, projScope *scope) *scope {
 	}
 	for _, e := range fromScope.extraCols {
 		// accessory cols used by ORDER_BY, HAVING
-		if !selectStr[e.col] {
+		if !selectStr[e.String()] {
 			selectExprs = append(selectExprs, e.scalarGf())
 			selectGfs = append(selectGfs, e.scalarGf())
-			selectStr[e.col] = true
+			selectStr[e.String()] = true
 		}
 	}
 

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -40,10 +40,33 @@ type planTest struct {
 
 func TestPlanBuilder(t *testing.T) {
 	var verbose, rewrite bool
-	verbose = true
+	//verbose = true
 	//rewrite = true
 
 	var tests = []planTest{
+		{
+			Query: "SELECT b.y as s1, a.y as s2, first_value(a.z) over (partition by a.y) from xy a join xy b on a.y = b.y",
+			ExpectedPlan: `
+Project
+ ├─ columns: [b.y:5!null as s1, a.y:2!null as s2, first_value(a.z) over ( partition by a.y rows between unbounded preceding and unbounded following):9!null as first_value(a.z) over (partition by a.y)]
+ └─ Window
+     ├─ first_value(a.z) over ( partition by a.y ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+     ├─ b.y:5!null
+     ├─ a.y:2!null
+     └─ InnerJoin
+         ├─ Eq
+         │   ├─ a.y:2!null
+         │   └─ b.y:5!null
+         ├─ TableAlias(a)
+         │   └─ Table
+         │       ├─ name: xy
+         │       └─ columns: [x y z]
+         └─ TableAlias(b)
+             └─ Table
+                 ├─ name: xy
+                 └─ columns: [x y z]
+`,
+		},
 		{
 			Query: "select a.x, b.y as s1, a.y as s2 from xy a join xy b on a.y = b.y group by b.y",
 			ExpectedPlan: `

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -40,10 +40,32 @@ type planTest struct {
 
 func TestPlanBuilder(t *testing.T) {
 	var verbose, rewrite bool
-	//verbose = true
+	verbose = true
 	//rewrite = true
 
 	var tests = []planTest{
+		{
+			Query: "select a.x, b.y as s1, a.y as s2 from xy a join xy b on a.y = b.y group by b.y",
+			ExpectedPlan: `
+Project
+ ├─ columns: [a.x:1!null, b.y:5!null as s1, a.y:2!null as s2]
+ └─ GroupBy
+     ├─ select: a.x:1!null, b.y:5!null, a.y:2!null
+     ├─ group: b.y:5!null
+     └─ InnerJoin
+         ├─ Eq
+         │   ├─ a.y:2!null
+         │   └─ b.y:5!null
+         ├─ TableAlias(a)
+         │   └─ Table
+         │       ├─ name: xy
+         │       └─ columns: [x y z]
+         └─ TableAlias(b)
+             └─ Table
+                 ├─ name: xy
+                 └─ columns: [x y z]
+`,
+		},
 		{
 			Query: "with cte(y,x) as (select x,y from xy) select * from cte",
 			ExpectedPlan: `

--- a/sql/sql_mode.go
+++ b/sql/sql_mode.go
@@ -34,7 +34,6 @@ func LoadSqlMode(ctx *Context) *SqlMode {
 	sqlMode, err := ctx.Session.GetSessionVariable(ctx, SqlModeSessionVar)
 	if err != nil {
 		// if system variables are not initialized, assume default sqlMode
-		ctx.GetLogger().Warn("sqlMode system variable has not been initialized")
 		return &SqlMode{modes: nil, modeString: ""}
 	}
 


### PR DESCRIPTION
Aggregation intermediate projections need to output all inputs for aliases in the target projection. The way we were tracking column source column references did not take into account that two join tables can have the same column name. Now we include the table name for alias dependency tracking.

close https://github.com/dolthub/dolt/issues/6578