### PR TITLE
error msg for invalid reference to non-existent table or column in existing view

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3742,6 +3742,43 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Querying existing view that references non-existing table",
+		SetUpScript: []string{
+			"CREATE TABLE a(id int primary key, col1 int);",
+			"CREATE VIEW b AS SELECT * FROM a;",
+			"CREATE VIEW f AS SELECT col1 AS npk FROM a;",
+			"RENAME TABLE a TO d;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT * FROM b;",
+				ExpectedErr: sql.ErrInvalidRefInView,
+			},
+			{
+				Query:    "RENAME TABLE d TO a;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "SELECT * FROM b;",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "ALTER TABLE a RENAME COLUMN col1 TO newcol;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				// TODO: View definition should have 'SELECT *' be unwrapped to each column of the referenced table
+				Skip: true,
+				Query:    "SELECT * FROM b;",
+				ExpectedErr: sql.ErrInvalidRefInView,
+			},
+			{
+				Query:    "SELECT * FROM f;",
+				ExpectedErr: sql.ErrInvalidRefInView,
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3752,6 +3752,16 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
+				Query:       "CREATE VIEW g AS SELECT * FROM nonexistenttable;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				// TODO: ALTER VIEWs are not supported
+				Skip:        true,
+				Query:       "ALTER VIEW b AS SELECT * FROM nonexistenttable;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
 				Query:       "SELECT * FROM b;",
 				ExpectedErr: sql.ErrInvalidRefInView,
 			},
@@ -3768,7 +3778,7 @@ var ScriptTests = []ScriptTest{
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				// TODO: View definition should have 'SELECT *' be unwrapped to each column of the referenced table
+				// TODO: View definition should have 'SELECT *' be expanded to each column of the referenced table
 				Skip:        true,
 				Query:       "SELECT * FROM b;",
 				ExpectedErr: sql.ErrInvalidRefInView,

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3752,7 +3752,7 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "SELECT * FROM b;",
+				Query:       "SELECT * FROM b;",
 				ExpectedErr: sql.ErrInvalidRefInView,
 			},
 			{
@@ -3769,12 +3769,12 @@ var ScriptTests = []ScriptTest{
 			},
 			{
 				// TODO: View definition should have 'SELECT *' be unwrapped to each column of the referenced table
-				Skip: true,
-				Query:    "SELECT * FROM b;",
+				Skip:        true,
+				Query:       "SELECT * FROM b;",
 				ExpectedErr: sql.ErrInvalidRefInView,
 			},
 			{
-				Query:    "SELECT * FROM f;",
+				Query:       "SELECT * FROM f;",
 				ExpectedErr: sql.ErrInvalidRefInView,
 			},
 		},

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -50,6 +50,10 @@ var (
 	// current scope.
 	ErrTableNotFound = errors.NewKind("table not found: %s")
 
+	// ErrInvalidRefInView is returned when querying existing view that references non-existent table.
+	// Creating new view or updating existing view to reference non-existent table/view do not apply here.
+	ErrInvalidRefInView = errors.NewKind("View '%s.%s' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them")
+
 	// ErrUnknownTable is returned when the non-table name is used for table actions.
 	ErrUnknownTable = errors.NewKind("Unknown table '%s'")
 

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -751,7 +751,7 @@ func (b *Builder) resolveView(name string, database sql.Database, asOf interface
 				// TODO: Need better way to determine the view usage here.
 				//  Creating new view or updating existing view to reference non-existent table/view do not apply here.
 				//  Need to account for non-existing functions or users without appropriate privilege to the referenced table/column/function.
-				if (sql.ErrTableNotFound.Is(err) || sql.ErrColumnNotFound.Is(err)) && strings.HasPrefix(strings.ToLower(b.ctx.Query()), "select"){
+				if (sql.ErrTableNotFound.Is(err) || sql.ErrColumnNotFound.Is(err)) && strings.HasPrefix(strings.ToLower(b.ctx.Query()), "select") {
 					err = sql.ErrInvalidRefInView.New(database.Name(), name)
 				}
 				b.handleErr(err)

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -748,6 +748,12 @@ func (b *Builder) resolveView(name string, database sql.Database, asOf interface
 			b.parserOpts = sql.NewSqlModeFromString(viewDef.SqlMode).ParserOptions()
 			node, _, _, err := b.Parse(viewDef.TextDefinition, false)
 			if err != nil {
+				// TODO: Need better way to determine the view usage here.
+				//  Creating new view or updating existing view to reference non-existent table/view do not apply here.
+				//  Need to account for non-existing functions or users without appropriate privilege to the referenced table/column/function.
+				if (sql.ErrTableNotFound.Is(err) || sql.ErrColumnNotFound.Is(err)) && strings.HasPrefix(strings.ToLower(b.ctx.Query()), "select"){
+					err = sql.ErrInvalidRefInView.New(database.Name(), name)
+				}
 				b.handleErr(err)
 			}
 			view = plan.NewSubqueryAlias(name, viewDef.TextDefinition, node).AsView(viewDef.CreateViewStatement)

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -751,12 +751,8 @@ func (b *Builder) resolveView(name string, database sql.Database, asOf interface
 				// TODO: Need to account for non-existing functions or
 				//  users without appropriate privilege to the referenced table/column/function.
 				if sql.ErrTableNotFound.Is(err) || sql.ErrColumnNotFound.Is(err) {
-					vd, exists, _ := vdb.GetViewDefinition(b.ctx, name)
-					// whether the view exists will eliminate CREATE VIEW stmts
-					// whether the view TextDefinition matches will eliminate ALTER VIEW stmts
-					if exists && vd.TextDefinition == viewDef.TextDefinition {
-						err = sql.ErrInvalidRefInView.New(database.Name(), name)
-					}
+					// TODO: ALTER VIEW should not return this error
+					err = sql.ErrInvalidRefInView.New(database.Name(), name)
 				}
 				b.handleErr(err)
 			}


### PR DESCRIPTION
It catches invalid reference to non-existent table or column in existing view. This includes `SELECT` queries on a view that references table or column that was removed or renamed. 

Note: For now, It does not catch references to invalid functions or users without appropriate privilege cases and queries other than `SELECT` queries.

Fixes: https://github.com/dolthub/dolt/issues/6691