### PR TITLE
Don't reorder joins that are too large to efficiently analyze.

### DIFF
--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -148,6 +148,12 @@ func NewJoinOrderBuilder(memo *Memo) *joinOrderBuilder {
 
 func (j *joinOrderBuilder) ReorderJoin(n sql.Node) {
 	j.populateSubgraph(n)
+	// `joinOrderBuilder.dbSube` currently computes every possible pair of relations-sets to see if they match an edge
+	// in the graph. This requires O(4^N) runtime on the number of relations and thus does not scale for large joins.
+	// If the number of relations is above a threshold, we won't attempt to reorder.
+	if len(j.vertices) > 20 {
+		return
+	}
 	j.ensureClosure(j.m.root)
 	j.dbSube()
 }


### PR DESCRIPTION
The current implementation of the join order builder scales poorly if there are too many joins. It's likely possible to improve it, but in the meantime, I'm disabling join reordering on joins that have too many tables (currently defined to be more than 20.)

In these situations, the analyzer takes longer to run the reordering than it does to actually execute any of our test cases, so running the analysis in this case can only slow us down.

I expect this is unlikely to adversely affect users because joins this large are rare, and when they do occur they are often written in a way that the explicit order is good enough. 

For example, this test from sqllogictests:

```
SELECT x63,x53,x62,x52,x11,x5,x40,x64,x27,x28,x21,x41,x22,x30,x16,x14,x56,x32,x46,x50,x1,x34   FROM t46,t34,t1,t32,t53,t21,t63,t11,t30,t62,t27,t50,t16,t64,t40,t56,t22,t28,t52,t5,t41,t14  WHERE a21=b5    AND b30=a52    AND a62=b46    AND a14=3    AND b52=a28    AND b53=a14    AND a63=b28    AND b40=a56    AND a11=b64    AND a53=b22    AND b1=a34    AND b32=a41    AND a50=b63    AND a64=b62    AND b11=a30    AND b27=a40    AND a22=b56    AND b21=a46    AND a1=b50    AND b34=a16    AND a27=b16  AND a5=b41;
```

takes 30 minutes to reorder, and 15 seconds to run when reordering is disabled.

MySQL runs the query in under a second, demonstrating that reordering can still massively improve performance if we can make the algorithm more efficient. But this is a good stopgap measure.