### PR TITLE
Change Project nodes so they can't return negative zero.

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7876,6 +7876,10 @@ SELECT * FROM my_cte;`,
 			{4},
 		},
 	},
+	{
+		Query:    `SELECT SUM(0) * -1`,
+		Expected: []sql.Row{{0.0}},
+	},
 }
 
 var KeylessQueries = []QueryTest{


### PR DESCRIPTION
In some cases we differ from MySQL in what types we use for intermediate results. This doesn't usually affect the final output, and can be more performant.

But if the final result of an expression is a float when MySQL deduces it to be a decimal, and we don't do anything else to value that would cause it to be coerced (such as inserting it into a table with a schema), then we could end up displaying a result of the wrong type to the user. Usually this doesn't matter, unless that result is the float value `-0` when the user expects a decimal.

Ideally we'd prefer to detect the expected type and do a cast, but this is an acceptable stopgap measure.