### PR TITLE
Push filters insensitive to table name

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -1609,7 +1609,7 @@ func evalIndexTest(t *testing.T, harness Harness, e QueryEngine, q string, index
 		}
 		var cmp []string
 		for _, i := range idxs {
-			cmp = append(cmp, i.ID())
+			cmp = append(cmp, strings.ToLower(i.ID()))
 		}
 		require.Equal(t, exp, cmp, fmt.Sprintf("unexpected plan:\n%s", sql.DebugString(a)))
 	})

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -199,7 +199,7 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	// t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
 			Name: "physical columns added after virtual one",

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -1210,36 +1210,36 @@ WHERE
 	   AND
 	       SWCQV = 0
 	`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ hu5a5.SWCQV:10!null\n" +
-			" │   └─ 0 (tinyint)\n" +
-			" └─ Project\n" +
-			"     ├─ columns: [hu5a5.id:0!null, HU5A5.TOFPN:1!null, HU5A5.I3VTA:2!null, HU5A5.SFJ6L:3, HU5A5.V5DPX:4!null, HU5A5.LJLUM:5!null, HU5A5.IDPK7:6!null, HU5A5.NO52D:7!null, HU5A5.ZRV3B:8!null, HU5A5.VYO5E:9, HU5A5.SWCQV:10!null, HU5A5.YKSSU:11, HU5A5.FHCYT:12]\n" +
-			"     └─ Filter\n" +
-			"         ├─ scalarSubq0.XMM6Q:13 IS NULL\n" +
-			"         └─ LeftOuterMergeJoin\n" +
-			"             ├─ cmp: Eq\n" +
-			"             │   ├─ hu5a5.id:0!null\n" +
-			"             │   └─ scalarSubq0.XMM6Q:13\n" +
-			"             ├─ IndexedTableAccess(HU5A5)\n" +
-			"             │   ├─ index: [HU5A5.id]\n" +
-			"             │   ├─ static: [{[NULL, ∞)}]\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: HU5A5\n" +
-			"             │       └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
-			"             └─ Project\n" +
-			"                 ├─ columns: [scalarSubq0.XMM6Q:7]\n" +
-			"                 └─ Filter\n" +
-			"                     ├─ NOT\n" +
-			"                     │   └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
-			"                     └─ TableAlias(scalarSubq0)\n" +
-			"                         └─ IndexedTableAccess(FLQLP)\n" +
-			"                             ├─ index: [FLQLP.XMM6Q]\n" +
-			"                             ├─ static: [{[NULL, ∞)}]\n" +
-			"                             └─ Table\n" +
-			"                                 ├─ name: FLQLP\n" +
-			"                                 └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [hu5a5.id:0!null, HU5A5.TOFPN:1!null, HU5A5.I3VTA:2!null, HU5A5.SFJ6L:3, HU5A5.V5DPX:4!null, HU5A5.LJLUM:5!null, HU5A5.IDPK7:6!null, HU5A5.NO52D:7!null, HU5A5.ZRV3B:8!null, HU5A5.VYO5E:9, hu5a5.SWCQV:10!null, HU5A5.YKSSU:11, HU5A5.FHCYT:12]\n" +
+			" └─ Filter\n" +
+			"     ├─ scalarSubq0.XMM6Q:13 IS NULL\n" +
+			"     └─ LeftOuterMergeJoin\n" +
+			"         ├─ cmp: Eq\n" +
+			"         │   ├─ hu5a5.id:0!null\n" +
+			"         │   └─ scalarSubq0.XMM6Q:13\n" +
+			"         ├─ Filter\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ hu5a5.SWCQV:10!null\n" +
+			"         │   │   └─ 0 (tinyint)\n" +
+			"         │   └─ IndexedTableAccess(HU5A5)\n" +
+			"         │       ├─ index: [HU5A5.id]\n" +
+			"         │       ├─ static: [{[NULL, ∞)}]\n" +
+			"         │       └─ Table\n" +
+			"         │           ├─ name: HU5A5\n" +
+			"         │           └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
+			"         └─ Project\n" +
+			"             ├─ columns: [scalarSubq0.XMM6Q:7]\n" +
+			"             └─ Filter\n" +
+			"                 ├─ NOT\n" +
+			"                 │   └─ scalarSubq0.XMM6Q:7 IS NULL\n" +
+			"                 └─ TableAlias(scalarSubq0)\n" +
+			"                     └─ IndexedTableAccess(FLQLP)\n" +
+			"                         ├─ index: [FLQLP.XMM6Q]\n" +
+			"                         ├─ static: [{[NULL, ∞)}]\n" +
+			"                         └─ Table\n" +
+			"                             ├─ name: FLQLP\n" +
+			"                             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -105,6 +105,18 @@ type ScriptTestAssertion struct {
 // the tests.
 var ScriptTests = []ScriptTest{
 	{
+		Name: "filter pushdown through join uppercase name",
+		SetUpScript: []string{
+			"create table A (A int primary key);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select /*+ JOIN_ORDER(A, b) */ * from A join A b where a.A = 1 and b.A = 1",
+				ExpectedIndexes: []string{"primary", "primary"},
+			},
+		},
+	},
+	{
 		Name: "correctness test indexes",
 		SetUpScript: []string{
 			`

