### PR TITLE
Generate more precise Functional Dependecy keys on Joins

### DIFF
--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -406,7 +406,7 @@ func convertAntiToLeftJoin(m *memo.Memo) error {
 			p := expression.NewLiteral(1, types.Int64)
 			projectExpressions = append(projectExpressions, m.MemoizeScalar(p))
 			gf := expression.NewGetField(0, types.Int64, "1", true)
-			m.Columns[gf.String()] = sql.ColumnId(len(m.Columns) + 1)
+			m.AddColumnId(gf.Table(), gf.Name())
 			m.MemoizeScalar(gf)
 			nullify = append(nullify, gf)
 		}

--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -175,6 +175,23 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 		join := NewInnerJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 7}})
 		assert.Equal(t, "key(6); constant(1-5,7); equiv(1,7)", join.String())
 	})
+	t.Run("simplify cols on join", func(t *testing.T) {
+		// create table t1 (id int primary key, value int)
+		// create table t2 (id int primary key, value int)
+
+		// SELECT * FROM t1 JOIN t2 ON t1.value = t2.id;
+
+		t1 := &FuncDepSet{all: cols(1, 2)}
+		t1.AddNotNullable(cols(1))
+		t1.AddStrictKey(cols(1))
+
+		t2 := &FuncDepSet{all: cols(3, 4)}
+		t2.AddNotNullable(cols(3))
+		t2.AddStrictKey(cols(3))
+
+		join := NewInnerJoinFDs(t1, t2, [][2]ColumnId{{2, 3}})
+		assert.Equal(t, "key(1); equiv(2,3)", join.String())
+	})
 }
 
 func TestFuncDeps_LeftJoin(t *testing.T) {

--- a/sql/memo/memo.go
+++ b/sql/memo/memo.go
@@ -109,6 +109,11 @@ func (m *Memo) AddColumnId(table, column string) {
 	m.ColumnNames[newId] = tableAndColumn
 }
 
+func (m *Memo) GetTableAndColumn(id sql.ColumnId) (table, column string) {
+	tableAndColumn := m.ColumnNames[id]
+	return tableAndColumn.tableName, tableAndColumn.columnName
+}
+
 // TODO we need to remove this as soon as name resolution refactor is in
 func (m *Memo) assignColumnIds(rel SourceRel) {
 	if rel.Name() == "" {

--- a/sql/memo/memo.go
+++ b/sql/memo/memo.go
@@ -28,16 +28,22 @@ import (
 type GroupId uint16
 type TableId uint16
 
+type TableAndColumn struct {
+	tableName  string
+	columnName string
+}
+
 // Memo collects a forest of query plans structured by logical and
 // physical equivalency. Logically equivalent plans, represented by
 // an exprGroup, produce the same rows (possibly unordered) and schema.
 // Physical plans are stored in a linked list within an expression group.
 type Memo struct {
-	cnt     uint16
-	root    *ExprGroup
-	exprs   map[uint64]*ExprGroup
-	Columns map[string]sql.ColumnId
-	hints   *joinHints
+	cnt         uint16
+	root        *ExprGroup
+	exprs       map[uint64]*ExprGroup
+	Columns     map[TableAndColumn]sql.ColumnId
+	ColumnNames map[sql.ColumnId]TableAndColumn
+	hints       *joinHints
 
 	c        Coster
 	s        Carder
@@ -51,16 +57,17 @@ type Memo struct {
 
 func NewMemo(ctx *sql.Context, stats sql.StatsReadWriter, s *plan.Scope, scopeLen int, cost Coster, card Carder) *Memo {
 	return &Memo{
-		Ctx:        ctx,
-		c:          cost,
-		s:          card,
-		statsRw:    stats,
-		scope:      s,
-		scopeLen:   scopeLen,
-		TableProps: newTableProps(),
-		hints:      &joinHints{},
-		Columns:    make(map[string]sql.ColumnId),
-		exprs:      make(map[uint64]*ExprGroup),
+		Ctx:         ctx,
+		c:           cost,
+		s:           card,
+		statsRw:     stats,
+		scope:       s,
+		scopeLen:    scopeLen,
+		TableProps:  newTableProps(),
+		hints:       &joinHints{},
+		Columns:     make(map[TableAndColumn]sql.ColumnId),
+		ColumnNames: make(map[sql.ColumnId]TableAndColumn),
+		exprs:       make(map[uint64]*ExprGroup),
 	}
 }
 
@@ -89,19 +96,33 @@ func (m *Memo) memoizeSourceRel(rel SourceRel) *ExprGroup {
 	return grp
 }
 
+func (m *Memo) AddColumnId(table, column string) {
+	tableAndColumn := TableAndColumn{
+		tableName:  table,
+		columnName: column,
+	}
+	if m.Columns[tableAndColumn] != 0 {
+		panic("Attempted to add previously added column to Memo")
+	}
+	newId := sql.ColumnId(len(m.Columns) + 1)
+	m.Columns[tableAndColumn] = newId
+	m.ColumnNames[newId] = tableAndColumn
+}
+
 // TODO we need to remove this as soon as name resolution refactor is in
 func (m *Memo) assignColumnIds(rel SourceRel) {
 	if rel.Name() == "" {
-		m.Columns["1"] = sql.ColumnId(len(m.Columns) + 1)
+		m.AddColumnId("", "1")
 	} else {
 		for _, c := range allTableCols(rel) {
-			var name string
+			var tableName string
 			if c.Source != "" {
-				name = fmt.Sprintf("%s.%s", strings.ToLower(c.Source), strings.ToLower(c.Name))
+				tableName = strings.ToLower(c.Source)
+
 			} else {
-				name = fmt.Sprintf("%s.%s", strings.ToLower(rel.Name()), strings.ToLower(c.Name))
+				tableName = strings.ToLower(rel.Name())
 			}
-			m.Columns[name] = sql.ColumnId(len(m.Columns) + 1)
+			m.AddColumnId(tableName, strings.ToLower(c.Name))
 		}
 	}
 }
@@ -111,13 +132,10 @@ func (m *Memo) getTableId(table string) (GroupId, bool) {
 }
 
 func (m *Memo) getColumnId(table, name string) (sql.ColumnId, bool) {
-	var tag string
-	if table != "" {
-		tag = fmt.Sprintf("%s.%s", strings.ToLower(table), strings.ToLower(name))
-	} else {
-		tag = name
-	}
-	id, ok := m.Columns[tag]
+	id, ok := m.Columns[TableAndColumn{
+		tableName:  table,
+		columnName: name,
+	}]
 	return id, ok
 }
 


### PR DESCRIPTION
We can do this by taking advantage of the fact that removing a key from one half of the join can't affect whether a column on the other half of the join is dependent.

Current testing of FDs seems pretty sparse. I'm not confident that this single test in enough.