### PR TITLE
fix db qualified column names in order by

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -192,7 +192,7 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
 			Name: "Multi-db Aliasing",
@@ -211,58 +211,10 @@ func TestSingleScript(t *testing.T) {
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query: "select db.t1.i from db1.t1 order by db.t1.i",
-					Expected: []sql.Row{
-						{1},
-					},
-				},
-				{
-					Query: "select db.t1.i from db1.t1 group by db.t1.i",
-					Expected: []sql.Row{
-						{1},
-					},
-				},
-				{
-					Query: "select (select db.t1.i from db1.t1 order by db.t1.i)",
-					Expected: []sql.Row{
-						{1},
-					},
-				},
-				{
-					Query: "select i from (select db.t1.i from db1.t1 order by db.t1.i) as t",
-					Expected: []sql.Row{
-						{1},
-					},
-				},
-				{
-					Query: "with cte as (select db.t1.i from db1.t1 order by db.t1.i) select * from cte",
-					Expected: []sql.Row{
-						{1},
-					},
-				},
-				{
-					Skip:  true, // incorrectly throws Not unique table/alias: t1
-					Query: "select db1.t1.i, db2.t1.i from db1.t1 join db2.t1 order by db1.t1, db2.t1.i",
+					//Skip:  true, // incorrectly throws Not unique table/alias: t1
+					Query: "select db1.t1.i, db2.t1.i from db1.t1 join db2.t1 order by db1.t1.i, db2.t1.i",
 					Expected: []sql.Row{
 						{1, 10},
-					},
-				},
-				{
-					Query: "select i, j from db1.t1 join db2.t2 order by i, j",
-					Expected: []sql.Row{
-						{1, 20},
-					},
-				},
-				{
-					Query: "select i, j from db1.t1 join db2.t2 group by i order by j",
-					Expected: []sql.Row{
-						{1, 20},
-					},
-				},
-				{
-					Query: "select db1.t1.i, db2.t2.j from db1.t1 join db2.t2 group by db1.t1.i order by db2.t2.j",
-					Expected: []sql.Row{
-						{1, 20},
 					},
 				},
 			},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -223,6 +223,24 @@ func TestSingleScript(t *testing.T) {
 					},
 				},
 				{
+					Query: "select (select db.t1.i from db1.t1 order by db.t1.i)",
+					Expected: []sql.Row{
+						{1},
+					},
+				},
+				{
+					Query: "select i from (select db.t1.i from db1.t1 order by db.t1.i) as t",
+					Expected: []sql.Row{
+						{1},
+					},
+				},
+				{
+					Query: "with cte as (select db.t1.i from db1.t1 order by db.t1.i) select * from cte",
+					Expected: []sql.Row{
+						{1},
+					},
+				},
+				{
 					Skip:  true, // incorrectly throws Not unique table/alias: t1
 					Query: "select db1.t1.i, db2.t1.i from db1.t1 join db2.t1 order by db1.t1, db2.t1.i",
 					Expected: []sql.Row{
@@ -236,7 +254,13 @@ func TestSingleScript(t *testing.T) {
 					},
 				},
 				{
-					Query: "select i, j from db1.t1 join db2.t2 order by i group by i",
+					Query: "select i, j from db1.t1 join db2.t2 group by i order by j",
+					Expected: []sql.Row{
+						{1, 20},
+					},
+				},
+				{
+					Query: "select db1.t1.i, db2.t2.j from db1.t1 join db2.t2 group by db1.t1.i order by db2.t2.j",
 					Expected: []sql.Row{
 						{1, 20},
 					},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -235,6 +235,12 @@ func TestSingleScript(t *testing.T) {
 						{1, 20},
 					},
 				},
+				{
+					Query: "select i, j from db1.t1 join db2.t2 order by i group by i",
+					Expected: []sql.Row{
+						{1, 20},
+					},
+				},
 			},
 		},
 	}

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3932,6 +3932,12 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
+				Query: "select db1.t1.i from db1.t1 where db1.t1.i > 0",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
 				Query: "select db1.t1.i from db1.t1 order by db1.t1.i",
 				Expected: []sql.Row{
 					{1},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3968,13 +3968,6 @@ var ScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true, // incorrectly throws Not unique table/alias: t1
-				Query: "select db1.t1.i, db2.t1.i from db1.t1 join db2.t1 order by db1.t1, db2.t1.i",
-				Expected: []sql.Row{
-					{1, 10},
-				},
-			},
-			{
 				Query: "select i, j from db1.t1 join db2.t2 order by i, j",
 				Expected: []sql.Row{
 					{1, 20},
@@ -3990,6 +3983,20 @@ var ScriptTests = []ScriptTest{
 				Query: "select db1.t1.i, db2.t2.j from db1.t1 join db2.t2 group by db1.t1.i order by db2.t2.j",
 				Expected: []sql.Row{
 					{1, 20},
+				},
+			},
+			{
+				Skip:  true, // incorrectly throws Not unique table/alias: t1
+				Query: "select db1.t1.i, db2.t1.i from db1.t1 join db2.t1 order by db1.t1, db2.t1.i",
+				Expected: []sql.Row{
+					{1, 10},
+				},
+			},
+			{
+				// Aliasing solves it
+				Query: "select a.i, b.i from db1.t1 a join db2.t1 b order by a.i, b.i",
+				Expected: []sql.Row{
+					{1, 10},
 				},
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3932,6 +3932,13 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
+				// surprisingly, this works
+				Query: "select db1.t1.i from db1.t1 where db1.``.i > 0",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
 				Query: "select db1.t1.i from db1.t1 where db1.t1.i > 0",
 				Expected: []sql.Row{
 					{1},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3974,6 +3974,12 @@ var ScriptTests = []ScriptTest{
 				},
 			},
 			{
+				Query: "select i, j from db1.t1 inner join db2.t2 on 20 * i = j",
+				Expected: []sql.Row{
+					{1, 20},
+				},
+			},
+			{
 				Query: "select i, j from db1.t1 join db2.t2 order by i, j",
 				Expected: []sql.Row{
 					{1, 20},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3932,13 +3932,37 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select db.t1.i from db1.t1 order by db.t1.i",
+				Query: "select db1.t1.i from db1.t1 order by db1.t1.i",
 				Expected: []sql.Row{
 					{1},
 				},
 			},
 			{
-				Query: "select db.t1.i from db1.t1 group by db.t1.i",
+				Query: "select db1.t1.i from db1.t1 group by db1.t1.i",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "select db1.t1.i from db1.t1 having db1.t1.i > 0",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "select (select db1.t1.i from db1.t1 order by db1.t1.i)",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "select i from (select db1.t1.i from db1.t1 order by db1.t1.i) as t",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "with cte as (select db1.t1.i from db1.t1 order by db1.t1.i) select * from cte",
 				Expected: []sql.Row{
 					{1},
 				},
@@ -3957,7 +3981,13 @@ var ScriptTests = []ScriptTest{
 				},
 			},
 			{
-				Query: "select i, j from db1.t1 join db2.t2 order by i group by i",
+				Query: "select i, j from db1.t1 join db2.t2 group by i order by j",
+				Expected: []sql.Row{
+					{1, 20},
+				},
+			},
+			{
+				Query: "select db1.t1.i, db2.t2.j from db1.t1 join db2.t2 group by db1.t1.i order by db2.t2.j",
 				Expected: []sql.Row{
 					{1, 20},
 				},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3956,6 +3956,12 @@ var ScriptTests = []ScriptTest{
 					{1, 20},
 				},
 			},
+			{
+				Query: "select i, j from db1.t1 join db2.t2 order by i group by i",
+				Expected: []sql.Row{
+					{1, 20},
+				},
+			},
 		},
 	},
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3980,6 +3980,12 @@ var ScriptTests = []ScriptTest{
 				},
 			},
 			{
+				Query: "select db1.t1.i, db2.t2.j from db1.t1 inner join db2.t2 on 20 * db1.t1.i = db2.t2.j",
+				Expected: []sql.Row{
+					{1, 20},
+				},
+			},
+			{
 				Query: "select i, j from db1.t1 join db2.t2 order by i, j",
 				Expected: []sql.Row{
 					{1, 20},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3915,6 +3915,49 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Multi-db Aliasing",
+		SetUpScript: []string{
+			"create database db1;",
+			"create table db1.t1 (i int primary key);",
+			"create table db1.t2 (j int primary key);",
+			"insert into db1.t1 values (1);",
+			"insert into db1.t2 values (2);",
+
+			"create database db2;",
+			"create table db2.t1 (i int primary key);",
+			"create table db2.t2 (j int primary key);",
+			"insert into db2.t1 values (10);",
+			"insert into db2.t2 values (20);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select db.t1.i from db1.t1 order by db.t1.i",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "select db.t1.i from db1.t1 group by db.t1.i",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Skip: true, // incorrectly throws Not unique table/alias: t1
+				Query: "select db1.t1.i, db2.t1.i from db1.t1 join db2.t1 order by db1.t1, db2.t1.i",
+				Expected: []sql.Row{
+					{1, 10},
+				},
+			},
+			{
+				Query: "select i, j from db1.t1 join db2.t2 order by i, j",
+				Expected: []sql.Row{
+					{1, 20},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -105,9 +105,11 @@ func (b *Builder) buildGroupingCols(fromScope, projScope *scope, groupby ast.Gro
 		case *ast.ColName:
 			var ok bool
 			// GROUP BY binds to column references before projections.
-			col, ok = fromScope.resolveColumn(strings.ToLower(e.Qualifier.Name.String()), strings.ToLower(e.Name.String()), true)
+			tblName := strings.ToLower(e.Qualifier.Name.String())
+			colName := strings.ToLower(e.Name.String())
+			col, ok = fromScope.resolveColumn(tblName, colName, true)
 			if !ok {
-				col, ok = projScope.resolveColumn(strings.ToLower(e.Qualifier.Name.String()), strings.ToLower(e.Name.String()), true)
+				col, ok = projScope.resolveColumn(tblName, colName, true)
 			}
 
 			if !ok {
@@ -712,12 +714,14 @@ func (b *Builder) analyzeHaving(fromScope, projScope *scope, having *ast.Where) 
 			}
 		case *ast.ColName:
 			// add to extra cols
-			c, ok := projScope.resolveColumn(strings.ToLower(n.Qualifier.String()), strings.ToLower(n.Name.String()), false)
+			tblName := strings.ToLower(n.Qualifier.Name.String())
+			colName := strings.ToLower(n.Name.String())
+			c, ok := projScope.resolveColumn(tblName, colName, false)
 			if ok {
 				// references projection alias
 				break
 			}
-			c, ok = fromScope.resolveColumn(strings.ToLower(n.Qualifier.String()), strings.ToLower(n.Name.String()), true)
+			c, ok = fromScope.resolveColumn(tblName, colName, true)
 			if !ok {
 				err := sql.ErrColumnNotFound.New(n.Name)
 				b.handleErr(err)

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -105,11 +105,12 @@ func (b *Builder) buildGroupingCols(fromScope, projScope *scope, groupby ast.Gro
 		case *ast.ColName:
 			var ok bool
 			// GROUP BY binds to column references before projections.
+			dbName := strings.ToLower(e.Qualifier.Qualifier.String())
 			tblName := strings.ToLower(e.Qualifier.Name.String())
 			colName := strings.ToLower(e.Name.String())
-			col, ok = fromScope.resolveColumn(tblName, colName, true)
+			col, ok = fromScope.resolveColumn(dbName, tblName, colName, true)
 			if !ok {
-				col, ok = projScope.resolveColumn(tblName, colName, true)
+				col, ok = projScope.resolveColumn(dbName, tblName, colName, true)
 			}
 
 			if !ok {
@@ -714,14 +715,15 @@ func (b *Builder) analyzeHaving(fromScope, projScope *scope, having *ast.Where) 
 			}
 		case *ast.ColName:
 			// add to extra cols
+			dbName := strings.ToLower(n.Qualifier.Qualifier.String())
 			tblName := strings.ToLower(n.Qualifier.Name.String())
 			colName := strings.ToLower(n.Name.String())
-			c, ok := projScope.resolveColumn(tblName, colName, false)
+			c, ok := projScope.resolveColumn(dbName, tblName, colName, false)
 			if ok {
 				// references projection alias
 				break
 			}
-			c, ok = fromScope.resolveColumn(tblName, colName, true)
+			c, ok = fromScope.resolveColumn(dbName, tblName, colName, true)
 			if !ok {
 				err := sql.ErrColumnNotFound.New(n.Name)
 				b.handleErr(err)

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -954,7 +954,7 @@ func (b *Builder) buildExternalCreateIndex(inScope *scope, ddl *ast.DDL) (outSco
 	cols := make([]sql.Expression, len(ddl.IndexSpec.Columns))
 	for i, col := range ddl.IndexSpec.Columns {
 		colName := strings.ToLower(col.Column.String())
-		c, ok := inScope.resolveColumn(tblName, colName, true)
+		c, ok := inScope.resolveColumn(dbName, tblName, colName, true)
 		if !ok {
 			b.handleErr(sql.ErrColumnNotFound.New(colName))
 		}

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -938,24 +938,25 @@ func (b *Builder) buildExternalCreateIndex(inScope *scope, ddl *ast.DDL) (outSco
 		}
 	}
 
-	dbName := ddl.Table.Qualifier.String()
-	tableName := ddl.Table.Name.String()
+	dbName := strings.ToLower(ddl.Table.Qualifier.String())
+	tblName := strings.ToLower(ddl.Table.Name.String())
 	var ok bool
-	outScope, ok = b.buildTablescan(inScope, dbName, tableName, nil)
+	outScope, ok = b.buildTablescan(inScope, dbName, tblName, nil)
 	if !ok {
-		b.handleErr(sql.ErrTableNotFound.New(tableName))
+		b.handleErr(sql.ErrTableNotFound.New(tblName))
 	}
 	table, ok := outScope.node.(*plan.ResolvedTable)
 	if !ok {
-		err := fmt.Errorf("expected resolved table: %s", tableName)
+		err := fmt.Errorf("expected resolved table: %s", tblName)
 		b.handleErr(err)
 	}
 
 	cols := make([]sql.Expression, len(ddl.IndexSpec.Columns))
 	for i, col := range ddl.IndexSpec.Columns {
-		c, ok := inScope.resolveColumn(tableName, strings.ToLower(col.Column.String()), true)
+		colName := strings.ToLower(col.Column.String())
+		c, ok := inScope.resolveColumn(tblName, colName, true)
 		if !ok {
-			b.handleErr(sql.ErrColumnNotFound.New(col.Column.String()))
+			b.handleErr(sql.ErrColumnNotFound.New(colName))
 		}
 		cols[i] = expression.NewGetFieldWithTable(int(c.id), c.typ, c.table, c.col, c.nullable)
 	}

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -267,14 +267,15 @@ func (b *Builder) buildOnDupLeft(inScope *scope, e ast.Expr) sql.Expression {
 	// expect col reference only
 	switch e := e.(type) {
 	case *ast.ColName:
-		tableName := strings.ToLower(e.Qualifier.Name.String())
+		dbName := strings.ToLower(e.Qualifier.Qualifier.String())
+		tblName := strings.ToLower(e.Qualifier.Name.String())
 		colName := strings.ToLower(e.Name.String())
-		c, ok := inScope.resolveColumn(tableName, colName, true)
+		c, ok := inScope.resolveColumn(dbName, tblName, colName, true)
 		if !ok {
-			if tableName != "" && !inScope.hasTable(tableName) {
-				b.handleErr(sql.ErrTableNotFound.New(tableName))
-			} else if tableName != "" {
-				b.handleErr(sql.ErrTableColumnNotFound.New(tableName, colName))
+			if tblName != "" && !inScope.hasTable(tblName) {
+				b.handleErr(sql.ErrTableNotFound.New(tblName))
+			} else if tblName != "" {
+				b.handleErr(sql.ErrTableColumnNotFound.New(tblName, colName))
 			}
 			b.handleErr(sql.ErrColumnNotFound.New(e))
 		}

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -204,11 +204,11 @@ func (b *Builder) buildUsingJoin(inScope, leftScope, rightScope *scope, te *ast.
 	for _, col := range te.Condition.Using {
 		colName := col.String()
 		// Every column in the USING clause must be in both tables.
-		lCol, ok := left.resolveColumn("", colName, false)
+		lCol, ok := left.resolveColumn("", "", colName, false)
 		if !ok {
 			b.handleErr(sql.ErrUnknownColumn.New(colName, "from clause"))
 		}
-		rCol, ok := right.resolveColumn("", colName, false)
+		rCol, ok := right.resolveColumn("", "", colName, false)
 		if !ok {
 			b.handleErr(sql.ErrUnknownColumn.New(colName, "from clause"))
 		}

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -52,7 +52,9 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 		switch e := o.Expr.(type) {
 		case *ast.ColName:
 			// check for projection alias first
-			c, ok := projScope.resolveColumn(strings.ToLower(e.Qualifier.String()), strings.ToLower(e.Name.String()), false)
+			tblName := strings.ToLower(e.Qualifier.Name.String())
+			colName := strings.ToLower(e.Name.String())
+			c, ok := projScope.resolveColumn(tblName, colName, false)
 			if ok {
 				c.descending = descending
 				outScope.addColumn(c)
@@ -60,7 +62,7 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 			}
 
 			// fromScope col
-			c, ok = fromScope.resolveColumn(strings.ToLower(e.Qualifier.String()), strings.ToLower(e.Name.String()), true)
+			c, ok = fromScope.resolveColumn(tblName, colName, true)
 			if !ok {
 				err := sql.ErrColumnNotFound.New(e.Name)
 				b.handleErr(err)

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -52,9 +52,10 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 		switch e := o.Expr.(type) {
 		case *ast.ColName:
 			// check for projection alias first
+			dbName := strings.ToLower(e.Qualifier.Qualifier.String())
 			tblName := strings.ToLower(e.Qualifier.Name.String())
 			colName := strings.ToLower(e.Name.String())
-			c, ok := projScope.resolveColumn(tblName, colName, false)
+			c, ok := projScope.resolveColumn(dbName, tblName, colName, false)
 			if ok {
 				c.descending = descending
 				outScope.addColumn(c)
@@ -62,7 +63,7 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 			}
 
 			// fromScope col
-			c, ok = fromScope.resolveColumn(tblName, colName, true)
+			c, ok = fromScope.resolveColumn(dbName, tblName, colName, true)
 			if !ok {
 				err := sql.ErrColumnNotFound.New(e.Name)
 				b.handleErr(err)
@@ -129,7 +130,7 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 				//  get fields outside of aggs need to be in extra cols
 				switch e := e.(type) {
 				case *expression.GetField:
-					c, ok := fromScope.resolveColumn(strings.ToLower(e.Table()), strings.ToLower(e.Name()), true)
+					c, ok := fromScope.resolveColumn("", strings.ToLower(e.Table()), strings.ToLower(e.Name()), true)
 					if !ok {
 						err := sql.ErrColumnNotFound.New(e.Name)
 						b.handleErr(err)

--- a/sql/planbuilder/proc.go
+++ b/sql/planbuilder/proc.go
@@ -405,7 +405,7 @@ func (b *Builder) buildFetchCursor(inScope *scope, fetchCursor *ast.FetchCursor)
 	outScope = inScope.push()
 	exprs := make([]sql.Expression, len(fetchCursor.Variables))
 	for i, v := range fetchCursor.Variables {
-		col, ok := inScope.resolveColumn("", strings.ToLower(v), true)
+		col, ok := inScope.resolveColumn("", "", strings.ToLower(v), true)
 		if !ok {
 			err := sql.ErrColumnNotFound.New(v)
 			b.handleErr(err)
@@ -526,7 +526,7 @@ func (b *Builder) buildSignal(inScope *scope, s *ast.Signal) (outScope *scope) {
 				si.StrValue = val
 			case *ast.ColName:
 				var ref sql.Expression
-				c, ok := inScope.resolveColumn("", v.Name.Lowered(), true)
+				c, ok := inScope.resolveColumn("", "", v.Name.Lowered(), true)
 				if ok {
 					ref = c.scalarGf()
 				} else {

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -85,9 +85,10 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) sql.Expression {
 	case *ast.NullVal:
 		return expression.NewLiteral(nil, types.Null)
 	case *ast.ColName:
-		tableName := strings.ToLower(v.Qualifier.Name.String())
+		dbName := strings.ToLower(v.Qualifier.Qualifier.String())
+		tblName := strings.ToLower(v.Qualifier.Name.String())
 		colName := strings.ToLower(v.Name.String())
-		c, ok := inScope.resolveColumn(tableName, colName, true)
+		c, ok := inScope.resolveColumn(dbName, tblName, colName, true)
 		if !ok {
 			sysVar, scope, ok := b.buildSysVar(v, ast.SetScope_None)
 			if ok {
@@ -100,10 +101,10 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) sql.Expression {
 				err = sql.ErrUnknownUserVariable.New(colName)
 			} else if scope == ast.SetScope_Global || scope == ast.SetScope_Session {
 				err = sql.ErrUnknownSystemVariable.New(colName)
-			} else if tableName != "" && !inScope.hasTable(tableName) {
-				err = sql.ErrTableNotFound.New(tableName)
-			} else if tableName != "" {
-				err = sql.ErrTableColumnNotFound.New(tableName, colName)
+			} else if tblName != "" && !inScope.hasTable(tblName) {
+				err = sql.ErrTableNotFound.New(tblName)
+			} else if tblName != "" {
+				err = sql.ErrTableColumnNotFound.New(tblName, colName)
 			} else {
 				err = sql.ErrColumnNotFound.New(v)
 			}
@@ -264,9 +265,10 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) sql.Expression {
 			if v.Name.Qualifier.Name.String() == "" {
 				v.Name.Qualifier.Name = ast.NewTableIdent(OnDupValuesPrefix)
 			}
-			tableName := strings.ToLower(v.Name.Qualifier.Name.String())
+			dbName := strings.ToLower(v.Name.Qualifier.Qualifier.String())
+			tblName := strings.ToLower(v.Name.Qualifier.Name.String())
 			colName := strings.ToLower(v.Name.Name.String())
-			col, ok := inScope.resolveColumn(tableName, colName, false)
+			col, ok := inScope.resolveColumn(dbName, tblName, colName, false)
 			if !ok {
 				err := fmt.Errorf("expected ON DUPLICATE KEY ... VALUES() to reference a column, found: %s", v.Name.String())
 				b.handleErr(err)

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -61,7 +61,7 @@ type scope struct {
 	proc  *procCtx
 }
 
-func (s *scope) resolveColumn(table, col string, checkParent bool) (scopeColumn, bool) {
+func (s *scope) resolveColumn(db, table, col string, checkParent bool) (scopeColumn, bool) {
 	// procedure params take precedence
 	if table == "" && checkParent && s.procActive() {
 		col, ok := s.proc.GetVar(col)
@@ -80,7 +80,7 @@ func (s *scope) resolveColumn(table, col string, checkParent bool) (scopeColumn,
 	var found scopeColumn
 	var foundCand bool
 	for _, c := range s.cols {
-		if strings.EqualFold(c.col, col) && (c.table == table || table == "") {
+		if strings.EqualFold(c.col, col) && (c.table == table || table == "") && (c.db == db || db == "") {
 			if foundCand {
 				if !s.b.TriggerCtx().Call && len(s.b.TriggerCtx().UnresolvedTables) > 0 {
 					c, ok := s.triggerCol(table, col)
@@ -108,7 +108,7 @@ func (s *scope) resolveColumn(table, col string, checkParent bool) (scopeColumn,
 	}
 
 	if s.groupBy != nil {
-		if c, ok := s.groupBy.outScope.resolveColumn(table, col, false); ok {
+		if c, ok := s.groupBy.outScope.resolveColumn(db, table, col, false); ok {
 			return c, true
 		}
 	}
@@ -124,7 +124,7 @@ func (s *scope) resolveColumn(table, col string, checkParent bool) (scopeColumn,
 		return scopeColumn{}, false
 	}
 
-	c, foundCand := s.parent.resolveColumn(table, col, true)
+	c, foundCand := s.parent.resolveColumn(db, table, col, true)
 	if !foundCand {
 		return scopeColumn{}, false
 	}

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -128,8 +128,8 @@ func (b *Builder) setExprsToExpressions(inScope *scope, e ast.SetVarExprs) []sql
 		// right => getSetExpr, not adapted for defaults yet, special keywords need to be converted, variables replaced
 		var setScope ast.SetScope
 
-		tableName := strings.ToLower(setExpr.Name.Qualifier.String())
-		c, ok := inScope.resolveColumn(tableName, strings.ToLower(setExpr.Name.Name.String()), true)
+		tblName := strings.ToLower(setExpr.Name.Qualifier.String())
+		c, ok := inScope.resolveColumn("", tblName, strings.ToLower(setExpr.Name.Name.String()), true)
 		var setVar sql.Expression
 		if ok {
 			setVar = c.scalarGf()
@@ -138,8 +138,8 @@ func (b *Builder) setExprsToExpressions(inScope *scope, e ast.SetVarExprs) []sql
 			if !ok {
 				switch setScope {
 				case ast.SetScope_None:
-					if tableName != "" && !inScope.hasTable(tableName) {
-						b.handleErr(sql.ErrTableNotFound.New(tableName))
+					if tblName != "" && !inScope.hasTable(tblName) {
+						b.handleErr(sql.ErrTableNotFound.New(tblName))
 					}
 					b.handleErr(sql.ErrColumnNotFound.New(setExpr.Name.String()))
 				case ast.SetScope_User:


### PR DESCRIPTION
We did not handle the case where database qualified column names would be in the order by clause.
This PR fixes that issue and adds a variety of tests with database qualified column names and database qualified table names.

There is still a case where joining two tables with the same name from two different databases results in an error; there's a skipped test for this, and a workaround is to alias the tables.

fixes https://github.com/dolthub/dolt/issues/6773