### PR TITLE
Fixes for subquery indexing/correlation tracking

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -11229,8 +11229,8 @@ WHERE
 			" │       │           │   ├─ aac.id:74!null\n" +
 			" │       │           │   └─ sl3s5.M22QN:63!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ Table\n" +
-			" │       │                   ├─ name: TPXBU\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │       │                   ├─ index: [TPXBU.id]\n" +
 			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
 			" │       └─ Project\n" +
@@ -11244,8 +11244,8 @@ WHERE
 			" │           │           │   ├─ aac.id:67!null\n" +
 			" │           │           │   └─ sl3s5.M22QN:19!null\n" +
 			" │           │           └─ TableAlias(aac)\n" +
-			" │           │               └─ Table\n" +
-			" │           │                   ├─ name: TPXBU\n" +
+			" │           │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │           │                   ├─ index: [TPXBU.id]\n" +
 			" │           │                   └─ columns: [id btxc5]\n" +
 			" │           │   as TPXBU, sl3s5.NO52D:21!null as NO52D, sl3s5.IDPK7:22!null as IDPK7]\n" +
 			" │           └─ HashJoin\n" +
@@ -11615,8 +11615,8 @@ WHERE
 			" │       │           │   ├─ aac.id:74!null\n" +
 			" │       │           │   └─ sl3s5.M22QN:63!null\n" +
 			" │       │           └─ TableAlias(aac)\n" +
-			" │       │               └─ Table\n" +
-			" │       │                   ├─ name: TPXBU\n" +
+			" │       │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │       │                   ├─ index: [TPXBU.id]\n" +
 			" │       │                   └─ columns: [id btxc5]\n" +
 			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
 			" │       └─ Project\n" +
@@ -11630,8 +11630,8 @@ WHERE
 			" │           │           │   ├─ aac.id:67!null\n" +
 			" │           │           │   └─ sl3s5.M22QN:19!null\n" +
 			" │           │           └─ TableAlias(aac)\n" +
-			" │           │               └─ Table\n" +
-			" │           │                   ├─ name: TPXBU\n" +
+			" │           │               └─ IndexedTableAccess(TPXBU)\n" +
+			" │           │                   ├─ index: [TPXBU.id]\n" +
 			" │           │                   └─ columns: [id btxc5]\n" +
 			" │           │   as TPXBU, sl3s5.NO52D:21!null as NO52D, sl3s5.IDPK7:22!null as IDPK7]\n" +
 			" │           └─ HashJoin\n" +
@@ -14217,8 +14217,8 @@ WHERE
 			"         │   │   │   │                       │   ├─ jtehg.BRQP2:22!null\n" +
 			"         │   │   │   │                       │   └─ mjr3d.BJUF2:1!null\n" +
 			"         │   │   │   │                       └─ TableAlias(jtehg)\n" +
-			"         │   │   │   │                           └─ Table\n" +
-			"         │   │   │   │                               ├─ name: NOXN3\n" +
+			"         │   │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
 			"         │   │   │   │                               └─ columns: [id brqp2]\n" +
 			"         │   │   │   └─ AND\n" +
 			"         │   │   │       ├─ AND\n" +
@@ -14237,8 +14237,8 @@ WHERE
 			"         │   │   │                       │   ├─ xmafz.BRQP2:22!null\n" +
 			"         │   │   │                       │   └─ mjr3d.FJDP5:0!null\n" +
 			"         │   │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │   │                           └─ Table\n" +
-			"         │   │   │                               ├─ name: NOXN3\n" +
+			"         │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
 			"         │   │   │                               └─ columns: [id brqp2]\n" +
 			"         │   │   └─ AND\n" +
 			"         │   │       ├─ AND\n" +
@@ -14258,8 +14258,8 @@ WHERE
 			"         │   │                       │   ├─ xmafz.BRQP2:22!null\n" +
 			"         │   │                       │   └─ mjr3d.BJUF2:1!null\n" +
 			"         │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │                           └─ Table\n" +
-			"         │   │                               ├─ name: NOXN3\n" +
+			"         │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"         │   │                               ├─ index: [NOXN3.BRQP2]\n" +
 			"         │   │                               └─ columns: [id brqp2]\n" +
 			"         │   ├─ SubqueryAlias\n" +
 			"         │   │   ├─ name: mjr3d\n" +
@@ -15008,8 +15008,8 @@ WHERE
 			"     │                                           │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"     │                                           │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"     │                                           │   │   │       │                       └─ Table\n" +
