### PR TITLE
Inline flatten aliases

### DIFF
--- a/sql/analyzer/rules.go
+++ b/sql/analyzer/rules.go
@@ -44,7 +44,6 @@ var OnceBeforeDefault = []Rule{
 // DefaultRules to apply when analyzing nodes.
 var DefaultRules = []Rule{
 	{validateStarExpressionsId, validateStarExpressions}, //TODO
-	{flattenTableAliasesId, flattenTableAliases},         //TODO
 	{pushdownSubqueryAliasFiltersId, pushdownSubqueryAliasFilters},
 	{pruneTablesId, pruneTables},
 	{fixupAuxiliaryExprsId, fixupAuxiliaryExprs},

--- a/sql/planbuilder/factory.go
+++ b/sql/planbuilder/factory.go
@@ -163,3 +163,17 @@ func (f *factory) buildJoin(l, r sql.Node, op plan.JoinType, cond sql.Expression
 	}
 	return plan.NewJoin(l, r, op, cond), nil
 }
+
+func (f *factory) buildTableAlias(name string, child sql.Node) (sql.Node, error) {
+	{
+		// deduplicate tableAlias->tableAlias and tableAlias->subqueryAlias
+		switch n := child.(type) {
+		case *plan.TableAlias:
+			return n.WithName(name), nil
+		case *plan.SubqueryAlias:
+			return n.WithName(name), nil
+		default:
+			return plan.NewTableAlias(name, child), nil
+		}
+	}
+}


### PR DESCRIPTION
This will skip a tree walk for most queries, inlining the rule in the places where nested table aliases can occur during binding.