### PR TITLE
Union NULL types cast to same type as neighbor

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -743,6 +743,27 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
+		Query: "select * from (select i, i2 from niltable) a(x,y) union select * from (select 1, NULL) b(x,y) union select * from (select i, i2 from niltable) c(x,y)",
+		ExpectedColumns: sql.Schema{
+			{
+				Name: "x",
+				Type: types.Int64,
+			},
+			{
+				Name: "y",
+				Type: types.Int64,
+			},
+		},
+		Expected: []sql.Row{
+			{1, nil},
+			{2, 2},
+			{3, nil},
+			{4, 4},
+			{5, nil},
+			{6, 6},
+		},
+	},
+	{
 		Query: "select * from (select 1, 1) a(x,y) union select * from (select 1, NULL) b(x,y) union select * from (select 1,1) c(x,y);",
 		ExpectedColumns: sql.Schema{
 			{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -743,6 +743,23 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
+		Query: "select * from (select 1, 1) a(x,y) union select * from (select 1, NULL) b(x,y) union select * from (select 1,1) c(x,y);",
+		ExpectedColumns: sql.Schema{
+			{
+				Name: "x",
+				Type: types.Int8,
+			},
+			{
+				Name: "y",
+				Type: types.Int64,
+			},
+		},
+		Expected: []sql.Row{
+			{1, 1},
+			{1, nil},
+		},
+	},
+	{
 		Query: `SELECT I,S from mytable order by 1`,
 		ExpectedColumns: sql.Schema{
 			{

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -104,6 +104,13 @@ func NewConvertWithLengthAndScale(expr sql.Expression, castToType string, typeLe
 // If neither sql.Type represent number, then converted to string. Otherwise, we try to get
 // the appropriate type to avoid any precision loss.
 func GetConvertToType(l, r sql.Type) string {
+	if types.Null == l {
+		return GetConvertToType(r, r)
+	}
+	if types.Null == r {
+		return GetConvertToType(l, l)
+	}
+
 	if !types.IsNumber(l) || !types.IsNumber(r) {
 		return ConvertToChar
 	}

--- a/sql/planbuilder/union.go
+++ b/sql/planbuilder/union.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
-	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 func (b *Builder) buildUnion(inScope *scope, u *ast.Union) (outScope *scope) {
@@ -111,9 +110,6 @@ func (b *Builder) mergeUnionSchemas(u *plan.Union) sql.Node {
 		les[i] = expression.NewGetFieldWithTable(i, ls[i].Type, ls[i].Source, ls[i].Name, ls[i].Nullable)
 		res[i] = expression.NewGetFieldWithTable(i, rs[i].Type, rs[i].Source, rs[i].Name, rs[i].Nullable)
 		if reflect.DeepEqual(ls[i].Type, rs[i].Type) {
-			continue
-		}
-		if types.IsDeferredType(ls[i].Type) || types.IsDeferredType(rs[i].Type) {
 			continue
 		}
 		hasdiff = true


### PR DESCRIPTION
3+-way unions are subject to a bug where a NULL projection will be cast to a char type, and then have a type clash with the subsequent table relation. Rearranging the query to have the NULL projection last appears to fix the bug because the `convert` cast  is moved to a position where it cannot have a type clash with a table relation to the right.