-			"     │                                           │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │   │       └─ NOT\n" +
 			"     │                                           │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15029,8 +15029,8 @@ WHERE
 			"     │                                           │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"     │                                           │   │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │   │       │                       └─ Table\n" +
-			"     │                                           │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"     │                                           │   └─ AND\n" +
@@ -15049,8 +15049,8 @@ WHERE
 			"     │                                           │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │       │                       └─ Table\n" +
-			"     │                                           │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │       └─ NOT\n" +
 			"     │                                           │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15349,8 +15349,8 @@ WHERE
 			"                                                 │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"                                                 │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ NOT\n" +
 			"                                                 │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15370,8 +15370,8 @@ WHERE
 			"                                                 │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"                                                 │   └─ AND\n" +
@@ -15390,8 +15390,8 @@ WHERE
 			"                                                 │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ NOT\n" +
 			"                                                 │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15851,8 +15851,8 @@ WHERE
 			"     │                                           │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"     │                                           │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"     │                                           │   │   │       │                       └─ Table\n" +
-			"     │                                           │   │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │   │       └─ NOT\n" +
 			"     │                                           │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -15872,8 +15872,8 @@ WHERE
 			"     │                                           │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"     │                                           │   │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │   │       │                       └─ Table\n" +
-			"     │                                           │   │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │   │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"     │                                           │   └─ AND\n" +
@@ -15892,8 +15892,8 @@ WHERE
 			"     │                                           │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"     │                                           │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"     │                                           │       │                   └─ TableAlias(xmafz)\n" +
-			"     │                                           │       │                       └─ Table\n" +
-			"     │                                           │       │                           ├─ name: NOXN3\n" +
+			"     │                                           │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"     │                                           │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"     │                                           │       │                           └─ columns: [id brqp2]\n" +
 			"     │                                           │       └─ NOT\n" +
 			"     │                                           │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16192,8 +16192,8 @@ WHERE
 			"                                                 │   │   │       │                   │   ├─ jtehg.BRQP2:21!null\n" +
 			"                                                 │   │   │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │   │   │       │                   └─ TableAlias(jtehg)\n" +
-			"                                                 │   │   │       │                       └─ Table\n" +
-			"                                                 │   │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │   │       └─ NOT\n" +
 			"                                                 │   │   │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -16213,8 +16213,8 @@ WHERE
 			"                                                 │   │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │   │       │                   │   └─ mjr3d.FJDP5:0!null\n" +
 			"                                                 │   │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │   │       │                       └─ Table\n" +
-			"                                                 │   │       │                           ├─ name: NOXN3\n" +
+			"                                                 │   │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │   │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │   │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │   │       └─ mjr3d.BJUF2:1!null IS NULL\n" +
 			"                                                 │   └─ AND\n" +
@@ -16233,8 +16233,8 @@ WHERE
 			"                                                 │       │                   │   ├─ xmafz.BRQP2:21!null\n" +
 			"                                                 │       │                   │   └─ mjr3d.BJUF2:1!null\n" +
 			"                                                 │       │                   └─ TableAlias(xmafz)\n" +
-			"                                                 │       │                       └─ Table\n" +
-			"                                                 │       │                           ├─ name: NOXN3\n" +
+			"                                                 │       │                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                                                 │       │                           ├─ index: [NOXN3.BRQP2]\n" +
 			"                                                 │       │                           └─ columns: [id brqp2]\n" +
 			"                                                 │       └─ NOT\n" +
 			"                                                 │           └─ mjr3d.BJUF2:1!null IS NULL\n" +
@@ -17723,8 +17723,8 @@ FROM
 			"                             │           ├─ Eq\n" +
 			"                             │           │   ├─ noxn3.id:6!null\n" +
 			"                             │           │   └─ new.WNUNU:1!null\n" +
-			"                             │           └─ Table\n" +
-			"                             │               ├─ name: NOXN3\n" +
+			"                             │           └─ IndexedTableAccess(NOXN3)\n" +
+			"                             │               ├─ index: [NOXN3.id]\n" +
 			"                             │               └─ columns: [id fftbj]\n" +
 			"                             └─ Subquery\n" +
 			"                                 ├─ cacheable: false\n" +
@@ -17735,8 +17735,8 @@ FROM
 			"                                         ├─ Eq\n" +
 			"                                         │   ├─ noxn3.id:6!null\n" +
 			"                                         │   └─ new.HHVLX:2!null\n" +
