### PR TITLE
Fix binding of time.Time via driver

### DIFF
--- a/driver/e2e_test.go
+++ b/driver/e2e_test.go
@@ -13,6 +13,7 @@ import (
 func TestQuery(t *testing.T) {
 	mtb, records := personMemTable("db", "person")
 	db := sqlOpen(t, mtb, t.Name()+"?jsonAs=object")
+	now := time.Now()
 
 	var id uint64
 	var name, email string
@@ -32,7 +33,7 @@ func TestQuery(t *testing.T) {
 		{"Select Name", "SELECT name FROM db.person", nil, []any{&name}, records.Columns(1)},
 		{"Select Count", "SELECT COUNT(1) FROM db.person", nil, []any{&count}, Records{{len(records)}}},
 
-		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', NOW())`, nil, []any{}, Records{}},
+		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', ?)`, []any{now}, []any{}, Records{}},
 		{"Select Inserted", "SELECT name, email, phone_numbers FROM db.person WHERE name = 'foo'", nil, []any{&name, &email, &numbers}, Records{{"foo", "bar", []any{"baz"}}}},
 
 		{"Update", "UPDATE db.person SET name = 'asdf' WHERE name = 'foo'", nil, []any{}, Records{}},

--- a/driver/e2e_test.go
+++ b/driver/e2e_test.go
@@ -33,13 +33,14 @@ func TestQuery(t *testing.T) {
 		{"Select Name", "SELECT name FROM db.person", nil, []any{&name}, records.Columns(1)},
 		{"Select Count", "SELECT COUNT(1) FROM db.person", nil, []any{&count}, Records{{len(records)}}},
 
-		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', ?)`, []any{now}, []any{}, Records{}},
+		{"Insert", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', NOW())`, nil, []any{}, Records{}},
 		{"Select Inserted", "SELECT name, email, phone_numbers FROM db.person WHERE name = 'foo'", nil, []any{&name, &email, &numbers}, Records{{"foo", "bar", []any{"baz"}}}},
 
 		{"Update", "UPDATE db.person SET name = 'asdf' WHERE name = 'foo'", nil, []any{}, Records{}},
 		{"Delete", "DELETE FROM db.person WHERE name = 'asdf'", nil, []any{}, Records{}},
 
 		{"Select Binary Args", `SELECT ?`, []any{[]byte{1, 2, 3}}, []any{&blob}, Records{{[]byte{1, 2, 3}}}},
+		{"Insert With time.Time", `INSERT INTO db.person (name, email, phone_numbers, created_at) VALUES ('foo', 'bar', '["baz"]', ?)`, []any{now}, []any{}, Records{}},
 	}
 
 	for _, c := range cases {

--- a/driver/value.go
+++ b/driver/value.go
@@ -98,7 +98,11 @@ func namedValuesToBindings(v []driver.NamedValue) (map[string]*querypb.BindVaria
 			name = "v" + strconv.FormatInt(int64(v.Ordinal), 10)
 		}
 
-		b[name], err = sqltypes.BuildBindVariable(v.Value)
+		val := v.Value
+		if t, ok := val.(time.Time); ok {
+			val = t.Format(time.RFC3339Nano)
+		}
+		b[name], err = sqltypes.BuildBindVariable(val)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When using the driver in v0.17.0, an error occurs when binding a variable of type time.Time as a query parameter.
The error message looks like this:

```
type time.Time not supported as bind var: 2023-10-01 17:37:49.382855116 +0900 JST m=+0.017340108
```

This issue did not occur in v0.16.0.

While it's possible to resolve this by modifying sqltypes.BuildBindVariable() in vitess,
this PR resolves it within the driver itself by converting the variable into a timestamp literal string.
