### PR TITLE
Add the mysql.procs_privs table

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -1379,6 +1380,8 @@ func TestInsertErrorScriptsPrepared(t *testing.T, harness Harness) {
 }
 
 func TestUserPrivileges(t *testing.T, harness ClientHarness) {
+	os.Setenv("DOLT_ROUTINE_GRANTS_ENABLED", "1")
+
 	harness.Setup(setup.MydbData, setup.MytableData)
 	for _, script := range queries.UserPrivTests {
 		t.Run(script.Name, func(t *testing.T) {

--- a/enginetest/queries/priv_auth_queries.go
+++ b/enginetest/queries/priv_auth_queries.go
@@ -859,6 +859,70 @@ var UserPrivTests = []UserPrivilegeTest{
 		},
 	},
 	{
+		Name: "GRANT Procedure and function privileges reflect in mysql.procs_priv",
+		SetUpScript: []string{
+			"CREATE USER tester1@localhost;",
+			"CREATE USER tester2@localhost;",
+			"GRANT EXECUTE ON PROCEDURE mydb.proc1 TO tester1@localhost;",
+			"GRANT GRANT OPTION ON PROCEDURE mydb.proc1 TO tester1@localhost;",
+			"GRANT ALTER ROUTINE ON FUNCTION mydb.func1 TO tester1@localhost;",
+			"GRANT GRANT OPTION ON FUNCTION mydb.func1 TO tester2@localhost;",
+		},
+		Assertions: []UserPrivilegeTestAssertion{
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "SELECT proc_priv from mysql.procs_priv WHERE Routine_type = 'PROCEDURE' AND User = 'tester1'",
+				Expected: []sql.Row{{"Grant,Execute"}},
+			},
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "SELECT proc_priv from mysql.procs_priv WHERE Routine_type = 'FUNCTION' AND User = 'tester1'",
+				Expected: []sql.Row{{"Alter Routine"}},
+			},
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "SELECT proc_priv from mysql.procs_priv WHERE Routine_type = 'FUNCTION' AND User = 'tester2'",
+				Expected: []sql.Row{{"Grant"}},
+			},
+		},
+	},
+	{
+		Name: "GRANT Procedure and function privileges reflect in mysql.procs_priv",
+		SetUpScript: []string{
+			"CREATE USER tester1@localhost;",
+			"CREATE USER tester2@localhost;",
+			"GRANT EXECUTE ON PROCEDURE mydb.proc1 TO tester1@localhost;",
+			"GRANT GRANT OPTION ON PROCEDURE mydb.proc1 TO tester1@localhost;",
+			"GRANT ALTER ROUTINE ON FUNCTION mydb.func1 TO tester1@localhost;",
+			"GRANT GRANT OPTION ON FUNCTION mydb.func1 TO tester2@localhost;",
+			"REVOKE EXECUTE ON PROCEDURE mydb.proc1 FROM tester1@localhost;",
+			"REVOKE ALTER ROUTINE ON FUNCTION mydb.func1 FROM tester1@localhost;",
+		},
+		Assertions: []UserPrivilegeTestAssertion{
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "SELECT proc_priv from mysql.procs_priv WHERE Routine_type = 'PROCEDURE' AND User = 'tester1'",
+				Expected: []sql.Row{{"Grant"}},
+			},
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "SELECT proc_priv from mysql.procs_priv WHERE Routine_type = 'FUNCTION' AND User = 'tester1'",
+				Expected: []sql.Row{},
+			},
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "SELECT proc_priv from mysql.procs_priv WHERE Routine_type = 'FUNCTION' AND User = 'tester2'",
+				Expected: []sql.Row{{"Grant"}},
+			},
+		},
+	},
+	{
 		Name: "Basic revoke SELECT privilege",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk BIGINT PRIMARY KEY);",

--- a/sql/mysql_db/fbs/mysql_db.fbs
+++ b/sql/mysql_db/fbs/mysql_db.fbs
@@ -22,11 +22,17 @@ table PrivilegeSetTable {
     privs:[int];
     columns:[PrivilegeSetColumn];
 }
