### PR TITLE
Failure to push filter causes dropped filter

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -86,7 +86,12 @@ var joinOpTests = []struct {
 		},
 		tests: []JoinOpTests{
 			{
-				Query:    "select /*+ JOIN_ORDER(pq,xy,uv) */ * from xy join uv on (x = u and u in (0,2)) join ab on (x = a and v < 2)",
+				// This query is a small repro of a larger query caused by the intersection of several
+				// bugs. The query below should 1) move the filters out of the join condition, and then
+				// 2) push those hoisted filters on top of |uv|, where they are safe for join planning.
+				// At the time of this addition, filters in the middle of join trees are unsafe and
+				// at risk of being lost.
+				Query:    "select /*+ JOIN_ORDER(ab,xy,uv) */ * from xy join uv on (x = u and u in (0,2)) join ab on (x = a and v < 2)",
 				Expected: []sql.Row{{0, 2, 0, 1, 0, 2}},
 			},
 		},

--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -76,11 +76,9 @@ var joinOpTests = []struct {
 			setup.MydbData[0],
 			{
 				"CREATE table xy (x int primary key, y int, unique index y_idx(y));",
-				"create table rs (r int primary key, s int, index s_idx(s));",
 				"CREATE table uv (u int primary key, v int);",
 				"CREATE table ab (a int primary key, b int);",
 				"insert into xy values (1,0), (2,1), (0,2), (3,3);",
-				"insert into rs values (0,0), (1,0), (2,0), (4,4), (5,4);",
 				"insert into uv values (0,1), (1,1), (2,2), (3,2);",
 				"insert into ab values (0,2), (1,2), (2,2), (3,1);",
 				"update information_schema.statistics set cardinality = 1000 where table_name in ('ab', 'rs', 'xy', 'uv');",

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -9409,11 +9409,8 @@ WHERE
 			" │                                       │           ├─ static: [{[NULL, ∞)}]\n" +
 			" │                                       │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			" │                                       └─ Filter\n" +
-			" │                                           ├─ AND\n" +
-			" │                                           │   ├─ NOT\n" +
-			" │                                           │   │   └─ scalarSubq0.PRUV2:9 IS NULL\n" +
-			" │                                           │   └─ NOT\n" +
-			" │                                           │       └─ scalarSubq0.PRUV2:9 IS NULL\n" +
+			" │                                           ├─ NOT\n" +
+			" │                                           │   └─ scalarSubq0.PRUV2:9 IS NULL\n" +
 			" │                                           └─ TableAlias(scalarSubq0)\n" +
 			" │                                               └─ IndexedTableAccess(HDDVB)\n" +
 			" │                                                   ├─ index: [HDDVB.PRUV2]\n" +
@@ -9931,11 +9928,8 @@ WHERE
 			"     │                       │           │           ├─ static: [{[NULL, ∞)}]\n" +
 			"     │                       │           │           └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"     │                       │           └─ Filter\n" +
-			"     │                       │               ├─ AND\n" +
-			"     │                       │               │   ├─ NOT\n" +
-			"     │                       │               │   │   └─ scalarSubq0.OCA7E:37 IS NULL\n" +
-			"     │                       │               │   └─ NOT\n" +
-			"     │                       │               │       └─ scalarSubq0.OCA7E:37 IS NULL\n" +
+			"     │                       │               ├─ NOT\n" +
+			"     │                       │               │   └─ scalarSubq0.OCA7E:37 IS NULL\n" +
 			"     │                       │               └─ TableAlias(scalarSubq0)\n" +
 			"     │                       │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │                       │                       ├─ index: [FLQLP.OCA7E]\n" +
@@ -10066,11 +10060,8 @@ WHERE
 			"     │               │   │               └─ Project\n" +
 			"     │               │   │                   ├─ columns: [scalarSubq0.NRURT:5]\n" +
 			"     │               │   │                   └─ Filter\n" +
-			"     │               │   │                       ├─ AND\n" +
-			"     │               │   │                       │   ├─ NOT\n" +
-			"     │               │   │                       │   │   └─ scalarSubq0.NRURT:5 IS NULL\n" +
-			"     │               │   │                       │   └─ NOT\n" +
-			"     │               │   │                       │       └─ scalarSubq0.NRURT:5 IS NULL\n" +
+			"     │               │   │                       ├─ NOT\n" +
+			"     │               │   │                       │   └─ scalarSubq0.NRURT:5 IS NULL\n" +
 			"     │               │   │                       └─ TableAlias(scalarSubq0)\n" +
 			"     │               │   │                           └─ Table\n" +
 			"     │               │   │                               ├─ name: FLQLP\n" +
@@ -10216,11 +10207,8 @@ WHERE
 			"             └─ Project\n" +
 			"                 ├─ columns: [scalarSubq0.XMM6Q:7]\n" +
 			"                 └─ Filter\n" +
-			"                     ├─ AND\n" +
-			"                     │   ├─ NOT\n" +
-			"                     │   │   └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
-			"                     │   └─ NOT\n" +
-			"                     │       └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
+			"                     ├─ NOT\n" +
+			"                     │   └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
 			"                     └─ TableAlias(scalarSubq0)\n" +
 			"                         └─ IndexedTableAccess(FLQLP)\n" +
 			"                             ├─ index: [FLQLP.XMM6Q]\n" +
@@ -11017,22 +11005,22 @@ WHERE
 			"     │               ├─ alias-string: select umf.id as ORB3K from SZW6V as TJ5D2 join NZKPM as umf on umf.T4IBQ = TJ5D2.T4IBQ and umf.FGG57 = TJ5D2.V7UFH and umf.SYPKF = TJ5D2.SYPKF where TJ5D2.SWCQV = 0 and TJ5D2.id not in (select QQV4M from HGMQ6 where QQV4M is not null)\n" +
 			"     │               └─ Project\n" +
 			"     │                   ├─ columns: [umf.id:79!null as ORB3K]\n" +
-			"     │                   └─ LookupJoin\n" +
-			"     │                       ├─ AND\n" +
+			"     │                   └─ AntiLookupJoin\n" +
+			"     │                       ├─ Eq\n" +
+			"     │                       │   ├─ tj5d2.id:71!null\n" +
+			"     │                       │   └─ scalarSubq0.QQV4M:104\n" +
+			"     │                       ├─ LookupJoin\n" +
 			"     │                       │   ├─ AND\n" +
-			"     │                       │   │   ├─ Eq\n" +
-			"     │                       │   │   │   ├─ umf.T4IBQ:80\n" +
-			"     │                       │   │   │   └─ tj5d2.T4IBQ:72!null\n" +
+			"     │                       │   │   ├─ AND\n" +
+			"     │                       │   │   │   ├─ Eq\n" +
+			"     │                       │   │   │   │   ├─ umf.T4IBQ:80\n" +
+			"     │                       │   │   │   │   └─ tj5d2.T4IBQ:72!null\n" +
+			"     │                       │   │   │   └─ Eq\n" +
+			"     │                       │   │   │       ├─ umf.FGG57:81\n" +
+			"     │                       │   │   │       └─ tj5d2.V7UFH:73!null\n" +
 			"     │                       │   │   └─ Eq\n" +
-			"     │                       │   │       ├─ umf.FGG57:81\n" +
-			"     │                       │   │       └─ tj5d2.V7UFH:73!null\n" +
-			"     │                       │   └─ Eq\n" +
-			"     │                       │       ├─ umf.SYPKF:87\n" +
-			"     │                       │       └─ tj5d2.SYPKF:74!null\n" +
-			"     │                       ├─ AntiLookupJoin\n" +
-			"     │                       │   ├─ Eq\n" +
-			"     │                       │   │   ├─ tj5d2.id:71!null\n" +
-			"     │                       │   │   └─ scalarSubq0.QQV4M:79\n" +
+			"     │                       │   │       ├─ umf.SYPKF:87\n" +
+			"     │                       │   │       └─ tj5d2.SYPKF:74!null\n" +
 			"     │                       │   ├─ Filter\n" +
 			"     │                       │   │   ├─ Eq\n" +
 			"     │                       │   │   │   ├─ tj5d2.SWCQV:76!null\n" +
@@ -11041,20 +11029,17 @@ WHERE
 			"     │                       │   │       └─ Table\n" +
 			"     │                       │   │           ├─ name: SZW6V\n" +
 			"     │                       │   │           └─ columns: [id t4ibq v7ufh sypkf h4dmt swcqv ykssu fhcyt]\n" +
-			"     │                       │   └─ Filter\n" +
-			"     │                       │       ├─ AND\n" +
-			"     │                       │       │   ├─ NOT\n" +
-			"     │                       │       │   │   └─ scalarSubq0.QQV4M:71 IS NULL\n" +
-			"     │                       │       │   └─ NOT\n" +
-			"     │                       │       │       └─ scalarSubq0.QQV4M:71 IS NULL\n" +
-			"     │                       │       └─ TableAlias(scalarSubq0)\n" +
-			"     │                       │           └─ IndexedTableAccess(HGMQ6)\n" +
-			"     │                       │               ├─ index: [HGMQ6.QQV4M]\n" +
-			"     │                       │               └─ columns: [qqv4m]\n" +
-			"     │                       └─ TableAlias(umf)\n" +
-			"     │                           └─ IndexedTableAccess(NZKPM)\n" +
-			"     │                               ├─ index: [NZKPM.FGG57]\n" +
-			"     │                               └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
+			"     │                       │   └─ TableAlias(umf)\n" +
+			"     │                       │       └─ IndexedTableAccess(NZKPM)\n" +
+			"     │                       │           ├─ index: [NZKPM.FGG57]\n" +
+			"     │                       │           └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
+			"     │                       └─ Filter\n" +
+			"     │                           ├─ NOT\n" +
+			"     │                           │   └─ scalarSubq0.QQV4M:71 IS NULL\n" +
+			"     │                           └─ TableAlias(scalarSubq0)\n" +
+			"     │                               └─ IndexedTableAccess(HGMQ6)\n" +
+			"     │                                   ├─ index: [HGMQ6.QQV4M]\n" +
+			"     │                                   └─ columns: [qqv4m]\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ bs.id:67!null\n" +
@@ -11385,13 +11370,9 @@ WHERE
 			" │               │           │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
 			" │               │           │           │   │   │           └─ columns: [id ftqlq]\n" +
 			" │               │           │           │   │   └─ Filter\n" +
-			" │               │           │           │   │       ├─ AND\n" +
-			" │               │           │           │   │       │   ├─ Eq\n" +
-			" │               │           │           │   │       │   │   ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │           │   │       │   │   └─ = (longtext)\n" +
-			" │               │           │           │   │       │   └─ Eq\n" +
-			" │               │           │           │   │       │       ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │           │   │       │       └─ = (longtext)\n" +
+			" │               │           │           │   │       ├─ Eq\n" +
+			" │               │           │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │   └─ = (longtext)\n" +
 			" │               │           │           │   │       └─ TableAlias(ct)\n" +
 			" │               │           │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			" │               │           │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
@@ -11783,13 +11764,9 @@ WHERE
 			" │               │           │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
 			" │               │           │           │   │   │           └─ columns: [id ftqlq]\n" +
 			" │               │           │           │   │   └─ Filter\n" +
-			" │               │           │           │   │       ├─ AND\n" +
-			" │               │           │           │   │       │   ├─ Eq\n" +
-			" │               │           │           │   │       │   │   ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │           │   │       │   │   └─ = (longtext)\n" +
-			" │               │           │           │   │       │   └─ Eq\n" +
-			" │               │           │           │   │       │       ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │           │   │       │       └─ = (longtext)\n" +
+			" │               │           │           │   │       ├─ Eq\n" +
+			" │               │           │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │   └─ = (longtext)\n" +
 			" │               │           │           │   │       └─ TableAlias(ct)\n" +
 			" │               │           │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			" │               │           │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -9409,8 +9409,11 @@ WHERE
 			" │                                       │           ├─ static: [{[NULL, ∞)}]\n" +
 			" │                                       │           └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			" │                                       └─ Filter\n" +
-			" │                                           ├─ NOT\n" +
-			" │                                           │   └─ scalarSubq0.PRUV2:9 IS NULL\n" +
+			" │                                           ├─ AND\n" +
+			" │                                           │   ├─ NOT\n" +
+			" │                                           │   │   └─ scalarSubq0.PRUV2:9 IS NULL\n" +
+			" │                                           │   └─ NOT\n" +
+			" │                                           │       └─ scalarSubq0.PRUV2:9 IS NULL\n" +
 			" │                                           └─ TableAlias(scalarSubq0)\n" +
 			" │                                               └─ IndexedTableAccess(HDDVB)\n" +
 			" │                                                   ├─ index: [HDDVB.PRUV2]\n" +
@@ -9928,8 +9931,11 @@ WHERE
 			"     │                       │           │           ├─ static: [{[NULL, ∞)}]\n" +
 			"     │                       │           │           └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"     │                       │           └─ Filter\n" +
-			"     │                       │               ├─ NOT\n" +
-			"     │                       │               │   └─ scalarSubq0.OCA7E:37 IS NULL\n" +
+			"     │                       │               ├─ AND\n" +
+			"     │                       │               │   ├─ NOT\n" +
+			"     │                       │               │   │   └─ scalarSubq0.OCA7E:37 IS NULL\n" +
+			"     │                       │               │   └─ NOT\n" +
+			"     │                       │               │       └─ scalarSubq0.OCA7E:37 IS NULL\n" +
 			"     │                       │               └─ TableAlias(scalarSubq0)\n" +
 			"     │                       │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │                       │                       ├─ index: [FLQLP.OCA7E]\n" +
@@ -10060,8 +10066,11 @@ WHERE
 			"     │               │   │               └─ Project\n" +
 			"     │               │   │                   ├─ columns: [scalarSubq0.NRURT:5]\n" +
 			"     │               │   │                   └─ Filter\n" +
-			"     │               │   │                       ├─ NOT\n" +
-			"     │               │   │                       │   └─ scalarSubq0.NRURT:5 IS NULL\n" +
+			"     │               │   │                       ├─ AND\n" +
+			"     │               │   │                       │   ├─ NOT\n" +
+			"     │               │   │                       │   │   └─ scalarSubq0.NRURT:5 IS NULL\n" +
+			"     │               │   │                       │   └─ NOT\n" +
+			"     │               │   │                       │       └─ scalarSubq0.NRURT:5 IS NULL\n" +
 			"     │               │   │                       └─ TableAlias(scalarSubq0)\n" +
 			"     │               │   │                           └─ Table\n" +
 			"     │               │   │                               ├─ name: FLQLP\n" +
@@ -10207,8 +10216,11 @@ WHERE
 			"             └─ Project\n" +
 			"                 ├─ columns: [scalarSubq0.XMM6Q:7]\n" +
 			"                 └─ Filter\n" +
-			"                     ├─ NOT\n" +
-			"                     │   └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
+			"                     ├─ AND\n" +
+			"                     │   ├─ NOT\n" +
+			"                     │   │   └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
+			"                     │   └─ NOT\n" +
+			"                     │       └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
 			"                     └─ TableAlias(scalarSubq0)\n" +
 			"                         └─ IndexedTableAccess(FLQLP)\n" +
 			"                             ├─ index: [FLQLP.XMM6Q]\n" +
@@ -11005,22 +11017,22 @@ WHERE
 			"     │               ├─ alias-string: select umf.id as ORB3K from SZW6V as TJ5D2 join NZKPM as umf on umf.T4IBQ = TJ5D2.T4IBQ and umf.FGG57 = TJ5D2.V7UFH and umf.SYPKF = TJ5D2.SYPKF where TJ5D2.SWCQV = 0 and TJ5D2.id not in (select QQV4M from HGMQ6 where QQV4M is not null)\n" +
 			"     │               └─ Project\n" +
 			"     │                   ├─ columns: [umf.id:79!null as ORB3K]\n" +
-			"     │                   └─ AntiLookupJoin\n" +
-			"     │                       ├─ Eq\n" +
-			"     │                       │   ├─ tj5d2.id:71!null\n" +
-			"     │                       │   └─ scalarSubq0.QQV4M:104\n" +
-			"     │                       ├─ LookupJoin\n" +
+			"     │                   └─ LookupJoin\n" +
+			"     │                       ├─ AND\n" +
 			"     │                       │   ├─ AND\n" +
-			"     │                       │   │   ├─ AND\n" +
-			"     │                       │   │   │   ├─ Eq\n" +
-			"     │                       │   │   │   │   ├─ umf.T4IBQ:80\n" +
-			"     │                       │   │   │   │   └─ tj5d2.T4IBQ:72!null\n" +
-			"     │                       │   │   │   └─ Eq\n" +
-			"     │                       │   │   │       ├─ umf.FGG57:81\n" +
-			"     │                       │   │   │       └─ tj5d2.V7UFH:73!null\n" +
+			"     │                       │   │   ├─ Eq\n" +
+			"     │                       │   │   │   ├─ umf.T4IBQ:80\n" +
+			"     │                       │   │   │   └─ tj5d2.T4IBQ:72!null\n" +
 			"     │                       │   │   └─ Eq\n" +
-			"     │                       │   │       ├─ umf.SYPKF:87\n" +
-			"     │                       │   │       └─ tj5d2.SYPKF:74!null\n" +
+			"     │                       │   │       ├─ umf.FGG57:81\n" +
+			"     │                       │   │       └─ tj5d2.V7UFH:73!null\n" +
+			"     │                       │   └─ Eq\n" +
+			"     │                       │       ├─ umf.SYPKF:87\n" +
+			"     │                       │       └─ tj5d2.SYPKF:74!null\n" +
+			"     │                       ├─ AntiLookupJoin\n" +
+			"     │                       │   ├─ Eq\n" +
+			"     │                       │   │   ├─ tj5d2.id:71!null\n" +
+			"     │                       │   │   └─ scalarSubq0.QQV4M:79\n" +
 			"     │                       │   ├─ Filter\n" +
 			"     │                       │   │   ├─ Eq\n" +
 			"     │                       │   │   │   ├─ tj5d2.SWCQV:76!null\n" +
@@ -11029,17 +11041,20 @@ WHERE
 			"     │                       │   │       └─ Table\n" +
 			"     │                       │   │           ├─ name: SZW6V\n" +
 			"     │                       │   │           └─ columns: [id t4ibq v7ufh sypkf h4dmt swcqv ykssu fhcyt]\n" +
-			"     │                       │   └─ TableAlias(umf)\n" +
-			"     │                       │       └─ IndexedTableAccess(NZKPM)\n" +
-			"     │                       │           ├─ index: [NZKPM.FGG57]\n" +
-			"     │                       │           └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
-			"     │                       └─ Filter\n" +
-			"     │                           ├─ NOT\n" +
-			"     │                           │   └─ scalarSubq0.QQV4M:71 IS NULL\n" +
-			"     │                           └─ TableAlias(scalarSubq0)\n" +
-			"     │                               └─ IndexedTableAccess(HGMQ6)\n" +
-			"     │                                   ├─ index: [HGMQ6.QQV4M]\n" +
-			"     │                                   └─ columns: [qqv4m]\n" +
+			"     │                       │   └─ Filter\n" +
+			"     │                       │       ├─ AND\n" +
+			"     │                       │       │   ├─ NOT\n" +
+			"     │                       │       │   │   └─ scalarSubq0.QQV4M:71 IS NULL\n" +
+			"     │                       │       │   └─ NOT\n" +
+			"     │                       │       │       └─ scalarSubq0.QQV4M:71 IS NULL\n" +
+			"     │                       │       └─ TableAlias(scalarSubq0)\n" +
+			"     │                       │           └─ IndexedTableAccess(HGMQ6)\n" +
+			"     │                       │               ├─ index: [HGMQ6.QQV4M]\n" +
+			"     │                       │               └─ columns: [qqv4m]\n" +
+			"     │                       └─ TableAlias(umf)\n" +
+			"     │                           └─ IndexedTableAccess(NZKPM)\n" +
+			"     │                               ├─ index: [NZKPM.FGG57]\n" +
+			"     │                               └─ columns: [id t4ibq fgg57 sshpj nla6o sfj6l tjpt7 arn5p sypkf ivfmk ide43 az6sp fsdy2 xosd4 hmw4h s76om vaf zroh6 qcgts lnfm6 tvawl hdlcl bhhw6 fhcyt qz6vt]\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ bs.id:67!null\n" +
@@ -11370,9 +11385,13 @@ WHERE
 			" │               │           │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
 			" │               │           │           │   │   │           └─ columns: [id ftqlq]\n" +
 			" │               │           │           │   │   └─ Filter\n" +
-			" │               │           │           │   │       ├─ Eq\n" +
-			" │               │           │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │           │   │       │   └─ = (longtext)\n" +
+			" │               │           │           │   │       ├─ AND\n" +
+			" │               │           │           │   │       │   ├─ Eq\n" +
+			" │               │           │           │   │       │   │   ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │   │   └─ = (longtext)\n" +
+			" │               │           │           │   │       │   └─ Eq\n" +
+			" │               │           │           │   │       │       ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │       └─ = (longtext)\n" +
 			" │               │           │           │   │       └─ TableAlias(ct)\n" +
 			" │               │           │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			" │               │           │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
@@ -11524,22 +11543,30 @@ WHERE
 			"                             │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
 			"                             │           │   │   │           └─ columns: [id ftqlq]\n" +
 			"                             │           │   │   └─ Filter\n" +
-			"                             │           │   │       ├─ Eq\n" +
-			"                             │           │   │       │   ├─ ct.M22QN:3!null\n" +
-			"                             │           │   │       │   └─ Subquery\n" +
-			"                             │           │   │       │       ├─ cacheable: true\n" +
-			"                             │           │   │       │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
-			"                             │           │   │       │       └─ Project\n" +
-			"                             │           │   │       │           ├─ columns: [aac.id:12!null]\n" +
-			"                             │           │   │       │           └─ Filter\n" +
-			"                             │           │   │       │               ├─ Eq\n" +
-			"                             │           │   │       │               │   ├─ aac.BTXC5:13\n" +
-			"                             │           │   │       │               │   └─ WT (longtext)\n" +
-			"                             │           │   │       │               └─ TableAlias(aac)\n" +
-			"                             │           │   │       │                   └─ IndexedTableAccess(TPXBU)\n" +
-			"                             │           │   │       │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"                             │           │   │       │                       ├─ static: [{[WT, WT]}]\n" +
-			"                             │           │   │       │                       └─ columns: [id btxc5]\n" +
+			"                             │           │   │       ├─ AND\n" +
+			"                             │           │   │       │   ├─ AND\n" +
+			"                             │           │   │       │   │   ├─ Eq\n" +
+			"                             │           │   │       │   │   │   ├─ ct.M22QN:3!null\n" +
+			"                             │           │   │       │   │   │   └─ Subquery\n" +
+			"                             │           │   │       │   │   │       ├─ cacheable: true\n" +
+			"                             │           │   │       │   │   │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
+			"                             │           │   │       │   │   │       └─ Project\n" +
+			"                             │           │   │       │   │   │           ├─ columns: [aac.id:12!null]\n" +
+			"                             │           │   │       │   │   │           └─ Filter\n" +
+			"                             │           │   │       │   │   │               ├─ Eq\n" +
+			"                             │           │   │       │   │   │               │   ├─ aac.BTXC5:13\n" +
+			"                             │           │   │       │   │   │               │   └─ WT (longtext)\n" +
+			"                             │           │   │       │   │   │               └─ TableAlias(aac)\n" +
+			"                             │           │   │       │   │   │                   └─ IndexedTableAccess(TPXBU)\n" +
+			"                             │           │   │       │   │   │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"                             │           │   │       │   │   │                       ├─ static: [{[WT, WT]}]\n" +
+			"                             │           │   │       │   │   │                       └─ columns: [id btxc5]\n" +
+			"                             │           │   │       │   │   └─ Eq\n" +
+			"                             │           │   │       │   │       ├─ ct.ZRV3B:10!null\n" +
+			"                             │           │   │       │   │       └─ = (longtext)\n" +
+			"                             │           │   │       │   └─ Eq\n" +
+			"                             │           │   │       │       ├─ ct.ZRV3B:10!null\n" +
+			"                             │           │   │       │       └─ = (longtext)\n" +
 			"                             │           │   │       └─ TableAlias(ct)\n" +
 			"                             │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			"                             │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
@@ -11756,9 +11783,13 @@ WHERE
 			" │               │           │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
 			" │               │           │           │   │   │           └─ columns: [id ftqlq]\n" +
 			" │               │           │           │   │   └─ Filter\n" +
-			" │               │           │           │   │       ├─ Eq\n" +
-			" │               │           │           │   │       │   ├─ ct.ZRV3B:5!null\n" +
-			" │               │           │           │   │       │   └─ = (longtext)\n" +
+			" │               │           │           │   │       ├─ AND\n" +
+			" │               │           │           │   │       │   ├─ Eq\n" +
+			" │               │           │           │   │       │   │   ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │   │   └─ = (longtext)\n" +
+			" │               │           │           │   │       │   └─ Eq\n" +
+			" │               │           │           │   │       │       ├─ ct.ZRV3B:5!null\n" +
+			" │               │           │           │   │       │       └─ = (longtext)\n" +
 			" │               │           │           │   │       └─ TableAlias(ct)\n" +
 			" │               │           │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			" │               │           │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +
@@ -11910,22 +11941,30 @@ WHERE
 			"                             │           │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
 			"                             │           │   │   │           └─ columns: [id ftqlq]\n" +
 			"                             │           │   │   └─ Filter\n" +
-			"                             │           │   │       ├─ Eq\n" +
-			"                             │           │   │       │   ├─ ct.M22QN:3!null\n" +
-			"                             │           │   │       │   └─ Subquery\n" +
-			"                             │           │   │       │       ├─ cacheable: true\n" +
-			"                             │           │   │       │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
-			"                             │           │   │       │       └─ Project\n" +
-			"                             │           │   │       │           ├─ columns: [aac.id:12!null]\n" +
-			"                             │           │   │       │           └─ Filter\n" +
-			"                             │           │   │       │               ├─ Eq\n" +
-			"                             │           │   │       │               │   ├─ aac.BTXC5:13\n" +
-			"                             │           │   │       │               │   └─ WT (longtext)\n" +
-			"                             │           │   │       │               └─ TableAlias(aac)\n" +
-			"                             │           │   │       │                   └─ IndexedTableAccess(TPXBU)\n" +
-			"                             │           │   │       │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"                             │           │   │       │                       ├─ static: [{[WT, WT]}]\n" +
-			"                             │           │   │       │                       └─ columns: [id btxc5]\n" +
+			"                             │           │   │       ├─ AND\n" +
+			"                             │           │   │       │   ├─ AND\n" +
+			"                             │           │   │       │   │   ├─ Eq\n" +
+			"                             │           │   │       │   │   │   ├─ ct.M22QN:3!null\n" +
+			"                             │           │   │       │   │   │   └─ Subquery\n" +
+			"                             │           │   │       │   │   │       ├─ cacheable: true\n" +
+			"                             │           │   │       │   │   │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
+			"                             │           │   │       │   │   │       └─ Project\n" +
+			"                             │           │   │       │   │   │           ├─ columns: [aac.id:12!null]\n" +
+			"                             │           │   │       │   │   │           └─ Filter\n" +
+			"                             │           │   │       │   │   │               ├─ Eq\n" +
+			"                             │           │   │       │   │   │               │   ├─ aac.BTXC5:13\n" +
+			"                             │           │   │       │   │   │               │   └─ WT (longtext)\n" +
+			"                             │           │   │       │   │   │               └─ TableAlias(aac)\n" +
+			"                             │           │   │       │   │   │                   └─ IndexedTableAccess(TPXBU)\n" +
+			"                             │           │   │       │   │   │                       ├─ index: [TPXBU.BTXC5]\n" +
+			"                             │           │   │       │   │   │                       ├─ static: [{[WT, WT]}]\n" +
+			"                             │           │   │       │   │   │                       └─ columns: [id btxc5]\n" +
+			"                             │           │   │       │   │   └─ Eq\n" +
+			"                             │           │   │       │   │       ├─ ct.ZRV3B:10!null\n" +
+			"                             │           │   │       │   │       └─ = (longtext)\n" +
+			"                             │           │   │       │   └─ Eq\n" +
+			"                             │           │   │       │       ├─ ct.ZRV3B:10!null\n" +
+			"                             │           │   │       │       └─ = (longtext)\n" +
 			"                             │           │   │       └─ TableAlias(ct)\n" +
 			"                             │           │   │           └─ IndexedTableAccess(FLQLP)\n" +
 			"                             │           │   │               ├─ index: [FLQLP.FZ2R5]\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25,6 +25,23 @@ type QueryPlanTest struct {
 // in testgen_test.go.
 var PlanTests = []QueryPlanTest{
 	{
+		Query: `select * from xy join uv on (x = u and u  > 0) where u < 2`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [xy.x:2!null, xy.y:3, uv.u:0!null, uv.v:1]\n" +
+			" └─ LookupJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ xy.x:2!null\n" +
+			"     │   └─ uv.u:0!null\n" +
+			"     ├─ IndexedTableAccess(uv)\n" +
+			"     │   ├─ index: [uv.u]\n" +
+			"     │   ├─ static: [{(0, 2)}]\n" +
+			"     │   └─ columns: [u v]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
+			"         ├─ index: [xy.x]\n" +
+			"         └─ columns: [x y]\n" +
+			"",
+	},
+	{
 		Query: `
 select
   case when x is null then 0


### PR DESCRIPTION
We make a hard assumption during join planning that there are no errant filters in the join tree. Every filter is either a join edge, or sitting on its relation. When this is not true, the memo can generate a transitive edge between two relations that loses track of the original filter. The process for triggering this bug is 1) filter in an ON condition gets moved to the middle of the tree, 2) the filter fails to get pushed to its join edge/relation, 3) we generate a transitive join edge that loses track of that filter, and then 4) we choose the transitive join edge in costing.

You'll see the filter restored in the integration query plans in the PR. I added a minimal repro with the appropriate ON conditions and forced a transitive edge that drops the filter if pushdown regresses in the future.