### PR TITLE
Max/view aliasing bug

### DIFF
--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -21,6 +21,24 @@ import (
 
 var ViewScripts = []ScriptTest{
 	{
+		Name: "view with expression name",
+		SetUpScript: []string{
+			`create view v as select 2+2`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT * from v;",
+				Expected: []sql.Row{{4}},
+				ExpectedColumns: sql.Schema{
+					{
+						Name: "2+2",
+						Type: types.Int64,
+					},
+				},
+			},
+		},
+	},
+	{
 		Name: "view with column names",
 		SetUpScript: []string{
 			`CREATE TABLE xy (x int primary key, y int);`,

--- a/sql/expression/function/json/json_length.go
+++ b/sql/expression/function/json/json_length.go
@@ -17,6 +17,7 @@ package json
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/dolthub/jsonpath"
 
 	"github.com/dolthub/go-mysql-server/sql"

--- a/sql/expression/function/json/json_length.go
+++ b/sql/expression/function/json/json_length.go
@@ -17,8 +17,6 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"log"
-
 	"github.com/dolthub/jsonpath"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -102,7 +100,6 @@ func (j *JsonLength) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("%v", path)
 
 	res, err := jsonpath.JsonPathLookup(jsonData, path.(string))
 	if err != nil {

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -421,7 +421,7 @@ func (b *Builder) buildCreateView(inScope *scope, query string, c *ast.DDL) (out
 	outScope = inScope.push()
 
 	selectStr := query[c.SubStatementPositionStart:c.SubStatementPositionEnd]
-	stmt, _, err := ast.ParseOne(selectStr)
+	stmt, _, err := ast.ParseOneWithOptions(selectStr, b.parserOpts)
 	if err != nil {
 		b.handleErr(err)
 	}

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -419,15 +419,19 @@ func (b *Builder) buildAlterEvent(inScope *scope, query string, c *ast.DDL) (out
 
 func (b *Builder) buildCreateView(inScope *scope, query string, c *ast.DDL) (outScope *scope) {
 	outScope = inScope.push()
-	selectStatement, ok := c.ViewSpec.ViewExpr.(ast.SelectStatement)
+
+	selectStr := query[c.SubStatementPositionStart:c.SubStatementPositionEnd]
+	stmt, _, err := ast.ParseOne(selectStr)
+	if err != nil {
+		b.handleErr(err)
+	}
+	selectStatement, ok := stmt.(ast.SelectStatement)
 	if !ok {
 		err := sql.ErrUnsupportedSyntax.New(ast.String(c.ViewSpec.ViewExpr))
 		b.handleErr(err)
 	}
-
 	queryScope := b.buildSelectStmt(inScope, selectStatement)
 
-	selectStr := query[c.SubStatementPositionStart:c.SubStatementPositionEnd]
 	queryAlias := plan.NewSubqueryAlias(c.ViewSpec.ViewName.Name.String(), selectStr, queryScope.node)
 	definer := getCurrentUserForDefiner(b.ctx, c.ViewSpec.Definer)
 

--- a/sql/planbuilder/parse.go
+++ b/sql/planbuilder/parse.go
@@ -107,6 +107,7 @@ func parse(ctx *sql.Context, cat sql.Catalog, query string, multi bool, options 
 	}
 
 	b := New(ctx, cat)
+	b.SetParserOptions(options)
 	outScope := b.build(nil, stmt, s)
 
 	return outScope.node, parsed, remainder, err


### PR DESCRIPTION
The `View.ViewExpr` AST object seems to drop aliasing information that we depend on for query schema presentation. I want to circle back to have the view AST expression be consistent with the view definition, but this forces a re-parsing to get the correct view schema.