### PR TITLE
pick float type if one side is non-number type

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -718,4 +718,28 @@ var JsonScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "json type value compared with number type value",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT JSON_EXTRACT('0.4', '$')",
+				Expected: []sql.Row{{types.MustJSON(`0.4`)}},
+			},
+			{
+				Query:    "SELECT JSON_EXTRACT('0.4', '$') > 0;",
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    "SELECT JSON_EXTRACT('0.4', '$') <= 0;",
+				Expected: []sql.Row{{false}},
+			}, {
+				Query:    "SELECT JSON_EXTRACT('0.4', '$') = 0;",
+				Expected: []sql.Row{{false}},
+			},
+			{
+				Query:    "SELECT JSON_EXTRACT('0.4', '$') = 0.4;",
+				Expected: []sql.Row{{true}},
+			},
+		},
+	},
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8190,25 +8190,6 @@ ORDER BY 1;`,
 			{3},
 		},
 	},
-	{
-		Query:    "SELECT JSON_EXTRACT('0.4', '$')",
-		Expected: []sql.Row{{types.MustJSON(`0.4`)}},
-	},
-	{
-		Query:    "SELECT JSON_EXTRACT('0.4', '$') > 0;",
-		Expected: []sql.Row{{true}},
-	},
-	{
-		Query:    "SELECT JSON_EXTRACT('0.4', '$') <= 0;",
-		Expected: []sql.Row{{false}},
-	}, {
-		Query:    "SELECT JSON_EXTRACT('0.4', '$') = 0;",
-		Expected: []sql.Row{{false}},
-	},
-	{
-		Query:    "SELECT JSON_EXTRACT('0.4', '$') = 0.4;",
-		Expected: []sql.Row{{true}},
-	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8201,7 +8201,7 @@ ORDER BY 1;`,
 	{
 		Query:    "SELECT JSON_EXTRACT('0.4', '$') <= 0;",
 		Expected: []sql.Row{{false}},
-	},{
+	}, {
 		Query:    "SELECT JSON_EXTRACT('0.4', '$') = 0;",
 		Expected: []sql.Row{{false}},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8190,6 +8190,25 @@ ORDER BY 1;`,
 			{3},
 		},
 	},
+	{
+		Query:    "SELECT JSON_EXTRACT('0.4', '$')",
+		Expected: []sql.Row{{types.MustJSON(`0.4`)}},
+	},
+	{
+		Query:    "SELECT JSON_EXTRACT('0.4', '$') > 0;",
+		Expected: []sql.Row{{true}},
+	},
+	{
+		Query:    "SELECT JSON_EXTRACT('0.4', '$') <= 0;",
+		Expected: []sql.Row{{false}},
+	},{
+		Query:    "SELECT JSON_EXTRACT('0.4', '$') = 0;",
+		Expected: []sql.Row{{false}},
+	},
+	{
+		Query:    "SELECT JSON_EXTRACT('0.4', '$') = 0.4;",
+		Expected: []sql.Row{{true}},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -215,21 +215,21 @@ func (c *comparison) castLeftAndRight(left, right interface{}) (interface{}, int
 			return l, r, types.Int64, nil
 		}
 
-		if types.IsNumber(leftType) || types.IsNumber(rightType) {
-			l, r, err := convertLeftAndRight(left, right, ConvertToDouble)
+		if types.IsUnsigned(leftType) && types.IsUnsigned(rightType) {
+			l, r, err := convertLeftAndRight(left, right, ConvertToUnsigned)
 			if err != nil {
 				return nil, nil, nil, err
 			}
 
-			return l, r, types.Float64, nil
+			return l, r, types.Uint64, nil
 		}
 
-		l, r, err := convertLeftAndRight(left, right, ConvertToUnsigned)
+		l, r, err := convertLeftAndRight(left, right, ConvertToDouble)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 
-		return l, r, types.Uint64, nil
+		return l, r, types.Float64, nil
 	}
 
 	left, right, err := convertLeftAndRight(left, right, ConvertToChar)

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -206,13 +206,22 @@ func (c *comparison) castLeftAndRight(left, right interface{}) (interface{}, int
 			return l, r, types.Float64, nil
 		}
 
-		if types.IsSigned(leftType) || types.IsSigned(rightType) {
+		if types.IsSigned(leftType) && types.IsSigned(rightType) {
 			l, r, err := convertLeftAndRight(left, right, ConvertToSigned)
 			if err != nil {
 				return nil, nil, nil, err
 			}
 
 			return l, r, types.Int64, nil
+		}
+
+		if types.IsNumber(leftType) || types.IsNumber(rightType) {
+			l, r, err := convertLeftAndRight(left, right, ConvertToDouble)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+
+			return l, r, types.Float64, nil
 		}
 
 		l, r, err := convertLeftAndRight(left, right, ConvertToUnsigned)


### PR DESCRIPTION
If one side or comparison is non-number type and the other side is number type, then convert to float to compare and the non-number type value can be float type.