### PR TITLE
[no-release-notes] set session time zone to UTC for tests that use unix_timestamp function

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -57,7 +57,6 @@ func TestQueries(t *testing.T, harness Harness) {
 	e := mustNewEngine(t, harness)
 	defer e.Close()
 	ctx := NewContext(harness)
-	RunQuery(t, e, harness, "SET @@SESSION.time_zone = 'UTC';")
 	for _, tt := range queries.QueryTests {
 		t.Run(tt.Query, func(t *testing.T) {
 			if sh, ok := harness.(SkippingHarness); ok {
@@ -334,8 +333,6 @@ func TestReadOnlyDatabases(t *testing.T, harness ReadOnlyDatabaseHarness) {
 	engine := mustNewEngine(t, harness)
 	engine, err := harness.NewReadOnlyEngine(engine.EngineAnalyzer().Catalog.Provider)
 	require.NoError(t, err)
-
-	RunQuery(t, engine, harness, "SET @@SESSION.time_zone = 'UTC';")
 
 	for _, querySet := range [][]queries.QueryTest{
 		queries.QueryTests,

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -57,6 +57,7 @@ func TestQueries(t *testing.T, harness Harness) {
 	e := mustNewEngine(t, harness)
 	defer e.Close()
 	ctx := NewContext(harness)
+	RunQuery(t, e, harness, "SET @@SESSION.time_zone = 'UTC';")
 	for _, tt := range queries.QueryTests {
 		t.Run(tt.Query, func(t *testing.T) {
 			if sh, ok := harness.(SkippingHarness); ok {
@@ -333,6 +334,8 @@ func TestReadOnlyDatabases(t *testing.T, harness ReadOnlyDatabaseHarness) {
 	engine := mustNewEngine(t, harness)
 	engine, err := harness.NewReadOnlyEngine(engine.EngineAnalyzer().Catalog.Provider)
 	require.NoError(t, err)
+
+	RunQuery(t, engine, harness, "SET @@SESSION.time_zone = 'UTC';")
 
 	for _, querySet := range [][]queries.QueryTest{
 		queries.QueryTests,

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3356,14 +3356,6 @@ Select * from (
 		Expected: []sql.Row{{1}, {2}},
 	},
 	{
-		Query: "SELECT unix_timestamp(timestamp_col) div 60 * 60 as timestamp_col, avg(i) from datetime_table group by 1 order by unix_timestamp(timestamp_col) div 60 * 60",
-		Expected: []sql.Row{
-			{int64(1577966400), 1.0},
-			{int64(1578225600), 2.0},
-			{int64(1578398400), 3.0}},
-		SkipPrepared: true,
-	},
-	{
 		Query:    "SELECT COUNT(*) FROM mytable;",
 		Expected: []sql.Row{{int64(3)}},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2026,7 +2026,6 @@ var ScriptTests = []ScriptTest{
 	{
 		Name: "Issue #499", // https://github.com/dolthub/go-mysql-server/issues/499
 		SetUpScript: []string{
-			"SET @@SESSION.time_zone = 'UTC';",
 			"CREATE TABLE test (time TIMESTAMP, value DOUBLE);",
 			`INSERT INTO test VALUES 
 			("2021-07-04 10:00:00", 1.0),

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2026,6 +2026,7 @@ var ScriptTests = []ScriptTest{
 	{
 		Name: "Issue #499", // https://github.com/dolthub/go-mysql-server/issues/499
 		SetUpScript: []string{
+			"SET @@SESSION.time_zone = 'UTC';",
 			"CREATE TABLE test (time TIMESTAMP, value DOUBLE);",
 			`INSERT INTO test VALUES 
 			("2021-07-04 10:00:00", 1.0),


### PR DESCRIPTION
the github jobs run in UTC TZ system, which causes tests that use `UNIX_TIMESTAMP` function to fail locally as the TZ is different. Therefore, we are explicitly setting the session time zone to 'UTC' for those test.