### PR TITLE
Fixed Full-Text defaults

### DIFF
--- a/enginetest/queries/fulltext_queries.go
+++ b/enginetest/queries/fulltext_queries.go
@@ -1040,4 +1040,28 @@ var FulltextTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Full-Text with default columns",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk BIGINT UNSIGNED NOT NULL DEFAULT '1', v1 VARCHAR(200) DEFAULT 'def', PRIMARY KEY(pk), FULLTEXT idx (v1));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "INSERT INTO test (v1) VALUES ('abc');",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1}}},
+			},
+			{
+				Query:    "INSERT INTO test (pk, v1) VALUES (2, 'def');",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1}}},
+			},
+			{
+				Query:    "SELECT * FROM test;",
+				Expected: []sql.Row{{uint64(1), "abc"}, {uint64(2), "def"}},
+			},
+			{
+				Query:    "SELECT * FROM test WHERE MATCH(v1) AGAINST ('def');",
+				Expected: []sql.Row{{uint64(2), "def"}},
+			},
+		},
+	},
 }

--- a/sql/fulltext/fulltext.go
+++ b/sql/fulltext/fulltext.go
@@ -791,6 +791,11 @@ func validateSchema(ftTblName string, parentSch sql.Schema, sch sql.Schema, expe
 	for i := range sch {
 		col := *sch[i]
 		expectedCol := *revisedExpected[i]
+		if col.Generated != nil || expectedCol.Generated != nil {
+			// It might be fine for Full-Text to reference generated columns, but we aren't completely sure of any
+			// potential implementation issues, so it's disabled for now.
+			return fmt.Errorf("Full-Text does not currently support generated columns")
+		}
 		// The expected schemas use the default collation, so we set them to the given column's collation for comparison
 		if expectedColStrType, ok := expectedCol.Type.(sql.TypeWithCollation); ok {
 			colStrType, ok := col.Type.(sql.TypeWithCollation)

--- a/sql/fulltext/fulltext.go
+++ b/sql/fulltext/fulltext.go
@@ -804,7 +804,7 @@ func validateSchema(ftTblName string, parentSch sql.Schema, sch sql.Schema, expe
 		}
 		// We can't just use the Equals() function on the columns as they care about fields that we do not.
 		if col.Name != expectedCol.Name || !col.Type.Equals(expectedCol.Type) || col.PrimaryKey != expectedCol.PrimaryKey || col.Nullable != expectedCol.Nullable ||
-			col.AutoIncrement != expectedCol.AutoIncrement || col.Default != expectedCol.Default {
+			col.AutoIncrement != expectedCol.AutoIncrement {
 			return fmt.Errorf("Full-Text table `%s` column `%s` has an incorrect definition", ftTblName, col.Name)
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/6941

Full-Text schema validation also considered the default expressions, which do not matter for the pseudo-index tables. The default expression evaluation occurs before the table editors are involved, so they're always receiving fully-realized rows. This means that we can skip the default check, since it doesn't matter whether the tables have default expressions or not.

The root cause for the bug was due to comparing pointers. Same contents for the expressions, but different pointers to different objects, so defaults would always cause failure.