### PR TITLE
Grant Options privs need the AdminOnly treatment too

### DIFF
--- a/enginetest/queries/priv_auth_queries.go
+++ b/enginetest/queries/priv_auth_queries.go
@@ -935,12 +935,23 @@ var UserPrivTests = []UserPrivilegeTest{
 					{"proc2", "PROCEDURE", "Alter Routine"},
 				},
 			},
-
 			{
 				User:     "root",
 				Host:     "localhost",
 				Query:    "SELECT Routine_name,Routine_type,proc_priv from mysql.procs_priv WHERE User = 'tester2'",
 				Expected: []sql.Row{{"proc1", "PROCEDURE", "Grant"}},
+			},
+			{
+				User:     "tester1",
+				Host:     "localhost",
+				Query:    "GRANT Execute ON PROCEDURE mydb.proc1 TO tester2@localhost",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				User:           "tester2",
+				Host:           "localhost",
+				Query:          "GRANT Execute ON PROCEDURE mydb.proc2 TO tester1@localhost",
+				ExpectedErrStr: "command denied to user 'tester2'@'localhost'",
 			},
 		},
 	},

--- a/sql/planbuilder/priv.go
+++ b/sql/planbuilder/priv.go
@@ -338,6 +338,7 @@ func (b *Builder) buildGrantPrivilege(inScope *scope, n *ast.GrantPrivilege) (ou
 		WithGrantOption: n.WithGrantOption,
 		As:              gau,
 		MySQLDb:         b.resolveDb("mysql"),
+		Catalog:         &b.cat,
 	}
 
 	return outScope


### PR DESCRIPTION
This addresses a gap discovered while writing dolt tests - Grant Option on procedures is not currently validated correctly, resulting in only super users being able to set grants on procedures. This should address that.