### PR TITLE
Fix panic in merge join when using custom Indexes that don't allow range lookups.

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -617,7 +617,7 @@ func TestTableFunctions(t *testing.T) {
 	harness.Setup(setup.MydbData)
 
 	databaseProvider := harness.NewDatabaseProvider()
-	testDatabaseProvider := NewTestProvider(&databaseProvider, SimpleTableFunction{}, memory.IntSequenceTable{})
+	testDatabaseProvider := NewTestProvider(&databaseProvider, SimpleTableFunction{}, memory.IntSequenceTable{}, memory.PointLookupTable{})
 
 	engine := enginetest.NewEngineWithProvider(t, harness, testDatabaseProvider)
 	engine.EngineAnalyzer().ExecBuilder = rowexec.DefaultBuilder

--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -112,6 +112,9 @@ func TestScriptWithEngine(t *testing.T, e QueryEngine, harness Harness, script q
 				if assertion.ExpectedIndexes != nil {
 					evalIndexTest(t, harness, e, assertion.Query, assertion.ExpectedIndexes, assertion.Skip)
 				}
+				if assertion.JoinTypes != nil {
+					evalJoinTypeTest(t, harness, e, assertion.Query, assertion.JoinTypes, assertion.Skip)
+				}
 			})
 		}
 	})

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -1482,7 +1482,7 @@ func TestJoinPlanning(t *testing.T, harness Harness) {
 			defer e.Close()
 			for _, tt := range tt.tests {
 				if tt.types != nil {
-					evalJoinTypeTest(t, harness, e, tt)
+					evalJoinTypeTest(t, harness, e, tt.q, tt.types, tt.skipOld)
 				}
 				if tt.indexes != nil {
 					evalIndexTest(t, harness, e, tt.q, tt.indexes, tt.skipOld)
@@ -1501,21 +1501,21 @@ func TestJoinPlanning(t *testing.T, harness Harness) {
 	}
 }
 
-func evalJoinTypeTest(t *testing.T, harness Harness, e QueryEngine, tt JoinPlanTest) {
-	t.Run(tt.q+" join types", func(t *testing.T) {
-		if tt.skipOld {
+func evalJoinTypeTest(t *testing.T, harness Harness, e QueryEngine, query string, types []plan.JoinType, skipOld bool) {
+	t.Run(query+" join types", func(t *testing.T) {
+		if skipOld {
 			t.Skip()
 		}
 
 		ctx := NewContext(harness)
-		ctx = ctx.WithQuery(tt.q)
+		ctx = ctx.WithQuery(query)
 
-		a, err := analyzeQuery(ctx, e, tt.q)
+		a, err := analyzeQuery(ctx, e, query)
 		require.NoError(t, err)
 
 		jts := collectJoinTypes(a)
 		var exp []string
-		for _, t := range tt.types {
+		for _, t := range types {
 			exp = append(exp, t.String())
 		}
 		var cmp []string

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -44,6 +44,8 @@ type ScriptTest struct {
 	ExpectedErr *errors.Kind
 	// For tests that make a single assertion, ExpectedIndexes can be set for the string representation of indexes that we expect to appear in the query plan
 	ExpectedIndexes []string
+	// For tests that perform join operations, JoinTypes can be set for the type of merge we expect to perform.
+	JoinTypes []plan.JoinType
 	// SkipPrepared is true when we skip a test for prepared statements only
 	SkipPrepared bool
 }
@@ -73,6 +75,9 @@ type ScriptTestAssertion struct {
 
 	// The string representation of indexes that we expect to appear in the query plan
 	ExpectedIndexes []string
+
+	// For tests that perform join operations, JoinTypes can be set for the type of merge we expect to perform.
+	JoinTypes []plan.JoinType
 
 	// SkipResultsCheck is used to skip assertions on expected Rows returned from a query. This should be used
 	// sparingly, such as in cases where you only want to test warning messages.

--- a/enginetest/queries/table_func_scripts.go
+++ b/enginetest/queries/table_func_scripts.go
@@ -170,8 +170,32 @@ var TableFunctionScriptTests = []ScriptTest{
 		Expected: []sql.Row{{0}, {1}, {2}, {3}, {4}},
 	},
 	{
+		Name:            "sequence_table allows point lookups",
 		Query:           "select * from sequence_table('x', 5) where x = 2",
 		Expected:        []sql.Row{{2}},
 		ExpectedIndexes: []string{"x"},
+	},
+	{
+		Name:            "sequence_table allows range lookups",
+		Query:           "select * from sequence_table('x', 5) where x >= 1 and x <= 3",
+		Expected:        []sql.Row{{1}, {2}, {3}},
+		ExpectedIndexes: []string{"x"},
+	},
+	{
+		Name:     "basic behavior of point_lookup_table",
+		Query:    "select seq.x from point_lookup_table('x', 5) seq",
+		Expected: []sql.Row{{0}, {1}, {2}, {3}, {4}},
+	},
+	{
+		Name:            "point_lookup_table allows point lookups",
+		Query:           "select * from point_lookup_table('x', 5) where x = 2",
+		Expected:        []sql.Row{{2}},
+		ExpectedIndexes: []string{"x"},
+	},
+	{
+		Name:            "point_lookup_table disallows range lookups",
+		Query:           "select * from point_lookup_table('x', 5) where x >= 1 and x <= 3",
+		Expected:        []sql.Row{{1}, {2}, {3}},
+		ExpectedIndexes: []string{},
 	},
 }

--- a/enginetest/queries/table_func_scripts.go
+++ b/enginetest/queries/table_func_scripts.go
@@ -14,7 +14,10 @@
 
 package queries
 
-import "github.com/dolthub/go-mysql-server/sql"
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+)
 
 var TableFunctionScriptTests = []ScriptTest{
 	{
@@ -197,5 +200,12 @@ var TableFunctionScriptTests = []ScriptTest{
 		Query:           "select * from point_lookup_table('x', 5) where x >= 1 and x <= 3",
 		Expected:        []sql.Row{{1}, {2}, {3}},
 		ExpectedIndexes: []string{},
+	},
+	{
+		Name:            "point_lookup_table disallows merge join",
+		Query:           "select /*+ MERGE_JOIN(l,r) */ * from point_lookup_table('x', 5) l join point_lookup_table('y', 5) r where x = y",
+		Expected:        []sql.Row{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}},
+		JoinTypes:       []plan.JoinType{plan.JoinTypeLookup},
+		ExpectedIndexes: []string{"x"},
 	},
 }

--- a/memory/point_lookup_table.go
+++ b/memory/point_lookup_table.go
@@ -1,0 +1,103 @@
+package memory
+
+import (
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+var _ sql.TableFunction = PointLookupTable{}
+var _ sql.CollationCoercible = PointLookupTable{}
+var _ sql.ExecSourceRel = PointLookupTable{}
+var _ sql.IndexAddressable = PointLookupTable{}
+var _ sql.IndexedTable = PointLookupTable{}
+var _ sql.TableNode = PointLookupTable{}
+
+// PointLookupTable is a table whose indexes only support point lookups but not range scans.
+// It's used for testing optimizations on indexes.
+type PointLookupTable struct {
+	IntSequenceTable
+}
+
+func (s PointLookupTable) UnderlyingTable() sql.Table {
+	return s
+}
+
+func (s PointLookupTable) NewInstance(ctx *sql.Context, db sql.Database, args []sql.Expression) (sql.Node, error) {
+	node, err := s.IntSequenceTable.NewInstance(ctx, db, args)
+	return PointLookupTable{node.(IntSequenceTable)}, err
+}
+
+func (s PointLookupTable) String() string {
+	return fmt.Sprintf("pointLookup")
+}
+
+func (s PointLookupTable) DebugString() string {
+	return "pointLookup"
+}
+
+func (s PointLookupTable) Name() string {
+	return "point_lookup_table"
+}
+
+func (s PointLookupTable) Description() string {
+	return "point_lookup_table"
+}
+
+var _ sql.Partition = (*sequencePartition)(nil)
+
+func (s PointLookupTable) GetIndexes(ctx *sql.Context) (indexes []sql.Index, err error) {
+	return []sql.Index{
+		pointLookupIndex{&Index{
+			DB:         "",
+			DriverName: "",
+			Tbl:        nil,
+			TableName:  s.Name(),
+			Exprs: []sql.Expression{
+				expression.NewGetFieldWithTable(0, types.Int64, s.Name(), s.name, false),
+			},
+			Name:         s.name,
+			Unique:       true,
+			Spatial:      false,
+			Fulltext:     false,
+			CommentStr:   "",
+			PrefixLens:   nil,
+			fulltextInfo: fulltextInfo{},
+		}},
+	}, nil
+}
+
+type pointLookupIndex struct {
+	sql.Index
+}
+
+func (i pointLookupIndex) CanSupport(ranges ...sql.Range) bool {
+	for _, r := range ranges {
+		if len(r) != 1 {
+			return false
+		}
+		below, ok := r[0].LowerBound.(sql.Below)
+		if !ok {
+			return false
+		}
+		belowKey, _, err := types.Int64.Convert(below.Key)
+		if err != nil {
+			return false
+		}
+
+		above, ok := r[0].UpperBound.(sql.Above)
+		if !ok {
+			return false
+		}
+		aboveKey, _, err := types.Int64.Convert(above.Key)
+		if err != nil {
+			return false
+		}
+
+		if belowKey != aboveKey {
+			return false
+		}
+	}
+	return true
+}

--- a/memory/point_lookup_table.go
+++ b/memory/point_lookup_table.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"fmt"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -927,7 +927,13 @@ func addMergeJoins(m *memo.Memo) error {
 						leftColId := getOnlyColumnId(matchedEqFilters[0].filter.Left)
 						rightColId := getOnlyColumnId(matchedEqFilters[0].filter.Right)
 						lIndexScan := makeIndexScan(lIndex, leftColId, lFilters)
+						if lIndexScan == nil {
+							continue
+						}
 						rIndexScan := makeIndexScan(rIndex, rightColId, rFilters)
+						if rIndexScan == nil {
+							continue
+						}
 						m.MemoizeMergeJoin(e.Group(), join.Left, join.Right, lIndexScan, rIndexScan, jb.Op.AsMerge(), newFilters, false)
 					}
 				}

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -926,12 +926,12 @@ func addMergeJoins(m *memo.Memo) error {
 						// To make the index scan, we need the first non-constant column in each index.
 						leftColId := getOnlyColumnId(matchedEqFilters[0].filter.Left)
 						rightColId := getOnlyColumnId(matchedEqFilters[0].filter.Right)
-						lIndexScan := makeIndexScan(lIndex, leftColId, lFilters)
-						if lIndexScan == nil {
+						lIndexScan, success := makeIndexScan(lIndex, leftColId, lFilters)
+						if !success {
 							continue
 						}
-						rIndexScan := makeIndexScan(rIndex, rightColId, rFilters)
-						if rIndexScan == nil {
+						rIndexScan, success := makeIndexScan(rIndex, rightColId, rFilters)
+						if !success {
 							continue
 						}
 						m.MemoizeMergeJoin(e.Group(), join.Left, join.Right, lIndexScan, rIndexScan, jb.Op.AsMerge(), newFilters, false)
@@ -1056,12 +1056,15 @@ func sortedIndexScansForTableCol(indexes []*memo.Index, targetCol *memo.ColRef, 
 		if !found {
 			continue
 		}
-		ret = append(ret, makeIndexScan(idx, matchedIdx, filters))
+		indexScan, success := makeIndexScan(idx, matchedIdx, filters)
+		if success {
+			ret = append(ret, indexScan)
+		}
 	}
 	return ret
 }
 
-func makeIndexScan(idx *memo.Index, matchedIdx sql.ColumnId, filters []memo.ScalarExpr) *memo.IndexScan {
+func makeIndexScan(idx *memo.Index, matchedIdx sql.ColumnId, filters []memo.ScalarExpr) (*memo.IndexScan, bool) {
 	rang := make(sql.Range, len(idx.Cols()))
 	var j int
 	for {
@@ -1096,12 +1099,12 @@ func makeIndexScan(idx *memo.Index, matchedIdx sql.ColumnId, filters []memo.Scal
 	}
 
 	if !idx.SqlIdx().CanSupport(rang) {
-		return nil
+		return nil, false
 	}
 	return &memo.IndexScan{
 		Idx:   idx,
 		Range: rang,
-	}
+	}, true
 }
 
 // isWeaklyMonotonic is a weak test of whether an expression


### PR DESCRIPTION
For instance, dolt has Commit indexes for tables that use commit hash as an index, but ranges don't make sense for those.

There's no equivalent in GMS, so I created "point_lookup_table" table function for use in tests.