### PR TITLE
Refactor prepareds to cache AST

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -475,7 +475,7 @@ func TestAnalyzer_Exp(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx := enginetest.NewContext(harness)
-			b, _ := planbuilder.New(ctx, e.EngineAnalyzer().Catalog)
+			b := planbuilder.New(ctx, e.EngineAnalyzer().Catalog)
 			parsed, _, _, err := b.Parse(tt.query, false)
 			require.NoError(t, err)
 

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -379,7 +379,7 @@ func injectBindVarsAndPrepare(
 		return q, nil, err
 	}
 
-	b, _ := planbuilder.New(ctx, sql.MapCatalog{})
+	b := planbuilder.New(ctx, sql.MapCatalog{})
 	_, isInsert := resPlan.(*plan.InsertInto)
 	bindVars := make(map[string]*querypb.BindVariable)
 	var bindCnt int

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4351,7 +4351,7 @@ var PreparedScriptTests = []ScriptTest{
 			},
 			{
 				Query:          "execute s",
-				ExpectedErrStr: "missing bind var v1",
+				ExpectedErrStr: "bind variable not provided: 'v1'",
 			},
 			{
 				Query: "execute s using @abc",
@@ -4409,7 +4409,7 @@ var PreparedScriptTests = []ScriptTest{
 			},
 			{
 				Query:          "execute s using @a",
-				ExpectedErrStr: "missing bind var v2",
+				ExpectedErrStr: "bind variable not provided: 'v2'",
 			},
 			{
 				Query: "execute s using @a, @b",

--- a/sql/analyzer/load_events.go
+++ b/sql/analyzer/load_events.go
@@ -86,10 +86,7 @@ func loadEventFromDb(ctx *sql.Context, cat sql.Catalog, db sql.Database, name st
 }
 
 func getEventDetailsFromEventDefinition(ctx *sql.Context, cat sql.Catalog, event sql.EventDefinition) (sql.EventDetails, error) {
-	b, err := planbuilder.New(ctx, cat)
-	if err != nil {
-		return sql.EventDetails{}, err
-	}
+	b := planbuilder.New(ctx, cat)
 	b.SetParserOptions(sql.NewSqlModeFromString(event.SqlMode).ParserOptions())
 	parsedCreateEvent, _, _, err := b.Parse(event.CreateStatement, false)
 	if err != nil {

--- a/sql/analyzer/stored_procedures.go
+++ b/sql/analyzer/stored_procedures.go
@@ -53,7 +53,7 @@ func loadStoredProcedures(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan
 			for _, procedure := range procedures {
 				var procToRegister *plan.Procedure
 				var parsedProcedure sql.Node
-				b, _ := planbuilder.New(ctx, a.Catalog)
+				b := planbuilder.New(ctx, a.Catalog)
 				b.SetParserOptions(sql.NewSqlModeFromString(procedure.SqlMode).ParserOptions())
 				parsedProcedure, _, _, err = b.Parse(procedure.CreateStatement, false)
 				if err != nil {
@@ -283,7 +283,7 @@ func applyProcedures(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 				return nil, transform.SameTree, err
 			}
 			var parsedProcedure sql.Node
-			b, _ := planbuilder.New(ctx, a.Catalog)
+			b := planbuilder.New(ctx, a.Catalog)
 			b.SetParserOptions(sql.NewSqlModeFromString(procedure.SqlMode).ParserOptions())
 			if call.AsOf() != nil {
 				asOf, err := call.AsOf().Eval(ctx, nil)

--- a/sql/analyzer/triggers.go
+++ b/sql/analyzer/triggers.go
@@ -183,7 +183,7 @@ func applyTriggers(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope,
 			return nil, transform.SameTree, err
 		}
 
-		b, _ := planbuilder.New(ctx, a.Catalog)
+		b := planbuilder.New(ctx, a.Catalog)
 		prevActive := b.TriggerCtx().Active
 		b.TriggerCtx().Active = true
 		defer func() {

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -110,8 +110,14 @@ func (b *Builder) buildGroupingCols(fromScope, projScope *scope, groupby ast.Gro
 			}
 		case *ast.SQLVal:
 			// literal -> index into targets
-			if e.Type == ast.IntVal {
-				lit := b.convertInt(string(e.Val), 10)
+			replace := b.normalizeValArg(e)
+			val, ok := replace.(*ast.SQLVal)
+			if !ok {
+				// ast.NullVal
+				continue
+			}
+			if val.Type == ast.IntVal {
+				lit := b.convertInt(string(val.Val), 10)
 				idx, _, err := types.Int64.Convert(lit.Value())
 				if err != nil {
 					b.handleErr(err)

--- a/sql/planbuilder/builder.go
+++ b/sql/planbuilder/builder.go
@@ -46,14 +46,13 @@ type Builder struct {
 	nesting         int
 }
 
-// ViewContext overwrites database root source of nested
-// calls.
+// BindvarContext holds bind variable replacement literals.
 type BindvarContext struct {
 	Bindings map[string]*querypb.BindVariable
 	used     map[string]struct{}
-	// skip indicates that we are resolving plan names,
-	// but will not error for missing bindvar replacement
-	skip bool
+	// resolveOnly indicates that we are resolving plan names,
+	// but will not error for missing bindvar replacements.
+	resolveOnly bool
 }
 
 func (bv *BindvarContext) GetSubstitute(s string) (*querypb.BindVariable, bool) {

--- a/sql/planbuilder/builder.go
+++ b/sql/planbuilder/builder.go
@@ -15,13 +15,19 @@
 package planbuilder
 
 import (
+	"sync"
+
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 
-	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
-
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
+
+var BinderFactory = &sync.Pool{New: func() interface{} {
+	return &Builder{f: &factory{}}
+}}
 
 type Builder struct {
 	ctx             *sql.Context
@@ -35,8 +41,41 @@ type Builder struct {
 	viewCtx         *ViewContext
 	procCtx         *ProcContext
 	triggerCtx      *TriggerContext
+	bindCtx         *BindvarContext
 	insertActive    bool
 	nesting         int
+}
+
+// ViewContext overwrites database root source of nested
+// calls.
+type BindvarContext struct {
+	Bindings map[string]*querypb.BindVariable
+	used     map[string]struct{}
+	// skip indicates that we are resolving plan names,
+	// but will not error for missing bindvar replacement
+	skip bool
+}
+
+func (bv *BindvarContext) GetSubstitute(s string) (*querypb.BindVariable, bool) {
+	if bv.Bindings != nil {
+		ret, ok := bv.Bindings[s]
+		bv.used[s] = struct{}{}
+		return ret, ok
+	}
+	return nil, false
+}
+
+func (bv *BindvarContext) UnusedBindings() []string {
+	if len(bv.used) == len(bv.Bindings) {
+		return nil
+	}
+	var unused []string
+	for k, _ := range bv.Bindings {
+		if _, ok := bv.used[k]; !ok {
+			unused = append(unused, k)
+		}
+	}
+	return unused
 }
 
 // ViewContext overwrites database root source of nested
@@ -60,17 +99,35 @@ type ProcContext struct {
 	DbName string
 }
 
-func New(ctx *sql.Context, cat sql.Catalog) (*Builder, error) {
+func New(ctx *sql.Context, cat sql.Catalog) *Builder {
 	sqlMode := sql.LoadSqlMode(ctx)
-	return &Builder{ctx: ctx, cat: cat, parserOpts: sqlMode.ParserOptions(), f: &factory{}}, nil
+	return &Builder{ctx: ctx, cat: cat, parserOpts: sqlMode.ParserOptions(), f: &factory{}}
+}
+
+func (b *Builder) Initialize(ctx *sql.Context, cat sql.Catalog, opts ast.ParserOptions) {
+	b.ctx = ctx
+	b.cat = cat
+	b.f.ctx = ctx
+	b.parserOpts = opts
 }
 
 func (b *Builder) SetDebug(val bool) {
 	b.f.debug = val
 }
 
+func (b *Builder) SetBindings(bindings map[string]*querypb.BindVariable) {
+	b.bindCtx = &BindvarContext{
+		Bindings: bindings,
+		used:     make(map[string]struct{}),
+	}
+}
+
 func (b *Builder) SetParserOptions(opts ast.ParserOptions) {
 	b.parserOpts = opts
+}
+
+func (b *Builder) BindCtx() *BindvarContext {
+	return b.bindCtx
 }
 
 func (b *Builder) ViewCtx() *ViewContext {
@@ -98,8 +155,17 @@ func (b *Builder) newScope() *scope {
 	return &scope{b: b}
 }
 
-func (b *Builder) reset() {
+func (b *Builder) Reset() {
 	b.colId = 0
+	b.bindCtx = nil
+	b.currentDatabase = nil
+	b.procCtx = nil
+	b.multiDDL = false
+	b.insertActive = false
+	b.tabId = 0
+	b.triggerCtx = nil
+	b.viewCtx = nil
+	b.nesting = 0
 }
 
 type parseErr struct {

--- a/sql/planbuilder/errors.go
+++ b/sql/planbuilder/errors.go
@@ -36,4 +36,6 @@ var (
 	ErrUnionSchemasDifferentLength = errors.NewKind(
 		"cannot union two queries whose schemas are different lengths; left has %d column(s) right has %d column(s).",
 	)
+
+	ErrOrderByBinding = errors.NewKind("bindings in sort clauses not supported yet")
 )

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/vitess/go/sqltypes"
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -71,8 +72,9 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 		case *ast.SQLVal:
 			// integer literal into projScope
 			// else throw away
-			if e.Type == ast.IntVal {
-				lit := b.convertInt(string(e.Val), 10)
+			expr := b.normalizeValArg(e)
+			if val, ok := expr.(*ast.SQLVal); ok && val.Type == ast.IntVal {
+				lit := b.convertInt(string(val.Val), 10)
 				idx, _, err := types.Int64.Convert(lit.Value())
 				if err != nil {
 					b.handleErr(err)
@@ -155,6 +157,38 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 		}
 	}
 	return
+}
+
+func (b *Builder) normalizeValArg(e *ast.SQLVal) ast.Expr {
+	if e.Type != ast.ValArg || b.bindCtx == nil {
+		return e
+	}
+	name := strings.TrimPrefix(string(e.Val), ":")
+	if b.bindCtx.Bindings == nil {
+		err := fmt.Errorf("bind variable not provided: '%s'", name)
+		b.handleErr(err)
+	}
+	bv, ok := b.bindCtx.GetSubstitute(name)
+	if !ok {
+		err := fmt.Errorf("bind variable not provided: '%s'", name)
+		b.handleErr(err)
+	}
+
+	val, err := sqltypes.BindVariableToValue(bv)
+	if err != nil {
+		b.handleErr(err)
+	}
+	expr, err := ast.ExprFromValue(val)
+	switch e := expr.(type) {
+	case *ast.SQLVal:
+		return e
+	case *ast.NullVal:
+		return e
+	default:
+		err := fmt.Errorf("unknown ast.Expr: %T", e)
+		b.handleErr(err)
+	}
+	return nil
 }
 
 func (b *Builder) buildOrderBy(inScope, orderByScope *scope) {

--- a/sql/planbuilder/parse.go
+++ b/sql/planbuilder/parse.go
@@ -106,10 +106,7 @@ func parse(ctx *sql.Context, cat sql.Catalog, query string, multi bool, options 
 		return nil, parsed, remainder, sql.ErrSyntaxError.New(err.Error())
 	}
 
-	b, err := New(ctx, cat)
-	if err != nil {
-		return nil, "", "", err
-	}
+	b := New(ctx, cat)
 	outScope := b.build(nil, stmt, s)
 
 	return outScope.node, parsed, remainder, err
@@ -170,6 +167,11 @@ func (b *Builder) Parse(query string, multi bool) (ret sql.Node, parsed, remaind
 	outScope := b.build(nil, stmt, s)
 
 	return outScope.node, parsed, remainder, err
+}
+
+func (b *Builder) ParseOne(query string) (ret sql.Node, err error) {
+	ret, _, _, err = b.Parse(query, false)
+	return ret, err
 }
 
 func (b *Builder) BindOnly(stmt ast.Statement, s string) (ret sql.Node, err error) {

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -1701,7 +1701,7 @@ Project
 	ctx := sql.NewEmptyContext()
 	ctx.SetCurrentDatabase("mydb")
 	cat := newTestCatalog()
-	b, _ := New(ctx, cat)
+	b := New(ctx, cat)
 
 	for _, tt := range tests {
 		t.Run(tt.Query, func(t *testing.T) {
@@ -1712,7 +1712,7 @@ Project
 			require.NoError(t, err)
 
 			outScope := b.build(nil, stmt, tt.Query)
-			defer b.reset()
+			defer b.Reset()
 			plan := sql.DebugString(outScope.node)
 
 			if rewrite {

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -749,7 +749,7 @@ func (b *Builder) ConvertVal(v *ast.SQLVal) sql.Expression {
 	case ast.ValArg:
 		name := strings.TrimPrefix(string(v.Val), ":")
 		if b.bindCtx != nil {
-			if b.bindCtx.skip {
+			if b.bindCtx.resolveOnly {
 				return expression.NewBindVar(name)
 			}
 			replacement := b.normalizeValArg(v)

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -445,79 +445,6 @@ func (b *Builder) buildBinaryScalar(inScope *scope, be *ast.BinaryExpr) sql.Expr
 	return nil
 }
 
-func (b *Builder) buildLiteral(inScope *scope, v *ast.SQLVal) sql.Expression {
-	switch v.Type {
-	case ast.StrVal:
-		return expression.NewLiteral(string(v.Val), types.CreateLongText(b.ctx.GetCollation()))
-	case ast.IntVal:
-		return b.convertInt(string(v.Val), 10)
-	case ast.FloatVal:
-		val, err := strconv.ParseFloat(string(v.Val), 64)
-		if err != nil {
-			b.handleErr(err)
-		}
-
-		// use the value as string format to keep precision and scale as defined for DECIMAL data type to avoid rounded up float64 value
-		if ps := strings.Split(string(v.Val), "."); len(ps) == 2 {
-			ogVal := string(v.Val)
-			floatVal := fmt.Sprintf("%v", val)
-			if len(ogVal) >= len(floatVal) && ogVal != floatVal {
-				p, s := expression.GetDecimalPrecisionAndScale(ogVal)
-				dt, err := types.CreateDecimalType(p, s)
-				if err != nil {
-					return expression.NewLiteral(string(v.Val), types.CreateLongText(b.ctx.GetCollation()))
-				}
-				dVal, _, err := dt.Convert(ogVal)
-				if err != nil {
-					return expression.NewLiteral(string(v.Val), types.CreateLongText(b.ctx.GetCollation()))
-				}
-				return expression.NewLiteral(dVal, dt)
-			}
-		}
-
-		return expression.NewLiteral(val, types.Float64)
-	case ast.HexNum:
-		//TODO: binary collation?
-		v := strings.ToLower(string(v.Val))
-		if strings.HasPrefix(v, "0x") {
-			v = v[2:]
-		} else if strings.HasPrefix(v, "x") {
-			v = strings.Trim(v[1:], "'")
-		}
-
-		valBytes := []byte(v)
-		dst := make([]byte, hex.DecodedLen(len(valBytes)))
-		_, err := hex.Decode(dst, valBytes)
-		if err != nil {
-			b.handleErr(err)
-		}
-		return expression.NewLiteral(dst, types.LongBlob)
-	case ast.HexVal:
-		//TODO: binary collation?
-		val, err := v.HexDecode()
-		if err != nil {
-			b.handleErr(err)
-		}
-		return expression.NewLiteral(val, types.LongBlob)
-	case ast.ValArg:
-		return expression.NewBindVar(strings.TrimPrefix(string(v.Val), ":"))
-	case ast.BitVal:
-		if len(v.Val) == 0 {
-			return expression.NewLiteral(0, types.Uint64)
-		}
-
-		res, err := strconv.ParseUint(string(v.Val), 2, 64)
-		if err != nil {
-			b.handleErr(err)
-		}
-
-		return expression.NewLiteral(res, types.Uint64)
-	}
-
-	b.handleErr(sql.ErrInvalidSQLValType.New(v.Type))
-	return nil
-}
-
 func (b *Builder) buildComparison(inScope *scope, c *ast.ComparisonExpr) sql.Expression {
 	left := b.buildScalar(inScope, c.Left)
 	right := b.buildScalar(inScope, c.Right)
@@ -820,7 +747,15 @@ func (b *Builder) ConvertVal(v *ast.SQLVal) sql.Expression {
 		}
 		return expression.NewLiteral(val, types.LongBlob)
 	case ast.ValArg:
-		return expression.NewBindVar(strings.TrimPrefix(string(v.Val), ":"))
+		name := strings.TrimPrefix(string(v.Val), ":")
+		if b.bindCtx != nil {
+			if b.bindCtx.skip {
+				return expression.NewBindVar(name)
+			}
+			replacement := b.normalizeValArg(v)
+			return b.buildScalar(&scope{}, replacement)
+		}
+		return expression.NewBindVar(name)
 	case ast.BitVal:
 		if len(v.Val) == 0 {
 			return expression.NewLiteral(0, types.Uint64)

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -507,7 +507,16 @@ func (b *Builder) buildAsOfLit(inScope *scope, t ast.Expr) interface{} {
 func (b *Builder) buildAsOfExpr(inScope *scope, time ast.Expr) sql.Expression {
 	switch v := time.(type) {
 	case *ast.SQLVal:
-		ret, _, err := types.Text.Convert(v.Val)
+		if v.Type == ast.ValArg && (b.bindCtx == nil || b.bindCtx.skip) {
+			return nil
+		}
+		repl := b.normalizeValArg(v)
+		val, ok := repl.(*ast.SQLVal)
+		if !ok {
+			// *ast.NullVal
+			return nil
+		}
+		ret, _, err := types.Text.Convert(val.Val)
 		if err != nil {
 			b.handleErr(err)
 		}

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -507,7 +507,7 @@ func (b *Builder) buildAsOfLit(inScope *scope, t ast.Expr) interface{} {
 func (b *Builder) buildAsOfExpr(inScope *scope, time ast.Expr) sql.Expression {
 	switch v := time.(type) {
 	case *ast.SQLVal:
-		if v.Type == ast.ValArg && (b.bindCtx == nil || b.bindCtx.skip) {
+		if v.Type == ast.ValArg && (b.bindCtx == nil || b.bindCtx.resolveOnly) {
 			return nil
 		}
 		repl := b.normalizeValArg(v)

--- a/sql/planbuilder/transactions.go
+++ b/sql/planbuilder/transactions.go
@@ -67,7 +67,7 @@ func (b *Builder) buildPrepare(inScope *scope, n *ast.Prepare) (outScope *scope)
 		b.bindCtx = oldCtx
 	}()
 	// test for query structure; bind variables will be discarded
-	b.bindCtx = &BindvarContext{skip: true}
+	b.bindCtx = &BindvarContext{resolveOnly: true}
 	childScope := b.build(inScope, childStmt, expr)
 	outScope.node = plan.NewPrepareQuery(n.Name, childScope.node)
 	return outScope

--- a/sql/planbuilder/transactions.go
+++ b/sql/planbuilder/transactions.go
@@ -62,8 +62,13 @@ func (b *Builder) buildPrepare(inScope *scope, n *ast.Prepare) (outScope *scope)
 		b.handleErr(err)
 	}
 
+	oldCtx := b.BindCtx()
+	defer func() {
+		b.bindCtx = oldCtx
+	}()
+	// test for query structure; bind variables will be discarded
+	b.bindCtx = &BindvarContext{skip: true}
 	childScope := b.build(inScope, childStmt, expr)
-
 	outScope.node = plan.NewPrepareQuery(n.Name, childScope.node)
 	return outScope
 }


### PR DESCRIPTION
Prepared statements were rewritten recently to cache a query string
with marked bind variable locations. Executing prepared statements
would generate a full SQL query string for re-parsing, binding, and
analysis. This update caches the AST. Executing a prepared statement
starts at binding an AST. Bind variables will be substituted in the
process of converting AST expression to plan expressions.

GMS bump: https://github.com/dolthub/dolt/pull/6593