### PR TITLE
Retaining display width for `TINYINT(1)`

### DIFF
--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -32,7 +32,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, b1 BOOL, b2 BOOLEAN NOT NULL, g DATETIME, h CHAR(40))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int,\n  `b` text,\n  `c` date,\n  `d` timestamp,\n  `e` varchar(20),\n  `f` blob NOT NULL,\n  `b1` tinyint,\n  `b2` tinyint NOT NULL,\n  `g` datetime,\n  `h` char(40)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `a` int,\n  `b` text,\n  `c` date,\n  `d` timestamp,\n  `e` varchar(20),\n  `f` blob NOT NULL,\n  `b1` tinyint(1),\n  `b2` tinyint(1) NOT NULL,\n  `g` datetime,\n  `h` char(40)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER NOT NULL PRIMARY KEY, b VARCHAR(10) NOT NULL)`,
@@ -44,7 +44,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, b TEXT NOT NULL COMMENT 'comment', c bool, primary key (a))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` text NOT NULL COMMENT 'comment',\n  `c` tinyint,\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` text NOT NULL COMMENT 'comment',\n  `c` tinyint(1),\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, create_time timestamp(6) NOT NULL DEFAULT NOW(6), primary key (a))`,

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -232,6 +232,37 @@ var CreateTableQueries = []WriteQueryTest{
 
 var CreateTableScriptTests = []ScriptTest{
 	{
+		// https://github.com/dolthub/dolt/issues/6682
+		Name: "display width for numeric types",
+		SetUpScript: []string{
+			"CREATE TABLE numericDisplayWidthTest (pk int primary key, b boolean, ti tinyint, ti1 tinyint(1), ti2 tinyint(2), i1 int(1));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SHOW CREATE TABLE numericDisplayWidthTest;",
+				Expected: []sql.Row{{"numericDisplayWidthTest",
+					"CREATE TABLE `numericDisplayWidthTest` (\n  `pk` int NOT NULL,\n  `b` tinyint(1),\n  `ti` tinyint,\n  `ti1` tinyint(1),\n  `ti2` tinyint,\n  `i1` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				// MySQL only honors display width when it is set to 1 and used with the TINYINT type;
+				// all other uses parse correctly, but are dropped.
+				Query: "SHOW FULL FIELDS FROM numericDisplayWidthTest;",
+				Expected: []sql.Row{
+					{"pk", "int", interface{}(nil), "NO", "PRI", "NULL", "", "", ""},
+					{"b", "tinyint(1)", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"ti", "tinyint", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"ti1", "tinyint(1)", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"ti2", "tinyint", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"i1", "int", interface{}(nil), "YES", "", "NULL", "", "", ""},
+				},
+			},
+			{
+				Query:          "CREATE TABLE errorTest(pk int primary key, ti tinyint(-1));",
+				ExpectedErrStr: "syntax error at position 56 near 'tinyint'",
+			},
+		},
+	},
+	{
 		Name: "Validate that CREATE LIKE preserves checks",
 		SetUpScript: []string{
 			"CREATE TABLE t1 (pk int primary key, test_score int, height int CHECK (height < 10) , CONSTRAINT mycheck CHECK (test_score >= 50))",

--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -1082,7 +1082,7 @@ FROM INFORMATION_SCHEMA.TRIGGERS WHERE trigger_schema = 'mydb'`,
 				Expected: []sql.Row{
 					{"ptable", "id", "NO", "int", "int", "PRI"},
 					{"ptable", "id2", "NO", "int", "int", "UNI"},
-					{"ptable", "col1", "YES", "tinyint", "tinyint", ""},
+					{"ptable", "col1", "YES", "tinyint", "tinyint(1)", ""},
 				},
 			},
 		},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -3608,7 +3608,7 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ Eq\n" +
 			" │   │   ├─ mytable.i:0!null\n" +
-			" │   │   └─ 1 (double)\n" +
+			" │   │   └─ 1 (bigint)\n" +
 			" │   └─ TUPLE(true (tinyint(1)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: mytable\n" +
@@ -3621,7 +3621,7 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ Eq\n" +
 			" │   │   ├─ mytable.i:0!null\n" +
-			" │   │   └─ 0 (double)\n" +
+			" │   │   └─ 0 (bigint)\n" +
 			" │   └─ TUPLE(true (tinyint(1)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: mytable\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -3574,7 +3574,7 @@ inner join pq on true
 			" │   ├─ GreaterThan\n" +
 			" │   │   ├─ mytable.i:0!null\n" +
 			" │   │   └─ 2 (tinyint)\n" +
-			" │   └─ TUPLE(true (tinyint))\n" +
+			" │   └─ TUPLE(true (tinyint(1)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: mytable\n" +
 			"     └─ columns: [i s]\n" +
@@ -3608,8 +3608,8 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ Eq\n" +
 			" │   │   ├─ mytable.i:0!null\n" +
-			" │   │   └─ 1 (bigint)\n" +
-			" │   └─ TUPLE(true (tinyint))\n" +
+			" │   │   └─ 1 (double)\n" +
+			" │   └─ TUPLE(true (tinyint(1)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: mytable\n" +
 			"     └─ columns: [i s]\n" +
@@ -3621,8 +3621,8 @@ inner join pq on true
 			" ├─ HashIn\n" +
 			" │   ├─ Eq\n" +
 			" │   │   ├─ mytable.i:0!null\n" +
-			" │   │   └─ 0 (bigint)\n" +
-			" │   └─ TUPLE(true (tinyint))\n" +
+			" │   │   └─ 0 (double)\n" +
+			" │   └─ TUPLE(true (tinyint(1)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: mytable\n" +
 			"     └─ columns: [i s]\n" +
@@ -3689,7 +3689,7 @@ inner join pq on true
 		Query: `SELECT * from mytable where true IN (i > 3)`,
 		ExpectedPlan: "Filter\n" +
 			" ├─ IN\n" +
-			" │   ├─ left: true (tinyint)\n" +
+			" │   ├─ left: true (tinyint(1))\n" +
 			" │   └─ right: TUPLE(GreaterThan\n" +
 			" │       ├─ mytable.i:0!null\n" +
 			" │       └─ 3 (tinyint)\n" +
@@ -7665,7 +7665,7 @@ inner join pq on true
 			" └─ Project\n" +
 			"     ├─ columns: [1 (tinyint)]\n" +
 			"     └─ SemiJoin\n" +
-			"         ├─ true (tinyint)\n" +
+			"         ├─ true (tinyint(1))\n" +
 			"         ├─ Table\n" +
 			"         │   ├─ name: \n" +
 			"         │   └─ columns: []\n" +
@@ -8020,7 +8020,7 @@ inner join pq on true
 			" └─ Project\n" +
 			"     ├─ columns: [1 (tinyint)]\n" +
 			"     └─ SemiJoin\n" +
-			"         ├─ true (tinyint)\n" +
+			"         ├─ true (tinyint(1))\n" +
 			"         ├─ Table\n" +
 			"         │   ├─ name: \n" +
 			"         │   └─ columns: []\n" +
@@ -12530,7 +12530,7 @@ WHERE
 			"                                     └─ Filter\n" +
 			"                                         ├─ Eq\n" +
 			"                                         │   ├─ ms.D237E:11!null\n" +
-			"                                         │   └─ true (tinyint)\n" +
+			"                                         │   └─ true (tinyint(1))\n" +
 			"                                         └─ LeftOuterHashJoin\n" +
 			"                                             ├─ Eq\n" +
 			"                                             │   ├─ nd.HPCMS:4!null\n" +
@@ -12974,7 +12974,7 @@ WHERE
 			"                                     └─ Filter\n" +
 			"                                         ├─ Eq\n" +
 			"                                         │   ├─ ms.D237E:11!null\n" +
-			"                                         │   └─ true (tinyint)\n" +
+			"                                         │   └─ true (tinyint(1))\n" +
 			"                                         └─ LeftOuterHashJoin\n" +
 			"                                             ├─ Eq\n" +
 			"                                             │   ├─ nd.HPCMS:4!null\n" +

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -284,6 +284,8 @@ var ScriptTests = []ScriptTest{
 					"CREATE TABLE `numericDisplayWidthTest` (\n  `pk` int NOT NULL,\n  `b` tinyint(1),\n  `ti` tinyint,\n  `ti1` tinyint(1),\n  `ti2` tinyint,\n  `i` int,\n  `i1` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
+				// MySQL only honors display width when it is set to 1 and used with the TINYINT type;
+				// all other uses parse correctly, but are dropped.
 				Query: "SHOW FULL FIELDS FROM numericDisplayWidthTest;",
 				Expected: []sql.Row{
 					{"pk", "int", interface{}(nil), "NO", "PRI", "NULL", "", "", ""},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -272,6 +272,36 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/6682
+		Name: "display width for numeric types",
+		SetUpScript: []string{
+			"CREATE TABLE numericDisplayWidthTest (pk int primary key, b boolean, ti tinyint, ti1 tinyint(1), ti2 tinyint(2), i int, i1 int(1));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SHOW CREATE TABLE numericDisplayWidthTest;",
+				Expected: []sql.Row{{"numericDisplayWidthTest",
+					"CREATE TABLE `numericDisplayWidthTest` (\n  `pk` int NOT NULL,\n  `b` tinyint(1),\n  `ti` tinyint,\n  `ti1` tinyint(1),\n  `ti2` tinyint,\n  `i` int,\n  `i1` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query: "SHOW FULL FIELDS FROM numericDisplayWidthTest;",
+				Expected: []sql.Row{
+					{"pk", "int", interface{}(nil), "NO", "PRI", "NULL", "", "", ""},
+					{"b", "tinyint(1)", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"ti", "tinyint", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"ti1", "tinyint(1)", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"ti2", "tinyint", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"i", "int", interface{}(nil), "YES", "", "NULL", "", "", ""},
+					{"i1", "int", interface{}(nil), "YES", "", "NULL", "", "", ""},
+				},
+			},
+			{
+				Query:          "CREATE TABLE errorTest(pk int primary key, ti tinyint(-1));",
+				ExpectedErrStr: "syntax error at position 56 near 'tinyint'",
+			},
+		},
+	},
+	{
 		Name: "enums with default, case-sensitive collation (utf8mb4_0900_bin)",
 		SetUpScript: []string{
 			"CREATE TABLE enumtest1 (pk int primary key, e enum('abc', 'XYZ'));",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -272,38 +272,6 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
-		// https://github.com/dolthub/dolt/issues/6682
-		Name: "display width for numeric types",
-		SetUpScript: []string{
-			"CREATE TABLE numericDisplayWidthTest (pk int primary key, b boolean, ti tinyint, ti1 tinyint(1), ti2 tinyint(2), i int, i1 int(1));",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query: "SHOW CREATE TABLE numericDisplayWidthTest;",
-				Expected: []sql.Row{{"numericDisplayWidthTest",
-					"CREATE TABLE `numericDisplayWidthTest` (\n  `pk` int NOT NULL,\n  `b` tinyint(1),\n  `ti` tinyint,\n  `ti1` tinyint(1),\n  `ti2` tinyint,\n  `i` int,\n  `i1` int,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
-			},
-			{
-				// MySQL only honors display width when it is set to 1 and used with the TINYINT type;
-				// all other uses parse correctly, but are dropped.
-				Query: "SHOW FULL FIELDS FROM numericDisplayWidthTest;",
-				Expected: []sql.Row{
-					{"pk", "int", interface{}(nil), "NO", "PRI", "NULL", "", "", ""},
-					{"b", "tinyint(1)", interface{}(nil), "YES", "", "NULL", "", "", ""},
-					{"ti", "tinyint", interface{}(nil), "YES", "", "NULL", "", "", ""},
-					{"ti1", "tinyint(1)", interface{}(nil), "YES", "", "NULL", "", "", ""},
-					{"ti2", "tinyint", interface{}(nil), "YES", "", "NULL", "", "", ""},
-					{"i", "int", interface{}(nil), "YES", "", "NULL", "", "", ""},
-					{"i1", "int", interface{}(nil), "YES", "", "NULL", "", "", ""},
-				},
-			},
-			{
-				Query:          "CREATE TABLE errorTest(pk int primary key, ti tinyint(-1));",
-				ExpectedErrStr: "syntax error at position 56 near 'tinyint'",
-			},
-		},
-	},
-	{
 		Name: "enums with default, case-sensitive collation (utf8mb4_0900_bin)",
 		SetUpScript: []string{
 			"CREATE TABLE enumtest1 (pk int primary key, e enum('abc', 'XYZ'));",

--- a/sql/expression/comparison_test.go
+++ b/sql/expression/comparison_test.go
@@ -143,7 +143,7 @@ func TestNullSafeEquals(t *testing.T) {
 		require.NotNil(get1)
 		seq := expression.NewNullSafeEquals(get0, get1)
 		require.NotNil(seq)
-		require.Equal(types.Int8, seq.Type())
+		require.Equal(types.Boolean, seq.Type())
 		for cmpResult, cases := range cmpCase {
 			for _, pair := range cases {
 				row := sql.NewRow(pair[0], pair[1])

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -1804,7 +1804,24 @@ func TestParseColumnTypeString(t *testing.T) {
 			types.Int8,
 		},
 		{
+			"tinyint(0)",
+			types.Int8,
+		},
+		{
+			// MySQL 8.1.0 only honors display width for TINYINT and only when the display width is 1
+			"tinyint(1)",
+			types.MustCreateNumberTypeWithDisplayWidth(sqltypes.Int8, 1),
+		},
+		{
+			"tinyint(2)",
+			types.Int8,
+		},
+		{
 			"SMALLINT",
+			types.Int16,
+		},
+		{
+			"SMALLINT(1)",
 			types.Int16,
 		},
 		{
@@ -1812,7 +1829,15 @@ func TestParseColumnTypeString(t *testing.T) {
 			types.Int24,
 		},
 		{
+			"MEDIUMINT(1)",
+			types.Int24,
+		},
+		{
 			"INT",
+			types.Int32,
+		},
+		{
+			"INT(0)",
 			types.Int32,
 		},
 		{
@@ -1820,7 +1845,15 @@ func TestParseColumnTypeString(t *testing.T) {
 			types.Int64,
 		},
 		{
+			"BIGINT(1)",
+			types.Int64,
+		},
+		{
 			"TINYINT UNSIGNED",
+			types.Uint8,
+		},
+		{
+			"TINYINT(1) UNSIGNED",
 			types.Uint8,
 		},
 		{
@@ -1828,7 +1861,15 @@ func TestParseColumnTypeString(t *testing.T) {
 			types.Uint16,
 		},
 		{
+			"SMALLINT(1) UNSIGNED",
+			types.Uint16,
+		},
+		{
 			"MEDIUMINT UNSIGNED",
+			types.Uint24,
+		},
+		{
+			"MEDIUMINT(1) UNSIGNED",
 			types.Uint24,
 		},
 		{
@@ -1836,12 +1877,21 @@ func TestParseColumnTypeString(t *testing.T) {
 			types.Uint32,
 		},
 		{
+			"INT(1) UNSIGNED",
+			types.Uint32,
+		},
+		{
 			"BIGINT UNSIGNED",
 			types.Uint64,
 		},
 		{
+			"BIGINT(1) UNSIGNED",
+			types.Uint64,
+		},
+		{
+			// Boolean is a synonym for TINYINT(1)
 			"BOOLEAN",
-			types.Int8,
+			types.MustCreateNumberTypeWithDisplayWidth(sqltypes.Int8, 1),
 		},
 		{
 			"FLOAT",

--- a/sql/type.go
+++ b/sql/type.go
@@ -117,6 +117,7 @@ type NumberType interface {
 	Type
 	IsSigned() bool
 	IsFloat() bool
+	DisplayWidth() int
 }
 
 // StringType represents all string types, including VARCHAR and BLOB.

--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -120,8 +120,23 @@ func ApproximateTypeFromValue(val interface{}) sql.Type {
 func ColumnTypeToType(ct *sqlparser.ColumnType) (sql.Type, error) {
 	switch strings.ToLower(ct.Type) {
 	case "boolean", "bool":
-		return Int8, nil
+		return CreateNumberTypeWithDisplayWidth(sqltypes.Int8, 1)
 	case "tinyint":
+		if ct.Length != nil {
+			displayWidth, err := strconv.Atoi(string(ct.Length.Val))
+			if err != nil {
+				return nil, fmt.Errorf("unable to parse display width value: %w", err)
+			}
+
+			// As of MySQL 8.1.0, TINYINT is the only integer type for which MySQL will retain a display width,
+			// and ONLY if it's 1. All other types and display width values are dropped. TINYINT(1) seems to be
+			// left for backwards compatibility with ORM tools like ActiveRecord that rely on it for mapping to
+			// a boolean type.
+			if !ct.Unsigned && displayWidth == 1 {
+				return CreateNumberTypeWithDisplayWidth(sqltypes.Int8, displayWidth)
+			}
+		}
+
 		if ct.Unsigned {
 			return Uint8, nil
 		}

--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -120,7 +120,7 @@ func ApproximateTypeFromValue(val interface{}) sql.Type {
 func ColumnTypeToType(ct *sqlparser.ColumnType) (sql.Type, error) {
 	switch strings.ToLower(ct.Type) {
 	case "boolean", "bool":
-		return CreateNumberTypeWithDisplayWidth(sqltypes.Int8, 1)
+		return Boolean, nil
 	case "tinyint":
 		if ct.Length != nil {
 			displayWidth, err := strconv.Atoi(string(ct.Length.Val))
@@ -133,7 +133,7 @@ func ColumnTypeToType(ct *sqlparser.ColumnType) (sql.Type, error) {
 			// left for backwards compatibility with ORM tools like ActiveRecord that rely on it for mapping to
 			// a boolean type.
 			if !ct.Unsigned && displayWidth == 1 {
-				return CreateNumberTypeWithDisplayWidth(sqltypes.Int8, displayWidth)
+				return Boolean, nil
 			}
 		}
 

--- a/sql/types/number.go
+++ b/sql/types/number.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	// Boolean is a synonym for TINYINT
-	Boolean = Int8
+	// Boolean is a synonym for TINYINT(1)
+	Boolean = MustCreateNumberTypeWithDisplayWidth(sqltypes.Int8, 1)
 	// Int8 is an integer of 8 bits
 	Int8 = MustCreateNumberType(sqltypes.Int8)
 	// Uint8 is an unsigned integer of 8 bits

--- a/sql/types/number_test.go
+++ b/sql/types/number_test.go
@@ -97,18 +97,18 @@ func TestNumberCreate(t *testing.T) {
 		expectedType NumberTypeImpl_
 		expectedErr  bool
 	}{
-		{sqltypes.Int8, NumberTypeImpl_{sqltypes.Int8}, false},
-		{sqltypes.Int16, NumberTypeImpl_{sqltypes.Int16}, false},
-		{sqltypes.Int24, NumberTypeImpl_{sqltypes.Int24}, false},
-		{sqltypes.Int32, NumberTypeImpl_{sqltypes.Int32}, false},
-		{sqltypes.Int64, NumberTypeImpl_{sqltypes.Int64}, false},
-		{sqltypes.Uint8, NumberTypeImpl_{sqltypes.Uint8}, false},
-		{sqltypes.Uint16, NumberTypeImpl_{sqltypes.Uint16}, false},
-		{sqltypes.Uint24, NumberTypeImpl_{sqltypes.Uint24}, false},
-		{sqltypes.Uint32, NumberTypeImpl_{sqltypes.Uint32}, false},
-		{sqltypes.Uint64, NumberTypeImpl_{sqltypes.Uint64}, false},
-		{sqltypes.Float32, NumberTypeImpl_{sqltypes.Float32}, false},
-		{sqltypes.Float64, NumberTypeImpl_{sqltypes.Float64}, false},
+		{sqltypes.Int8, NumberTypeImpl_{sqltypes.Int8, 0}, false},
+		{sqltypes.Int16, NumberTypeImpl_{sqltypes.Int16, 0}, false},
+		{sqltypes.Int24, NumberTypeImpl_{sqltypes.Int24, 0}, false},
+		{sqltypes.Int32, NumberTypeImpl_{sqltypes.Int32, 0}, false},
+		{sqltypes.Int64, NumberTypeImpl_{sqltypes.Int64, 0}, false},
+		{sqltypes.Uint8, NumberTypeImpl_{sqltypes.Uint8, 0}, false},
+		{sqltypes.Uint16, NumberTypeImpl_{sqltypes.Uint16, 0}, false},
+		{sqltypes.Uint24, NumberTypeImpl_{sqltypes.Uint24, 0}, false},
+		{sqltypes.Uint32, NumberTypeImpl_{sqltypes.Uint32, 0}, false},
+		{sqltypes.Uint64, NumberTypeImpl_{sqltypes.Uint64, 0}, false},
+		{sqltypes.Float32, NumberTypeImpl_{sqltypes.Float32, 0}, false},
+		{sqltypes.Float64, NumberTypeImpl_{sqltypes.Float64, 0}, false},
 	}
 
 	for _, test := range tests {

--- a/sql/types/number_test.go
+++ b/sql/types/number_test.go
@@ -258,7 +258,7 @@ func TestNumberString(t *testing.T) {
 		typ         sql.Type
 		expectedStr string
 	}{
-		{Boolean, "tinyint"},
+		{Boolean, "tinyint(1)"},
 		{Int8, "tinyint"},
 		{Int16, "smallint"},
 		{Int24, "mediumint"},

--- a/sql/types/typecheck.go
+++ b/sql/types/typecheck.go
@@ -102,7 +102,7 @@ func IsSigned(t sql.Type) bool {
 	if _, ok := t.(SystemBoolType); ok {
 		return true
 	}
-	return t == Int8 || t == Int16 || t == Int24 || t == Int32 || t == Int64
+	return t == Int8 || t == Int16 || t == Int24 || t == Int32 || t == Int64 || t == Boolean
 }
 
 // IsText checks if t is a CHAR, VARCHAR, TEXT, BINARY, VARBINARY, or BLOB (including TEXT and BLOB variants).


### PR DESCRIPTION
MySQL allows integer fields to specify a display width (e.g. `TINYINT(1)`). `go-mysql-server` currently parses that information, but doesn't retain it anywhere. This PR changes that behavior to match MySQL and retain the display width setting so that it can be passed back to callers. 

As of MySQL 8.1.0, the display width setting is ONLY retained for signed `TINYINT` fields and ONLY when the display width is set to 1. 

Fixes: https://github.com/dolthub/dolt/issues/6682

Corresponding Dolt PR: https://github.com/dolthub/dolt/pull/6688