### PR TITLE
[no-release-notes] Table functions must track their database so that TableIDs on GetFields will match.

### DIFF
--- a/memory/sequence_table.go
+++ b/memory/sequence_table.go
@@ -20,6 +20,7 @@ var _ sql.TableNode = IntSequenceTable{}
 // IntSequenceTable a simple table function that returns a sequence
 // of integers.
 type IntSequenceTable struct {
+	db   sql.Database
 	name string
 	Len  int64
 }
@@ -28,7 +29,7 @@ func (s IntSequenceTable) UnderlyingTable() sql.Table {
 	return s
 }
 
-func (s IntSequenceTable) NewInstance(_ *sql.Context, _ sql.Database, args []sql.Expression) (sql.Node, error) {
+func (s IntSequenceTable) NewInstance(_ *sql.Context, db sql.Database, args []sql.Expression) (sql.Node, error) {
 	if len(args) != 2 {
 		return nil, fmt.Errorf("sequence table expects 2 arguments: (name, len)")
 	}
@@ -48,7 +49,7 @@ func (s IntSequenceTable) NewInstance(_ *sql.Context, _ sql.Database, args []sql
 	if !ok {
 		return nil, fmt.Errorf("%w; sequence table expects 2nd argument to be a sequence length integer", err)
 	}
-	return IntSequenceTable{name: name, Len: length.(int64)}, nil
+	return IntSequenceTable{db: db, name: name, Len: length.(int64)}, nil
 }
 
 func (s IntSequenceTable) Resolved() bool {
@@ -76,9 +77,11 @@ func (s IntSequenceTable) DebugString() string {
 
 func (s IntSequenceTable) Schema() sql.Schema {
 	schema := []*sql.Column{
-		&sql.Column{
-			Name: s.name,
-			Type: types.Int64,
+		{
+			DatabaseSource: s.db.Name(),
+			Source:         s.Name(),
+			Name:           s.name,
+			Type:           types.Int64,
 		},
 	}
 
@@ -121,7 +124,7 @@ func (s IntSequenceTable) WithExpressions(e ...sql.Expression) (sql.Node, error)
 }
 
 func (s IntSequenceTable) Database() sql.Database {
-	return nil
+	return s.db
 }
 
 func (s IntSequenceTable) WithDatabase(_ sql.Database) (sql.Node, error) {
@@ -222,7 +225,7 @@ func (s IntSequenceTable) IndexedAccess(lookup sql.IndexLookup) sql.IndexedTable
 func (s IntSequenceTable) GetIndexes(ctx *sql.Context) ([]sql.Index, error) {
 	return []sql.Index{
 		&Index{
-			DB:         "",
+			DB:         s.db.Name(),
 			DriverName: "",
 			Tbl:        nil,
 			TableName:  s.Name(),

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -501,8 +501,7 @@ func (b *Builder) buildTableFunc(inScope *scope, t *ast.TableFuncExpr) (outScope
 	outScope.node = newAlias
 	for _, c := range newAlias.Schema() {
 		outScope.newColumn(scopeColumn{
-			// table function names do not belong to a database.
-			tableId: sql.NewAliasID(name),
+			tableId: sql.NewTableID(database.Name(), name),
 			col:     c.Name,
 			typ:     c.Type,
 		})


### PR DESCRIPTION
This was supposed to be included in https://github.com/dolthub/go-mysql-server/pull/2090

`generateIndexScans` uses the database optionally returned by the table function to compute the table id (currently a database/table tuple) to match against. This is the right call because some table functions in dolt depend on the current database (like `dolt_diff`)

When creating table ids for GetFields on function tables, the builder doesn't know if the table function will store the database or not, so it has to assume that it will. Thus, all table functions must actually store and return their database.

This is needed for the corresponding dolt PR.