+table PrivilegeSetRoutine {
+    name:string;
+    privs:[int];
+    is_proc:bool;
+}
 
 table PrivilegeSetDatabase {
     name:string;
     privs:[int];
     tables:[PrivilegeSetTable];
+    routines:[PrivilegeSetRoutine];
 }
 
 table PrivilegeSet {

--- a/sql/mysql_db/fbs/mysql_db.fbs
+++ b/sql/mysql_db/fbs/mysql_db.fbs
@@ -22,6 +22,7 @@ table PrivilegeSetTable {
     privs:[int];
     columns:[PrivilegeSetColumn];
 }
+
 table PrivilegeSetRoutine {
     name:string;
     privs:[int];

--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -68,11 +68,11 @@ type MySQLDb struct {
 
 	db            *in_mem_table.MultiIndexedSetTable[*User]
 	tables_priv   *in_mem_table.MultiIndexedSetTable[*User]
+	procs_priv    *in_mem_table.MultiIndexedSetTable[*User]
 	global_grants *in_mem_table.MultiIndexedSetTable[*User]
 
 	//TODO: add the rest of these tables
 	//columns_priv     *mysqlTable
-	//procs_priv       *mysqlTable
 	//proxies_priv     *mysqlTable
 	//default_roles    *mysqlTable
 	//password_history *mysqlTable
@@ -120,6 +120,7 @@ func CreateEmptyMySQLDb() *MySQLDb {
 	// multi tables
 	mysqlDb.db = NewUserDBIndexedSetTable(userSet, lock, rlock)
 	mysqlDb.tables_priv = NewUserTablesIndexedSetTable(userSet, lock, rlock)
+	mysqlDb.procs_priv = NewUserProcsIndexedSetTable(userSet, lock, rlock)
 	mysqlDb.global_grants = NewUserGlobalGrantsIndexedSetTable(userSet, lock, rlock)
 
 	// Start the counter at 1, all new sessions will start at zero so this forces an update for any new session
@@ -673,6 +674,8 @@ func (db *MySQLDb) GetTableInsensitive(_ *sql.Context, tblName string) (sql.Tabl
 		return db.db, true, nil
 	case tablesPrivTblName:
 		return db.tables_priv, true, nil
+	case procsPrivTblName:
+		return db.procs_priv, true, nil
 	case replicaSourceInfoTblName:
 		return db.replica_source_info, true, nil
 	case helpTopicTableName:
@@ -694,6 +697,7 @@ func (db *MySQLDb) GetTableNames(ctx *sql.Context) ([]string, error) {
 		userTblName,
 		dbTblName,
 		tablesPrivTblName,
+		procsPrivTblName,
 		roleEdgesTblName,
 		replicaSourceInfoTblName,
 		helpTopicTableName,

--- a/sql/mysql_db/mysql_db_serialize.go
+++ b/sql/mysql_db/mysql_db_serialize.go
@@ -98,7 +98,6 @@ func serializeTables(b *flatbuffers.Builder, tables []PrivilegeSetTable) flatbuf
 }
 
 func serializeRoutines(b *flatbuffers.Builder, routines []PrivilegeSetRoutine) flatbuffers.UOffsetT {
-
 	offsets := make([]flatbuffers.UOffsetT, len(routines))
 	for i, routine := range routines {
 		name := b.CreateString(routine.RoutineName())

--- a/sql/mysql_db/privilege_set.go
+++ b/sql/mysql_db/privilege_set.go
@@ -441,6 +441,12 @@ func (ps PrivilegeSetDatabase) HasPrivileges() bool {
 			return true
 		}
 	}
+	for _, routineSet := range ps.routines {
+		if routineSet.HasPrivileges() {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/sql/mysql_db/privilege_set.go
+++ b/sql/mysql_db/privilege_set.go
@@ -512,6 +512,26 @@ func (ps PrivilegeSetDatabase) GetRoutines() []sql.PrivilegeSetRoutine {
 	return routineSets
 }
 
+func (ps PrivilegeSetDatabase) getRoutines() []PrivilegeSetRoutine {
+	if ps.routines == nil || len(ps.routines) == 0 {
+		return []PrivilegeSetRoutine{}
+	}
+
+	routineSets := make([]PrivilegeSetRoutine, 0, len(ps.routines))
+	for _, routine := range ps.routines {
+		routineSets = append(routineSets, routine)
+	}
+
+	sort.Slice(routineSets, func(i, j int) bool {
+		if routineSets[i].RoutineName() != routineSets[j].RoutineType() {
+			return routineSets[i].RoutineName() < routineSets[j].RoutineName()
+		}
+		return routineSets[i].RoutineType() < routineSets[j].RoutineType()
+	})
+
+	return routineSets
+}
+
 // Equals returns whether the given set of privileges is equivalent to the calling set.
 func (ps PrivilegeSetDatabase) Equals(otherPsd sql.PrivilegeSetDatabase) bool {
 	otherPs := otherPsd.(PrivilegeSetDatabase)

--- a/sql/mysql_db/procs_priv.go
+++ b/sql/mysql_db/procs_priv.go
@@ -19,11 +19,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dolthub/vitess/go/sqltypes"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/in_mem_table"
 	"github.com/dolthub/go-mysql-server/sql/types"
-	"github.com/dolthub/vitess/go/sqltypes"
 )
 
 const procsPrivTblName = "procs_priv"

--- a/sql/mysql_db/procs_priv.go
+++ b/sql/mysql_db/procs_priv.go
@@ -1,0 +1,125 @@
+// Copyright 2023 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysql_db
+
+import (
+	"sync"
+	"time"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/in_mem_table"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
+)
+
+const procsPrivTblName = "procs_priv"
+
+var procsPrivTblSchema = buildProcsPrivSchema()
+
+func NewUserProcsIndexedSetTable(set in_mem_table.IndexedSet[*User], lock, rlock sync.Locker) *in_mem_table.MultiIndexedSetTable[*User] {
+	table := in_mem_table.NewMultiIndexedSetTable[*User](
+		procsPrivTblName,
+		procsPrivTblSchema,
+		sql.Collation_utf8mb3_bin,
+		set,
+		in_mem_table.MultiValueOps[*User]{
+			ToRows:    nil, // NM4
+			FromRow:   nil, // NM4
+			AddRow:    nil, // NM4
+			DeleteRow: nil, // NM4
+		},
+		lock,
+		rlock,
+	)
+	return table
+}
+
+// buildProcsPrivSchema builds the schema for the "procs_priv" Grant Table.
+// MySQL Table for reference:
+//
+// mysql> show create table mysql.procs_priv:
+//
+// CREATE TABLE `procs_priv` (
+//
+//	 `Host` char(255) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT '',
+//	 `Db` char(64) COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+//	 `User` char(32) COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+//	 `Routine_name` char(64) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT '',
+//	 `Routine_type` enum('FUNCTION','PROCEDURE') COLLATE utf8mb3_bin NOT NULL,
+//	 `Grantor` varchar(288) COLLATE utf8mb3_bin NOT NULL DEFAULT '',
+//	 `Proc_priv` set('Execute','Alter Routine','Grant') CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci NOT NULL DEFAULT '',
+//	 `Timestamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+//	 PRIMARY KEY (`Host`,`User`,`Db`,`Routine_name`,`Routine_type`),
+//	 KEY `Grantor` (`Grantor`
+//	)
+func buildProcsPrivSchema() sql.Schema {
+	len255_asciii := types.MustCreateString(sqltypes.Char, 255, sql.Collation_ascii_general_ci)
+	len64_utf8_bin := types.MustCreateString(sqltypes.Char, 64, sql.Collation_utf8_bin)
+	len64_utf8_gen := types.MustCreateString(sqltypes.Char, 64, sql.Collation_utf8_general_ci)
+	len32_utf8 := types.MustCreateString(sqltypes.Char, 32, sql.Collation_utf8_bin)
+	routine_types_enum := types.MustCreateEnumType([]string{"FUNCTION", "PROCEDURE"}, sql.Collation_utf8_bin)
+	varchar288_utf8 := types.MustCreateString(sqltypes.VarChar, 288, sql.Collation_utf8_bin)
+	set_privs := types.MustCreateSetType([]string{"Execute", "Alter Routine", "Grant"}, sql.Collation_utf8_general_ci)
+
+	return sql.Schema{
+		columnTemplate("Host", procsPrivTblName, true, &sql.Column{
+			Type:     len255_asciii,
+			Default:  mustDefault(expression.NewLiteral("", len255_asciii), len255_asciii, true, false),
+			Nullable: false}),
+		columnTemplate("Db", procsPrivTblName, true, &sql.Column{
+			Type:     len64_utf8_bin,
+			Default:  mustDefault(expression.NewLiteral("", len64_utf8_bin), len64_utf8_bin, true, false),
+			Nullable: false}),
+		columnTemplate("User", procsPrivTblName, true, &sql.Column{
+			Type:     len32_utf8,
+			Default:  mustDefault(expression.NewLiteral("", len32_utf8), len32_utf8, true, false),
+			Nullable: false}),
+		columnTemplate("Routine_name", procsPrivTblName, true, &sql.Column{
+			Type:     len64_utf8_gen,
+			Default:  mustDefault(expression.NewLiteral("", len64_utf8_gen), len64_utf8_gen, true, false),
+			Nullable: false}),
+		columnTemplate("Routine_type", procsPrivTblName, true, &sql.Column{
+			Type:     routine_types_enum,
+			Default:  mustDefault(expression.NewLiteral("PROCEDURE", routine_types_enum), routine_types_enum, true, false),
+			Nullable: false}),
+		columnTemplate("Grantor", procsPrivTblName, false, &sql.Column{
+			Type:     varchar288_utf8,
+			Default:  mustDefault(expression.NewLiteral("", varchar288_utf8), varchar288_utf8, true, false),
+			Nullable: false}),
+		columnTemplate("Proc_priv", procsPrivTblName, false, &sql.Column{
+			Type:     set_privs,
+			Default:  mustDefault(expression.NewLiteral("", set_privs), set_privs, true, false),
+			Nullable: false}),
+		columnTemplate("Timestamp", tablesPrivTblName, false, &sql.Column{
+			Type:     types.Timestamp,
+			Default:  mustDefault(expression.NewLiteral(time.Unix(1, 0).UTC(), types.Timestamp), types.Timestamp, true, false),
+			Nullable: false}),
+	}
+}
+
+// The column indexes of the "procs_priv" Grant Table.
+// https://dev.mysql.com/doc/refman/8.0/en/grant-tables.html#grant-tables-procs-priv
+// https://mariadb.com/kb/en/mysqlprocs_priv-table/
+const (
+	procsPrivTblColIndex_Host int = iota
+	procsPrivTblColIndex_Db
+	procsPrivTblColIndex_User
+	procsPrivTblColIndex_RoutineName
+	procsPrivTblColIndex_RoutineType
+	procsPrivTblColIndex_Grantor
+	procsPrivTblColIndex_ProcPriv
+	procsPrivTblColIndex_Timestamp
+)

--- a/sql/mysql_db/serial/mysql_db.go
+++ b/sql/mysql_db/serial/mysql_db.go
@@ -253,6 +253,117 @@ func PrivilegeSetTableEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
+type PrivilegeSetRoutine struct {
+	_tab flatbuffers.Table
+}
+
+func InitPrivilegeSetRoutineRoot(o *PrivilegeSetRoutine, buf []byte, offset flatbuffers.UOffsetT) error {
+	n := flatbuffers.GetUOffsetT(buf[offset:])
+	o.Init(buf, n+offset)
+	if PrivilegeSetRoutineNumFields < o.Table().NumFields() {
+		return flatbuffers.ErrTableHasUnknownFields
+	}
+	return nil
+}
+
+func TryGetRootAsPrivilegeSetRoutine(buf []byte, offset flatbuffers.UOffsetT) (*PrivilegeSetRoutine, error) {
+	x := &PrivilegeSetRoutine{}
+	return x, InitPrivilegeSetRoutineRoot(x, buf, offset)
+}
+
+func GetRootAsPrivilegeSetRoutine(buf []byte, offset flatbuffers.UOffsetT) *PrivilegeSetRoutine {
+	x := &PrivilegeSetRoutine{}
+	InitPrivilegeSetRoutineRoot(x, buf, offset)
+	return x
+}
+
+func TryGetSizePrefixedRootAsPrivilegeSetRoutine(buf []byte, offset flatbuffers.UOffsetT) (*PrivilegeSetRoutine, error) {
+	x := &PrivilegeSetRoutine{}
+	return x, InitPrivilegeSetRoutineRoot(x, buf, offset+flatbuffers.SizeUint32)
+}
+
+func GetSizePrefixedRootAsPrivilegeSetRoutine(buf []byte, offset flatbuffers.UOffsetT) *PrivilegeSetRoutine {
+	x := &PrivilegeSetRoutine{}
+	InitPrivilegeSetRoutineRoot(x, buf, offset+flatbuffers.SizeUint32)
+	return x
+}
+
+func (rcv *PrivilegeSetRoutine) Init(buf []byte, i flatbuffers.UOffsetT) {
+	rcv._tab.Bytes = buf
+	rcv._tab.Pos = i
+}
+
+func (rcv *PrivilegeSetRoutine) Table() flatbuffers.Table {
+	return rcv._tab
+}
+
+func (rcv *PrivilegeSetRoutine) Name() []byte {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
+	if o != 0 {
+		return rcv._tab.ByteVector(o + rcv._tab.Pos)
+	}
+	return nil
+}
+
+func (rcv *PrivilegeSetRoutine) Privs(j int) int32 {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.GetInt32(a + flatbuffers.UOffsetT(j*4))
+	}
+	return 0
+}
+
+func (rcv *PrivilegeSetRoutine) PrivsLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+func (rcv *PrivilegeSetRoutine) MutatePrivs(j int, n int32) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(6))
+	if o != 0 {
+		a := rcv._tab.Vector(o)
+		return rcv._tab.MutateInt32(a+flatbuffers.UOffsetT(j*4), n)
+	}
+	return false
+}
+
+func (rcv *PrivilegeSetRoutine) IsProc() bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(8))
+	if o != 0 {
+		return rcv._tab.GetBool(o + rcv._tab.Pos)
+	}
+	return false
+}
+
+func (rcv *PrivilegeSetRoutine) MutateIsProc(n bool) bool {
+	return rcv._tab.MutateBoolSlot(8, n)
+}
+
+const PrivilegeSetRoutineNumFields = 3
+
+func PrivilegeSetRoutineStart(builder *flatbuffers.Builder) {
+	builder.StartObject(PrivilegeSetRoutineNumFields)
+}
+func PrivilegeSetRoutineAddName(builder *flatbuffers.Builder, name flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(name), 0)
+}
+func PrivilegeSetRoutineAddPrivs(builder *flatbuffers.Builder, privs flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(privs), 0)
+}
+func PrivilegeSetRoutineStartPrivsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(4, numElems, 4)
+}
+func PrivilegeSetRoutineAddIsProc(builder *flatbuffers.Builder, isProc bool) {
+	builder.PrependBoolSlot(2, isProc, false)
+}
+func PrivilegeSetRoutineEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+	return builder.EndObject()
+}
+
 type PrivilegeSetDatabase struct {
 	_tab flatbuffers.Table
 }
