### PR TITLE
Remove redundant information_schema creation in the driver example

### DIFF
--- a/driver/_example/create.go
+++ b/driver/_example/create.go
@@ -21,7 +21,6 @@ import (
 	"github.com/dolthub/go-mysql-server/driver"
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/information_schema"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -30,7 +29,6 @@ type factory struct{}
 func (factory) Resolve(name string, options *driver.Options) (string, sql.DatabaseProvider, error) {
 	provider := memory.NewDBProvider(
 		createTestDatabase(),
-		information_schema.NewInformationSchemaDatabase(),
 	)
 	return name, provider, nil
 }


### PR DESCRIPTION
In the driver's example, `information_schema` is duplicated.

It is created in two places. 
1. [factory.Resolve()](/dolthub/go-mysql-server/blob/a8bd5ad7fb920fdce9f53f92817238e11e656e17/driver/_example/create.go#L33)
2. [Catalog](/dolthub/go-mysql-server/blob/a8bd5ad7fb920fdce9f53f92817238e11e656e17/sql/analyzer/catalog.go#L62) in [Analyzer](/dolthub/go-mysql-server/blob/a8bd5ad7fb920fdce9f53f92817238e11e656e17/sql/analyzer/analyzer.go#L269) in [Driver.OpenConnector()](/dolthub/go-mysql-server/blob/a8bd5ad7fb920fdce9f53f92817238e11e656e17/driver/driver.go#L166)

There is no need to create it in the `factory.Resolve()`.

I checked databases using this:
```diff
diff --git a/driver/_example/main.go b/driver/_example/main.go
index 34e0580ed..adbc1a249 100644
--- a/driver/_example/main.go
+++ b/driver/_example/main.go
@@ -35,6 +35,14 @@ func main() {
        rows, err := db.Query("SELECT * FROM mytable")
        must(err)
        dump(rows)
+
+       rows, err = db.Query("SHOW DATABASES")
+       must(err)
+       for rows.Next() {
+               var db string
+               must(rows.Scan(&db))
+               fmt.Println("db:", db)
+       }
 }
 
 func must(err error) {
```