### PR TITLE
Fix information_schema row count regression

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -45,6 +45,19 @@ var JoinPlanningTests = []struct {
 	tests []JoinPlanTest
 }{
 	{
+		name: "info schema plans",
+		setup: []string{
+			"CREATE table xy (x int primary key, y int);",
+		},
+		tests: []JoinPlanTest{
+			{
+				q:     "select count(t.*) from information_schema.columns c join information_schema.tables t on `t`.`TABLE_NAME` = `c`.`TABLE_NAME`",
+				types: []plan.JoinType{plan.JoinTypeHash},
+				exp:   []sql.Row{{735}},
+			},
+		},
+	},
+	{
 		name: "merge join unary index",
 		setup: []string{
 			"CREATE table xy (x int primary key, y int, unique index y_idx(y));",

--- a/sql/information_schema/columns_table.go
+++ b/sql/information_schema/columns_table.go
@@ -61,6 +61,8 @@ type ColumnsTable struct {
 }
 
 var _ sql.Table = (*ColumnsTable)(nil)
+var _ sql.StatisticsTable = (*ColumnsTable)(nil)
+var _ sql.Databaseable = (*ColumnsTable)(nil)
 var _ sql.DynamicColumnsTable = (*ColumnsTable)(nil)
 
 // String implements the sql.Table interface.
@@ -81,6 +83,19 @@ func (c *ColumnsTable) Collation() sql.CollationID {
 // Name implements the sql.Table interface.
 func (c *ColumnsTable) Name() string {
 	return ColumnsTableName
+}
+
+// Database implements the sql.Databaseable interface.
+func (c *ColumnsTable) Database() string {
+	return sql.InformationSchemaDatabaseName
+}
+
+func (c *ColumnsTable) DataLength(ctx *sql.Context) (uint64, error) {
+	return 500, nil
+}
+
+func (c *ColumnsTable) RowCount(ctx *sql.Context) (uint64, error) {
+	return 1000, nil
 }
 
 func (c *ColumnsTable) AssignCatalog(cat sql.Catalog) sql.Table {

--- a/sql/information_schema/columns_table.go
+++ b/sql/information_schema/columns_table.go
@@ -32,6 +32,8 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
+const defaultColumnsTableRowCount = 1000
+
 var typeToNumericPrecision = map[query.Type]int{
 	sqltypes.Int8:    3,
 	sqltypes.Uint8:   3,
@@ -90,12 +92,12 @@ func (c *ColumnsTable) Database() string {
 	return sql.InformationSchemaDatabaseName
 }
 
-func (c *ColumnsTable) DataLength(ctx *sql.Context) (uint64, error) {
-	return 500, nil
+func (c *ColumnsTable) DataLength(_ *sql.Context) (uint64, error) {
+	return uint64(len(c.Schema()) * int(types.Text.MaxByteLength()) * defaultColumnsTableRowCount), nil
 }
 
-func (c *ColumnsTable) RowCount(ctx *sql.Context) (uint64, error) {
-	return 1000, nil
+func (c *ColumnsTable) RowCount(_ *sql.Context) (uint64, error) {
+	return defaultColumnsTableRowCount, nil
 }
 
 func (c *ColumnsTable) AssignCatalog(cat sql.Catalog) sql.Table {

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -130,6 +130,8 @@ const (
 	ViewTableUsageTableName = "view_table_usage"
 	// ViewsTableName is the name of the VIEWS table.
 	ViewsTableName = "views"
+	// defaultInfoSchemaRowCount is a default row count estimate
+	defaultInfoSchemaRowCount = 1000
 )
 
 var sqlModeSetType = types.MustCreateSetType([]string{
@@ -2701,12 +2703,12 @@ func (t *informationSchemaTable) Schema() Schema {
 	return t.schema
 }
 
-func (t *informationSchemaTable) DataLength(ctx *Context) (uint64, error) {
-	return 500, nil
+func (t *informationSchemaTable) DataLength(_ *Context) (uint64, error) {
+	return uint64(len(t.Schema()) * int(types.Text.MaxByteLength()) * defaultInfoSchemaRowCount), nil
 }
 
-func (t *informationSchemaTable) RowCount(ctx *Context) (uint64, error) {
-	return 1000, nil
+func (t *informationSchemaTable) RowCount(_ *Context) (uint64, error) {
+	return defaultInfoSchemaRowCount, nil
 }
 
 // Collation implements the sql.Table interface.

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -164,10 +164,12 @@ type informationSchemaPartitionIter struct {
 }
 
 var (
-	_ Database      = (*informationSchemaDatabase)(nil)
-	_ Table         = (*informationSchemaTable)(nil)
-	_ Partition     = (*informationSchemaPartition)(nil)
-	_ PartitionIter = (*informationSchemaPartitionIter)(nil)
+	_ Database        = (*informationSchemaDatabase)(nil)
+	_ Table           = (*informationSchemaTable)(nil)
+	_ StatisticsTable = (*informationSchemaTable)(nil)
+	_ Databaseable    = (*informationSchemaTable)(nil)
+	_ Partition       = (*informationSchemaPartition)(nil)
+	_ PartitionIter   = (*informationSchemaPartitionIter)(nil)
 )
 
 var administrableRoleAuthorizationsSchema = Schema{
@@ -2689,9 +2691,22 @@ func (t *informationSchemaTable) Name() string {
 	return t.name
 }
 
+// Database implements the sql.Databaseable interface.
+func (c *informationSchemaTable) Database() string {
+	return InformationSchemaDatabaseName
+}
+
 // Schema implements the sql.Table interface.
 func (t *informationSchemaTable) Schema() Schema {
 	return t.schema
+}
+
+func (t *informationSchemaTable) DataLength(ctx *Context) (uint64, error) {
+	return 500, nil
+}
+
+func (t *informationSchemaTable) RowCount(ctx *Context) (uint64, error) {
+	return 1000, nil
 }
 
 // Collation implements the sql.Table interface.

--- a/sql/information_schema/routines_table.go
+++ b/sql/information_schema/routines_table.go
@@ -25,6 +25,8 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
+const defaultRoutinesTableRowCount = 10
+
 type routineTable struct {
 	name       string
 	schema     Schema
@@ -77,12 +79,12 @@ func (r *routineTable) Database() string {
 	return InformationSchemaDatabaseName
 }
 
-func (r *routineTable) DataLength(ctx *Context) (uint64, error) {
-	return 500, nil
+func (r *routineTable) DataLength(_ *Context) (uint64, error) {
+	return uint64(len(r.Schema()) * int(types.Text.MaxByteLength()) * defaultRoutinesTableRowCount), nil
 }
 
-func (r *routineTable) RowCount(ctx *Context) (uint64, error) {
-	return 1000, nil
+func (r *routineTable) RowCount(_ *Context) (uint64, error) {
+	return defaultRoutinesTableRowCount, nil
 }
 
 // Name implements the sql.Table interface.

--- a/sql/information_schema/routines_table.go
+++ b/sql/information_schema/routines_table.go
@@ -35,7 +35,9 @@ type routineTable struct {
 }
 
 var (
-	_ Table = (*routineTable)(nil)
+	_ Table           = (*routineTable)(nil)
+	_ Databaseable    = (*ColumnsTable)(nil)
+	_ StatisticsTable = (*ColumnsTable)(nil)
 )
 
 var doltProcedureAliasSet = map[string]interface{}{
@@ -59,15 +61,28 @@ var doltProcedureAliasSet = map[string]interface{}{
 	"dverify_all_constraints": nil,
 }
 
-func (t *routineTable) AssignCatalog(cat Catalog) Table {
-	t.catalog = cat
-	return t
+func (r *routineTable) AssignCatalog(cat Catalog) Table {
+	r.catalog = cat
+	return r
 }
 
 func (r *routineTable) AssignProcedures(p map[string][]*plan.Procedure) Table {
 	// TODO: should also assign functions
 	r.procedures = p
 	return r
+}
+
+// Database implements the sql.Databaseable interface.
+func (r *routineTable) Database() string {
+	return InformationSchemaDatabaseName
+}
+
+func (r *routineTable) DataLength(ctx *Context) (uint64, error) {
+	return 500, nil
+}
+
+func (r *routineTable) RowCount(ctx *Context) (uint64, error) {
+	return 1000, nil
 }
 
 // Name implements the sql.Table interface.

--- a/sql/memo/coster.go
+++ b/sql/memo/coster.go
@@ -124,7 +124,12 @@ func (c *coster) costScan(ctx *sql.Context, t *TableScan, s sql.StatsProvider) (
 }
 
 func (c *coster) costRead(ctx *sql.Context, t sql.Table, s sql.StatsProvider) (float64, error) {
-	db := ctx.GetCurrentDatabase()
+	var db string
+	if dbt, ok := t.(sql.Databaseable); ok {
+		db = dbt.Database()
+	} else {
+		db = ctx.GetCurrentDatabase()
+	}
 	card, err := s.RowCount(ctx, db, t.Name())
 	if err != nil {
 		// TODO: better estimates for derived tables


### PR DESCRIPTION
If a table does not implement RowCount() we used to use 1000 as a default value for row costing. A recent refactor changed that to 0. This fixes information schema tables to report the 1000 value again, which is usually accurate for small databases because of default tables and columns. I also fixed some issues with database reporting for info schema tables.

This regression probably still exists for some dolt tables and table functions. I will do a pass and see if I can add some more accurate values on the Dolt side.