### PR TITLE
ignore default for eraseProjection

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -192,22 +192,36 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "add new generated column",
+			// TODO: add tests using create ... from select ...
+			Name: "DELETE ME",
 			SetUpScript: []string{
-				"create table t1 (a int primary key, b int)",
-				"insert into t1 values (1,2), (2,3), (3,4)",
+				"create table t (i int primary key, j int default 0)",
 			},
 			Assertions: []queries.ScriptTestAssertion{
+				//{
+				//	Query:    "explain select * from t",
+				//	Expected: []sql.Row{},
+				//},
+				//{
+				//	Query:    "explain select j, i from t",
+				//	Expected: []sql.Row{},
+				//},
+				//{
+				//	Query:    "explain select i as ii, j as jj from t",
+				//	Expected: []sql.Row{},
+				//},
 				{
-					Query:    "alter table t1 add column c int as (a + b) stored",
-					Expected: []sql.Row{{types.NewOkResult(0)}},
+					Query:    "create table tmp (j int default 0)",
 				},
 				{
-					Query:    "select * from t1 order by a",
-					Expected: []sql.Row{{1, 2, 3}, {2, 3, 5}, {3, 4, 7}},
+					Query: "create table tt as select * from t",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "show create table tt",
+					Expected: []sql.Row{},
 				},
 			},
 		},
