### PR TITLE
"CREATE TABLE" fails with a "database not found" error when using the driver

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -95,8 +95,6 @@ func New(provider Provider, options *Options) *Driver {
 	var sessionBuilder SessionBuilder
 	if provWithSessionBuilder, ok := provider.(ProviderWithSessionBuilder); ok {
 		sessionBuilder = provWithSessionBuilder
-	} else {
-		sessionBuilder = NewDefaultSessionBuilder()
 	}
 
 	var contextBuilder ContextBuilder
@@ -156,6 +154,10 @@ func (d *Driver) OpenConnector(dsn string) (driver.Connector, error) {
 	serverName, pro, err := d.provider.Resolve(dsn, options)
 	if err != nil {
 		return nil, err
+	}
+
+	if d.sessions == nil {
+		d.sessions = NewDefaultSessionBuilder(pro)
 	}
 
 	d.mu.Lock()

--- a/driver/session.go
+++ b/driver/session.go
@@ -14,12 +14,12 @@ type SessionBuilder interface {
 
 // DefaultSessionBuilder creates basic SQL sessions.
 type DefaultSessionBuilder struct {
-	provider *memory.DbProvider
+	provider sql.DatabaseProvider
 }
 
-func NewDefaultSessionBuilder() *DefaultSessionBuilder {
+func NewDefaultSessionBuilder(provider sql.DatabaseProvider) *DefaultSessionBuilder {
 	return &DefaultSessionBuilder{
-		provider: memory.NewDBProvider(),
+		provider: provider,
 	}
 }
 

--- a/memory/session.go
+++ b/memory/session.go
@@ -24,7 +24,7 @@ import (
 type GlobalsMap = map[string]interface{}
 type Session struct {
 	*sql.BaseSession
-	dbProvider       *DbProvider
+	dbProvider       sql.DatabaseProvider
 	tables           map[tableKey]*TableData
 	editAccumulators map[tableKey]tableEditAccumulator
 	persistedGlobals GlobalsMap
@@ -37,7 +37,7 @@ var _ sql.Transaction = (*Transaction)(nil)
 var _ sql.PersistableSession = (*Session)(nil)
 
 // NewSession returns the new session for this object
-func NewSession(baseSession *sql.BaseSession, provider *DbProvider) *Session {
+func NewSession(baseSession *sql.BaseSession, provider sql.DatabaseProvider) *Session {
 	return &Session{
 		BaseSession:      baseSession,
 		dbProvider:       provider,


### PR DESCRIPTION
In the main branch ([commit 4cc2f2c](/dolthub/go-mysql-server/tree/4cc2f2ca38ce3fa01d42af0eec1457edf0fa724c)), executing the following SQL in the driver's example ([driver/_example](/dolthub/go-mysql-server/tree/4cc2f2ca38ce3fa01d42af0eec1457edf0fa724c/driver/_example/)) failes with the error `database not found: mydb`:

```diff
diff --git a/driver/_example/main.go b/driver/_example/main.go
index 34e0580ed..64fe11a2b 100644
--- a/driver/_example/main.go
+++ b/driver/_example/main.go
@@ -35,6 +35,9 @@ func main() {
        rows, err := db.Query("SELECT * FROM mytable")
        must(err)
        dump(rows)
+
+       _, err = db.Exec("CREATE TABLE table2 (id integer, primary key (id))")
+       must(err)
 }
 
 func must(err error) {
```

output:
```text
John Doe john@doe.com ["555-555-555"] 2023-10-09 21:29:48.750044594 +0900 JST m=+0.016306123
John Doe johnalt@doe.com [] 2023-10-09 21:29:48.750060666 +0900 JST m=+0.016322195
Jane Doe jane@doe.com [] 2023-10-09 21:29:48.750067418 +0900 JST m=+0.016328947
Evil Bob evilbob@gmail.com ["555-666-555", "666-666-666"] 2023-10-09 21:29:48.750073628 +0900 JST m=+0.016335158
2023/10/09 21:29:48 database not found: mydb
exit status 1
```

This is because the DefaultSessionBuilder of the driver is initialized with an empty DBProvider.
[driver/session.go:22](/dolthub/go-mysql-server/blob/4cc2f2ca38ce3fa01d42af0eec1457edf0fa724c/driver/session.go#L22)

In this PR, I have fixed this by passing the DatabaseProvider returned by [`factory.Resolve()`](/dolthub/go-mysql-server/blob/4cc2f2ca38ce3fa01d42af0eec1457edf0fa724c/driver/_example/create.go#L30) to the SessionBuilder.