### PR TITLE
Fix table lookup bug for nil asOf

### DIFF
--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -23,6 +23,10 @@ import (
 
 var InfoSchemaQueries = []QueryTest{
 	{
+		Query:    "SHOW KEYS FROM `columns` FROM `information_schema`;",
+		Expected: []sql.Row{},
+	},
+	{
 		Query: `SELECT 
      table_name, index_name, comment, non_unique, GROUP_CONCAT(column_name ORDER BY seq_in_index) AS COLUMNS 
    FROM information_schema.statistics 

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8525,6 +8525,10 @@ type QueryErrorTest struct {
 
 var ErrorQueries = []QueryErrorTest{
 	{
+		Query:       "SHOW KEYS FROM `columns` FROM `information_schema`;",
+		ExpectedErr: sql.ErrTableNotFound,
+	},
+	{
 		Query:       "select i from (select * from mytable a join mytable b on a.i = b.i) dt",
 		ExpectedErr: sql.ErrAmbiguousColumnName,
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8525,10 +8525,6 @@ type QueryErrorTest struct {
 
 var ErrorQueries = []QueryErrorTest{
 	{
-		Query:       "SHOW KEYS FROM `columns` FROM `information_schema`;",
-		ExpectedErr: sql.ErrTableNotFound,
-	},
-	{
 		Query:       "select i from (select * from mytable a join mytable b on a.i = b.i) dt",
 		ExpectedErr: sql.ErrAmbiguousColumnName,
 	},

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -397,7 +397,14 @@ func columnsToStrings(cols ast.Columns) []string {
 }
 
 func (b *Builder) resolveTable(tab, db string, asOf interface{}) *plan.ResolvedTable {
-	table, database, err := b.cat.TableAsOf(b.ctx, db, tab, asOf)
+	var table sql.Table
+	var database sql.Database
+	var err error
+	if asOf != nil {
+		table, database, err = b.cat.TableAsOf(b.ctx, db, tab, asOf)
+	} else {
+		table, database, err = b.cat.Table(b.ctx, db, tab)
+	}
 	if sql.ErrAsOfNotSupported.Is(err) {
 		if asOf != nil {
 			b.handleErr(err)


### PR DESCRIPTION
Edit: Show keys for info schema table should work the same way as MySQL now.

Prev: This error message is not correct, MySQL finds the table and does not error. But this at least reverts the behavior to what Dolt did before the name resolution refactors.