### PR TITLE
Trigger view errors don't prevent writes on database with preexisting trigger views

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3636,7 +3636,7 @@ var ScriptTests = []ScriptTest{
 			},
 			{
 				Query:       "alter table v1 rename to view1",
-				ExpectedErr: sql.ErrNotBaseTable,
+				ExpectedErr: sql.ErrExpectedTableFoundView,
 			},
 			{
 				Query:    "show tables;",

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3145,6 +3145,6 @@ var TriggerErrorTests = []ScriptTest{
 			"create view v as select * from x",
 		},
 		Query:       "create trigger trig before insert on v for each row set b = 1",
-		ExpectedErr: sql.ErrNotBaseTable,
+		ExpectedErr: sql.ErrExpectedTableFoundView,
 	},
 }

--- a/memory/database.go
+++ b/memory/database.go
@@ -324,18 +324,18 @@ func (d *BaseDatabase) RenameTable(ctx *sql.Context, oldName, newName string) er
 	return nil
 }
 
-func (d *BaseDatabase) GetTriggers(ctx *sql.Context) ([]sql.TriggerDefinition, error) {
+func (d *BaseDatabase) GetTriggers(_ *sql.Context) ([]sql.TriggerDefinition, error) {
 	var triggers []sql.TriggerDefinition
 	triggers = append(triggers, d.triggers...)
 	return triggers, nil
 }
 
-func (d *BaseDatabase) CreateTrigger(ctx *sql.Context, definition sql.TriggerDefinition) error {
+func (d *BaseDatabase) CreateTrigger(_ *sql.Context, definition sql.TriggerDefinition) error {
 	d.triggers = append(d.triggers, definition)
 	return nil
 }
 
-func (d *BaseDatabase) DropTrigger(ctx *sql.Context, name string) error {
+func (d *BaseDatabase) DropTrigger(_ *sql.Context, name string) error {
 	found := false
 	for i, trigger := range d.triggers {
 		if trigger.Name == name {

--- a/sql/analyzer/triggers.go
+++ b/sql/analyzer/triggers.go
@@ -204,7 +204,12 @@ func applyTriggers(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope,
 				return nil, transform.SameTree, sql.ErrTriggerCreateStatementInvalid.New(trigger.CreateStatement)
 			}
 
-			triggerTable := getTableName(ct.Table)
+			var triggerTable string
+			switch t := ct.Table.(type) {
+			case *plan.ResolvedTable:
+				triggerTable = t.Name()
+			default:
+			}
 			if stringContains(affectedTables, triggerTable) && triggerEventsMatch(triggerEvent, ct.TriggerEvent) {
 				// first pass allows unresolved before we know whether trigger is relevant
 				// TODO store destination table name with trigger, so we don't have to do parse twice

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -565,8 +565,8 @@ var (
 	// ErrViewsNotSupported is returned when attempting to access a view on a database that doesn't support them.
 	ErrViewsNotSupported = errors.NewKind("database '%s' doesn't support views")
 
-	// ErrNotBaseTable is returned when attempting to rename a view using ALTER TABLE statement.
-	ErrNotBaseTable = errors.NewKind("'%s' is not BASE TABLE")
+	// ErrExpectedTableFoundView is returned when attempting to rename a view using ALTER TABLE statement.
+	ErrExpectedTableFoundView = errors.NewKind("expected a table and found view: '%s' ")
 
 	// ErrExistingView is returned when a CREATE VIEW statement uses a name that already exists
 	ErrExistingView = errors.NewKind("the view %s.%s already exists")

--- a/sql/plan/alter_table.go
+++ b/sql/plan/alter_table.go
@@ -176,7 +176,7 @@ func (r *RenameTable) renameView(ctx *sql.Context, viewDb sql.ViewDatabase, vr *
 		}
 
 		if r.alterTblDef {
-			return false, sql.ErrNotBaseTable.New(fmt.Sprintf("'%s.%s'", r.Db.Name(), oldName))
+			return false, sql.ErrExpectedTableFoundView.New(fmt.Sprintf("'%s.%s'", r.Db.Name(), oldName))
 		}
 
 		err = viewDb.DropView(ctx, oldName)
@@ -197,7 +197,7 @@ func (r *RenameTable) renameView(ctx *sql.Context, viewDb sql.ViewDatabase, vr *
 		}
 
 		if r.alterTblDef {
-			return false, sql.ErrNotBaseTable.New(fmt.Sprintf("'%s.%s'", r.Db.Name(), oldName))
+			return false, sql.ErrExpectedTableFoundView.New(fmt.Sprintf("'%s.%s'", r.Db.Name(), oldName))
 		}
 
 		err := vr.Delete(r.Db.Name(), oldName)


### PR DESCRIPTION
PR https://github.com/dolthub/go-mysql-server/pull/2034 made it so that we can not DDL triggers on views. But past versions of Dolt permitted creating those triggers. After this change, databases with a trigger view will be have all writes blocked with the trigger view error. We should probably not try to parse and bind all triggers for every write, but as long as we do this adds a warning rather than an error for a non-DDL trigger parse.