### PR TITLE
Insert on dup col ordinal bug

### DIFF
--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -83,6 +83,8 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 	}
 	srcScope := b.insertRowsToNode(inScope, i.Rows, columns, sch)
 
+	// TODO: on duplicate expressions need to reference both VALUES and
+	//  derived columns equally in ON DUPLICATE UPDATE expressions.
 	combinedScope := inScope.replace()
 	for i, c := range destScope.cols {
 		combinedScope.newColumn(c)

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -261,7 +261,9 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) sql.Expression {
 		return expression.NewCollatedExpression(innerExpr, collation)
 	case *ast.ValuesFuncExpr:
 		if b.insertActive {
-			v.Name.Qualifier.Name = ast.NewTableIdent(OnDupValuesPrefix)
+			if v.Name.Qualifier.Name.String() == "" {
+				v.Name.Qualifier.Name = ast.NewTableIdent(OnDupValuesPrefix)
+			}
 			tableName := strings.ToLower(v.Name.Qualifier.Name.String())
 			colName := strings.ToLower(v.Name.Name.String())
 			col, ok := inScope.resolveColumn(tableName, colName, false)


### PR DESCRIPTION
A certain set of conditions causes an error for indexing `on duplicate update` expressions:
- The source is a SELECT statement (not a VALUES row)
- All columns are specified by the INSERT (not sure why, but partial columns seems to get rearranged correctly. I think we must insert a compensating projection to handle column defaults)
- The source columns are not the same order as the destination table schema
- On duplicate update expression references a column from the new row

For the query below, we were indexing the on duplicate expression in the wrong order, causing the output row to be two zero types:
```sql
create table xy (x int primary key, y datetime);
insert into xy (y,x)
select * from (select cast('2019-12-31T12:00:00Z' as date), 0) dt(a,b)
on duplicate key update x=dt.b+1, y=dt.a;
```

The way we resolve inserts is still a bit weird. We resolve the source, and then afterwards add a projection to rearrange columns to match the target schema. I ran into a lot of problems trying to rearrange that ordering (first add projection, then analyze), mostly due to our inability to fix indexes on the source node's projection (VALUE nodes don't have a schema, and it isn't obvious when walking a tree that a given projection is going to be special). When we add the projection afterwards, however, it avoids the indexing rule so we can inline the values safely.

My current fix is to mimic the projection mapping inside indexing. Index the duplicate expression values based on the ordinal of the destination schema. LOAD DATA for some reason needs its insert columns to not be specified, which will probably the source of different issues at some point.

fixes: https://github.com/dolthub/dolt/issues/6675