-			"                                         └─ Table\n" +
-			"                                             ├─ name: NOXN3\n" +
+			"                                         └─ IndexedTableAccess(NOXN3)\n" +
+			"                                             ├─ index: [NOXN3.id]\n" +
 			"                                             └─ columns: [id brqp2]\n" +
 			"                        )\n" +
 			"                         └─ BLOCK\n" +
@@ -18002,8 +18002,8 @@ WHERE
 			"                 │               ├─ Eq\n" +
 			"                 │               │   ├─ e2i7u.id:8!null\n" +
 			"                 │               │   └─ new.LUEVY:2!null\n" +
-			"                 │               └─ Table\n" +
-			"                 │                   ├─ name: E2I7U\n" +
+			"                 │               └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │                   ├─ index: [E2I7U.id]\n" +
 			"                 │                   └─ columns: [id fgg57]\n" +
 			"                 │       IS NULL)\n" +
 			"                 │       └─ BLOCK\n" +
@@ -18180,8 +18180,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18352,8 +18352,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18524,8 +18524,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -18696,8 +18696,8 @@ WHERE
 			"                 │           │           ├─ Eq\n" +
 			"                 │           │           │   ├─ xoaop.id:5!null\n" +
 			"                 │           │           │   └─ new.CH3FR:2!null\n" +
-			"                 │           │           └─ Table\n" +
-			"                 │           │               ├─ name: XOAOP\n" +
+			"                 │           │           └─ IndexedTableAccess(XOAOP)\n" +
+			"                 │           │               ├─ index: [XOAOP.id]\n" +
 			"                 │           │               └─ columns: [id dzlim]\n" +
 			"                 │           └─ right: TUPLE(NER (longtext), BER (longtext), HR (longtext), MMR (longtext))\n" +
 			"                 │      )\n" +
@@ -19579,8 +19579,8 @@ FROM
 			"                     │           │   ├─ aac.BTXC5:18\n" +
 			"                     │           │   └─ bpnw2.SYPKF:3\n" +
 			"                     │           └─ TableAlias(aac)\n" +
-			"                     │               └─ Table\n" +
-			"                     │                   ├─ name: TPXBU\n" +
+			"                     │               └─ IndexedTableAccess(TPXBU)\n" +
+			"                     │                   ├─ index: [TPXBU.BTXC5]\n" +
 			"                     │                   └─ columns: [id btxc5]\n" +
 			"                     │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
 			"                     └─ Project\n" +
@@ -19594,8 +19594,8 @@ FROM
 			"                         │           │   ├─ aac.BTXC5:9\n" +
 			"                         │           │   └─ bpnw2.SYPKF:3\n" +
 			"                         │           └─ TableAlias(aac)\n" +
-			"                         │               └─ Table\n" +
-			"                         │                   ├─ name: TPXBU\n" +
+			"                         │               └─ IndexedTableAccess(TPXBU)\n" +
+			"                         │                   ├─ index: [TPXBU.BTXC5]\n" +
 			"                         │                   └─ columns: [id btxc5]\n" +
 			"                         │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
 			"                         └─ SubqueryAlias\n" +

