### PR TITLE
Improve functional dependency analysis for joins.

### DIFF
--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -105,7 +105,7 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewInnerJoinFDs(abcde, mnpq, [][2]ColumnId{{1, 6}})
-		assert.Equal(t, "key(6); constant(7); equiv(1,6); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(6); constant(7); equiv(1,6); fd(1)/(1-5); lax-fd(2,3)/(1-5); fd(6)/(6-9)", join.String())
 	})
 
 	t.Run("ware X cust", func(t *testing.T) {
@@ -129,7 +129,7 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 		ware.AddStrictKey(cols(6))
 
 		join := NewInnerJoinFDs(cust, ware, [][2]ColumnId{{3, 6}})
-		assert.Equal(t, "key(); constant(1-3,6); equiv(3,6)", join.String())
+		assert.Equal(t, "key(); constant(1-3,6); equiv(3,6); fd(3)/(1-5); fd()/(6)", join.String())
 	})
 	t.Run("equiv on both sides inner join", func(t *testing.T) {
 		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}
@@ -144,7 +144,7 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewInnerJoinFDs(mnpq, abcde, [][2]ColumnId{})
-		assert.Equal(t, "key(1,6,7); equiv(6,8,9); equiv(2-4); lax-fd(3)", join.String())
+		assert.Equal(t, "key(1,6,7); equiv(6,8,9); equiv(2-4); fd(6,7)/(6-9); fd(1)/(1-5); lax-fd(3)/(1-5)", join.String())
 	})
 	t.Run("max1Row inner join", func(t *testing.T) {
 		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}
@@ -173,7 +173,7 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6))
 
 		join := NewInnerJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 7}})
-		assert.Equal(t, "key(6); constant(1-5,7); equiv(1,7)", join.String())
+		assert.Equal(t, "key(6); constant(1-5,7); equiv(1,7); fd(6)/(6-9); fd()/(1-5)", join.String())
 	})
 	t.Run("simplify cols on join", func(t *testing.T) {
 		// create table t1 (id int primary key, value int)

--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -73,7 +73,7 @@ func TestFuncDeps_CrossJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewCrossJoinFDs(abcde, mnpq)
-		assert.Equal(t, "key(1,6,7); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(1,6,7); fd(1); lax-fd(2,3); fd(6,7)", join.String())
 	})
 	t.Run("cross product one-sided equiv", func(t *testing.T) {
 		abcde := &FuncDepSet{}
@@ -87,7 +87,7 @@ func TestFuncDeps_CrossJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewCrossJoinFDs(abcde, mnpq)
-		assert.Equal(t, "key(1,6,7); equiv(1,5); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(1,6,7); equiv(1,5); fd(1); lax-fd(2,3); fd(6,7)", join.String())
 	})
 }
 
@@ -288,7 +288,7 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
-		assert.Equal(t, "key(1,6,7); constant(8,9); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(1,6,7); constant(8,9); lax-fd(2,3)/(1-5)", join.String())
 	})
 	t.Run("preserved-side equiv constants kept", func(t *testing.T) {
 		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}
@@ -303,7 +303,7 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
-		assert.Equal(t, "key(1,6,7); constant(8,9); equiv(8,9); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(1,6,7); constant(8,9); equiv(8,9); lax-fd(2,3)/(1-5)", join.String())
 	})
 	t.Run("preserved-side key constants kept", func(t *testing.T) {
 		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}
@@ -317,7 +317,7 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
-		assert.Equal(t, "key(1,7); constant(6,8,9); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(1,7); constant(6,8,9); lax-fd(2,3)/(1-5)", join.String())
 	})
 	t.Run("null-project side constants removed", func(t *testing.T) {
 		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}
@@ -331,7 +331,7 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
-		assert.Equal(t, "key(1,6,7); lax-fd(2)", join.String())
+		assert.Equal(t, "key(1,6,7); lax-fd(2)/(1-5)", join.String())
 	})
 	t.Run("equiv on both sides left join", func(t *testing.T) {
 		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}
@@ -346,7 +346,7 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{})
-		assert.Equal(t, "key(1,6,7); equiv(6,8,9); lax-fd(3)", join.String())
+		assert.Equal(t, "key(1,6,7); equiv(6,8,9); lax-fd(3)/(1-5)", join.String())
 	})
 	t.Run("join filter equiv", func(t *testing.T) {
 		// SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m
@@ -360,7 +360,7 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 6}})
-		assert.Equal(t, "key(6,7); fd(1); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(6,7); fd(1)/(1-5); lax-fd(2,3)/(1-5)", join.String())
 	})
 	t.Run("join filter equiv and null-side rel equiv", func(t *testing.T) {
 		//   SELECT * FROM abcde RIGHT OUTER JOIN mnpq ON a=m AND a=b
@@ -374,7 +374,7 @@ func TestFuncDeps_LeftJoin(t *testing.T) {
 		mnpq.AddStrictKey(cols(6, 7))
 
 		join := NewLeftJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 6}, {1, 2}})
-		assert.Equal(t, "key(6,7); fd(1); lax-fd(2,3)", join.String())
+		assert.Equal(t, "key(6,7); fd(1)/(1-5); lax-fd(2,3)/(1-5)", join.String())
 	})
 	t.Run("max1Row left join", func(t *testing.T) {
 		abcde := &FuncDepSet{all: cols(1, 2, 3, 4, 5)}

--- a/sql/func_deps_test.go
+++ b/sql/func_deps_test.go
@@ -175,6 +175,23 @@ func TestFuncDeps_InnerJoin(t *testing.T) {
 		join := NewInnerJoinFDs(mnpq, abcde, [][2]ColumnId{{1, 7}})
 		assert.Equal(t, "key(6); constant(1-5,7); equiv(1,7)", join.String())
 	})
+	t.Run("simplify cols on join", func(t *testing.T) {
+		// create table t1 (id int primary key, value int)
+		// create table t2 (id int primary key, value int)
+
+		// SELECT * FROM t1 JOIN t2 ON t1.value = t2.id;
+
+		t1 := &FuncDepSet{all: cols(1, 2)}
+		t1.AddNotNullable(cols(1))
+		t1.AddStrictKey(cols(1))
+
+		t2 := &FuncDepSet{all: cols(3, 4)}
+		t2.AddNotNullable(cols(3))
+		t2.AddStrictKey(cols(3))
+
+		join := NewInnerJoinFDs(t1, t2, [][2]ColumnId{{2, 3}})
+		assert.Equal(t, "key(1); equiv(2,3)", join.String())
+	})
 }
 
 func TestFuncDeps_LeftJoin(t *testing.T) {


### PR DESCRIPTION
This is a prerequisite for fixing https://github.com/dolthub/dolt/issues/6713.

Basically, this PR does two things:

- Adds additional bookkeeping to FDS in order to track "partial FDS keys", that is, column sets that determine some (but not all) of the other columns in a relation. Before this PR, we attempted to only track keys that determined the entire relation. This would cause us to lose some information and prohibit some optimizations. (There were also a couple of cases in nested joins where we accidentally added partial keys to FDS anyway (by adding a key from a child table to the FDS of the parent.) If we ever used these keys it could have caused correctness issues, but it doesn't look like we ever did.
- Improves the `simplifyCols` method in FDS to use partial keys in order to improve analysis.

Overall, these changes allow us to compute much better FDS keys for complicated joins, by allowing us to remember and reuse keys derived from child tables to improve the computed key for tables later in the join.