### PR TITLE
Fixed character set IDs

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -593,9 +593,9 @@ func row2ToSQL(s sql.Schema, row sql.Row2) ([]sqltypes.Value, error) {
 func schemaToFields(ctx *sql.Context, s sql.Schema) []*query.Field {
 	fields := make([]*query.Field, len(s))
 	for i, c := range s {
-		var charset uint32 = mysql.CharacterSetUtf8
-		if types.IsBinaryType(c.Type) {
-			charset = mysql.CharacterSetBinary
+		charset := uint32(sql.Collation_Default.CharacterSet())
+		if collatedType, ok := c.Type.(sql.TypeWithCollation); ok {
+			charset = uint32(collatedType.Collation().CharacterSet())
 		}
 
 		fields[i] = &query.Field{

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -261,7 +261,7 @@ func TestHandlerComPrepare(t *testing.T) {
 			name:      "select statement returns non-nil schema",
 			statement: "select c1 from test where c1 > ?",
 			expected: []*query.Field{
-				{Name: "c1", Type: query.Type_INT32, Charset: mysql.CharacterSetUtf8, ColumnLength: 11},
+				{Name: "c1", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
 			},
 		},
 		{
@@ -332,7 +332,7 @@ func TestHandlerComPrepareExecute(t *testing.T) {
 				},
 			},
 			schema: []*query.Field{
-				{Name: "c1", Type: query.Type_INT32, Charset: mysql.CharacterSetUtf8, ColumnLength: 11},
+				{Name: "c1", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
 			},
 			expected: []sql.Row{
 				{0}, {1}, {2}, {3}, {4},
@@ -414,7 +414,7 @@ func TestHandlerComPrepareExecuteWithPreparedDisabled(t *testing.T) {
 				},
 			},
 			schema: []*query.Field{
-				{Name: "c1", Type: query.Type_INT32, Charset: mysql.CharacterSetUtf8, ColumnLength: 11},
+				{Name: "c1", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
 			},
 			expected: []sql.Row{
 				{0}, {1}, {2}, {3}, {4},
@@ -688,53 +688,53 @@ func TestSchemaToFields(t *testing.T) {
 		{Name: "blob", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 65_535},
 		{Name: "mediumblob", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 16_777_215},
 		{Name: "longblob", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
-		{Name: "tinytext", Type: query.Type_TEXT, Charset: mysql.CharacterSetUtf8, ColumnLength: 1020},
-		{Name: "text", Type: query.Type_TEXT, Charset: mysql.CharacterSetUtf8, ColumnLength: 262_140},
-		{Name: "mediumtext", Type: query.Type_TEXT, Charset: mysql.CharacterSetUtf8, ColumnLength: 67_108_860},
-		{Name: "longtext", Type: query.Type_TEXT, Charset: mysql.CharacterSetUtf8, ColumnLength: 4_294_967_295},
-		{Name: "json", Type: query.Type_JSON, Charset: mysql.CharacterSetUtf8, ColumnLength: 4_294_967_295},
+		{Name: "tinytext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 1020},
+		{Name: "text", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 262_140},
+		{Name: "mediumtext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 67_108_860},
+		{Name: "longtext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
+		{Name: "json", Type: query.Type_JSON, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
 
 		// Geometry Types
-		{Name: "geometry", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetUtf8, ColumnLength: 4_294_967_295},
-		{Name: "point", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetUtf8, ColumnLength: 4_294_967_295},
-		{Name: "polygon", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetUtf8, ColumnLength: 4_294_967_295},
-		{Name: "linestring", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetUtf8, ColumnLength: 4_294_967_295},
+		{Name: "geometry", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
+		{Name: "point", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
+		{Name: "polygon", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
+		{Name: "linestring", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
 
 		// Integer Types
-		{Name: "uint8", Type: query.Type_UINT8, Charset: mysql.CharacterSetUtf8, ColumnLength: 3},
-		{Name: "int8", Type: query.Type_INT8, Charset: mysql.CharacterSetUtf8, ColumnLength: 4},
-		{Name: "uint16", Type: query.Type_UINT16, Charset: mysql.CharacterSetUtf8, ColumnLength: 5},
-		{Name: "int16", Type: query.Type_INT16, Charset: mysql.CharacterSetUtf8, ColumnLength: 6},
-		{Name: "uint24", Type: query.Type_UINT24, Charset: mysql.CharacterSetUtf8, ColumnLength: 8},
-		{Name: "int24", Type: query.Type_INT24, Charset: mysql.CharacterSetUtf8, ColumnLength: 9},
-		{Name: "uint32", Type: query.Type_UINT32, Charset: mysql.CharacterSetUtf8, ColumnLength: 10},
-		{Name: "int32", Type: query.Type_INT32, Charset: mysql.CharacterSetUtf8, ColumnLength: 11},
-		{Name: "uint64", Type: query.Type_UINT64, Charset: mysql.CharacterSetUtf8, ColumnLength: 20},
-		{Name: "int64", Type: query.Type_INT64, Charset: mysql.CharacterSetUtf8, ColumnLength: 20},
+		{Name: "uint8", Type: query.Type_UINT8, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 3},
+		{Name: "int8", Type: query.Type_INT8, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4},
+		{Name: "uint16", Type: query.Type_UINT16, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 5},
+		{Name: "int16", Type: query.Type_INT16, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 6},
+		{Name: "uint24", Type: query.Type_UINT24, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 8},
+		{Name: "int24", Type: query.Type_INT24, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 9},
+		{Name: "uint32", Type: query.Type_UINT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 10},
+		{Name: "int32", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
+		{Name: "uint64", Type: query.Type_UINT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
+		{Name: "int64", Type: query.Type_INT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
 
 		// Floating Point and Decimal Types
-		{Name: "float32", Type: query.Type_FLOAT32, Charset: mysql.CharacterSetUtf8, ColumnLength: 12},
-		{Name: "float64", Type: query.Type_FLOAT64, Charset: mysql.CharacterSetUtf8, ColumnLength: 22},
-		{Name: "decimal10_0", Type: query.Type_DECIMAL, Charset: mysql.CharacterSetUtf8, ColumnLength: 11, Decimals: 0},
-		{Name: "decimal60_30", Type: query.Type_DECIMAL, Charset: mysql.CharacterSetUtf8, ColumnLength: 62, Decimals: 30},
+		{Name: "float32", Type: query.Type_FLOAT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 12},
+		{Name: "float64", Type: query.Type_FLOAT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 22},
+		{Name: "decimal10_0", Type: query.Type_DECIMAL, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11, Decimals: 0},
+		{Name: "decimal60_30", Type: query.Type_DECIMAL, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 62, Decimals: 30},
 
 		// Char, Binary, and Bit Types
-		{Name: "varchar50", Type: query.Type_VARCHAR, Charset: mysql.CharacterSetUtf8, ColumnLength: 50 * 4},
+		{Name: "varchar50", Type: query.Type_VARCHAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 50 * 4},
 		{Name: "varbinary12345", Type: query.Type_VARBINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 12345},
 		{Name: "binary123", Type: query.Type_BINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 123},
-		{Name: "char123", Type: query.Type_CHAR, Charset: mysql.CharacterSetUtf8, ColumnLength: 123 * 4},
-		{Name: "bit12", Type: query.Type_BIT, Charset: mysql.CharacterSetUtf8, ColumnLength: 12},
+		{Name: "char123", Type: query.Type_CHAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 123 * 4},
+		{Name: "bit12", Type: query.Type_BIT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 12},
 
 		// Dates
-		{Name: "datetime", Type: query.Type_DATETIME, Charset: mysql.CharacterSetUtf8, ColumnLength: 26},
-		{Name: "timestamp", Type: query.Type_TIMESTAMP, Charset: mysql.CharacterSetUtf8, ColumnLength: 26},
-		{Name: "date", Type: query.Type_DATE, Charset: mysql.CharacterSetUtf8, ColumnLength: 10},
-		{Name: "time", Type: query.Type_TIME, Charset: mysql.CharacterSetUtf8, ColumnLength: 17},
-		{Name: "year", Type: query.Type_YEAR, Charset: mysql.CharacterSetUtf8, ColumnLength: 4},
+		{Name: "datetime", Type: query.Type_DATETIME, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 26},
+		{Name: "timestamp", Type: query.Type_TIMESTAMP, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 26},
+		{Name: "date", Type: query.Type_DATE, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 10},
+		{Name: "time", Type: query.Type_TIME, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 17},
+		{Name: "year", Type: query.Type_YEAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4},
 
 		// Set and Enum Types
-		{Name: "set", Type: query.Type_SET, Charset: mysql.CharacterSetUtf8, ColumnLength: 72},
-		{Name: "enum", Type: query.Type_ENUM, Charset: mysql.CharacterSetUtf8, ColumnLength: 20},
+		{Name: "set", Type: query.Type_SET, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 72},
+		{Name: "enum", Type: query.Type_ENUM, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
 	}
 
 	require.Equal(len(schema), len(expected))

--- a/sql/charactersets.go
+++ b/sql/charactersets.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Dolthub, Inc.
+// Copyright 2022-2023 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,56 +37,55 @@ type CharacterSetsIterator struct {
 }
 
 // CharacterSetID represents a character set. Unlike collations, this ID is not intended for storage and may change as
-// new character sets are added. It is recommended to use the character set's name if persistence is desired.
+// the default collation changes. It is recommended to use the character set's name if persistence is desired.
 type CharacterSetID uint16
 
 // The character sets below are ordered alphabetically to make it easier to visually parse them.
 // As each ID acts as an index to the `characterSetArray`, they are explicitly defined.
-// It is recommended not to change any IDs when adding a new character set, as it will also require adjusting the array.
-// Instead, give it the next highest number, and insert it into the correct position alphabetically.
+// A character set's ID is defined as the default collation's ID.
 
 const (
-	CharacterSet_armscii8 CharacterSetID = 1
-	CharacterSet_ascii    CharacterSetID = 2
-	CharacterSet_big5     CharacterSetID = 3
-	CharacterSet_binary   CharacterSetID = 4
-	CharacterSet_cp1250   CharacterSetID = 5
-	CharacterSet_cp1251   CharacterSetID = 6
-	CharacterSet_cp1256   CharacterSetID = 7
-	CharacterSet_cp1257   CharacterSetID = 8
-	CharacterSet_cp850    CharacterSetID = 9
-	CharacterSet_cp852    CharacterSetID = 10
-	CharacterSet_cp866    CharacterSetID = 11
-	CharacterSet_cp932    CharacterSetID = 12
-	CharacterSet_dec8     CharacterSetID = 13
-	CharacterSet_eucjpms  CharacterSetID = 14
-	CharacterSet_euckr    CharacterSetID = 15
-	CharacterSet_gb18030  CharacterSetID = 16
-	CharacterSet_gb2312   CharacterSetID = 17
-	CharacterSet_gbk      CharacterSetID = 18
-	CharacterSet_geostd8  CharacterSetID = 19
-	CharacterSet_greek    CharacterSetID = 20
-	CharacterSet_hebrew   CharacterSetID = 21
-	CharacterSet_hp8      CharacterSetID = 22
-	CharacterSet_keybcs2  CharacterSetID = 23
-	CharacterSet_koi8r    CharacterSetID = 24
-	CharacterSet_koi8u    CharacterSetID = 25
-	CharacterSet_latin1   CharacterSetID = 26
-	CharacterSet_latin2   CharacterSetID = 27
-	CharacterSet_latin5   CharacterSetID = 28
-	CharacterSet_latin7   CharacterSetID = 29
-	CharacterSet_macce    CharacterSetID = 30
-	CharacterSet_macroman CharacterSetID = 31
-	CharacterSet_sjis     CharacterSetID = 32
-	CharacterSet_swe7     CharacterSetID = 33
-	CharacterSet_tis620   CharacterSetID = 34
+	CharacterSet_armscii8 CharacterSetID = 32
+	CharacterSet_ascii    CharacterSetID = 11
+	CharacterSet_big5     CharacterSetID = 1
+	CharacterSet_binary   CharacterSetID = 63
+	CharacterSet_cp1250   CharacterSetID = 26
+	CharacterSet_cp1251   CharacterSetID = 51
+	CharacterSet_cp1256   CharacterSetID = 57
+	CharacterSet_cp1257   CharacterSetID = 59
+	CharacterSet_cp850    CharacterSetID = 4
+	CharacterSet_cp852    CharacterSetID = 40
+	CharacterSet_cp866    CharacterSetID = 36
+	CharacterSet_cp932    CharacterSetID = 95
+	CharacterSet_dec8     CharacterSetID = 3
+	CharacterSet_eucjpms  CharacterSetID = 97
+	CharacterSet_euckr    CharacterSetID = 19
+	CharacterSet_gb18030  CharacterSetID = 248
+	CharacterSet_gb2312   CharacterSetID = 24
+	CharacterSet_gbk      CharacterSetID = 28
+	CharacterSet_geostd8  CharacterSetID = 92
+	CharacterSet_greek    CharacterSetID = 25
+	CharacterSet_hebrew   CharacterSetID = 16
+	CharacterSet_hp8      CharacterSetID = 6
+	CharacterSet_keybcs2  CharacterSetID = 37
+	CharacterSet_koi8r    CharacterSetID = 7
+	CharacterSet_koi8u    CharacterSetID = 22
+	CharacterSet_latin1   CharacterSetID = 8
+	CharacterSet_latin2   CharacterSetID = 9
+	CharacterSet_latin5   CharacterSetID = 30
+	CharacterSet_latin7   CharacterSetID = 41
+	CharacterSet_macce    CharacterSetID = 38
+	CharacterSet_macroman CharacterSetID = 39
+	CharacterSet_sjis     CharacterSetID = 13
+	CharacterSet_swe7     CharacterSetID = 10
+	CharacterSet_tis620   CharacterSetID = 18
 	CharacterSet_ucs2     CharacterSetID = 35
-	CharacterSet_ujis     CharacterSetID = 36
-	CharacterSet_utf16    CharacterSetID = 37
-	CharacterSet_utf16le  CharacterSetID = 38
-	CharacterSet_utf32    CharacterSetID = 39
-	CharacterSet_utf8mb3  CharacterSetID = 40
-	CharacterSet_utf8mb4  CharacterSetID = 41
+	CharacterSet_ujis     CharacterSetID = 12
+	CharacterSet_utf16    CharacterSetID = 54
+	CharacterSet_utf16le  CharacterSetID = 56
+	CharacterSet_utf32    CharacterSetID = 60
+	CharacterSet_utf8mb3  CharacterSetID = 33
+	CharacterSet_utf8mb4  CharacterSetID = 255
 
 	CharacterSet_utf8 = CharacterSet_utf8mb3
 
@@ -100,49 +99,263 @@ const (
 // characterSetArray contains the details of every character set, indexed by their ID. This allows for character sets to
 // be efficiently passed around (since only an uint16 is needed), while still being able to quickly access all of their
 // properties (index lookups are significantly faster than map lookups).
-var characterSetArray = [42]CharacterSet{
-	/*00*/ {CharacterSet_Unspecified, "", Collation_Unspecified, Collation_Unspecified, "", 0, nil},
-	/*01*/ {CharacterSet_armscii8, "armscii8", Collation_armscii8_general_ci, Collation_armscii8_bin, "ARMSCII-8 Armenian", 1, nil},
-	/*02*/ {CharacterSet_ascii, "ascii", Collation_ascii_general_ci, Collation_ascii_bin, "US ASCII", 1, encodings.Ascii},
-	/*03*/ {CharacterSet_big5, "big5", Collation_big5_chinese_ci, Collation_big5_bin, "Big5 Traditional Chinese", 2, nil},
-	/*04*/ {CharacterSet_binary, "binary", Collation_binary, Collation_binary, "Binary pseudo charset", 1, encodings.Binary},
-	/*05*/ {CharacterSet_cp1250, "cp1250", Collation_cp1250_general_ci, Collation_cp1250_bin, "Windows Central European", 1, nil},
-	/*06*/ {CharacterSet_cp1251, "cp1251", Collation_cp1251_general_ci, Collation_cp1251_bin, "Windows Cyrillic", 1, nil},
-	/*07*/ {CharacterSet_cp1256, "cp1256", Collation_cp1256_general_ci, Collation_cp1256_bin, "Windows Arabic", 1, encodings.Cp1256},
-	/*08*/ {CharacterSet_cp1257, "cp1257", Collation_cp1257_general_ci, Collation_cp1257_bin, "Windows Baltic", 1, encodings.Cp1257},
-	/*09*/ {CharacterSet_cp850, "cp850", Collation_cp850_general_ci, Collation_cp850_bin, "DOS West European", 1, nil},
-	/*10*/ {CharacterSet_cp852, "cp852", Collation_cp852_general_ci, Collation_cp852_bin, "DOS Central European", 1, nil},
-	/*11*/ {CharacterSet_cp866, "cp866", Collation_cp866_general_ci, Collation_cp866_bin, "DOS Russian", 1, nil},
-	/*12*/ {CharacterSet_cp932, "cp932", Collation_cp932_japanese_ci, Collation_cp932_bin, "SJIS for Windows Japanese", 2, nil},
-	/*13*/ {CharacterSet_dec8, "dec8", Collation_dec8_swedish_ci, Collation_dec8_bin, "DEC West European", 1, encodings.Dec8},
-	/*14*/ {CharacterSet_eucjpms, "eucjpms", Collation_eucjpms_japanese_ci, Collation_eucjpms_bin, "UJIS for Windows Japanese", 3, nil},
-	/*15*/ {CharacterSet_euckr, "euckr", Collation_euckr_korean_ci, Collation_euckr_bin, "EUC-KR Korean", 2, nil},
-	/*16*/ {CharacterSet_gb18030, "gb18030", Collation_gb18030_chinese_ci, Collation_gb18030_bin, "China National Standard GB18030", 4, nil},
-	/*17*/ {CharacterSet_gb2312, "gb2312", Collation_gb2312_chinese_ci, Collation_gb2312_bin, "GB2312 Simplified Chinese", 2, nil},
-	/*18*/ {CharacterSet_gbk, "gbk", Collation_gbk_chinese_ci, Collation_gbk_bin, "GBK Simplified Chinese", 2, nil},
-	/*19*/ {CharacterSet_geostd8, "geostd8", Collation_geostd8_general_ci, Collation_geostd8_bin, "GEOSTD8 Georgian", 1, encodings.Geostd8},
-	/*20*/ {CharacterSet_greek, "greek", Collation_greek_general_ci, Collation_greek_bin, "ISO 8859-7 Greek", 1, nil},
-	/*21*/ {CharacterSet_hebrew, "hebrew", Collation_hebrew_general_ci, Collation_hebrew_bin, "ISO 8859-8 Hebrew", 1, nil},
-	/*22*/ {CharacterSet_hp8, "hp8", Collation_hp8_english_ci, Collation_hp8_bin, "HP West European", 1, nil},
-	/*23*/ {CharacterSet_keybcs2, "keybcs2", Collation_keybcs2_general_ci, Collation_keybcs2_bin, "DOS Kamenicky Czech-Slovak", 1, nil},
-	/*24*/ {CharacterSet_koi8r, "koi8r", Collation_koi8r_general_ci, Collation_koi8r_bin, "KOI8-R Relcom Russian", 1, nil},
-	/*25*/ {CharacterSet_koi8u, "koi8u", Collation_koi8u_general_ci, Collation_koi8u_bin, "KOI8-U Ukrainian", 1, nil},
-	/*26*/ {CharacterSet_latin1, "latin1", Collation_latin1_swedish_ci, Collation_latin1_bin, "cp1252 West European", 1, encodings.Latin1},
-	/*27*/ {CharacterSet_latin2, "latin2", Collation_latin2_general_ci, Collation_latin2_bin, "ISO 8859-2 Central European", 1, nil},
-	/*28*/ {CharacterSet_latin5, "latin5", Collation_latin5_turkish_ci, Collation_latin5_bin, "ISO 8859-9 Turkish", 1, nil},
-	/*29*/ {CharacterSet_latin7, "latin7", Collation_latin7_general_ci, Collation_latin7_bin, "ISO 8859-13 Baltic", 1, encodings.Latin7},
-	/*30*/ {CharacterSet_macce, "macce", Collation_macce_general_ci, Collation_macce_bin, "Mac Central European", 1, nil},
-	/*31*/ {CharacterSet_macroman, "macroman", Collation_macroman_general_ci, Collation_macroman_bin, "Mac West European", 1, nil},
-	/*32*/ {CharacterSet_sjis, "sjis", Collation_sjis_japanese_ci, Collation_sjis_bin, "Shift-JIS Japanese", 2, nil},
-	/*33*/ {CharacterSet_swe7, "swe7", Collation_swe7_swedish_ci, Collation_swe7_bin, "7bit Swedish", 1, encodings.Swe7},
-	/*34*/ {CharacterSet_tis620, "tis620", Collation_tis620_thai_ci, Collation_tis620_bin, "TIS620 Thai", 1, nil},
-	/*35*/ {CharacterSet_ucs2, "ucs2", Collation_ucs2_general_ci, Collation_ucs2_bin, "UCS-2 Unicode", 2, nil},
-	/*36*/ {CharacterSet_ujis, "ujis", Collation_ujis_japanese_ci, Collation_ujis_bin, "EUC-JP Japanese", 3, nil},
-	/*37*/ {CharacterSet_utf16, "utf16", Collation_utf16_general_ci, Collation_utf16_bin, "UTF-16 Unicode", 4, encodings.Utf16},
-	/*38*/ {CharacterSet_utf16le, "utf16le", Collation_utf16le_general_ci, Collation_utf16le_bin, "UTF-16LE Unicode", 4, nil},
-	/*39*/ {CharacterSet_utf32, "utf32", Collation_utf32_general_ci, Collation_utf32_bin, "UTF-32 Unicode", 4, encodings.Utf32},
-	/*40*/ {CharacterSet_utf8mb3, "utf8mb3", Collation_utf8mb3_general_ci, Collation_utf8mb3_bin, "UTF-8 Unicode", 3, encodings.Utf8mb3},
-	/*41*/ {CharacterSet_utf8mb4, "utf8mb4", Collation_utf8mb4_0900_ai_ci, Collation_utf8mb4_bin, "UTF-8 Unicode", 4, encodings.Utf8mb4},
+var characterSetArray = [256]CharacterSet{
+	/*000*/ {CharacterSet_Unspecified, "", Collation_Unspecified, Collation_Unspecified, "", 0, nil},
+	/*001*/ {CharacterSet_big5, "big5", Collation_big5_chinese_ci, Collation_big5_bin, "Big5 Traditional Chinese", 2, nil},
+	/*002*/ {},
+	/*003*/ {CharacterSet_dec8, "dec8", Collation_dec8_swedish_ci, Collation_dec8_bin, "DEC West European", 1, encodings.Dec8},
+	/*004*/ {CharacterSet_cp850, "cp850", Collation_cp850_general_ci, Collation_cp850_bin, "DOS West European", 1, nil},
+	/*005*/ {},
+	/*006*/ {CharacterSet_hp8, "hp8", Collation_hp8_english_ci, Collation_hp8_bin, "HP West European", 1, nil},
+	/*007*/ {CharacterSet_koi8r, "koi8r", Collation_koi8r_general_ci, Collation_koi8r_bin, "KOI8-R Relcom Russian", 1, nil},
+	/*008*/ {CharacterSet_latin1, "latin1", Collation_latin1_swedish_ci, Collation_latin1_bin, "cp1252 West European", 1, encodings.Latin1},
+	/*009*/ {CharacterSet_latin2, "latin2", Collation_latin2_general_ci, Collation_latin2_bin, "ISO 8859-2 Central European", 1, nil},
+	/*010*/ {CharacterSet_swe7, "swe7", Collation_swe7_swedish_ci, Collation_swe7_bin, "7bit Swedish", 1, encodings.Swe7},
+	/*011*/ {CharacterSet_ascii, "ascii", Collation_ascii_general_ci, Collation_ascii_bin, "US ASCII", 1, encodings.Ascii},
+	/*012*/ {CharacterSet_ujis, "ujis", Collation_ujis_japanese_ci, Collation_ujis_bin, "EUC-JP Japanese", 3, nil},
+	/*013*/ {CharacterSet_sjis, "sjis", Collation_sjis_japanese_ci, Collation_sjis_bin, "Shift-JIS Japanese", 2, nil},
+	/*014*/ {},
+	/*015*/ {},
+	/*016*/ {CharacterSet_hebrew, "hebrew", Collation_hebrew_general_ci, Collation_hebrew_bin, "ISO 8859-8 Hebrew", 1, nil},
+	/*017*/ {},
+	/*018*/ {CharacterSet_tis620, "tis620", Collation_tis620_thai_ci, Collation_tis620_bin, "TIS620 Thai", 1, nil},
+	/*019*/ {CharacterSet_euckr, "euckr", Collation_euckr_korean_ci, Collation_euckr_bin, "EUC-KR Korean", 2, nil},
+	/*020*/ {},
+	/*021*/ {},
+	/*022*/ {CharacterSet_koi8u, "koi8u", Collation_koi8u_general_ci, Collation_koi8u_bin, "KOI8-U Ukrainian", 1, nil},
+	/*023*/ {},
+	/*024*/ {CharacterSet_gb2312, "gb2312", Collation_gb2312_chinese_ci, Collation_gb2312_bin, "GB2312 Simplified Chinese", 2, nil},
+	/*025*/ {CharacterSet_greek, "greek", Collation_greek_general_ci, Collation_greek_bin, "ISO 8859-7 Greek", 1, nil},
+	/*026*/ {CharacterSet_cp1250, "cp1250", Collation_cp1250_general_ci, Collation_cp1250_bin, "Windows Central European", 1, nil},
+	/*027*/ {},
+	/*028*/ {CharacterSet_gbk, "gbk", Collation_gbk_chinese_ci, Collation_gbk_bin, "GBK Simplified Chinese", 2, nil},
+	/*029*/ {},
+	/*030*/ {CharacterSet_latin5, "latin5", Collation_latin5_turkish_ci, Collation_latin5_bin, "ISO 8859-9 Turkish", 1, nil},
+	/*031*/ {},
+	/*032*/ {CharacterSet_armscii8, "armscii8", Collation_armscii8_general_ci, Collation_armscii8_bin, "ARMSCII-8 Armenian", 1, nil},
+	/*033*/ {CharacterSet_utf8mb3, "utf8mb3", Collation_utf8mb3_general_ci, Collation_utf8mb3_bin, "UTF-8 Unicode", 3, encodings.Utf8mb3},
+	/*034*/ {},
+	/*035*/ {CharacterSet_ucs2, "ucs2", Collation_ucs2_general_ci, Collation_ucs2_bin, "UCS-2 Unicode", 2, nil},
+	/*036*/ {CharacterSet_cp866, "cp866", Collation_cp866_general_ci, Collation_cp866_bin, "DOS Russian", 1, nil},
+	/*037*/ {CharacterSet_keybcs2, "keybcs2", Collation_keybcs2_general_ci, Collation_keybcs2_bin, "DOS Kamenicky Czech-Slovak", 1, nil},
+	/*038*/ {CharacterSet_macce, "macce", Collation_macce_general_ci, Collation_macce_bin, "Mac Central European", 1, nil},
+	/*039*/ {CharacterSet_macroman, "macroman", Collation_macroman_general_ci, Collation_macroman_bin, "Mac West European", 1, nil},
+	/*040*/ {CharacterSet_cp852, "cp852", Collation_cp852_general_ci, Collation_cp852_bin, "DOS Central European", 1, nil},
+	/*041*/ {CharacterSet_latin7, "latin7", Collation_latin7_general_ci, Collation_latin7_bin, "ISO 8859-13 Baltic", 1, encodings.Latin7},
+	/*042*/ {},
+	/*043*/ {},
+	/*044*/ {},
+	/*045*/ {},
+	/*046*/ {},
+	/*047*/ {},
+	/*048*/ {},
+	/*049*/ {},
+	/*050*/ {},
+	/*051*/ {CharacterSet_cp1251, "cp1251", Collation_cp1251_general_ci, Collation_cp1251_bin, "Windows Cyrillic", 1, nil},
+	/*052*/ {},
+	/*053*/ {},
+	/*054*/ {CharacterSet_utf16, "utf16", Collation_utf16_general_ci, Collation_utf16_bin, "UTF-16 Unicode", 4, encodings.Utf16},
+	/*055*/ {},
+	/*056*/ {CharacterSet_utf16le, "utf16le", Collation_utf16le_general_ci, Collation_utf16le_bin, "UTF-16LE Unicode", 4, nil},
+	/*057*/ {CharacterSet_cp1256, "cp1256", Collation_cp1256_general_ci, Collation_cp1256_bin, "Windows Arabic", 1, encodings.Cp1256},
+	/*058*/ {},
+	/*059*/ {CharacterSet_cp1257, "cp1257", Collation_cp1257_general_ci, Collation_cp1257_bin, "Windows Baltic", 1, encodings.Cp1257},
+	/*060*/ {CharacterSet_utf32, "utf32", Collation_utf32_general_ci, Collation_utf32_bin, "UTF-32 Unicode", 4, encodings.Utf32},
+	/*061*/ {},
+	/*062*/ {},
+	/*063*/ {CharacterSet_binary, "binary", Collation_binary, Collation_binary, "Binary pseudo charset", 1, encodings.Binary},
+	/*064*/ {},
+	/*065*/ {},
+	/*066*/ {},
+	/*067*/ {},
+	/*068*/ {},
+	/*069*/ {},
+	/*070*/ {},
+	/*071*/ {},
+	/*072*/ {},
+	/*073*/ {},
+	/*074*/ {},
+	/*075*/ {},
+	/*076*/ {},
+	/*077*/ {},
+	/*078*/ {},
+	/*079*/ {},
+	/*080*/ {},
+	/*081*/ {},
+	/*082*/ {},
+	/*083*/ {},
+	/*084*/ {},
+	/*085*/ {},
+	/*086*/ {},
+	/*087*/ {},
+	/*088*/ {},
+	/*089*/ {},
+	/*090*/ {},
+	/*091*/ {},
+	/*092*/ {CharacterSet_geostd8, "geostd8", Collation_geostd8_general_ci, Collation_geostd8_bin, "GEOSTD8 Georgian", 1, encodings.Geostd8},
+	/*093*/ {},
+	/*094*/ {},
+	/*095*/ {CharacterSet_cp932, "cp932", Collation_cp932_japanese_ci, Collation_cp932_bin, "SJIS for Windows Japanese", 2, nil},
+	/*096*/ {},
+	/*097*/ {CharacterSet_eucjpms, "eucjpms", Collation_eucjpms_japanese_ci, Collation_eucjpms_bin, "UJIS for Windows Japanese", 3, nil},
+	/*098*/ {},
+	/*099*/ {},
+	/*100*/ {},
+	/*101*/ {},
+	/*102*/ {},
+	/*103*/ {},
+	/*104*/ {},
+	/*105*/ {},
+	/*106*/ {},
+	/*107*/ {},
+	/*108*/ {},
+	/*109*/ {},
+	/*110*/ {},
+	/*111*/ {},
+	/*112*/ {},
+	/*113*/ {},
+	/*114*/ {},
+	/*115*/ {},
+	/*116*/ {},
+	/*117*/ {},
+	/*118*/ {},
+	/*119*/ {},
+	/*120*/ {},
+	/*121*/ {},
+	/*122*/ {},
+	/*123*/ {},
+	/*124*/ {},
+	/*125*/ {},
+	/*126*/ {},
+	/*127*/ {},
+	/*128*/ {},
+	/*129*/ {},
+	/*130*/ {},
+	/*131*/ {},
+	/*132*/ {},
+	/*133*/ {},
+	/*134*/ {},
+	/*135*/ {},
+	/*136*/ {},
+	/*137*/ {},
+	/*138*/ {},
+	/*139*/ {},
+	/*140*/ {},
+	/*141*/ {},
+	/*142*/ {},
+	/*143*/ {},
+	/*144*/ {},
+	/*145*/ {},
+	/*146*/ {},
+	/*147*/ {},
+	/*148*/ {},
+	/*149*/ {},
+	/*150*/ {},
+	/*151*/ {},
+	/*152*/ {},
+	/*153*/ {},
+	/*154*/ {},
+	/*155*/ {},
+	/*156*/ {},
+	/*157*/ {},
+	/*158*/ {},
+	/*159*/ {},
+	/*160*/ {},
+	/*161*/ {},
+	/*162*/ {},
+	/*163*/ {},
+	/*164*/ {},
+	/*165*/ {},
+	/*166*/ {},
+	/*167*/ {},
+	/*168*/ {},
+	/*169*/ {},
+	/*170*/ {},
+	/*171*/ {},
+	/*172*/ {},
+	/*173*/ {},
+	/*174*/ {},
+	/*175*/ {},
+	/*176*/ {},
+	/*177*/ {},
+	/*178*/ {},
+	/*179*/ {},
+	/*180*/ {},
+	/*181*/ {},
+	/*182*/ {},
+	/*183*/ {},
+	/*184*/ {},
+	/*185*/ {},
+	/*186*/ {},
+	/*187*/ {},
+	/*188*/ {},
+	/*189*/ {},
+	/*100*/ {},
+	/*191*/ {},
+	/*192*/ {},
+	/*193*/ {},
+	/*194*/ {},
+	/*195*/ {},
+	/*196*/ {},
+	/*197*/ {},
+	/*198*/ {},
+	/*199*/ {},
+	/*200*/ {},
+	/*201*/ {},
+	/*202*/ {},
+	/*203*/ {},
+	/*204*/ {},
+	/*205*/ {},
+	/*206*/ {},
+	/*207*/ {},
+	/*208*/ {},
+	/*209*/ {},
+	/*210*/ {},
+	/*211*/ {},
+	/*212*/ {},
+	/*213*/ {},
+	/*214*/ {},
+	/*215*/ {},
+	/*216*/ {},
+	/*217*/ {},
+	/*218*/ {},
+	/*219*/ {},
+	/*220*/ {},
+	/*221*/ {},
+	/*222*/ {},
+	/*223*/ {},
+	/*224*/ {},
+	/*225*/ {},
+	/*226*/ {},
+	/*227*/ {},
+	/*228*/ {},
+	/*229*/ {},
+	/*230*/ {},
+	/*231*/ {},
+	/*232*/ {},
+	/*233*/ {},
+	/*234*/ {},
+	/*235*/ {},
+	/*236*/ {},
+	/*237*/ {},
+	/*238*/ {},
+	/*239*/ {},
+	/*240*/ {},
+	/*241*/ {},
+	/*242*/ {},
+	/*243*/ {},
+	/*244*/ {},
+	/*245*/ {},
+	/*246*/ {},
+	/*247*/ {},
+	/*248*/ {CharacterSet_gb18030, "gb18030", Collation_gb18030_chinese_ci, Collation_gb18030_bin, "China National Standard GB18030", 4, nil},
+	/*249*/ {},
+	/*250*/ {},
+	/*251*/ {},
+	/*252*/ {},
+	/*253*/ {},
+	/*254*/ {},
+	/*255*/ {CharacterSet_utf8mb4, "utf8mb4", Collation_utf8mb4_0900_ai_ci, Collation_utf8mb4_bin, "UTF-8 Unicode", 4, encodings.Utf8mb4},
 }
 
 // init is used to set the unspecified character set's details to match those of the default collation's character set.
@@ -257,14 +470,17 @@ func (cs CharacterSetID) Encoder() encodings.Encoder {
 
 // NewCharacterSetsIterator returns a new CharacterSetsIterator.
 func NewCharacterSetsIterator() *CharacterSetsIterator {
-	return &CharacterSetsIterator{1}
+	return &CharacterSetsIterator{0}
 }
 
 // Next returns the next character set. If all character sets have been iterated over, returns false.
 func (csi *CharacterSetsIterator) Next() (CharacterSet, bool) {
-	if csi.idx >= len(characterSetArray) {
-		return CharacterSet{}, false
+	for ; csi.idx < len(characterSetArray); csi.idx++ {
+		if characterSetArray[csi.idx].ID == 0 {
+			continue
+		}
+		csi.idx++
+		return characterSetArray[csi.idx-1], true
 	}
-	csi.idx++
-	return characterSetArray[csi.idx-1], true
+	return CharacterSet{}, false
 }

--- a/sql/collations.go
+++ b/sql/collations.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Dolthub, Inc.
+// Copyright 2022-2023 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Character set IDs should correlate with their default collation's ID. Previously, they were arbitrarily assigned by sorting their names alphabetically. This _should not_ be a breaking change for anyone, as the comment on the `CharacterSetID` mentions that the ID may change, and should not be persisted. Dolt, the largest integrator, abides by this rule.