### PR TITLE
Semi join and FDs bug

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -290,6 +290,11 @@ var JoinPlanningTests = []struct {
 		},
 		tests: []JoinPlanTest{
 			{
+				q:     "select /*+ LOOKUP_JOIN(scalarSubq0,xy) JOIN_ORDER(scalarSubq0,xy) */ * from xy where x = 1 and y in (select a from ab);",
+				types: []plan.JoinType{plan.JoinTypeLookup},
+				exp:   []sql.Row{{1, 0}},
+			},
+			{
 				q:     "select /*+ LOOKUP_JOIN(xy,scalarSubq0) */ * from xy where x in (select b from ab where a in (0,1,2));",
 				types: []plan.JoinType{plan.JoinTypeLookup},
 				exp:   []sql.Row{{2, 1}},

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -512,6 +512,28 @@ func addRightSemiJoins(m *memo.Memo) error {
 			return nil
 		}
 		tableGrp, indexes, filters := lookupCandidates(semi.Left.First)
+		rightOutTables := semi.Right.RelProps.OutputTables()
+
+		var projectExpressions []*memo.ExprGroup
+		onlyEquality := true
+		for _, f := range semi.Filter {
+			_ = memo.DfsScalar(f, func(e memo.ScalarExpr) error {
+				switch e := e.(type) {
+				case *memo.ColRef:
+					if rightOutTables.Contains(int(memo.TableIdForSource(e.Table))) {
+						projectExpressions = append(projectExpressions, e.Group())
+					}
+				case *memo.Literal, *memo.And, *memo.Or, *memo.Equal, *memo.Arithmetic, *memo.Bindvar:
+				default:
+					onlyEquality = false
+					return memo.HaltErr
+				}
+				return nil
+			})
+			if !onlyEquality {
+				return nil
+			}
+		}
 
 		for _, idx := range indexes {
 			if !semi.Group().RelProps.FuncDeps().ColsAreStrictKey(idx.ColSet()) {
@@ -521,16 +543,6 @@ func addRightSemiJoins(m *memo.Memo) error {
 			keyExprs, nullmask := keyExprsForIndex(tableGrp, idx.Cols(), append(semi.Filter, filters...))
 			if keyExprs == nil {
 				continue
-			}
-
-			var projectExpressions []*memo.ExprGroup
-			for _, e := range keyExprs {
-				memo.DfsScalar(e, func(e memo.ScalarExpr) error {
-					if c, ok := e.(*memo.ColRef); ok {
-						projectExpressions = append(projectExpressions, c.Group())
-					}
-					return nil
-				})
 			}
 
 			rGroup := m.MemoizeProject(nil, semi.Right, projectExpressions)

--- a/sql/func_deps.go
+++ b/sql/func_deps.go
@@ -433,8 +433,16 @@ func NewInnerJoinFDs(left, right *FuncDepSet, filters [][2]ColumnId) *FuncDepSet
 	ret := &FuncDepSet{all: left.all.Union(right.all)}
 	ret.AddNotNullable(left.notNull)
 	ret.AddNotNullable(right.notNull)
-	ret.AddConstants(left.consts)
-	ret.AddConstants(right.consts)
+	if left.HasMax1Row() {
+		ret.AddConstants(left.all)
+	} else {
+		ret.AddConstants(left.consts)
+	}
+	if right.HasMax1Row() {
+		ret.AddConstants(right.all)
+	} else {
+		ret.AddConstants(right.consts)
+	}
 	for _, set := range left.Equiv().Sets() {
 		ret.AddEquivSet(set)
 	}

--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -160,7 +160,20 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewInnerJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 6}, {1, 2}})
-		assert.Equal(t, "key(); constant(1-3,6,7); equiv(1-3,6)", join.String())
+		assert.Equal(t, "key(); constant(1-9); equiv(1-3,6)", join.String())
+	})
+	t.Run("infer constants from max1Row", func(t *testing.T) {
+		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}
+		abcde.AddNotNullable(cols(1, 2, 3))
+		abcde.AddConstants(cols(1))
+		abcde.AddStrictKey(cols(1))
+
+		mnpq := &FuncDepSet{all: cols(6, 7, 8, 9)}
+		mnpq.AddNotNullable(cols(6))
+		mnpq.AddStrictKey(cols(6))
+
+		join := NewInnerJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 7}})
+		assert.Equal(t, "key(6); constant(1-5,7); equiv(1,7)", join.String())
 	})
 }
 


### PR DESCRIPTION
Returning no projections from a table causes "column not found errors" when we try to reference those expressions higher in the tree. This fixes the semi join transform to creating empty projections.

This fixes two bugs. The first is that we were too conservative checking whether index keys were strict FDs for a join relation.  When a relation has a constant applied to a primary key, we can assume all of the columns returned by that join will be constant. Fixing that made it easer to test certain semi -> right lookup join transforms which were buggy. For the same case, when we are doing a lookup into table where a constant filter satisfies an index key, we need to still return a projection set that covers non-pruneable columns used in higher-level nodes.