### PR TITLE
Delete fixidx from pushdown

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -246,29 +246,25 @@ WHERE
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNTDISTINCT([stock1.s_i_id])\n" +
 			"     ├─ group: \n" +
-			"     └─ Filter\n" +
-			"         ├─ LessThan\n" +
-			"         │   ├─ stock1.s_quantity:6\n" +
-			"         │   └─ 15 (tinyint)\n" +
-			"         └─ HashJoin\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ stock1.s_i_id:4!null\n" +
-			"             │   └─ order_line1.ol_i_id:3\n" +
-			"             ├─ IndexedTableAccess(order_line1)\n" +
-			"             │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"             │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
-			"             │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
-			"             └─ HashLookup\n" +
-			"                 ├─ left-key: TUPLE(order_line1.ol_i_id:3)\n" +
-			"                 ├─ right-key: TUPLE(stock1.s_i_id:0!null)\n" +
-			"                 └─ Filter\n" +
-			"                     ├─ LessThan\n" +
-			"                     │   ├─ stock1.s_quantity:2\n" +
-			"                     │   └─ 15 (tinyint)\n" +
-			"                     └─ IndexedTableAccess(stock1)\n" +
-			"                         ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                         ├─ static: [{[5, 5], [NULL, ∞)}]\n" +
-			"                         └─ columns: [s_i_id s_w_id s_quantity]\n" +
+			"     └─ HashJoin\n" +
+			"         ├─ Eq\n" +
+			"         │   ├─ stock1.s_i_id:4!null\n" +
+			"         │   └─ order_line1.ol_i_id:3\n" +
+			"         ├─ IndexedTableAccess(order_line1)\n" +
+			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
+			"         │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
+			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
+			"         └─ HashLookup\n" +
+			"             ├─ left-key: TUPLE(order_line1.ol_i_id:3)\n" +
+			"             ├─ right-key: TUPLE(stock1.s_i_id:0!null)\n" +
+			"             └─ Filter\n" +
+			"                 ├─ LessThan\n" +
+			"                 │   ├─ stock1.s_quantity:2\n" +
+			"                 │   └─ 15 (tinyint)\n" +
+			"                 └─ IndexedTableAccess(stock1)\n" +
+			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
+			"                     ├─ static: [{[5, 5], [NULL, ∞)}]\n" +
+			"                     └─ columns: [s_i_id s_w_id s_quantity]\n" +
 			"",
 	},
 	{
@@ -345,91 +341,67 @@ where
 `,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [style.assetId:9]\n" +
-			" └─ Filter\n" +
+			" └─ LookupJoin\n" +
 			"     ├─ AND\n" +
-			"     │   ├─ AND\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ style.assetId:9\n" +
+			"     │   │   └─ dimension.assetId:5\n" +
+			"     │   └─ Eq\n" +
+			"     │       ├─ style.assetId:9\n" +
+			"     │       └─ color.assetId:1\n" +
+			"     ├─ LookupJoin\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ dimension.assetId:5\n" +
+			"     │   │   └─ color.assetId:1\n" +
+			"     │   ├─ Filter\n" +
 			"     │   │   ├─ AND\n" +
 			"     │   │   │   ├─ AND\n" +
-			"     │   │   │   │   ├─ AND\n" +
-			"     │   │   │   │   │   ├─ Eq\n" +
-			"     │   │   │   │   │   │   ├─ dimension.val:7\n" +
-			"     │   │   │   │   │   │   └─ wide (longtext)\n" +
-			"     │   │   │   │   │   └─ Eq\n" +
-			"     │   │   │   │   │       ├─ color.val:3\n" +
-			"     │   │   │   │   │       └─ blue (longtext)\n" +
+			"     │   │   │   │   ├─ Eq\n" +
+			"     │   │   │   │   │   ├─ color.val:3\n" +
+			"     │   │   │   │   │   └─ blue (longtext)\n" +
 			"     │   │   │   │   └─ Eq\n" +
-			"     │   │   │   │       ├─ dimension.name:6\n" +
-			"     │   │   │   │       └─ dimension (longtext)\n" +
+			"     │   │   │   │       ├─ color.name:2\n" +
+			"     │   │   │   │       └─ color (longtext)\n" +
 			"     │   │   │   └─ Eq\n" +
-			"     │   │   │       ├─ color.name:2\n" +
-			"     │   │   │       └─ color (longtext)\n" +
-			"     │   │   └─ Eq\n" +
-			"     │   │       ├─ dimension.orgId:4\n" +
-			"     │   │       └─ org1 (longtext)\n" +
-			"     │   └─ Eq\n" +
-			"     │       ├─ color.orgId:0\n" +
-			"     │       └─ org1 (longtext)\n" +
-			"     └─ LookupJoin\n" +
+			"     │   │   │       ├─ color.orgId:0\n" +
+			"     │   │   │       └─ org1 (longtext)\n" +
+			"     │   │   └─ TableAlias(color)\n" +
+			"     │   │       └─ IndexedTableAccess(asset)\n" +
+			"     │   │           ├─ index: [asset.orgId,asset.name,asset.val]\n" +
+			"     │   │           ├─ static: [{[org1, org1], [color, color], [blue, blue]}]\n" +
+			"     │   │           └─ columns: [orgid assetid name val]\n" +
+			"     │   └─ Filter\n" +
+			"     │       ├─ AND\n" +
+			"     │       │   ├─ AND\n" +
+			"     │       │   │   ├─ Eq\n" +
+			"     │       │   │   │   ├─ dimension.val:3\n" +
+			"     │       │   │   │   └─ wide (longtext)\n" +
+			"     │       │   │   └─ Eq\n" +
+			"     │       │   │       ├─ dimension.name:2\n" +
+			"     │       │   │       └─ dimension (longtext)\n" +
+			"     │       │   └─ Eq\n" +
+			"     │       │       ├─ dimension.orgId:0\n" +
+			"     │       │       └─ org1 (longtext)\n" +
+			"     │       └─ TableAlias(dimension)\n" +
+			"     │           └─ IndexedTableAccess(asset)\n" +
+			"     │               ├─ index: [asset.orgId,asset.name,asset.assetId]\n" +
+			"     │               └─ columns: [orgid assetid name val]\n" +
+			"     └─ Filter\n" +
 			"         ├─ AND\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ style.assetId:9\n" +
-			"         │   │   └─ dimension.assetId:5\n" +
+			"         │   ├─ AND\n" +
+			"         │   │   ├─ Eq\n" +
+			"         │   │   │   ├─ style.val:3\n" +
+			"         │   │   │   └─ curve (longtext)\n" +
+			"         │   │   └─ Eq\n" +
+			"         │   │       ├─ style.name:2\n" +
+			"         │   │       └─ style (longtext)\n" +
 			"         │   └─ Eq\n" +
-			"         │       ├─ style.assetId:9\n" +
-			"         │       └─ color.assetId:1\n" +
-			"         ├─ LookupJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ dimension.assetId:5\n" +
-			"         │   │   └─ color.assetId:1\n" +
-			"         │   ├─ Filter\n" +
-			"         │   │   ├─ AND\n" +
-			"         │   │   │   ├─ AND\n" +
-			"         │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   ├─ color.val:3\n" +
-			"         │   │   │   │   │   └─ blue (longtext)\n" +
-			"         │   │   │   │   └─ Eq\n" +
-			"         │   │   │   │       ├─ color.name:2\n" +
-			"         │   │   │   │       └─ color (longtext)\n" +
-			"         │   │   │   └─ Eq\n" +
-			"         │   │   │       ├─ color.orgId:0\n" +
-			"         │   │   │       └─ org1 (longtext)\n" +
-			"         │   │   └─ TableAlias(color)\n" +
-			"         │   │       └─ IndexedTableAccess(asset)\n" +
-			"         │   │           ├─ index: [asset.orgId,asset.name,asset.val]\n" +
-			"         │   │           ├─ static: [{[org1, org1], [color, color], [blue, blue]}]\n" +
-			"         │   │           └─ columns: [orgid assetid name val]\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ AND\n" +
-			"         │       │   ├─ AND\n" +
-			"         │       │   │   ├─ Eq\n" +
-			"         │       │   │   │   ├─ dimension.val:3\n" +
-			"         │       │   │   │   └─ wide (longtext)\n" +
-			"         │       │   │   └─ Eq\n" +
-			"         │       │   │       ├─ dimension.name:2\n" +
-			"         │       │   │       └─ dimension (longtext)\n" +
-			"         │       │   └─ Eq\n" +
-			"         │       │       ├─ dimension.orgId:0\n" +
-			"         │       │       └─ org1 (longtext)\n" +
-			"         │       └─ TableAlias(dimension)\n" +
-			"         │           └─ IndexedTableAccess(asset)\n" +
-			"         │               ├─ index: [asset.orgId,asset.name,asset.assetId]\n" +
-			"         │               └─ columns: [orgid assetid name val]\n" +
-			"         └─ Filter\n" +
-			"             ├─ AND\n" +
-			"             │   ├─ AND\n" +
-			"             │   │   ├─ Eq\n" +
-			"             │   │   │   ├─ style.val:3\n" +
-			"             │   │   │   └─ curve (longtext)\n" +
-			"             │   │   └─ Eq\n" +
-			"             │   │       ├─ style.name:2\n" +
-			"             │   │       └─ style (longtext)\n" +
-			"             │   └─ Eq\n" +
-			"             │       ├─ style.orgId:0\n" +
-			"             │       └─ org1 (longtext)\n" +
-			"             └─ TableAlias(style)\n" +
-			"                 └─ IndexedTableAccess(asset)\n" +
-			"                     ├─ index: [asset.orgId,asset.name,asset.assetId]\n" +
-			"                     └─ columns: [orgid assetid name val]\n" +
+			"         │       ├─ style.orgId:0\n" +
+			"         │       └─ org1 (longtext)\n" +
+			"         └─ TableAlias(style)\n" +
+			"             └─ IndexedTableAccess(asset)\n" +
+			"                 ├─ index: [asset.orgId,asset.name,asset.assetId]\n" +
+			"                 └─ columns: [orgid assetid name val]\n" +
 			"",
 	},
 	{
@@ -2361,31 +2333,27 @@ inner join pq on true
 		Query: `SELECT t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [t1.i:1!null]\n" +
-			" └─ Filter\n" +
+			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ t2.i:0!null\n" +
-			"     │   └─ 1 (tinyint)\n" +
-			"     └─ LookupJoin\n" +
+			"     │   ├─ t1.i:1!null\n" +
+			"     │   └─ (t2.i:0!null + 1 (tinyint))\n" +
+			"     ├─ Filter\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ t2.i:0!null\n" +
+			"     │   │   └─ 1 (tinyint)\n" +
+			"     │   └─ TableAlias(t2)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           ├─ static: [{[1, 1]}]\n" +
+			"     │           └─ columns: [i]\n" +
+			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ t1.i:1!null\n" +
-			"         │   └─ (t2.i:0!null + 1 (tinyint))\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ t2.i:0!null\n" +
-			"         │   │   └─ 1 (tinyint)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ IndexedTableAccess(mytable)\n" +
-			"         │           ├─ index: [mytable.i]\n" +
-			"         │           ├─ static: [{[1, 1]}]\n" +
-			"         │           └─ columns: [i]\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ t1.i:0!null\n" +
-			"             │   └─ 2 (tinyint)\n" +
-			"             └─ TableAlias(t1)\n" +
-			"                 └─ IndexedTableAccess(mytable)\n" +
-			"                     ├─ index: [mytable.i]\n" +
-			"                     └─ columns: [i]\n" +
+			"         │   ├─ t1.i:0!null\n" +
+			"         │   └─ 2 (tinyint)\n" +
+			"         └─ TableAlias(t1)\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
+			"                 ├─ index: [mytable.i]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2499,155 +2467,135 @@ inner join pq on true
 			"         ├─ columns: [i:0!null, s:1!null]\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [t1.i:1!null, hello (longtext)]\n" +
-			"             └─ Filter\n" +
+			"             └─ LookupJoin\n" +
 			"                 ├─ Eq\n" +
-			"                 │   ├─ t2.i:0!null\n" +
-			"                 │   └─ 1 (tinyint)\n" +
-			"                 └─ LookupJoin\n" +
+			"                 │   ├─ t1.i:1!null\n" +
+			"                 │   └─ (t2.i:0!null + 1 (tinyint))\n" +
+			"                 ├─ Filter\n" +
+			"                 │   ├─ Eq\n" +
+			"                 │   │   ├─ t2.i:0!null\n" +
+			"                 │   │   └─ 1 (tinyint)\n" +
+			"                 │   └─ TableAlias(t2)\n" +
+			"                 │       └─ IndexedTableAccess(mytable)\n" +
+			"                 │           ├─ index: [mytable.i]\n" +
+			"                 │           ├─ static: [{[1, 1]}]\n" +
+			"                 │           └─ columns: [i]\n" +
+			"                 └─ Filter\n" +
 			"                     ├─ Eq\n" +
-			"                     │   ├─ t1.i:1!null\n" +
-			"                     │   └─ (t2.i:0!null + 1 (tinyint))\n" +
-			"                     ├─ Filter\n" +
-			"                     │   ├─ Eq\n" +
-			"                     │   │   ├─ t2.i:0!null\n" +
-			"                     │   │   └─ 1 (tinyint)\n" +
-			"                     │   └─ TableAlias(t2)\n" +
-			"                     │       └─ IndexedTableAccess(mytable)\n" +
-			"                     │           ├─ index: [mytable.i]\n" +
-			"                     │           ├─ static: [{[1, 1]}]\n" +
-			"                     │           └─ columns: [i]\n" +
-			"                     └─ Filter\n" +
-			"                         ├─ Eq\n" +
-			"                         │   ├─ t1.i:0!null\n" +
-			"                         │   └─ 2 (tinyint)\n" +
-			"                         └─ TableAlias(t1)\n" +
-			"                             └─ IndexedTableAccess(mytable)\n" +
-			"                                 ├─ index: [mytable.i]\n" +
-			"                                 └─ columns: [i]\n" +
+			"                     │   ├─ t1.i:0!null\n" +
+			"                     │   └─ 2 (tinyint)\n" +
+			"                     └─ TableAlias(t1)\n" +
+			"                         └─ IndexedTableAccess(mytable)\n" +
+			"                             ├─ index: [mytable.i]\n" +
+			"                             └─ columns: [i]\n" +
 			"",
 	},
 	{
 		Query: `SELECT /*+ JOIN_ORDER(t1, t2) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [t1.i:0!null]\n" +
-			" └─ Filter\n" +
+			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ t2.i:1!null\n" +
-			"     │   └─ 1 (tinyint)\n" +
-			"     └─ LookupJoin\n" +
+			"     │   ├─ t1.i:0!null\n" +
+			"     │   └─ (t2.i:1!null + 1 (tinyint))\n" +
+			"     ├─ Filter\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ t1.i:0!null\n" +
+			"     │   │   └─ 2 (tinyint)\n" +
+			"     │   └─ TableAlias(t1)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           ├─ static: [{[2, 2]}]\n" +
+			"     │           └─ columns: [i]\n" +
+			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ t1.i:0!null\n" +
-			"         │   └─ (t2.i:1!null + 1 (tinyint))\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ t1.i:0!null\n" +
-			"         │   │   └─ 2 (tinyint)\n" +
-			"         │   └─ TableAlias(t1)\n" +
-			"         │       └─ IndexedTableAccess(mytable)\n" +
-			"         │           ├─ index: [mytable.i]\n" +
-			"         │           ├─ static: [{[2, 2]}]\n" +
-			"         │           └─ columns: [i]\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ t2.i:0!null\n" +
-			"             │   └─ 1 (tinyint)\n" +
-			"             └─ TableAlias(t2)\n" +
-			"                 └─ IndexedTableAccess(mytable)\n" +
-			"                     ├─ index: [mytable.i]\n" +
-			"                     └─ columns: [i]\n" +
+			"         │   ├─ t2.i:0!null\n" +
+			"         │   └─ 1 (tinyint)\n" +
+			"         └─ TableAlias(t2)\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
+			"                 ├─ index: [mytable.i]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
 		Query: `SELECT /*+ JOIN_ORDER(t1, mytable) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [t1.i:1!null]\n" +
-			" └─ Filter\n" +
+			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ t2.i:0!null\n" +
-			"     │   └─ 1 (tinyint)\n" +
-			"     └─ LookupJoin\n" +
+			"     │   ├─ t1.i:1!null\n" +
+			"     │   └─ (t2.i:0!null + 1 (tinyint))\n" +
+			"     ├─ Filter\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ t2.i:0!null\n" +
+			"     │   │   └─ 1 (tinyint)\n" +
+			"     │   └─ TableAlias(t2)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           ├─ static: [{[1, 1]}]\n" +
+			"     │           └─ columns: [i]\n" +
+			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ t1.i:1!null\n" +
-			"         │   └─ (t2.i:0!null + 1 (tinyint))\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ t2.i:0!null\n" +
-			"         │   │   └─ 1 (tinyint)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ IndexedTableAccess(mytable)\n" +
-			"         │           ├─ index: [mytable.i]\n" +
-			"         │           ├─ static: [{[1, 1]}]\n" +
-			"         │           └─ columns: [i]\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ t1.i:0!null\n" +
-			"             │   └─ 2 (tinyint)\n" +
-			"             └─ TableAlias(t1)\n" +
-			"                 └─ IndexedTableAccess(mytable)\n" +
-			"                     ├─ index: [mytable.i]\n" +
-			"                     └─ columns: [i]\n" +
+			"         │   ├─ t1.i:0!null\n" +
+			"         │   └─ 2 (tinyint)\n" +
+			"         └─ TableAlias(t1)\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
+			"                 ├─ index: [mytable.i]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
 		Query: `SELECT /*+ JOIN_ORDER(t1, t2, t3) */ t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [t1.i:1!null]\n" +
-			" └─ Filter\n" +
+			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ t2.i:0!null\n" +
-			"     │   └─ 1 (tinyint)\n" +
-			"     └─ LookupJoin\n" +
+			"     │   ├─ t1.i:1!null\n" +
+			"     │   └─ (t2.i:0!null + 1 (tinyint))\n" +
+			"     ├─ Filter\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ t2.i:0!null\n" +
+			"     │   │   └─ 1 (tinyint)\n" +
+			"     │   └─ TableAlias(t2)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           ├─ static: [{[1, 1]}]\n" +
+			"     │           └─ columns: [i]\n" +
+			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ t1.i:1!null\n" +
-			"         │   └─ (t2.i:0!null + 1 (tinyint))\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ t2.i:0!null\n" +
-			"         │   │   └─ 1 (tinyint)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ IndexedTableAccess(mytable)\n" +
-			"         │           ├─ index: [mytable.i]\n" +
-			"         │           ├─ static: [{[1, 1]}]\n" +
-			"         │           └─ columns: [i]\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ t1.i:0!null\n" +
-			"             │   └─ 2 (tinyint)\n" +
-			"             └─ TableAlias(t1)\n" +
-			"                 └─ IndexedTableAccess(mytable)\n" +
-			"                     ├─ index: [mytable.i]\n" +
-			"                     └─ columns: [i]\n" +
+			"         │   ├─ t1.i:0!null\n" +
+			"         │   └─ 2 (tinyint)\n" +
+			"         └─ TableAlias(t1)\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
+			"                 ├─ index: [mytable.i]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
 		Query: `SELECT t1.i FROM mytable t1 JOIN mytable t2 on t1.i = t2.i + 1 where t1.i = 2 and t2.i = 1`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [t1.i:1!null]\n" +
-			" └─ Filter\n" +
+			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ t2.i:0!null\n" +
-			"     │   └─ 1 (tinyint)\n" +
-			"     └─ LookupJoin\n" +
+			"     │   ├─ t1.i:1!null\n" +
+			"     │   └─ (t2.i:0!null + 1 (tinyint))\n" +
+			"     ├─ Filter\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ t2.i:0!null\n" +
+			"     │   │   └─ 1 (tinyint)\n" +
+			"     │   └─ TableAlias(t2)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           ├─ static: [{[1, 1]}]\n" +
+			"     │           └─ columns: [i]\n" +
+			"     └─ Filter\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ t1.i:1!null\n" +
-			"         │   └─ (t2.i:0!null + 1 (tinyint))\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ t2.i:0!null\n" +
-			"         │   │   └─ 1 (tinyint)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ IndexedTableAccess(mytable)\n" +
-			"         │           ├─ index: [mytable.i]\n" +
-			"         │           ├─ static: [{[1, 1]}]\n" +
-			"         │           └─ columns: [i]\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ t1.i:0!null\n" +
-			"             │   └─ 2 (tinyint)\n" +
-			"             └─ TableAlias(t1)\n" +
-			"                 └─ IndexedTableAccess(mytable)\n" +
-			"                     ├─ index: [mytable.i]\n" +
-			"                     └─ columns: [i]\n" +
+			"         │   ├─ t1.i:0!null\n" +
+			"         │   └─ 2 (tinyint)\n" +
+			"         └─ TableAlias(t1)\n" +
+			"             └─ IndexedTableAccess(mytable)\n" +
+			"                 ├─ index: [mytable.i]\n" +
+			"                 └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -2899,32 +2847,25 @@ inner join pq on true
 			"         ├─ cacheable: true\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [mytable.i:2!null, othertable.i2:1!null, othertable.s2:0!null]\n" +
-			"             └─ Filter\n" +
-			"                 ├─ NOT\n" +
-			"                 │   └─ Eq\n" +
-			"                 │       ├─ convert\n" +
-			"                 │       │   ├─ type: signed\n" +
-			"                 │       │   └─ othertable.s2:0!null\n" +
-			"                 │       └─ 0 (tinyint)\n" +
-			"                 └─ MergeJoin\n" +
-			"                     ├─ cmp: Eq\n" +
-			"                     │   ├─ othertable.i2:1!null\n" +
-			"                     │   └─ mytable.i:2!null\n" +
-			"                     ├─ Filter\n" +
-			"                     │   ├─ NOT\n" +
-			"                     │   │   └─ Eq\n" +
-			"                     │   │       ├─ convert\n" +
-			"                     │   │       │   ├─ type: signed\n" +
-			"                     │   │       │   └─ othertable.s2:0!null\n" +
-			"                     │   │       └─ 0 (tinyint)\n" +
-			"                     │   └─ IndexedTableAccess(othertable)\n" +
-			"                     │       ├─ index: [othertable.i2]\n" +
-			"                     │       ├─ static: [{[NULL, ∞)}]\n" +
-			"                     │       └─ columns: [s2 i2]\n" +
-			"                     └─ IndexedTableAccess(mytable)\n" +
-			"                         ├─ index: [mytable.i]\n" +
-			"                         ├─ static: [{[NULL, ∞)}]\n" +
-			"                         └─ columns: [i]\n" +
+			"             └─ MergeJoin\n" +
+			"                 ├─ cmp: Eq\n" +
+			"                 │   ├─ othertable.i2:1!null\n" +
+			"                 │   └─ mytable.i:2!null\n" +
+			"                 ├─ Filter\n" +
+			"                 │   ├─ NOT\n" +
+			"                 │   │   └─ Eq\n" +
+			"                 │   │       ├─ convert\n" +
+			"                 │   │       │   ├─ type: signed\n" +
+			"                 │   │       │   └─ othertable.s2:0!null\n" +
+			"                 │   │       └─ 0 (tinyint)\n" +
+			"                 │   └─ IndexedTableAccess(othertable)\n" +
+			"                 │       ├─ index: [othertable.i2]\n" +
+			"                 │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │       └─ columns: [s2 i2]\n" +
+			"                 └─ IndexedTableAccess(mytable)\n" +
+			"                     ├─ index: [mytable.i]\n" +
+			"                     ├─ static: [{[NULL, ∞)}]\n" +
+			"                     └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -3843,52 +3784,48 @@ inner join pq on true
 		Query: `SELECT a.* FROM mytable a, mytable b, mytable c, mytable d where a.i = b.i AND b.i = c.i AND c.i = d.i AND c.i = 2`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ Filter\n" +
-			"     ├─ Eq\n" +
-			"     │   ├─ c.i:2!null\n" +
-			"     │   └─ 2 (tinyint)\n" +
-			"     └─ LookupJoin\n" +
-			"         ├─ AND\n" +
-			"         │   ├─ AND\n" +
-			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ a.i:0!null\n" +
-			"         │   │   │   └─ b.i:4!null\n" +
-			"         │   │   └─ Eq\n" +
-			"         │   │       ├─ b.i:4!null\n" +
-			"         │   │       └─ c.i:2!null\n" +
-			"         │   └─ Eq\n" +
-			"         │       ├─ b.i:4!null\n" +
-			"         │       └─ d.i:3!null\n" +
-			"         ├─ LookupJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ c.i:2!null\n" +
-			"         │   │   └─ d.i:3!null\n" +
-			"         │   ├─ MergeJoin\n" +
-			"         │   │   ├─ cmp: Eq\n" +
-			"         │   │   │   ├─ a.i:0!null\n" +
-			"         │   │   │   └─ c.i:2!null\n" +
-			"         │   │   ├─ TableAlias(a)\n" +
-			"         │   │   │   └─ IndexedTableAccess(mytable)\n" +
-			"         │   │   │       ├─ index: [mytable.i]\n" +
-			"         │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │   │       └─ columns: [i s]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ Eq\n" +
-			"         │   │       │   ├─ c.i:0!null\n" +
-			"         │   │       │   └─ 2 (tinyint)\n" +
-			"         │   │       └─ TableAlias(c)\n" +
-			"         │   │           └─ IndexedTableAccess(mytable)\n" +
-			"         │   │               ├─ index: [mytable.i]\n" +
-			"         │   │               ├─ static: [{[2, 2]}]\n" +
-			"         │   │               └─ columns: [i]\n" +
-			"         │   └─ TableAlias(d)\n" +
-			"         │       └─ IndexedTableAccess(mytable)\n" +
-			"         │           ├─ index: [mytable.i]\n" +
-			"         │           └─ columns: [i]\n" +
-			"         └─ TableAlias(b)\n" +
-			"             └─ IndexedTableAccess(mytable)\n" +
-			"                 ├─ index: [mytable.i]\n" +
-			"                 └─ columns: [i]\n" +
+			" └─ LookupJoin\n" +
+			"     ├─ AND\n" +
+			"     │   ├─ AND\n" +
+			"     │   │   ├─ Eq\n" +
+			"     │   │   │   ├─ a.i:0!null\n" +
+			"     │   │   │   └─ b.i:4!null\n" +
+			"     │   │   └─ Eq\n" +
+			"     │   │       ├─ b.i:4!null\n" +
+			"     │   │       └─ c.i:2!null\n" +
+			"     │   └─ Eq\n" +
+			"     │       ├─ b.i:4!null\n" +
+			"     │       └─ d.i:3!null\n" +
+			"     ├─ LookupJoin\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ c.i:2!null\n" +
+			"     │   │   └─ d.i:3!null\n" +
+			"     │   ├─ MergeJoin\n" +
+			"     │   │   ├─ cmp: Eq\n" +
+			"     │   │   │   ├─ a.i:0!null\n" +
+			"     │   │   │   └─ c.i:2!null\n" +
+			"     │   │   ├─ TableAlias(a)\n" +
+			"     │   │   │   └─ IndexedTableAccess(mytable)\n" +
+			"     │   │   │       ├─ index: [mytable.i]\n" +
+			"     │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"     │   │   │       └─ columns: [i s]\n" +
+			"     │   │   └─ Filter\n" +
+			"     │   │       ├─ Eq\n" +
+			"     │   │       │   ├─ c.i:0!null\n" +
+			"     │   │       │   └─ 2 (tinyint)\n" +
+			"     │   │       └─ TableAlias(c)\n" +
+			"     │   │           └─ IndexedTableAccess(mytable)\n" +
+			"     │   │               ├─ index: [mytable.i]\n" +
+			"     │   │               ├─ static: [{[2, 2]}]\n" +
+			"     │   │               └─ columns: [i]\n" +
+			"     │   └─ TableAlias(d)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           └─ columns: [i]\n" +
+			"     └─ TableAlias(b)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.i]\n" +
+			"             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -4108,52 +4045,48 @@ inner join pq on true
 		Query: `SELECT a.* FROM mytable a CROSS JOIN mytable b CROSS JOIN mytable c CROSS JOIN mytable d where a.i = b.i AND b.i = c.i AND c.i = d.i AND c.i = 2`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
-			" └─ Filter\n" +
-			"     ├─ Eq\n" +
-			"     │   ├─ c.i:2!null\n" +
-			"     │   └─ 2 (tinyint)\n" +
-			"     └─ LookupJoin\n" +
-			"         ├─ AND\n" +
-			"         │   ├─ AND\n" +
-			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ a.i:0!null\n" +
-			"         │   │   │   └─ b.i:4!null\n" +
-			"         │   │   └─ Eq\n" +
-			"         │   │       ├─ b.i:4!null\n" +
-			"         │   │       └─ c.i:2!null\n" +
-			"         │   └─ Eq\n" +
-			"         │       ├─ b.i:4!null\n" +
-			"         │       └─ d.i:3!null\n" +
-			"         ├─ LookupJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ c.i:2!null\n" +
-			"         │   │   └─ d.i:3!null\n" +
-			"         │   ├─ MergeJoin\n" +
-			"         │   │   ├─ cmp: Eq\n" +
-			"         │   │   │   ├─ a.i:0!null\n" +
-			"         │   │   │   └─ c.i:2!null\n" +
-			"         │   │   ├─ TableAlias(a)\n" +
-			"         │   │   │   └─ IndexedTableAccess(mytable)\n" +
-			"         │   │   │       ├─ index: [mytable.i]\n" +
-			"         │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │   │       └─ columns: [i s]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ Eq\n" +
-			"         │   │       │   ├─ c.i:0!null\n" +
-			"         │   │       │   └─ 2 (tinyint)\n" +
-			"         │   │       └─ TableAlias(c)\n" +
-			"         │   │           └─ IndexedTableAccess(mytable)\n" +
-			"         │   │               ├─ index: [mytable.i]\n" +
-			"         │   │               ├─ static: [{[2, 2]}]\n" +
-			"         │   │               └─ columns: [i]\n" +
-			"         │   └─ TableAlias(d)\n" +
-			"         │       └─ IndexedTableAccess(mytable)\n" +
-			"         │           ├─ index: [mytable.i]\n" +
-			"         │           └─ columns: [i]\n" +
-			"         └─ TableAlias(b)\n" +
-			"             └─ IndexedTableAccess(mytable)\n" +
-			"                 ├─ index: [mytable.i]\n" +
-			"                 └─ columns: [i]\n" +
+			" └─ LookupJoin\n" +
+			"     ├─ AND\n" +
+			"     │   ├─ AND\n" +
+			"     │   │   ├─ Eq\n" +
+			"     │   │   │   ├─ a.i:0!null\n" +
+			"     │   │   │   └─ b.i:4!null\n" +
+			"     │   │   └─ Eq\n" +
+			"     │   │       ├─ b.i:4!null\n" +
+			"     │   │       └─ c.i:2!null\n" +
+			"     │   └─ Eq\n" +
+			"     │       ├─ b.i:4!null\n" +
+			"     │       └─ d.i:3!null\n" +
+			"     ├─ LookupJoin\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ c.i:2!null\n" +
+			"     │   │   └─ d.i:3!null\n" +
+			"     │   ├─ MergeJoin\n" +
+			"     │   │   ├─ cmp: Eq\n" +
+			"     │   │   │   ├─ a.i:0!null\n" +
+			"     │   │   │   └─ c.i:2!null\n" +
+			"     │   │   ├─ TableAlias(a)\n" +
+			"     │   │   │   └─ IndexedTableAccess(mytable)\n" +
+			"     │   │   │       ├─ index: [mytable.i]\n" +
+			"     │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"     │   │   │       └─ columns: [i s]\n" +
+			"     │   │   └─ Filter\n" +
+			"     │   │       ├─ Eq\n" +
+			"     │   │       │   ├─ c.i:0!null\n" +
+			"     │   │       │   └─ 2 (tinyint)\n" +
+			"     │   │       └─ TableAlias(c)\n" +
+			"     │   │           └─ IndexedTableAccess(mytable)\n" +
+			"     │   │               ├─ index: [mytable.i]\n" +
+			"     │   │               ├─ static: [{[2, 2]}]\n" +
+			"     │   │               └─ columns: [i]\n" +
+			"     │   └─ TableAlias(d)\n" +
+			"     │       └─ IndexedTableAccess(mytable)\n" +
+			"     │           ├─ index: [mytable.i]\n" +
+			"     │           └─ columns: [i]\n" +
+			"     └─ TableAlias(b)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.i]\n" +
+			"             └─ columns: [i]\n" +
 			"",
 	},
 	{
@@ -6358,31 +6291,27 @@ inner join pq on true
 			" └─ Sort(t1.pk:0!null ASC nullsFirst, t2.pk2:7!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [t1.pk:7!null, t1.c1:8, t1.c2:9, t1.c3:10, t1.c4:11, t1.c5:12, t2.pk1:0!null, t2.pk2:1!null, t2.c1:2!null, t2.c2:3!null, t2.c3:4!null, t2.c4:5!null, t2.c5:6!null]\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ t2.pk2:1!null\n" +
-			"             │   └─ 1 (tinyint)\n" +
-			"             └─ CrossHashJoin\n" +
-			"                 ├─ Filter\n" +
-			"                 │   ├─ Eq\n" +
-			"                 │   │   ├─ t2.pk2:1!null\n" +
-			"                 │   │   └─ 1 (tinyint)\n" +
-			"                 │   └─ TableAlias(t2)\n" +
-			"                 │       └─ Table\n" +
-			"                 │           ├─ name: two_pk\n" +
-			"                 │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			"                 └─ HashLookup\n" +
-			"                     ├─ left-key: TUPLE()\n" +
-			"                     ├─ right-key: TUPLE()\n" +
-			"                     └─ Filter\n" +
-			"                         ├─ Eq\n" +
-			"                         │   ├─ t1.pk:0!null\n" +
-			"                         │   └─ 1 (tinyint)\n" +
-			"                         └─ TableAlias(t1)\n" +
-			"                             └─ IndexedTableAccess(one_pk)\n" +
-			"                                 ├─ index: [one_pk.pk]\n" +
-			"                                 ├─ static: [{[1, 1]}]\n" +
-			"                                 └─ columns: [pk c1 c2 c3 c4 c5]\n" +
+			"         └─ CrossHashJoin\n" +
+			"             ├─ Filter\n" +
+			"             │   ├─ Eq\n" +
+			"             │   │   ├─ t2.pk2:1!null\n" +
+			"             │   │   └─ 1 (tinyint)\n" +
+			"             │   └─ TableAlias(t2)\n" +
+			"             │       └─ Table\n" +
+			"             │           ├─ name: two_pk\n" +
+			"             │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			"             └─ HashLookup\n" +
+			"                 ├─ left-key: TUPLE()\n" +
+			"                 ├─ right-key: TUPLE()\n" +
+			"                 └─ Filter\n" +
+			"                     ├─ Eq\n" +
+			"                     │   ├─ t1.pk:0!null\n" +
+			"                     │   └─ 1 (tinyint)\n" +
+			"                     └─ TableAlias(t1)\n" +
+			"                         └─ IndexedTableAccess(one_pk)\n" +
+			"                             ├─ index: [one_pk.pk]\n" +
+			"                             ├─ static: [{[1, 1]}]\n" +
+			"                             └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -6392,40 +6321,32 @@ inner join pq on true
 			" └─ Sort(t1.pk:0!null ASC nullsFirst, t2.pk1:6!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [t1.pk:7!null, t1.c1:8, t1.c2:9, t1.c3:10, t1.c4:11, t1.c5:12, t2.pk1:0!null, t2.pk2:1!null, t2.c1:2!null, t2.c2:3!null, t2.c3:4!null, t2.c4:5!null, t2.c5:6!null]\n" +
-			"         └─ Filter\n" +
-			"             ├─ AND\n" +
-			"             │   ├─ Eq\n" +
-			"             │   │   ├─ t2.pk2:1!null\n" +
-			"             │   │   └─ 1 (tinyint)\n" +
-			"             │   └─ Eq\n" +
-			"             │       ├─ t2.pk1:0!null\n" +
-			"             │       └─ 1 (tinyint)\n" +
-			"             └─ CrossHashJoin\n" +
-			"                 ├─ Filter\n" +
-			"                 │   ├─ AND\n" +
-			"                 │   │   ├─ Eq\n" +
-			"                 │   │   │   ├─ t2.pk2:1!null\n" +
-			"                 │   │   │   └─ 1 (tinyint)\n" +
-			"                 │   │   └─ Eq\n" +
-			"                 │   │       ├─ t2.pk1:0!null\n" +
-			"                 │   │       └─ 1 (tinyint)\n" +
-			"                 │   └─ TableAlias(t2)\n" +
-			"                 │       └─ IndexedTableAccess(two_pk)\n" +
-			"                 │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 │           ├─ static: [{[1, 1], [1, 1]}]\n" +
-			"                 │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			"                 └─ HashLookup\n" +
-			"                     ├─ left-key: TUPLE()\n" +
-			"                     ├─ right-key: TUPLE()\n" +
-			"                     └─ Filter\n" +
-			"                         ├─ Eq\n" +
-			"                         │   ├─ t1.pk:0!null\n" +
-			"                         │   └─ 1 (tinyint)\n" +
-			"                         └─ TableAlias(t1)\n" +
-			"                             └─ IndexedTableAccess(one_pk)\n" +
-			"                                 ├─ index: [one_pk.pk]\n" +
-			"                                 ├─ static: [{[1, 1]}]\n" +
-			"                                 └─ columns: [pk c1 c2 c3 c4 c5]\n" +
+			"         └─ CrossHashJoin\n" +
+			"             ├─ Filter\n" +
+			"             │   ├─ AND\n" +
+			"             │   │   ├─ Eq\n" +
+			"             │   │   │   ├─ t2.pk2:1!null\n" +
+			"             │   │   │   └─ 1 (tinyint)\n" +
+			"             │   │   └─ Eq\n" +
+			"             │   │       ├─ t2.pk1:0!null\n" +
+			"             │   │       └─ 1 (tinyint)\n" +
+			"             │   └─ TableAlias(t2)\n" +
+			"             │       └─ IndexedTableAccess(two_pk)\n" +
+			"             │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"             │           ├─ static: [{[1, 1], [1, 1]}]\n" +
+			"             │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			"             └─ HashLookup\n" +
+			"                 ├─ left-key: TUPLE()\n" +
+			"                 ├─ right-key: TUPLE()\n" +
+			"                 └─ Filter\n" +
+			"                     ├─ Eq\n" +
+			"                     │   ├─ t1.pk:0!null\n" +
+			"                     │   └─ 1 (tinyint)\n" +
+			"                     └─ TableAlias(t1)\n" +
+			"                         └─ IndexedTableAccess(one_pk)\n" +
+			"                             ├─ index: [one_pk.pk]\n" +
+			"                             ├─ static: [{[1, 1]}]\n" +
+			"                             └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -6524,31 +6445,27 @@ inner join pq on true
 			" └─ Sort(t1.pk:0!null ASC nullsFirst, t2.pk2:7!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [t1.pk:7!null, t1.c1:8, t1.c2:9, t1.c3:10, t1.c4:11, t1.c5:12, t2.pk1:0!null, t2.pk2:1!null, t2.c1:2!null, t2.c2:3!null, t2.c3:4!null, t2.c4:5!null, t2.c5:6!null]\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ t2.pk2:1!null\n" +
-			"             │   └─ 1 (tinyint)\n" +
-			"             └─ CrossHashJoin\n" +
-			"                 ├─ Filter\n" +
-			"                 │   ├─ Eq\n" +
-			"                 │   │   ├─ t2.pk2:1!null\n" +
-			"                 │   │   └─ 1 (tinyint)\n" +
-			"                 │   └─ TableAlias(t2)\n" +
-			"                 │       └─ Table\n" +
-			"                 │           ├─ name: two_pk\n" +
-			"                 │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			"                 └─ HashLookup\n" +
-			"                     ├─ left-key: TUPLE()\n" +
-			"                     ├─ right-key: TUPLE()\n" +
-			"                     └─ Filter\n" +
-			"                         ├─ Eq\n" +
-			"                         │   ├─ t1.pk:0!null\n" +
-			"                         │   └─ 1 (tinyint)\n" +
-			"                         └─ TableAlias(t1)\n" +
-			"                             └─ IndexedTableAccess(one_pk)\n" +
-			"                                 ├─ index: [one_pk.pk]\n" +
-			"                                 ├─ static: [{[1, 1]}]\n" +
-			"                                 └─ columns: [pk c1 c2 c3 c4 c5]\n" +
+			"         └─ CrossHashJoin\n" +
+			"             ├─ Filter\n" +
+			"             │   ├─ Eq\n" +
+			"             │   │   ├─ t2.pk2:1!null\n" +
+			"             │   │   └─ 1 (tinyint)\n" +
+			"             │   └─ TableAlias(t2)\n" +
+			"             │       └─ Table\n" +
+			"             │           ├─ name: two_pk\n" +
+			"             │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			"             └─ HashLookup\n" +
+			"                 ├─ left-key: TUPLE()\n" +
+			"                 ├─ right-key: TUPLE()\n" +
+			"                 └─ Filter\n" +
+			"                     ├─ Eq\n" +
+			"                     │   ├─ t1.pk:0!null\n" +
+			"                     │   └─ 1 (tinyint)\n" +
+			"                     └─ TableAlias(t1)\n" +
+			"                         └─ IndexedTableAccess(one_pk)\n" +
+			"                             ├─ index: [one_pk.pk]\n" +
+			"                             ├─ static: [{[1, 1]}]\n" +
+			"                             └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -7081,39 +6998,35 @@ inner join pq on true
 		Query: `select a.pk, c.v2 from one_pk_three_idx a cross join one_pk_three_idx b left join one_pk_three_idx c on b.pk = c.v1 where b.pk = 0 and a.v2 = 1;`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [a.pk:1!null, c.v2:4]\n" +
-			" └─ Filter\n" +
+			" └─ LeftOuterLookupJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ b.pk:0!null\n" +
-			"     │   └─ 0 (tinyint)\n" +
-			"     └─ LeftOuterLookupJoin\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ b.pk:0!null\n" +
-			"         │   └─ c.v1:3\n" +
-			"         ├─ CrossHashJoin\n" +
-			"         │   ├─ Filter\n" +
-			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ b.pk:0!null\n" +
-			"         │   │   │   └─ 0 (tinyint)\n" +
-			"         │   │   └─ TableAlias(b)\n" +
-			"         │   │       └─ IndexedTableAccess(one_pk_three_idx)\n" +
-			"         │   │           ├─ index: [one_pk_three_idx.pk]\n" +
-			"         │   │           ├─ static: [{[0, 0]}]\n" +
-			"         │   │           └─ columns: [pk]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: TUPLE()\n" +
-			"         │       ├─ right-key: TUPLE()\n" +
-			"         │       └─ Filter\n" +
-			"         │           ├─ Eq\n" +
-			"         │           │   ├─ a.v2:1\n" +
-			"         │           │   └─ 1 (tinyint)\n" +
-			"         │           └─ TableAlias(a)\n" +
-			"         │               └─ Table\n" +
-			"         │                   ├─ name: one_pk_three_idx\n" +
-			"         │                   └─ columns: [pk v2]\n" +
-			"         └─ TableAlias(c)\n" +
-			"             └─ IndexedTableAccess(one_pk_three_idx)\n" +
-			"                 ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
-			"                 └─ columns: [v1 v2]\n" +
+			"     │   └─ c.v1:3\n" +
+			"     ├─ CrossHashJoin\n" +
+			"     │   ├─ Filter\n" +
+			"     │   │   ├─ Eq\n" +
+			"     │   │   │   ├─ b.pk:0!null\n" +
+			"     │   │   │   └─ 0 (tinyint)\n" +
+			"     │   │   └─ TableAlias(b)\n" +
+			"     │   │       └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"     │   │           ├─ index: [one_pk_three_idx.pk]\n" +
+			"     │   │           ├─ static: [{[0, 0]}]\n" +
+			"     │   │           └─ columns: [pk]\n" +
+			"     │   └─ HashLookup\n" +
+			"     │       ├─ left-key: TUPLE()\n" +
+			"     │       ├─ right-key: TUPLE()\n" +
+			"     │       └─ Filter\n" +
+			"     │           ├─ Eq\n" +
+			"     │           │   ├─ a.v2:1\n" +
+			"     │           │   └─ 1 (tinyint)\n" +
+			"     │           └─ TableAlias(a)\n" +
+			"     │               └─ Table\n" +
+			"     │                   ├─ name: one_pk_three_idx\n" +
+			"     │                   └─ columns: [pk v2]\n" +
+			"     └─ TableAlias(c)\n" +
+			"         └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"             ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"             └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -7721,40 +7634,32 @@ inner join pq on true
 			" └─ Sort(t1.pk:0!null ASC nullsFirst, t2.pk1:6!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [t1.pk:7!null, t1.c1:8, t1.c2:9, t1.c3:10, t1.c4:11, t1.c5:12, t2.pk1:0!null, t2.pk2:1!null, t2.c1:2!null, t2.c2:3!null, t2.c3:4!null, t2.c4:5!null, t2.c5:6!null]\n" +
-			"         └─ Filter\n" +
-			"             ├─ AND\n" +
-			"             │   ├─ Eq\n" +
-			"             │   │   ├─ t2.pk2:1!null\n" +
-			"             │   │   └─ 1 (tinyint)\n" +
-			"             │   └─ Eq\n" +
-			"             │       ├─ t2.pk1:0!null\n" +
-			"             │       └─ 1 (tinyint)\n" +
-			"             └─ CrossHashJoin\n" +
-			"                 ├─ Filter\n" +
-			"                 │   ├─ AND\n" +
-			"                 │   │   ├─ Eq\n" +
-			"                 │   │   │   ├─ t2.pk2:1!null\n" +
-			"                 │   │   │   └─ 1 (tinyint)\n" +
-			"                 │   │   └─ Eq\n" +
-			"                 │   │       ├─ t2.pk1:0!null\n" +
-			"                 │   │       └─ 1 (tinyint)\n" +
-			"                 │   └─ TableAlias(t2)\n" +
-			"                 │       └─ IndexedTableAccess(two_pk)\n" +
-			"                 │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"                 │           ├─ static: [{[1, 1], [1, 1]}]\n" +
-			"                 │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
-			"                 └─ HashLookup\n" +
-			"                     ├─ left-key: TUPLE()\n" +
-			"                     ├─ right-key: TUPLE()\n" +
-			"                     └─ Filter\n" +
-			"                         ├─ Eq\n" +
-			"                         │   ├─ t1.pk:0!null\n" +
-			"                         │   └─ 1 (tinyint)\n" +
-			"                         └─ TableAlias(t1)\n" +
-			"                             └─ IndexedTableAccess(one_pk)\n" +
-			"                                 ├─ index: [one_pk.pk]\n" +
-			"                                 ├─ static: [{[1, 1]}]\n" +
-			"                                 └─ columns: [pk c1 c2 c3 c4 c5]\n" +
+			"         └─ CrossHashJoin\n" +
+			"             ├─ Filter\n" +
+			"             │   ├─ AND\n" +
+			"             │   │   ├─ Eq\n" +
+			"             │   │   │   ├─ t2.pk2:1!null\n" +
+			"             │   │   │   └─ 1 (tinyint)\n" +
+			"             │   │   └─ Eq\n" +
+			"             │   │       ├─ t2.pk1:0!null\n" +
+			"             │   │       └─ 1 (tinyint)\n" +
+			"             │   └─ TableAlias(t2)\n" +
+			"             │       └─ IndexedTableAccess(two_pk)\n" +
+			"             │           ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"             │           ├─ static: [{[1, 1], [1, 1]}]\n" +
+			"             │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			"             └─ HashLookup\n" +
+			"                 ├─ left-key: TUPLE()\n" +
+			"                 ├─ right-key: TUPLE()\n" +
+			"                 └─ Filter\n" +
+			"                     ├─ Eq\n" +
+			"                     │   ├─ t1.pk:0!null\n" +
+			"                     │   └─ 1 (tinyint)\n" +
+			"                     └─ TableAlias(t1)\n" +
+			"                         └─ IndexedTableAccess(one_pk)\n" +
+			"                             ├─ index: [one_pk.pk]\n" +
+			"                             ├─ static: [{[1, 1]}]\n" +
+			"                             └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
 	{
@@ -7839,14 +7744,14 @@ inner join pq on true
 	{
 		Query: `with recursive a(x) as (select 1 union select 2) select * from a where x > 1 union select * from a where x > 1;`,
 		ExpectedPlan: "Union distinct\n" +
-			" ├─ SubqueryAlias\n" +
-			" │   ├─ name: a\n" +
-			" │   ├─ outerVisibility: false\n" +
-			" │   ├─ cacheable: true\n" +
-			" │   └─ Filter\n" +
-			" │       ├─ GreaterThan\n" +
-			" │       │   ├─ 1:0!null\n" +
-			" │       │   └─ 1 (tinyint)\n" +
+			" ├─ Filter\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ a.x:0!null\n" +
+			" │   │   └─ 1 (tinyint)\n" +
+			" │   └─ SubqueryAlias\n" +
+			" │       ├─ name: a\n" +
+			" │       ├─ outerVisibility: false\n" +
+			" │       ├─ cacheable: true\n" +
 			" │       └─ Union distinct\n" +
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [1 (tinyint)]\n" +
@@ -7858,14 +7763,14 @@ inner join pq on true
 			" │               └─ Table\n" +
 			" │                   ├─ name: \n" +
 			" │                   └─ columns: []\n" +
-			" └─ SubqueryAlias\n" +
-			"     ├─ name: a\n" +
-			"     ├─ outerVisibility: false\n" +
-			"     ├─ cacheable: true\n" +
-			"     └─ Filter\n" +
-			"         ├─ GreaterThan\n" +
-			"         │   ├─ 1:0!null\n" +
-			"         │   └─ 1 (tinyint)\n" +
+			" └─ Filter\n" +
+			"     ├─ GreaterThan\n" +
+			"     │   ├─ a.x:0!null\n" +
+			"     │   └─ 1 (tinyint)\n" +
+			"     └─ SubqueryAlias\n" +
+			"         ├─ name: a\n" +
+			"         ├─ outerVisibility: false\n" +
+			"         ├─ cacheable: true\n" +
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1 (tinyint)]\n" +
@@ -10147,59 +10052,55 @@ WHERE
 	`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [ct.id:0!null as id, ci.FTQLQ:13!null as VCGT3, nd.TW55N:15!null as UWBAI, aac.BTXC5:9 as TPXBU, ct.V5DPX:5!null as V5DPX, ct.S3Q3Y:6!null as S3Q3Y, ct.ZRV3B:7!null as ZRV3B]\n" +
-			" └─ Filter\n" +
+			" └─ HashJoin\n" +
 			"     ├─ Eq\n" +
-			"     │   ├─ tvtjs.SWCQV:11!null\n" +
-			"     │   └─ 1 (tinyint)\n" +
-			"     └─ HashJoin\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ nd.id:14!null\n" +
-			"         │   └─ ct.LUEVY:2!null\n" +
-			"         ├─ HashJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ ci.id:12!null\n" +
-			"         │   │   └─ ct.FZ2R5:1!null\n" +
-			"         │   ├─ HashJoin\n" +
-			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ tvtjs.id:10!null\n" +
-			"         │   │   │   └─ ct.XMM6Q:4\n" +
-			"         │   │   ├─ LookupJoin\n" +
-			"         │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   ├─ aac.id:8!null\n" +
-			"         │   │   │   │   └─ ct.M22QN:3!null\n" +
-			"         │   │   │   ├─ TableAlias(ct)\n" +
-			"         │   │   │   │   └─ Table\n" +
-			"         │   │   │   │       ├─ name: FLQLP\n" +
-			"         │   │   │   │       └─ columns: [id fz2r5 luevy m22qn xmm6q v5dpx s3q3y zrv3b]\n" +
-			"         │   │   │   └─ TableAlias(aac)\n" +
-			"         │   │   │       └─ IndexedTableAccess(TPXBU)\n" +
-			"         │   │   │           ├─ index: [TPXBU.id]\n" +
-			"         │   │   │           └─ columns: [id btxc5]\n" +
-			"         │   │   └─ HashLookup\n" +
-			"         │   │       ├─ left-key: TUPLE(ct.XMM6Q:4)\n" +
-			"         │   │       ├─ right-key: TUPLE(tvtjs.id:0!null)\n" +
-			"         │   │       └─ Filter\n" +
-			"         │   │           ├─ Eq\n" +
-			"         │   │           │   ├─ tvtjs.SWCQV:1!null\n" +
-			"         │   │           │   └─ 1 (tinyint)\n" +
-			"         │   │           └─ TableAlias(tvtjs)\n" +
-			"         │   │               └─ Table\n" +
-			"         │   │                   ├─ name: HU5A5\n" +
-			"         │   │                   └─ columns: [id swcqv]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: TUPLE(ct.FZ2R5:1!null)\n" +
-			"         │       ├─ right-key: TUPLE(ci.id:0!null)\n" +
-			"         │       └─ TableAlias(ci)\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: JDLNA\n" +
-			"         │               └─ columns: [id ftqlq]\n" +
-			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(ct.LUEVY:2!null)\n" +
-			"             ├─ right-key: TUPLE(nd.id:0!null)\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: E2I7U\n" +
-			"                     └─ columns: [id tw55n]\n" +
+			"     │   ├─ nd.id:14!null\n" +
+			"     │   └─ ct.LUEVY:2!null\n" +
+			"     ├─ HashJoin\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ ci.id:12!null\n" +
+			"     │   │   └─ ct.FZ2R5:1!null\n" +
+			"     │   ├─ HashJoin\n" +
+			"     │   │   ├─ Eq\n" +
+			"     │   │   │   ├─ tvtjs.id:10!null\n" +
+			"     │   │   │   └─ ct.XMM6Q:4\n" +
+			"     │   │   ├─ LookupJoin\n" +
+			"     │   │   │   ├─ Eq\n" +
+			"     │   │   │   │   ├─ aac.id:8!null\n" +
+			"     │   │   │   │   └─ ct.M22QN:3!null\n" +
+			"     │   │   │   ├─ TableAlias(ct)\n" +
+			"     │   │   │   │   └─ Table\n" +
+			"     │   │   │   │       ├─ name: FLQLP\n" +
+			"     │   │   │   │       └─ columns: [id fz2r5 luevy m22qn xmm6q v5dpx s3q3y zrv3b]\n" +
+			"     │   │   │   └─ TableAlias(aac)\n" +
+			"     │   │   │       └─ IndexedTableAccess(TPXBU)\n" +
+			"     │   │   │           ├─ index: [TPXBU.id]\n" +
+			"     │   │   │           └─ columns: [id btxc5]\n" +
+			"     │   │   └─ HashLookup\n" +
+			"     │   │       ├─ left-key: TUPLE(ct.XMM6Q:4)\n" +
+			"     │   │       ├─ right-key: TUPLE(tvtjs.id:0!null)\n" +
+			"     │   │       └─ Filter\n" +
+			"     │   │           ├─ Eq\n" +
+			"     │   │           │   ├─ tvtjs.SWCQV:1!null\n" +
+			"     │   │           │   └─ 1 (tinyint)\n" +
+			"     │   │           └─ TableAlias(tvtjs)\n" +
+			"     │   │               └─ Table\n" +
+			"     │   │                   ├─ name: HU5A5\n" +
+			"     │   │                   └─ columns: [id swcqv]\n" +
+			"     │   └─ HashLookup\n" +
+			"     │       ├─ left-key: TUPLE(ct.FZ2R5:1!null)\n" +
+			"     │       ├─ right-key: TUPLE(ci.id:0!null)\n" +
+			"     │       └─ TableAlias(ci)\n" +
+			"     │           └─ Table\n" +
+			"     │               ├─ name: JDLNA\n" +
+			"     │               └─ columns: [id ftqlq]\n" +
+			"     └─ HashLookup\n" +
+			"         ├─ left-key: TUPLE(ct.LUEVY:2!null)\n" +
+			"         ├─ right-key: TUPLE(nd.id:0!null)\n" +
+			"         └─ TableAlias(nd)\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: E2I7U\n" +
+			"                 └─ columns: [id tw55n]\n" +
 			"",
 	},
 	{
@@ -10746,56 +10647,53 @@ WHERE
 		ExpectedPlan: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
-			"     └─ Filter\n" +
-			"         ├─ NOT\n" +
-			"         │   └─ nd.ZH72S:48 IS NULL\n" +
-			"         └─ HashJoin\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ nd.ZH72S:48\n" +
-			"             │   └─ ufc.ZH72S:2\n" +
-			"             ├─ HashJoin\n" +
-			"             │   ├─ Eq\n" +
-			"             │   │   ├─ cla.FTQLQ:12!null\n" +
-			"             │   │   └─ ufc.T4IBQ:1\n" +
-			"             │   ├─ Project\n" +
-			"             │   │   ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
-			"             │   │   └─ Filter\n" +
-			"             │   │       ├─ scalarSubq0.KKGN5:11 IS NULL\n" +
-			"             │   │       └─ LeftOuterHashJoinExcludeNulls\n" +
-			"             │   │           ├─ Eq\n" +
-			"             │   │           │   ├─ ufc.id:0!null\n" +
-			"             │   │           │   └─ scalarSubq0.KKGN5:11\n" +
-			"             │   │           ├─ TableAlias(ufc)\n" +
-			"             │   │           │   └─ Table\n" +
-			"             │   │           │       ├─ name: SISUT\n" +
-			"             │   │           │       └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
-			"             │   │           └─ HashLookup\n" +
-			"             │   │               ├─ left-key: TUPLE(ufc.id:0!null)\n" +
-			"             │   │               ├─ right-key: TUPLE(scalarSubq0.KKGN5:0)\n" +
-			"             │   │               └─ Project\n" +
-			"             │   │                   ├─ columns: [scalarSubq0.KKGN5:7]\n" +
-			"             │   │                   └─ TableAlias(scalarSubq0)\n" +
-			"             │   │                       └─ Table\n" +
-			"             │   │                           ├─ name: AMYXQ\n" +
-			"             │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
-			"             │   └─ HashLookup\n" +
-			"             │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
-			"             │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
-			"             │       └─ TableAlias(cla)\n" +
-			"             │           └─ Table\n" +
-			"             │               ├─ name: YK2GW\n" +
-			"             │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
-			"             └─ HashLookup\n" +
-			"                 ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
-			"                 ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
-			"                 └─ Filter\n" +
-			"                     ├─ NOT\n" +
-			"                     │   └─ nd.ZH72S:7 IS NULL\n" +
-			"                     └─ TableAlias(nd)\n" +
-			"                         └─ IndexedTableAccess(E2I7U)\n" +
-			"                             ├─ index: [E2I7U.ZH72S]\n" +
-			"                             ├─ static: [{(NULL, ∞)}]\n" +
-			"                             └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     └─ HashJoin\n" +
+			"         ├─ Eq\n" +
+			"         │   ├─ nd.ZH72S:48\n" +
+			"         │   └─ ufc.ZH72S:2\n" +
+			"         ├─ HashJoin\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ cla.FTQLQ:12!null\n" +
+			"         │   │   └─ ufc.T4IBQ:1\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ scalarSubq0.KKGN5:11 IS NULL\n" +
+			"         │   │       └─ LeftOuterHashJoinExcludeNulls\n" +
+			"         │   │           ├─ Eq\n" +
+			"         │   │           │   ├─ ufc.id:0!null\n" +
+			"         │   │           │   └─ scalarSubq0.KKGN5:11\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ Table\n" +
+			"         │   │           │       ├─ name: SISUT\n" +
+			"         │   │           │       └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
+			"         │   │           └─ HashLookup\n" +
+			"         │   │               ├─ left-key: TUPLE(ufc.id:0!null)\n" +
+			"         │   │               ├─ right-key: TUPLE(scalarSubq0.KKGN5:0)\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [scalarSubq0.KKGN5:7]\n" +
+			"         │   │                   └─ TableAlias(scalarSubq0)\n" +
+			"         │   │                       └─ Table\n" +
+			"         │   │                           ├─ name: AMYXQ\n" +
+			"         │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
+			"         │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ Table\n" +
+			"         │               ├─ name: YK2GW\n" +
+			"         │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"         └─ HashLookup\n" +
+			"             ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
+			"             ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
+			"             └─ Filter\n" +
+			"                 ├─ NOT\n" +
+			"                 │   └─ nd.ZH72S:7 IS NULL\n" +
+			"                 └─ TableAlias(nd)\n" +
+			"                     └─ IndexedTableAccess(E2I7U)\n" +
+			"                         ├─ index: [E2I7U.ZH72S]\n" +
+			"                         ├─ static: [{(NULL, ∞)}]\n" +
+			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -10820,56 +10718,53 @@ WHERE
 		ExpectedPlan: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
-			"     └─ Filter\n" +
-			"         ├─ NOT\n" +
-			"         │   └─ nd.ZH72S:48 IS NULL\n" +
-			"         └─ HashJoin\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ nd.ZH72S:48\n" +
-			"             │   └─ ufc.ZH72S:2\n" +
-			"             ├─ HashJoin\n" +
-			"             │   ├─ Eq\n" +
-			"             │   │   ├─ cla.FTQLQ:12!null\n" +
-			"             │   │   └─ ufc.T4IBQ:1\n" +
-			"             │   ├─ Project\n" +
-			"             │   │   ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
-			"             │   │   └─ Filter\n" +
-			"             │   │       ├─ scalarSubq0.KKGN5:11 IS NULL\n" +
-			"             │   │       └─ LeftOuterHashJoinExcludeNulls\n" +
-			"             │   │           ├─ Eq\n" +
-			"             │   │           │   ├─ ufc.id:0!null\n" +
-			"             │   │           │   └─ scalarSubq0.KKGN5:11\n" +
-			"             │   │           ├─ TableAlias(ufc)\n" +
-			"             │   │           │   └─ Table\n" +
-			"             │   │           │       ├─ name: SISUT\n" +
-			"             │   │           │       └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
-			"             │   │           └─ HashLookup\n" +
-			"             │   │               ├─ left-key: TUPLE(ufc.id:0!null)\n" +
-			"             │   │               ├─ right-key: TUPLE(scalarSubq0.KKGN5:0)\n" +
-			"             │   │               └─ Project\n" +
-			"             │   │                   ├─ columns: [scalarSubq0.KKGN5:7]\n" +
-			"             │   │                   └─ TableAlias(scalarSubq0)\n" +
-			"             │   │                       └─ Table\n" +
-			"             │   │                           ├─ name: AMYXQ\n" +
-			"             │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
-			"             │   └─ HashLookup\n" +
-			"             │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
-			"             │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
-			"             │       └─ TableAlias(cla)\n" +
-			"             │           └─ Table\n" +
-			"             │               ├─ name: YK2GW\n" +
-			"             │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
-			"             └─ HashLookup\n" +
-			"                 ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
-			"                 ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
-			"                 └─ Filter\n" +
-			"                     ├─ NOT\n" +
-			"                     │   └─ nd.ZH72S:7 IS NULL\n" +
-			"                     └─ TableAlias(nd)\n" +
-			"                         └─ IndexedTableAccess(E2I7U)\n" +
-			"                             ├─ index: [E2I7U.ZH72S]\n" +
-			"                             ├─ static: [{(NULL, ∞)}]\n" +
-			"                             └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     └─ HashJoin\n" +
+			"         ├─ Eq\n" +
+			"         │   ├─ nd.ZH72S:48\n" +
+			"         │   └─ ufc.ZH72S:2\n" +
+			"         ├─ HashJoin\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ cla.FTQLQ:12!null\n" +
+			"         │   │   └─ ufc.T4IBQ:1\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ scalarSubq0.KKGN5:11 IS NULL\n" +
+			"         │   │       └─ LeftOuterHashJoinExcludeNulls\n" +
+			"         │   │           ├─ Eq\n" +
+			"         │   │           │   ├─ ufc.id:0!null\n" +
+			"         │   │           │   └─ scalarSubq0.KKGN5:11\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ Table\n" +
+			"         │   │           │       ├─ name: SISUT\n" +
+			"         │   │           │       └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
+			"         │   │           └─ HashLookup\n" +
+			"         │   │               ├─ left-key: TUPLE(ufc.id:0!null)\n" +
+			"         │   │               ├─ right-key: TUPLE(scalarSubq0.KKGN5:0)\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [scalarSubq0.KKGN5:7]\n" +
+			"         │   │                   └─ TableAlias(scalarSubq0)\n" +
+			"         │   │                       └─ Table\n" +
+			"         │   │                           ├─ name: AMYXQ\n" +
+			"         │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
+			"         │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ Table\n" +
+			"         │               ├─ name: YK2GW\n" +
+			"         │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"         └─ HashLookup\n" +
+			"             ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
+			"             ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
+			"             └─ Filter\n" +
+			"                 ├─ NOT\n" +
+			"                 │   └─ nd.ZH72S:7 IS NULL\n" +
+			"                 └─ TableAlias(nd)\n" +
+			"                     └─ IndexedTableAccess(E2I7U)\n" +
+			"                         ├─ index: [E2I7U.ZH72S]\n" +
+			"                         ├─ static: [{(NULL, ∞)}]\n" +
+			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -11149,61 +11044,58 @@ WHERE
 	`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [umf.id:0!null, umf.T4IBQ:1, umf.FGG57:2, umf.SSHPJ:3, umf.NLA6O:4, umf.SFJ6L:5, umf.TJPT7:6, umf.ARN5P:7, umf.SYPKF:8, umf.IVFMK:9, umf.IDE43:10, umf.AZ6SP:11, umf.FSDY2:12, umf.XOSD4:13, umf.HMW4H:14, umf.S76OM:15, umf.vaf:16, umf.ZROH6:17, umf.QCGTS:18, umf.LNFM6:19, umf.TVAWL:20, umf.HDLCL:21, umf.BHHW6:22, umf.FHCYT:23, umf.QZ6VT:24]\n" +
-			" └─ Filter\n" +
-			"     ├─ NOT\n" +
-			"     │   └─ nd.FGG57:61 IS NULL\n" +
-			"     └─ HashJoin\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ nd.FGG57:61\n" +
-			"         │   └─ umf.FGG57:2\n" +
-			"         ├─ HashJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ cla.FTQLQ:26!null\n" +
-			"         │   │   └─ umf.T4IBQ:1\n" +
-			"         │   ├─ Project\n" +
-			"         │   │   ├─ columns: [umf.id:0!null, umf.T4IBQ:1, umf.FGG57:2, umf.SSHPJ:3, umf.NLA6O:4, umf.SFJ6L:5, umf.TJPT7:6, umf.ARN5P:7, umf.SYPKF:8, umf.IVFMK:9, umf.IDE43:10, umf.AZ6SP:11, umf.FSDY2:12, umf.XOSD4:13, umf.HMW4H:14, umf.S76OM:15, umf.vaf:16, umf.ZROH6:17, umf.QCGTS:18, umf.LNFM6:19, umf.TVAWL:20, umf.HDLCL:21, umf.BHHW6:22, umf.FHCYT:23, umf.QZ6VT:24]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ scalarSubq0.TEUJA:25 IS NULL\n" +
-			"         │   │       └─ LeftOuterHashJoinExcludeNulls\n" +
-			"         │   │           ├─ Eq\n" +
-			"         │   │           │   ├─ umf.id:0!null\n" +
-			"         │   │           │   └─ scalarSubq0.TEUJA:25\n" +
-			"         │   │           ├─ Filter\n" +
-			"         │   │           │   ├─ NOT\n" +
-			"         │   │           │   │   └─ Eq\n" +
-			"         │   │           │   │       ├─ umf.ARN5P:7\n" +
-			"         │   │           │   │       └─ N/A (longtext)\n" +
-			"         │   │           │   └─ TableAlias(umf)\n" +
-			"         │   │           │       └─ Table\n" +
-			"         │   │           │           ├─ name: NZKPM\n" +
-			"         │   │           │           └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
-			"         │   │           └─ HashLookup\n" +
-			"         │   │               ├─ left-key: TUPLE(umf.id:0!null)\n" +
-			"         │   │               ├─ right-key: TUPLE(scalarSubq0.TEUJA:0)\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [scalarSubq0.TEUJA:14]\n" +
-			"         │   │                   └─ TableAlias(scalarSubq0)\n" +
-			"         │   │                       └─ Table\n" +
-			"         │   │                           ├─ name: HGMQ6\n" +
-			"         │   │                           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: TUPLE(umf.T4IBQ:1)\n" +
-			"         │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
-			"         │       └─ TableAlias(cla)\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: YK2GW\n" +
-			"         │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
-			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(umf.FGG57:2)\n" +
-			"             ├─ right-key: TUPLE(nd.FGG57:6)\n" +
-			"             └─ Filter\n" +
-			"                 ├─ NOT\n" +
-			"                 │   └─ nd.FGG57:6 IS NULL\n" +
-			"                 └─ TableAlias(nd)\n" +
-			"                     └─ IndexedTableAccess(E2I7U)\n" +
-			"                         ├─ index: [E2I7U.FGG57]\n" +
-			"                         ├─ static: [{(NULL, ∞)}]\n" +
-			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			" └─ HashJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ nd.FGG57:61\n" +
+			"     │   └─ umf.FGG57:2\n" +
+			"     ├─ HashJoin\n" +
+			"     │   ├─ Eq\n" +
+			"     │   │   ├─ cla.FTQLQ:26!null\n" +
+			"     │   │   └─ umf.T4IBQ:1\n" +
+			"     │   ├─ Project\n" +
+			"     │   │   ├─ columns: [umf.id:0!null, umf.T4IBQ:1, umf.FGG57:2, umf.SSHPJ:3, umf.NLA6O:4, umf.SFJ6L:5, umf.TJPT7:6, umf.ARN5P:7, umf.SYPKF:8, umf.IVFMK:9, umf.IDE43:10, umf.AZ6SP:11, umf.FSDY2:12, umf.XOSD4:13, umf.HMW4H:14, umf.S76OM:15, umf.vaf:16, umf.ZROH6:17, umf.QCGTS:18, umf.LNFM6:19, umf.TVAWL:20, umf.HDLCL:21, umf.BHHW6:22, umf.FHCYT:23, umf.QZ6VT:24]\n" +
+			"     │   │   └─ Filter\n" +
+			"     │   │       ├─ scalarSubq0.TEUJA:25 IS NULL\n" +
+			"     │   │       └─ LeftOuterHashJoinExcludeNulls\n" +
+			"     │   │           ├─ Eq\n" +
+			"     │   │           │   ├─ umf.id:0!null\n" +
+			"     │   │           │   └─ scalarSubq0.TEUJA:25\n" +
+			"     │   │           ├─ Filter\n" +
+			"     │   │           │   ├─ NOT\n" +
+			"     │   │           │   │   └─ Eq\n" +
+			"     │   │           │   │       ├─ umf.ARN5P:7\n" +
+			"     │   │           │   │       └─ N/A (longtext)\n" +
+			"     │   │           │   └─ TableAlias(umf)\n" +
+			"     │   │           │       └─ Table\n" +
+			"     │   │           │           ├─ name: NZKPM\n" +
+			"     │   │           │           └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
+			"     │   │           └─ HashLookup\n" +
+			"     │   │               ├─ left-key: TUPLE(umf.id:0!null)\n" +
+			"     │   │               ├─ right-key: TUPLE(scalarSubq0.TEUJA:0)\n" +
+			"     │   │               └─ Project\n" +
+			"     │   │                   ├─ columns: [scalarSubq0.TEUJA:14]\n" +
+			"     │   │                   └─ TableAlias(scalarSubq0)\n" +
+			"     │   │                       └─ Table\n" +
+			"     │   │                           ├─ name: HGMQ6\n" +
+			"     │   │                           └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
+			"     │   └─ HashLookup\n" +
+			"     │       ├─ left-key: TUPLE(umf.T4IBQ:1)\n" +
+			"     │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
+			"     │       └─ TableAlias(cla)\n" +
+			"     │           └─ Table\n" +
+			"     │               ├─ name: YK2GW\n" +
+			"     │               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"     └─ HashLookup\n" +
+			"         ├─ left-key: TUPLE(umf.FGG57:2)\n" +
+			"         ├─ right-key: TUPLE(nd.FGG57:6)\n" +
+			"         └─ Filter\n" +
+			"             ├─ NOT\n" +
+			"             │   └─ nd.FGG57:6 IS NULL\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     ├─ index: [E2I7U.FGG57]\n" +
+			"                     ├─ static: [{(NULL, ∞)}]\n" +
+			"                     └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 	},
 	{
@@ -11337,8 +11229,8 @@ WHERE
 			" │       │           │   ├─ aac.id:74!null\n" +
 			" │       │           │   └─ sl3s5.M22QN:63!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			" │       │                   ├─ index: [TPXBU.id]\n" +
+			" │       │               └─ Table\n" +
+			" │       │                   ├─ name: TPXBU\n" +
 			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
 			" │       └─ Project\n" +
@@ -11352,8 +11244,8 @@ WHERE
 			" │           │           │   ├─ aac.id:67!null\n" +
 			" │           │           │   └─ sl3s5.M22QN:19!null\n" +
 			" │           │           └─ TableAlias(aac)\n" +
-			" │           │               └─ IndexedTableAccess(TPXBU)\n" +
-			" │           │                   ├─ index: [TPXBU.id]\n" +
+			" │           │               └─ Table\n" +
+			" │           │                   ├─ name: TPXBU\n" +
 			" │           │                   └─ columns: [id btxc5]\n" +
 			" │           │   as TPXBU, sl3s5.NO52D:21!null as NO52D, sl3s5.IDPK7:22!null as IDPK7]\n" +
 			" │           └─ HashJoin\n" +
@@ -11385,76 +11277,72 @@ WHERE
 			" │               │           │   ├─ cacheable: true\n" +
 			" │               │           │   └─ Project\n" +
 			" │               │           │       ├─ columns: [khjjo.BDNYB:12!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:4!null as M22QN, cec.ADURZ:10!null as ADURZ, cec.NO52D:9!null as NO52D, ct.S3Q3Y:6!null as IDPK7]\n" +
-			" │               │           │       └─ Filter\n" +
-			" │               │           │           ├─ HashIn\n" +
-			" │               │           │           │   ├─ ci.FTQLQ:1!null\n" +
-			" │               │           │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │               │           │           └─ HashJoin\n" +
-			" │               │           │               ├─ AND\n" +
-			" │               │           │               │   ├─ Eq\n" +
-			" │               │           │               │   │   ├─ ct.M22QN:4!null\n" +
-			" │               │           │               │   │   └─ khjjo.M22QN:11!null\n" +
-			" │               │           │               │   └─ Eq\n" +
-			" │               │           │               │       ├─ ct.LUEVY:3!null\n" +
-			" │               │           │               │       └─ khjjo.LUEVY:13!null\n" +
-			" │               │           │               ├─ HashJoin\n" +
-			" │               │           │               │   ├─ Eq\n" +
-			" │               │           │               │   │   ├─ cec.id:8!null\n" +
-			" │               │           │               │   │   └─ ct.OVE3E:5!null\n" +
-			" │               │           │               │   ├─ MergeJoin\n" +
-			" │               │           │               │   │   ├─ cmp: Eq\n" +
-			" │               │           │               │   │   │   ├─ ci.id:0!null\n" +
-			" │               │           │               │   │   │   └─ ct.FZ2R5:2!null\n" +
-			" │               │           │               │   │   ├─ Filter\n" +
-			" │               │           │               │   │   │   ├─ HashIn\n" +
-			" │               │           │               │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
-			" │               │           │               │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │               │           │               │   │   │   └─ TableAlias(ci)\n" +
-			" │               │           │               │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
-			" │               │           │               │   │   │           ├─ index: [JDLNA.id]\n" +
-			" │               │           │               │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			" │               │           │               │   │   │           └─ columns: [id ftqlq]\n" +
-			" │               │           │               │   │   └─ Filter\n" +
-			" │               │           │               │   │       ├─ Eq\n" +
-			" │               │           │               │   │       │   ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │               │   │       │   └─ = (longtext)\n" +
-			" │               │           │               │   │       └─ TableAlias(ct)\n" +
-			" │               │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			" │               │           │               │   │               ├─ index: [FLQLP.FZ2R5]\n" +
-			" │               │           │               │   │               ├─ static: [{[NULL, ∞)}]\n" +
-			" │               │           │               │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
-			" │               │           │               │   └─ HashLookup\n" +
-			" │               │           │               │       ├─ left-key: TUPLE(ct.OVE3E:5!null)\n" +
-			" │               │           │               │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
-			" │               │           │               │       └─ TableAlias(cec)\n" +
-			" │               │           │               │           └─ Table\n" +
-			" │               │           │               │               ├─ name: SFEGG\n" +
-			" │               │           │               │               └─ columns: [id no52d adurz]\n" +
-			" │               │           │               └─ HashLookup\n" +
-			" │               │           │                   ├─ left-key: TUPLE(ct.M22QN:4!null, ct.LUEVY:3!null)\n" +
-			" │               │           │                   ├─ right-key: TUPLE(khjjo.M22QN:0!null, khjjo.LUEVY:2!null)\n" +
-			" │               │           │                   └─ SubqueryAlias\n" +
-			" │               │           │                       ├─ name: khjjo\n" +
-			" │               │           │                       ├─ outerVisibility: false\n" +
-			" │               │           │                       ├─ cacheable: true\n" +
-			" │               │           │                       └─ Distinct\n" +
-			" │               │           │                           └─ Project\n" +
-			" │               │           │                               ├─ columns: [mf.M22QN:3!null as M22QN, sn.id:17!null as BDNYB, mf.LUEVY:2!null as LUEVY]\n" +
-			" │               │           │                               └─ HashJoin\n" +
-			" │               │           │                                   ├─ Eq\n" +
-			" │               │           │                                   │   ├─ sn.BRQP2:18!null\n" +
-			" │               │           │                                   │   └─ mf.LUEVY:2!null\n" +
-			" │               │           │                                   ├─ TableAlias(mf)\n" +
-			" │               │           │                                   │   └─ Table\n" +
-			" │               │           │                                   │       ├─ name: HGMQ6\n" +
-			" │               │           │                                   │       └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
-			" │               │           │                                   └─ HashLookup\n" +
-			" │               │           │                                       ├─ left-key: TUPLE(mf.LUEVY:2!null)\n" +
-			" │               │           │                                       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			" │               │           │                                       └─ TableAlias(sn)\n" +
-			" │               │           │                                           └─ Table\n" +
-			" │               │           │                                               ├─ name: NOXN3\n" +
-			" │               │           │                                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			" │               │           │       └─ HashJoin\n" +
+			" │               │           │           ├─ AND\n" +
+			" │               │           │           │   ├─ Eq\n" +
+			" │               │           │           │   │   ├─ ct.M22QN:4!null\n" +
+			" │               │           │           │   │   └─ khjjo.M22QN:11!null\n" +
+			" │               │           │           │   └─ Eq\n" +
+			" │               │           │           │       ├─ ct.LUEVY:3!null\n" +
+			" │               │           │           │       └─ khjjo.LUEVY:13!null\n" +
+			" │               │           │           ├─ HashJoin\n" +
+			" │               │           │           │   ├─ Eq\n" +
+			" │               │           │           │   │   ├─ cec.id:8!null\n" +
+			" │               │           │           │   │   └─ ct.OVE3E:5!null\n" +
+			" │               │           │           │   ├─ MergeJoin\n" +
+			" │               │           │           │   │   ├─ cmp: Eq\n" +
+			" │               │           │           │   │   │   ├─ ci.id:0!null\n" +
+			" │               │           │           │   │   │   └─ ct.FZ2R5:2!null\n" +
+			" │               │           │           │   │   ├─ Filter\n" +
+			" │               │           │           │   │   │   ├─ HashIn\n" +
+			" │               │           │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
+			" │               │           │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			" │               │           │           │   │   │   └─ TableAlias(ci)\n" +
+			" │               │           │           │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
+			" │               │           │           │   │   │           ├─ index: [JDLNA.id]\n" +
+			" │               │           │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			" │               │           │           │   │   │           └─ columns: [id ftqlq]\n" +
+			" │               │           │           │   │   └─ Filter\n" +
+			" │               │           │           │   │       ├─ Eq\n" +
+			" │               │           │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │   └─ = (longtext)\n" +
+			" │               │           │           │   │       └─ TableAlias(ct)\n" +
+			" │               │           │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			" │               │           │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
+			" │               │           │           │   │               ├─ static: [{[NULL, ∞)}]\n" +
+			" │               │           │           │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
+			" │               │           │           │   └─ HashLookup\n" +
+			" │               │           │           │       ├─ left-key: TUPLE(ct.OVE3E:5!null)\n" +
+			" │               │           │           │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
+			" │               │           │           │       └─ TableAlias(cec)\n" +
+			" │               │           │           │           └─ Table\n" +
+			" │               │           │           │               ├─ name: SFEGG\n" +
+			" │               │           │           │               └─ columns: [id no52d adurz]\n" +
+			" │               │           │           └─ HashLookup\n" +
+			" │               │           │               ├─ left-key: TUPLE(ct.M22QN:4!null, ct.LUEVY:3!null)\n" +
+			" │               │           │               ├─ right-key: TUPLE(khjjo.M22QN:0!null, khjjo.LUEVY:2!null)\n" +
+			" │               │           │               └─ SubqueryAlias\n" +
+			" │               │           │                   ├─ name: khjjo\n" +
+			" │               │           │                   ├─ outerVisibility: false\n" +
+			" │               │           │                   ├─ cacheable: true\n" +
+			" │               │           │                   └─ Distinct\n" +
+			" │               │           │                       └─ Project\n" +
+			" │               │           │                           ├─ columns: [mf.M22QN:3!null as M22QN, sn.id:17!null as BDNYB, mf.LUEVY:2!null as LUEVY]\n" +
+			" │               │           │                           └─ HashJoin\n" +
+			" │               │           │                               ├─ Eq\n" +
+			" │               │           │                               │   ├─ sn.BRQP2:18!null\n" +
+			" │               │           │                               │   └─ mf.LUEVY:2!null\n" +
+			" │               │           │                               ├─ TableAlias(mf)\n" +
+			" │               │           │                               │   └─ Table\n" +
+			" │               │           │                               │       ├─ name: HGMQ6\n" +
+			" │               │           │                               │       └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
+			" │               │           │                               └─ HashLookup\n" +
+			" │               │           │                                   ├─ left-key: TUPLE(mf.LUEVY:2!null)\n" +
+			" │               │           │                                   ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			" │               │           │                                   └─ TableAlias(sn)\n" +
+			" │               │           │                                       └─ Table\n" +
+			" │               │           │                                           ├─ name: NOXN3\n" +
+			" │               │           │                                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" │               │           └─ TableAlias(sn)\n" +
 			" │               │               └─ IndexedTableAccess(NOXN3)\n" +
 			" │               │                   ├─ index: [NOXN3.id]\n" +
@@ -11547,67 +11435,63 @@ WHERE
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
 			"                             │       ├─ columns: [sn.id:17!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:5!null as M22QN, cec.ADURZ:16!null as ADURZ, cec.NO52D:15!null as NO52D, ct.S3Q3Y:11!null as IDPK7]\n" +
-			"                             │       └─ Filter\n" +
-			"                             │           ├─ HashIn\n" +
-			"                             │           │   ├─ ci.FTQLQ:1!null\n" +
-			"                             │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │           └─ HashJoin\n" +
-			"                             │               ├─ Eq\n" +
-			"                             │               │   ├─ ct.LUEVY:4!null\n" +
-			"                             │               │   └─ sn.BRQP2:18!null\n" +
-			"                             │               ├─ HashJoin\n" +
-			"                             │               │   ├─ Eq\n" +
-			"                             │               │   │   ├─ cec.id:14!null\n" +
-			"                             │               │   │   └─ ct.OVE3E:6!null\n" +
-			"                             │               │   ├─ MergeJoin\n" +
-			"                             │               │   │   ├─ cmp: Eq\n" +
-			"                             │               │   │   │   ├─ ci.id:0!null\n" +
-			"                             │               │   │   │   └─ ct.FZ2R5:3!null\n" +
-			"                             │               │   │   ├─ Filter\n" +
-			"                             │               │   │   │   ├─ HashIn\n" +
-			"                             │               │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
-			"                             │               │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │               │   │   │   └─ TableAlias(ci)\n" +
-			"                             │               │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
-			"                             │               │   │   │           ├─ index: [JDLNA.id]\n" +
-			"                             │               │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │               │   │   │           └─ columns: [id ftqlq]\n" +
-			"                             │               │   │   └─ Filter\n" +
-			"                             │               │   │       ├─ Eq\n" +
-			"                             │               │   │       │   ├─ ct.M22QN:3!null\n" +
-			"                             │               │   │       │   └─ Subquery\n" +
-			"                             │               │   │       │       ├─ cacheable: true\n" +
-			"                             │               │   │       │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
-			"                             │               │   │       │       └─ Project\n" +
-			"                             │               │   │       │           ├─ columns: [aac.id:12!null]\n" +
-			"                             │               │   │       │           └─ Filter\n" +
-			"                             │               │   │       │               ├─ Eq\n" +
-			"                             │               │   │       │               │   ├─ aac.BTXC5:13\n" +
-			"                             │               │   │       │               │   └─ WT (longtext)\n" +
-			"                             │               │   │       │               └─ TableAlias(aac)\n" +
-			"                             │               │   │       │                   └─ IndexedTableAccess(TPXBU)\n" +
-			"                             │               │   │       │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"                             │               │   │       │                       ├─ static: [{[WT, WT]}]\n" +
-			"                             │               │   │       │                       └─ columns: [id btxc5]\n" +
-			"                             │               │   │       └─ TableAlias(ct)\n" +
-			"                             │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			"                             │               │   │               ├─ index: [FLQLP.FZ2R5]\n" +
-			"                             │               │   │               ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │               │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
-			"                             │               │   └─ HashLookup\n" +
-			"                             │               │       ├─ left-key: TUPLE(ct.OVE3E:6!null)\n" +
-			"                             │               │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
-			"                             │               │       └─ TableAlias(cec)\n" +
-			"                             │               │           └─ Table\n" +
-			"                             │               │               ├─ name: SFEGG\n" +
-			"                             │               │               └─ columns: [id no52d adurz]\n" +
-			"                             │               └─ HashLookup\n" +
-			"                             │                   ├─ left-key: TUPLE(ct.LUEVY:4!null)\n" +
-			"                             │                   ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"                             │                   └─ TableAlias(sn)\n" +
-			"                             │                       └─ Table\n" +
-			"                             │                           ├─ name: NOXN3\n" +
-			"                             │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			"                             │       └─ HashJoin\n" +
+			"                             │           ├─ Eq\n" +
+			"                             │           │   ├─ ct.LUEVY:4!null\n" +
+			"                             │           │   └─ sn.BRQP2:18!null\n" +
+			"                             │           ├─ HashJoin\n" +
+			"                             │           │   ├─ Eq\n" +
+			"                             │           │   │   ├─ cec.id:14!null\n" +
+			"                             │           │   │   └─ ct.OVE3E:6!null\n" +
+			"                             │           │   ├─ MergeJoin\n" +
+			"                             │           │   │   ├─ cmp: Eq\n" +
+			"                             │           │   │   │   ├─ ci.id:0!null\n" +
+			"                             │           │   │   │   └─ ct.FZ2R5:3!null\n" +
+			"                             │           │   │   ├─ Filter\n" +
+			"                             │           │   │   │   ├─ HashIn\n" +
+			"                             │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
+			"                             │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                             │           │   │   │   └─ TableAlias(ci)\n" +
+			"                             │           │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
+			"                             │           │   │   │           ├─ index: [JDLNA.id]\n" +
+			"                             │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │           │   │   │           └─ columns: [id ftqlq]\n" +
+			"                             │           │   │   └─ Filter\n" +
+			"                             │           │   │       ├─ Eq\n" +
+			"                             │           │   │       │   ├─ ct.M22QN:3!null\n" +
+			"                             │           │   │       │   └─ Subquery\n" +
+			"                             │           │   │       │       ├─ cacheable: true\n" +
+			"                             │           │   │       │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
+			"                             │           │   │       │       └─ Project\n" +
+			"                             │           │   │       │           ├─ columns: [aac.id:12!null]\n" +
+			"                             │           │   │       │           └─ Filter\n" +
+			"                             │           │   │       │               ├─ Eq\n" +
+			"                             │           │   │       │               │   ├─ aac.BTXC5:13\n" +
+			"                             │           │   │       │               │   └─ WT (longtext)\n" +
+			"                             │           │   │       │               └─ TableAlias(aac)\n" +
+			"                             │           │   │       │                   └─ IndexedTableAccess(TPXBU)\n" +
+			"                             │           │   │       │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"                             │           │   │       │                       ├─ static: [{[WT, WT]}]\n" +
+			"                             │           │   │       │                       └─ columns: [id btxc5]\n" +
+			"                             │           │   │       └─ TableAlias(ct)\n" +
+			"                             │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			"                             │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
+			"                             │           │   │               ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │           │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
+			"                             │           │   └─ HashLookup\n" +
+			"                             │           │       ├─ left-key: TUPLE(ct.OVE3E:6!null)\n" +
+			"                             │           │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
+			"                             │           │       └─ TableAlias(cec)\n" +
+			"                             │           │           └─ Table\n" +
+			"                             │           │               ├─ name: SFEGG\n" +
+			"                             │           │               └─ columns: [id no52d adurz]\n" +
+			"                             │           └─ HashLookup\n" +
+			"                             │               ├─ left-key: TUPLE(ct.LUEVY:4!null)\n" +
+			"                             │               ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"                             │               └─ TableAlias(sn)\n" +
+			"                             │                   └─ Table\n" +
+			"                             │                       ├─ name: NOXN3\n" +
+			"                             │                       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                             └─ TableAlias(sn)\n" +
 			"                                 └─ IndexedTableAccess(NOXN3)\n" +
 			"                                     ├─ index: [NOXN3.id]\n" +
@@ -11731,8 +11615,8 @@ WHERE
 			" │       │           │   ├─ aac.id:74!null\n" +
 			" │       │           │   └─ sl3s5.M22QN:63!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
-			" │       │                   ├─ index: [TPXBU.id]\n" +
+			" │       │               └─ Table\n" +
+			" │       │                   ├─ name: TPXBU\n" +
 			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
 			" │       └─ Project\n" +
@@ -11746,8 +11630,8 @@ WHERE
 			" │           │           │   ├─ aac.id:67!null\n" +
 			" │           │           │   └─ sl3s5.M22QN:19!null\n" +
 			" │           │           └─ TableAlias(aac)\n" +
-			" │           │               └─ IndexedTableAccess(TPXBU)\n" +
-			" │           │                   ├─ index: [TPXBU.id]\n" +
+			" │           │               └─ Table\n" +
+			" │           │                   ├─ name: TPXBU\n" +
 			" │           │                   └─ columns: [id btxc5]\n" +
 			" │           │   as TPXBU, sl3s5.NO52D:21!null as NO52D, sl3s5.IDPK7:22!null as IDPK7]\n" +
 			" │           └─ HashJoin\n" +
@@ -11779,76 +11663,72 @@ WHERE
 			" │               │           │   ├─ cacheable: true\n" +
 			" │               │           │   └─ Project\n" +
 			" │               │           │       ├─ columns: [khjjo.BDNYB:12!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:4!null as M22QN, cec.ADURZ:10!null as ADURZ, cec.NO52D:9!null as NO52D, ct.S3Q3Y:6!null as IDPK7]\n" +
-			" │               │           │       └─ Filter\n" +
-			" │               │           │           ├─ HashIn\n" +
-			" │               │           │           │   ├─ ci.FTQLQ:1!null\n" +
-			" │               │           │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │               │           │           └─ HashJoin\n" +
-			" │               │           │               ├─ AND\n" +
-			" │               │           │               │   ├─ Eq\n" +
-			" │               │           │               │   │   ├─ ct.M22QN:4!null\n" +
-			" │               │           │               │   │   └─ khjjo.M22QN:11!null\n" +
-			" │               │           │               │   └─ Eq\n" +
-			" │               │           │               │       ├─ ct.LUEVY:3!null\n" +
-			" │               │           │               │       └─ khjjo.LUEVY:13!null\n" +
-			" │               │           │               ├─ HashJoin\n" +
-			" │               │           │               │   ├─ Eq\n" +
-			" │               │           │               │   │   ├─ cec.id:8!null\n" +
-			" │               │           │               │   │   └─ ct.OVE3E:5!null\n" +
-			" │               │           │               │   ├─ MergeJoin\n" +
-			" │               │           │               │   │   ├─ cmp: Eq\n" +
-			" │               │           │               │   │   │   ├─ ci.id:0!null\n" +
-			" │               │           │               │   │   │   └─ ct.FZ2R5:2!null\n" +
-			" │               │           │               │   │   ├─ Filter\n" +
-			" │               │           │               │   │   │   ├─ HashIn\n" +
-			" │               │           │               │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
-			" │               │           │               │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │               │           │               │   │   │   └─ TableAlias(ci)\n" +
-			" │               │           │               │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
-			" │               │           │               │   │   │           ├─ index: [JDLNA.id]\n" +
-			" │               │           │               │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			" │               │           │               │   │   │           └─ columns: [id ftqlq]\n" +
-			" │               │           │               │   │   └─ Filter\n" +
-			" │               │           │               │   │       ├─ Eq\n" +
-			" │               │           │               │   │       │   ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │               │   │       │   └─ = (longtext)\n" +
-			" │               │           │               │   │       └─ TableAlias(ct)\n" +
-			" │               │           │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			" │               │           │               │   │               ├─ index: [FLQLP.FZ2R5]\n" +
-			" │               │           │               │   │               ├─ static: [{[NULL, ∞)}]\n" +
-			" │               │           │               │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
-			" │               │           │               │   └─ HashLookup\n" +
-			" │               │           │               │       ├─ left-key: TUPLE(ct.OVE3E:5!null)\n" +
-			" │               │           │               │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
-			" │               │           │               │       └─ TableAlias(cec)\n" +
-			" │               │           │               │           └─ Table\n" +
-			" │               │           │               │               ├─ name: SFEGG\n" +
-			" │               │           │               │               └─ columns: [id no52d adurz]\n" +
-			" │               │           │               └─ HashLookup\n" +
-			" │               │           │                   ├─ left-key: TUPLE(ct.M22QN:4!null, ct.LUEVY:3!null)\n" +
-			" │               │           │                   ├─ right-key: TUPLE(khjjo.M22QN:0!null, khjjo.LUEVY:2!null)\n" +
-			" │               │           │                   └─ SubqueryAlias\n" +
-			" │               │           │                       ├─ name: khjjo\n" +
-			" │               │           │                       ├─ outerVisibility: false\n" +
-			" │               │           │                       ├─ cacheable: true\n" +
-			" │               │           │                       └─ Distinct\n" +
-			" │               │           │                           └─ Project\n" +
-			" │               │           │                               ├─ columns: [mf.M22QN:3!null as M22QN, sn.id:17!null as BDNYB, mf.LUEVY:2!null as LUEVY]\n" +
-			" │               │           │                               └─ HashJoin\n" +
-			" │               │           │                                   ├─ Eq\n" +
-			" │               │           │                                   │   ├─ sn.BRQP2:18!null\n" +
-			" │               │           │                                   │   └─ mf.LUEVY:2!null\n" +
-			" │               │           │                                   ├─ TableAlias(mf)\n" +
-			" │               │           │                                   │   └─ Table\n" +
-			" │               │           │                                   │       ├─ name: HGMQ6\n" +
-			" │               │           │                                   │       └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
-			" │               │           │                                   └─ HashLookup\n" +
-			" │               │           │                                       ├─ left-key: TUPLE(mf.LUEVY:2!null)\n" +
-			" │               │           │                                       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			" │               │           │                                       └─ TableAlias(sn)\n" +
-			" │               │           │                                           └─ Table\n" +
-			" │               │           │                                               ├─ name: NOXN3\n" +
-			" │               │           │                                               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			" │               │           │       └─ HashJoin\n" +
+			" │               │           │           ├─ AND\n" +
+			" │               │           │           │   ├─ Eq\n" +
+			" │               │           │           │   │   ├─ ct.M22QN:4!null\n" +
+			" │               │           │           │   │   └─ khjjo.M22QN:11!null\n" +
+			" │               │           │           │   └─ Eq\n" +
+			" │               │           │           │       ├─ ct.LUEVY:3!null\n" +
+			" │               │           │           │       └─ khjjo.LUEVY:13!null\n" +
+			" │               │           │           ├─ HashJoin\n" +
+			" │               │           │           │   ├─ Eq\n" +
+			" │               │           │           │   │   ├─ cec.id:8!null\n" +
+			" │               │           │           │   │   └─ ct.OVE3E:5!null\n" +
+			" │               │           │           │   ├─ MergeJoin\n" +
+			" │               │           │           │   │   ├─ cmp: Eq\n" +
+			" │               │           │           │   │   │   ├─ ci.id:0!null\n" +
+			" │               │           │           │   │   │   └─ ct.FZ2R5:2!null\n" +
+			" │               │           │           │   │   ├─ Filter\n" +
+			" │               │           │           │   │   │   ├─ HashIn\n" +
+			" │               │           │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
+			" │               │           │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			" │               │           │           │   │   │   └─ TableAlias(ci)\n" +
+			" │               │           │           │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
+			" │               │           │           │   │   │           ├─ index: [JDLNA.id]\n" +
+			" │               │           │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			" │               │           │           │   │   │           └─ columns: [id ftqlq]\n" +
+			" │               │           │           │   │   └─ Filter\n" +
+			" │               │           │           │   │       ├─ Eq\n" +
+			" │               │           │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │   └─ = (longtext)\n" +
+			" │               │           │           │   │       └─ TableAlias(ct)\n" +
+			" │               │           │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			" │               │           │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
+			" │               │           │           │   │               ├─ static: [{[NULL, ∞)}]\n" +
+			" │               │           │           │   │               └─ columns: [fz2r5 luevy m22qn ove3e s3q3y zrv3b]\n" +
+			" │               │           │           │   └─ HashLookup\n" +
+			" │               │           │           │       ├─ left-key: TUPLE(ct.OVE3E:5!null)\n" +
+			" │               │           │           │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
+			" │               │           │           │       └─ TableAlias(cec)\n" +
+			" │               │           │           │           └─ Table\n" +
+			" │               │           │           │               ├─ name: SFEGG\n" +
+			" │               │           │           │               └─ columns: [id no52d adurz]\n" +
+			" │               │           │           └─ HashLookup\n" +
+			" │               │           │               ├─ left-key: TUPLE(ct.M22QN:4!null, ct.LUEVY:3!null)\n" +
+			" │               │           │               ├─ right-key: TUPLE(khjjo.M22QN:0!null, khjjo.LUEVY:2!null)\n" +
+			" │               │           │               └─ SubqueryAlias\n" +
+			" │               │           │                   ├─ name: khjjo\n" +
+			" │               │           │                   ├─ outerVisibility: false\n" +
+			" │               │           │                   ├─ cacheable: true\n" +
+			" │               │           │                   └─ Distinct\n" +
+			" │               │           │                       └─ Project\n" +
+			" │               │           │                           ├─ columns: [mf.M22QN:3!null as M22QN, sn.id:17!null as BDNYB, mf.LUEVY:2!null as LUEVY]\n" +
+			" │               │           │                           └─ HashJoin\n" +
+			" │               │           │                               ├─ Eq\n" +
+			" │               │           │                               │   ├─ sn.BRQP2:18!null\n" +
+			" │               │           │                               │   └─ mf.LUEVY:2!null\n" +
+			" │               │           │                               ├─ TableAlias(mf)\n" +
+			" │               │           │                               │   └─ Table\n" +
+			" │               │           │                               │       ├─ name: HGMQ6\n" +
+			" │               │           │                               │       └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
+			" │               │           │                               └─ HashLookup\n" +
+			" │               │           │                                   ├─ left-key: TUPLE(mf.LUEVY:2!null)\n" +
+			" │               │           │                                   ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			" │               │           │                                   └─ TableAlias(sn)\n" +
+			" │               │           │                                       └─ Table\n" +
+			" │               │           │                                           ├─ name: NOXN3\n" +
+			" │               │           │                                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			" │               │           └─ TableAlias(sn)\n" +
 			" │               │               └─ IndexedTableAccess(NOXN3)\n" +
 			" │               │                   ├─ index: [NOXN3.id]\n" +
@@ -11941,67 +11821,63 @@ WHERE
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
 			"                             │       ├─ columns: [sn.id:17!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:5!null as M22QN, cec.ADURZ:16!null as ADURZ, cec.NO52D:15!null as NO52D, ct.S3Q3Y:11!null as IDPK7]\n" +
-			"                             │       └─ Filter\n" +
-			"                             │           ├─ HashIn\n" +
-			"                             │           │   ├─ ci.FTQLQ:1!null\n" +
-			"                             │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │           └─ HashJoin\n" +
-			"                             │               ├─ Eq\n" +
-			"                             │               │   ├─ ct.LUEVY:4!null\n" +
-			"                             │               │   └─ sn.BRQP2:18!null\n" +
-			"                             │               ├─ HashJoin\n" +
-			"                             │               │   ├─ Eq\n" +
-			"                             │               │   │   ├─ cec.id:14!null\n" +
-			"                             │               │   │   └─ ct.OVE3E:6!null\n" +
-			"                             │               │   ├─ MergeJoin\n" +
-			"                             │               │   │   ├─ cmp: Eq\n" +
-			"                             │               │   │   │   ├─ ci.id:0!null\n" +
-			"                             │               │   │   │   └─ ct.FZ2R5:3!null\n" +
-			"                             │               │   │   ├─ Filter\n" +
-			"                             │               │   │   │   ├─ HashIn\n" +
-			"                             │               │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
-			"                             │               │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │               │   │   │   └─ TableAlias(ci)\n" +
-			"                             │               │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
-			"                             │               │   │   │           ├─ index: [JDLNA.id]\n" +
-			"                             │               │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │               │   │   │           └─ columns: [id ftqlq]\n" +
-			"                             │               │   │   └─ Filter\n" +
-			"                             │               │   │       ├─ Eq\n" +
-			"                             │               │   │       │   ├─ ct.M22QN:3!null\n" +
-			"                             │               │   │       │   └─ Subquery\n" +
-			"                             │               │   │       │       ├─ cacheable: true\n" +
-			"                             │               │   │       │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
-			"                             │               │   │       │       └─ Project\n" +
-			"                             │               │   │       │           ├─ columns: [aac.id:12!null]\n" +
-			"                             │               │   │       │           └─ Filter\n" +
-			"                             │               │   │       │               ├─ Eq\n" +
-			"                             │               │   │       │               │   ├─ aac.BTXC5:13\n" +
-			"                             │               │   │       │               │   └─ WT (longtext)\n" +
-			"                             │               │   │       │               └─ TableAlias(aac)\n" +
-			"                             │               │   │       │                   └─ IndexedTableAccess(TPXBU)\n" +
-			"                             │               │   │       │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"                             │               │   │       │                       ├─ static: [{[WT, WT]}]\n" +
-			"                             │               │   │       │                       └─ columns: [id btxc5]\n" +
-			"                             │               │   │       └─ TableAlias(ct)\n" +
-			"                             │               │   │           └─ IndexedTableAccess(FLQLP)\n" +
-			"                             │               │   │               ├─ index: [FLQLP.FZ2R5]\n" +
-			"                             │               │   │               ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │               │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
-			"                             │               │   └─ HashLookup\n" +
-			"                             │               │       ├─ left-key: TUPLE(ct.OVE3E:6!null)\n" +
-			"                             │               │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
-			"                             │               │       └─ TableAlias(cec)\n" +
-			"                             │               │           └─ Table\n" +
-			"                             │               │               ├─ name: SFEGG\n" +
-			"                             │               │               └─ columns: [id no52d adurz]\n" +
-			"                             │               └─ HashLookup\n" +
-			"                             │                   ├─ left-key: TUPLE(ct.LUEVY:4!null)\n" +
-			"                             │                   ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"                             │                   └─ TableAlias(sn)\n" +
-			"                             │                       └─ Table\n" +
-			"                             │                           ├─ name: NOXN3\n" +
-			"                             │                           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			"                             │       └─ HashJoin\n" +
+			"                             │           ├─ Eq\n" +
+			"                             │           │   ├─ ct.LUEVY:4!null\n" +
+			"                             │           │   └─ sn.BRQP2:18!null\n" +
+			"                             │           ├─ HashJoin\n" +
+			"                             │           │   ├─ Eq\n" +
+			"                             │           │   │   ├─ cec.id:14!null\n" +
+			"                             │           │   │   └─ ct.OVE3E:6!null\n" +
+			"                             │           │   ├─ MergeJoin\n" +
+			"                             │           │   │   ├─ cmp: Eq\n" +
+			"                             │           │   │   │   ├─ ci.id:0!null\n" +
+			"                             │           │   │   │   └─ ct.FZ2R5:3!null\n" +
+			"                             │           │   │   ├─ Filter\n" +
+			"                             │           │   │   │   ├─ HashIn\n" +
+			"                             │           │   │   │   │   ├─ ci.FTQLQ:1!null\n" +
+			"                             │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                             │           │   │   │   └─ TableAlias(ci)\n" +
+			"                             │           │   │   │       └─ IndexedTableAccess(JDLNA)\n" +
+			"                             │           │   │   │           ├─ index: [JDLNA.id]\n" +
+			"                             │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │           │   │   │           └─ columns: [id ftqlq]\n" +
+			"                             │           │   │   └─ Filter\n" +
+			"                             │           │   │       ├─ Eq\n" +
+			"                             │           │   │       │   ├─ ct.M22QN:3!null\n" +
+			"                             │           │   │       │   └─ Subquery\n" +
+			"                             │           │   │       │       ├─ cacheable: true\n" +
+			"                             │           │   │       │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
+			"                             │           │   │       │       └─ Project\n" +
+			"                             │           │   │       │           ├─ columns: [aac.id:12!null]\n" +
+			"                             │           │   │       │           └─ Filter\n" +
+			"                             │           │   │       │               ├─ Eq\n" +
+			"                             │           │   │       │               │   ├─ aac.BTXC5:13\n" +
+			"                             │           │   │       │               │   └─ WT (longtext)\n" +
+			"                             │           │   │       │               └─ TableAlias(aac)\n" +
+			"                             │           │   │       │                   └─ IndexedTableAccess(TPXBU)\n" +
+			"                             │           │   │       │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"                             │           │   │       │                       ├─ static: [{[WT, WT]}]\n" +
+			"                             │           │   │       │                       └─ columns: [id btxc5]\n" +
+			"                             │           │   │       └─ TableAlias(ct)\n" +
+			"                             │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
+			"                             │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
+			"                             │           │   │               ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │           │   │               └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
+			"                             │           │   └─ HashLookup\n" +
+			"                             │           │       ├─ left-key: TUPLE(ct.OVE3E:6!null)\n" +
+			"                             │           │       ├─ right-key: TUPLE(cec.id:0!null)\n" +
+			"                             │           │       └─ TableAlias(cec)\n" +
+			"                             │           │           └─ Table\n" +
+			"                             │           │               ├─ name: SFEGG\n" +
+			"                             │           │               └─ columns: [id no52d adurz]\n" +
+			"                             │           └─ HashLookup\n" +
+			"                             │               ├─ left-key: TUPLE(ct.LUEVY:4!null)\n" +
+			"                             │               ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"                             │               └─ TableAlias(sn)\n" +
+			"                             │                   └─ Table\n" +
+			"                             │                       ├─ name: NOXN3\n" +
+			"                             │                       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
 			"                             └─ TableAlias(sn)\n" +
 			"                                 └─ IndexedTableAccess(NOXN3)\n" +
 			"                                     ├─ index: [NOXN3.id]\n" +
@@ -12231,40 +12107,35 @@ WHERE
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [nd.TW55N:11!null, il.LIILR:2, il.KSFXH:3, il.KLMAU:4, il.ecm:5]\n" +
 			" └─ Sort(nd.TW55N:11!null ASC nullsFirst)\n" +
-			"     └─ Filter\n" +
-			"         ├─ NOT\n" +
-			"         │   └─ Eq\n" +
-			"         │       ├─ nt.DZLIM:26!null\n" +
-			"         │       └─ SUZTA (longtext)\n" +
-			"         └─ HashJoin\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ nd.DKCAJ:9!null\n" +
-			"             │   └─ nt.id:25!null\n" +
-			"             ├─ LookupJoin\n" +
-			"             │   ├─ Eq\n" +
-			"             │   │   ├─ il.LUEVY:1!null\n" +
-			"             │   │   └─ nd.id:8!null\n" +
-			"             │   ├─ TableAlias(il)\n" +
-			"             │   │   └─ Table\n" +
-			"             │   │       ├─ name: RLOHD\n" +
-			"             │   │       └─ columns: [id luevy liilr ksfxh klmau ecm rqi4m fhcyt]\n" +
-			"             │   └─ TableAlias(nd)\n" +
-			"             │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │           ├─ index: [E2I7U.id]\n" +
-			"             │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             └─ HashLookup\n" +
-			"                 ├─ left-key: TUPLE(nd.DKCAJ:9!null)\n" +
-			"                 ├─ right-key: TUPLE(nt.id:0!null)\n" +
-			"                 └─ Filter\n" +
-			"                     ├─ NOT\n" +
-			"                     │   └─ Eq\n" +
-			"                     │       ├─ nt.DZLIM:1!null\n" +
-			"                     │       └─ SUZTA (longtext)\n" +
-			"                     └─ TableAlias(nt)\n" +
-			"                         └─ IndexedTableAccess(F35MI)\n" +
-			"                             ├─ index: [F35MI.DZLIM]\n" +
-			"                             ├─ static: [{(NULL, SUZTA)}, {(SUZTA, ∞)}]\n" +
-			"                             └─ columns: [id dzlim f3yue]\n" +
+			"     └─ HashJoin\n" +
+			"         ├─ Eq\n" +
+			"         │   ├─ nd.DKCAJ:9!null\n" +
+			"         │   └─ nt.id:25!null\n" +
+			"         ├─ LookupJoin\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ il.LUEVY:1!null\n" +
+			"         │   │   └─ nd.id:8!null\n" +
+			"         │   ├─ TableAlias(il)\n" +
+			"         │   │   └─ Table\n" +
+			"         │   │       ├─ name: RLOHD\n" +
+			"         │   │       └─ columns: [id luevy liilr ksfxh klmau ecm rqi4m fhcyt]\n" +
+			"         │   └─ TableAlias(nd)\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"         └─ HashLookup\n" +
+			"             ├─ left-key: TUPLE(nd.DKCAJ:9!null)\n" +
+			"             ├─ right-key: TUPLE(nt.id:0!null)\n" +
+			"             └─ Filter\n" +
+			"                 ├─ NOT\n" +
+			"                 │   └─ Eq\n" +
+			"                 │       ├─ nt.DZLIM:1!null\n" +
+			"                 │       └─ SUZTA (longtext)\n" +
+			"                 └─ TableAlias(nt)\n" +
+			"                     └─ IndexedTableAccess(F35MI)\n" +
+			"                         ├─ index: [F35MI.DZLIM]\n" +
+			"                         ├─ static: [{(SUZTA, ∞)}, {(NULL, SUZTA)}]\n" +
+			"                         └─ columns: [id dzlim f3yue]\n" +
 			"",
 	},
 	{
@@ -12798,75 +12669,71 @@ WHERE
 			"                                             │                   │   │   ├─ cacheable: true\n" +
 			"                                             │                   │   │   └─ Project\n" +
 			"                                             │                   │   │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.BRQP2:12!null, mf.id:4!null as Z7CP5, mf.FSDY2:7!null, nma.DZLIM:11!null as IDWIO]\n" +
-			"                                             │                   │   │       └─ Filter\n" +
-			"                                             │                   │   │           ├─ HashIn\n" +
-			"                                             │                   │   │           │   ├─ cla.FTQLQ:1!null\n" +
-			"                                             │                   │   │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                                             │                   │   │           └─ HashJoin\n" +
-			"                                             │                   │   │               ├─ AND\n" +
-			"                                             │                   │   │               │   ├─ Eq\n" +
-			"                                             │                   │   │               │   │   ├─ mf.LUEVY:6!null\n" +
-			"                                             │                   │   │               │   │   └─ nd.id:8!null\n" +
-			"                                             │                   │   │               │   └─ Eq\n" +
-			"                                             │                   │   │               │       ├─ mf.LUEVY:6!null\n" +
-			"                                             │                   │   │               │       └─ sn.BRQP2:12!null\n" +
-			"                                             │                   │   │               ├─ HashJoin\n" +
-			"                                             │                   │   │               │   ├─ Eq\n" +
-			"                                             │                   │   │               │   │   ├─ mf.GXLUB:5!null\n" +
-			"                                             │                   │   │               │   │   └─ bs.id:2!null\n" +
-			"                                             │                   │   │               │   ├─ MergeJoin\n" +
-			"                                             │                   │   │               │   │   ├─ cmp: Eq\n" +
-			"                                             │                   │   │               │   │   │   ├─ cla.id:0!null\n" +
-			"                                             │                   │   │               │   │   │   └─ bs.IXUXU:3\n" +
-			"                                             │                   │   │               │   │   ├─ Filter\n" +
-			"                                             │                   │   │               │   │   │   ├─ HashIn\n" +
-			"                                             │                   │   │               │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
-			"                                             │                   │   │               │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                                             │                   │   │               │   │   │   └─ TableAlias(cla)\n" +
-			"                                             │                   │   │               │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                                             │                   │   │               │   │   │           ├─ index: [YK2GW.id]\n" +
-			"                                             │                   │   │               │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │               │   │   │           └─ columns: [id ftqlq]\n" +
-			"                                             │                   │   │               │   │   └─ TableAlias(bs)\n" +
-			"                                             │                   │   │               │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"                                             │                   │   │               │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"                                             │                   │   │               │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │               │   │           └─ columns: [id ixuxu]\n" +
-			"                                             │                   │   │               │   └─ HashLookup\n" +
-			"                                             │                   │   │               │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
-			"                                             │                   │   │               │       ├─ right-key: TUPLE(mf.GXLUB:1!null)\n" +
-			"                                             │                   │   │               │       └─ TableAlias(mf)\n" +
-			"                                             │                   │   │               │           └─ Table\n" +
-			"                                             │                   │   │               │               ├─ name: HGMQ6\n" +
-			"                                             │                   │   │               │               └─ columns: [id gxlub luevy fsdy2]\n" +
-			"                                             │                   │   │               └─ HashLookup\n" +
-			"                                             │                   │   │                   ├─ left-key: TUPLE(mf.LUEVY:6!null, mf.LUEVY:6!null)\n" +
-			"                                             │                   │   │                   ├─ right-key: TUPLE(nd.id:0!null, sn.BRQP2:4!null)\n" +
-			"                                             │                   │   │                   └─ HashJoin\n" +
-			"                                             │                   │   │                       ├─ Eq\n" +
-			"                                             │                   │   │                       │   ├─ sn.BRQP2:12!null\n" +
-			"                                             │                   │   │                       │   └─ nd.id:8!null\n" +
-			"                                             │                   │   │                       ├─ MergeJoin\n" +
-			"                                             │                   │   │                       │   ├─ cmp: Eq\n" +
-			"                                             │                   │   │                       │   │   ├─ nd.HPCMS:9!null\n" +
-			"                                             │                   │   │                       │   │   └─ nma.id:10!null\n" +
-			"                                             │                   │   │                       │   ├─ TableAlias(nd)\n" +
-			"                                             │                   │   │                       │   │   └─ IndexedTableAccess(E2I7U)\n" +
-			"                                             │                   │   │                       │   │       ├─ index: [E2I7U.HPCMS]\n" +
-			"                                             │                   │   │                       │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │                       │   │       └─ columns: [id hpcms]\n" +
-			"                                             │                   │   │                       │   └─ TableAlias(nma)\n" +
-			"                                             │                   │   │                       │       └─ IndexedTableAccess(TNMXI)\n" +
-			"                                             │                   │   │                       │           ├─ index: [TNMXI.id]\n" +
-			"                                             │                   │   │                       │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │                       │           └─ columns: [id dzlim]\n" +
-			"                                             │                   │   │                       └─ HashLookup\n" +
-			"                                             │                   │   │                           ├─ left-key: TUPLE(nd.id:8!null)\n" +
-			"                                             │                   │   │                           ├─ right-key: TUPLE(sn.BRQP2:0!null)\n" +
-			"                                             │                   │   │                           └─ TableAlias(sn)\n" +
-			"                                             │                   │   │                               └─ Table\n" +
-			"                                             │                   │   │                                   ├─ name: NOXN3\n" +
-			"                                             │                   │   │                                   └─ columns: [brqp2]\n" +
+			"                                             │                   │   │       └─ HashJoin\n" +
+			"                                             │                   │   │           ├─ AND\n" +
+			"                                             │                   │   │           │   ├─ Eq\n" +
+			"                                             │                   │   │           │   │   ├─ mf.LUEVY:6!null\n" +
+			"                                             │                   │   │           │   │   └─ nd.id:8!null\n" +
+			"                                             │                   │   │           │   └─ Eq\n" +
+			"                                             │                   │   │           │       ├─ mf.LUEVY:6!null\n" +
+			"                                             │                   │   │           │       └─ sn.BRQP2:12!null\n" +
+			"                                             │                   │   │           ├─ HashJoin\n" +
+			"                                             │                   │   │           │   ├─ Eq\n" +
+			"                                             │                   │   │           │   │   ├─ mf.GXLUB:5!null\n" +
+			"                                             │                   │   │           │   │   └─ bs.id:2!null\n" +
+			"                                             │                   │   │           │   ├─ MergeJoin\n" +
+			"                                             │                   │   │           │   │   ├─ cmp: Eq\n" +
+			"                                             │                   │   │           │   │   │   ├─ cla.id:0!null\n" +
+			"                                             │                   │   │           │   │   │   └─ bs.IXUXU:3\n" +
+			"                                             │                   │   │           │   │   ├─ Filter\n" +
+			"                                             │                   │   │           │   │   │   ├─ HashIn\n" +
+			"                                             │                   │   │           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
+			"                                             │                   │   │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                                             │                   │   │           │   │   │   └─ TableAlias(cla)\n" +
+			"                                             │                   │   │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                                             │                   │   │           │   │   │           ├─ index: [YK2GW.id]\n" +
+			"                                             │                   │   │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │           │   │   │           └─ columns: [id ftqlq]\n" +
+			"                                             │                   │   │           │   │   └─ TableAlias(bs)\n" +
+			"                                             │                   │   │           │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"                                             │                   │   │           │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"                                             │                   │   │           │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │           │   │           └─ columns: [id ixuxu]\n" +
+			"                                             │                   │   │           │   └─ HashLookup\n" +
+			"                                             │                   │   │           │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
+			"                                             │                   │   │           │       ├─ right-key: TUPLE(mf.GXLUB:1!null)\n" +
+			"                                             │                   │   │           │       └─ TableAlias(mf)\n" +
+			"                                             │                   │   │           │           └─ Table\n" +
+			"                                             │                   │   │           │               ├─ name: HGMQ6\n" +
+			"                                             │                   │   │           │               └─ columns: [id gxlub luevy fsdy2]\n" +
+			"                                             │                   │   │           └─ HashLookup\n" +
+			"                                             │                   │   │               ├─ left-key: TUPLE(mf.LUEVY:6!null, mf.LUEVY:6!null)\n" +
+			"                                             │                   │   │               ├─ right-key: TUPLE(nd.id:0!null, sn.BRQP2:4!null)\n" +
+			"                                             │                   │   │               └─ HashJoin\n" +
+			"                                             │                   │   │                   ├─ Eq\n" +
+			"                                             │                   │   │                   │   ├─ sn.BRQP2:12!null\n" +
+			"                                             │                   │   │                   │   └─ nd.id:8!null\n" +
+			"                                             │                   │   │                   ├─ MergeJoin\n" +
+			"                                             │                   │   │                   │   ├─ cmp: Eq\n" +
+			"                                             │                   │   │                   │   │   ├─ nd.HPCMS:9!null\n" +
+			"                                             │                   │   │                   │   │   └─ nma.id:10!null\n" +
+			"                                             │                   │   │                   │   ├─ TableAlias(nd)\n" +
+			"                                             │                   │   │                   │   │   └─ IndexedTableAccess(E2I7U)\n" +
+			"                                             │                   │   │                   │   │       ├─ index: [E2I7U.HPCMS]\n" +
+			"                                             │                   │   │                   │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │                   │   │       └─ columns: [id hpcms]\n" +
+			"                                             │                   │   │                   │   └─ TableAlias(nma)\n" +
+			"                                             │                   │   │                   │       └─ IndexedTableAccess(TNMXI)\n" +
+			"                                             │                   │   │                   │           ├─ index: [TNMXI.id]\n" +
+			"                                             │                   │   │                   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │                   │           └─ columns: [id dzlim]\n" +
+			"                                             │                   │   │                   └─ HashLookup\n" +
+			"                                             │                   │   │                       ├─ left-key: TUPLE(nd.id:8!null)\n" +
+			"                                             │                   │   │                       ├─ right-key: TUPLE(sn.BRQP2:0!null)\n" +
+			"                                             │                   │   │                       └─ TableAlias(sn)\n" +
+			"                                             │                   │   │                           └─ Table\n" +
+			"                                             │                   │   │                               ├─ name: NOXN3\n" +
+			"                                             │                   │   │                               └─ columns: [brqp2]\n" +
 			"                                             │                   │   └─ HashLookup\n" +
 			"                                             │                   │       ├─ left-key: TUPLE(iq.Z7CP5:2!null)\n" +
 			"                                             │                   │       ├─ right-key: TUPLE(w2mao.Z7CP5:0!null)\n" +
@@ -13246,76 +13113,72 @@ WHERE
 			"                                             │                   │   │   ├─ cacheable: true\n" +
 			"                                             │                   │   │   └─ Project\n" +
 			"                                             │                   │   │       ├─ columns: [cla.FTQLQ:7!null as T4IBQ, sn.BRQP2:8!null, mf.id:2!null as Z7CP5, mf.FSDY2:5!null, nma.DZLIM:10!null as IDWIO]\n" +
-			"                                             │                   │   │       └─ Filter\n" +
-			"                                             │                   │   │           ├─ HashIn\n" +
-			"                                             │                   │   │           │   ├─ cla.FTQLQ:7!null\n" +
-			"                                             │                   │   │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                                             │                   │   │           └─ HashJoin\n" +
-			"                                             │                   │   │               ├─ AND\n" +
-			"                                             │                   │   │               │   ├─ Eq\n" +
-			"                                             │                   │   │               │   │   ├─ mf.LUEVY:4!null\n" +
-			"                                             │                   │   │               │   │   └─ nd.id:11!null\n" +
-			"                                             │                   │   │               │   └─ Eq\n" +
-			"                                             │                   │   │               │       ├─ mf.LUEVY:4!null\n" +
-			"                                             │                   │   │               │       └─ sn.BRQP2:8!null\n" +
-			"                                             │                   │   │               ├─ HashJoin\n" +
-			"                                             │                   │   │               │   ├─ Eq\n" +
-			"                                             │                   │   │               │   │   ├─ bs.IXUXU:1\n" +
-			"                                             │                   │   │               │   │   └─ cla.id:6!null\n" +
-			"                                             │                   │   │               │   ├─ MergeJoin\n" +
-			"                                             │                   │   │               │   │   ├─ cmp: Eq\n" +
-			"                                             │                   │   │               │   │   │   ├─ bs.id:0!null\n" +
-			"                                             │                   │   │               │   │   │   └─ mf.GXLUB:3!null\n" +
-			"                                             │                   │   │               │   │   ├─ TableAlias(bs)\n" +
-			"                                             │                   │   │               │   │   │   └─ IndexedTableAccess(THNTS)\n" +
-			"                                             │                   │   │               │   │   │       ├─ index: [THNTS.id]\n" +
-			"                                             │                   │   │               │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │               │   │   │       └─ columns: [id ixuxu]\n" +
-			"                                             │                   │   │               │   │   └─ TableAlias(mf)\n" +
-			"                                             │                   │   │               │   │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"                                             │                   │   │               │   │           ├─ index: [HGMQ6.GXLUB]\n" +
-			"                                             │                   │   │               │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │               │   │           └─ columns: [id gxlub luevy fsdy2]\n" +
-			"                                             │                   │   │               │   └─ HashLookup\n" +
-			"                                             │                   │   │               │       ├─ left-key: TUPLE(bs.IXUXU:1)\n" +
-			"                                             │                   │   │               │       ├─ right-key: TUPLE(cla.id:0!null)\n" +
-			"                                             │                   │   │               │       └─ Filter\n" +
-			"                                             │                   │   │               │           ├─ HashIn\n" +
-			"                                             │                   │   │               │           │   ├─ cla.FTQLQ:1!null\n" +
-			"                                             │                   │   │               │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                                             │                   │   │               │           └─ TableAlias(cla)\n" +
-			"                                             │                   │   │               │               └─ IndexedTableAccess(YK2GW)\n" +
-			"                                             │                   │   │               │                   ├─ index: [YK2GW.FTQLQ]\n" +
-			"                                             │                   │   │               │                   ├─ static: [{[SQ1, SQ1]}]\n" +
-			"                                             │                   │   │               │                   └─ columns: [id ftqlq]\n" +
-			"                                             │                   │   │               └─ HashLookup\n" +
-			"                                             │                   │   │                   ├─ left-key: TUPLE(mf.LUEVY:4!null, mf.LUEVY:4!null)\n" +
-			"                                             │                   │   │                   ├─ right-key: TUPLE(nd.id:3!null, sn.BRQP2:0!null)\n" +
-			"                                             │                   │   │                   └─ HashJoin\n" +
-			"                                             │                   │   │                       ├─ Eq\n" +
-			"                                             │                   │   │                       │   ├─ sn.BRQP2:8!null\n" +
-			"                                             │                   │   │                       │   └─ nd.id:11!null\n" +
-			"                                             │                   │   │                       ├─ TableAlias(sn)\n" +
-			"                                             │                   │   │                       │   └─ Table\n" +
-			"                                             │                   │   │                       │       ├─ name: NOXN3\n" +
-			"                                             │                   │   │                       │       └─ columns: [brqp2]\n" +
-			"                                             │                   │   │                       └─ HashLookup\n" +
-			"                                             │                   │   │                           ├─ left-key: TUPLE(sn.BRQP2:8!null)\n" +
-			"                                             │                   │   │                           ├─ right-key: TUPLE(nd.id:2!null)\n" +
-			"                                             │                   │   │                           └─ MergeJoin\n" +
-			"                                             │                   │   │                               ├─ cmp: Eq\n" +
-			"                                             │                   │   │                               │   ├─ nma.id:9!null\n" +
-			"                                             │                   │   │                               │   └─ nd.HPCMS:12!null\n" +
-			"                                             │                   │   │                               ├─ TableAlias(nma)\n" +
-			"                                             │                   │   │                               │   └─ IndexedTableAccess(TNMXI)\n" +
-			"                                             │                   │   │                               │       ├─ index: [TNMXI.id]\n" +
-			"                                             │                   │   │                               │       ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │                               │       └─ columns: [id dzlim]\n" +
-			"                                             │                   │   │                               └─ TableAlias(nd)\n" +
-			"                                             │                   │   │                                   └─ IndexedTableAccess(E2I7U)\n" +
-			"                                             │                   │   │                                       ├─ index: [E2I7U.HPCMS]\n" +
-			"                                             │                   │   │                                       ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             │                   │   │                                       └─ columns: [id hpcms]\n" +
+			"                                             │                   │   │       └─ HashJoin\n" +
+			"                                             │                   │   │           ├─ AND\n" +
+			"                                             │                   │   │           │   ├─ Eq\n" +
+			"                                             │                   │   │           │   │   ├─ mf.LUEVY:4!null\n" +
+			"                                             │                   │   │           │   │   └─ nd.id:11!null\n" +
+			"                                             │                   │   │           │   └─ Eq\n" +
+			"                                             │                   │   │           │       ├─ mf.LUEVY:4!null\n" +
+			"                                             │                   │   │           │       └─ sn.BRQP2:8!null\n" +
+			"                                             │                   │   │           ├─ HashJoin\n" +
+			"                                             │                   │   │           │   ├─ Eq\n" +
+			"                                             │                   │   │           │   │   ├─ bs.IXUXU:1\n" +
+			"                                             │                   │   │           │   │   └─ cla.id:6!null\n" +
+			"                                             │                   │   │           │   ├─ MergeJoin\n" +
+			"                                             │                   │   │           │   │   ├─ cmp: Eq\n" +
+			"                                             │                   │   │           │   │   │   ├─ bs.id:0!null\n" +
+			"                                             │                   │   │           │   │   │   └─ mf.GXLUB:3!null\n" +
+			"                                             │                   │   │           │   │   ├─ TableAlias(bs)\n" +
+			"                                             │                   │   │           │   │   │   └─ IndexedTableAccess(THNTS)\n" +
+			"                                             │                   │   │           │   │   │       ├─ index: [THNTS.id]\n" +
+			"                                             │                   │   │           │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │           │   │   │       └─ columns: [id ixuxu]\n" +
+			"                                             │                   │   │           │   │   └─ TableAlias(mf)\n" +
+			"                                             │                   │   │           │   │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"                                             │                   │   │           │   │           ├─ index: [HGMQ6.GXLUB]\n" +
+			"                                             │                   │   │           │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │           │   │           └─ columns: [id gxlub luevy fsdy2]\n" +
+			"                                             │                   │   │           │   └─ HashLookup\n" +
+			"                                             │                   │   │           │       ├─ left-key: TUPLE(bs.IXUXU:1)\n" +
+			"                                             │                   │   │           │       ├─ right-key: TUPLE(cla.id:0!null)\n" +
+			"                                             │                   │   │           │       └─ Filter\n" +
+			"                                             │                   │   │           │           ├─ HashIn\n" +
+			"                                             │                   │   │           │           │   ├─ cla.FTQLQ:1!null\n" +
+			"                                             │                   │   │           │           │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                                             │                   │   │           │           └─ TableAlias(cla)\n" +
+			"                                             │                   │   │           │               └─ IndexedTableAccess(YK2GW)\n" +
+			"                                             │                   │   │           │                   ├─ index: [YK2GW.FTQLQ]\n" +
+			"                                             │                   │   │           │                   ├─ static: [{[SQ1, SQ1]}]\n" +
+			"                                             │                   │   │           │                   └─ columns: [id ftqlq]\n" +
+			"                                             │                   │   │           └─ HashLookup\n" +
+			"                                             │                   │   │               ├─ left-key: TUPLE(mf.LUEVY:4!null, mf.LUEVY:4!null)\n" +
+			"                                             │                   │   │               ├─ right-key: TUPLE(nd.id:3!null, sn.BRQP2:0!null)\n" +
+			"                                             │                   │   │               └─ HashJoin\n" +
+			"                                             │                   │   │                   ├─ Eq\n" +
+			"                                             │                   │   │                   │   ├─ sn.BRQP2:8!null\n" +
+			"                                             │                   │   │                   │   └─ nd.id:11!null\n" +
+			"                                             │                   │   │                   ├─ TableAlias(sn)\n" +
+			"                                             │                   │   │                   │   └─ Table\n" +
+			"                                             │                   │   │                   │       ├─ name: NOXN3\n" +
+			"                                             │                   │   │                   │       └─ columns: [brqp2]\n" +
+			"                                             │                   │   │                   └─ HashLookup\n" +
+			"                                             │                   │   │                       ├─ left-key: TUPLE(sn.BRQP2:8!null)\n" +
+			"                                             │                   │   │                       ├─ right-key: TUPLE(nd.id:2!null)\n" +
+			"                                             │                   │   │                       └─ MergeJoin\n" +
+			"                                             │                   │   │                           ├─ cmp: Eq\n" +
+			"                                             │                   │   │                           │   ├─ nma.id:9!null\n" +
+			"                                             │                   │   │                           │   └─ nd.HPCMS:12!null\n" +
+			"                                             │                   │   │                           ├─ TableAlias(nma)\n" +
+			"                                             │                   │   │                           │   └─ IndexedTableAccess(TNMXI)\n" +
+			"                                             │                   │   │                           │       ├─ index: [TNMXI.id]\n" +
+			"                                             │                   │   │                           │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │                           │       └─ columns: [id dzlim]\n" +
+			"                                             │                   │   │                           └─ TableAlias(nd)\n" +
+			"                                             │                   │   │                               └─ IndexedTableAccess(E2I7U)\n" +
+			"                                             │                   │   │                                   ├─ index: [E2I7U.HPCMS]\n" +
+			"                                             │                   │   │                                   ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │                   │   │                                   └─ columns: [id hpcms]\n" +
 			"                                             │                   │   └─ HashLookup\n" +
 			"                                             │                   │       ├─ left-key: TUPLE(iq.Z7CP5:2!null)\n" +
 			"                                             │                   │       ├─ right-key: TUPLE(w2mao.Z7CP5:0!null)\n" +
@@ -13680,86 +13543,82 @@ WHERE
 			"                 │               │   ├─ vc.ZNP4P:19!null\n" +
 			"                 │               │   └─ L5Q44 (longtext)\n" +
 			"                 │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
-			"                 │               └─ Filter\n" +
-			"                 │                   ├─ HashIn\n" +
-			"                 │                   │   ├─ mf.FSDY2:8!null\n" +
-			"                 │                   │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
-			"                 │                   └─ HashJoin\n" +
-			"                 │                       ├─ Eq\n" +
-			"                 │                       │   ├─ w2mao.Z7CP5:16!null\n" +
-			"                 │                       │   └─ mf.id:4!null\n" +
-			"                 │                       ├─ HashJoin\n" +
-			"                 │                       │   ├─ Eq\n" +
-			"                 │                       │   │   ├─ aac.id:14!null\n" +
-			"                 │                       │   │   └─ mf.M22QN:7!null\n" +
-			"                 │                       │   ├─ HashJoin\n" +
-			"                 │                       │   │   ├─ Eq\n" +
-			"                 │                       │   │   │   ├─ sn.BRQP2:13!null\n" +
-			"                 │                       │   │   │   └─ mf.LUEVY:6!null\n" +
-			"                 │                       │   │   ├─ HashJoin\n" +
-			"                 │                       │   │   │   ├─ Eq\n" +
-			"                 │                       │   │   │   │   ├─ mf.GXLUB:5!null\n" +
-			"                 │                       │   │   │   │   └─ bs.id:2!null\n" +
-			"                 │                       │   │   │   ├─ MergeJoin\n" +
-			"                 │                       │   │   │   │   ├─ cmp: Eq\n" +
-			"                 │                       │   │   │   │   │   ├─ cla.id:0!null\n" +
-			"                 │                       │   │   │   │   │   └─ bs.IXUXU:3\n" +
-			"                 │                       │   │   │   │   ├─ Filter\n" +
-			"                 │                       │   │   │   │   │   ├─ HashIn\n" +
-			"                 │                       │   │   │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
-			"                 │                       │   │   │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                 │                       │   │   │   │   │   └─ TableAlias(cla)\n" +
-			"                 │                       │   │   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                 │                       │   │   │   │   │           ├─ index: [YK2GW.id]\n" +
-			"                 │                       │   │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                       │   │   │   │   │           └─ columns: [id ftqlq]\n" +
-			"                 │                       │   │   │   │   └─ TableAlias(bs)\n" +
-			"                 │                       │   │   │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"                 │                       │   │   │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"                 │                       │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                       │   │   │   │           └─ columns: [id ixuxu]\n" +
-			"                 │                       │   │   │   └─ HashLookup\n" +
-			"                 │                       │   │   │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
-			"                 │                       │   │   │       ├─ right-key: TUPLE(mf.GXLUB:1!null)\n" +
-			"                 │                       │   │   │       └─ Filter\n" +
-			"                 │                       │   │   │           ├─ HashIn\n" +
-			"                 │                       │   │   │           │   ├─ mf.FSDY2:4!null\n" +
-			"                 │                       │   │   │           │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
-			"                 │                       │   │   │           └─ TableAlias(mf)\n" +
-			"                 │                       │   │   │               └─ Table\n" +
-			"                 │                       │   │   │                   ├─ name: HGMQ6\n" +
-			"                 │                       │   │   │                   └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
-			"                 │                       │   │   └─ HashLookup\n" +
-			"                 │                       │   │       ├─ left-key: TUPLE(mf.LUEVY:6!null)\n" +
-			"                 │                       │   │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"                 │                       │   │       └─ TableAlias(sn)\n" +
-			"                 │                       │   │           └─ Table\n" +
-			"                 │                       │   │               ├─ name: NOXN3\n" +
-			"                 │                       │   │               └─ columns: [id brqp2]\n" +
-			"                 │                       │   └─ HashLookup\n" +
-			"                 │                       │       ├─ left-key: TUPLE(mf.M22QN:7!null)\n" +
-			"                 │                       │       ├─ right-key: TUPLE(aac.id:0!null)\n" +
-			"                 │                       │       └─ TableAlias(aac)\n" +
-			"                 │                       │           └─ Table\n" +
-			"                 │                       │               ├─ name: TPXBU\n" +
-			"                 │                       │               └─ columns: [id btxc5]\n" +
-			"                 │                       └─ HashLookup\n" +
-			"                 │                           ├─ left-key: TUPLE(mf.id:4!null)\n" +
-			"                 │                           ├─ right-key: TUPLE(w2mao.Z7CP5:0!null)\n" +
-			"                 │                           └─ MergeJoin\n" +
-			"                 │                               ├─ cmp: Eq\n" +
-			"                 │                               │   ├─ w2mao.YH4XB:17!null\n" +
-			"                 │                               │   └─ vc.id:18!null\n" +
-			"                 │                               ├─ TableAlias(w2mao)\n" +
-			"                 │                               │   └─ IndexedTableAccess(SEQS3)\n" +
-			"                 │                               │       ├─ index: [SEQS3.YH4XB]\n" +
-			"                 │                               │       ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                               │       └─ columns: [z7cp5 yh4xb]\n" +
-			"                 │                               └─ TableAlias(vc)\n" +
-			"                 │                                   └─ IndexedTableAccess(D34QP)\n" +
-			"                 │                                       ├─ index: [D34QP.id]\n" +
-			"                 │                                       ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                                       └─ columns: [id znp4p]\n" +
+			"                 │               └─ HashJoin\n" +
+			"                 │                   ├─ Eq\n" +
+			"                 │                   │   ├─ w2mao.Z7CP5:16!null\n" +
+			"                 │                   │   └─ mf.id:4!null\n" +
+			"                 │                   ├─ HashJoin\n" +
+			"                 │                   │   ├─ Eq\n" +
+			"                 │                   │   │   ├─ aac.id:14!null\n" +
+			"                 │                   │   │   └─ mf.M22QN:7!null\n" +
+			"                 │                   │   ├─ HashJoin\n" +
+			"                 │                   │   │   ├─ Eq\n" +
+			"                 │                   │   │   │   ├─ sn.BRQP2:13!null\n" +
+			"                 │                   │   │   │   └─ mf.LUEVY:6!null\n" +
+			"                 │                   │   │   ├─ HashJoin\n" +
+			"                 │                   │   │   │   ├─ Eq\n" +
+			"                 │                   │   │   │   │   ├─ mf.GXLUB:5!null\n" +
+			"                 │                   │   │   │   │   └─ bs.id:2!null\n" +
+			"                 │                   │   │   │   ├─ MergeJoin\n" +
+			"                 │                   │   │   │   │   ├─ cmp: Eq\n" +
+			"                 │                   │   │   │   │   │   ├─ cla.id:0!null\n" +
+			"                 │                   │   │   │   │   │   └─ bs.IXUXU:3\n" +
+			"                 │                   │   │   │   │   ├─ Filter\n" +
+			"                 │                   │   │   │   │   │   ├─ HashIn\n" +
+			"                 │                   │   │   │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
+			"                 │                   │   │   │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                 │                   │   │   │   │   │   └─ TableAlias(cla)\n" +
+			"                 │                   │   │   │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                 │                   │   │   │   │   │           ├─ index: [YK2GW.id]\n" +
+			"                 │                   │   │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                   │   │   │   │   │           └─ columns: [id ftqlq]\n" +
+			"                 │                   │   │   │   │   └─ TableAlias(bs)\n" +
+			"                 │                   │   │   │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"                 │                   │   │   │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"                 │                   │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                   │   │   │   │           └─ columns: [id ixuxu]\n" +
+			"                 │                   │   │   │   └─ HashLookup\n" +
+			"                 │                   │   │   │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
+			"                 │                   │   │   │       ├─ right-key: TUPLE(mf.GXLUB:1!null)\n" +
+			"                 │                   │   │   │       └─ Filter\n" +
+			"                 │                   │   │   │           ├─ HashIn\n" +
+			"                 │                   │   │   │           │   ├─ mf.FSDY2:4!null\n" +
+			"                 │                   │   │   │           │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
+			"                 │                   │   │   │           └─ TableAlias(mf)\n" +
+			"                 │                   │   │   │               └─ Table\n" +
+			"                 │                   │   │   │                   ├─ name: HGMQ6\n" +
+			"                 │                   │   │   │                   └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
+			"                 │                   │   │   └─ HashLookup\n" +
+			"                 │                   │   │       ├─ left-key: TUPLE(mf.LUEVY:6!null)\n" +
+			"                 │                   │   │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"                 │                   │   │       └─ TableAlias(sn)\n" +
+			"                 │                   │   │           └─ Table\n" +
+			"                 │                   │   │               ├─ name: NOXN3\n" +
+			"                 │                   │   │               └─ columns: [id brqp2]\n" +
+			"                 │                   │   └─ HashLookup\n" +
+			"                 │                   │       ├─ left-key: TUPLE(mf.M22QN:7!null)\n" +
+			"                 │                   │       ├─ right-key: TUPLE(aac.id:0!null)\n" +
+			"                 │                   │       └─ TableAlias(aac)\n" +
+			"                 │                   │           └─ Table\n" +
+			"                 │                   │               ├─ name: TPXBU\n" +
+			"                 │                   │               └─ columns: [id btxc5]\n" +
+			"                 │                   └─ HashLookup\n" +
+			"                 │                       ├─ left-key: TUPLE(mf.id:4!null)\n" +
+			"                 │                       ├─ right-key: TUPLE(w2mao.Z7CP5:0!null)\n" +
+			"                 │                       └─ MergeJoin\n" +
+			"                 │                           ├─ cmp: Eq\n" +
+			"                 │                           │   ├─ w2mao.YH4XB:17!null\n" +
+			"                 │                           │   └─ vc.id:18!null\n" +
+			"                 │                           ├─ TableAlias(w2mao)\n" +
+			"                 │                           │   └─ IndexedTableAccess(SEQS3)\n" +
+			"                 │                           │       ├─ index: [SEQS3.YH4XB]\n" +
+			"                 │                           │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                           │       └─ columns: [z7cp5 yh4xb]\n" +
+			"                 │                           └─ TableAlias(vc)\n" +
+			"                 │                               └─ IndexedTableAccess(D34QP)\n" +
+			"                 │                                   ├─ index: [D34QP.id]\n" +
+			"                 │                                   ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                                   └─ columns: [id znp4p]\n" +
 			"                 └─ HashLookup\n" +
 			"                     ├─ left-key: TUPLE(oxxei.BDNYB:3!null, ckele.LWQ6O:0!null)\n" +
 			"                     ├─ right-key: TUPLE(e52ap.BDNYB:1!null, e52ap.BDNYB:1!null)\n" +
@@ -13923,86 +13782,82 @@ WHERE
 			"                 │               │   ├─ vc.ZNP4P:17!null\n" +
 			"                 │               │   └─ L5Q44 (longtext)\n" +
 			"                 │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
-			"                 │               └─ Filter\n" +
-			"                 │                   ├─ HashIn\n" +
-			"                 │                   │   ├─ mf.FSDY2:4!null\n" +
-			"                 │                   │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
-			"                 │                   └─ HashJoin\n" +
-			"                 │                       ├─ Eq\n" +
-			"                 │                       │   ├─ w2mao.Z7CP5:18!null\n" +
-			"                 │                       │   └─ mf.id:0!null\n" +
-			"                 │                       ├─ HashJoin\n" +
-			"                 │                       │   ├─ Eq\n" +
-			"                 │                       │   │   ├─ mf.GXLUB:1!null\n" +
-			"                 │                       │   │   └─ bs.id:12!null\n" +
-			"                 │                       │   ├─ HashJoin\n" +
-			"                 │                       │   │   ├─ Eq\n" +
-			"                 │                       │   │   │   ├─ aac.id:10!null\n" +
-			"                 │                       │   │   │   └─ mf.M22QN:3!null\n" +
-			"                 │                       │   │   ├─ HashJoin\n" +
-			"                 │                       │   │   │   ├─ Eq\n" +
-			"                 │                       │   │   │   │   ├─ sn.BRQP2:9!null\n" +
-			"                 │                       │   │   │   │   └─ mf.LUEVY:2!null\n" +
-			"                 │                       │   │   │   ├─ Filter\n" +
-			"                 │                       │   │   │   │   ├─ HashIn\n" +
-			"                 │                       │   │   │   │   │   ├─ mf.FSDY2:4!null\n" +
-			"                 │                       │   │   │   │   │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
-			"                 │                       │   │   │   │   └─ TableAlias(mf)\n" +
-			"                 │                       │   │   │   │       └─ Table\n" +
-			"                 │                       │   │   │   │           ├─ name: HGMQ6\n" +
-			"                 │                       │   │   │   │           └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
-			"                 │                       │   │   │   └─ HashLookup\n" +
-			"                 │                       │   │   │       ├─ left-key: TUPLE(mf.LUEVY:2!null)\n" +
-			"                 │                       │   │   │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"                 │                       │   │   │       └─ TableAlias(sn)\n" +
-			"                 │                       │   │   │           └─ Table\n" +
-			"                 │                       │   │   │               ├─ name: NOXN3\n" +
-			"                 │                       │   │   │               └─ columns: [id brqp2]\n" +
-			"                 │                       │   │   └─ HashLookup\n" +
-			"                 │                       │   │       ├─ left-key: TUPLE(mf.M22QN:3!null)\n" +
-			"                 │                       │   │       ├─ right-key: TUPLE(aac.id:0!null)\n" +
-			"                 │                       │   │       └─ TableAlias(aac)\n" +
-			"                 │                       │   │           └─ Table\n" +
-			"                 │                       │   │               ├─ name: TPXBU\n" +
-			"                 │                       │   │               └─ columns: [id btxc5]\n" +
-			"                 │                       │   └─ HashLookup\n" +
-			"                 │                       │       ├─ left-key: TUPLE(mf.GXLUB:1!null)\n" +
-			"                 │                       │       ├─ right-key: TUPLE(bs.id:0!null)\n" +
-			"                 │                       │       └─ MergeJoin\n" +
-			"                 │                       │           ├─ cmp: Eq\n" +
-			"                 │                       │           │   ├─ bs.IXUXU:13\n" +
-			"                 │                       │           │   └─ cla.id:14!null\n" +
-			"                 │                       │           ├─ TableAlias(bs)\n" +
-			"                 │                       │           │   └─ IndexedTableAccess(THNTS)\n" +
-			"                 │                       │           │       ├─ index: [THNTS.IXUXU]\n" +
-			"                 │                       │           │       ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                       │           │       └─ columns: [id ixuxu]\n" +
-			"                 │                       │           └─ Filter\n" +
-			"                 │                       │               ├─ HashIn\n" +
-			"                 │                       │               │   ├─ cla.FTQLQ:1!null\n" +
-			"                 │                       │               │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                 │                       │               └─ TableAlias(cla)\n" +
-			"                 │                       │                   └─ IndexedTableAccess(YK2GW)\n" +
-			"                 │                       │                       ├─ index: [YK2GW.id]\n" +
-			"                 │                       │                       ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                       │                       └─ columns: [id ftqlq]\n" +
-			"                 │                       └─ HashLookup\n" +
-			"                 │                           ├─ left-key: TUPLE(mf.id:0!null)\n" +
-			"                 │                           ├─ right-key: TUPLE(w2mao.Z7CP5:2!null)\n" +
-			"                 │                           └─ MergeJoin\n" +
-			"                 │                               ├─ cmp: Eq\n" +
-			"                 │                               │   ├─ vc.id:16!null\n" +
-			"                 │                               │   └─ w2mao.YH4XB:19!null\n" +
-			"                 │                               ├─ TableAlias(vc)\n" +
-			"                 │                               │   └─ IndexedTableAccess(D34QP)\n" +
-			"                 │                               │       ├─ index: [D34QP.id]\n" +
-			"                 │                               │       ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                               │       └─ columns: [id znp4p]\n" +
-			"                 │                               └─ TableAlias(w2mao)\n" +
-			"                 │                                   └─ IndexedTableAccess(SEQS3)\n" +
-			"                 │                                       ├─ index: [SEQS3.YH4XB]\n" +
-			"                 │                                       ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │                                       └─ columns: [z7cp5 yh4xb]\n" +
+			"                 │               └─ HashJoin\n" +
+			"                 │                   ├─ Eq\n" +
+			"                 │                   │   ├─ w2mao.Z7CP5:18!null\n" +
+			"                 │                   │   └─ mf.id:0!null\n" +
+			"                 │                   ├─ HashJoin\n" +
+			"                 │                   │   ├─ Eq\n" +
+			"                 │                   │   │   ├─ mf.GXLUB:1!null\n" +
+			"                 │                   │   │   └─ bs.id:12!null\n" +
+			"                 │                   │   ├─ HashJoin\n" +
+			"                 │                   │   │   ├─ Eq\n" +
+			"                 │                   │   │   │   ├─ aac.id:10!null\n" +
+			"                 │                   │   │   │   └─ mf.M22QN:3!null\n" +
+			"                 │                   │   │   ├─ HashJoin\n" +
+			"                 │                   │   │   │   ├─ Eq\n" +
+			"                 │                   │   │   │   │   ├─ sn.BRQP2:9!null\n" +
+			"                 │                   │   │   │   │   └─ mf.LUEVY:2!null\n" +
+			"                 │                   │   │   │   ├─ Filter\n" +
+			"                 │                   │   │   │   │   ├─ HashIn\n" +
+			"                 │                   │   │   │   │   │   ├─ mf.FSDY2:4!null\n" +
+			"                 │                   │   │   │   │   │   └─ TUPLE(SRARY (longtext), UBQWG (longtext))\n" +
+			"                 │                   │   │   │   │   └─ TableAlias(mf)\n" +
+			"                 │                   │   │   │   │       └─ Table\n" +
+			"                 │                   │   │   │   │           ├─ name: HGMQ6\n" +
+			"                 │                   │   │   │   │           └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
+			"                 │                   │   │   │   └─ HashLookup\n" +
+			"                 │                   │   │   │       ├─ left-key: TUPLE(mf.LUEVY:2!null)\n" +
+			"                 │                   │   │   │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"                 │                   │   │   │       └─ TableAlias(sn)\n" +
+			"                 │                   │   │   │           └─ Table\n" +
+			"                 │                   │   │   │               ├─ name: NOXN3\n" +
+			"                 │                   │   │   │               └─ columns: [id brqp2]\n" +
+			"                 │                   │   │   └─ HashLookup\n" +
+			"                 │                   │   │       ├─ left-key: TUPLE(mf.M22QN:3!null)\n" +
+			"                 │                   │   │       ├─ right-key: TUPLE(aac.id:0!null)\n" +
+			"                 │                   │   │       └─ TableAlias(aac)\n" +
+			"                 │                   │   │           └─ Table\n" +
+			"                 │                   │   │               ├─ name: TPXBU\n" +
+			"                 │                   │   │               └─ columns: [id btxc5]\n" +
+			"                 │                   │   └─ HashLookup\n" +
+			"                 │                   │       ├─ left-key: TUPLE(mf.GXLUB:1!null)\n" +
+			"                 │                   │       ├─ right-key: TUPLE(bs.id:0!null)\n" +
+			"                 │                   │       └─ MergeJoin\n" +
+			"                 │                   │           ├─ cmp: Eq\n" +
+			"                 │                   │           │   ├─ bs.IXUXU:13\n" +
+			"                 │                   │           │   └─ cla.id:14!null\n" +
+			"                 │                   │           ├─ TableAlias(bs)\n" +
+			"                 │                   │           │   └─ IndexedTableAccess(THNTS)\n" +
+			"                 │                   │           │       ├─ index: [THNTS.IXUXU]\n" +
+			"                 │                   │           │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                   │           │       └─ columns: [id ixuxu]\n" +
+			"                 │                   │           └─ Filter\n" +
+			"                 │                   │               ├─ HashIn\n" +
+			"                 │                   │               │   ├─ cla.FTQLQ:1!null\n" +
+			"                 │                   │               │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                 │                   │               └─ TableAlias(cla)\n" +
+			"                 │                   │                   └─ IndexedTableAccess(YK2GW)\n" +
+			"                 │                   │                       ├─ index: [YK2GW.id]\n" +
+			"                 │                   │                       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                   │                       └─ columns: [id ftqlq]\n" +
+			"                 │                   └─ HashLookup\n" +
+			"                 │                       ├─ left-key: TUPLE(mf.id:0!null)\n" +
+			"                 │                       ├─ right-key: TUPLE(w2mao.Z7CP5:2!null)\n" +
+			"                 │                       └─ MergeJoin\n" +
+			"                 │                           ├─ cmp: Eq\n" +
+			"                 │                           │   ├─ vc.id:16!null\n" +
+			"                 │                           │   └─ w2mao.YH4XB:19!null\n" +
+			"                 │                           ├─ TableAlias(vc)\n" +
+			"                 │                           │   └─ IndexedTableAccess(D34QP)\n" +
+			"                 │                           │       ├─ index: [D34QP.id]\n" +
+			"                 │                           │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                           │       └─ columns: [id znp4p]\n" +
+			"                 │                           └─ TableAlias(w2mao)\n" +
+			"                 │                               └─ IndexedTableAccess(SEQS3)\n" +
+			"                 │                                   ├─ index: [SEQS3.YH4XB]\n" +
+			"                 │                                   ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │                                   └─ columns: [z7cp5 yh4xb]\n" +
 			"                 └─ HashLookup\n" +
 			"                     ├─ left-key: TUPLE(oxxei.BDNYB:3!null, ckele.LWQ6O:0!null)\n" +
 			"                     ├─ right-key: TUPLE(e52ap.BDNYB:1!null, e52ap.BDNYB:1!null)\n" +
@@ -14362,8 +14217,8 @@ WHERE
 			"         │   │   │   │                       │   ├─ jtehg.BRQP2:22!null\n" +
 			"         │   │   │   │                       │   └─ mjr3d.BJUF2:1!null\n" +
 			"         │   │   │   │                       └─ TableAlias(jtehg)\n" +
-			"         │   │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"         │   │   │   │                           └─ Table\n" +
+			"         │   │   │   │                               ├─ name: NOXN3\n" +
 			"         │   │   │   │                               └─ columns: [id brqp2]\n" +
 			"         │   │   │   └─ AND\n" +
 			"         │   │   │       ├─ AND\n" +
@@ -14382,8 +14237,8 @@ WHERE
 			"         │   │   │                       │   ├─ xmafz.BRQP2:22!null\n" +
 			"         │   │   │                       │   └─ mjr3d.FJDP5:0!null\n" +
 			"         │   │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"         │   │   │                           └─ Table\n" +
+			"         │   │   │                               ├─ name: NOXN3\n" +
 			"         │   │   │                               └─ columns: [id brqp2]\n" +
 			"         │   │   └─ AND\n" +
 			"         │   │       ├─ AND\n" +
@@ -14403,8 +14258,8 @@ WHERE
 			"         │   │                       │   ├─ xmafz.BRQP2:22!null\n" +
 			"         │   │                       │   └─ mjr3d.BJUF2:1!null\n" +
 			"         │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"         │   │                           └─ Table\n" +
+			"         │   │                               ├─ name: NOXN3\n" +
 			"         │   │                               └─ columns: [id brqp2]\n" +
 			"         │   ├─ SubqueryAlias\n" +
 			"         │   │   ├─ name: mjr3d\n" +
@@ -14975,50 +14830,46 @@ WHERE
 			"     │           │               ├─ cacheable: true\n" +
 			"     │           │               └─ Project\n" +
 			"     │           │                   ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
-			"     │           │                   └─ Filter\n" +
-			"     │           │                       ├─ HashIn\n" +
-			"     │           │                       │   ├─ cla.FTQLQ:1!null\n" +
-			"     │           │                       │   └─ TUPLE(SQ1 (longtext))\n" +
-			"     │           │                       └─ HashJoin\n" +
-			"     │           │                           ├─ Eq\n" +
-			"     │           │                           │   ├─ sn.BRQP2:8!null\n" +
-			"     │           │                           │   └─ mf.LUEVY:5!null\n" +
-			"     │           │                           ├─ HashJoin\n" +
-			"     │           │                           │   ├─ Eq\n" +
-			"     │           │                           │   │   ├─ bs.id:2!null\n" +
-			"     │           │                           │   │   └─ mf.GXLUB:4!null\n" +
-			"     │           │                           │   ├─ MergeJoin\n" +
-			"     │           │                           │   │   ├─ cmp: Eq\n" +
-			"     │           │                           │   │   │   ├─ cla.id:0!null\n" +
-			"     │           │                           │   │   │   └─ bs.IXUXU:3\n" +
-			"     │           │                           │   │   ├─ Filter\n" +
-			"     │           │                           │   │   │   ├─ HashIn\n" +
-			"     │           │                           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
-			"     │           │                           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"     │           │                           │   │   │   └─ TableAlias(cla)\n" +
-			"     │           │                           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
-			"     │           │                           │   │   │           ├─ index: [YK2GW.id]\n" +
-			"     │           │                           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           │                           │   │   │           └─ columns: [id ftqlq]\n" +
-			"     │           │                           │   │   └─ TableAlias(bs)\n" +
-			"     │           │                           │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"     │           │                           │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"     │           │                           │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           │                           │   │           └─ columns: [id ixuxu]\n" +
-			"     │           │                           │   └─ HashLookup\n" +
-			"     │           │                           │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
-			"     │           │                           │       ├─ right-key: TUPLE(mf.GXLUB:0!null)\n" +
-			"     │           │                           │       └─ TableAlias(mf)\n" +
-			"     │           │                           │           └─ Table\n" +
-			"     │           │                           │               ├─ name: HGMQ6\n" +
-			"     │           │                           │               └─ columns: [gxlub luevy m22qn]\n" +
-			"     │           │                           └─ HashLookup\n" +
-			"     │           │                               ├─ left-key: TUPLE(mf.LUEVY:5!null)\n" +
-			"     │           │                               ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"     │           │                               └─ TableAlias(sn)\n" +
-			"     │           │                                   └─ Table\n" +
-			"     │           │                                       ├─ name: NOXN3\n" +
-			"     │           │                                       └─ columns: [id brqp2]\n" +
+			"     │           │                   └─ HashJoin\n" +
+			"     │           │                       ├─ Eq\n" +
+			"     │           │                       │   ├─ sn.BRQP2:8!null\n" +
+			"     │           │                       │   └─ mf.LUEVY:5!null\n" +
+			"     │           │                       ├─ HashJoin\n" +
+			"     │           │                       │   ├─ Eq\n" +
+			"     │           │                       │   │   ├─ bs.id:2!null\n" +
+			"     │           │                       │   │   └─ mf.GXLUB:4!null\n" +
+			"     │           │                       │   ├─ MergeJoin\n" +
+			"     │           │                       │   │   ├─ cmp: Eq\n" +
+			"     │           │                       │   │   │   ├─ cla.id:0!null\n" +
+			"     │           │                       │   │   │   └─ bs.IXUXU:3\n" +
+			"     │           │                       │   │   ├─ Filter\n" +
+			"     │           │                       │   │   │   ├─ HashIn\n" +
+			"     │           │                       │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
+			"     │           │                       │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"     │           │                       │   │   │   └─ TableAlias(cla)\n" +
+			"     │           │                       │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
+			"     │           │                       │   │   │           ├─ index: [YK2GW.id]\n" +
+			"     │           │                       │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"     │           │                       │   │   │           └─ columns: [id ftqlq]\n" +
+			"     │           │                       │   │   └─ TableAlias(bs)\n" +
+			"     │           │                       │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"     │           │                       │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"     │           │                       │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"     │           │                       │   │           └─ columns: [id ixuxu]\n" +
+			"     │           │                       │   └─ HashLookup\n" +
+			"     │           │                       │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
+			"     │           │                       │       ├─ right-key: TUPLE(mf.GXLUB:0!null)\n" +
+			"     │           │                       │       └─ TableAlias(mf)\n" +
+			"     │           │                       │           └─ Table\n" +
+			"     │           │                       │               ├─ name: HGMQ6\n" +
+			"     │           │                       │               └─ columns: [gxlub luevy m22qn]\n" +
+			"     │           │                       └─ HashLookup\n" +
+			"     │           │                           ├─ left-key: TUPLE(mf.LUEVY:5!null)\n" +
+			"     │           │                           ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"     │           │                           └─ TableAlias(sn)\n" +
+			"     │           │                               └─ Table\n" +
+			"     │           │                                   ├─ name: NOXN3\n" +
+			"     │           │                                   └─ columns: [id brqp2]\n" +
 			"     │           └─ HashLookup\n" +
 			"     │               ├─ left-key: TUPLE()\n" +
 			"     │               ├─ right-key: TUPLE()\n" +
@@ -15157,8 +15008,8 @@ WHERE
 			"     │                                           │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"     │                                           │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"     │                                           │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │                                           │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │                                           │   │   │       │                       └─ Table\n" +
+			"     │                                           │   │   │       │                           ├─ name: NOXN3\n" +
 			"     │                                           │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │   │       └─ NOT\n" +
 			"     │                                           │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15178,8 +15029,8 @@ WHERE
 			"     │                                           │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"     │                                           │   │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │                                           │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │                                           │   │       │                       └─ Table\n" +
+			"     │                                           │   │       │                           ├─ name: NOXN3\n" +
 			"     │                                           │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"     │                                           │   └─ AND\n" +
@@ -15198,8 +15049,8 @@ WHERE
 			"     │                                           │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │                                           │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │                                           │       │                       └─ Table\n" +
+			"     │                                           │       │                           ├─ name: NOXN3\n" +
 			"     │                                           │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │       └─ NOT\n" +
 			"     │                                           │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15215,14 +15066,11 @@ WHERE
 			"     │                                           │   │       └─ Project\n" +
 			"     │                                           │   │           ├─ columns: [ism.FV24E:9!null as FJDP5, cpmfe.id:27!null as BJUF2, ism.M22QN:11!null as M22QN, g3yxs.TUV25:5 as TUV25, g3yxs.ESFVY:1!null as ESFVY, yqif4.id:44!null as QNI57, yvhjz.id:54!null as TDEIU]\n" +
 			"     │                                           │   │           └─ Filter\n" +
-			"     │                                           │   │               ├─ AND\n" +
+			"     │                                           │   │               ├─ Or\n" +
 			"     │                                           │   │               │   ├─ NOT\n" +
-			"     │                                           │   │               │   │   └─ g3yxs.TUV25:5 IS NULL\n" +
-			"     │                                           │   │               │   └─ Or\n" +
-			"     │                                           │   │               │       ├─ NOT\n" +
-			"     │                                           │   │               │       │   └─ yqif4.id:44!null IS NULL\n" +
-			"     │                                           │   │               │       └─ NOT\n" +
-			"     │                                           │   │               │           └─ yvhjz.id:54!null IS NULL\n" +
+			"     │                                           │   │               │   │   └─ yqif4.id:44!null IS NULL\n" +
+			"     │                                           │   │               │   └─ NOT\n" +
+			"     │                                           │   │               │       └─ yvhjz.id:54!null IS NULL\n" +
 			"     │                                           │   │               └─ LeftOuterHashJoin\n" +
 			"     │                                           │   │                   ├─ AND\n" +
 			"     │                                           │   │                   │   ├─ Eq\n" +
@@ -15330,50 +15178,46 @@ WHERE
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
 			"                             │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
-			"                             │       └─ Filter\n" +
-			"                             │           ├─ HashIn\n" +
-			"                             │           │   ├─ cla.FTQLQ:1!null\n" +
-			"                             │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │           └─ HashJoin\n" +
-			"                             │               ├─ Eq\n" +
-			"                             │               │   ├─ sn.BRQP2:8!null\n" +
-			"                             │               │   └─ mf.LUEVY:5!null\n" +
-			"                             │               ├─ HashJoin\n" +
-			"                             │               │   ├─ Eq\n" +
-			"                             │               │   │   ├─ bs.id:2!null\n" +
-			"                             │               │   │   └─ mf.GXLUB:4!null\n" +
-			"                             │               │   ├─ MergeJoin\n" +
-			"                             │               │   │   ├─ cmp: Eq\n" +
-			"                             │               │   │   │   ├─ cla.id:0!null\n" +
-			"                             │               │   │   │   └─ bs.IXUXU:3\n" +
-			"                             │               │   │   ├─ Filter\n" +
-			"                             │               │   │   │   ├─ HashIn\n" +
-			"                             │               │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
-			"                             │               │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │               │   │   │   └─ TableAlias(cla)\n" +
-			"                             │               │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                             │               │   │   │           ├─ index: [YK2GW.id]\n" +
-			"                             │               │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │               │   │   │           └─ columns: [id ftqlq]\n" +
-			"                             │               │   │   └─ TableAlias(bs)\n" +
-			"                             │               │   │       └─ IndexedTableAccess(THNTS)\n" +
-			"                             │               │   │           ├─ index: [THNTS.IXUXU]\n" +
-			"                             │               │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │               │   │           └─ columns: [id ixuxu]\n" +
-			"                             │               │   └─ HashLookup\n" +
-			"                             │               │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
-			"                             │               │       ├─ right-key: TUPLE(mf.GXLUB:0!null)\n" +
-			"                             │               │       └─ TableAlias(mf)\n" +
-			"                             │               │           └─ Table\n" +
-			"                             │               │               ├─ name: HGMQ6\n" +
-			"                             │               │               └─ columns: [gxlub luevy m22qn]\n" +
-			"                             │               └─ HashLookup\n" +
-			"                             │                   ├─ left-key: TUPLE(mf.LUEVY:5!null)\n" +
-			"                             │                   ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"                             │                   └─ TableAlias(sn)\n" +
-			"                             │                       └─ Table\n" +
-			"                             │                           ├─ name: NOXN3\n" +
-			"                             │                           └─ columns: [id brqp2]\n" +
+			"                             │       └─ HashJoin\n" +
+			"                             │           ├─ Eq\n" +
+			"                             │           │   ├─ sn.BRQP2:8!null\n" +
+			"                             │           │   └─ mf.LUEVY:5!null\n" +
+			"                             │           ├─ HashJoin\n" +
+			"                             │           │   ├─ Eq\n" +
+			"                             │           │   │   ├─ bs.id:2!null\n" +
+			"                             │           │   │   └─ mf.GXLUB:4!null\n" +
+			"                             │           │   ├─ MergeJoin\n" +
+			"                             │           │   │   ├─ cmp: Eq\n" +
+			"                             │           │   │   │   ├─ cla.id:0!null\n" +
+			"                             │           │   │   │   └─ bs.IXUXU:3\n" +
+			"                             │           │   │   ├─ Filter\n" +
+			"                             │           │   │   │   ├─ HashIn\n" +
+			"                             │           │   │   │   │   ├─ cla.FTQLQ:1!null\n" +
+			"                             │           │   │   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                             │           │   │   │   └─ TableAlias(cla)\n" +
+			"                             │           │   │   │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                             │           │   │   │           ├─ index: [YK2GW.id]\n" +
+			"                             │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │           │   │   │           └─ columns: [id ftqlq]\n" +
+			"                             │           │   │   └─ TableAlias(bs)\n" +
+			"                             │           │   │       └─ IndexedTableAccess(THNTS)\n" +
+			"                             │           │   │           ├─ index: [THNTS.IXUXU]\n" +
+			"                             │           │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │           │   │           └─ columns: [id ixuxu]\n" +
+			"                             │           │   └─ HashLookup\n" +
+			"                             │           │       ├─ left-key: TUPLE(bs.id:2!null)\n" +
+			"                             │           │       ├─ right-key: TUPLE(mf.GXLUB:0!null)\n" +
+			"                             │           │       └─ TableAlias(mf)\n" +
+			"                             │           │           └─ Table\n" +
+			"                             │           │               ├─ name: HGMQ6\n" +
+			"                             │           │               └─ columns: [gxlub luevy m22qn]\n" +
+			"                             │           └─ HashLookup\n" +
+			"                             │               ├─ left-key: TUPLE(mf.LUEVY:5!null)\n" +
+			"                             │               ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"                             │               └─ TableAlias(sn)\n" +
+			"                             │                   └─ Table\n" +
+			"                             │                       ├─ name: NOXN3\n" +
+			"                             │                       └─ columns: [id brqp2]\n" +
 			"                             └─ HashLookup\n" +
 			"                                 ├─ left-key: TUPLE(cld.BDNYB:1!null, cld.M22QN:2!null)\n" +
 			"                                 ├─ right-key: TUPLE(p4pjz.LWQ6O:3!null, p4pjz.NTOFG:2!null)\n" +
@@ -15505,8 +15349,8 @@ WHERE
 			"                                                 │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"                                                 │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"                                                 │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │   │       │                       └─ Table\n" +
+			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
 			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ NOT\n" +
 			"                                                 │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15526,8 +15370,8 @@ WHERE
 			"                                                 │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │       │                       └─ Table\n" +
+			"                                                 │   │       │                           ├─ name: NOXN3\n" +
 			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"                                                 │   └─ AND\n" +
@@ -15546,8 +15390,8 @@ WHERE
 			"                                                 │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │       │                       └─ Table\n" +
+			"                                                 │       │                           ├─ name: NOXN3\n" +
 			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ NOT\n" +
 			"                                                 │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15563,14 +15407,11 @@ WHERE
 			"                                                 │   │       └─ Project\n" +
 			"                                                 │   │           ├─ columns: [ism.FV24E:9!null as FJDP5, cpmfe.id:27!null as BJUF2, ism.M22QN:11!null as M22QN, g3yxs.TUV25:5 as TUV25, g3yxs.ESFVY:1!null as ESFVY, yqif4.id:44!null as QNI57, yvhjz.id:54!null as TDEIU]\n" +
 			"                                                 │   │           └─ Filter\n" +
-			"                                                 │   │               ├─ AND\n" +
+			"                                                 │   │               ├─ Or\n" +
 			"                                                 │   │               │   ├─ NOT\n" +
-			"                                                 │   │               │   │   └─ g3yxs.TUV25:5 IS NULL\n" +
-			"                                                 │   │               │   └─ Or\n" +
-			"                                                 │   │               │       ├─ NOT\n" +
-			"                                                 │   │               │       │   └─ yqif4.id:44!null IS NULL\n" +
-			"                                                 │   │               │       └─ NOT\n" +
-			"                                                 │   │               │           └─ yvhjz.id:54!null IS NULL\n" +
+			"                                                 │   │               │   │   └─ yqif4.id:44!null IS NULL\n" +
+			"                                                 │   │               │   └─ NOT\n" +
+			"                                                 │   │               │       └─ yvhjz.id:54!null IS NULL\n" +
 			"                                                 │   │               └─ LeftOuterHashJoin\n" +
 			"                                                 │   │                   ├─ AND\n" +
 			"                                                 │   │                   │   ├─ Eq\n" +
@@ -15832,50 +15673,46 @@ WHERE
 			"     │           │               ├─ cacheable: true\n" +
 			"     │           │               └─ Project\n" +
 			"     │           │                   ├─ columns: [cla.FTQLQ:6!null as T4IBQ, sn.id:3!null as BDNYB, mf.M22QN:2!null as M22QN]\n" +
-			"     │           │                   └─ Filter\n" +
-			"     │           │                       ├─ HashIn\n" +
-			"     │           │                       │   ├─ cla.FTQLQ:6!null\n" +
-			"     │           │                       │   └─ TUPLE(SQ1 (longtext))\n" +
-			"     │           │                       └─ HashJoin\n" +
-			"     │           │                           ├─ Eq\n" +
-			"     │           │                           │   ├─ bs.id:7!null\n" +
-			"     │           │                           │   └─ mf.GXLUB:0!null\n" +
-			"     │           │                           ├─ HashJoin\n" +
-			"     │           │                           │   ├─ Eq\n" +
-			"     │           │                           │   │   ├─ sn.BRQP2:4!null\n" +
-			"     │           │                           │   │   └─ mf.LUEVY:1!null\n" +
-			"     │           │                           │   ├─ TableAlias(mf)\n" +
-			"     │           │                           │   │   └─ Table\n" +
-			"     │           │                           │   │       ├─ name: HGMQ6\n" +
-			"     │           │                           │   │       └─ columns: [gxlub luevy m22qn]\n" +
-			"     │           │                           │   └─ HashLookup\n" +
-			"     │           │                           │       ├─ left-key: TUPLE(mf.LUEVY:1!null)\n" +
-			"     │           │                           │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"     │           │                           │       └─ TableAlias(sn)\n" +
-			"     │           │                           │           └─ Table\n" +
-			"     │           │                           │               ├─ name: NOXN3\n" +
-			"     │           │                           │               └─ columns: [id brqp2]\n" +
-			"     │           │                           └─ HashLookup\n" +
-			"     │           │                               ├─ left-key: TUPLE(mf.GXLUB:0!null)\n" +
-			"     │           │                               ├─ right-key: TUPLE(bs.id:2!null)\n" +
-			"     │           │                               └─ MergeJoin\n" +
-			"     │           │                                   ├─ cmp: Eq\n" +
-			"     │           │                                   │   ├─ cla.id:5!null\n" +
-			"     │           │                                   │   └─ bs.IXUXU:8\n" +
-			"     │           │                                   ├─ Filter\n" +
-			"     │           │                                   │   ├─ HashIn\n" +
-			"     │           │                                   │   │   ├─ cla.FTQLQ:1!null\n" +
-			"     │           │                                   │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"     │           │                                   │   └─ TableAlias(cla)\n" +
-			"     │           │                                   │       └─ IndexedTableAccess(YK2GW)\n" +
-			"     │           │                                   │           ├─ index: [YK2GW.id]\n" +
-			"     │           │                                   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           │                                   │           └─ columns: [id ftqlq]\n" +
-			"     │           │                                   └─ TableAlias(bs)\n" +
-			"     │           │                                       └─ IndexedTableAccess(THNTS)\n" +
-			"     │           │                                           ├─ index: [THNTS.IXUXU]\n" +
-			"     │           │                                           ├─ static: [{[NULL, ∞)}]\n" +
-			"     │           │                                           └─ columns: [id ixuxu]\n" +
+			"     │           │                   └─ HashJoin\n" +
+			"     │           │                       ├─ Eq\n" +
+			"     │           │                       │   ├─ bs.id:7!null\n" +
+			"     │           │                       │   └─ mf.GXLUB:0!null\n" +
+			"     │           │                       ├─ HashJoin\n" +
+			"     │           │                       │   ├─ Eq\n" +
+			"     │           │                       │   │   ├─ sn.BRQP2:4!null\n" +
+			"     │           │                       │   │   └─ mf.LUEVY:1!null\n" +
+			"     │           │                       │   ├─ TableAlias(mf)\n" +
+			"     │           │                       │   │   └─ Table\n" +
+			"     │           │                       │   │       ├─ name: HGMQ6\n" +
+			"     │           │                       │   │       └─ columns: [gxlub luevy m22qn]\n" +
+			"     │           │                       │   └─ HashLookup\n" +
+			"     │           │                       │       ├─ left-key: TUPLE(mf.LUEVY:1!null)\n" +
+			"     │           │                       │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"     │           │                       │       └─ TableAlias(sn)\n" +
+			"     │           │                       │           └─ Table\n" +
+			"     │           │                       │               ├─ name: NOXN3\n" +
+			"     │           │                       │               └─ columns: [id brqp2]\n" +
+			"     │           │                       └─ HashLookup\n" +
+			"     │           │                           ├─ left-key: TUPLE(mf.GXLUB:0!null)\n" +
+			"     │           │                           ├─ right-key: TUPLE(bs.id:2!null)\n" +
+			"     │           │                           └─ MergeJoin\n" +
+			"     │           │                               ├─ cmp: Eq\n" +
+			"     │           │                               │   ├─ cla.id:5!null\n" +
+			"     │           │                               │   └─ bs.IXUXU:8\n" +
+			"     │           │                               ├─ Filter\n" +
+			"     │           │                               │   ├─ HashIn\n" +
+			"     │           │                               │   │   ├─ cla.FTQLQ:1!null\n" +
+			"     │           │                               │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"     │           │                               │   └─ TableAlias(cla)\n" +
+			"     │           │                               │       └─ IndexedTableAccess(YK2GW)\n" +
+			"     │           │                               │           ├─ index: [YK2GW.id]\n" +
+			"     │           │                               │           ├─ static: [{[NULL, ∞)}]\n" +
+			"     │           │                               │           └─ columns: [id ftqlq]\n" +
+			"     │           │                               └─ TableAlias(bs)\n" +
+			"     │           │                                   └─ IndexedTableAccess(THNTS)\n" +
+			"     │           │                                       ├─ index: [THNTS.IXUXU]\n" +
+			"     │           │                                       ├─ static: [{[NULL, ∞)}]\n" +
+			"     │           │                                       └─ columns: [id ixuxu]\n" +
 			"     │           └─ HashLookup\n" +
 			"     │               ├─ left-key: TUPLE()\n" +
 			"     │               ├─ right-key: TUPLE()\n" +
@@ -16014,8 +15851,8 @@ WHERE
 			"     │                                           │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"     │                                           │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"     │                                           │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │                                           │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │                                           │   │   │       │                       └─ Table\n" +
+			"     │                                           │   │   │       │                           ├─ name: NOXN3\n" +
 			"     │                                           │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │   │       └─ NOT\n" +
 			"     │                                           │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16035,8 +15872,8 @@ WHERE
 			"     │                                           │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"     │                                           │   │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │                                           │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │                                           │   │       │                       └─ Table\n" +
+			"     │                                           │   │       │                           ├─ name: NOXN3\n" +
 			"     │                                           │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"     │                                           │   └─ AND\n" +
@@ -16055,8 +15892,8 @@ WHERE
 			"     │                                           │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"     │                                           │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"     │                                           │       │                       └─ Table\n" +
+			"     │                                           │       │                           ├─ name: NOXN3\n" +
 			"     │                                           │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │       └─ NOT\n" +
 			"     │                                           │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16072,14 +15909,11 @@ WHERE
 			"     │                                           │   │       └─ Project\n" +
 			"     │                                           │   │           ├─ columns: [ism.FV24E:9!null as FJDP5, cpmfe.id:27!null as BJUF2, ism.M22QN:11!null as M22QN, g3yxs.TUV25:5 as TUV25, g3yxs.ESFVY:1!null as ESFVY, yqif4.id:44!null as QNI57, yvhjz.id:54!null as TDEIU]\n" +
 			"     │                                           │   │           └─ Filter\n" +
-			"     │                                           │   │               ├─ AND\n" +
+			"     │                                           │   │               ├─ Or\n" +
 			"     │                                           │   │               │   ├─ NOT\n" +
-			"     │                                           │   │               │   │   └─ g3yxs.TUV25:5 IS NULL\n" +
-			"     │                                           │   │               │   └─ Or\n" +
-			"     │                                           │   │               │       ├─ NOT\n" +
-			"     │                                           │   │               │       │   └─ yqif4.id:44!null IS NULL\n" +
-			"     │                                           │   │               │       └─ NOT\n" +
-			"     │                                           │   │               │           └─ yvhjz.id:54!null IS NULL\n" +
+			"     │                                           │   │               │   │   └─ yqif4.id:44!null IS NULL\n" +
+			"     │                                           │   │               │   └─ NOT\n" +
+			"     │                                           │   │               │       └─ yvhjz.id:54!null IS NULL\n" +
 			"     │                                           │   │               └─ LeftOuterHashJoin\n" +
 			"     │                                           │   │                   ├─ AND\n" +
 			"     │                                           │   │                   │   ├─ Eq\n" +
@@ -16187,50 +16021,46 @@ WHERE
 			"                             │   ├─ cacheable: true\n" +
 			"                             │   └─ Project\n" +
 			"                             │       ├─ columns: [cla.FTQLQ:6!null as T4IBQ, sn.id:3!null as BDNYB, mf.M22QN:2!null as M22QN]\n" +
-			"                             │       └─ Filter\n" +
-			"                             │           ├─ HashIn\n" +
-			"                             │           │   ├─ cla.FTQLQ:6!null\n" +
-			"                             │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │           └─ HashJoin\n" +
-			"                             │               ├─ Eq\n" +
-			"                             │               │   ├─ bs.id:7!null\n" +
-			"                             │               │   └─ mf.GXLUB:0!null\n" +
-			"                             │               ├─ HashJoin\n" +
-			"                             │               │   ├─ Eq\n" +
-			"                             │               │   │   ├─ sn.BRQP2:4!null\n" +
-			"                             │               │   │   └─ mf.LUEVY:1!null\n" +
-			"                             │               │   ├─ TableAlias(mf)\n" +
-			"                             │               │   │   └─ Table\n" +
-			"                             │               │   │       ├─ name: HGMQ6\n" +
-			"                             │               │   │       └─ columns: [gxlub luevy m22qn]\n" +
-			"                             │               │   └─ HashLookup\n" +
-			"                             │               │       ├─ left-key: TUPLE(mf.LUEVY:1!null)\n" +
-			"                             │               │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
-			"                             │               │       └─ TableAlias(sn)\n" +
-			"                             │               │           └─ Table\n" +
-			"                             │               │               ├─ name: NOXN3\n" +
-			"                             │               │               └─ columns: [id brqp2]\n" +
-			"                             │               └─ HashLookup\n" +
-			"                             │                   ├─ left-key: TUPLE(mf.GXLUB:0!null)\n" +
-			"                             │                   ├─ right-key: TUPLE(bs.id:2!null)\n" +
-			"                             │                   └─ MergeJoin\n" +
-			"                             │                       ├─ cmp: Eq\n" +
-			"                             │                       │   ├─ cla.id:5!null\n" +
-			"                             │                       │   └─ bs.IXUXU:8\n" +
-			"                             │                       ├─ Filter\n" +
-			"                             │                       │   ├─ HashIn\n" +
-			"                             │                       │   │   ├─ cla.FTQLQ:1!null\n" +
-			"                             │                       │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                             │                       │   └─ TableAlias(cla)\n" +
-			"                             │                       │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                             │                       │           ├─ index: [YK2GW.id]\n" +
-			"                             │                       │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │                       │           └─ columns: [id ftqlq]\n" +
-			"                             │                       └─ TableAlias(bs)\n" +
-			"                             │                           └─ IndexedTableAccess(THNTS)\n" +
-			"                             │                               ├─ index: [THNTS.IXUXU]\n" +
-			"                             │                               ├─ static: [{[NULL, ∞)}]\n" +
-			"                             │                               └─ columns: [id ixuxu]\n" +
+			"                             │       └─ HashJoin\n" +
+			"                             │           ├─ Eq\n" +
+			"                             │           │   ├─ bs.id:7!null\n" +
+			"                             │           │   └─ mf.GXLUB:0!null\n" +
+			"                             │           ├─ HashJoin\n" +
+			"                             │           │   ├─ Eq\n" +
+			"                             │           │   │   ├─ sn.BRQP2:4!null\n" +
+			"                             │           │   │   └─ mf.LUEVY:1!null\n" +
+			"                             │           │   ├─ TableAlias(mf)\n" +
+			"                             │           │   │   └─ Table\n" +
+			"                             │           │   │       ├─ name: HGMQ6\n" +
+			"                             │           │   │       └─ columns: [gxlub luevy m22qn]\n" +
+			"                             │           │   └─ HashLookup\n" +
+			"                             │           │       ├─ left-key: TUPLE(mf.LUEVY:1!null)\n" +
+			"                             │           │       ├─ right-key: TUPLE(sn.BRQP2:1!null)\n" +
+			"                             │           │       └─ TableAlias(sn)\n" +
+			"                             │           │           └─ Table\n" +
+			"                             │           │               ├─ name: NOXN3\n" +
+			"                             │           │               └─ columns: [id brqp2]\n" +
+			"                             │           └─ HashLookup\n" +
+			"                             │               ├─ left-key: TUPLE(mf.GXLUB:0!null)\n" +
+			"                             │               ├─ right-key: TUPLE(bs.id:2!null)\n" +
+			"                             │               └─ MergeJoin\n" +
+			"                             │                   ├─ cmp: Eq\n" +
+			"                             │                   │   ├─ cla.id:5!null\n" +
+			"                             │                   │   └─ bs.IXUXU:8\n" +
+			"                             │                   ├─ Filter\n" +
+			"                             │                   │   ├─ HashIn\n" +
+			"                             │                   │   │   ├─ cla.FTQLQ:1!null\n" +
+			"                             │                   │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                             │                   │   └─ TableAlias(cla)\n" +
+			"                             │                   │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                             │                   │           ├─ index: [YK2GW.id]\n" +
+			"                             │                   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │                   │           └─ columns: [id ftqlq]\n" +
+			"                             │                   └─ TableAlias(bs)\n" +
+			"                             │                       └─ IndexedTableAccess(THNTS)\n" +
+			"                             │                           ├─ index: [THNTS.IXUXU]\n" +
+			"                             │                           ├─ static: [{[NULL, ∞)}]\n" +
+			"                             │                           └─ columns: [id ixuxu]\n" +
 			"                             └─ HashLookup\n" +
 			"                                 ├─ left-key: TUPLE(cld.BDNYB:1!null, cld.M22QN:2!null)\n" +
 			"                                 ├─ right-key: TUPLE(p4pjz.LWQ6O:3!null, p4pjz.NTOFG:2!null)\n" +
@@ -16362,8 +16192,8 @@ WHERE
 			"                                                 │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"                                                 │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"                                                 │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │   │       │                       └─ Table\n" +
+			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
 			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ NOT\n" +
 			"                                                 │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16383,8 +16213,8 @@ WHERE
 			"                                                 │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │   │       │                       └─ Table\n" +
+			"                                                 │   │       │                           ├─ name: NOXN3\n" +
 			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"                                                 │   └─ AND\n" +
@@ -16403,8 +16233,8 @@ WHERE
 			"                                                 │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │       │                       └─ IndexedTableAccess(NOXN3)\n" +
-			"                                                 │       │                           ├─ index: [NOXN3.BRQP2]\n" +
+			"                                                 │       │                       └─ Table\n" +
+			"                                                 │       │                           ├─ name: NOXN3\n" +
 			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ NOT\n" +
 			"                                                 │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16420,14 +16250,11 @@ WHERE
 			"                                                 │   │       └─ Project\n" +
 			"                                                 │   │           ├─ columns: [ism.FV24E:9!null as FJDP5, cpmfe.id:27!null as BJUF2, ism.M22QN:11!null as M22QN, g3yxs.TUV25:5 as TUV25, g3yxs.ESFVY:1!null as ESFVY, yqif4.id:44!null as QNI57, yvhjz.id:54!null as TDEIU]\n" +
 			"                                                 │   │           └─ Filter\n" +
-			"                                                 │   │               ├─ AND\n" +
+			"                                                 │   │               ├─ Or\n" +
 			"                                                 │   │               │   ├─ NOT\n" +
-			"                                                 │   │               │   │   └─ g3yxs.TUV25:5 IS NULL\n" +
-			"                                                 │   │               │   └─ Or\n" +
-			"                                                 │   │               │       ├─ NOT\n" +
-			"                                                 │   │               │       │   └─ yqif4.id:44!null IS NULL\n" +
-			"                                                 │   │               │       └─ NOT\n" +
-			"                                                 │   │               │           └─ yvhjz.id:54!null IS NULL\n" +
+			"                                                 │   │               │   │   └─ yqif4.id:44!null IS NULL\n" +
+			"                                                 │   │               │   └─ NOT\n" +
+			"                                                 │   │               │       └─ yvhjz.id:54!null IS NULL\n" +
 			"                                                 │   │               └─ LeftOuterHashJoin\n" +
 			"                                                 │   │                   ├─ AND\n" +
 			"                                                 │   │                   │   ├─ Eq\n" +
@@ -17896,8 +17723,8 @@ FROM
 			"                             │           ├─ Eq\n" +
 			"                             │           │   ├─ noxn3.id:6!null\n" +
 			"                             │           │   └─ new.WNUNU:1!null\n" +
-			"                             │           └─ IndexedTableAccess(NOXN3)\n" +
-			"                             │               ├─ index: [NOXN3.id]\n" +
+			"                             │           └─ Table\n" +
+			"                             │               ├─ name: NOXN3\n" +
 			"                             │               └─ columns: [id fftbj]\n" +
 			"                             └─ Subquery\n" +
 			"                                 ├─ cacheable: false\n" +
@@ -17908,8 +17735,8 @@ FROM
 			"                                         ├─ Eq\n" +
 			"                                         │   ├─ noxn3.id:6!null\n" +
 			"                                         │   └─ new.HHVLX:2!null\n" +
-			"                                         └─ IndexedTableAccess(NOXN3)\n" +
-			"                                             ├─ index: [NOXN3.id]\n" +
+			"                                         └─ Table\n" +
+			"                                             ├─ name: NOXN3\n" +
 			"                                             └─ columns: [id brqp2]\n" +
 			"                        )\n" +
 			"                         └─ BLOCK\n" +
@@ -18175,8 +18002,8 @@ WHERE
 			"                 │               ├─ Eq\n" +
 			"                 │               │   ├─ e2i7u.id:8!null\n" +
 			"                 │               │   └─ new.LUEVY:2!null\n" +
-			"                 │               └─ IndexedTableAccess(E2I7U)\n" +
-			"                 │                   ├─ index: [E2I7U.id]\n" +
+			"                 │               └─ Table\n" +
+			"                 │                   ├─ name: E2I7U\n" +
 			"                 │                   └─ columns: [id fgg57]\n" +
 			"                 │       IS NULL)\n" +
 			"                 │       └─ BLOCK\n" +
@@ -18353,8 +18180,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"                 │           │               ├─ index: [XOAOP.id]\n" +
+			"                 │           │           └─ Table\n" +
+			"                 │           │               ├─ name: XOAOP\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18525,8 +18352,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"                 │           │               ├─ index: [XOAOP.id]\n" +
+			"                 │           │           └─ Table\n" +
+			"                 │           │               ├─ name: XOAOP\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18697,8 +18524,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"                 │           │               ├─ index: [XOAOP.id]\n" +
+			"                 │           │           └─ Table\n" +
+			"                 │           │               ├─ name: XOAOP\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18869,8 +18696,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"                 │           │               ├─ index: [XOAOP.id]\n" +
+			"                 │           │           └─ Table\n" +
+			"                 │           │               ├─ name: XOAOP\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -19465,26 +19292,22 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			"                 │   ├─ cacheable: true\n" +
 			"                 │   └─ Project\n" +
 			"                 │       ├─ columns: [mf.id:0!null as id, umf.AZ6SP:3 as AZ6SP]\n" +
-			"                 │       └─ Filter\n" +
-			"                 │           ├─ HashIn\n" +
+			"                 │       └─ LookupJoin\n" +
+			"                 │           ├─ Eq\n" +
 			"                 │           │   ├─ umf.id:2!null\n" +
-			"                 │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"                 │           └─ LookupJoin\n" +
-			"                 │               ├─ Eq\n" +
-			"                 │               │   ├─ umf.id:2!null\n" +
-			"                 │               │   └─ mf.TEUJA:1\n" +
-			"                 │               ├─ TableAlias(mf)\n" +
-			"                 │               │   └─ Table\n" +
-			"                 │               │       ├─ name: HGMQ6\n" +
-			"                 │               │       └─ columns: [id teuja]\n" +
-			"                 │               └─ Filter\n" +
-			"                 │                   ├─ HashIn\n" +
-			"                 │                   │   ├─ umf.id:0!null\n" +
-			"                 │                   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"                 │                   └─ TableAlias(umf)\n" +
-			"                 │                       └─ IndexedTableAccess(NZKPM)\n" +
-			"                 │                           ├─ index: [NZKPM.id]\n" +
-			"                 │                           └─ columns: [id az6sp]\n" +
+			"                 │           │   └─ mf.TEUJA:1\n" +
+			"                 │           ├─ TableAlias(mf)\n" +
+			"                 │           │   └─ Table\n" +
+			"                 │           │       ├─ name: HGMQ6\n" +
+			"                 │           │       └─ columns: [id teuja]\n" +
+			"                 │           └─ Filter\n" +
+			"                 │               ├─ HashIn\n" +
+			"                 │               │   ├─ umf.id:0!null\n" +
+			"                 │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
+			"                 │               └─ TableAlias(umf)\n" +
+			"                 │                   └─ IndexedTableAccess(NZKPM)\n" +
+			"                 │                       ├─ index: [NZKPM.id]\n" +
+			"                 │                       └─ columns: [id az6sp]\n" +
 			"                 └─ TableAlias(vc)\n" +
 			"                     └─ Table\n" +
 			"                         ├─ name: D34QP\n" +
@@ -19756,8 +19579,8 @@ FROM
 			"                     │           │   ├─ aac.BTXC5:18\n" +
 			"                     │           │   └─ bpnw2.SYPKF:3\n" +
 			"                     │           └─ TableAlias(aac)\n" +
-			"                     │               └─ IndexedTableAccess(TPXBU)\n" +
-			"                     │                   ├─ index: [TPXBU.BTXC5]\n" +
+			"                     │               └─ Table\n" +
+			"                     │                   ├─ name: TPXBU\n" +
 			"                     │                   └─ columns: [id btxc5]\n" +
 			"                     │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
 			"                     └─ Project\n" +
@@ -19771,8 +19594,8 @@ FROM
 			"                         │           │   ├─ aac.BTXC5:9\n" +
 			"                         │           │   └─ bpnw2.SYPKF:3\n" +
 			"                         │           └─ TableAlias(aac)\n" +
-			"                         │               └─ IndexedTableAccess(TPXBU)\n" +
-			"                         │                   ├─ index: [TPXBU.BTXC5]\n" +
+			"                         │               └─ Table\n" +
+			"                         │                   ├─ name: TPXBU\n" +
 			"                         │                   └─ columns: [id btxc5]\n" +
 			"                         │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
 			"                         └─ SubqueryAlias\n" +
@@ -20375,234 +20198,234 @@ WHERE
 			"             │           │                   ├─ index: [TPXBU.BTXC5]\n" +
 			"             │           │                   └─ columns: [id btxc5]\n" +
 			"             │           │   as M22QN, pqsxb.OVE3E:1 as OVE3E, pqsxb.NRURT:2!null as NRURT, pqsxb.OCA7E:3!null as OCA7E, pqsxb.XMM6Q:4 as XMM6Q, pqsxb.V5DPX:5 as V5DPX, pqsxb.S3Q3Y:6 as S3Q3Y, pqsxb.ZRV3B:7 as ZRV3B, pqsxb.FHCYT:8 as FHCYT]\n" +
-			"             │           └─ LookupJoin\n" +
-			"             │               ├─ Or\n" +
-			"             │               │   ├─ AND\n" +
-			"             │               │   │   ├─ NOT\n" +
-			"             │               │   │   │   └─ pqsxb.H4DMT:11!null IS NULL\n" +
-			"             │               │   │   └─ Eq\n" +
-			"             │               │   │       ├─ nd.TW55N:15!null\n" +
-			"             │               │   │       └─ pqsxb.H4DMT:11!null\n" +
-			"             │               │   └─ AND\n" +
-			"             │               │       ├─ pqsxb.H4DMT:11!null IS NULL\n" +
-			"             │               │       └─ Eq\n" +
-			"             │               │           ├─ nd.ZH72S:19\n" +
-			"             │               │           └─ pqsxb.K3B6V:9\n" +
-			"             │               ├─ SubqueryAlias\n" +
-			"             │               │   ├─ name: pqsxb\n" +
-			"             │               │   ├─ outerVisibility: false\n" +
-			"             │               │   ├─ cacheable: true\n" +
-			"             │               │   └─ Filter\n" +
-			"             │               │       ├─ NOT\n" +
-			"             │               │       │   └─ OVE3E:1 IS NULL\n" +
-			"             │               │       └─ Project\n" +
-			"             │               │           ├─ columns: [Subquery\n" +
-			"             │               │           │   ├─ cacheable: false\n" +
-			"             │               │           │   ├─ alias-string: select id from JDLNA where JDLNA.FTQLQ = uct.FTQLQ\n" +
-			"             │               │           │   └─ Project\n" +
-			"             │               │           │       ├─ columns: [jdlna.id:33!null]\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ Eq\n" +
-			"             │               │           │           │   ├─ jdlna.FTQLQ:34!null\n" +
-			"             │               │           │           │   └─ uct.FTQLQ:1\n" +
-			"             │               │           │           └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │           │               ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │           │               └─ columns: [id ftqlq]\n" +
-			"             │               │           │   as FZ2R5, Subquery\n" +
-			"             │               │           │   ├─ cacheable: false\n" +
-			"             │               │           │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = uct.NO52D and (SFEGG.VYO5E = uct.VYO5E or (SFEGG.VYO5E is null and (uct.VYO5E is null or uct.VYO5E = 'N/A' or uct.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end)\n" +
-			"             │               │           │   └─ Project\n" +
-			"             │               │           │       ├─ columns: [sfegg.id:33!null]\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ AND\n" +
-			"             │               │           │           │   ├─ AND\n" +
-			"             │               │           │           │   │   ├─ Eq\n" +
-			"             │               │           │           │   │   │   ├─ sfegg.NO52D:34!null\n" +
-			"             │               │           │           │   │   │   └─ uct.NO52D:7\n" +
-			"             │               │           │           │   │   └─ Or\n" +
-			"             │               │           │           │   │       ├─ Eq\n" +
-			"             │               │           │           │   │       │   ├─ sfegg.VYO5E:35\n" +
-			"             │               │           │           │   │       │   └─ uct.VYO5E:9\n" +
-			"             │               │           │           │   │       └─ AND\n" +
-			"             │               │           │           │   │           ├─ sfegg.VYO5E:35 IS NULL\n" +
-			"             │               │           │           │   │           └─ Or\n" +
-			"             │               │           │           │   │               ├─ Or\n" +
-			"             │               │           │           │   │               │   ├─ uct.VYO5E:9 IS NULL\n" +
-			"             │               │           │           │   │               │   └─ Eq\n" +
-			"             │               │           │           │   │               │       ├─ uct.VYO5E:9\n" +
-			"             │               │           │           │   │               │       └─ N/A (longtext)\n" +
-			"             │               │           │           │   │               └─ Eq\n" +
-			"             │               │           │           │   │                   ├─ uct.VYO5E:9\n" +
-			"             │               │           │           │   │                   └─ NA (longtext)\n" +
-			"             │               │           │           │   └─ Eq\n" +
-			"             │               │           │           │       ├─ sfegg.DKCAJ:36!null\n" +
-			"             │               │           │           │       └─ Subquery\n" +
-			"             │               │           │           │           ├─ cacheable: false\n" +
-			"             │               │           │           │           ├─ alias-string: select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end\n" +
-			"             │               │           │           │           └─ Project\n" +
-			"             │               │           │           │               ├─ columns: [CASE  WHEN i7hcr.FVUCX:17!null IS NULL THEN Subquery\n" +
-			"             │               │           │           │               │   ├─ cacheable: false\n" +
-			"             │               │           │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1\n" +
-			"             │               │           │           │               │   └─ Limit(1)\n" +
-			"             │               │           │           │               │       └─ Project\n" +
-			"             │               │           │           │               │           ├─ columns: [nd.DKCAJ:40!null]\n" +
-			"             │               │           │           │               │           └─ Filter\n" +
-			"             │               │           │           │               │               ├─ Eq\n" +
-			"             │               │           │           │               │               │   ├─ nd.ZH72S:41\n" +
-			"             │               │           │           │               │               │   └─ uct.ZH72S:2\n" +
-			"             │               │           │           │               │               └─ TableAlias(nd)\n" +
-			"             │               │           │           │               │                   └─ IndexedTableAccess(E2I7U)\n" +
-			"             │               │           │           │               │                       ├─ index: [E2I7U.ZH72S]\n" +
-			"             │               │           │           │               │                       └─ columns: [dkcaj zh72s]\n" +
-			"             │               │           │           │               │   ELSE Subquery\n" +
-			"             │               │           │           │               │   ├─ cacheable: false\n" +
-			"             │               │           │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX\n" +
-			"             │               │           │           │               │   └─ Project\n" +
-			"             │               │           │           │               │       ├─ columns: [nd.DKCAJ:40!null]\n" +
-			"             │               │           │           │               │       └─ Filter\n" +
-			"             │               │           │           │               │           ├─ Eq\n" +
-			"             │               │           │           │               │           │   ├─ nd.TW55N:41!null\n" +
-			"             │               │           │           │               │           │   └─ i7hcr.FVUCX:17!null\n" +
-			"             │               │           │           │               │           └─ TableAlias(nd)\n" +
-			"             │               │           │           │               │               └─ IndexedTableAccess(E2I7U)\n" +
-			"             │               │           │           │               │                   ├─ index: [E2I7U.TW55N]\n" +
-			"             │               │           │           │               │                   └─ columns: [dkcaj tw55n]\n" +
-			"             │               │           │           │               │   END]\n" +
-			"             │               │           │           │               └─ Table\n" +
-			"             │               │           │           │                   ├─ name: \n" +
-			"             │               │           │           │                   └─ columns: []\n" +
-			"             │               │           │           └─ IndexedTableAccess(SFEGG)\n" +
-			"             │               │           │               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"             │               │           │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
-			"             │               │           │   as OVE3E, uct.id:0!null as NRURT, i7hcr.id:13!null as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN NOT\n" +
-			"             │               │           │   └─ Eq\n" +
-			"             │               │           │       ├─ uct.FHCYT:11\n" +
-			"             │               │           │       └─ N/A (longtext)\n" +
-			"             │               │           │   THEN uct.FHCYT:11 ELSE NULL (null) END as FHCYT, uct.ZH72S:2 as K3B6V, uct.LJLUM:5 as BTXC5, i7hcr.FVUCX:17!null as H4DMT]\n" +
-			"             │               │           └─ Project\n" +
-			"             │               │               ├─ columns: [uct.id:0!null, uct.FTQLQ:1, uct.ZH72S:2, uct.SFJ6L:3, uct.V5DPX:4, uct.LJLUM:5, uct.IDPK7:6, uct.NO52D:7, uct.ZRV3B:8, uct.VYO5E:9, uct.YKSSU:10, uct.FHCYT:11, uct.QZ6VT:12, i7hcr.id:13!null, i7hcr.TOFPN:14!null, i7hcr.SJYN2:15!null, i7hcr.BTXC5:16!null, i7hcr.FVUCX:17!null, i7hcr.SWCQV:18!null, i7hcr.YKSSU:19, i7hcr.FHCYT:20, Subquery\n" +
-			"             │               │               │   ├─ cacheable: false\n" +
-			"             │               │               │   ├─ alias-string: select id from JDLNA where JDLNA.FTQLQ = uct.FTQLQ\n" +
-			"             │               │               │   └─ Project\n" +
-			"             │               │               │       ├─ columns: [jdlna.id:21!null]\n" +
-			"             │               │               │       └─ Filter\n" +
-			"             │               │               │           ├─ Eq\n" +
-			"             │               │               │           │   ├─ jdlna.FTQLQ:22!null\n" +
-			"             │               │               │           │   └─ uct.FTQLQ:1\n" +
-			"             │               │               │           └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │               │               ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │               │               └─ columns: [id ftqlq]\n" +
-			"             │               │               │   as FZ2R5, Subquery\n" +
-			"             │               │               │   ├─ cacheable: false\n" +
-			"             │               │               │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = uct.NO52D and (SFEGG.VYO5E = uct.VYO5E or (SFEGG.VYO5E is null and (uct.VYO5E is null or uct.VYO5E = 'N/A' or uct.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end)\n" +
-			"             │               │               │   └─ Project\n" +
-			"             │               │               │       ├─ columns: [sfegg.id:21!null]\n" +
-			"             │               │               │       └─ Filter\n" +
-			"             │               │               │           ├─ AND\n" +
-			"             │               │               │           │   ├─ AND\n" +
-			"             │               │               │           │   │   ├─ Eq\n" +
-			"             │               │               │           │   │   │   ├─ sfegg.NO52D:22!null\n" +
-			"             │               │               │           │   │   │   └─ uct.NO52D:7\n" +
-			"             │               │               │           │   │   └─ Or\n" +
-			"             │               │               │           │   │       ├─ Eq\n" +
-			"             │               │               │           │   │       │   ├─ sfegg.VYO5E:23\n" +
-			"             │               │               │           │   │       │   └─ uct.VYO5E:9\n" +
-			"             │               │               │           │   │       └─ AND\n" +
-			"             │               │               │           │   │           ├─ sfegg.VYO5E:23 IS NULL\n" +
-			"             │               │               │           │   │           └─ Or\n" +
-			"             │               │               │           │   │               ├─ Or\n" +
-			"             │               │               │           │   │               │   ├─ uct.VYO5E:9 IS NULL\n" +
-			"             │               │               │           │   │               │   └─ Eq\n" +
-			"             │               │               │           │   │               │       ├─ uct.VYO5E:9\n" +
-			"             │               │               │           │   │               │       └─ N/A (longtext)\n" +
-			"             │               │               │           │   │               └─ Eq\n" +
-			"             │               │               │           │   │                   ├─ uct.VYO5E:9\n" +
-			"             │               │               │           │   │                   └─ NA (longtext)\n" +
-			"             │               │               │           │   └─ Eq\n" +
-			"             │               │               │           │       ├─ sfegg.DKCAJ:24!null\n" +
-			"             │               │               │           │       └─ Subquery\n" +
-			"             │               │               │           │           ├─ cacheable: false\n" +
-			"             │               │               │           │           ├─ alias-string: select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end\n" +
-			"             │               │               │           │           └─ Project\n" +
-			"             │               │               │           │               ├─ columns: [CASE  WHEN i7hcr.FVUCX:17!null IS NULL THEN Subquery\n" +
-			"             │               │               │           │               │   ├─ cacheable: false\n" +
-			"             │               │               │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1\n" +
-			"             │               │               │           │               │   └─ Limit(1)\n" +
-			"             │               │               │           │               │       └─ Project\n" +
-			"             │               │               │           │               │           ├─ columns: [nd.DKCAJ:28!null]\n" +
-			"             │               │               │           │               │           └─ Filter\n" +
-			"             │               │               │           │               │               ├─ Eq\n" +
-			"             │               │               │           │               │               │   ├─ nd.ZH72S:29\n" +
-			"             │               │               │           │               │               │   └─ uct.ZH72S:2\n" +
-			"             │               │               │           │               │               └─ TableAlias(nd)\n" +
-			"             │               │               │           │               │                   └─ IndexedTableAccess(E2I7U)\n" +
-			"             │               │               │           │               │                       ├─ index: [E2I7U.ZH72S]\n" +
-			"             │               │               │           │               │                       └─ columns: [dkcaj zh72s]\n" +
-			"             │               │               │           │               │   ELSE Subquery\n" +
-			"             │               │               │           │               │   ├─ cacheable: false\n" +
-			"             │               │               │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX\n" +
-			"             │               │               │           │               │   └─ Project\n" +
-			"             │               │               │           │               │       ├─ columns: [nd.DKCAJ:28!null]\n" +
-			"             │               │               │           │               │       └─ Filter\n" +
-			"             │               │               │           │               │           ├─ Eq\n" +
-			"             │               │               │           │               │           │   ├─ nd.TW55N:29!null\n" +
-			"             │               │               │           │               │           │   └─ i7hcr.FVUCX:17!null\n" +
-			"             │               │               │           │               │           └─ TableAlias(nd)\n" +
-			"             │               │               │           │               │               └─ IndexedTableAccess(E2I7U)\n" +
-			"             │               │               │           │               │                   ├─ index: [E2I7U.TW55N]\n" +
-			"             │               │               │           │               │                   └─ columns: [dkcaj tw55n]\n" +
-			"             │               │               │           │               │   END]\n" +
-			"             │               │               │           │               └─ Table\n" +
-			"             │               │               │           │                   ├─ name: \n" +
-			"             │               │               │           │                   └─ columns: []\n" +
-			"             │               │               │           └─ IndexedTableAccess(SFEGG)\n" +
-			"             │               │               │               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"             │               │               │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
-			"             │               │               │   as OVE3E, uct.id:0!null as NRURT, i7hcr.id:13!null as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN NOT\n" +
-			"             │               │               │   └─ Eq\n" +
-			"             │               │               │       ├─ uct.FHCYT:11\n" +
-			"             │               │               │       └─ N/A (longtext)\n" +
-			"             │               │               │   THEN uct.FHCYT:11 ELSE NULL (null) END as FHCYT, uct.ZH72S:2 as K3B6V, uct.LJLUM:5 as BTXC5, i7hcr.FVUCX:17!null as H4DMT]\n" +
-			"             │               │               └─ LeftOuterHashJoin\n" +
-			"             │               │                   ├─ AND\n" +
-			"             │               │                   │   ├─ AND\n" +
-			"             │               │                   │   │   ├─ AND\n" +
-			"             │               │                   │   │   │   ├─ Eq\n" +
-			"             │               │                   │   │   │   │   ├─ i7hcr.SWCQV:18!null\n" +
-			"             │               │                   │   │   │   │   └─ 0 (tinyint)\n" +
-			"             │               │                   │   │   │   └─ Eq\n" +
-			"             │               │                   │   │   │       ├─ i7hcr.TOFPN:14!null\n" +
-			"             │               │                   │   │   │       └─ uct.FTQLQ:1\n" +
-			"             │               │                   │   │   └─ Eq\n" +
-			"             │               │                   │   │       ├─ i7hcr.SJYN2:15!null\n" +
-			"             │               │                   │   │       └─ uct.ZH72S:2\n" +
-			"             │               │                   │   └─ Eq\n" +
-			"             │               │                   │       ├─ i7hcr.BTXC5:16!null\n" +
-			"             │               │                   │       └─ uct.LJLUM:5\n" +
-			"             │               │                   ├─ Filter\n" +
-			"             │               │                   │   ├─ HashIn\n" +
-			"             │               │                   │   │   ├─ uct.id:0!null\n" +
-			"             │               │                   │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               │                   │   └─ TableAlias(uct)\n" +
-			"             │               │                   │       └─ IndexedTableAccess(OUBDL)\n" +
-			"             │               │                   │           ├─ index: [OUBDL.id]\n" +
-			"             │               │                   │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │               │                   │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
-			"             │               │                   └─ HashLookup\n" +
-			"             │               │                       ├─ left-key: TUPLE(0 (tinyint), uct.FTQLQ:1, uct.ZH72S:2, uct.LJLUM:5)\n" +
-			"             │               │                       ├─ right-key: TUPLE(i7hcr.SWCQV:5!null, i7hcr.TOFPN:1!null, i7hcr.SJYN2:2!null, i7hcr.BTXC5:3!null)\n" +
-			"             │               │                       └─ TableAlias(i7hcr)\n" +
-			"             │               │                           └─ Table\n" +
-			"             │               │                               ├─ name: EPZU6\n" +
-			"             │               │                               └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
-			"             │               └─ TableAlias(nd)\n" +
-			"             │                   └─ Concat\n" +
-			"             │                       ├─ IndexedTableAccess(E2I7U)\n" +
-			"             │                       │   ├─ index: [E2I7U.ZH72S]\n" +
-			"             │                       │   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                           ├─ index: [E2I7U.TW55N]\n" +
-			"             │                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"             │           └─ Filter\n" +
+			"             │               ├─ NOT\n" +
+			"             │               │   └─ pqsxb.OVE3E:1 IS NULL\n" +
+			"             │               └─ LookupJoin\n" +
+			"             │                   ├─ Or\n" +
+			"             │                   │   ├─ AND\n" +
+			"             │                   │   │   ├─ NOT\n" +
+			"             │                   │   │   │   └─ pqsxb.H4DMT:11!null IS NULL\n" +
+			"             │                   │   │   └─ Eq\n" +
+			"             │                   │   │       ├─ nd.TW55N:15!null\n" +
+			"             │                   │   │       └─ pqsxb.H4DMT:11!null\n" +
+			"             │                   │   └─ AND\n" +
+			"             │                   │       ├─ pqsxb.H4DMT:11!null IS NULL\n" +
+			"             │                   │       └─ Eq\n" +
+			"             │                   │           ├─ nd.ZH72S:19\n" +
+			"             │                   │           └─ pqsxb.K3B6V:9\n" +
+			"             │                   ├─ SubqueryAlias\n" +
+			"             │                   │   ├─ name: pqsxb\n" +
+			"             │                   │   ├─ outerVisibility: false\n" +
+			"             │                   │   ├─ cacheable: true\n" +
+			"             │                   │   └─ Project\n" +
+			"             │                   │       ├─ columns: [Subquery\n" +
+			"             │                   │       │   ├─ cacheable: false\n" +
+			"             │                   │       │   ├─ alias-string: select id from JDLNA where JDLNA.FTQLQ = uct.FTQLQ\n" +
+			"             │                   │       │   └─ Project\n" +
+			"             │                   │       │       ├─ columns: [jdlna.id:33!null]\n" +
+			"             │                   │       │       └─ Filter\n" +
+			"             │                   │       │           ├─ Eq\n" +
+			"             │                   │       │           │   ├─ jdlna.FTQLQ:34!null\n" +
+			"             │                   │       │           │   └─ uct.FTQLQ:1\n" +
+			"             │                   │       │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │                   │       │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │                   │       │               └─ columns: [id ftqlq]\n" +
+			"             │                   │       │   as FZ2R5, Subquery\n" +
+			"             │                   │       │   ├─ cacheable: false\n" +
+			"             │                   │       │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = uct.NO52D and (SFEGG.VYO5E = uct.VYO5E or (SFEGG.VYO5E is null and (uct.VYO5E is null or uct.VYO5E = 'N/A' or uct.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end)\n" +
+			"             │                   │       │   └─ Project\n" +
+			"             │                   │       │       ├─ columns: [sfegg.id:33!null]\n" +
+			"             │                   │       │       └─ Filter\n" +
+			"             │                   │       │           ├─ AND\n" +
+			"             │                   │       │           │   ├─ AND\n" +
+			"             │                   │       │           │   │   ├─ Eq\n" +
+			"             │                   │       │           │   │   │   ├─ sfegg.NO52D:34!null\n" +
+			"             │                   │       │           │   │   │   └─ uct.NO52D:7\n" +
+			"             │                   │       │           │   │   └─ Or\n" +
+			"             │                   │       │           │   │       ├─ Eq\n" +
+			"             │                   │       │           │   │       │   ├─ sfegg.VYO5E:35\n" +
+			"             │                   │       │           │   │       │   └─ uct.VYO5E:9\n" +
+			"             │                   │       │           │   │       └─ AND\n" +
+			"             │                   │       │           │   │           ├─ sfegg.VYO5E:35 IS NULL\n" +
+			"             │                   │       │           │   │           └─ Or\n" +
+			"             │                   │       │           │   │               ├─ Or\n" +
+			"             │                   │       │           │   │               │   ├─ uct.VYO5E:9 IS NULL\n" +
+			"             │                   │       │           │   │               │   └─ Eq\n" +
+			"             │                   │       │           │   │               │       ├─ uct.VYO5E:9\n" +
+			"             │                   │       │           │   │               │       └─ N/A (longtext)\n" +
+			"             │                   │       │           │   │               └─ Eq\n" +
+			"             │                   │       │           │   │                   ├─ uct.VYO5E:9\n" +
+			"             │                   │       │           │   │                   └─ NA (longtext)\n" +
+			"             │                   │       │           │   └─ Eq\n" +
+			"             │                   │       │           │       ├─ sfegg.DKCAJ:36!null\n" +
+			"             │                   │       │           │       └─ Subquery\n" +
+			"             │                   │       │           │           ├─ cacheable: false\n" +
+			"             │                   │       │           │           ├─ alias-string: select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end\n" +
+			"             │                   │       │           │           └─ Project\n" +
+			"             │                   │       │           │               ├─ columns: [CASE  WHEN i7hcr.FVUCX:17!null IS NULL THEN Subquery\n" +
+			"             │                   │       │           │               │   ├─ cacheable: false\n" +
+			"             │                   │       │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1\n" +
+			"             │                   │       │           │               │   └─ Limit(1)\n" +
+			"             │                   │       │           │               │       └─ Project\n" +
+			"             │                   │       │           │               │           ├─ columns: [nd.DKCAJ:40!null]\n" +
+			"             │                   │       │           │               │           └─ Filter\n" +
+			"             │                   │       │           │               │               ├─ Eq\n" +
+			"             │                   │       │           │               │               │   ├─ nd.ZH72S:41\n" +
+			"             │                   │       │           │               │               │   └─ uct.ZH72S:2\n" +
+			"             │                   │       │           │               │               └─ TableAlias(nd)\n" +
+			"             │                   │       │           │               │                   └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                   │       │           │               │                       ├─ index: [E2I7U.ZH72S]\n" +
+			"             │                   │       │           │               │                       └─ columns: [dkcaj zh72s]\n" +
+			"             │                   │       │           │               │   ELSE Subquery\n" +
+			"             │                   │       │           │               │   ├─ cacheable: false\n" +
+			"             │                   │       │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX\n" +
+			"             │                   │       │           │               │   └─ Project\n" +
+			"             │                   │       │           │               │       ├─ columns: [nd.DKCAJ:40!null]\n" +
+			"             │                   │       │           │               │       └─ Filter\n" +
+			"             │                   │       │           │               │           ├─ Eq\n" +
+			"             │                   │       │           │               │           │   ├─ nd.TW55N:41!null\n" +
+			"             │                   │       │           │               │           │   └─ i7hcr.FVUCX:17!null\n" +
+			"             │                   │       │           │               │           └─ TableAlias(nd)\n" +
+			"             │                   │       │           │               │               └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                   │       │           │               │                   ├─ index: [E2I7U.TW55N]\n" +
+			"             │                   │       │           │               │                   └─ columns: [dkcaj tw55n]\n" +
+			"             │                   │       │           │               │   END]\n" +
+			"             │                   │       │           │               └─ Table\n" +
+			"             │                   │       │           │                   ├─ name: \n" +
+			"             │                   │       │           │                   └─ columns: []\n" +
+			"             │                   │       │           └─ IndexedTableAccess(SFEGG)\n" +
+			"             │                   │       │               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"             │                   │       │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
+			"             │                   │       │   as OVE3E, uct.id:0!null as NRURT, i7hcr.id:13!null as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN NOT\n" +
+			"             │                   │       │   └─ Eq\n" +
+			"             │                   │       │       ├─ uct.FHCYT:11\n" +
+			"             │                   │       │       └─ N/A (longtext)\n" +
+			"             │                   │       │   THEN uct.FHCYT:11 ELSE NULL (null) END as FHCYT, uct.ZH72S:2 as K3B6V, uct.LJLUM:5 as BTXC5, i7hcr.FVUCX:17!null as H4DMT]\n" +
+			"             │                   │       └─ Project\n" +
+			"             │                   │           ├─ columns: [uct.id:0!null, uct.FTQLQ:1, uct.ZH72S:2, uct.SFJ6L:3, uct.V5DPX:4, uct.LJLUM:5, uct.IDPK7:6, uct.NO52D:7, uct.ZRV3B:8, uct.VYO5E:9, uct.YKSSU:10, uct.FHCYT:11, uct.QZ6VT:12, i7hcr.id:13!null, i7hcr.TOFPN:14!null, i7hcr.SJYN2:15!null, i7hcr.BTXC5:16!null, i7hcr.FVUCX:17!null, i7hcr.SWCQV:18!null, i7hcr.YKSSU:19, i7hcr.FHCYT:20, Subquery\n" +
+			"             │                   │           │   ├─ cacheable: false\n" +
+			"             │                   │           │   ├─ alias-string: select id from JDLNA where JDLNA.FTQLQ = uct.FTQLQ\n" +
+			"             │                   │           │   └─ Project\n" +
+			"             │                   │           │       ├─ columns: [jdlna.id:21!null]\n" +
+			"             │                   │           │       └─ Filter\n" +
+			"             │                   │           │           ├─ Eq\n" +
+			"             │                   │           │           │   ├─ jdlna.FTQLQ:22!null\n" +
+			"             │                   │           │           │   └─ uct.FTQLQ:1\n" +
+			"             │                   │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │                   │           │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │                   │           │               └─ columns: [id ftqlq]\n" +
+			"             │                   │           │   as FZ2R5, Subquery\n" +
+			"             │                   │           │   ├─ cacheable: false\n" +
+			"             │                   │           │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = uct.NO52D and (SFEGG.VYO5E = uct.VYO5E or (SFEGG.VYO5E is null and (uct.VYO5E is null or uct.VYO5E = 'N/A' or uct.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end)\n" +
+			"             │                   │           │   └─ Project\n" +
+			"             │                   │           │       ├─ columns: [sfegg.id:21!null]\n" +
+			"             │                   │           │       └─ Filter\n" +
+			"             │                   │           │           ├─ AND\n" +
+			"             │                   │           │           │   ├─ AND\n" +
+			"             │                   │           │           │   │   ├─ Eq\n" +
+			"             │                   │           │           │   │   │   ├─ sfegg.NO52D:22!null\n" +
+			"             │                   │           │           │   │   │   └─ uct.NO52D:7\n" +
+			"             │                   │           │           │   │   └─ Or\n" +
+			"             │                   │           │           │   │       ├─ Eq\n" +
+			"             │                   │           │           │   │       │   ├─ sfegg.VYO5E:23\n" +
+			"             │                   │           │           │   │       │   └─ uct.VYO5E:9\n" +
+			"             │                   │           │           │   │       └─ AND\n" +
+			"             │                   │           │           │   │           ├─ sfegg.VYO5E:23 IS NULL\n" +
+			"             │                   │           │           │   │           └─ Or\n" +
+			"             │                   │           │           │   │               ├─ Or\n" +
+			"             │                   │           │           │   │               │   ├─ uct.VYO5E:9 IS NULL\n" +
+			"             │                   │           │           │   │               │   └─ Eq\n" +
+			"             │                   │           │           │   │               │       ├─ uct.VYO5E:9\n" +
+			"             │                   │           │           │   │               │       └─ N/A (longtext)\n" +
+			"             │                   │           │           │   │               └─ Eq\n" +
+			"             │                   │           │           │   │                   ├─ uct.VYO5E:9\n" +
+			"             │                   │           │           │   │                   └─ NA (longtext)\n" +
+			"             │                   │           │           │   └─ Eq\n" +
+			"             │                   │           │           │       ├─ sfegg.DKCAJ:24!null\n" +
+			"             │                   │           │           │       └─ Subquery\n" +
+			"             │                   │           │           │           ├─ cacheable: false\n" +
+			"             │                   │           │           │           ├─ alias-string: select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end\n" +
+			"             │                   │           │           │           └─ Project\n" +
+			"             │                   │           │           │               ├─ columns: [CASE  WHEN i7hcr.FVUCX:17!null IS NULL THEN Subquery\n" +
+			"             │                   │           │           │               │   ├─ cacheable: false\n" +
+			"             │                   │           │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1\n" +
+			"             │                   │           │           │               │   └─ Limit(1)\n" +
+			"             │                   │           │           │               │       └─ Project\n" +
+			"             │                   │           │           │               │           ├─ columns: [nd.DKCAJ:28!null]\n" +
+			"             │                   │           │           │               │           └─ Filter\n" +
+			"             │                   │           │           │               │               ├─ Eq\n" +
+			"             │                   │           │           │               │               │   ├─ nd.ZH72S:29\n" +
+			"             │                   │           │           │               │               │   └─ uct.ZH72S:2\n" +
+			"             │                   │           │           │               │               └─ TableAlias(nd)\n" +
+			"             │                   │           │           │               │                   └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                   │           │           │               │                       ├─ index: [E2I7U.ZH72S]\n" +
+			"             │                   │           │           │               │                       └─ columns: [dkcaj zh72s]\n" +
+			"             │                   │           │           │               │   ELSE Subquery\n" +
+			"             │                   │           │           │               │   ├─ cacheable: false\n" +
+			"             │                   │           │           │               │   ├─ alias-string: select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX\n" +
+			"             │                   │           │           │               │   └─ Project\n" +
+			"             │                   │           │           │               │       ├─ columns: [nd.DKCAJ:28!null]\n" +
+			"             │                   │           │           │               │       └─ Filter\n" +
+			"             │                   │           │           │               │           ├─ Eq\n" +
+			"             │                   │           │           │               │           │   ├─ nd.TW55N:29!null\n" +
+			"             │                   │           │           │               │           │   └─ i7hcr.FVUCX:17!null\n" +
+			"             │                   │           │           │               │           └─ TableAlias(nd)\n" +
+			"             │                   │           │           │               │               └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                   │           │           │               │                   ├─ index: [E2I7U.TW55N]\n" +
+			"             │                   │           │           │               │                   └─ columns: [dkcaj tw55n]\n" +
+			"             │                   │           │           │               │   END]\n" +
+			"             │                   │           │           │               └─ Table\n" +
+			"             │                   │           │           │                   ├─ name: \n" +
+			"             │                   │           │           │                   └─ columns: []\n" +
+			"             │                   │           │           └─ IndexedTableAccess(SFEGG)\n" +
+			"             │                   │           │               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"             │                   │           │               └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
+			"             │                   │           │   as OVE3E, uct.id:0!null as NRURT, i7hcr.id:13!null as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN NOT\n" +
+			"             │                   │           │   └─ Eq\n" +
+			"             │                   │           │       ├─ uct.FHCYT:11\n" +
+			"             │                   │           │       └─ N/A (longtext)\n" +
+			"             │                   │           │   THEN uct.FHCYT:11 ELSE NULL (null) END as FHCYT, uct.ZH72S:2 as K3B6V, uct.LJLUM:5 as BTXC5, i7hcr.FVUCX:17!null as H4DMT]\n" +
+			"             │                   │           └─ LeftOuterHashJoin\n" +
+			"             │                   │               ├─ AND\n" +
+			"             │                   │               │   ├─ AND\n" +
+			"             │                   │               │   │   ├─ AND\n" +
+			"             │                   │               │   │   │   ├─ Eq\n" +
+			"             │                   │               │   │   │   │   ├─ i7hcr.SWCQV:18!null\n" +
+			"             │                   │               │   │   │   │   └─ 0 (tinyint)\n" +
+			"             │                   │               │   │   │   └─ Eq\n" +
+			"             │                   │               │   │   │       ├─ i7hcr.TOFPN:14!null\n" +
+			"             │                   │               │   │   │       └─ uct.FTQLQ:1\n" +
+			"             │                   │               │   │   └─ Eq\n" +
+			"             │                   │               │   │       ├─ i7hcr.SJYN2:15!null\n" +
+			"             │                   │               │   │       └─ uct.ZH72S:2\n" +
+			"             │                   │               │   └─ Eq\n" +
+			"             │                   │               │       ├─ i7hcr.BTXC5:16!null\n" +
+			"             │                   │               │       └─ uct.LJLUM:5\n" +
+			"             │                   │               ├─ Filter\n" +
+			"             │                   │               │   ├─ HashIn\n" +
+			"             │                   │               │   │   ├─ uct.id:0!null\n" +
+			"             │                   │               │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
+			"             │                   │               │   └─ TableAlias(uct)\n" +
+			"             │                   │               │       └─ IndexedTableAccess(OUBDL)\n" +
+			"             │                   │               │           ├─ index: [OUBDL.id]\n" +
+			"             │                   │               │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                   │               │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
+			"             │                   │               └─ HashLookup\n" +
+			"             │                   │                   ├─ left-key: TUPLE(0 (tinyint), uct.FTQLQ:1, uct.ZH72S:2, uct.LJLUM:5)\n" +
+			"             │                   │                   ├─ right-key: TUPLE(i7hcr.SWCQV:5!null, i7hcr.TOFPN:1!null, i7hcr.SJYN2:2!null, i7hcr.BTXC5:3!null)\n" +
+			"             │                   │                   └─ TableAlias(i7hcr)\n" +
+			"             │                   │                       └─ Table\n" +
+			"             │                   │                           ├─ name: EPZU6\n" +
+			"             │                   │                           └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
+			"             │                   └─ TableAlias(nd)\n" +
+			"             │                       └─ Concat\n" +
+			"             │                           ├─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │   ├─ index: [E2I7U.ZH72S]\n" +
+			"             │                           │   └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"             │                           └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                               ├─ index: [E2I7U.TW55N]\n" +
+			"             │                               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(InSubquery\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -11229,8 +11229,8 @@ WHERE
 			" │       │           │   ├─ aac.id:74!null\n" +
 			" │       │           │   └─ sl3s5.M22QN:63!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ Table\n" +
-			" │       │                   ├─ name: TPXBU\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │       │                   ├─ index: [TPXBU.id]\n" +
 			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
 			" │       └─ Project\n" +
@@ -11244,8 +11244,8 @@ WHERE
 			" │           │           │   ├─ aac.id:67!null\n" +
 			" │           │           │   └─ sl3s5.M22QN:19!null\n" +
 			" │           │           └─ TableAlias(aac)\n" +
-			" │           │               └─ Table\n" +
-			" │           │                   ├─ name: TPXBU\n" +
+			" │           │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │           │                   ├─ index: [TPXBU.id]\n" +
 			" │           │                   └─ columns: [id btxc5]\n" +
 			" │           │   as TPXBU, sl3s5.NO52D:21!null as NO52D, sl3s5.IDPK7:22!null as IDPK7]\n" +
 			" │           └─ HashJoin\n" +
@@ -11615,8 +11615,8 @@ WHERE
 			" │       │           │   ├─ aac.id:74!null\n" +
 			" │       │           │   └─ sl3s5.M22QN:63!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ Table\n" +
-			" │       │                   ├─ name: TPXBU\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │       │                   ├─ index: [TPXBU.id]\n" +
 			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
 			" │       └─ Project\n" +
@@ -11630,8 +11630,8 @@ WHERE
 			" │           │           │   ├─ aac.id:67!null\n" +
 			" │           │           │   └─ sl3s5.M22QN:19!null\n" +
 			" │           │           └─ TableAlias(aac)\n" +
-			" │           │               └─ Table\n" +
-			" │           │                   ├─ name: TPXBU\n" +
+			" │           │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │           │                   ├─ index: [TPXBU.id]\n" +
 			" │           │                   └─ columns: [id btxc5]\n" +
 			" │           │   as TPXBU, sl3s5.NO52D:21!null as NO52D, sl3s5.IDPK7:22!null as IDPK7]\n" +
 			" │           └─ HashJoin\n" +
@@ -14217,8 +14217,8 @@ WHERE
 			"         │   │   │   │                       │   ├─ jtehg.BRQP2:22!null\n" +
 			"         │   │   │   │                       │   └─ mjr3d.BJUF2:1!null\n" +
 			"         │   │   │   │                       └─ TableAlias(jtehg)\n" +
-			"         │   │   │   │                           └─ Table\n" +
-			"         │   │   │   │                               ├─ name: NOXN3\n" +
+			"         │   │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
 			"         │   │   │   │                               └─ columns: [id brqp2]\n" +
 			"         │   │   │   └─ AND\n" +
 			"         │   │   │       ├─ AND\n" +
@@ -14237,8 +14237,8 @@ WHERE
 			"         │   │   │                       │   ├─ xmafz.BRQP2:22!null\n" +
 			"         │   │   │                       │   └─ mjr3d.FJDP5:0!null\n" +
 			"         │   │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │   │                           └─ Table\n" +
-			"         │   │   │                               ├─ name: NOXN3\n" +
+			"         │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
 			"         │   │   │                               └─ columns: [id brqp2]\n" +
 			"         │   │   └─ AND\n" +
 			"         │   │       ├─ AND\n" +
@@ -14258,8 +14258,8 @@ WHERE
 			"         │   │                       │   ├─ xmafz.BRQP2:22!null\n" +
 			"         │   │                       │   └─ mjr3d.BJUF2:1!null\n" +
 			"         │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │                           └─ Table\n" +
-			"         │   │                               ├─ name: NOXN3\n" +
+			"         │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │                               ├─ index: [NOXN3.BRQP2]\n" +
 			"         │   │                               └─ columns: [id brqp2]\n" +
 			"         │   ├─ SubqueryAlias\n" +
 			"         │   │   ├─ name: mjr3d\n" +
@@ -15008,8 +15008,8 @@ WHERE
 			"     │                                           │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"     │                                           │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"     │                                           │   │   │       │                       └─ Table\n" +
-			"     │                                           │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │   │       └─ NOT\n" +
 			"     │                                           │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15029,8 +15029,8 @@ WHERE
 			"     │                                           │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"     │                                           │   │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │   │       │                       └─ Table\n" +
-			"     │                                           │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"     │                                           │   └─ AND\n" +
@@ -15049,8 +15049,8 @@ WHERE
 			"     │                                           │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │       │                       └─ Table\n" +
-			"     │                                           │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │       └─ NOT\n" +
 			"     │                                           │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15349,8 +15349,8 @@ WHERE
 			"                                                 │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"                                                 │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ NOT\n" +
 			"                                                 │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15370,8 +15370,8 @@ WHERE
 			"                                                 │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"                                                 │   └─ AND\n" +
@@ -15390,8 +15390,8 @@ WHERE
 			"                                                 │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ NOT\n" +
 			"                                                 │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15851,8 +15851,8 @@ WHERE
 			"     │                                           │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"     │                                           │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"     │                                           │   │   │       │                       └─ Table\n" +
-			"     │                                           │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │   │       └─ NOT\n" +
 			"     │                                           │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15872,8 +15872,8 @@ WHERE
 			"     │                                           │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"     │                                           │   │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │   │       │                       └─ Table\n" +
-			"     │                                           │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"     │                                           │   └─ AND\n" +
@@ -15892,8 +15892,8 @@ WHERE
 			"     │                                           │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │       │                       └─ Table\n" +
-			"     │                                           │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │       └─ NOT\n" +
 			"     │                                           │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16192,8 +16192,8 @@ WHERE
 			"                                                 │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"                                                 │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ NOT\n" +
 			"                                                 │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16213,8 +16213,8 @@ WHERE
 			"                                                 │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"                                                 │   └─ AND\n" +
@@ -16233,8 +16233,8 @@ WHERE
 			"                                                 │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ NOT\n" +
 			"                                                 │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -17723,8 +17723,8 @@ FROM
 			"                             │           ├─ Eq\n" +
 			"                             │           │   ├─ noxn3.id:6!null\n" +
 			"                             │           │   └─ new.WNUNU:1!null\n" +
-			"                             │           └─ Table\n" +
-			"                             │               ├─ name: NOXN3\n" +
+			"                             │           └─ IndexedTableAccess(NOXN3)\n" +
+			"                             │               ├─ index: [NOXN3.id]\n" +
 			"                             │               └─ columns: [id fftbj]\n" +
 			"                             └─ Subquery\n" +
 			"                                 ├─ cacheable: false\n" +
@@ -17735,8 +17735,8 @@ FROM
 			"                                         ├─ Eq\n" +
 			"                                         │   ├─ noxn3.id:6!null\n" +
 			"                                         │   └─ new.HHVLX:2!null\n" +
-			"                                         └─ Table\n" +
-			"                                             ├─ name: NOXN3\n" +
+			"                                         └─ IndexedTableAccess(NOXN3)\n" +
+			"                                             ├─ index: [NOXN3.id]\n" +
 			"                                             └─ columns: [id brqp2]\n" +
 			"                        )\n" +
 			"                         └─ BLOCK\n" +
@@ -18002,8 +18002,8 @@ WHERE
 			"                 │               ├─ Eq\n" +
 			"                 │               │   ├─ e2i7u.id:8!null\n" +
 			"                 │               │   └─ new.LUEVY:2!null\n" +
-			"                 │               └─ Table\n" +
-			"                 │                   ├─ name: E2I7U\n" +
+			"                 │               └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │                   ├─ index: [E2I7U.id]\n" +
 			"                 │                   └─ columns: [id fgg57]\n" +
 			"                 │       IS NULL)\n" +
 			"                 │       └─ BLOCK\n" +
@@ -18180,8 +18180,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18352,8 +18352,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18524,8 +18524,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18696,8 +18696,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -19579,8 +19579,8 @@ FROM
 			"                     │           │   ├─ aac.BTXC5:18\n" +
 			"                     │           │   └─ bpnw2.SYPKF:3\n" +
 			"                     │           └─ TableAlias(aac)\n" +
-			"                     │               └─ Table\n" +
-			"                     │                   ├─ name: TPXBU\n" +
+			"                     │               └─ IndexedTableAccess(TPXBU)\n" +
+			"                     │                   ├─ index: [TPXBU.BTXC5]\n" +
 			"                     │                   └─ columns: [id btxc5]\n" +
 			"                     │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
 			"                     └─ Project\n" +
@@ -19594,8 +19594,8 @@ FROM
 			"                         │           │   ├─ aac.BTXC5:9\n" +
 			"                         │           │   └─ bpnw2.SYPKF:3\n" +
 			"                         │           └─ TableAlias(aac)\n" +
-			"                         │               └─ Table\n" +
-			"                         │                   ├─ name: TPXBU\n" +
+			"                         │               └─ IndexedTableAccess(TPXBU)\n" +
+			"                         │                   ├─ index: [TPXBU.BTXC5]\n" +
 			"                         │                   └─ columns: [id btxc5]\n" +
 			"                         │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
 			"                         └─ SubqueryAlias\n" +

--- a/optgen/cmd/source/memo.yaml
+++ b/optgen/cmd/source/memo.yaml
@@ -48,8 +48,6 @@ exprs:
   sourceType: "*plan.RecursiveCte"
 - name: "SubqueryAlias"
   sourceType: "*plan.SubqueryAlias"
-- name: "Max1Row"
-  sourceType: "sql.NameableNode"
 - name: "TableFunc"
   sourceType: "sql.TableFunction"
 - name: "JSONTable"
@@ -63,6 +61,8 @@ exprs:
 - name: "Distinct"
   unary:  true
   skipExec: true
+- name: "Max1Row"
+  unary:  true
 
 # scalar
 - name: "Filter"

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -468,7 +468,8 @@ func NewFinalizeUnionSel(sel RuleSelector) RuleSelector {
 func newInsertSourceSelector(sel RuleSelector) RuleSelector {
 	return func(id RuleId) bool {
 		switch id {
-		case transformJoinApplyId:
+		case transformJoinApplyId,
+			pushdownSubqueryAliasFiltersId:
 			return false
 		}
 		return sel(id)

--- a/sql/analyzer/apply_hash_in.go
+++ b/sql/analyzer/apply_hash_in.go
@@ -46,8 +46,11 @@ func applyHashIn(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, s
 		if same {
 			return node, transform.SameTree, nil
 		}
-		node, err = filter.WithExpressions(e)
-		return node, transform.NewTree, err
+		ret, err := filter.WithExpressions(e)
+		if err != nil {
+			return node, transform.SameTree, nil
+		}
+		return ret, transform.NewTree, err
 	})
 }
 

--- a/sql/analyzer/apply_indexes_from_outer_scope.go
+++ b/sql/analyzer/apply_indexes_from_outer_scope.go
@@ -233,9 +233,6 @@ func getSubqueryIndexes(
 	ia *indexAnalyzer,
 	tableAliases TableAliases,
 ) (map[string]sql.Index, joinExpressionsByTable, error) {
-
-	scopeLen := len(scope.Schema())
-
 	// build a list of candidate predicate expressions, those that might be used for an index lookup
 	var candidatePredicates []sql.Expression
 
@@ -245,7 +242,7 @@ func getSubqueryIndexes(
 		isScopeExpr := false
 		sql.Inspect(e, func(e sql.Expression) bool {
 			if gf, ok := e.(*expression.GetField); ok {
-				if gf.Index() < scopeLen {
+				if scope.Correlated().Contains(sql.ColumnId(gf.Id())) {
 					isScopeExpr = true
 					return false
 				}

--- a/sql/analyzer/experimental_rules.go
+++ b/sql/analyzer/experimental_rules.go
@@ -34,7 +34,7 @@ func fixupAuxiliaryExprsHelper(ctx *sql.Context, a *Analyzer, n sql.Node, scope 
 			ret, same2, err := transform.OneNodeExpressions(ret, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				switch e := e.(type) {
 				case *plan.Subquery:
-					newQ, same, err := fixupAuxiliaryExprsHelper(ctx, a, e.Query, scope.NewScopeFromSubqueryExpression(ret))
+					newQ, same, err := fixupAuxiliaryExprsHelper(ctx, a, e.Query, scope.NewScopeFromSubqueryExpression(ret, e.Correlated()))
 					if same || err != nil {
 						return e, transform.SameTree, err
 					}

--- a/sql/analyzer/generate_index_scans.go
+++ b/sql/analyzer/generate_index_scans.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/dolthub/go-mysql-server/sql/fixidx"
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/rowexec"
@@ -123,13 +122,9 @@ func convertFiltersToIndexedAccess(
 			filters.markFiltersHandled(handled...)
 			newF := removePushedDownPredicates(ctx, a, n, filters)
 			if newF == nil {
-				return fixidx.FixFieldIndexesForExpressions(ctx, a.LogFn(), n, scope)
+				return n, transform.SameTree, nil
 			}
-			ret, _, err := fixidx.FixFieldIndexesForExpressions(ctx, a.LogFn(), newF, scope)
-			if err != nil {
-				return n, transform.SameTree, err
-			}
-			return ret, transform.NewTree, nil
+			return newF, transform.NewTree, nil
 		case *plan.TableAlias, *plan.ResolvedTable:
 			nameable := n.(sql.NameableNode)
 			ret, same, err, lookup := pushdownIndexesToTable(ctx, scope, a, nameable, indexes)
@@ -146,10 +141,8 @@ func convertFiltersToIndexedAccess(
 			}
 			handled = append(handled, handledF...)
 			return ret, transform.NewTree, nil
-		case *plan.JSONTable:
-			return n, transform.SameTree, nil
 		default:
-			return pushdownFixIndices(ctx, a, n, scope)
+			return n, transform.SameTree, nil
 		}
 	})
 }
@@ -195,17 +188,7 @@ func pushdownIndexesToTable(ctx *sql.Context, scope *plan.Scope, a *Analyzer, ta
 
 						// save reference
 						lookup = indexLookup
-
-						newExprs, _, err := fixidx.FixFieldIndexesOnExpressions(scope, a.LogFn(), table.Schema(), ita.Expressions()...)
-						if err != nil {
-							return nil, transform.SameTree, err
-						}
-						ret, err := ita.WithExpressions(newExprs...)
-						if err != nil {
-							return nil, transform.SameTree, err
-						}
-
-						return ret, transform.NewTree, nil
+						return ita, transform.NewTree, nil
 					}
 				}
 			}

--- a/sql/analyzer/hoist_filters.go
+++ b/sql/analyzer/hoist_filters.go
@@ -165,7 +165,7 @@ func partitionFilterByScope(e sql.Expression, corr sql.ColSet) (inScope, outOfSc
 		case *expression.GetField:
 			// we're searching for anything in-scope
 			// return true if not correlated from outerscope
-			id := sql.ColumnId(e.Index())
+			id := e.Id()
 			if corr.Contains(id) {
 				outOfScope.Add(id)
 			} else {

--- a/sql/analyzer/hoist_select_exists.go
+++ b/sql/analyzer/hoist_select_exists.go
@@ -151,7 +151,7 @@ func hoistExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, filt
 
 		// recurse
 		if s.inner != nil {
-			s.inner, _, err = hoistSelectExistsHelper(ctx, scope.NewScopeFromSubqueryExpression(filter), a, s.inner, aliasDisambig)
+			s.inner, _, err = hoistSelectExistsHelper(ctx, scope.NewScopeFromSubqueryExpression(filter, sq.Correlated()), a, s.inner, aliasDisambig)
 			if err != nil {
 				return nil, transform.SameTree, err
 			}
@@ -248,7 +248,7 @@ func decorrelateOuterCols(sqChild sql.Node, aliasDisambig *aliasDisambiguator, c
 		filters := expression.SplitConjunction(f.Expression)
 		for _, f := range filters {
 			outerRef := transform.InspectExpr(f, func(e sql.Expression) bool {
-				if gf, ok := e.(*expression.GetField); ok && corr.Contains(sql.ColumnId(gf.Index())) {
+				if gf, ok := e.(*expression.GetField); ok && corr.Contains(gf.Id()) {
 					return true
 				}
 				return false

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -115,6 +115,7 @@ func inOrderReplanJoin(
 	// two different base cases, depending on whether we reorder or not
 	if reorder {
 		scope.SetJoin(true)
+		scope.SetLateralJoin(j.Op.IsLateral())
 		ret, err := replanJoin(ctx, j, a, scope)
 		if err != nil {
 			return nil, transform.SameTree, fmt.Errorf("failed to replan join: %w", err)

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -295,7 +295,7 @@ func pushdownFiltersUnderSubqueryAlias(ctx *sql.Context, a *Analyzer, sa *plan.S
 	for i, h := range handled {
 		expressionsForChild[i], _, err = transform.Expr(h, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if gt, ok := e.(*expression.GetField); ok {
-				gf, ok := sa.ScopeMapping[sql.ColumnId(gt.Index())]
+				gf, ok := sa.ScopeMapping[gt.Id()]
 				if !ok {
 					return e, transform.SameTree, fmt.Errorf("unable to find child with id: %d", gt.Index())
 				}

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -80,11 +80,13 @@ func finalizeSubqueriesHelper(ctx *sql.Context, a *Analyzer, node sql.Node, scop
 			if sqa.OuterScopeVisibility && joinParent != nil {
 				if stripChild, ok := joinParent.Right().(*plan.StripRowNode); ok && stripChild.Child == sqa {
 					subScope := scope.NewScopeInJoin(joinParent.Children()[0])
+					subScope.SetLateralJoin(joinParent.Op.IsLateral())
 					newSqa, same2, err = analyzeSubqueryAlias(ctx, a, sqa, subScope, sel, true)
 				} else {
 					// IsLateral means that the subquery should have visibility into the left scope.
 					if sqa.IsLateral {
 						subScope := addLeftTablesToScope(scope, joinParent.Left())
+						subScope.SetLateralJoin(true)
 						newSqa, same2, err = analyzeSubqueryAlias(ctx, a, sqa, subScope, sel, true)
 					} else {
 						newSqa, same2, err = analyzeSubqueryAlias(ctx, a, sqa, scope, sel, true)
@@ -94,6 +96,7 @@ func finalizeSubqueriesHelper(ctx *sql.Context, a *Analyzer, node sql.Node, scop
 				// IsLateral means that the subquery should have visibility into the left scope.
 				if joinParent != nil && sqa.IsLateral {
 					subScope := addLeftTablesToScope(scope, joinParent.Left())
+					subScope.SetLateralJoin(true)
 					newSqa, same2, err = analyzeSubqueryAlias(ctx, a, sqa, subScope, sel, true)
 				} else {
 					newSqa, same2, err = analyzeSubqueryAlias(ctx, a, sqa, scope, sel, true)

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -27,6 +27,10 @@ import (
 type GetField struct {
 	table      string
 	fieldIndex int
+	// exprId lets the lifecycle of getFields be idempotent. We can re-index
+	// or re-apply scope/caching optimizations without worrying about losing
+	// the reference to the unique id.
+	exprId     sql.ColumnId
 	name       string
 	fieldType  sql.Type
 	fieldType2 sql.Type2
@@ -52,11 +56,14 @@ func NewGetFieldWithTable(index int, fieldType sql.Type, table, fieldName string
 		fieldType2: fieldType2,
 		name:       fieldName,
 		nullable:   nullable,
+		exprId:     sql.ColumnId(index),
 	}
 }
 
 // Index returns the index where the GetField will look for the value from a sql.Row.
 func (p *GetField) Index() int { return p.fieldIndex }
+
+func (p *GetField) Id() sql.ColumnId { return p.exprId }
 
 // Children implements the Expression interface.
 func (*GetField) Children() []sql.Expression {

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -324,17 +324,14 @@ func (hit *HashInTuple) Resolved() bool {
 
 func (hit *HashInTuple) Type() sql.Type {
 	return hit.in.Type()
-
 }
 
 func (hit *HashInTuple) IsNullable() bool {
 	return hit.in.IsNullable()
-
 }
 
 func (hit *HashInTuple) Children() []sql.Expression {
 	return hit.in.Children()
-
 }
 
 func (hit *HashInTuple) WithChildren(children ...sql.Expression) (sql.Expression, error) {

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -159,13 +159,14 @@ func NewNotInTuple(left sql.Expression, right sql.Expression) sql.Expression {
 
 // HashInTuple is an expression that checks an expression is inside a list of expressions using a hashmap.
 type HashInTuple struct {
-	InTuple
+	in      *InTuple
 	cmp     map[uint64]sql.Expression
 	hasNull bool
 }
 
-var _ Comparer = (*InTuple)(nil)
-var _ sql.CollationCoercible = (*InTuple)(nil)
+var _ Comparer = (*HashInTuple)(nil)
+var _ sql.CollationCoercible = (*HashInTuple)(nil)
+var _ sql.Expression = (*HashInTuple)(nil)
 
 // NewHashInTuple creates an InTuple expression.
 func NewHashInTuple(ctx *sql.Context, left, right sql.Expression) (*HashInTuple, error) {
@@ -179,7 +180,7 @@ func NewHashInTuple(ctx *sql.Context, left, right sql.Expression) (*HashInTuple,
 		return nil, err
 	}
 
-	return &HashInTuple{InTuple: *NewInTuple(left, right), cmp: cmp, hasNull: hasNull}, nil
+	return &HashInTuple{in: NewInTuple(left, right), cmp: cmp, hasNull: hasNull}, nil
 }
 
 // newInMap hashes static expressions in the right child Tuple of a InTuple node
@@ -252,9 +253,9 @@ func (hit *HashInTuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 		return nil, nil
 	}
 
-	leftElems := types.NumColumns(hit.Left().Type().Promote())
+	leftElems := types.NumColumns(hit.in.Left().Type().Promote())
 
-	leftVal, err := hit.Left().Eval(ctx, row)
+	leftVal, err := hit.in.Left().Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +264,7 @@ func (hit *HashInTuple) Eval(ctx *sql.Context, row sql.Row) (interface{}, error)
 		return nil, nil
 	}
 
-	key, err := hashOfSimple(ctx, leftVal, hit.Left().Type())
+	key, err := hashOfSimple(ctx, leftVal, hit.in.Left().Type())
 	if err != nil {
 		return nil, err
 	}
@@ -313,14 +314,59 @@ func convertOrTruncate(ctx *sql.Context, i interface{}, t sql.Type) (interface{}
 	return t.Zero(), nil
 }
 
+func (hit *HashInTuple) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return hit.in.CollationCoercibility(ctx)
+}
+
+func (hit *HashInTuple) Resolved() bool {
+	return hit.in.Resolved()
+}
+
+func (hit *HashInTuple) Type() sql.Type {
+	return hit.in.Type()
+
+}
+
+func (hit *HashInTuple) IsNullable() bool {
+	return hit.in.IsNullable()
+
+}
+
+func (hit *HashInTuple) Children() []sql.Expression {
+	return hit.in.Children()
+
+}
+
+func (hit *HashInTuple) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 2 {
+		return nil, sql.ErrInvalidChildrenNumber.New(hit, len(children), 2)
+	}
+	ret := *hit
+	newIn, err := ret.in.WithChildren(children...)
+	ret.in = newIn.(*InTuple)
+	return &ret, err
+}
+
+func (hit *HashInTuple) Compare(ctx *sql.Context, row sql.Row) (int, error) {
+	return hit.in.Compare(ctx, row)
+}
+
+func (hit *HashInTuple) Left() sql.Expression {
+	return hit.in.Left()
+}
+
+func (hit *HashInTuple) Right() sql.Expression {
+	return hit.in.Right()
+}
+
 func (hit *HashInTuple) String() string {
-	return fmt.Sprintf("(%s HASH IN %s)", hit.Left(), hit.Right())
+	return fmt.Sprintf("(%s HASH IN %s)", hit.in.Left(), hit.in.Right())
 }
 
 func (hit *HashInTuple) DebugString() string {
 	pr := sql.NewTreePrinter()
 	_ = pr.WriteNode("HashIn")
-	children := []string{sql.DebugString(hit.Left()), sql.DebugString(hit.Right())}
+	children := []string{sql.DebugString(hit.in.Left()), sql.DebugString(hit.in.Right())}
 	_ = pr.WriteChildren(children...)
 	return pr.String()
 }

--- a/sql/fixidx/fix_field_indexes.go
+++ b/sql/fixidx/fix_field_indexes.go
@@ -77,13 +77,7 @@ func FixFieldIndexes(scope *plan.Scope, logFn func(string, ...any), schema sql.S
 						if logFn != nil {
 							logFn("Rewriting field %s.%s from index %d to %d", e.Table(), e.Name(), e.Index(), newIndex)
 						}
-						return expression.NewGetFieldWithTable(
-							newIndex,
-							e.Type(),
-							e.Table(),
-							e.Name(),
-							e.IsNullable(),
-						), transform.NewTree, nil
+						return e.WithIndex(newIndex), transform.NewTree, nil
 					}
 					return e, transform.SameTree, nil
 				}
@@ -93,13 +87,7 @@ func FixFieldIndexes(scope *plan.Scope, logFn func(string, ...any), schema sql.S
 					if logFn != nil {
 						logFn("Rewriting field %s.%s from index %d to %d", e.Table(), e.Name(), e.Index(), partial)
 					}
-					return expression.NewGetFieldWithTable(
-						partial,
-						e.Type(),
-						e.Table(),
-						e.Name(),
-						e.IsNullable(),
-					), transform.NewTree, nil
+					return e.WithIndex(partial), transform.NewTree, nil
 				}
 				return e, transform.SameTree, nil
 			}
@@ -117,13 +105,7 @@ func FixFieldIndexes(scope *plan.Scope, logFn func(string, ...any), schema sql.S
 							if logFn != nil {
 								logFn("Rewriting field %s.%s from index %d to %d", e.Table(), e.Name(), e.Index(), newIndex)
 							}
-							return expression.NewGetFieldWithTable(
-								newIndex,
-								e.Type(),
-								e.Table(),
-								e.Name(),
-								e.IsNullable(),
-							), transform.NewTree, nil
+							return e.WithIndex(newIndex), transform.NewTree, nil
 						}
 						return e, transform.SameTree, nil
 					}
@@ -294,7 +276,7 @@ func FixFieldIndexesForNode(ctx *sql.Context, logFn func(string, ...any), scope 
 		}
 		ret, sameE, err := transform.NodeExprs(ret, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if sq, ok := e.(*plan.Subquery); ok {
-				newQ, same, err := FixFieldIndexesForNode(ctx, logFn, scope.NewScopeFromSubqueryExpression(ret), sq.Query)
+				newQ, same, err := FixFieldIndexesForNode(ctx, logFn, scope.NewScopeFromSubqueryExpression(ret, sq.Correlated()), sq.Query)
 				if err != nil || same {
 					return sq, transform.SameTree, err
 				}

--- a/sql/fixidx/fix_field_indexes.go
+++ b/sql/fixidx/fix_field_indexes.go
@@ -155,7 +155,7 @@ func FixFieldIndexesForExpressions(ctx *sql.Context, logFn func(string, ...any),
 
 	var sameF transform.TreeIdentity
 	if scope.InJoin() {
-		scopeSch := scope.Schema()
+		scopeSch := append(scope.Schema(), node.Schema()...)
 		var newN sql.Node
 		var err error
 		newN, sameF, err = transform.OneNodeExprsWithNode(node, func(_ sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
@@ -216,7 +216,7 @@ func FixFieldIndexesForExpressions(ctx *sql.Context, logFn func(string, ...any),
 
 	j, ok := n.(*plan.JoinNode)
 	if !ok {
-		return n, sameC, nil
+		return n, sameC && sameF, nil
 	}
 	sameJ := transform.SameTree
 	var cond sql.Expression

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -384,7 +384,7 @@ func (b *ExecBuilder) buildSubqueryAlias(r *SubqueryAlias, input sql.Schema, chi
 }
 
 func (b *ExecBuilder) buildMax1Row(r *Max1Row, input sql.Schema, children ...sql.Node) (sql.Node, error) {
-	return r.Table, nil
+	return plan.NewMax1Row(children[0], ""), nil
 }
 
 func (b *ExecBuilder) buildTableFunc(r *TableFunc, input sql.Schema, children ...sql.Node) (sql.Node, error) {

--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -341,11 +341,10 @@ func (j *joinOrderBuilder) buildMax1Row(n *plan.Max1Row) (vertexSet, edgeSet, *E
 	// memoize child
 	childV, childE, childGrp := j.populateSubgraph(n.Child)
 
-	filterGrp := j.m.MemoizeMax1Row(nil, childGrp)
+	max1Grp := j.m.MemoizeMax1Row(nil, childGrp)
 
-	// filter will absorb child relation for join reordering
-	j.plans[childV] = filterGrp
-	return childV, childE, filterGrp
+	j.plans[childV] = max1Grp
+	return childV, childE, max1Grp
 }
 
 func (j *joinOrderBuilder) buildJoinLeaf(n sql.Nameable) *ExprGroup {

--- a/sql/memo/memo.go
+++ b/sql/memo/memo.go
@@ -484,6 +484,19 @@ func (m *Memo) MemoizeFilter(grp, child *ExprGroup, filters []*ExprGroup) *ExprG
 	return grp
 }
 
+func (m *Memo) MemoizeMax1Row(grp, child *ExprGroup) *ExprGroup {
+	rel := &Max1Row{
+		relBase: &relBase{},
+		Child:   child,
+	}
+	if grp == nil {
+		return m.NewExprGroup(rel)
+	}
+	rel.g = grp
+	grp.Prepend(rel)
+	return grp
+}
+
 // OptimizeRoot finds the implementation for the root expression
 // that has the lowest cost.
 func (m *Memo) OptimizeRoot() error {

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -91,20 +91,6 @@ func (p *relProps) populateFds() {
 			fds = sql.NewInnerJoinFDs(jp.Left.RelProps.FuncDeps(), jp.Right.RelProps.FuncDeps(), getEquivs(jp.Filter))
 		}
 	case *Max1Row:
-		//start := len(rel.Group().m.Columns)
-		//rel.Group().m.assignColumnIds(rel)
-		//end := len(rel.Group().m.Columns)
-		//
-		//sch := allTableCols(rel)
-		//
-		//var all sql.ColSet
-		//var notNull sql.ColSet
-		//for i := start; i < end; i++ {
-		//	all.Add(sql.ColumnId(i + 1))
-		//	if !sch[i-start].Nullable {
-		//		notNull.Add(sql.ColumnId(i + 1))
-		//	}
-		//}
 		all := rel.Child.RelProps.FuncDeps().All()
 		notNull := rel.Child.RelProps.FuncDeps().NotNull()
 		fds = sql.NewMax1RowFDs(all, notNull)

--- a/sql/plan/scope.go
+++ b/sql/plan/scope.go
@@ -37,6 +37,9 @@ type Scope struct {
 
 	Procedures *ProcedureCache
 
+	// corr is the aggregated set of correlated columns tracked by the subquery
+	// chain that produced this scope.
+	corr          sql.ColSet
 	inJoin        bool
 	inLateralJoin bool
 	joinSiblings  []sql.Node
@@ -90,11 +93,17 @@ func (s *Scope) NewScope(node sql.Node) *Scope {
 	}
 }
 
-// NewScopeFromSubqueryExpression returns a new subscope created from a subquery expression contained by the specified
-// node.
-func (s *Scope) NewScopeFromSubqueryExpression(node sql.Node) *Scope {
+// NewScopeFromSubqueryExpression returns a new subscope created from a
+// subquery expression contained by the specified node. |corr| is the
+// set of correlated columns referenced in this subquery, which is only
+// implicit here because the subquery is distanced from its parent |node|.
+func (s *Scope) NewScopeFromSubqueryExpression(node sql.Node, corr sql.ColSet) *Scope {
 	subScope := s.NewScope(node)
 	subScope.CurrentNodeIsFromSubqueryExpression = true
+	subScope.corr = corr
+	if s != nil {
+		subScope.corr = s.corr.Union(corr)
+	}
 	return subScope
 }
 
@@ -126,6 +135,7 @@ func (s *Scope) NewScopeInJoin(node sql.Node) *Scope {
 		recursionDepth: s.recursionDepth + 1,
 		Procedures:     s.Procedures,
 		joinSiblings:   newNodes,
+		corr:           s.corr,
 	}
 }
 
@@ -138,6 +148,7 @@ func (s *Scope) NewScopeNoJoin() *Scope {
 		recursionDepth:  s.recursionDepth + 1,
 		Procedures:      s.Procedures,
 		EnforceReadOnly: s.EnforceReadOnly,
+		corr:            s.corr,
 	}
 }
 
@@ -146,6 +157,7 @@ func (s *Scope) NewScopeNoJoin() *Scope {
 // expression, they may reference tables from the scopes outside the subquery expression's scope.
 func (s *Scope) NewScopeFromSubqueryAlias(sqa *SubqueryAlias) *Scope {
 	subScope := newScopeWithDepth(s.RecursionDepth() + 1)
+	subScope.corr = sqa.Correlated
 	if s != nil {
 		if len(s.nodes) > 0 {
 			// As of MySQL 8.0.14, MySQL provides OUTER scope visibility to derived tables. Unlike LATERAL scope visibility, which
@@ -163,6 +175,7 @@ func (s *Scope) NewScopeFromSubqueryAlias(sqa *SubqueryAlias) *Scope {
 		}
 		subScope.inJoin = s.inJoin
 		subScope.inLateralJoin = s.inLateralJoin
+		subScope.corr = s.corr.Union(sqa.Correlated)
 	}
 
 	return subScope
@@ -320,4 +333,8 @@ func (s *Scope) InLateralJoin() bool {
 
 func (s *Scope) JoinSiblings() []sql.Node {
 	return s.joinSiblings
+}
+
+func (s *Scope) Correlated() sql.ColSet {
+	return s.corr
 }

--- a/sql/plan/scope.go
+++ b/sql/plan/scope.go
@@ -37,8 +37,9 @@ type Scope struct {
 
 	Procedures *ProcedureCache
 
-	inJoin       bool
-	joinSiblings []sql.Node
+	inJoin        bool
+	inLateralJoin bool
+	joinSiblings  []sql.Node
 }
 
 func (s *Scope) SetJoin(b bool) {
@@ -46,6 +47,13 @@ func (s *Scope) SetJoin(b bool) {
 		return
 	}
 	s.inJoin = b
+}
+
+func (s *Scope) SetLateralJoin(b bool) {
+	if s == nil {
+		return
+	}
+	s.inLateralJoin = b
 }
 
 func (s *Scope) IsEmpty() bool {
@@ -154,6 +162,7 @@ func (s *Scope) NewScopeFromSubqueryAlias(sqa *SubqueryAlias) *Scope {
 			subScope.joinSiblings = append(subScope.joinSiblings, s.joinSiblings...)
 		}
 		subScope.inJoin = s.inJoin
+		subScope.inLateralJoin = s.inLateralJoin
 	}
 
 	return subScope
@@ -300,4 +309,15 @@ func (s *Scope) InJoin() bool {
 		return false
 	}
 	return s.inJoin
+}
+
+func (s *Scope) InLateralJoin() bool {
+	if s == nil {
+		return false
+	}
+	return s.inLateralJoin
+}
+
+func (s *Scope) JoinSiblings() []sql.Node {
+	return s.joinSiblings
 }

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -16,7 +16,6 @@ package plan
 
 import (
 	"fmt"
-
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
@@ -33,6 +32,7 @@ type SubqueryAlias struct {
 	Volatile             bool
 	CacheableCTESource   bool
 	IsLateral            bool
+	ScopeMapping         map[sql.ColumnId]sql.Expression
 }
 
 var _ sql.Node = (*SubqueryAlias)(nil)
@@ -121,6 +121,12 @@ func (sq *SubqueryAlias) WithCorrelated(cols sql.ColSet) *SubqueryAlias {
 func (sq *SubqueryAlias) WithVolatile(v bool) *SubqueryAlias {
 	ret := *sq
 	ret.Volatile = v
+	return &ret
+}
+
+func (sq *SubqueryAlias) WithScopeMapping(cols map[sql.ColumnId]sql.Expression) *SubqueryAlias {
+	ret := *sq
+	ret.ScopeMapping = cols
 	return &ret
 }
 

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"fmt"
+
 	"github.com/dolthub/go-mysql-server/sql"
 )
 

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -52,7 +52,7 @@ func (b *Builder) analyzeSelectList(inScope, outScope *scope, selectExprs ast.Se
 			switch e := e.(type) {
 			case *expression.GetField:
 				if e.Table() == "" {
-					id = columnId(e.Index())
+					id = columnId(e.Id())
 					aRef = e.Name()
 				}
 			case *expression.Alias:

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -229,9 +229,8 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) sql.Expression {
 	case *ast.UnaryExpr:
 		return b.buildUnaryScalar(inScope, v)
 	case *ast.Subquery:
-		sqScope := inScope.push()
+		sqScope := inScope.pushSubquery()
 		selectString := ast.String(v.Select)
-		sqScope.initSubquery()
 		selScope := b.buildSelectStmt(sqScope, v.Select)
 		// TODO: get the original select statement, not the reconstruction
 		sq := plan.NewSubquery(selScope.node, selectString)

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -38,7 +38,8 @@ type scope struct {
 	refsSubquery   bool
 
 	// cols are definitions provided by this scope
-	cols []scopeColumn
+	cols   []scopeColumn
+	colset sql.ColSet
 	// extraCols are auxillary output columns required
 	// for sorting or grouping
 	extraCols []scopeColumn
@@ -213,14 +214,14 @@ func (s *scope) initGroupBy() {
 // pushSubquery creates a new scope with the subquery already initialized.
 func (s *scope) pushSubquery() *scope {
 	newScope := s.push()
-	newScope.activeSubquery = &subquery{}
+	newScope.activeSubquery = &subquery{parent: s.nearestSubquery()}
 	return newScope
 }
 
 // replaceSubquery creates a new scope with the subquery already initialized.
 func (s *scope) replaceSubquery() *scope {
 	newScope := s.replace()
-	newScope.activeSubquery = &subquery{}
+	newScope.activeSubquery = &subquery{parent: s.nearestSubquery()}
 	return newScope
 }
 
@@ -372,6 +373,9 @@ func (s *scope) copy() *scope {
 		ret.cols = make([]scopeColumn, len(s.cols))
 		copy(ret.cols, s.cols)
 	}
+	if !s.colset.Empty() {
+		ret.colset = s.colset.Copy()
+	}
 
 	return &ret
 }
@@ -424,6 +428,7 @@ func (s *scope) redirect(from, to scopeColumn) {
 // column identity
 func (s *scope) addColumn(col scopeColumn) {
 	s.cols = append(s.cols, col)
+	s.colset.Add(sql.ColumnId(col.id))
 	if s.exprs == nil {
 		s.exprs = make(map[string]columnId)
 	}

--- a/sql/planbuilder/subquery.go
+++ b/sql/planbuilder/subquery.go
@@ -17,14 +17,30 @@ package planbuilder
 import "github.com/dolthub/go-mysql-server/sql"
 
 type subquery struct {
+	parent     *subquery
 	correlated sql.ColSet
 	volatile   bool
 }
 
+// addOutOfScope is used to tag subqueries that failed to resolve a column.
+// The way this works is that we have a scope where we initiate a resolve
+// (scope_0), and we will work upwards through the scope chain until we find
+// the scope with the column (ex: scope_n). After finding the column, we wind
+// back upwards through the callstack to return the column. During the unwind,
+// check and tag every scope in between scope_0...scope_n-1 that is a subquery.
+// This prevents propagating the correlation tag above the scope where the
+// column is defined.
 func (s *subquery) addOutOfScope(c columnId) {
+	if s == nil {
+		return
+	}
 	s.correlated.Add(sql.ColumnId(c))
 }
 
+// markVolatile marks this and every parent subquery as volatile.
 func (s *subquery) markVolatile() {
 	s.volatile = true
+	if s.parent != nil {
+		s.parent.markVolatile()
+	}
 }

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -1460,7 +1460,7 @@ func addColumnToSchema(schema sql.Schema, column *sql.Column, order *sql.ColumnO
 						if idx < 0 {
 							return nil, transform.SameTree, sql.ErrTableColumnNotFound.New(schema[0].Source, s.Name())
 						}
-						return s.WithIndex(idx), transform.NewTree, nil
+						return expression.NewGetFieldWithTable(idx, s.Type(), s.Table(), s.Name(), s.IsNullable()), transform.NewTree, nil
 					default:
 						return s, transform.SameTree, nil
 					}


### PR DESCRIPTION
Summary:
- delete `fixidx` usages in `pushdownFilters` and `generateIndexScans`
- use a mapping on subquery aliases when pushing filters through subqueries
- better max1Row memo now
- misc changes to re-indexing to compensate for work previously done during pushdown