### PR TITLE
Allow ScriptTestAssertion to specify when an assertion needs a new session

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -104,6 +104,13 @@ func TestScriptWithEngine(t *testing.T, e QueryEngine, harness Harness, script q
 
 		for _, assertion := range assertions {
 			t.Run(assertion.Query, func(t *testing.T) {
+				if assertion.NewSession {
+					th, ok := harness.(TransactionHarness)
+					require.True(t, ok, "ScriptTestAssertion requested a NewSession, "+
+						"but harness doesn't implement TransactionHarness")
+					ctx = th.NewSession()
+				}
+
 				if sh, ok := harness.(SkippingHarness); ok && sh.SkipQueryTest(assertion.Query) {
 					t.Skip()
 				}

--- a/enginetest/harness.go
+++ b/enginetest/harness.go
@@ -37,7 +37,7 @@ type Harness interface {
 	Parallelism() int
 	// NewContext allows a harness to specify any sessions or context variables necessary for the proper functioning of
 	// their engine implementation. Every harnessed engine test uses the context created by this method, with some
-	// additional information (e.g. current DB) set uniformly. To replicated the behavior of tests during setup,
+	// additional information (e.g. current DB) set uniformly. To replicate the behavior of tests during setup,
 	// harnesses should generally dispatch to enginetest.NewContext(harness), rather than calling this method themselves.
 	NewContext() *sql.Context
 	// Setup supplies a test suite's setup scripts, which must be stored and used to create a new Engine on demand via
@@ -59,7 +59,7 @@ type ClientHarness interface {
 type ServerHarness interface {
 	Harness
 
-	// SessinBuilder returns a function that creates a new session for connections to a server
+	// SessionBuilder returns a function that creates a new session for connections to a server
 	SessionBuilder() server.SessionBuilder
 }
 

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -80,6 +80,11 @@ type ScriptTestAssertion struct {
 	// For tests that perform join operations, JoinTypes can be set for the type of merge we expect to perform.
 	JoinTypes []plan.JoinType
 
+	// NewSession instructs the test framework that this assertion requires a new session to be created before the
+	// query is executed. This is generally only needed when a test script is testing functionality that invalidates
+	// a session and prevents additional queries from being executed on the session.
+	NewSession bool
+
 	// SkipResultsCheck is used to skip assertions on expected Rows returned from a query. This should be used
 	// sparingly, such as in cases where you only want to test warning messages.
 	SkipResultsCheck bool


### PR DESCRIPTION
As part of testing Dolt's reflog feature, I need to call `dolt_gc()` and then check the reflog behavior. Because `dolt_gc()` invalidates the session, I needed to add this hook that signals the test framework to create a new session for a ScriptTestAssertion. 