### PR TITLE
Avoid corrupting the privileges file

### DIFF
--- a/sql/mysql_db/privilege_set.go
+++ b/sql/mysql_db/privilege_set.go
@@ -280,8 +280,12 @@ func (ps *PrivilegeSet) ClearGlobal() {
 
 // ClearDatabase removes all privileges for the given database.
 func (ps PrivilegeSet) ClearDatabase(dbName string) {
-	ps.getUseableDb(dbName).clear()
-	delete(ps.databases, strings.ToLower(dbName))
+	lowerDbName := strings.ToLower(dbName)
+	dbSet, ok := ps.databases[lowerDbName]
+	if ok {
+		dbSet.clear()
+		delete(ps.databases, lowerDbName)
+	}
 }
 
 // ClearTable removes all privileges for the given table.

--- a/sql/mysql_db/privilege_set.go
+++ b/sql/mysql_db/privilege_set.go
@@ -142,6 +142,10 @@ func (ps PrivilegeSet) RemoveDatabase(dbName string, privileges ...sql.Privilege
 			delete(dbSet.privs, priv)
 		}
 	}
+
+	if len(dbSet.privs) == 0 {
+		delete(ps.databases, strings.ToLower(dbName))
+	}
 }
 
 // RemoveTable removes the given table privilege(s).

--- a/sql/mysql_db/privilege_set.go
+++ b/sql/mysql_db/privilege_set.go
@@ -281,6 +281,7 @@ func (ps *PrivilegeSet) ClearGlobal() {
 // ClearDatabase removes all privileges for the given database.
 func (ps PrivilegeSet) ClearDatabase(dbName string) {
 	ps.getUseableDb(dbName).clear()
+	delete(ps.databases, strings.ToLower(dbName))
 }
 
 // ClearTable removes all privileges for the given table.


### PR DESCRIPTION
Currently, the last of these commands results in a panic due to the revoke inserting a database with an empty string for a name. This is fairly awkward to test in GMS, so I'm going to take the easy route and create a bats test in dolt.

```
lcl:~/Documents/data_dir_1/db3$ dolt init
Successfully initialized dolt data repository.
lcl:~/Documents/data_dir_1/db3$ dolt sql
# Welcome to the DoltSQL shell.
# Statements must be terminated with ';'.
# "exit" or "quit" (or Ctrl-D) to exit.
db3> CREATE USER 'testuser'@'localhost' IDENTIFIED BY 'password';
Query OK, 0 rows affected (0.00 sec)
db3> CREATE DATABASE foo;
db3> GRANT INSERT ON foo.* TO 'testuser'@'localhost';
Query OK, 0 rows affected (0.00 sec)
db3> REVOKE INSERT ON foo.* FROM 'testuser'@'localhost';
Query OK, 0 rows affected (0.00 sec)
db3> SHOW GRANTS FOR testuser@localhost;
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x101940894]
```

