### PR TITLE
ReferenceChecker interface

### DIFF
--- a/sql/tables.go
+++ b/sql/tables.go
@@ -179,6 +179,14 @@ type ForeignKeyEditor interface {
 	IndexAddressable
 }
 
+// ReferenceChecker is usually an IndexAddressableTable that does key
+// lookups for existence checks. Indicating that the engine is performing
+// a reference check lets the integrator avoid expensive deserialization
+// steps.
+type ReferenceChecker interface {
+	SetReferenceCheck() error
+}
+
 // CheckTable is a table that declares check constraints.
 type CheckTable interface {
 	Table


### PR DESCRIPTION
re: https://github.com/dolthub/dolt/pull/6957 It is expensive and unnecessary to deserialize blobs during FK reference check lookups.