### PR TITLE
Set column defaults with explicit DEFAULT keyword

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1312,6 +1312,14 @@ var InsertScripts = []ScriptTest{
 				Expected: []sql.Row{{2}, {2}, {4}},
 			},
 			{
+				Query:    "INSERT INTO t3 (a, b) VALUES (5, DEFAULT)",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1}}},
+			},
+			{
+				Query:    "SELECT b FROM t3 ORDER BY b ASC",
+				Expected: []sql.Row{{2}, {2}, {4}, {10}},
+			},
+			{
 				Query:    "INSERT INTO T4 (c1, c0) values (DEFAULT, NULL)",
 				Expected: []sql.Row{{types.OkResult{RowsAffected: 1}}},
 			},
@@ -2653,18 +2661,6 @@ var InsertBrokenScripts = []ScriptTest{
 					{types.OkResult{RowsAffected: 1}},
 				},
 				ExpectedWarning: mysql.ERTruncatedWrongValueForField,
-			},
-		},
-	},
-	{
-		Name: "Test explicit default with column reference",
-		SetUpScript: []string{
-			"CREATE TABLE t1 (a int default 1, b int default (a+1));",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:    "INSERT INTO t1 (a,b) values (1, DEFAULT)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1}}},
 			},
 		},
 	},

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -432,7 +432,10 @@ func fixExprToScope(e sql.Expression, scopes ...*idxScope) sql.Expression {
 	ret, _, _ := transform.Expr(e, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 		switch e := e.(type) {
 		case *expression.GetField:
-			idx, _ := newScope.getIdx(e.String())
+			idx, ok := newScope.getIdx(e.String())
+			if !ok && e.Index() != -1 {
+				return e, transform.NewTree, nil
+			}
 			return e.WithIndex(idx), transform.NewTree, nil
 		case *plan.Subquery:
 			// this |outScope| prepends the subquery scope

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -528,6 +528,10 @@ func (c scopeColumn) empty() bool {
 	return c.id == 0
 }
 
+func (c scopeColumn) ScopeColumnIdForSource() columnId {
+	return c.id - 1
+}
+
 func (c scopeColumn) withOriginal(col string) scopeColumn {
 	if c.db != sql.InformationSchemaDatabaseName {
 		// info schema columns always presented as uppercase
@@ -544,9 +548,9 @@ func (c scopeColumn) scalarGf() sql.Expression {
 		}
 	}
 	if c.originalCol != "" {
-		return expression.NewGetFieldWithTable(int(c.id), c.typ, c.table, c.originalCol, c.nullable)
+		return expression.NewGetFieldWithTable(int(c.ScopeColumnIdForSource()), c.typ, c.table, c.originalCol, c.nullable)
 	}
-	return expression.NewGetFieldWithTable(int(c.id), c.typ, c.table, c.col, c.nullable)
+	return expression.NewGetFieldWithTable(int(c.ScopeColumnIdForSource()), c.typ, c.table, c.col, c.nullable)
 }
 
 func (c scopeColumn) String() string {


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6430
There were a few things at play here:
- As far as I can see, scopeColumn is 1-indexed, rather than 0-indexed (with 0 denoting an empty column), so to make sure our index references are valid for the FieldIndex of a GetField, we need to subtract 1
- There are some cases where we've previously correctly resolved the GetField's FieldIndex, but we end up with a null scope in `getIdx`, and hence no columns to compare to - in this case, if we've already set a FieldIndex so far, use that rather than the 'not found' -1 index and erroring out. I think there was some logic akin to this in the old implementation of fixing field indexes
- In buildValues, we need a second pass to ensure defaults are set before we try to use them