### PR TITLE
adding new ways to say varchar

### DIFF
--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -261,7 +261,7 @@ func ColumnTypeToType(ct *sqlparser.ColumnType) (sql.Type, error) {
 			}
 		}
 		return CreateString(sqltypes.Char, length, sql.Collation_utf8mb3_general_ci)
-	case "varchar", "character varying":
+	case "varchar", "char varying", "character varying":
 		collation, err := sql.ParseCollation(&ct.Charset, &ct.Collate, ct.BinaryCollate)
 		if err != nil {
 			return nil, err
@@ -281,7 +281,7 @@ func ColumnTypeToType(ct *sqlparser.ColumnType) (sql.Type, error) {
 			}
 		}
 		return CreateString(sqltypes.VarChar, length, collation)
-	case "nvarchar", "national varchar", "national character varying":
+	case "nchar varchar", "nchar varying", "nvarchar", "national varchar", "national char varying", "national character varying":
 		if ct.Length == nil {
 			return nil, fmt.Errorf("VARCHAR requires a length")
 		}

--- a/sql/types/conversion_test.go
+++ b/sql/types/conversion_test.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"github.com/dolthub/vitess/go/sqltypes"
 	"testing"
 
 	"github.com/dolthub/vitess/go/vt/sqlparser"
@@ -113,6 +114,47 @@ func TestColumnTypeToType_Time(t *testing.T) {
 			} else {
 				assert.Equal(t, test.expected, res)
 			}
+		})
+	}
+}
+
+func TestColumnCharTypes(t *testing.T) {
+	test := []struct {
+		typ string
+		len int64
+		exp sql.Type
+	}{
+		{
+			typ: "nchar varchar",
+			len: 10,
+			exp: StringType{baseType: sqltypes.VarChar, maxCharLength: 10, maxByteLength: 30, collation: 33},
+		},
+		{
+			typ: "char varying",
+			len: 10,
+			exp: StringType{baseType: sqltypes.VarChar, maxCharLength: 10, maxByteLength: 40},
+		},
+		{
+			typ: "nchar varying",
+			len: 10,
+			exp: StringType{baseType: sqltypes.VarChar, maxCharLength: 10, maxByteLength: 30, collation: 33},
+		},
+		{
+			typ: "national char varying",
+			len: 10,
+			exp: StringType{baseType: sqltypes.VarChar, maxCharLength: 10, maxByteLength: 30, collation: 33},
+		},
+	}
+
+	for _, test := range test {
+		t.Run(fmt.Sprintf("%v %v", test.typ, test.exp), func(t *testing.T) {
+			ct := &sqlparser.ColumnType{
+				Type: test.typ,
+				Length: &sqlparser.SQLVal{Type: sqlparser.IntVal, Val: []byte(fmt.Sprintf("%v", test.len))},
+			}
+			res, err := ColumnTypeToType(ct)
+			assert.NoError(t, err)
+			assert.Equal(t, test.exp, res)
 		})
 	}
 }

--- a/sql/types/conversion_test.go
+++ b/sql/types/conversion_test.go
@@ -16,9 +16,9 @@ package types
 
 import (
 	"fmt"
-	"github.com/dolthub/vitess/go/sqltypes"
 	"testing"
 
+	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/stretchr/testify/assert"
 
@@ -149,7 +149,7 @@ func TestColumnCharTypes(t *testing.T) {
 	for _, test := range test {
 		t.Run(fmt.Sprintf("%v %v", test.typ, test.exp), func(t *testing.T) {
 			ct := &sqlparser.ColumnType{
-				Type: test.typ,
+				Type:   test.typ,
 				Length: &sqlparser.SQLVal{Type: sqlparser.IntVal, Val: []byte(fmt.Sprintf("%v", test.len))},
 			}
 			res, err := ColumnTypeToType(ct)


### PR DESCRIPTION
This PR makes to so the engine recognizes more ways to specify that a column is of type `VARCHAR`
Companion PR: https://github.com/dolthub/vitess/pull/270

Fixes https://github.com/dolthub/dolt/issues/6650