### PR TITLE
Fix ExistsSubquery with functions

### DIFF
--- a/enginetest/queries/logic_test_scripts.go
+++ b/enginetest/queries/logic_test_scripts.go
@@ -461,8 +461,31 @@ var SQLLogicSubqueryTests = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "SELECT c_id, bill FROM c AS c2 WHERE EXISTS(SELECT * FROM (SELECT c_id, coalesce(ship, bill) AS state FROM o WHERE c_id=c2.c_id) AS o WHERE state=bill);",
+				Expected: []sql.Row{
+					{1, "CA"},
+					{2, "TX"},
+					{4, "TX"},
+				},
+			},
+			{
+				Query: "SELECT c_id, bill FROM c AS c2 WHERE EXISTS(SELECT * FROM (SELECT c_id, coalesce(ship, bill) AS state FROM o) AS o WHERE c_id = c2.c_id AND state = bill);",
+				Expected: []sql.Row{
+					{1, "CA"},
+					{2, "TX"},
+					{4, "TX"},
+				},
+			},
+			{
+				Query: "SELECT c_id, bill FROM c AS c2 WHERE EXISTS(SELECT * FROM (SELECT c_id, ship AS state FROM o) AS o WHERE c_id = c2.c_id AND coalesce(state, bill) = bill);",
+				Expected: []sql.Row{
+					{1, "CA"},
+					{2, "TX"},
+					{4, "TX"},
+				},
+			},
+			{
+				Query: "SELECT c_id, bill FROM c AS c2 WHERE EXISTS(SELECT * FROM (SELECT c_id, ship AS state FROM o) AS o WHERE c_id = c2.c_id AND coalesce(state, bill) = bill);",
 				Expected: []sql.Row{
 					{1, "CA"},
 					{2, "TX"},

--- a/enginetest/queries/logic_test_scripts.go
+++ b/enginetest/queries/logic_test_scripts.go
@@ -485,6 +485,14 @@ var SQLLogicSubqueryTests = []ScriptTest{
 				},
 			},
 			{
+				Query: "SELECT c_id, bill FROM c AS c2 WHERE EXISTS(SELECT c_id, ship FROM o WHERE c_id = c2.c_id AND coalesce(ship, bill) = bill);",
+				Expected: []sql.Row{
+					{1, "CA"},
+					{2, "TX"},
+					{4, "TX"},
+				},
+			},
+			{
 				Query: "SELECT c_id, bill FROM c AS c2 WHERE EXISTS(SELECT * FROM (SELECT c_id, ship AS state FROM o) AS o WHERE c_id = c2.c_id AND coalesce(state, bill) = bill);",
 				Expected: []sql.Row{
 					{1, "CA"},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -8398,7 +8398,7 @@ inner join pq on true
 			"     └─ Filter\n" +
 			"         ├─ GreaterThanOrEqual\n" +
 			"         │   ├─ NOW()\n" +
-			"         │   └─ coalesce(NULL,NULL,NOW())\n" +
+			"         │   └─ coalesce(NULL (null),NULL (null),NOW())\n" +
 			"         └─ TableAlias(a)\n" +
 			"             └─ IndexedTableAccess(mytable)\n" +
 			"                 ├─ index: [mytable.i]\n" +

--- a/enginetest/queries/tpcc_plans.go
+++ b/enginetest/queries/tpcc_plans.go
@@ -27,7 +27,7 @@ WHERE
   o_c_id = 20001 AND
   o_id = (SELECT MAX(o_id) FROM orders2 WHERE o_w_id = 1 AND o_d_id = 3 AND o_c_id = 20001)`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [orders2.o_id:1!null, orders2.o_entry_d:5, coalesce(orders2.o_carrier_id,0) as COALESCE(o_carrier_id,0)]\n" +
+			" ├─ columns: [orders2.o_id:1!null, orders2.o_entry_d:5, coalesce(orders2.o_carrier_id:6,0 (tinyint)) as COALESCE(o_carrier_id,0)]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ orders2.o_id:1!null\n" +

--- a/sql/analyzer/hoist_select_exists.go
+++ b/sql/analyzer/hoist_select_exists.go
@@ -160,6 +160,12 @@ func hoistExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, filt
 			}
 		}
 
+		if sqa, ok := s.inner.(*plan.SubqueryAlias); ok {
+			if !sqa.CanCacheResults() {
+				return filter, transform.SameTree, nil
+			}
+		}
+
 		// if we reached here, |s| contains the state we need to
 		// decorrelate the subquery expression into a new node
 		same = transform.NewTree

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -352,6 +352,7 @@ func convertSemiToInnerJoin(a *Analyzer, m *memo.Memo) error {
 
 		// join and its commute are a new group
 		joinGrp := m.MemoizeInnerJoin(nil, semi.Left, rightGrp, plan.JoinTypeInner, semi.Filter)
+		// TODO: can't commute if right SubqueryAlias references outside scope (OuterScopeVisibility/IsLateral)
 		m.MemoizeInnerJoin(joinGrp, rightGrp, semi.Left, plan.JoinTypeInner, semi.Filter)
 
 		// project belongs to the original group

--- a/sql/expression/function/coalesce.go
+++ b/sql/expression/function/coalesce.go
@@ -97,6 +97,14 @@ func (c *Coalesce) String() string {
 	return fmt.Sprintf("%s(%s)", c.FunctionName(), strings.Join(args, ","))
 }
 
+func (c *Coalesce) DebugString() string {
+	var args = make([]string, len(c.args))
+	for i, arg := range c.args {
+		args[i] = sql.DebugString(arg)
+	}
+	return fmt.Sprintf("%s(%s)", c.FunctionName(), strings.Join(args, ","))
+}
+
 // WithChildren implements the Expression interface.
 func (*Coalesce) WithChildren(children ...sql.Expression) (sql.Expression, error) {
 	return NewCoalesce(children...)

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -173,16 +173,10 @@ func prependRowInPlanForTriggerExecution(row sql.Row) func(c transform.Context) 
 			case *plan.InsertInto, *plan.TriggerExecutor:
 				return n, transform.SameTree, nil
 			default:
-				return &plan.PrependNode{
-					UnaryNode: plan.UnaryNode{Child: n},
-					Row:       row,
-				}, transform.NewTree, nil
+				return plan.NewPrependNode(n, row), transform.NewTree, nil
 			}
 		case *plan.ResolvedTable, *plan.IndexedTableAccess:
-			return &plan.PrependNode{
-				UnaryNode: plan.UnaryNode{Child: n},
-				Row:       row,
-			}, transform.NewTree, nil
+			return plan.NewPrependNode(n, row), transform.NewTree, nil
 		default:
 			return n, transform.SameTree, nil
 		}


### PR DESCRIPTION
Our `hoistSelectExists` optimization incorrectly generates `SemiJoins` when there are OuterScope column references in projections in subqueries. In the future, a possible optimization could be to have `SemiLateralJoins` that properly grant this visibility.

Also contains small refactoring and extra debug information for `coalesce` function.

Fixes one of the queries here: https://github.com/dolthub/dolt/issues/6898