@@ -366,7 +477,42 @@ func (rcv *PrivilegeSetDatabase) TablesLength() int {
 	return 0
 }
 
-const PrivilegeSetDatabaseNumFields = 3
+func (rcv *PrivilegeSetDatabase) Routines(obj *PrivilegeSetRoutine, j int) bool {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	if o != 0 {
+		x := rcv._tab.Vector(o)
+		x += flatbuffers.UOffsetT(j) * 4
+		x = rcv._tab.Indirect(x)
+		obj.Init(rcv._tab.Bytes, x)
+		return true
+	}
+	return false
+}
+
+func (rcv *PrivilegeSetDatabase) TryRoutines(obj *PrivilegeSetRoutine, j int) (bool, error) {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	if o != 0 {
+		x := rcv._tab.Vector(o)
+		x += flatbuffers.UOffsetT(j) * 4
+		x = rcv._tab.Indirect(x)
+		obj.Init(rcv._tab.Bytes, x)
+		if PrivilegeSetRoutineNumFields < obj.Table().NumFields() {
+			return false, flatbuffers.ErrTableHasUnknownFields
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+func (rcv *PrivilegeSetDatabase) RoutinesLength() int {
+	o := flatbuffers.UOffsetT(rcv._tab.Offset(10))
+	if o != 0 {
+		return rcv._tab.VectorLen(o)
+	}
+	return 0
+}
+
+const PrivilegeSetDatabaseNumFields = 4
 
 func PrivilegeSetDatabaseStart(builder *flatbuffers.Builder) {
 	builder.StartObject(PrivilegeSetDatabaseNumFields)
@@ -384,6 +530,12 @@ func PrivilegeSetDatabaseAddTables(builder *flatbuffers.Builder, tables flatbuff
 	builder.PrependUOffsetTSlot(2, flatbuffers.UOffsetT(tables), 0)
 }
 func PrivilegeSetDatabaseStartTablesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+	return builder.StartVector(4, numElems, 4)
+}
+func PrivilegeSetDatabaseAddRoutines(builder *flatbuffers.Builder, routines flatbuffers.UOffsetT) {
+	builder.PrependUOffsetTSlot(3, flatbuffers.UOffsetT(routines), 0)
+}
+func PrivilegeSetDatabaseStartRoutinesVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
 func PrivilegeSetDatabaseEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {

--- a/sql/plan/grant.go
+++ b/sql/plan/grant.go
@@ -486,6 +486,22 @@ func (n *Grant) HandleTablePrivileges(user *mysql_db.User, dbName string, tblNam
 	return nil
 }
 
+func (n *Grant) HandleRoutinePrivileges(user *mysql_db.User, dbName string, routineName string, isProcedureType bool) error {
+	for _, priv := range n.Privileges {
+		switch priv.Type {
+		case PrivilegeType_Execute:
+			user.PrivilegeSet.AddRoutine(dbName, routineName, isProcedureType, sql.PrivilegeType_Execute)
+		case PrivilegeType_AlterRoutine:
+			user.PrivilegeSet.AddRoutine(dbName, routineName, isProcedureType, sql.PrivilegeType_AlterRoutine)
+		case PrivilegeType_GrantOption:
+			user.PrivilegeSet.AddRoutine(dbName, routineName, isProcedureType, sql.PrivilegeType_GrantOption)
+		default:
+			return sql.ErrGrantRevokeIllegalPrivilege.New()
+		}
+	}
+	return nil
+}
+
 // GrantRole represents the statement GRANT [role...] TO [user...].
 type GrantRole struct {
 	Roles           []UserName

--- a/sql/plan/revoke.go
+++ b/sql/plan/revoke.go
@@ -400,6 +400,22 @@ func (n *Revoke) HandleTablePrivileges(user *mysql_db.User, dbName string, tblNa
 	return nil
 }
 
+func (n *Revoke) HandleRoutinePrivileges(user *mysql_db.User, dbName string, routineName string, isProcedureType bool) error {
+	for _, priv := range n.Privileges {
+		switch priv.Type {
+		case PrivilegeType_AlterRoutine:
+			user.PrivilegeSet.RemoveRoutine(dbName, routineName, isProcedureType, sql.PrivilegeType_AlterRoutine)
+		case PrivilegeType_Execute:
+			user.PrivilegeSet.RemoveRoutine(dbName, routineName, isProcedureType, sql.PrivilegeType_Execute)
+		case PrivilegeType_GrantOption:
+			user.PrivilegeSet.RemoveRoutine(dbName, routineName, isProcedureType, sql.PrivilegeType_GrantOption)
+		default:
+			return sql.ErrGrantRevokeIllegalPrivilege.New()
+		}
+	}
+	return nil
+}
+
 // RevokeAll represents the statement REVOKE ALL PRIVILEGES.
 type RevokeAll struct {
 	Users []UserName

--- a/sql/plan/show_grants.go
+++ b/sql/plan/show_grants.go
@@ -34,16 +34,6 @@ var _ sql.Node = (*ShowGrants)(nil)
 var _ sql.Databaser = (*ShowGrants)(nil)
 var _ sql.CollationCoercible = (*ShowGrants)(nil)
 
-// NewShowGrants returns a new ShowGrants node.
-func NewShowGrants(currentUser bool, targetUser *UserName, using []UserName) *ShowGrants {
-	return &ShowGrants{
-		CurrentUser: currentUser,
-		For:         targetUser,
-		Using:       using,
-		MySQLDb:     sql.UnresolvedDatabase("mysql"),
-	}
-}
-
 // Schema implements the interface sql.Node.
 func (n *ShowGrants) Schema() sql.Schema {
 	user := n.For

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -643,9 +643,15 @@ func (b *BaseBuilder) buildShowGrants(ctx *sql.Context, n *plan.ShowGrants, row 
 			privStr = generatePrivStrings(dbStr, tblStr, userStr, tbl.ToSlice())
 			rows = append(rows, sql.Row{privStr})
 		}
-	}
 
-	// TODO: display column privileges
+		for _, routine := range db.GetRoutines() {
+			quotedRoutine := fmt.Sprintf("`%s`", routine.RoutineName())
+			privStr = generateRoutinePrivStrings(dbStr, quotedRoutine, routine.RoutineType(), userStr, routine.ToSlice())
+			rows = append(rows, sql.Row{privStr})
+		}
+
+		// TODO: display column privileges
+	}
 
 	sb := strings.Builder{}
 

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -132,6 +132,30 @@ func generatePrivStrings(db, tbl, user string, privs []sql.PrivilegeType) string
 	return fmt.Sprintf("GRANT %s ON %s.%s TO %s%s", privStr, db, tbl, user, withGrantOption)
 }
 
+// generateRoutinePrivStrings creates a formatted GRANT <PRILEDGE_LIST> on <ROUTINE_TYPE> <ROUTINE> to <user@host> string
+func generateRoutinePrivStrings(db, routine, routine_type, user string, privs []sql.PrivilegeType) string {
+	privStrs := make([]string, 0, len(privs))
+	grantOption := ""
+	for _, priv := range privs {
+		if priv == sql.PrivilegeType_GrantOption {
+			grantOption = " WITH GRANT OPTION"
+			continue
+		}
+
+		privStr := priv.String()
+		privStrs = append(privStrs, privStr)
+	}
+
+	// This is kind of an odd word to insert in the output, but it's what MySQL does when you have no privileges other
+	// than Grant Options.
+	finalPrivStr := "USAGE"
+	if len(privStrs) > 0 {
+		finalPrivStr = strings.Join(privStrs, ", ")
+	}
+
+	return fmt.Sprintf("GRANT %s ON %s %s.%s TO %s%s", finalPrivStr, routine_type, db, routine, user, grantOption)
+}
+
 func newIndexesToShow(indexes []sql.Index) *indexesToShow {
 	return &indexesToShow{
 		indexes: indexes,


### PR DESCRIPTION
In order to support procedure and function permissions, the mysql.procs_priv needs to be supported. This change add support, but gates the ability to create these grants because they are not being used for actual permission checks yet. That will come next.

I have engine tests on another branch due to the gate. I'll add them when the feature is complete. There are also bats tests in flight in the dolt repo which can be seen here:
https://github.com/dolthub/dolt/compare/4d8fe2a8757ef97503a172138b659980bdd2eaac...macneale4/privs_tests_wip