### PR TITLE
Update `MaxUpperBound` when inserting into `RangeTree`

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4197,6 +4197,34 @@ CREATE TABLE tab3 (
 			},
 		},
 	},
+	{
+		Name: "Complex Filter Index Scan",
+		SetUpScript: []string{
+			`CREATE TABLE tab2 (
+              pk int NOT NULL,
+              col0 int,
+              col1 float,
+              col2 text,
+              col3 int,
+              col4 float,
+              col5 text,
+              PRIMARY KEY (pk),
+              UNIQUE KEY idx_tab2_0 (col3,col4),
+              UNIQUE KEY idx_tab2_1 (col1,col4),
+              UNIQUE KEY idx_tab2_2 (col3,col0,col4),
+              UNIQUE KEY idx_tab2_3 (col1,col3)
+            );`,
+            `insert into tab2 values ( 63, 587, 465.59 , 'aggxb', 303 , 763.91, 'tgpqr');`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT pk FROM tab2 WHERE col4 IS NULL OR col0 > 560 AND (col3 < 848) OR (col3 > 883) OR (((col4 >= 539.78 AND col3 <= 953))) OR ((col3 IN (258)) OR (col3 IN (583,234,372)) AND col4 >= 488.43)",
+				Expected: []sql.Row{
+					{63},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/range_tree.go
+++ b/sql/range_tree.go
@@ -289,6 +289,10 @@ func (tree *RangeColumnExprTree) insert(rang Range, colExprIdx int) error {
 					insertedNode = node.Right
 					loop = false
 				} else {
+					node.MaxUpperbound, err = GetRangeCutMax(colExpr.Typ, node.MaxUpperbound, colExpr.UpperBound)
+					if err != nil {
+						return err
+					}
 					node = node.Right
 				}
 			} else /* cmp == 0 */ {


### PR DESCRIPTION
Recent changes to index costing exposed a bug in `RangeTree`. This bug is responsible for a small regression in the sqllogictests, involving a complicated filter.

When generating ranges over an index to satisfy a filter, we have to ensure that the resulting ranges do not overlap; we accomplish this efficiently through the use of a RangeTree (a multi-dimensional red-black tree) to split up and merge ranges.
Given a Range, the RangeTree returns a set of Ranges that overlap it, and we replace these with a set of ranges that cover the same area, minus the overlap.

However, during insertion (specifically when the new node is a right child), we do not update the parent's `MaxUpperBound`. This is important for deciding to search subtrees during `FindConnection()`. As a result, the RangeTree did not find all overlapping ranges, and would produce a set of Ranges that still contained overlaps.

Additionally, this PR adds a slightly better method of checking if the resulting ranges have overlaps.

There is also a skipped test; it's possible that there are multiple sets of non overlapping ranges that satisfy the same sets of filters.
There will be a follow up PR that has a better method of verifying the correctness of these ranges.