### PR TITLE
JSON Mutation functions implemented as stored procedures

### DIFF
--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -21,7 +21,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
-// getJSONVal returns a JSONValue from the given row and expression. The underling value is deeply copied so that
+// getMutableJSONVal returns a JSONValue from the given row and expression. The underling value is deeply copied so that
 // you are free to use the mutation functions on the returned value.
 // nil will be returned only if the inputs are nil. This will not return an error, so callers must check.
 func getMutableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (types.MutableJSONValue, error) {

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -21,47 +21,37 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
+// getJSONVal returns a JSONValue from the given row and expression. The underling value is deeply copied so that
+// you are free to use the mutation functions on the returned value.
+// nil will be returned only if the inputs are nil. This will not return an error, so callers must check.
 func getMutableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (types.MutableJSONValue, error) {
-	js, err := json.Eval(ctx, row)
-	if err != nil {
+	doc, err := getJSONDocumentFromRow(ctx, row, json)
+	if err != nil || doc == nil || doc.Val == nil {
 		return nil, err
 	}
-	if js == nil {
-		return nil, nil
-	}
 
-	var converted interface{}
-	switch js.(type) {
-	case string, []interface{}, map[string]interface{}, types.JSONValue:
-		converted, _, err = types.JSON.Convert(js)
-		if err != nil {
-			return nil, sql.ErrInvalidJSONText.New(js)
-		}
-	default:
-		return nil, sql.ErrInvalidArgument.New(fmt.Sprintf("%v", js))
-	}
-
-	////  NM4 Gotta do a deep copy.
-
-	mutable, ok := converted.(types.MutableJSONValue)
-	if !ok {
-		mutable, err = js.(types.JSONValue).Unmarshall(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return mutable, nil
-
+	mutable := types.DeepCopyJson(doc.Val)
+	return types.JSONDocument{Val: mutable}, nil
 }
 
+// getSearchableJSONVal returns a SearchableJSONValue from the given row and expression. The underling value is not copied
+// so it is intended to be used for read-only operations.
+// nil will be returned only if the inputs are nil. This will not return an error, so callers must check.
 func getSearchableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (types.SearchableJSONValue, error) {
-	js, err := json.Eval(ctx, row)
-	if err != nil {
+	doc, err := getJSONDocumentFromRow(ctx, row, json)
+	if err != nil || doc == nil || doc.Val == nil {
 		return nil, err
 	}
-	if js == nil {
-		return nil, nil
+
+	return doc, nil
+}
+
+// getJSONDocumentFromRow returns a JSONDocument from the given row and expression. Helper function only intended to be
+// used by functions in this file.
+func getJSONDocumentFromRow(ctx *sql.Context, row sql.Row, json sql.Expression) (*types.JSONDocument, error) {
+	js, err := json.Eval(ctx, row)
+	if err != nil || js == nil {
+		return nil, err
 	}
 
 	var converted interface{}
@@ -75,13 +65,50 @@ func getSearchableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (t
 		return nil, sql.ErrInvalidArgument.New(fmt.Sprintf("%v", js))
 	}
 
-	searchable, ok := converted.(types.SearchableJSONValue)
+	doc, ok := converted.(types.JSONDocument)
 	if !ok {
-		searchable, err = js.(types.JSONValue).Unmarshall(ctx)
+		// This should never happen, but just in case.
+		doc, err = js.(types.JSONValue).Unmarshall(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return searchable, nil
+	return &doc, nil
+}
+
+// pathValPair is a helper struct for use by functions which take json paths paired with a json value. eg. JSON_SET, JSON_INSERT, etc.
+type pathValPair struct {
+	path string
+	val  types.JSONValue
+}
+
+// buildPathValue builds a pathValPair from the given row and expressions. This is a common pattern in json methods to have
+// pairs of arguments, and this ensures they are of the right type, non-nil, and they wrapped in a struct as a unit.
+func buildPathValue(ctx *sql.Context, pathExp sql.Expression, valExp sql.Expression, row sql.Row) (*pathValPair, error) {
+	path, err := pathExp.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if path == nil {
+		// MySQL documented behavior is to return null, not error, if any path is null.
+		return nil, nil
+	}
+
+	// make sure path is string
+	if _, ok := path.(string); !ok {
+		return nil, fmt.Errorf("Invalid JSON path expression")
+	}
+
+	val, err := valExp.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	jsonVal, ok := val.(types.JSONValue)
+	if !ok {
+		jsonVal = types.JSONDocument{val}
+	}
+
+	return &pathValPair{path.(string), jsonVal}, nil
 }

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -1,0 +1,87 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+func getMutableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (types.MutableJSONValue, error) {
+	js, err := json.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	if js == nil {
+		return nil, nil
+	}
+
+	var converted interface{}
+	switch js.(type) {
+	case string, []interface{}, map[string]interface{}, types.JSONValue:
+		converted, _, err = types.JSON.Convert(js)
+		if err != nil {
+			return nil, sql.ErrInvalidJSONText.New(js)
+		}
+	default:
+		return nil, sql.ErrInvalidArgument.New(fmt.Sprintf("%v", js))
+	}
+
+	////  NM4 Gotta do a deep copy.
+
+	mutable, ok := converted.(types.MutableJSONValue)
+	if !ok {
+		mutable, err = js.(types.JSONValue).Unmarshall(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return mutable, nil
+
+}
+
+func getSearchableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (types.SearchableJSONValue, error) {
+	js, err := json.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	if js == nil {
+		return nil, nil
+	}
+
+	var converted interface{}
+	switch js.(type) {
+	case string, []interface{}, map[string]interface{}, types.JSONValue:
+		converted, _, err = types.JSON.Convert(js)
+		if err != nil {
+			return nil, sql.ErrInvalidJSONText.New(js)
+		}
+	default:
+		return nil, sql.ErrInvalidArgument.New(fmt.Sprintf("%v", js))
+	}
+
+	searchable, ok := converted.(types.SearchableJSONValue)
+	if !ok {
+		searchable, err = js.(types.JSONValue).Unmarshall(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return searchable, nil
+}

--- a/sql/expression/function/json/json_contains.go
+++ b/sql/expression/function/json/json_contains.go
@@ -165,37 +165,6 @@ func (j *JSONContains) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 	return target.Contains(ctx, candidate)
 }
 
-func getSearchableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (types.SearchableJSONValue, error) {
-	js, err := json.Eval(ctx, row)
-	if err != nil {
-		return nil, err
-	}
-	if js == nil {
-		return nil, nil
-	}
-
-	var converted interface{}
-	switch js.(type) {
-	case string, []interface{}, map[string]interface{}, types.JSONValue:
-		converted, _, err = types.JSON.Convert(js)
-		if err != nil {
-			return nil, sql.ErrInvalidJSONText.New(js)
-		}
-	default:
-		return nil, sql.ErrInvalidArgument.New(fmt.Sprintf("%v", js))
-	}
-
-	searchable, ok := converted.(types.SearchableJSONValue)
-	if !ok {
-		searchable, err = js.(types.JSONValue).Unmarshall(ctx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return searchable, nil
-}
-
 func (j *JSONContains) Children() []sql.Expression {
 	if j.Path != nil {
 		return []sql.Expression{j.JSONTarget, j.JSONCandidate, j.Path}

--- a/sql/expression/function/json/json_insert.go
+++ b/sql/expression/function/json/json_insert.go
@@ -1,0 +1,120 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// JSON_INSERT(json_doc, path, val[, path, val] ...)
+//
+// JSONInsert Inserts data into a JSON document and returns the result. Returns NULL if any argument is NULL. An error
+// occurs if the json_doc argument is not a valid JSON document or any path argument is not a valid path expression or
+// contains a * or ** wildcard. The path-value pairs are evaluated left to right. The document produced by evaluating
+// one pair becomes the new value against which the next pair is evaluated. A path-value pair for an existing path in
+// the document is ignored and does not overwrite the existing document value. A path-value pair for a nonexisting path
+// in the document adds the value to the document if the path identifies one of these types of values:
+//   - A member not present in an existing object. The member is added to the object and associated with the new value.
+//   - A position past the end of an existing array. The array is extended with the new value. If the existing value is
+//     not an array, it is autowrapped as an array, then extended with the new value.
+//
+// Otherwise, a path-value pair for a nonexisting path in the document is ignored and has no effect.
+//
+// https://dev.mysql.com/doc/refman/8.0/en/json-modification-functions.html#function_json-insert
+type JSONInsert struct {
+	doc      sql.Expression
+	pathVals []sql.Expression
+}
+
+var _ sql.FunctionExpression = JSONInsert{}
+
+func (j JSONInsert) Resolved() bool {
+	for _, child := range j.Children() {
+		if child != nil && !child.Resolved() {
+			return false
+		}
+	}
+	return true
+}
+
+func (j JSONInsert) String() string {
+	children := j.Children()
+	var parts = make([]string, len(children))
+
+	for i, c := range children {
+		parts[i] = c.String()
+	}
+
+	return fmt.Sprintf("%s(%s)", j.FunctionName(), strings.Join(parts, ","))
+}
+
+func (j JSONInsert) Type() sql.Type {
+	return types.JSON
+}
+
+func (j JSONInsert) IsNullable() bool {
+	for _, arg := range j.pathVals {
+		if arg.IsNullable() {
+			return true
+		}
+	}
+	return j.doc.IsNullable()
+}
+
+func (j JSONInsert) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (j JSONInsert) Children() []sql.Expression {
+	return append([]sql.Expression{j.doc}, j.pathVals...)
+}
+
+func (j JSONInsert) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(j.Children()) != len(children) {
+		return nil, fmt.Errorf("json_replace did not receive the correct amount of args")
+	}
+	return NewJSONInsert(children...)
+}
+
+// NewJSONInsert creates a new JSONInsert function.
+func NewJSONInsert(args ...sql.Expression) (sql.Expression, error) {
+	if len(args) <= 1 {
+		return nil, sql.ErrInvalidArgumentNumber.New("JSON_INSERT", "more than 1", len(args))
+	} else if (len(args)-1)%2 == 1 {
+		return nil, sql.ErrInvalidArgumentNumber.New("JSON_INSERT", "even number of path/val", len(args)-1)
+	}
+
+	return JSONInsert{args[0], args[1:]}, nil
+}
+
+// FunctionName implements sql.FunctionExpression
+func (j JSONInsert) FunctionName() string {
+	return "json_insert"
+}
+
+// Description implements sql.FunctionExpression
+func (j JSONInsert) Description() string {
+	return "inserts data into JSON document"
+}
+
+// IsUnsupported implements sql.UnsupportedFunctionStub
+func (j JSONInsert) IsUnsupported() bool {
+	return false
+}

--- a/sql/expression/function/json/json_insert.go
+++ b/sql/expression/function/json/json_insert.go
@@ -78,8 +78,56 @@ func (j JSONInsert) IsNullable() bool {
 }
 
 func (j JSONInsert) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	//TODO implement me
-	panic("implement me")
+	doc, err := getMutableJSONVal(ctx, row, j.doc)
+	if err != nil {
+		return nil, err
+	}
+	if doc == nil {
+		return nil, nil
+	}
+
+	type pathValPair struct {
+		path string
+		val  types.JSONValue
+	}
+	pairs := make([]pathValPair, 0, len(j.pathVals)/2)
+	for i := 0; i < len(j.pathVals); i += 2 {
+		path, err := j.pathVals[i].Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+
+		if path == nil {
+			// MySQL documented behavior is to return null, not error, if path is null.
+			return nil, nil
+		}
+
+		// make sure path is string
+		if _, ok := path.(string); !ok {
+			return nil, fmt.Errorf("Invalid JSON path expression")
+		}
+
+		val, err := j.pathVals[i+1].Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+		jsonVal, ok := val.(types.JSONValue)
+		if !ok {
+			jsonVal = types.JSONDocument{val}
+		}
+
+		pairs = append(pairs, pathValPair{path.(string), jsonVal})
+	}
+
+	// Apply the path-value pairs to the document.
+	for _, pair := range pairs {
+		doc, _, err = doc.Insert(ctx, pair.path, pair.val)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return doc, nil
 }
 
 func (j JSONInsert) Children() []sql.Expression {

--- a/sql/expression/function/json/json_insert.go
+++ b/sql/expression/function/json/json_insert.go
@@ -134,8 +134,3 @@ func (j JSONInsert) FunctionName() string {
 func (j JSONInsert) Description() string {
 	return "inserts data into JSON document"
 }
-
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONInsert) IsUnsupported() bool {
-	return false
-}

--- a/sql/expression/function/json/json_insert_test.go
+++ b/sql/expression/function/json/json_insert_test.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import "testing"
+
+func TestInsert(t *testing.T) {
+
+}

--- a/sql/expression/function/json/json_insert_test.go
+++ b/sql/expression/function/json/json_insert_test.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/stretchr/testify/require"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 func TestInsert(t *testing.T) {

--- a/sql/expression/function/json/json_insert_test.go
+++ b/sql/expression/function/json/json_insert_test.go
@@ -14,8 +14,95 @@
 
 package json
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"gopkg.in/src-d/go-errors.v1"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
+)
 
 func TestInsert(t *testing.T) {
+	_, err := NewJSONInsert()
+	require.True(t, errors.Is(err, sql.ErrInvalidArgumentNumber))
+
+	f1 := buildGetFieldExpressions(t, NewJSONInsert, 3)
+	f2 := buildGetFieldExpressions(t, NewJSONInsert, 5)
+
+	json := `{"a": 1, "b": [2, 3], "c": {"d": "foo"}}`
+
+	testCases := []struct {
+		f        sql.Expression
+		row      sql.Row
+		expected interface{}
+		err      error
+	}{
+		{f1, sql.Row{json, "$.a", 10.1}, json, nil},                                                                    // insert existing does nothing
+		{f1, sql.Row{json, "$.e", "new"}, `{"a": 1, "b": [2, 3], "c": {"d": "foo"},"e":"new"}`, nil},                   // insert new
+		{f1, sql.Row{json, "$.c.d", "test"}, json, nil},                                                                // insert existing nested does nothing
+		{f2, sql.Row{json, "$.a", 10.1, "$.e", "new"}, `{"a": 1, "b": [2, 3], "c": {"d": "foo"},"e":"new"}`, nil},      // insert multiple, one change.
+		{f1, sql.Row{json, "$.a.e", "test"}, json, nil},                                                                // insert nested does nothing
+		{f1, sql.Row{json, "$.c.e", "test"}, `{"a": 1, "b": [2, 3], "c": {"d": "foo","e":"test"}}`, nil},               // insert nested in existing struct
+		{f1, sql.Row{json, "$.c[5]", 4.1}, `{"a": 1, "b": [2, 3], "c": [{"d": "foo"}, 4.1]}`, nil},                     // insert struct with indexing out of range
+		{f1, sql.Row{json, "$.b[0]", 4.1}, json, nil},                                                                  // insert element in array does nothing
+		{f1, sql.Row{json, "$.b[5]", 4.1}, `{"a": 1, "b": [2, 3, 4.1], "c": {"d": "foo"}}`, nil},                       // insert element in array out of range
+		{f1, sql.Row{json, "$.b.c", 4}, json, nil},                                                                     // insert nested in array does nothing
+		{f1, sql.Row{json, "$.a[0]", 4.1}, json, nil},                                                                  // struct as array does nothing
+		{f1, sql.Row{json, "$[0]", 4.1}, json, nil},                                                                    // struct does nothing.
+		{f1, sql.Row{json, "$.[0]", 4.1}, nil, fmt.Errorf("Invalid JSON path expression")},                             // improper struct indexing
+		{f1, sql.Row{json, "foo", "test"}, nil, fmt.Errorf("Invalid JSON path expression")},                            // invalid path
+		{f1, sql.Row{json, "$.c.*", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")},  // path contains * wildcard
+		{f1, sql.Row{json, "$.c.**", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")}, // path contains ** wildcard
+		{f1, sql.Row{json, "$", 10.1}, json, nil},                                                                      // whole document no opt
+		{f1, sql.Row{nil, "$", 42.7}, nil, nil},                                                                        // null document returns null
+		{f1, sql.Row{json, nil, 10}, nil, nil},                                                                         // if any path is null, return null
+
+		// mysql> select JSON_INSERT(JSON_ARRAY(), "$[2]", 1 , "$[2]", 2 ,"$[2]", 3 ,"$[2]", 4);
+		// +------------------------------------------------------------------------+
+		// | JSON_INSERT(JSON_ARRAY(), "$[2]", 1 , "$[2]", 2 ,"$[2]", 3 ,"$[2]", 4) |
+		// +------------------------------------------------------------------------+
+		// | [1, 2, 3]                                                              |
+		// +------------------------------------------------------------------------+
+		{buildGetFieldExpressions(t, NewJSONInsert, 9),
+			sql.Row{`[]`,
+				"$[2]", 1.1, // [] -> [1.1]
+				"$[2]", 2.2, // [1.1] -> [1.1,2.2]
+				"$[2]", 3.3, // [1.1, 2.2] -> [1.1, 2.2, 3.3]
+				"$[2]", 4.4}, // [1.1, 2.2, 3.3] -> [1.1, 2.2, 3.3]
+			`[1.1, 2.2, 3.3]`, nil},
+	}
+
+	for _, tstC := range testCases {
+		var paths []string
+		for _, path := range tstC.row[1:] {
+			if _, ok := path.(string); ok {
+				paths = append(paths, path.(string))
+			}
+		}
+
+		t.Run(tstC.f.String()+"."+strings.Join(paths, ","), func(t *testing.T) {
+			req := require.New(t)
+			result, err := tstC.f.Eval(sql.NewEmptyContext(), tstC.row)
+			if tstC.err == nil {
+				req.NoError(err)
+
+				var expect interface{}
+				if tstC.expected != nil {
+					expect, _, err = types.JSON.Convert(tstC.expected)
+					if err != nil {
+						panic("Bad test string. Can't convert string to JSONDocument: " + tstC.expected.(string))
+					}
+				}
+
+				req.Equal(expect, result)
+			} else {
+				req.Error(tstC.err, err)
+			}
+		})
+	}
 
 }

--- a/sql/expression/function/json/json_remove.go
+++ b/sql/expression/function/json/json_remove.go
@@ -1,0 +1,112 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// JSON_REMOVE(json_doc, path[, path] ...)
+//
+// JSONRemove Removes data from a JSON document and returns the result. Returns NULL if any argument is NULL. An error
+// occurs if the json_doc argument is not a valid JSON document or any path argument is not a valid path expression or
+// is $ or contains a * or ** wildcard. The path arguments are evaluated left to right. The document produced by
+// evaluating one path becomes the new value against which the next path is evaluated. It is not an error if the element
+// to be removed does not exist in the document; in that case, the path does not affect the document.
+//
+// https://dev.mysql.com/doc/refman/8.0/en/json-modification-functions.html#function_json-remove
+type JSONRemove struct {
+	doc   sql.Expression
+	paths []sql.Expression
+}
+
+func (j JSONRemove) Resolved() bool {
+	for _, child := range j.Children() {
+		if child != nil && !child.Resolved() {
+			return false
+		}
+	}
+	return true
+}
+
+func (j JSONRemove) String() string {
+	children := j.Children()
+	var parts = make([]string, len(children))
+
+	for i, c := range children {
+		parts[i] = c.String()
+	}
+
+	return fmt.Sprintf("%s(%s)", j.FunctionName(), strings.Join(parts, ","))
+}
+
+func (j JSONRemove) Type() sql.Type {
+	return types.JSON
+}
+
+func (j JSONRemove) IsNullable() bool {
+	for _, path := range j.paths {
+		if path.IsNullable() {
+			return true
+		}
+	}
+	return j.doc.IsNullable()
+}
+
+func (j JSONRemove) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (j JSONRemove) Children() []sql.Expression {
+	return append([]sql.Expression{j.doc}, j.paths...)
+}
+
+func (j JSONRemove) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(j.Children()) != len(children) {
+		return nil, fmt.Errorf("json_remove did not receive the correct amount of args")
+	}
+	return NewJSONRemove(children...)
+}
+
+var _ sql.FunctionExpression = JSONRemove{}
+
+// NewJSONRemove creates a new JSONRemove function.
+func NewJSONRemove(args ...sql.Expression) (sql.Expression, error) {
+	if len(args) < 2 {
+		return nil, sql.ErrInvalidArgumentNumber.New("JSON_REMOVE", "2 or more", len(args))
+	}
+
+	return JSONRemove{args[0], args[1:]}, nil
+}
+
+// FunctionName implements sql.FunctionExpression
+func (j JSONRemove) FunctionName() string {
+	return "json_remove"
+}
+
+// Description implements sql.FunctionExpression
+func (j JSONRemove) Description() string {
+	return "removes data from JSON document."
+}
+
+// IsUnsupported implements sql.UnsupportedFunctionStub
+func (j JSONRemove) IsUnsupported() bool {
+	return false
+}

--- a/sql/expression/function/json/json_remove.go
+++ b/sql/expression/function/json/json_remove.go
@@ -101,11 +101,6 @@ func (j JSONRemove) Description() string {
 	return "removes data from JSON document."
 }
 
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONRemove) IsUnsupported() bool {
-	return false
-}
-
 func (j JSONRemove) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	doc, err := getMutableJSONVal(ctx, row, j.doc)
 	if err != nil || doc == nil {

--- a/sql/expression/function/json/json_remove.go
+++ b/sql/expression/function/json/json_remove.go
@@ -108,11 +108,8 @@ func (j JSONRemove) IsUnsupported() bool {
 
 func (j JSONRemove) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	doc, err := getMutableJSONVal(ctx, row, j.doc)
-	if err != nil {
+	if err != nil || doc == nil {
 		return nil, err
-	}
-	if doc == nil {
-		return nil, nil
 	}
 
 	for _, path := range j.paths {

--- a/sql/expression/function/json/json_remove_test.go
+++ b/sql/expression/function/json/json_remove_test.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRemove(t *testing.T) {

--- a/sql/expression/function/json/json_remove_test.go
+++ b/sql/expression/function/json/json_remove_test.go
@@ -42,17 +42,16 @@ func TestRemove(t *testing.T) {
 		expected interface{}
 		err      error
 	}{
-		{f1, sql.Row{json, "$.a"}, `{"b": [2, 3], "c": {"d": "foo"}}`, nil},                                            // update existing
-		{f1, sql.Row{json, "$.b[0]"}, `{"a": 1, "b": [3], "c": {"d": "foo"}}`, nil},                                    // set new
-		{f1, sql.Row{json, "$.c.d"}, `{"a": 1, "b": [2, 3], "c": {}}`, nil},                                            // update existing nested
-		{f1, sql.Row{json, "$.c"}, `{"a": 1, "b": [2, 3]}`, nil},                                                       // update existing and set new
-		{f1, sql.Row{json, "$.a.e"}, json, nil},                                                                        // set new nested does nothing
-		{f1, sql.Row{json, "$.c[5]"}, json, nil},                                                                       // update struct with indexing out of range
-		{f1, sql.Row{json, "$.b[last]"}, `{"a": 1, "b": [2], "c": {"d": "foo"}}`, nil},                                 // update element in array
-		{f1, sql.Row{json, "$.b[5]"}, json, nil},                                                                       // update element in array out of range
-		{f1, sql.Row{json, "$.b.c", 4}, json, nil},                                                                     // set nested in array does nothing
-		{f1, sql.Row{json, "$[0]", 4.1}, json, nil},                                                                    // struct indexing
-		{f1, sql.Row{json, "$.[0]", 4.1}, nil, fmt.Errorf("Invalid JSON path expression")},                             // improper struct indexing
+		{f1, sql.Row{json, "$.a"}, `{"b": [2, 3], "c": {"d": "foo"}}`, nil},                                            // remove existing
+		{f1, sql.Row{json, "$.b[0]"}, `{"a": 1, "b": [3], "c": {"d": "foo"}}`, nil},                                    // remove existing array element
+		{f1, sql.Row{json, "$.c.d"}, `{"a": 1, "b": [2, 3], "c": {}}`, nil},                                            // remove existing nested
+		{f1, sql.Row{json, "$.c"}, `{"a": 1, "b": [2, 3]}`, nil},                                                       // remove existing object
+		{f1, sql.Row{json, "$.a.e"}, json, nil},                                                                        // remove nothing when path not found
+		{f1, sql.Row{json, "$.c[5]"}, json, nil},                                                                       // remove nothing when path not found
+		{f1, sql.Row{json, "$.b[last]"}, `{"a": 1, "b": [2], "c": {"d": "foo"}}`, nil},                                 // remove last element in array
+		{f1, sql.Row{json, "$.b[5]"}, json, nil},                                                                       // remove nothing when array index out of bounds
+		{f1, sql.Row{json, "$[0]"}, json, nil},                                                                         // remove nothing when provided a bogus path.
+		{f1, sql.Row{json, "$.[0]"}, nil, fmt.Errorf("Invalid JSON path expression")},                                  // improper struct indexing
 		{f1, sql.Row{json, "foo", "test"}, nil, fmt.Errorf("Invalid JSON path expression")},                            // invalid path
 		{f1, sql.Row{json, "$.c.*", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")},  // path contains * wildcard
 		{f1, sql.Row{json, "$.c.**", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")}, // path contains ** wildcard

--- a/sql/expression/function/json/json_remove_test.go
+++ b/sql/expression/function/json/json_remove_test.go
@@ -14,8 +14,80 @@
 
 package json
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gopkg.in/src-d/go-errors.v1"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/stretchr/testify/require"
+)
 
 func TestRemove(t *testing.T) {
+	_, err := NewJSONRemove()
+	require.True(t, errors.Is(err, sql.ErrInvalidArgumentNumber))
 
+	f1 := buildGetFieldExpressions(t, NewJSONRemove, 2)
+
+	f2 := buildGetFieldExpressions(t, NewJSONRemove, 3)
+
+	json := `{"a": 1, "b": [2, 3], "c": {"d": "foo"}}`
+
+	testCases := []struct {
+		f        sql.Expression
+		row      sql.Row
+		expected interface{}
+		err      error
+	}{
+		{f1, sql.Row{json, "$.a"}, `{"b": [2, 3], "c": {"d": "foo"}}`, nil},                                            // update existing
+		{f1, sql.Row{json, "$.b[0]"}, `{"a": 1, "b": [3], "c": {"d": "foo"}}`, nil},                                    // set new
+		{f1, sql.Row{json, "$.c.d"}, `{"a": 1, "b": [2, 3], "c": {}}`, nil},                                            // update existing nested
+		{f1, sql.Row{json, "$.c"}, `{"a": 1, "b": [2, 3]}`, nil},                                                       // update existing and set new
+		{f1, sql.Row{json, "$.a.e"}, json, nil},                                                                        // set new nested does nothing
+		{f1, sql.Row{json, "$.c[5]"}, json, nil},                                                                       // update struct with indexing out of range
+		{f1, sql.Row{json, "$.b[last]"}, `{"a": 1, "b": [2], "c": {"d": "foo"}}`, nil},                                 // update element in array
+		{f1, sql.Row{json, "$.b[5]"}, json, nil},                                                                       // update element in array out of range
+		{f1, sql.Row{json, "$.b.c", 4}, json, nil},                                                                     // set nested in array does nothing
+		{f1, sql.Row{json, "$[0]", 4.1}, json, nil},                                                                    // struct indexing
+		{f1, sql.Row{json, "$.[0]", 4.1}, nil, fmt.Errorf("Invalid JSON path expression")},                             // improper struct indexing
+		{f1, sql.Row{json, "foo", "test"}, nil, fmt.Errorf("Invalid JSON path expression")},                            // invalid path
+		{f1, sql.Row{json, "$.c.*", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")},  // path contains * wildcard
+		{f1, sql.Row{json, "$.c.**", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")}, // path contains ** wildcard
+		{f1, sql.Row{json, "$"}, nil, fmt.Errorf("The path expression '$' is not allowed in this context.")},           // whole document
+		{f1, sql.Row{nil, "$"}, nil, nil},                                                                              // null document
+		{f2, sql.Row{json, "$.foo", nil}, nil, nil},                                                                    // if any path is null, return null
+		{f2, sql.Row{json, "$.a", "$.b"}, `{"c": {"d": "foo"}}`, nil},                                                  // remove multiple paths
+	}
+
+	for _, tstC := range testCases {
+		var paths []string
+		for _, path := range tstC.row[1:] {
+			if _, ok := path.(string); ok {
+				paths = append(paths, path.(string))
+			}
+		}
+
+		t.Run(tstC.f.String()+"."+strings.Join(paths, ","), func(t *testing.T) {
+			req := require.New(t)
+			result, err := tstC.f.Eval(sql.NewEmptyContext(), tstC.row)
+			if tstC.err == nil {
+				req.NoError(err)
+
+				var expect interface{}
+				if tstC.expected != nil {
+					expect, _, err = types.JSON.Convert(tstC.expected)
+					if err != nil {
+						panic("Bad test string. Can't convert string to JSONDocument: " + tstC.expected.(string))
+					}
+				}
+
+				req.Equal(expect, result)
+			} else {
+				req.Error(tstC.err, err)
+			}
+		})
+	}
 }

--- a/sql/expression/function/json/json_remove_test.go
+++ b/sql/expression/function/json/json_remove_test.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import "testing"
+
+func TestRemove(t *testing.T) {
+
+}

--- a/sql/expression/function/json/json_replace.go
+++ b/sql/expression/function/json/json_replace.go
@@ -122,11 +122,6 @@ func NewJSONReplace(args ...sql.Expression) (sql.Expression, error) {
 	return JSONReplace{args[0], args[1:]}, nil
 }
 
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONReplace) IsUnsupported() bool {
-	return false
-}
-
 // FunctionName implements sql.FunctionExpression
 func (j JSONReplace) FunctionName() string {
 	return "json_replace"

--- a/sql/expression/function/json/json_replace.go
+++ b/sql/expression/function/json/json_replace.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// JSON_REPLACE(json_doc, path, val[, path, val] ...)
+//
+// JSONReplace Replaces existing values in a JSON document and returns the result. Returns NULL if any argument is NULL.
+// An error occurs if the json_doc argument is not a valid JSON document or any path argument is not a valid path
+// expression or contains a * or ** wildcard. The path-value pairs are evaluated left to right. The document produced by
+// evaluating one pair becomes the new value against which the next pair is evaluated. A path-value pair for an existing
+// path in the document overwrites the existing document value with the new value. A path-value pair for a non-existing
+// path in the document is ignored and has no effect.
+//
+// https://dev.mysql.com/doc/refman/8.0/en/json-modification-functions.html#function_json-replace
+type JSONReplace struct {
+	doc      sql.Expression
+	pathVals []sql.Expression
+}
+
+var _ sql.FunctionExpression = JSONReplace{}
+
+func (j JSONReplace) Resolved() bool {
+	for _, child := range j.Children() {
+		if child != nil && !child.Resolved() {
+			return false
+		}
+	}
+	return true
+}
+
+func (j JSONReplace) String() string {
+	children := j.Children()
+	var parts = make([]string, len(children))
+
+	for i, c := range children {
+		parts[i] = c.String()
+	}
+
+	return fmt.Sprintf("%s(%s)", j.FunctionName(), strings.Join(parts, ","))
+}
+
+func (j JSONReplace) Type() sql.Type {
+	return types.JSON
+}
+
+func (j JSONReplace) IsNullable() bool {
+	for _, arg := range j.pathVals {
+		if arg.IsNullable() {
+			return true
+		}
+	}
+	return j.doc.IsNullable()
+}
+
+func (j JSONReplace) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (j JSONReplace) Children() []sql.Expression {
+	return append([]sql.Expression{j.doc}, j.pathVals...)
+}
+
+func (j JSONReplace) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(j.Children()) != len(children) {
+		return nil, fmt.Errorf("json_replace did not receive the correct amount of args")
+	}
+	return NewJSONReplace(children...)
+}
+
+var _ sql.FunctionExpression = JSONReplace{}
+
+// NewJSONReplace creates a new JSONReplace function.
+func NewJSONReplace(args ...sql.Expression) (sql.Expression, error) {
+	if len(args) <= 1 {
+		return nil, sql.ErrInvalidArgumentNumber.New("JSON_REPLACE", "more than 1", len(args))
+	} else if (len(args)-1)%2 == 1 {
+		return nil, sql.ErrInvalidArgumentNumber.New("JSON_REPLACE", "even number of path/val", len(args)-1)
+	}
+
+	return JSONReplace{args[0], args[1:]}, nil
+}
+
+// IsUnsupported implements sql.UnsupportedFunctionStub
+func (j JSONReplace) IsUnsupported() bool {
+	return false
+}
+
+// FunctionName implements sql.FunctionExpression
+func (j JSONReplace) FunctionName() string {
+	return "json_replace"
+}
+
+// Description implements sql.FunctionExpression
+func (j JSONReplace) Description() string {
+	return "replaces values in JSON document."
+}

--- a/sql/expression/function/json/json_replace.go
+++ b/sql/expression/function/json/json_replace.go
@@ -73,8 +73,56 @@ func (j JSONReplace) IsNullable() bool {
 }
 
 func (j JSONReplace) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	//TODO implement me
-	panic("implement me")
+	doc, err := getMutableJSONVal(ctx, row, j.doc)
+	if err != nil {
+		return nil, err
+	}
+	if doc == nil {
+		return nil, nil
+	}
+
+	type pathValPair struct {
+		path string
+		val  types.JSONValue
+	}
+	pairs := make([]pathValPair, 0, len(j.pathVals)/2)
+	for i := 0; i < len(j.pathVals); i += 2 {
+		path, err := j.pathVals[i].Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+
+		if path == nil {
+			// MySQL documented behavior is to return null, not error, if path is null.
+			return nil, nil
+		}
+
+		// make sure path is string
+		if _, ok := path.(string); !ok {
+			return nil, fmt.Errorf("Invalid JSON path expression")
+		}
+
+		val, err := j.pathVals[i+1].Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+		jsonVal, ok := val.(types.JSONValue)
+		if !ok {
+			jsonVal = types.JSONDocument{val}
+		}
+
+		pairs = append(pairs, pathValPair{path.(string), jsonVal})
+	}
+
+	// Apply the path-value pairs to the document.
+	for _, pair := range pairs {
+		doc, _, err = doc.Replace(ctx, pair.path, pair.val)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return doc, nil
 }
 
 func (j JSONReplace) Children() []sql.Expression {

--- a/sql/expression/function/json/json_replace.go
+++ b/sql/expression/function/json/json_replace.go
@@ -74,44 +74,17 @@ func (j JSONReplace) IsNullable() bool {
 
 func (j JSONReplace) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	doc, err := getMutableJSONVal(ctx, row, j.doc)
-	if err != nil {
+	if err != nil || doc == nil {
 		return nil, err
 	}
-	if doc == nil {
-		return nil, nil
-	}
 
-	type pathValPair struct {
-		path string
-		val  types.JSONValue
-	}
 	pairs := make([]pathValPair, 0, len(j.pathVals)/2)
 	for i := 0; i < len(j.pathVals); i += 2 {
-		path, err := j.pathVals[i].Eval(ctx, row)
-		if err != nil {
+		argPair, err := buildPathValue(ctx, j.pathVals[i], j.pathVals[i+1], row)
+		if argPair == nil || err != nil {
 			return nil, err
 		}
-
-		if path == nil {
-			// MySQL documented behavior is to return null, not error, if path is null.
-			return nil, nil
-		}
-
-		// make sure path is string
-		if _, ok := path.(string); !ok {
-			return nil, fmt.Errorf("Invalid JSON path expression")
-		}
-
-		val, err := j.pathVals[i+1].Eval(ctx, row)
-		if err != nil {
-			return nil, err
-		}
-		jsonVal, ok := val.(types.JSONValue)
-		if !ok {
-			jsonVal = types.JSONDocument{val}
-		}
-
-		pairs = append(pairs, pathValPair{path.(string), jsonVal})
+		pairs = append(pairs, *argPair)
 	}
 
 	// Apply the path-value pairs to the document.

--- a/sql/expression/function/json/json_replace_test.go
+++ b/sql/expression/function/json/json_replace_test.go
@@ -15,9 +15,80 @@
 package json
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"gopkg.in/src-d/go-errors.v1"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReplace(t *testing.T) {
 
+	_, err := NewJSONReplace()
+	require.True(t, errors.Is(err, sql.ErrInvalidArgumentNumber))
+
+	f1 := buildGetFieldExpressions(t, NewJSONReplace, 3)
+	f2 := buildGetFieldExpressions(t, NewJSONReplace, 5)
+
+	json := `{"a": 1, "b": [2, 3], "c": {"d": "foo"}}`
+
+	testCases := []struct {
+		f        sql.Expression
+		row      sql.Row
+		expected interface{}
+		err      error
+	}{
+		{f1, sql.Row{json, "$.a", 10.1}, `{"a": 10.1, "b": [2, 3], "c": {"d": "foo"}}`, nil},                           // replace existing
+		{f1, sql.Row{json, "$.e", "new"}, json, nil},                                                                   // replace non-existing does nothing
+		{f1, sql.Row{json, "$.c.d", "test"}, `{"a": 1, "b": [2, 3], "c": {"d": "test"}}`, nil},                         // replace nested
+		{f2, sql.Row{json, "$.a", 10.1, "$.e", "new"}, `{"a": 10.1, "b": [2, 3], "c": {"d": "foo"}}`, nil},             // replace multiple, one change.
+		{f1, sql.Row{json, "$.a.e", "test"}, json, nil},                                                                // replace nested non-existent does nothing
+		{f1, sql.Row{json, "$.c.e", "test"}, json, nil},                                                                // replace nested in existing struct missing field does nothing
+		{f1, sql.Row{json, "$.c[5]", 4.1}, json, nil},                                                                  // replace struct with indexing out of range
+		{f1, sql.Row{json, "$.b[0]", 4.1}, `{"a": 1, "b": [4.1, 3], "c": {"d": "foo"}}`, nil},                          // replace element in array
+		{f1, sql.Row{json, "$.b[5]", 4.1}, json, nil},                                                                  // replace element in array out of range does nothing
+		{f1, sql.Row{json, "$.b.c", 4}, json, nil},                                                                     // replace nested in array does nothing
+		{f1, sql.Row{json, "$.a[0]", 4.1}, `{"a": 4.1, "b": [2, 3], "c": {"d": "foo"}}`, nil},                          // replace scalar when treated as array
+		{f1, sql.Row{json, "$[0]", 4.1}, `4.1`, nil},                                                                   // Replace root element when treated as array
+		{f1, sql.Row{json, "$.[0]", 4.1}, nil, fmt.Errorf("Invalid JSON path expression")},                             // improper struct indexing
+		{f1, sql.Row{json, "foo", "test"}, nil, fmt.Errorf("Invalid JSON path expression")},                            // invalid path
+		{f1, sql.Row{json, "$.c.*", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")},  // path contains * wildcard
+		{f1, sql.Row{json, "$.c.**", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")}, // path contains ** wildcard
+		{f1, sql.Row{json, "$", 10.1}, `10.1`, nil},                                                                    // replace root element
+		{f1, sql.Row{nil, "$", 42.7}, nil, nil},                                                                        // null document returns null
+		{f1, sql.Row{json, nil, 10}, nil, nil},                                                                         // if any path is null, return null
+	}
+
+	for _, tstC := range testCases {
+		var paths []string
+		for _, path := range tstC.row[1:] {
+			if _, ok := path.(string); ok {
+				paths = append(paths, path.(string))
+			}
+		}
+
+		t.Run(tstC.f.String()+"."+strings.Join(paths, ","), func(t *testing.T) {
+			req := require.New(t)
+			result, err := tstC.f.Eval(sql.NewEmptyContext(), tstC.row)
+			if tstC.err == nil {
+				req.NoError(err)
+
+				var expect interface{}
+				if tstC.expected != nil {
+					expect, _, err = types.JSON.Convert(tstC.expected)
+					if err != nil {
+						panic("Bad test string. Can't convert string to JSONDocument: " + tstC.expected.(string))
+					}
+				}
+
+				req.Equal(expect, result)
+			} else {
+				req.Error(tstC.err, err)
+			}
+		})
+	}
 }

--- a/sql/expression/function/json/json_replace_test.go
+++ b/sql/expression/function/json/json_replace_test.go
@@ -1,0 +1,21 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import "testing"
+
+func TestReplace(t *testing.T) {
+
+}

--- a/sql/expression/function/json/json_replace_test.go
+++ b/sql/expression/function/json/json_replace_test.go
@@ -19,11 +19,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/stretchr/testify/require"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 func TestReplace(t *testing.T) {

--- a/sql/expression/function/json/json_replace_test.go
+++ b/sql/expression/function/json/json_replace_test.go
@@ -14,7 +14,9 @@
 
 package json
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestReplace(t *testing.T) {
 

--- a/sql/expression/function/json/json_replace_test.go
+++ b/sql/expression/function/json/json_replace_test.go
@@ -53,7 +53,7 @@ func TestReplace(t *testing.T) {
 		{f1, sql.Row{json, "$.b[5]", 4.1}, json, nil},                                                                  // replace element in array out of range does nothing
 		{f1, sql.Row{json, "$.b.c", 4}, json, nil},                                                                     // replace nested in array does nothing
 		{f1, sql.Row{json, "$.a[0]", 4.1}, `{"a": 4.1, "b": [2, 3], "c": {"d": "foo"}}`, nil},                          // replace scalar when treated as array
-		{f1, sql.Row{json, "$[0]", 4.1}, `4.1`, nil},                                                                   // Replace root element when treated as array
+		{f1, sql.Row{json, "$[0]", 4.1}, `4.1`, nil},                                                                   // replace root element when treated as array
 		{f1, sql.Row{json, "$.[0]", 4.1}, nil, fmt.Errorf("Invalid JSON path expression")},                             // improper struct indexing
 		{f1, sql.Row{json, "foo", "test"}, nil, fmt.Errorf("Invalid JSON path expression")},                            // invalid path
 		{f1, sql.Row{json, "$.c.*", "test"}, nil, fmt.Errorf("Path expressions may not contain the * and ** tokens")},  // path contains * wildcard

--- a/sql/expression/function/json/json_set.go
+++ b/sql/expression/function/json/json_set.go
@@ -15,13 +15,8 @@
 package json
 
 import (
-	"errors"
 	"fmt"
-	"strconv"
 	"strings"
-
-	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -119,7 +114,7 @@ func (j *JSONSet) IsNullable() bool {
 }
 
 func (j *JSONSet) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	doc, err := j.JSONDoc.Eval(ctx, row)
+	doc, err := getMutableJSONVal(ctx, row, j.JSONDoc)
 	if err != nil {
 		return nil, err
 	}
@@ -127,213 +122,46 @@ func (j *JSONSet) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	doc, _, err = j.Type().Convert(doc)
-	if err != nil {
-		return nil, err
+	type pathValPair struct {
+		path string
+		val  types.JSONValue
 	}
-
-	parsed, err := doc.(types.JSONValue).Unmarshall(ctx)
-	if err != nil {
-		return nil, err
-	}
-	val, err := parsed.ToString(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	isPath := true
-	var path string
-	pass := false      // indicates whether the path should do nothing
-	returnVal := false // indicates whether we should just return the value
-	for _, e := range j.PathAndVals {
-		expr, err := e.Eval(ctx, row)
+	pairs := make([]pathValPair, 0, len(j.PathAndVals)/2)
+	for i := 0; i < len(j.PathAndVals); i += 2 {
+		path, err := j.PathAndVals[i].Eval(ctx, row)
 		if err != nil {
 			return nil, err
 		}
 
-		if isPath {
-			// if any path arg is null, we return null
-			if expr == nil {
-				return nil, nil
-			}
+		if path == nil {
+			// MySQL documented behavior is to return null, not error, if path is null.
+			return nil, nil
+		}
 
-			// make sure path is string
-			if _, ok := expr.(string); !ok {
-				return nil, fmt.Errorf("Invalid JSON path expression")
-			}
-			path = expr.(string)
+		// make sure path is string
+		if _, ok := path.(string); !ok {
+			return nil, fmt.Errorf("Invalid JSON path expression")
+		}
 
-			path, pass, err = processPath(val, path)
-			if err != nil {
-				if err.Error() == "return value for whole doc" {
-					returnVal = true
-				} else {
-					return nil, err
-				}
-			}
+		val, err := j.PathAndVals[i+1].Eval(ctx, row)
+		if err != nil {
+			return nil, err
+		}
+		jsonVal, ok := val.(types.JSONValue)
+		if !ok {
+			jsonVal = types.JSONDocument{val}
+		}
 
-			isPath = false
-		} else if !pass {
-			if returnVal {
-				return fmt.Sprintf("%v", expr), nil
-			}
-			val, err = sjson.Set(val, path, expr)
-			if err != nil {
-				return nil, err
-			}
-			isPath = true
+		pairs = append(pairs, pathValPair{path.(string), jsonVal})
+	}
+
+	// Apply the path-value pairs to the document.
+	for _, pair := range pairs {
+		doc, _, err = doc.Set(ctx, pair.path, pair.val)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	return val, nil
-}
-
-// processPath checks the given json path for the correct mysql syntax, checks nested paths for their existence
-// in the provided json doc, determines whether JSON_SET will do nothing with no error for this path, and processes
-// the given json path to use the appropriate sjson syntax. Returns the formatted path, whether the function should do
-// nothing for this path-value pair, and any errors.
-func processPath(doc, path string) (string, bool, error) {
-	err := checkPath(path)
-	if err != nil {
-		return "", false, err
-	}
-	path = path[1:]
-
-	// tokenize each field of the path
-	var parsed parsedPath
-	parsed.parts = strings.Split(path, ".")
-	if parsed.parts[0] == "" {
-		parsed.parts = parsed.parts[1:]
-	}
-
-	// process each field of the path
-	for partIdx, part := range parsed.parts {
-		formattedPart := part
-
-		// handle any indexing in this field
-		if strings.Contains(part, "[") {
-			var pass bool
-			formattedPart, pass, err = processIndexedField(doc, formattedPart, parsed, partIdx)
-			if pass {
-				return "", pass, nil
-			}
-			if err != nil {
-				return "", pass, err
-			}
-		}
-
-		if partIdx == 0 {
-			parsed.formattedPath = parsed.formattedPath + formattedPart
-		} else {
-			previousVal := gjson.Get(doc, parsed.formattedPath)
-			if !previousVal.Exists() { // if parent doesn't exist in json already, do nothing
-				return path, true, nil
-			}
-			if !previousVal.IsObject() { // if parent isn't a map, do nothing
-				return path, true, nil
-			}
-			parsed.formattedPath = parsed.formattedPath + "." + formattedPart
-		}
-	}
-
-	return parsed.formattedPath, false, nil
-}
-
-type parsedPath struct {
-	parts         []string
-	formattedPath string // stores the path in format usable by sjson
-}
-
-// checkPath checks the given path for basic syntax correctness and simple edge cases
-func checkPath(path string) error {
-	if path == "" {
-		return fmt.Errorf("Invalid JSON path expression")
-	}
-	// path starts with '$'
-	if path[0] != '$' {
-		return fmt.Errorf("Invalid JSON path expression")
-	}
-	// no wildcards in path
-	if strings.Contains(path, "*") {
-		return fmt.Errorf("Path expressions may not contain the * and ** tokens")
-	}
-
-	if path == "$" || path == "$[0]" {
-		return errors.New("return value for whole doc")
-	}
-
-	if len(path) == 2 {
-		return fmt.Errorf("Invalid JSON path expression")
-	}
-
-	return nil
-}
-
-// processIndexedField checks the given part path for correct syntax, checks nested indexes for their existence
-// in the provided json doc, determines whether JSON_SET will do nothing with no error for this path, and processes
-// the given json path to use the appropriate sjson syntax. Returns the formatted part path, whether the function should do
-// nothing for this part, and any errors.
-func processIndexedField(doc, path string, parsed parsedPath, partIdx int) (string, bool, error) {
-	// tokenize indexes
-	path = strings.ReplaceAll(path, "]", "")
-	tokens := strings.Split(path, "[")
-	if tokens[0] == "" {
-		tokens = tokens[1:]
-	}
-	path = ""
-
-	// process each token
-	for tokenIdx, token := range tokens {
-		// if token is an int, it's an index
-		if idx, err := strconv.Atoi(token); err == nil {
-			if tokenIdx == 0 {
-				if partIdx == 0 {
-					return "", false, fmt.Errorf("ordinal indexing currently unsupported")
-				} else {
-					return "", false, fmt.Errorf("Invalid JSON path expression")
-				}
-			}
-
-			parentVal := gjson.Get(doc, parsed.formattedPath+path)
-
-			// if parent doesn't exist in json already, do nothing
-			if !parentVal.Exists() {
-				return path, true, nil
-			}
-			switch {
-			case parentVal.IsObject():
-				arr := parentVal.Value().(map[string]interface{})
-				if idx >= len(arr) {
-					return "", false, fmt.Errorf("index out of range for maps currently unsupported")
-				}
-				path = path + "." + token
-			case parentVal.IsArray():
-				arr := parentVal.Value().([]interface{})
-				// if index out of range, append to end
-				if idx >= len(arr) {
-					path = path + ".-1"
-				} else {
-					path = path + "." + token
-				}
-			default:
-				if idx == 0 {
-					// if there are remaining tokens/fields, do nothing
-					if tokenIdx != len(tokens)-1 || partIdx != len(parsed.parts)-1 {
-						return path, true, nil
-					}
-				} else {
-					return "", false, fmt.Errorf("index out of range for single values currently unsupported")
-				}
-			}
-		} else {
-			if tokenIdx == 0 {
-				path = path + token
-			} else {
-				path = path + "." + token
-			}
-
-		}
-	}
-
-	return path, false, nil
+	return doc, nil
 }

--- a/sql/expression/function/json/json_set.go
+++ b/sql/expression/function/json/json_set.go
@@ -115,44 +115,17 @@ func (j *JSONSet) IsNullable() bool {
 
 func (j *JSONSet) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	doc, err := getMutableJSONVal(ctx, row, j.JSONDoc)
-	if err != nil {
+	if err != nil || doc == nil {
 		return nil, err
 	}
-	if doc == nil {
-		return nil, nil
-	}
 
-	type pathValPair struct {
-		path string
-		val  types.JSONValue
-	}
 	pairs := make([]pathValPair, 0, len(j.PathAndVals)/2)
 	for i := 0; i < len(j.PathAndVals); i += 2 {
-		path, err := j.PathAndVals[i].Eval(ctx, row)
-		if err != nil {
+		argPair, err := buildPathValue(ctx, j.PathAndVals[i], j.PathAndVals[i+1], row)
+		if argPair == nil || err != nil {
 			return nil, err
 		}
-
-		if path == nil {
-			// MySQL documented behavior is to return null, not error, if path is null.
-			return nil, nil
-		}
-
-		// make sure path is string
-		if _, ok := path.(string); !ok {
-			return nil, fmt.Errorf("Invalid JSON path expression")
-		}
-
-		val, err := j.PathAndVals[i+1].Eval(ctx, row)
-		if err != nil {
-			return nil, err
-		}
-		jsonVal, ok := val.(types.JSONValue)
-		if !ok {
-			jsonVal = types.JSONDocument{val}
-		}
-
-		pairs = append(pairs, pathValPair{path.(string), jsonVal})
+		pairs = append(pairs, *argPair)
 	}
 
 	// Apply the path-value pairs to the document.

--- a/sql/expression/function/json/json_set_test.go
+++ b/sql/expression/function/json/json_set_test.go
@@ -44,9 +44,9 @@ func TestJSONSet(t *testing.T) {
 	)
 	require.True(t, errors.Is(err, sql.ErrInvalidArgumentNumber))
 
-	f1 := buildGetFieldExpressions(t, 3)
+	f1 := buildGetFieldExpressions(t, NewJSONSet, 3)
 
-	f2 := buildGetFieldExpressions(t, 5)
+	f2 := buildGetFieldExpressions(t, NewJSONSet, 5)
 
 	json := `{"a": 1, "b": [2, 3], "c": {"d": "foo"}}`
 
@@ -83,7 +83,7 @@ func TestJSONSet(t *testing.T) {
 		// +---------------------------------------------------------------------+
 		// | [1, 2, 4]                                                           |
 		// +---------------------------------------------------------------------+
-		{buildGetFieldExpressions(t, 9),
+		{buildGetFieldExpressions(t, NewJSONSet, 9),
 			sql.Row{`[]`,
 				"$[2]", 1.1, // [] -> [1.1]
 				"$[2]", 2.2, // [1.1] -> [1.1,2.2]
@@ -131,13 +131,13 @@ func TestJSONSet(t *testing.T) {
 	}
 }
 
-func buildGetFieldExpressions(t *testing.T, argCount int) sql.Expression {
+func buildGetFieldExpressions(t *testing.T, construct func(...sql.Expression) (sql.Expression, error), argCount int) sql.Expression {
 	expressions := make([]sql.Expression, 0, argCount)
 	for i := 0; i < argCount; i++ {
 		expressions = append(expressions, expression.NewGetField(i, types.LongText, "arg"+strconv.Itoa(i), false))
 	}
 
-	result, err := NewJSONSet(expressions...)
+	result, err := construct(expressions...)
 	require.NoError(t, err)
 
 	return result

--- a/sql/expression/function/json/json_unsupported.go
+++ b/sql/expression/function/json/json_unsupported.go
@@ -415,41 +415,6 @@ type JSONMerge struct {
 	sql.Expression
 }
 
-// JSON_REMOVE(json_doc, path[, path] ...)
-//
-// JSONRemove Removes data from a JSON document and returns the result. Returns NULL if any argument is NULL. An error
-// occurs if the json_doc argument is not a valid JSON document or any path argument is not a valid path expression or
-// is $ or contains a * or ** wildcard. The path arguments are evaluated left to right. The document produced by
-// evaluating one path becomes the new value against which the next path is evaluated. It is not an error if the element
-// to be removed does not exist in the document; in that case, the path does not affect the document.
-//
-// https://dev.mysql.com/doc/refman/8.0/en/json-modification-functions.html#function_json-remove
-type JSONRemove struct {
-	sql.Expression
-}
-
-var _ sql.FunctionExpression = JSONRemove{}
-
-// NewJSONRemove creates a new JSONRemove function.
-func NewJSONRemove(args ...sql.Expression) (sql.Expression, error) {
-	return nil, ErrUnsupportedJSONFunction.New(JSONRemove{}.FunctionName())
-}
-
-// FunctionName implements sql.FunctionExpression
-func (j JSONRemove) FunctionName() string {
-	return "json_remove"
-}
-
-// Description implements sql.FunctionExpression
-func (j JSONRemove) Description() string {
-	return "removes data from JSON document."
-}
-
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONRemove) IsUnsupported() bool {
-	return true
-}
-
 // JSON_REPLACE(json_doc, path, val[, path, val] ...)
 //
 // JSONReplace Replaces existing values in a JSON document and returns the result. Returns NULL if any argument is NULL.

--- a/sql/expression/function/json/json_unsupported.go
+++ b/sql/expression/function/json/json_unsupported.go
@@ -313,47 +313,6 @@ func (j JSONArrayInsert) IsUnsupported() bool {
 	return true
 }
 
-// JSON_INSERT(json_doc, path, val[, path, val] ...)
-//
-// JSONInsert Inserts data into a JSON document and returns the result. Returns NULL if any argument is NULL. An error
-// occurs if the json_doc argument is not a valid JSON document or any path argument is not a valid path expression or
-// contains a * or ** wildcard. The path-value pairs are evaluated left to right. The document produced by evaluating
-// one pair becomes the new value against which the next pair is evaluated. A path-value pair for an existing path in
-// the document is ignored and does not overwrite the existing document value. A path-value pair for a nonexisting path
-// in the document adds the value to the document if the path identifies one of these types of values:
-//   - A member not present in an existing object. The member is added to the object and associated with the new value.
-//   - A position past the end of an existing array. The array is extended with the new value. If the existing value is
-//     not an array, it is autowrapped as an array, then extended with the new value.
-//
-// Otherwise, a path-value pair for a nonexisting path in the document is ignored and has no effect.
-//
-// https://dev.mysql.com/doc/refman/8.0/en/json-modification-functions.html#function_json-insert
-type JSONInsert struct {
-	sql.Expression
-}
-
-var _ sql.FunctionExpression = JSONInsert{}
-
-// NewJSONInsert creates a new JSONInsert function.
-func NewJSONInsert(args ...sql.Expression) (sql.Expression, error) {
-	return nil, ErrUnsupportedJSONFunction.New(JSONInsert{}.FunctionName())
-}
-
-// FunctionName implements sql.FunctionExpression
-func (j JSONInsert) FunctionName() string {
-	return "json_insert"
-}
-
-// Description implements sql.FunctionExpression
-func (j JSONInsert) Description() string {
-	return "inserts data into JSON document"
-}
-
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONInsert) IsUnsupported() bool {
-	return true
-}
-
 // JSON_MERGE_PATCH(json_doc, json_doc[, json_doc] ...)
 //
 // JSONMergePatch Performs an RFC 7396 compliant merge of two or more JSON documents and returns the merged result,

--- a/sql/expression/function/json/json_unsupported.go
+++ b/sql/expression/function/json/json_unsupported.go
@@ -415,42 +415,6 @@ type JSONMerge struct {
 	sql.Expression
 }
 
-// JSON_REPLACE(json_doc, path, val[, path, val] ...)
-//
-// JSONReplace Replaces existing values in a JSON document and returns the result. Returns NULL if any argument is NULL.
-// An error occurs if the json_doc argument is not a valid JSON document or any path argument is not a valid path
-// expression or contains a * or ** wildcard. The path-value pairs are evaluated left to right. The document produced by
-// evaluating one pair becomes the new value against which the next pair is evaluated. A path-value pair for an existing
-// path in the document overwrites the existing document value with the new value. A path-value pair for a non-existing
-// path in the document is ignored and has no effect.
-//
-// https://dev.mysql.com/doc/refman/8.0/en/json-modification-functions.html#function_json-replace
-type JSONReplace struct {
-	sql.Expression
-}
-
-var _ sql.FunctionExpression = JSONReplace{}
-
-// NewJSONReplace creates a new JSONReplace function.
-func NewJSONReplace(args ...sql.Expression) (sql.Expression, error) {
-	return nil, ErrUnsupportedJSONFunction.New(JSONReplace{}.FunctionName())
-}
-
-// FunctionName implements sql.FunctionExpression
-func (j JSONReplace) FunctionName() string {
-	return "json_replace"
-}
-
-// Description implements sql.FunctionExpression
-func (j JSONReplace) Description() string {
-	return "replaces values in JSON document."
-}
-
-// IsUnsupported implements sql.UnsupportedFunctionStub
-func (j JSONReplace) IsUnsupported() bool {
-	return true
-}
-
 //////////////////////////////
 // JSON attribute functions //
 //////////////////////////////

--- a/sql/types/json_test.go
+++ b/sql/types/json_test.go
@@ -552,6 +552,32 @@ var JsonSetTests = []JsonMutationTest{
 		value:     `null`,
 		resultVal: `null`,
 	},
+
+	/* Known ways we don't behave like MySQL. Frankly if anyone is depending on these behaviors they are doing it wrong.
+		   mysql> select JSON_SET('{"a": 1}', "$[0][0]", 42);
+		+-------------------------------------+
+		| JSON_SET('{"a": 1}', "$[0][0]", 42) |
+		+-------------------------------------+
+		| 42                                  |
+		+-------------------------------------+
+
+		mysql> select JSON_SET('{"a": 1}', "$[0][1]", 42);
+		+-------------------------------------+
+		| JSON_SET('{"a": 1}', "$[0][1]", 42) |
+		+-------------------------------------+
+		| [{"a": 1}, 42]                      |
+		+-------------------------------------+
+
+		mysql> select JSON_SET('{"a": 1}', "$[0][last-3]", 42);
+		+------------------------------------------+
+		| JSON_SET('{"a": 1}', "$[0][last-3]", 42) |
+		+------------------------------------------+
+		| [42, {"a": 1}]                           |
+		+------------------------------------------+
+	    The three examples above seems to indicate that MySQL coerces objects to arrays earlier in the search process than we do.
+		Reason for thinking this is that  JSON_SET('{"a": 1}', "$[0][0][ANYTHING]", 42); is a no op.
+	*/
+
 }
 
 func TestJsonSet(t *testing.T) {


### PR DESCRIPTION
Earlier PR (https://github.com/dolthub/go-mysql-server/pull/1983) enabled us to modify json document objects, but none of that functionality was exposed as actual JSON_* functions. This change ties it together. The following functions will behave identically to MySQL (to the best of my knowledge).

* [JSON_SET](https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-set)
* [JSON_INSERT](https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-insert)
* [JSON_REPLACE](https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-replace)
* [JSON_REMOVE](https://dev.mysql.com/doc/refman/5.7/en/json-modification-functions.html#function_json-remove)

Related: https://github.com/dolthub/dolt/issues/6585