### PR TITLE
For joins that are too large to brute force reordering, use a hueristic reordering instead.

### DIFF
--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -464,7 +464,7 @@ func (j *joinOrderBuilder) checkSize() {
 // adding plans to the tree when we find two sets that can
 // be joined
 func (j *joinOrderBuilder) dbSube(grp *ExprGroup) {
-	if j.forceFastReorderForTest || j.shouldUseFastReorder(grp) {
+	if j.forceFastReorderForTest || j.shouldUseFastReorder() {
 		j.fastReorder()
 		return
 	}
@@ -489,10 +489,8 @@ func (j *joinOrderBuilder) dbSube(grp *ExprGroup) {
 // We do this because `joinOrderBuilder.dbSube` currently computes every possible pair of relations-sets to see if they
 // match an edge in the graph. This requires O(4^N) runtime on the number of relations and thus does not scale
 // for large joins. Thus, if the number of relations is above a threshold, we won't attempt to reorder.
-func (j *joinOrderBuilder) shouldUseFastReorder(grp *ExprGroup) bool {
-	fds := grp.RelProps.FuncDeps()
-	_, hasStrictKey := fds.StrictKey()
-	return hasStrictKey && len(j.vertices) > 20
+func (j *joinOrderBuilder) shouldUseFastReorder() bool {
+	return len(j.vertices) > 20
 }
 
 // fastReorder is an alternate implementation of dbSube that is optimized for joins on a large number of tables.

--- a/sql/memo/join_order_builder_test.go
+++ b/sql/memo/join_order_builder_test.go
@@ -715,14 +715,17 @@ func TestEnsureClosure(t *testing.T) {
 	}
 }
 
-var childSchema = sql.NewPrimaryKeySchema(sql.Schema{
-	{Name: "x", Type: types.Int64, Nullable: true},
-	{Name: "y", Type: types.Text, Nullable: true},
-	{Name: "z", Type: types.Int64, Nullable: true},
-}, 0)
+func childSchema(source string) sql.PrimaryKeySchema {
+	return sql.NewPrimaryKeySchema(sql.Schema{
+		{Name: "x", Source: source, Type: types.Int64, Nullable: false},
+		{Name: "y", Source: source, Type: types.Text, Nullable: true},
+		{Name: "z", Source: source, Type: types.Int64, Nullable: true},
+	}, 0)
+}
 
 func tableNode(db *memory.Database, name string) sql.Node {
-	t := memory.NewTable(db, name, childSchema, nil)
+	t := memory.NewTable(db, name, childSchema(name), nil)
+	t.EnablePrimaryKeyIndexes()
 	return plan.NewResolvedTable(t, nil, nil)
 }
 

--- a/sql/memo/memo.go
+++ b/sql/memo/memo.go
@@ -656,28 +656,39 @@ func (m *Memo) String() string {
 			r = r.Next()
 		}
 	}
+	maxId := 0
 	for len(groups) > 0 {
 		newGroups := make([]*ExprGroup, 0)
 		for _, g := range groups {
-			if exprs[int(TableIdForSource(g.Id))] != "" {
+			id := int(TableIdForSource(g.Id))
+			if exprs[id] != "" {
 				continue
 			}
-			exprs[int(TableIdForSource(g.Id))] = g.String()
+			exprs[id] = g.String()
 			newGroups = append(newGroups, g.children()...)
+			if id > maxId {
+				maxId = id
+			}
 		}
 		groups = newGroups
 	}
 	for _, e := range m.exprs {
-		exprs[int(TableIdForSource(e.Id))] = e.String()
+		id := int(TableIdForSource(e.Id))
+		exprs[id] = e.String()
+		if id > maxId {
+			maxId = id
+		}
 	}
 	b := strings.Builder{}
 	b.WriteString("memo:\n")
 	beg := "├──"
 	for i, g := range exprs {
-		if i == len(exprs)-1 {
+		if i == maxId {
 			beg = "└──"
 		}
-		b.WriteString(fmt.Sprintf("%s G%d: %s\n", beg, i+1, g))
+		if g != "" {
+			b.WriteString(fmt.Sprintf("%s G%d: %s\n", beg, i+1, g))
+		}
 	}
 	return b.String()
 }


### PR DESCRIPTION
This is kind of a hack, but is a sample of the kind of heuristics we could be doing to improve join planning.

I experimented with applying this "fast reordering" more generally, not just to really big queries. I suspect in the fast majority of cases it should give us what we want. But there were some existing planning tests that generated less optimal plans (replacing a lookup join with an unoptimized join.) This could potentially be improved, but my main priority is improving the performance of the slow test queries, so in the meantime this is limited to only running on those queries (joins on 20+ tables)

This passes a bunch of previously timing out sqllogictests and doesn't break any existing tests. I can add more tests before merging.