### PR TITLE
Fixed behavior for CONVERT(x USING y)

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1295,6 +1295,19 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "CONVERT USING still converts between incompatible character sets",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 VARCHAR(200)) COLLATE=utf8mb4_0900_ai_ci;",
+			"INSERT INTO test VALUES (1, '63273াম'), (2, 'GHD30r'), (3, '8জ্রিয277'), (4, NULL);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT pk, v1, CONVERT(CONVERT(v1 USING latin1) USING utf8mb4) AS round_trip FROM test WHERE v1 <> CONVERT(CONVERT(v1 USING latin1) USING utf8mb4);",
+				Expected: []sql.Row{{int64(1), "63273াম", "63273??"}, {int64(3), "8জ্রিয277", "8?????277"}},
+			},
+		},
+	},
+	{
 		Name: "ALTER TABLE ... ALTER COLUMN SET / DROP DEFAULT",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIGINT NOT NULL DEFAULT 88);",

--- a/sql/encodings/binary.go
+++ b/sql/encodings/binary.go
@@ -32,6 +32,11 @@ func (binaryEncoder) Encode(str []byte) ([]byte, bool) {
 	return str, true
 }
 
+// EncodeReplaceUnknown implements the Encoder interface.
+func (binaryEncoder) EncodeReplaceUnknown(str []byte) []byte {
+	return str
+}
+
 // DecodeRune implements the Encoder interface.
 func (binaryEncoder) DecodeRune(r []byte) ([]byte, bool) {
 	return r, true

--- a/sql/encodings/encoder.go
+++ b/sql/encodings/encoder.go
@@ -33,6 +33,12 @@ type Encoder interface {
 	// EncodeRune. Do note that the string parameter is NOT modified in any way. Refer to IsReturnSafe to check if the
 	// returned byte slice must be copied before modifications may be made.
 	Encode(str []byte) ([]byte, bool)
+	// EncodeReplaceUnknown converts from Go's string encoding (utf8mb4-equivalent) to the encoding represented by this Encoder.
+	// This is intended for encoding whole strings (that are represented as byte slices), to encode individual codepoints use
+	// EncodeRune. Do note that the string parameter is NOT modified in any way. Refer to IsReturnSafe to check if the
+	// returned byte slice must be copied before modifications may be made. Unlike the standard Encode function, this will
+	// replace unknown sequences with a question mark (?), meaning that all encodings will return a result.
+	EncodeReplaceUnknown(str []byte) []byte
 	// DecodeRune converts from the encoding represented by this Encoder to Go's rune encoding (utf8mb4-equivalent).
 	// Refer to IsReturnSafe to check if the returned byte slice must be copied before modifications may be made.
 	DecodeRune(r []byte) ([]byte, bool)

--- a/sql/encodings/utf8mb4.go
+++ b/sql/encodings/utf8mb4.go
@@ -37,6 +37,11 @@ func (utf8mb4Encoder) Encode(str []byte) ([]byte, bool) {
 	return str, true
 }
 
+// EncodeReplaceUnknown implements the Encoder interface.
+func (utf8mb4Encoder) EncodeReplaceUnknown(str []byte) []byte {
+	return str
+}
+
 // DecodeRune implements the Encoder interface.
 func (utf8mb4Encoder) DecodeRune(r []byte) ([]byte, bool) {
 	return r, true

--- a/sql/expression/convertusing.go
+++ b/sql/expression/convertusing.go
@@ -1,0 +1,86 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/encodings"
+)
+
+// ConvertUsing represents a CONVERT(X USING T) operation that casts the expression X to the character set T.
+type ConvertUsing struct {
+	UnaryExpression
+	TargetCharSet sql.CharacterSetID
+}
+
+var _ sql.Expression = (*ConvertUsing)(nil)
+var _ sql.CollationCoercible = (*ConvertUsing)(nil)
+
+func NewConvertUsing(expr sql.Expression, targetCharSet sql.CharacterSetID) *ConvertUsing {
+	return &ConvertUsing{
+		UnaryExpression: UnaryExpression{Child: expr},
+		TargetCharSet:   targetCharSet,
+	}
+}
+
+// String implements the interface sql.Expression.
+func (c *ConvertUsing) String() string {
+	return fmt.Sprintf("CONVERT(%s USING %s)", c.Child.String(), c.TargetCharSet.Name())
+}
+
+// Type implements the interface sql.Expression.
+func (c *ConvertUsing) Type() sql.Type {
+	typ := c.Child.Type()
+	if collatedType, ok := typ.(sql.TypeWithCollation); ok {
+		newTyp, _ := collatedType.WithNewCollation(c.TargetCharSet.DefaultCollation())
+		return newTyp
+	}
+	return typ
+}
+
+// Eval implements the interface sql.Expression.
+func (c *ConvertUsing) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	val, err := c.Child.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
+		return nil, nil
+	}
+
+	var valBytes []byte
+	if v, ok := val.([]byte); ok {
+		valBytes = v
+	} else if v, ok := val.(string); ok {
+		valBytes = encodings.StringToBytes(v)
+	}
+	newString := c.TargetCharSet.Encoder().EncodeReplaceUnknown(valBytes)
+	return encodings.BytesToString(newString), nil
+}
+
+// WithChildren implements the interface sql.Expression.
+func (c *ConvertUsing) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
+	}
+	return NewConvertUsing(children[0], c.TargetCharSet), nil
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (c *ConvertUsing) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return c.TargetCharSet.DefaultCollation(), 2
+}

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -161,12 +161,11 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) sql.Expression {
 		return expression.NewXor(lhs, rhs)
 	case *ast.ConvertUsingExpr:
 		expr := b.buildScalar(inScope, v.Expr)
-		collation, err := sql.ParseCollation(&v.Type, nil, false)
+		charset, err := sql.ParseCharacterSet(v.Type)
 		if err != nil {
 			b.handleErr(err)
 		}
-
-		return expression.NewCollatedExpression(expr, collation)
+		return expression.NewConvertUsing(expr, charset)
 	case *ast.ConvertExpr:
 		var err error
 		typeLength := 0


### PR DESCRIPTION
The `CONVERT(x USING y)` expression allows us to convert between character sets. When a string does not have a representing rune in the target character set, it should be replaced by a question mark. This is consistent with MySQL. Our previous behavior logged an error, which is valid in many scenarios, but not for this particular expression.