--- a/sql/analyzer/apply_indexes_from_outer_scope.go
+++ b/sql/analyzer/apply_indexes_from_outer_scope.go
@@ -233,9 +233,6 @@ func getSubqueryIndexes(
 	ia *indexAnalyzer,
 	tableAliases TableAliases,
 ) (map[string]sql.Index, joinExpressionsByTable, error) {
-
-	scopeLen := len(scope.Schema())
-
 	// build a list of candidate predicate expressions, those that might be used for an index lookup
 	var candidatePredicates []sql.Expression
 
@@ -245,7 +242,7 @@ func getSubqueryIndexes(
 		isScopeExpr := false
 		sql.Inspect(e, func(e sql.Expression) bool {
 			if gf, ok := e.(*expression.GetField); ok {
-				if gf.Index() < scopeLen {
+				if scope.Correlated().Contains(sql.ColumnId(gf.Id())) {
 					isScopeExpr = true
 					return false
 				}

--- a/sql/analyzer/experimental_rules.go
+++ b/sql/analyzer/experimental_rules.go
@@ -34,7 +34,7 @@ func fixupAuxiliaryExprsHelper(ctx *sql.Context, a *Analyzer, n sql.Node, scope 
 			ret, same2, err := transform.OneNodeExpressions(ret, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				switch e := e.(type) {
 				case *plan.Subquery:
-					newQ, same, err := fixupAuxiliaryExprsHelper(ctx, a, e.Query, scope.NewScopeFromSubqueryExpression(ret))
+					newQ, same, err := fixupAuxiliaryExprsHelper(ctx, a, e.Query, scope.NewScopeFromSubqueryExpression(ret, e.Correlated()))
 					if same || err != nil {
 						return e, transform.SameTree, err
 					}

--- a/sql/analyzer/hoist_filters.go
+++ b/sql/analyzer/hoist_filters.go
@@ -165,7 +165,7 @@ func partitionFilterByScope(e sql.Expression, corr sql.ColSet) (inScope, outOfSc
 		case *expression.GetField:
 			// we're searching for anything in-scope
 			// return true if not correlated from outerscope
-			id := sql.ColumnId(e.Index())
+			id := e.Id()
 			if corr.Contains(id) {
 				outOfScope.Add(id)
 			} else {

--- a/sql/analyzer/hoist_select_exists.go
+++ b/sql/analyzer/hoist_select_exists.go
@@ -151,7 +151,7 @@ func hoistExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, filt
 
 		// recurse
 		if s.inner != nil {
-			s.inner, _, err = hoistSelectExistsHelper(ctx, scope.NewScopeFromSubqueryExpression(filter), a, s.inner, aliasDisambig)
+			s.inner, _, err = hoistSelectExistsHelper(ctx, scope.NewScopeFromSubqueryExpression(filter, sq.Correlated()), a, s.inner, aliasDisambig)
 			if err != nil {
 				return nil, transform.SameTree, err
 			}
@@ -248,7 +248,7 @@ func decorrelateOuterCols(sqChild sql.Node, aliasDisambig *aliasDisambiguator, c
 		filters := expression.SplitConjunction(f.Expression)
 		for _, f := range filters {
 			outerRef := transform.InspectExpr(f, func(e sql.Expression) bool {
-				if gf, ok := e.(*expression.GetField); ok && corr.Contains(sql.ColumnId(gf.Index())) {
+				if gf, ok := e.(*expression.GetField); ok && corr.Contains(gf.Id()) {
 					return true
 				}
 				return false

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -295,7 +295,7 @@ func pushdownFiltersUnderSubqueryAlias(ctx *sql.Context, a *Analyzer, sa *plan.S
 	for i, h := range handled {
 		expressionsForChild[i], _, err = transform.Expr(h, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if gt, ok := e.(*expression.GetField); ok {
-				gf, ok := sa.ScopeMapping[sql.ColumnId(gt.Index())]
+				gf, ok := sa.ScopeMapping[gt.Id()]
 				if !ok {
 					return e, transform.SameTree, fmt.Errorf("unable to find child with id: %d", gt.Index())
 				}

--- a/sql/expression/get_field.go
+++ b/sql/expression/get_field.go
@@ -27,6 +27,10 @@ import (
 type GetField struct {
 	table      string
 	fieldIndex int
+	// exprId lets the lifecycle of getFields be idempotent. We can re-index
+	// or re-apply scope/caching optimizations without worrying about losing
+	// the reference to the unique id.
+	exprId     sql.ColumnId
 	name       string
 	fieldType  sql.Type
 	fieldType2 sql.Type2
@@ -52,11 +56,14 @@ func NewGetFieldWithTable(index int, fieldType sql.Type, table, fieldName string
 		fieldType2: fieldType2,
 		name:       fieldName,
 		nullable:   nullable,
+		exprId:     sql.ColumnId(index),
 	}
 }
 
 // Index returns the index where the GetField will look for the value from a sql.Row.
 func (p *GetField) Index() int { return p.fieldIndex }
+
+func (p *GetField) Id() sql.ColumnId { return p.exprId }
 
 // Children implements the Expression interface.
 func (*GetField) Children() []sql.Expression {

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -324,17 +324,14 @@ func (hit *HashInTuple) Resolved() bool {
 
 func (hit *HashInTuple) Type() sql.Type {
 	return hit.in.Type()
-
 }
 
 func (hit *HashInTuple) IsNullable() bool {
 	return hit.in.IsNullable()
-
 }
 
 func (hit *HashInTuple) Children() []sql.Expression {
 	return hit.in.Children()
-
 }
 
 func (hit *HashInTuple) WithChildren(children ...sql.Expression) (sql.Expression, error) {

--- a/sql/fixidx/fix_field_indexes.go
+++ b/sql/fixidx/fix_field_indexes.go
@@ -77,13 +77,7 @@ func FixFieldIndexes(scope *plan.Scope, logFn func(string, ...any), schema sql.S
 						if logFn != nil {
 							logFn("Rewriting field %s.%s from index %d to %d", e.Table(), e.Name(), e.Index(), newIndex)
 						}
-						return expression.NewGetFieldWithTable(
-							newIndex,
-							e.Type(),
-							e.Table(),
-							e.Name(),
-							e.IsNullable(),
-						), transform.NewTree, nil
+						return e.WithIndex(newIndex), transform.NewTree, nil
 					}
 					return e, transform.SameTree, nil
 				}
@@ -93,13 +87,7 @@ func FixFieldIndexes(scope *plan.Scope, logFn func(string, ...any), schema sql.S
 					if logFn != nil {
 						logFn("Rewriting field %s.%s from index %d to %d", e.Table(), e.Name(), e.Index(), partial)
 					}
-					return expression.NewGetFieldWithTable(
-						partial,
-						e.Type(),
-						e.Table(),
-						e.Name(),
-						e.IsNullable(),
-					), transform.NewTree, nil
+					return e.WithIndex(partial), transform.NewTree, nil
 				}
 				return e, transform.SameTree, nil
 			}
@@ -117,13 +105,7 @@ func FixFieldIndexes(scope *plan.Scope, logFn func(string, ...any), schema sql.S
 							if logFn != nil {
 								logFn("Rewriting field %s.%s from index %d to %d", e.Table(), e.Name(), e.Index(), newIndex)
 							}
-							return expression.NewGetFieldWithTable(
-								newIndex,
-								e.Type(),
-								e.Table(),
-								e.Name(),
-								e.IsNullable(),
-							), transform.NewTree, nil
+							return e.WithIndex(newIndex), transform.NewTree, nil
 						}
 						return e, transform.SameTree, nil
 					}
@@ -294,7 +276,7 @@ func FixFieldIndexesForNode(ctx *sql.Context, logFn func(string, ...any), scope 
 		}
 		ret, sameE, err := transform.NodeExprs(ret, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if sq, ok := e.(*plan.Subquery); ok {
-				newQ, same, err := FixFieldIndexesForNode(ctx, logFn, scope.NewScopeFromSubqueryExpression(ret), sq.Query)
+				newQ, same, err := FixFieldIndexesForNode(ctx, logFn, scope.NewScopeFromSubqueryExpression(ret, sq.Correlated()), sq.Query)
 				if err != nil || same {
 					return sq, transform.SameTree, err
 				}

--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -341,11 +341,10 @@ func (j *joinOrderBuilder) buildMax1Row(n *plan.Max1Row) (vertexSet, edgeSet, *E
 	// memoize child
 	childV, childE, childGrp := j.populateSubgraph(n.Child)
 
-	filterGrp := j.m.MemoizeMax1Row(nil, childGrp)
+	max1Grp := j.m.MemoizeMax1Row(nil, childGrp)
 
-	// filter will absorb child relation for join reordering
-	j.plans[childV] = filterGrp
-	return childV, childE, filterGrp
+	j.plans[childV] = max1Grp
+	return childV, childE, max1Grp
 }
 
 func (j *joinOrderBuilder) buildJoinLeaf(n sql.Nameable) *ExprGroup {

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -91,20 +91,6 @@ func (p *relProps) populateFds() {
 			fds = sql.NewInnerJoinFDs(jp.Left.RelProps.FuncDeps(), jp.Right.RelProps.FuncDeps(), getEquivs(jp.Filter))
 		}
 	case *Max1Row:
-		//start := len(rel.Group().m.Columns)
-		//rel.Group().m.assignColumnIds(rel)
-		//end := len(rel.Group().m.Columns)
-		//
-		//sch := allTableCols(rel)
-		//
-		//var all sql.ColSet
-		//var notNull sql.ColSet
-		//for i := start; i < end; i++ {
-		//	all.Add(sql.ColumnId(i + 1))
-		//	if !sch[i-start].Nullable {
-		//		notNull.Add(sql.ColumnId(i + 1))
-		//	}
-		//}
 		all := rel.Child.RelProps.FuncDeps().All()
 		notNull := rel.Child.RelProps.FuncDeps().NotNull()
 		fds = sql.NewMax1RowFDs(all, notNull)

--- a/sql/plan/scope.go
+++ b/sql/plan/scope.go
@@ -37,6 +37,8 @@ type Scope struct {
 
 	Procedures *ProcedureCache
 
+	// corr is the aggregated set of correlated columns tracked by the subquery
+	// chain that produced this scope.
 	corr          sql.ColSet
 	inJoin        bool
 	inLateralJoin bool
@@ -91,8 +93,10 @@ func (s *Scope) NewScope(node sql.Node) *Scope {
 	}
 }
 
-// NewScopeFromSubqueryExpression returns a new subscope created from a subquery expression contained by the specified
-// node.
+// NewScopeFromSubqueryExpression returns a new subscope created from a
+// subquery expression contained by the specified node. |corr| is the
+// set of correlated columns referenced in this subquery, which is only
+// implicit here because the subquery is distanced from its parent |node|.
 func (s *Scope) NewScopeFromSubqueryExpression(node sql.Node, corr sql.ColSet) *Scope {
 	subScope := s.NewScope(node)
 	subScope.CurrentNodeIsFromSubqueryExpression = true

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -52,7 +52,7 @@ func (b *Builder) analyzeSelectList(inScope, outScope *scope, selectExprs ast.Se
 			switch e := e.(type) {
 			case *expression.GetField:
 				if e.Table() == "" {
-					id = columnId(e.Index())
+					id = columnId(e.Id())
 					aRef = e.Name()
 				}
 			case *expression.Alias:

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -229,9 +229,8 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) sql.Expression {
 	case *ast.UnaryExpr:
 		return b.buildUnaryScalar(inScope, v)
 	case *ast.Subquery:
-		sqScope := inScope.push()
+		sqScope := inScope.pushSubquery()
 		selectString := ast.String(v.Select)
-		sqScope.initSubquery()
 		selScope := b.buildSelectStmt(sqScope, v.Select)
 		// TODO: get the original select statement, not the reconstruction
 		sq := plan.NewSubquery(selScope.node, selectString)

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -128,7 +128,6 @@ func (s *scope) resolveColumn(table, col string, checkParent bool) (scopeColumn,
 	if !foundCand {
 		return scopeColumn{}, false
 	}
-	//s.parent.nearestSubquery().addOutOfScope(c.id)
 
 	if s.parent.activeSubquery != nil {
 		s.parent.activeSubquery.addOutOfScope(c.id)

--- a/sql/planbuilder/subquery.go
+++ b/sql/planbuilder/subquery.go
@@ -17,14 +17,30 @@ package planbuilder
 import "github.com/dolthub/go-mysql-server/sql"
 
 type subquery struct {
+	parent     *subquery
 	correlated sql.ColSet
 	volatile   bool
 }
 
+// addOutOfScope is used to tag subqueries that failed to resolve a column.
+// The way this works is that we have a scope where we initiate a resolve
+// (scope_0), and we will work upwards through the scope chain until we find
+// the scope with the column (ex: scope_n). After finding the column, we wind
+// back upwards through the callstack to return the column. During the unwind,
+// check and tag every scope in between scope_0...scope_n-1 that is a subquery.
+// This prevents propagating the correlation tag above the scope where the
+// column is defined.
 func (s *subquery) addOutOfScope(c columnId) {
+	if s == nil {
+		return
+	}
 	s.correlated.Add(sql.ColumnId(c))
 }
 
+// markVolatile marks this and every parent subquery as volatile.
 func (s *subquery) markVolatile() {
 	s.volatile = true
+	if s.parent != nil {
+		s.parent.markVolatile()
+	}
 }

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -1460,7 +1460,7 @@ func addColumnToSchema(schema sql.Schema, column *sql.Column, order *sql.ColumnO
 						if idx < 0 {
 							return nil, transform.SameTree, sql.ErrTableColumnNotFound.New(schema[0].Source, s.Name())
 						}
-						return s.WithIndex(idx), transform.NewTree, nil
+						return expression.NewGetFieldWithTable(idx, s.Type(), s.Table(), s.Name(), s.IsNullable()), transform.NewTree, nil
 					default:
 						return s, transform.SameTree, nil
 					}


### PR DESCRIPTION
I missed a place where we were using getField indexes to do a correlation check. This adds the changes necessary to replace that check with one that uses a subquery's tracked correlation column set. This also adds an expression id column to GetField expression that preserves the id tracking information between iterative passes of the analyzer. It would probably be preferable to avoid all cases where we unnecessarily re-run rules, but this is more near at hand.