--- a/enginetest/queries/tpch_plans.go
+++ b/enginetest/queries/tpch_plans.go
@@ -1805,33 +1805,9 @@ order by
 			"             │       │               │           └─ columns: [ps_partkey ps_suppkey ps_availqty ps_supplycost ps_comment]\n" +
 			"             │       │               └─ Filter\n" +
 			"             │       │                   ├─ AND\n" +
-			"             │       │                   │   ├─ AND\n" +
-			"             │       │                   │   │   ├─ AND\n" +
-			"             │       │                   │   │   │   ├─ AND\n" +
-			"             │       │                   │   │   │   │   ├─ AND\n" +
-			"             │       │                   │   │   │   │   │   ├─ AND\n" +
-			"             │       │                   │   │   │   │   │   │   ├─ AND\n" +
-			"             │       │                   │   │   │   │   │   │   │   ├─ GreaterThanOrEqual\n" +
-			"             │       │                   │   │   │   │   │   │   │   │   ├─ scalarSubq1.p_name:1!null\n" +
-			"             │       │                   │   │   │   │   │   │   │   │   └─ forest (longtext)\n" +
-			"             │       │                   │   │   │   │   │   │   │   └─ LessThanOrEqual\n" +
-			"             │       │                   │   │   │   │   │   │   │       ├─ scalarSubq1.p_name:1!null\n" +
-			"             │       │                   │   │   │   │   │   │   │       └─ forestÿ (longtext)\n" +
-			"             │       │                   │   │   │   │   │   │   └─ GreaterThanOrEqual\n" +
-			"             │       │                   │   │   │   │   │   │       ├─ scalarSubq1.p_name:1!null\n" +
-			"             │       │                   │   │   │   │   │   │       └─ forest (longtext)\n" +
-			"             │       │                   │   │   │   │   │   └─ LessThanOrEqual\n" +
-			"             │       │                   │   │   │   │   │       ├─ scalarSubq1.p_name:1!null\n" +
-			"             │       │                   │   │   │   │   │       └─ forestÿ (longtext)\n" +
-			"             │       │                   │   │   │   │   └─ GreaterThanOrEqual\n" +
-			"             │       │                   │   │   │   │       ├─ scalarSubq1.p_name:1!null\n" +
-			"             │       │                   │   │   │   │       └─ forest (longtext)\n" +
-			"             │       │                   │   │   │   └─ LessThanOrEqual\n" +
-			"             │       │                   │   │   │       ├─ scalarSubq1.p_name:1!null\n" +
-			"             │       │                   │   │   │       └─ forestÿ (longtext)\n" +
-			"             │       │                   │   │   └─ GreaterThanOrEqual\n" +
-			"             │       │                   │   │       ├─ scalarSubq1.p_name:1!null\n" +
-			"             │       │                   │   │       └─ forest (longtext)\n" +
+			"             │       │                   │   ├─ GreaterThanOrEqual\n" +
+			"             │       │                   │   │   ├─ scalarSubq1.p_name:1!null\n" +
+			"             │       │                   │   │   └─ forest (longtext)\n" +
 			"             │       │                   │   └─ LessThanOrEqual\n" +
 			"             │       │                   │       ├─ scalarSubq1.p_name:1!null\n" +
 			"             │       │                   │       └─ forestÿ (longtext)\n" +

--- a/sql/analyzer/filters.go
+++ b/sql/analyzer/filters.go
@@ -16,6 +16,7 @@ package analyzer
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -111,7 +112,7 @@ func newFilterSet(filter sql.Expression, filtersByTable filtersByTable, tableAli
 // availableFiltersForTable returns the filters that are still available for the table given (not previously marked
 // handled)
 func (fs *filterSet) availableFiltersForTable(ctx *sql.Context, table string) []sql.Expression {
-	filters, ok := fs.filtersByTable[table]
+	filters, ok := fs.filtersByTable[strings.ToLower(table)]
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
Filter pushing bug that is specific to 1) table names with capital letters, and 2) filters that need to move through joins. The problem is not indexing specifically, but checking for an index is the easiest way to test this.

dolt bump: https://github.com/dolthub/dolt/pull/7001