### PR TITLE
UNIX_TIMESTAMP() respects session time zone

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1890,10 +1890,10 @@ var ScriptTests = []ScriptTest{
 				Query: `SELECT UNIX_TIMESTAMP(time) DIV 60 * 60 AS "time", avg(value) AS "value"
 				FROM test GROUP BY 1 ORDER BY UNIX_TIMESTAMP(test.time) DIV 60 * 60`,
 				Expected: []sql.Row{
-					{int64(1625158800), 4.0},
-					{int64(1625245200), 3.0},
-					{int64(1625331600), 2.0},
-					{int64(1625418000), 1.0},
+					{int64(1625133600), 4.0},
+					{int64(1625220000), 3.0},
+					{int64(1625306400), 2.0},
+					{int64(1625392800), 1.0},
 				},
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1890,10 +1890,10 @@ var ScriptTests = []ScriptTest{
 				Query: `SELECT UNIX_TIMESTAMP(time) DIV 60 * 60 AS "time", avg(value) AS "value"
 				FROM test GROUP BY 1 ORDER BY UNIX_TIMESTAMP(test.time) DIV 60 * 60`,
 				Expected: []sql.Row{
-					{int64(1625133600), 4.0},
-					{int64(1625220000), 3.0},
-					{int64(1625306400), 2.0},
-					{int64(1625392800), 1.0},
+					{int64(1625158800), 4.0},
+					{int64(1625245200), 3.0},
+					{int64(1625331600), 2.0},
+					{int64(1625418000), 1.0},
 				},
 			},
 		},
@@ -3706,6 +3706,39 @@ var ScriptTests = []ScriptTest{
 					"  `vAL3` int,\n" +
 					"  PRIMARY KEY (`iD`)\n" +
 					") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+		},
+	},
+	{
+		Name: "UNIX_TIMESTAMP function usage with session different time zones",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SET time_zone = '+07:00';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    "SELECT UNIX_TIMESTAMP('2023-09-25 07:02:57');",
+				Expected: []sql.Row{{float64(1695600177)}},
+			},
+			{
+				Query:    "SELECT UNIX_TIMESTAMP(CONVERT_TZ('2023-09-25 07:02:57', '+00:00', @@session.time_zone));",
+				Expected: []sql.Row{{float64(1695625377)}},
+			},
+			{
+				Query:    "SET time_zone = '+00:00';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    "SELECT UNIX_TIMESTAMP('2023-09-25 07:02:57');",
+				Expected: []sql.Row{{float64(1695625377)}},
+			},
+			{
+				Query:    "SET time_zone = '-06:00';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    "SELECT UNIX_TIMESTAMP('2023-09-25 07:02:57');",
+				Expected: []sql.Row{{float64(1695646977)}},
 			},
 		},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5068,4 +5068,25 @@ var BrokenScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "TIMESTAMP type value should be converted from session TZ to UTC TZ to be stored",
+		SetUpScript: []string{
+			"CREATE TABLE timezone_test (ts TIMESTAMP, dt DATETIME)",
+			"INSERT INTO timezone_test VALUES ('2023-02-14 08:47', '2023-02-14 08:47');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SET SESSION time_zone = '-05:00';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query:    "SELECT DATE_FORMAT(ts, '%H:%i:%s'), DATE_FORMAT(dt, '%H:%i:%s') from timezone_test;",
+				Expected: []sql.Row{{"11:47:00", "08:47:00"}},
+			},
+			{
+				Query:    "SELECT UNIX_TIMESTAMP(ts), UNIX_TIMESTAMP(dt) from timezone_test;",
+				Expected: []sql.Row{{float64(1676393220), float64(1676382420)}},
+			},
+		},
+	},
 }

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -65,6 +65,14 @@ func SystemTimezoneOffset() string {
 	return SecondsToMySQLOffset(offset)
 }
 
+// SystemTimezoneName returns the current system timezone name.
+func SystemTimezoneName() string {
+	t := time.Now()
+	name, _ := t.Zone()
+
+	return name
+}
+
 // SecondsToMySQLOffset takes in a timezone offset in seconds (as returned by time.Time.Zone()) and returns it as a
 // MySQL timezone offset (e.g. "+01:00").
 func SecondsToMySQLOffset(offset int) string {

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -446,6 +447,23 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 		// a warning to match MySQL's behavior
 		ctx.Warn(1292, "Incorrect datetime value: %s", ut.Date.String())
 		return 0, nil
+	}
+
+	// The function above returns the time value in UTC time zone.
+	// Instead, it should use the current session time zone.
+
+	// For example, if the current session TZ is set to +07:00 and given value is '2023-09-25 07:02:57',
+	// then the correct time value is '2023-09-25 07:02:57 +07:00'.
+	// Currently, we get '2023-09-25 07:02:57 +00:00' from the above function.
+	// ConvertTimeZone function is used to get the value in +07:00 TZ
+	// It will return the correct value of '2023-09-25 00:02:57 +00:00',
+	// which is equivalent of '2023-09-25 07:02:57 +07:00'.
+	stz, err := SessionTimeZone(ctx)
+	if err == nil {
+		tt, ok := gmstime.ConvertTimeZone(date.(time.Time), stz, "UTC")
+		if ok {
+			date = tt
+		}
 	}
 
 	return toUnixTimestamp(date.(time.Time))

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -459,11 +459,13 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 	// It will return the correct value of '2023-09-25 00:02:57 +00:00',
 	// which is equivalent of '2023-09-25 07:02:57 +07:00'.
 	stz, err := SessionTimeZone(ctx)
-	if err == nil {
-		tt, ok := gmstime.ConvertTimeZone(date.(time.Time), stz, "UTC")
-		if ok {
-			date = tt
-		}
+	if err != nil {
+		return nil, err
+	}
+
+	ctz, ok := gmstime.ConvertTimeZone(date.(time.Time), stz, "UTC")
+	if ok {
+		date = ctz
 	}
 
 	return toUnixTimestamp(date.(time.Time))

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -940,7 +940,7 @@ func (n *Now) Eval(ctx *sql.Context, _ sql.Row) (interface{}, error) {
 		s += subSecondPrecision(t, *n.precision)
 	}*/
 
-	sessionTimeZone, err := sessionTimeZone(ctx)
+	sessionTimeZone, err := SessionTimeZone(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -961,9 +961,9 @@ func (n *Now) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return NewNow(children...)
 }
 
-// sessionTimeZone returns a MySQL timezone offset string for the value of @@session_time_zone. If the session
+// SessionTimeZone returns a MySQL timezone offset string for the value of @@session_time_zone. If the session
 // timezone is set to SYSTEM, then the system timezone offset is calculated and returned.
-func sessionTimeZone(ctx *sql.Context) (string, error) {
+func SessionTimeZone(ctx *sql.Context) (string, error) {
 	sessionTimeZoneVar, err := ctx.GetSessionVariable(ctx, "time_zone")
 	if err != nil {
 		return "", err

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -2502,7 +2503,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("system_time_zone"),
-		Default:           "UTC",
+		Default:           gmstime.SystemTimezoneName(),
 	},
 	"table_definition_cache": {
 		Name:              "table_definition_cache",


### PR DESCRIPTION
- For `UNIX_TIMESTAMP()` function, it converts the time value to be in the current session TZ instead of UTC TZ before returning the final value because the initial value is parsed as in UTC TZ, which is incorrect.
- The default value of `system_time_zone` global variable will be set to the system TZ instead of `UTC`.