@@ -220,11 +234,42 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		engine.EngineAnalyzer().Debug = true
-		engine.EngineAnalyzer().Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}
+	//t.Skip()
+	//var scripts = []queries.ScriptTest{
+	//	{
+	//		Name: "add new generated column",
+	//		SetUpScript: []string{
+	//			"create table t1 (a int primary key, b int)",
+	//			"insert into t1 values (1,2), (2,3), (3,4)",
+	//		},
+	//		Assertions: []queries.ScriptTestAssertion{
+	//			{
+	//				Query:    "alter table t1 add column c int as (a + b) stored",
+	//				Expected: []sql.Row{{types.NewOkResult(0)}},
+	//			},
+	//			{
+	//				Query:    "select * from t1 order by a",
+	//				Expected: []sql.Row{{1, 2, 3}, {2, 3, 5}, {3, 4, 7}},
+	//			},
+	//		},
+	//	},
+	//}
+	//
+	//for _, test := range scripts {
+	//	harness := enginetest.NewMemoryHarness("", 1, testNumPartitions, true, nil)
+	//	harness.Setup(setup.MydbData)
+	//	engine, err := harness.NewEngine(t)
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//	engine.EngineAnalyzer().Debug = true
+	//	engine.EngineAnalyzer().Verbose = true
+	//
+	//	enginetest.TestScriptWithEngine(t, engine, harness, test)
+	//}
 }
 
 func TestUnbuildableIndex(t *testing.T) {

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -214,19 +214,19 @@ func TestSingleScript(t *testing.T) {
 					Expected: []sql.Row{},
 				},
 				{
-					Query: "create table tt as select * from t",
+					Query:    "create table tt as select * from t",
 					Expected: []sql.Row{},
 				},
 				{
-					Query: "show create table tt",
+					Query:    "show create table tt",
 					Expected: []sql.Row{},
 				},
 				{
-					Query: "create table ttt as select j, i from t",
+					Query:    "create table ttt as select j, i from t",
 					Expected: []sql.Row{},
 				},
 				{
-					Query: "show create table ttt",
+					Query:    "show create table ttt",
 					Expected: []sql.Row{},
 				},
 			},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -211,8 +211,8 @@ func TestSingleScript(t *testing.T) {
 					},
 				},
 				{
-					Skip: true,
-					Query:    "show create table t1",
+					Skip:  true,
+					Query: "show create table t1",
 					Expected: []sql.Row{
 						{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
@@ -224,8 +224,8 @@ func TestSingleScript(t *testing.T) {
 					},
 				},
 				{
-					Skip: true,
-					Query:    "show create table t2",
+					Skip:  true,
+					Query: "show create table t2",
 					Expected: []sql.Row{
 						{"t2", "CREATE TABLE `t2` (\n  `j` int DEFAULT '0',\n  `i` int NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
@@ -237,8 +237,8 @@ func TestSingleScript(t *testing.T) {
 					},
 				},
 				{
-					Skip: true,
-					Query:    "show create table t3",
+					Skip:  true,
+					Query: "show create table t3",
 					Expected: []sql.Row{
 						{"t3", "CREATE TABLE `t3` (\n  `a` int NOT NULL,\n  `b` int DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},
@@ -250,7 +250,7 @@ func TestSingleScript(t *testing.T) {
 					},
 				},
 				{
-					Query:    "show create table tt",
+					Query: "show create table tt",
 					Expected: []sql.Row{
 						{"tt", "CREATE TABLE `tt` (\n  `1` tinyint NOT NULL,\n  `2.0` decimal(2,1) NOT NULL,\n  `'3'` longtext NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 					},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -192,6 +192,7 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
 			// TODO: add tests using create ... from select ...
@@ -200,20 +201,17 @@ func TestSingleScript(t *testing.T) {
 				"create table t (i int primary key, j int default 0)",
 			},
 			Assertions: []queries.ScriptTestAssertion{
-				//{
-				//	Query:    "explain select * from t",
-				//	Expected: []sql.Row{},
-				//},
-				//{
-				//	Query:    "explain select j, i from t",
-				//	Expected: []sql.Row{},
-				//},
-				//{
-				//	Query:    "explain select i as ii, j as jj from t",
-				//	Expected: []sql.Row{},
-				//},
 				{
-					Query:    "create table tmp (j int default 0)",
+					Query:    "explain select * from t",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "explain select j, i from t",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "explain select i as ii, j as jj from t",
+					Expected: []sql.Row{},
 				},
 				{
 					Query: "create table tt as select * from t",
@@ -221,6 +219,14 @@ func TestSingleScript(t *testing.T) {
 				},
 				{
 					Query: "show create table tt",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "create table ttt as select j, i from t",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "show create table ttt",
 					Expected: []sql.Row{},
 				},
 			},

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -496,6 +496,70 @@ var CreateTableScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "create table as select with defaults",
+		SetUpScript: []string{
+			"create table t (i int primary key, j int default 0);",
+			"insert into t(i) values (1);",
+			"create table t1 as select * from t;",
+			"create table t2 as select j, i from t;",
+			"create table t3 as select i as a, j as b from t;",
+			"create table tt as select 1, 2.0, '3';",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from t1;",
+				Expected: []sql.Row{
+					{1, 0},
+				},
+			},
+			{
+				Skip: true,
+				Query:    "show create table t1",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "select * from t2;",
+				Expected: []sql.Row{
+					{0, 1},
+				},
+			},
+			{
+				Skip: true,
+				Query:    "show create table t2",
+				Expected: []sql.Row{
+					{"t2", "CREATE TABLE `t2` (\n  `j` int DEFAULT '0',\n  `i` int NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "select * from t3;",
+				Expected: []sql.Row{
+					{1, 0},
+				},
+			},
+			{
+				Skip: true,
+				Query:    "show create table t3",
+				Expected: []sql.Row{
+					{"t3", "CREATE TABLE `t3` (\n  `a` int NOT NULL,\n  `b` int DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "select * from tt;",
+				Expected: []sql.Row{
+					{1, "2.0", "3"},
+				},
+			},
+			{
+				Query:    "show create table tt",
+				Expected: []sql.Row{
+					{"tt", "CREATE TABLE `tt` (\n  `1` tinyint NOT NULL,\n  `2.0` decimal(2,1) NOT NULL,\n  `'3'` longtext NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
 }
 
 var CreateTableAutoIncrementTests = []ScriptTest{

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -514,8 +514,8 @@ var CreateTableScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Skip: true,
-				Query:    "show create table t1",
+				Skip:  true,
+				Query: "show create table t1",
 				Expected: []sql.Row{
 					{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -527,8 +527,8 @@ var CreateTableScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Skip: true,
-				Query:    "show create table t2",
+				Skip:  true,
+				Query: "show create table t2",
 				Expected: []sql.Row{
 					{"t2", "CREATE TABLE `t2` (\n  `j` int DEFAULT '0',\n  `i` int NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -540,8 +540,8 @@ var CreateTableScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Skip: true,
-				Query:    "show create table t3",
+				Skip:  true,
+				Query: "show create table t3",
 				Expected: []sql.Row{
 					{"t3", "CREATE TABLE `t3` (\n  `a` int NOT NULL,\n  `b` int DEFAULT '0'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -553,7 +553,7 @@ var CreateTableScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query:    "show create table tt",
+				Query: "show create table tt",
 				Expected: []sql.Row{
 					{"tt", "CREATE TABLE `tt` (\n  `1` tinyint NOT NULL,\n  `2.0` decimal(2,1) NOT NULL,\n  `'3'` longtext NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -9072,4 +9072,11 @@ WHERE keyless.c0 IN (
 			"                 └─ columns: [u v]\n" +
 			"",
 	},
+	{
+		Query: `select * from default_tbl`,
+		ExpectedPlan: "Table\n" +
+			" ├─ name: default_tbl\n" +
+			" └─ columns: [i j]\n" +
+			"",
+	},
 }

--- a/enginetest/scriptgen/setup/helper.go
+++ b/enginetest/scriptgen/setup/helper.go
@@ -113,5 +113,6 @@ var (
 		XyData,
 		Invert_pkData,
 		JoinData,
+		Default_tblData,
 	}
 )

--- a/enginetest/scriptgen/setup/scripts/default_tbl
+++ b/enginetest/scriptgen/setup/scripts/default_tbl
@@ -1,0 +1,7 @@
+exec
+CREATE TABLE `default_tbl` (
+  `i` int,
+  `j` int default 0,
+  PRIMARY KEY (`i`)
+)
+----

--- a/enginetest/scriptgen/setup/setup_data.sg.go
+++ b/enginetest/scriptgen/setup/setup_data.sg.go
@@ -116,6 +116,10 @@ var DatetimetableData = []SetupScript{{
 	`create index datetime_table_ts on datetime_table (timestamp_col)`,
 }}
 
+var Default_tblData = []SetupScript{{
+	"CREATE TABLE `default_tbl` (   `i` int,   `j` int default 0,   PRIMARY KEY (`i`) )",
+}}
+
 var EmptytableData = []SetupScript{{
 	`create table emptytable (i mediumint primary key, s varchar(20))`,
 }}

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -38,6 +38,7 @@ func eraseProjection(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 		if proj, ok := node.(*plan.Project); ok {
 			projSch := proj.Schema()
 			childSch := proj.Child.Schema()
+			
 			if projSch.CaseSensitiveEquals(childSch) {
 				a.Log("project erased")
 				return proj.Child, transform.NewTree, nil

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -35,10 +35,17 @@ func eraseProjection(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 	}
 
 	return transform.Node(node, func(node sql.Node) (sql.Node, transform.TreeIdentity, error) {
-		project, ok := node.(*plan.Project)
-		if ok && project.Schema().CaseSensitiveEquals(project.Child.Schema()) {
-			a.Log("project erased")
-			return project.Child, transform.NewTree, nil
+		if proj, ok := node.(*plan.Project); ok {
+			projSch := proj.Schema()
+			childSch := proj.Child.Schema().Copy()
+			// cols in projSch do not have Default, so remove them from childSch cols
+			for i := range childSch {
+				childSch[i].Default = nil
+			}
+			if projSch.CaseSensitiveEquals(childSch) {
+				a.Log("project erased")
+				return proj.Child, transform.NewTree, nil
+			}
 		}
 
 		return node, transform.SameTree, nil

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -37,11 +37,7 @@ func eraseProjection(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 	return transform.Node(node, func(node sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		if proj, ok := node.(*plan.Project); ok {
 			projSch := proj.Schema()
-			childSch := proj.Child.Schema().Copy()
-			// cols in projSch do not have Default, so remove them from childSch cols
-			for i := range childSch {
-				childSch[i].Default = nil
-			}
+			childSch := proj.Child.Schema()
 			if projSch.CaseSensitiveEquals(childSch) {
 				a.Log("project erased")
 				return proj.Child, transform.NewTree, nil

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -38,7 +38,6 @@ func eraseProjection(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 		if proj, ok := node.(*plan.Project); ok {
 			projSch := proj.Schema()
 			childSch := proj.Child.Schema()
-			
 			if projSch.CaseSensitiveEquals(childSch) {
 				a.Log("project erased")
 				return proj.Child, transform.NewTree, nil

--- a/sql/analyzer/resolve_create_select.go
+++ b/sql/analyzer/resolve_create_select.go
@@ -27,6 +27,8 @@ func resolveCreateSelect(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.
 	// We don't want to carry any information about keys, constraints, defaults, etc. from a `create table as select`
 	// statement. When the underlying select node is a table, we must remove all such info from its schema. The only
 	// exception is NOT NULL constraints, which we leave alone.
+	// TODO: we actually want to carry information about defaults, but we need to be able to evaluate them in the
+	//  context of the select query. This is a bit tricky, but we should do it.
 	selectSchema := stripSchema(analyzedSelect.Schema())
 	mergedSchema := mergeSchemas(inputSpec.Schema.Schema, selectSchema)
 	newSch := make(sql.Schema, len(mergedSchema))
@@ -61,7 +63,7 @@ func resolveCreateSelect(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.
 func stripSchema(schema sql.Schema) sql.Schema {
 	sch := schema.Copy()
 	for i := range schema {
-		sch[i].Default = nil
+		//sch[i].Default = nil
 		sch[i].Generated = nil
 		sch[i].AutoIncrement = false
 		sch[i].PrimaryKey = false

--- a/sql/analyzer/resolve_create_select.go
+++ b/sql/analyzer/resolve_create_select.go
@@ -28,7 +28,8 @@ func resolveCreateSelect(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.
 	// statement. When the underlying select node is a table, we must remove all such info from its schema. The only
 	// exception is NOT NULL constraints, which we leave alone.
 	// TODO: we actually want to carry information about defaults, but we need to be able to evaluate them in the
-	//  context of the select query. This is a bit tricky, but we should do it.
+	//  context of the select query. This has to happen after the select query is analyzed, but
+	//  resolveColumnDefaultExpression runs before that.
 	selectSchema := stripSchema(analyzedSelect.Schema())
 	mergedSchema := mergeSchemas(inputSpec.Schema.Schema, selectSchema)
 	newSch := make(sql.Schema, len(mergedSchema))
@@ -63,7 +64,7 @@ func resolveCreateSelect(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.
 func stripSchema(schema sql.Schema) sql.Schema {
 	sch := schema.Copy()
 	for i := range schema {
-		//sch[i].Default = nil
+		sch[i].Default = nil // TODO: should keep this
 		sch[i].Generated = nil
 		sch[i].AutoIncrement = false
 		sch[i].PrimaryKey = false


### PR DESCRIPTION
It seems like CaseSensitiveEquals is only used for `eraseProjection`, so it's possible to just modify the comparator instead, but I think this is a safer change.

fixes https://github.com/dolthub/dolt/issues/6396