### PR TITLE
prevent projections to be pushed past lateral joins

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -1261,7 +1261,7 @@ var LateralJoinScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    `
+				Query: `
 select name, class.class_name, grade.max_grade
 from students,
 LATERAL (

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -1292,4 +1292,24 @@ LATERAL (
 			},
 		},
 	},
+	{
+		Name: "lateral join with subquery",
+		SetUpScript: []string{
+			"create table xy (x int primary key, y int);",
+			"create table uv (u int primary key, v int);",
+			"insert into xy values (1, 0), (2, 1), (3, 2), (4, 3);",
+			"insert into uv values (0, 0), (1, 1), (2, 2), (3, 3);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select x, u from xy, lateral (select * from uv where y = u) uv;",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 1},
+					{3, 2},
+					{4, 3},
+				},
+			},
+		},
+	},
 }

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -9050,4 +9050,26 @@ WHERE keyless.c0 IN (
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
+	{
+		Query: `select x, u from xy, lateral (select * from uv where y = u) uv;`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [xy.x:0!null, uv.u:2!null]\n" +
+			" └─ LateralCrossJoin\n" +
+			"     ├─ true (tinyint(1))\n" +
+			"     ├─ Table\n" +
+			"     │   ├─ name: xy\n" +
+			"     │   └─ columns: [x y]\n" +
+			"     └─ SubqueryAlias\n" +
+			"         ├─ name: uv\n" +
+			"         ├─ outerVisibility: false\n" +
+			"         ├─ cacheable: false\n" +
+			"         └─ Filter\n" +
+			"             ├─ Eq\n" +
+			"             │   ├─ xy.y:1\n" +
+			"             │   └─ uv.u:2!null\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: uv\n" +
+			"                 └─ columns: [u v]\n" +
+			"",
+	},
 }

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -729,7 +729,7 @@ func (b *BaseBuilder) buildSetOp(ctx *sql.Context, s *plan.SetOp, row sql.Row) (
 func (b *BaseBuilder) buildSubqueryAlias(ctx *sql.Context, n *plan.SubqueryAlias, row sql.Row) (sql.RowIter, error) {
 	span, ctx := ctx.Span("plan.SubqueryAlias")
 
-	if !n.OuterScopeVisibility {
+	if !n.OuterScopeVisibility && !n.IsLateral {
 		row = nil
 	}
 	iter, err := b.buildNodeExec(ctx, n.Child, row)


### PR DESCRIPTION
`pruneTables` will pushdown projections as low as possible to avoid passing around columns that won't make it to the final result.
In the case of lateral joins, a column that isn't referenced in the topmost projection may still be referenced by subqueries, which causes problems. This PR prevents the projection pushdown optimization from applying to the children of lateral joins.

A better solution might be to determine which columns are referenced, and trim out all others. However, that seems hard.

fixes https://github.com/dolthub/dolt/issues/6741