### PR TITLE
Enable use of slices in tuples for HashLookups

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -124,6 +124,26 @@ var joinOpTests = []struct {
 		},
 	},
 	{
+		name: "left join on array data",
+		setup: [][]string{
+			{
+				"create table xy (x binary(2) primary key, y binary(2))",
+				"create table uv (u binary(2) primary key, v binary(2))",
+				"insert into xy values (x'F0F0',x'1234'),(x'2345',x'3456');",
+				"insert into uv values (x'fedc',x'F0F0');",
+			},
+		},
+		tests: []JoinOpTests{
+			{
+				Query: "select HEX(x),HEX(u) from xy left join uv on x = v OR y = u",
+				Expected: []sql.Row{
+					{"2345", nil},
+					{"F0F0", "FEDC"},
+				},
+			},
+		},
+	},
+	{
 		name: "point lookups",
 		setup: [][]string{
 			setup.MydbData[0],

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -132,22 +132,7 @@ func (n *HashLookup) GetHashKey(ctx *sql.Context, e sql.Expression, row sql.Row)
 		return nil, err
 	}
 	if s, ok := key.([]interface{}); ok {
-		switch len(s) {
-		case 0:
-			return [0]interface{}{}, nil
-		case 1:
-			return [1]interface{}{s[0]}, nil
-		case 2:
-			return [2]interface{}{s[0], s[1]}, nil
-		case 3:
-			return [3]interface{}{s[0], s[1], s[2]}, nil
-		case 4:
-			return [4]interface{}{s[0], s[1], s[2], s[3]}, nil
-		case 5:
-			return [5]interface{}{s[0], s[1], s[2], s[3], s[4]}, nil
-		default:
-			return sql.HashOf(s)
-		}
+		return sql.HashOf(s)
 	}
 	// byte slices are not hashable
 	if k, ok := key.([]byte); ok {


### PR DESCRIPTION
Currently FusionAuth crashes Dolt with the following error:

```
panic: runtime error: hash of unhashable type []uint8
```

All FusionAuth IDs are binary(16), and join on those values in a HashLookup was resulting in using two `[]uint8` being used as a key to a hashtable. Nested arrays in tuples were tripping on an optimization made for short arrays. We've verified that optimization doesn't actually made a difference, so this change simplifies the code and makes it more generic.