### PR TITLE
Fixing field metadata for `JSON` and `geometry` types

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -612,9 +612,11 @@ func schemaToFields(ctx *sql.Context, s sql.Schema) []*query.Field {
 			charset = uint32(collatedType.Collation().CharacterSet())
 		}
 
-		// If a result character set has been set for this session, make sure we use
-		// it for any non-binary types
-		if !types.IsBinaryType(c.Type) && charSetResults != sql.CharacterSet_Unspecified {
+		// Binary types always use a binary collation, but non-binary types must
+		// respect character_set_results if it is set.
+		if types.IsBinaryType(c.Type) {
+			charset = uint32(sql.Collation_binary)
+		} else if charSetResults != sql.CharacterSet_Unspecified {
 			charset = uint32(charSetResults)
 		}
 

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -671,13 +671,13 @@ func TestSchemaToFields(t *testing.T) {
 		{Name: "text", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 262_140},
 		{Name: "mediumtext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 67_108_860},
 		{Name: "longtext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
-		{Name: "json", Type: query.Type_JSON, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
+		{Name: "json", Type: query.Type_JSON, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
 
 		// Geometry Types
-		{Name: "geometry", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
-		{Name: "point", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
-		{Name: "polygon", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
-		{Name: "linestring", Type: query.Type_GEOMETRY, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
+		{Name: "geometry", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "point", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "polygon", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "linestring", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
 
 		// Integer Types
 		{Name: "uint8", Type: query.Type_UINT8, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 3},

--- a/sql/types/typecheck.go
+++ b/sql/types/typecheck.go
@@ -36,7 +36,7 @@ func IsBinaryType(t sql.Type) bool {
 		return false
 	}
 	switch t.Type() {
-	case sqltypes.Binary, sqltypes.VarBinary, sqltypes.Blob:
+	case sqltypes.Binary, sqltypes.VarBinary, sqltypes.Blob, sqltypes.TypeJSON, sqltypes.Geometry:
 		return true
 	default:
 		return false


### PR DESCRIPTION
`JSON` and `geometry` types should always report a binary collation in MySQL's field metadata. While debugging https://github.com/dolthub/dolt/issues/6970, I noticed that MySQL was sending a binary collation for these types, but GMS was sending back the default collation. 