### PR TITLE
fix panic when order by column is out of range

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -9098,7 +9098,7 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: sql.ErrAmbiguousColumnOrAliasName,
 	},
 	{
-		Query: "select * from mytable order by 999",
+		Query:          "select * from mytable order by 999",
 		ExpectedErrStr: "column \"999\" could not be found in any table in scope",
 	},
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -9097,6 +9097,10 @@ var ErrorQueries = []QueryErrorTest{
 		Query:       `SELECT s as i, i as i from mytable order by i`,
 		ExpectedErr: sql.ErrAmbiguousColumnOrAliasName,
 	},
+	{
+		Query: "select * from mytable order by 999",
+		ExpectedErrStr: "column \"999\" could not be found in any table in scope",
+	},
 }
 
 var BrokenErrorQueries = []QueryErrorTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4081,7 +4081,7 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "select * from t order by `100`",
+				Query: "select * from t order by `100`",
 				Expected: []sql.Row{
 					{2, 1},
 					{1, 2},
@@ -4092,7 +4092,7 @@ var ScriptTests = []ScriptTest{
 				ExpectedErrStr: "column \"100\" could not be found in any table in scope",
 			},
 			{
-				Query:    "select i as `200`, `100` from t order by `200`",
+				Query: "select i as `200`, `100` from t order by `200`",
 				Expected: []sql.Row{
 					{1, 2},
 					{2, 1},
@@ -4103,11 +4103,11 @@ var ScriptTests = []ScriptTest{
 				ExpectedErrStr: "column \"200\" could not be found in any table in scope",
 			},
 			{
-				Query:    "select * from t order by 0",
+				Query:          "select * from t order by 0",
 				ExpectedErrStr: "column \"0\" could not be found in any table in scope",
 			},
 			{
-				Query:    "select * from t order by -999",
+				Query: "select * from t order by -999",
 				Expected: []sql.Row{
 					{1, 2},
 					{2, 1},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4073,6 +4073,30 @@ var ScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "order by with numbers",
+		SetUpScript: []string{
+			"create table t (i int primary key, `100` int);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from t order by `100`",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "select * from t order by 100",
+				ExpectedErrStr: "column \"100\" could not be found in any table in scope",
+			},
+			{
+				Query: "select i as `200` from t order by `200`",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "select i as `200` from t order by 200",
+				ExpectedErrStr: "column \"200\" could not be found in any table in scope",
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4080,19 +4080,19 @@ var ScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from t order by `100`",
+				Query:    "select * from t order by `100`",
 				Expected: []sql.Row{},
 			},
 			{
-				Query: "select * from t order by 100",
+				Query:          "select * from t order by 100",
 				ExpectedErrStr: "column \"100\" could not be found in any table in scope",
 			},
 			{
-				Query: "select i as `200` from t order by `200`",
+				Query:    "select i as `200` from t order by `200`",
 				Expected: []sql.Row{},
 			},
 			{
-				Query: "select i as `200` from t order by 200",
+				Query:          "select i as `200` from t order by 200",
 				ExpectedErrStr: "column \"200\" could not be found in any table in scope",
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4074,26 +4074,44 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "order by with numbers",
+		Name: "order by with index",
 		SetUpScript: []string{
 			"create table t (i int primary key, `100` int);",
+			"insert into t values (1, 2), (2, 1)",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "select * from t order by `100`",
-				Expected: []sql.Row{},
+				Expected: []sql.Row{
+					{2, 1},
+					{1, 2},
+				},
 			},
 			{
 				Query:          "select * from t order by 100",
 				ExpectedErrStr: "column \"100\" could not be found in any table in scope",
 			},
 			{
-				Query:    "select i as `200` from t order by `200`",
-				Expected: []sql.Row{},
+				Query:    "select i as `200`, `100` from t order by `200`",
+				Expected: []sql.Row{
+					{1, 2},
+					{2, 1},
+				},
 			},
 			{
 				Query:          "select i as `200` from t order by 200",
 				ExpectedErrStr: "column \"200\" could not be found in any table in scope",
+			},
+			{
+				Query:    "select * from t order by 0",
+				ExpectedErrStr: "column \"0\" could not be found in any table in scope",
+			},
+			{
+				Query:    "select * from t order by -999",
+				Expected: []sql.Row{
+					{1, 2},
+					{2, 1},
+				},
 			},
 		},
 	},

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -93,6 +93,10 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 					err := fmt.Errorf("invalid order by ordinal context")
 					b.handleErr(err)
 				}
+				if intIdx > int64(len(projScope.cols)) {
+					err := sql.ErrColumnNotFound.New(fmt.Sprintf("%d", intIdx))
+					b.handleErr(err)
+				}
 				target := projScope.cols[intIdx-1]
 				scalar := target.scalar
 				if scalar == nil {

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -86,6 +86,7 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 				if !ok {
 					b.handleErr(fmt.Errorf("expected integer order by literal"))
 				}
+				// negative intIdx is allowed in MySQL, and is treated as a no-op
 				if intIdx < 0 {
 					continue
 				}
@@ -93,6 +94,7 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 					err := fmt.Errorf("invalid order by ordinal context")
 					b.handleErr(err)
 				}
+				// MySQL throws a column not found for intIdx = 0 and intIdx > len(cols)
 				if intIdx > int64(len(projScope.cols)) || intIdx == 0 {
 					err := sql.ErrColumnNotFound.New(fmt.Sprintf("%d", intIdx))
 					b.handleErr(err)

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -86,14 +86,14 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 				if !ok {
 					b.handleErr(fmt.Errorf("expected integer order by literal"))
 				}
-				if intIdx < 1 {
-					b.handleErr(fmt.Errorf("expected positive integer order by literal"))
+				if intIdx < 0 {
+					continue
 				}
 				if projScope == nil || len(projScope.cols) == 0 {
 					err := fmt.Errorf("invalid order by ordinal context")
 					b.handleErr(err)
 				}
-				if intIdx > int64(len(projScope.cols)) {
+				if intIdx > int64(len(projScope.cols)) || intIdx == 0 {
 					err := sql.ErrColumnNotFound.New(fmt.Sprintf("%d", intIdx))
 					b.handleErr(err)
 				}


### PR DESCRIPTION
We used to blindly index ORDER BY values, which resulted in panics.
Now, we throw the appropriate error.

Additionally, this matches MySQL behavior when performing ORDER BY with indexes `< 1`.
 - `ORDER BY 0` = error
 - `ORDER BY -1` = noop
