### PR TITLE
fix `order by` on unioned schemas

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -96,12 +96,19 @@ type ScriptTestAssertion struct {
 // the tests.
 var ScriptTests = []ScriptTest{
 	{
-		Name: "union schema merge",
+		Name: "set op schema merge",
 		SetUpScript: []string{
 			"create table `left` (i int primary key, j mediumint, k varchar(20));",
 			"create table `right` (i int primary key, j bigint, k text);",
 			"insert into `left` values (1,2, 'a')",
 			"insert into `right` values (3,4, 'b')",
+
+			"create table t1 (i int);",
+			"insert into t1 values (1), (2), (3);",
+			"create table t2 (i int);",
+			"insert into t2 values (1), (3);",
+			"create table t3 (j int);",
+			"insert into t3 values (1), (3);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -133,9 +140,151 @@ var ScriptTests = []ScriptTest{
 				Expected: []sql.Row{{1, "a"}, {3, "b"}},
 			},
 			{
+				Query: "select i, j, k from `left` union select i, j, k from `right`",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "i",
+						Type: types.Int32,
+					},
+					{
+						Name: "j",
+						Type: types.Int64,
+					},
+					{
+						Name: "k",
+						Type: types.LongText,
+					},
+				},
+				Expected: []sql.Row{{1, 2, "a"}, {3, 4, "b"}},
+			},
+			{
 				Query:       "select i, k from `left` union select i, j, k from `right`",
 				ExpectedErr: planbuilder.ErrUnionSchemasDifferentLength,
 			},
+			{
+				Query:    "table t1 union table t2 order by i;",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "i",
+						Type: types.Int32,
+					},
+				},
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query:    "table t1 union table t2 order by i;",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "i",
+						Type: types.Int32,
+					},
+				},
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query:    "table t3 union table t1 order by j;",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "j",
+						Type: types.Int32,
+					},
+				},
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query:    "select j as i from t3 union table t1 order by i;",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "i",
+						Type: types.Int32,
+					},
+				},
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query:    "table t1 union table t2 order by 1;",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "i",
+						Type: types.Int32,
+					},
+				},
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query:    "table t1 union table t3 order by 1;",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "i",
+						Type: types.Int32,
+					},
+				},
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				// This looks wrong, but it actually matches MySQL
+				Query:    "table t1 union select i as j from t2 order by i;",
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "i",
+						Type: types.Int32,
+					},
+				},
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query:    "table t1 union table t3 order by j;",
+				ExpectedErr: sql.ErrColumnNotFound,
+			},
+			{
+				Query:    "table t1 union table t2 order by t1.i;",
+				ExpectedErr: planbuilder.ErrQualifiedOrderBy,
+			},
+			{
+				Query:    "table t1 union table t2 order by t2.i;",
+				ExpectedErr: planbuilder.ErrQualifiedOrderBy,
+			},
+			{
+				Query:    "table t1 union table t3 order by t3.i;",
+				ExpectedErr: planbuilder.ErrQualifiedOrderBy,
+			},
+			{
+				Query:    "table t1 union table t3 order by t3.j;",
+				ExpectedErr: planbuilder.ErrQualifiedOrderBy,
+			},
+			{
+				Query:    "table t1 union table t3 order by t1.j;",
+				ExpectedErr: planbuilder.ErrQualifiedOrderBy,
+			},
+
 		},
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -155,6 +155,10 @@ var ScriptTests = []ScriptTest{
 			"insert into l values (1), (1), (1);",
 			"create table r (i int);",
 			"insert into r values (1);",
+			"create table x (i int);",
+			"insert into x values (1), (2), (3);",
+			"create table y (i bigint);",
+			"insert into y values (1), (3);",
 		},
 		Assertions: []ScriptTestAssertion{
 			// Intersect tests
@@ -199,20 +203,26 @@ var ScriptTests = []ScriptTest{
 				},
 			},
 			{
-				// Resulting type is string for some reason
-				Skip:  true,
-				Query: "table t1 intersect table t2;",
+				Query: "table x intersect table y order by i;",
 				Expected: []sql.Row{
 					{1},
 					{3},
 				},
 			},
 			{
-				// Field indexing error
-				Skip:  true,
-				Query: "table t1 intersect table t2 order by i;",
+				Query: "table x intersect table y order by 1;",
 				Expected: []sql.Row{
-					{1.0},
+					{1},
+					{3},
+				},
+			},
+			{
+				// Resulting type is string for some reason
+				Skip:  true,
+				Query: "table t1 intersect table t2;",
+				Expected: []sql.Row{
+					{1},
+					{3},
 				},
 			},
 
@@ -262,11 +272,9 @@ var ScriptTests = []ScriptTest{
 				},
 			},
 			{
-				// Resulting type is string for some reason
-				Skip:  true,
-				Query: "table t1 except table t2 order by i;",
+				Query: "table x except table y order by i;",
 				Expected: []sql.Row{
-					{2.0},
+					{2},
 				},
 			},
 			{

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -110,6 +110,7 @@ func (s *idxScope) getIdx(n string) (int, bool) {
 			return i, true
 		}
 	}
+	// This should only apply to column names for set_op, where we have two different tables
 	n = unqualify(n)
 	for i := len(s.columns) - 1; i >= 0; i-- {
 		if strings.EqualFold(n, unqualify(s.columns[i])) {

--- a/sql/planbuilder/errors.go
+++ b/sql/planbuilder/errors.go
@@ -37,5 +37,7 @@ var (
 		"cannot union two queries whose schemas are different lengths; left has %d column(s) right has %d column(s).",
 	)
 
+	ErrQualifiedOrderBy = errors.NewKind("Table '%s' from one of the SELECTs cannot be used in global ORDER clause")
+
 	ErrOrderByBinding = errors.NewKind("bindings in sort clauses not supported yet")
 )

--- a/sql/planbuilder/set_op.go
+++ b/sql/planbuilder/set_op.go
@@ -73,6 +73,12 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 	limit := b.buildLimit(inScope, u.Limit)
 	offset := b.buildOffset(inScope, u.Limit)
 
+	for _, o := range u.OrderBy {
+		if expr, ok := o.Expr.(*ast.ColName); ok && len(expr.Qualifier.Name.String()) != 0 {
+			b.handleErr(ErrQualifiedOrderBy.New(expr.Qualifier.Name.String()))
+		}
+	}
+
 	// mysql errors for order by right projection
 	orderByScope := b.analyzeOrderBy(leftScope, leftScope, u.OrderBy)
 
@@ -87,7 +93,7 @@ func (b *Builder) buildSetOp(inScope *scope, u *ast.SetOp) (outScope *scope) {
 			scalar = c.scalarGf()
 		}
 		// Unions pass order bys to the top scope, where the original
-		// order by get field may not longer be accessible. Here it is
+		// order by get field may no longer be accessible. Here it is
 		// safe to assume the alias has already been computed.
 		scalar, _, _ = transform.Expr(scalar, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			switch e := e.(type) {


### PR DESCRIPTION
When unioning two `SELECT` statements that have different column types, we would get -1 during `assignExecIndexes`, resulting in a panic.

This PR fixes the issue by matching on unqualified column names when we don't have an exact match.
We don't find these matches because the second table has an unqualified alias over the column name because it is wrapping it in a convert node.