### PR TITLE
Respect `character_set_results` when emitting field metadata

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4838,9 +4838,9 @@ func testCharsetCollationWire(t *testing.T, h Harness, sessionBuilder server.Ses
 							}
 							assert.Equal(t, query.Expected[rowIdx], outRow)
 
-							if query.ExpectedCharSets != nil {
-								for i, expectedCharSet := range query.ExpectedCharSets {
-									assert.Equal(t, uint64(expectedCharSet), extractCharSetIdForField(r, i))
+							if query.ExpectedCollations != nil {
+								for i, expectedCollation := range query.ExpectedCollations {
+									assert.Equal(t, uint64(expectedCollation), extractCollationIdForField(r, i))
 								}
 							}
 						}
@@ -4852,11 +4852,11 @@ func testCharsetCollationWire(t *testing.T, h Harness, sessionBuilder server.Ses
 	}
 }
 
-// extractCharSetIdForField uses reflection to access the MySQL field metadata for field |i| in result set |r| and
+// extractCollationIdForField uses reflection to access the MySQL field metadata for field |i| in result set |r| and
 // returns the field's character set ID metadata. This character set ID is not exposed through the standard golang
 // sql database interfaces, so we have to use reflection to access this so we can validate that we are sending the
 // correct character set metadata for fields.
-func extractCharSetIdForField(r *dsql.Rows, i int) uint64 {
+func extractCollationIdForField(r *dsql.Rows, i int) uint64 {
 	rowsi := reflect.ValueOf(r).Elem().FieldByName("rowsi")
 	mysqlRows := rowsi.Elem().Elem().FieldByName("mysqlRows")
 	rs := mysqlRows.FieldByName("rs")

--- a/enginetest/queries/charset_collation_wire.go
+++ b/enginetest/queries/charset_collation_wire.go
@@ -31,9 +31,9 @@ type CharsetCollationWireTestQuery struct {
 	Query    string
 	Expected []sql.Row
 	Error    bool
-	// ExpectedCharSets is an optional field, and when populated the test framework will assert that
-	// the MySQL field metadata has these expected character set IDs.
-	ExpectedCharSets []int
+	// ExpectedCollations is an optional field, and when populated the test framework will assert that
+	// the MySQL field metadata has these expected collation IDs.
+	ExpectedCollations []sql.CollationID
 }
 
 // CharsetCollationWireTests are used to ensure that character sets and collations have the correct behavior over the
@@ -364,36 +364,36 @@ var CharsetCollationWireTests = []CharsetCollationWireTest{
 		},
 		Queries: []CharsetCollationWireTestQuery{
 			{
-				Query:            "SELECT * FROM test;",
-				Expected:         []sql.Row{{"\x00h\x00e\x00y"}},
-				ExpectedCharSets: []int{63}, // binary COLLATE binary
+				Query:              "SELECT * FROM test;",
+				Expected:           []sql.Row{{"\x00h\x00e\x00y"}},
+				ExpectedCollations: []sql.CollationID{sql.Collation_binary},
 			},
 			{
 				Query:    "SET character_set_results = 'utf8mb4';",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:            "SELECT * FROM test;",
-				Expected:         []sql.Row{{"hey"}},
-				ExpectedCharSets: []int{255}, // utf8mb4 COLLATE utf8mb4_900_ai_ci
+				Query:              "SELECT * FROM test;",
+				Expected:           []sql.Row{{"hey"}},
+				ExpectedCollations: []sql.CollationID{sql.Collation_utf8mb4_0900_ai_ci},
 			},
 			{
 				Query:    "SET character_set_results = 'utf32';",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:            "SELECT * FROM test;",
-				Expected:         []sql.Row{{"\x00\x00\x00h\x00\x00\x00e\x00\x00\x00y"}},
-				ExpectedCharSets: []int{60}, // unknown
+				Query:              "SELECT * FROM test;",
+				Expected:           []sql.Row{{"\x00\x00\x00h\x00\x00\x00e\x00\x00\x00y"}},
+				ExpectedCollations: []sql.CollationID{sql.Collation_utf32_general_ci},
 			},
 			{
 				Query:    "SET character_set_results = NULL;",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:            "SELECT * FROM test;",
-				Expected:         []sql.Row{{"\x00h\x00e\x00y"}},
-				ExpectedCharSets: []int{54}, // utf16_unicode_ci
+				Query:              "SELECT * FROM test;",
+				Expected:           []sql.Row{{"\x00h\x00e\x00y"}},
+				ExpectedCollations: []sql.CollationID{sql.Collation_utf16_general_ci},
 			},
 		},
 	},

--- a/server/handler.go
+++ b/server/handler.go
@@ -613,8 +613,6 @@ func schemaToFields(ctx *sql.Context, s sql.Schema) []*query.Field {
 		}
 
 		// If a result character set has been set for this session, make sure we use that
-		// TODO: This only sends the expected metadata, to fully honor character_set_results, we need to
-		//       translate the character data into the target character set when we send it out over the wire.
 		if charSetResults != sql.CharacterSet_Unspecified {
 			charset = uint32(charSetResults)
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -612,8 +612,9 @@ func schemaToFields(ctx *sql.Context, s sql.Schema) []*query.Field {
 			charset = uint32(collatedType.Collation().CharacterSet())
 		}
 
-		// If a result character set has been set for this session, make sure we use that
-		if charSetResults != sql.CharacterSet_Unspecified {
+		// If a result character set has been set for this session, make sure we use
+		// it for any non-binary types
+		if !types.IsBinaryType(c.Type) && charSetResults != sql.CharacterSet_Unspecified {
 			charset = uint32(charSetResults)
 		}
 


### PR DESCRIPTION
For non-binary types, we need to respect the value for the `character_set_results` session var (when not `NULL`) and use that for the field metadata returned in the MySQL wire protocol. 

The unexpected charset/collation metadata is causing DataGrip to be unable to work with some types in the table editor ( see https://github.com/dolthub/dolt/issues/6970 for more details). 

I've validated this behavior with MySQL by inspecting packets with Wireshark. For testing, we were already testing the behavior of `character_set_results` and the charset translation, but we weren't testing the field metadata. I added support to check against the expect charset field metadata, but had to use reflection to get that data from the MySQL driver, since it's not exposed through the standard golang sql database APIs. 