### PR TITLE
Server handling parsed statements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20231011212939-750452c13fa0
+	github.com/dolthub/vitess v0.0.0-20231018185551-6acf9c09c4fa
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72 h1:NfWmngMi1CYU
 github.com/dolthub/jsonpath v0.0.2-0.20230525180605-8dc13778fd72/go.mod h1:ZWUdY4iszqRQ8OcoXClkxiAVAoWoK3cq0Hvv4ddGRuM=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20231010151643-9ebf1a784d37 h1:tFWZESxJqu04VcGzr3QqemUc3yHP5gbj2srBcbuMZ7s=
-github.com/dolthub/vitess v0.0.0-20231010151643-9ebf1a784d37/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
-github.com/dolthub/vitess v0.0.0-20231011212939-750452c13fa0 h1:ETjYviQleYq+2KuflGbTdRLuk0zw45HXCHS6ApVM6o8=
-github.com/dolthub/vitess v0.0.0-20231011212939-750452c13fa0/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20231018185551-6acf9c09c4fa h1:5k+dGyoUAnan2RZmLiYEp8svmEFlJIUfaSKbZ5xXv1s=
+github.com/dolthub/vitess v0.0.0-20231018185551-6acf9c09c4fa/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/server/golden/proxy.go
+++ b/server/golden/proxy.go
@@ -206,6 +206,16 @@ func (h MySqlProxy) ComQuery(
 	return err
 }
 
+// ComParsedQuery implements mysql.Handler.
+func (h MySqlProxy) ComParsedQuery(
+	c *mysql.Conn,
+	query string,
+	parsed sqlparser.Statement,
+	callback func(*sqltypes.Result, bool) error,
+) error {
+	return h.ComQuery(c, query, callback)
+}
+
 func (h MySqlProxy) processQuery(
 	c *mysql.Conn,
 	proxy proxyConn,

--- a/server/golden/validator.go
+++ b/server/golden/validator.go
@@ -143,6 +143,16 @@ func (v Validator) ComQuery(
 	return nil
 }
 
+// ComQuery executes a SQL query on the SQLe engine.
+func (v Validator) ComParsedQuery(
+	c *mysql.Conn,
+	query string,
+	parsed sqlparser.Statement,
+	callback func(*sqltypes.Result, bool) error,
+) error {
+	return v.ComQuery(c, query, callback)
+}
+
 // WarningCount is called at the end of each query to obtain
 // the value to be returned to the client in the EOF packet.
 // Note that this will be called either in the context of the


### PR DESCRIPTION
Initially this was going to be a bit more involved, as I was planning on having Dolt expose a new interface, and we'd directly pass in GMS ASTs rather than Vitess ASTs. The Dolt interface approach turned out to be _a lot_ more involved than first anticipated, and the construction of GMS ASTs needs state that we will not have at higher layers, and exposing such state is also a lot more involved. Therefore, I've made a compromise by accepting Vitess ASTs instead, which makes this vastly simpler. It's not going to be quite as powerful, but I think it can still serve our purposes for the foreseeable future.

This basically works by hijacking that fact that we'll sometimes process Vitess ASTs via the prepared cache. If we receive a Vitess AST, then we skip the cache, otherwise we access the cache like the normal workflow.