### PR TITLE
updating `RangeTree` node `MaxUpperBound` again

### DIFF
--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -1575,7 +1575,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((((v1 BETWEEN 1 AND 11) OR (v1>2 AND v3<=93 AND v2 BETWEEN 28 AND 84)) OR (v1 BETWEEN 34 AND 52 AND v2=73)) OR (v1<>80 AND v2<=32 AND v3 BETWEEN 3 AND 7));`,
 		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, 1), (NULL, 32], [3, 7]}, {[1, 11], [NULL, ∞), [NULL, ∞)}, {(11, 34), [28, 84], (NULL, 93]}, {(11, 52], (NULL, 28), [3, 7]}, {[34, 52], [28, 73), (NULL, 93]}, {[34, 52], [73, 73], [NULL, ∞)}, {[34, 52], (73, 84], (NULL, 93]}, {(52, 80), (NULL, 28), [3, 7]}, {(52, ∞), [28, 84], (NULL, 93]}, {(80, ∞), (NULL, 28), [3, 7]}]\n" +
+			" ├─ static: [{(NULL, 1), (NULL, 32], [3, 7]}, {[1, 11], [NULL, ∞), [NULL, ∞)}, {(11, 34), [28, 84], (NULL, 93]}, {(11, 80), (NULL, 28), [3, 7]}, {[34, 52], [28, 73), (NULL, 93]}, {[34, 52], [73, 73], [NULL, ∞)}, {[34, 52], (73, 84], (NULL, 93]}, {(52, ∞), [28, 84], (NULL, 93]}, {(80, ∞), (NULL, 28), [3, 7]}]\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
@@ -6415,7 +6415,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1>25 AND v2 BETWEEN 23 AND 54) OR (v1<>40 AND v3>90)) OR (v1<>7 AND v4<=78));`,
 		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{(NULL, 7), [NULL, ∞), [NULL, 90], (NULL, 78]}, {(NULL, 40), [NULL, ∞), (90, ∞), [NULL, ∞)}, {(7, 25], [NULL, ∞), [NULL, 90], (NULL, 78]}, {(25, 40), [NULL, 23), [NULL, 90], (NULL, 78]}, {(25, 40), (54, ∞), [NULL, 90], (NULL, 78]}, {(25, ∞), [23, 54], [NULL, ∞), [NULL, ∞)}, {[40, 40], [NULL, 23), [NULL, ∞), (NULL, 78]}, {[40, 40], (54, ∞), [NULL, ∞), (NULL, 78]}, {(40, ∞), [NULL, 23), [NULL, 90], (NULL, 78]}, {(40, ∞), [NULL, 23), (90, ∞), [NULL, ∞)}, {(40, ∞), (54, ∞), [NULL, 90], (NULL, 78]}, {(40, ∞), (54, ∞), (90, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, 7), [NULL, ∞), [NULL, 90], (NULL, 78]}, {(NULL, 25], [NULL, ∞), (90, ∞), [NULL, ∞)}, {(7, 25], [NULL, ∞), [NULL, 90], (NULL, 78]}, {(25, 40), [NULL, 23), [NULL, 90], (NULL, 78]}, {(25, 40), [NULL, 23), (90, ∞), [NULL, ∞)}, {(25, 40), (54, ∞), [NULL, 90], (NULL, 78]}, {(25, 40), (54, ∞), (90, ∞), [NULL, ∞)}, {(25, ∞), [23, 54], [NULL, ∞), [NULL, ∞)}, {[40, 40], [NULL, 23), [NULL, ∞), (NULL, 78]}, {[40, 40], (54, ∞), [NULL, ∞), (NULL, 78]}, {(40, ∞), [NULL, 23), [NULL, 90], (NULL, 78]}, {(40, ∞), [NULL, 23), (90, ∞), [NULL, ∞)}, {(40, ∞), (54, ∞), [NULL, 90], (NULL, 78]}, {(40, ∞), (54, ∞), (90, ∞), [NULL, ∞)}]\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
@@ -6575,7 +6575,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((((v1>87) OR (v1>82 AND v4>=22)) OR (v1>=52 AND v2<>47 AND v3=37)) OR (v1<=14 AND v2<57 AND v3<10));`,
 		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
 			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{(NULL, 14], (NULL, 57), (NULL, 10), [NULL, ∞)}, {[52, 82], (NULL, 47), [37, 37], [NULL, ∞)}, {[52, 87], (47, ∞), [37, 37], [NULL, ∞)}, {(82, 87], [NULL, NULL], [NULL, ∞), [22, ∞)}, {(82, 87], (NULL, 47), [NULL, 37), [22, ∞)}, {(82, 87], (NULL, 47), [37, 37], [NULL, ∞)}, {(82, 87], (NULL, 47), (37, ∞), [22, ∞)}, {(82, 87], [47, 47], [NULL, ∞), [22, ∞)}, {(82, 87], (47, ∞), [NULL, 37), [22, ∞)}, {(82, 87], (47, ∞), (37, ∞), [22, ∞)}, {(87, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, 14], (NULL, 57), (NULL, 10), [NULL, ∞)}, {[52, 87], (NULL, 47), [37, 37], [NULL, ∞)}, {[52, 87], (47, ∞), [37, 37], [NULL, ∞)}, {(82, 87], [NULL, NULL], [NULL, ∞), [22, ∞)}, {(82, 87], (NULL, 47), [NULL, 37), [22, ∞)}, {(82, 87], (NULL, 47), (37, ∞), [22, ∞)}, {(82, 87], [47, 47], [NULL, ∞), [22, ∞)}, {(82, 87], (47, ∞), [NULL, 37), [22, ∞)}, {(82, 87], (47, ∞), (37, ∞), [22, ∞)}, {(87, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4237,6 +4237,22 @@ CREATE TABLE tab3 (
 			},
 		},
 	},
+	{
+		Name: "Complex Filter Index Scan",
+		SetUpScript: []string{
+			"create table t (pk int primary key, v1 int, v2 int, v3 int, v4 int);",
+			"create index v_idx on t (v1, v2, v3, v4);",
+			"insert into t values (0, 26, 24, 91, 0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from t where (((v1>25 and v2 between 23 and 54) or (v1<>40 and v3>90)) or (v1<>7 and v4<=78));",
+				Expected: []sql.Row{
+					{0, 26, 24, 91, 0},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -153,6 +153,9 @@ func costedIndexScans(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sco
 			b.leftover = append(b.leftover, leftover)
 		}
 		ranges, err := b.buildRangeCollection(root)
+		if err != nil {
+			return nil, transform.SameTree, err
+		}
 
 		var emptyLookup bool
 		if len(ranges) == 0 {

--- a/sql/range.go
+++ b/sql/range.go
@@ -481,7 +481,16 @@ func RemoveOverlappingRanges(ranges ...Range) (RangeCollection, error) {
 		}
 	}
 
-	return rangeTree.GetRangeCollection()
+	rangeColl, err := rangeTree.GetRangeCollection()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = validateRangeCollection(rangeColl); err != nil {
+		return nil, err
+	}
+
+	return rangeColl, nil
 }
 
 // SortRanges sorts the given ranges, returning a new slice of ranges.
@@ -497,4 +506,17 @@ func SortRanges(ranges ...Range) ([]Range, error) {
 		return cmp == -1
 	})
 	return sortedRanges, err
+}
+
+func validateRangeCollection(rangeColl RangeCollection) error {
+	for i := 0; i < len(rangeColl)-1; i++ {
+		for j := i + 1; j < len(rangeColl); j++ {
+			if ok, err := rangeColl[i].Overlaps(rangeColl[j]); err != nil {
+				return err
+			} else if ok {
+				return fmt.Errorf("overlapping ranges: %s and %s", rangeColl[i].String(), rangeColl[j].String())
+			}
+		}
+	}
+	return nil
 }

--- a/sql/range_tree.go
+++ b/sql/range_tree.go
@@ -268,6 +268,7 @@ func (tree *RangeColumnExprTree) insert(rang Range, colExprIdx int) error {
 					node = node.Left
 				}
 			} else if cmp > 0 {
+				node.MaxUpperbound, err = GetRangeCutMax(colExpr.Typ, node.MaxUpperbound, colExpr.UpperBound)
 				if node.Right == nil {
 					var inner *RangeColumnExprTree
 					if len(rang)-colExprIdx > 1 {
@@ -289,7 +290,6 @@ func (tree *RangeColumnExprTree) insert(rang Range, colExprIdx int) error {
 					insertedNode = node.Right
 					loop = false
 				} else {
-					node.MaxUpperbound, err = GetRangeCutMax(colExpr.Typ, node.MaxUpperbound, colExpr.UpperBound)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
A previous fix involved updating the MaxUpperBound in the RangeTree when traversing the right node, turns out we need to do that when creating a new node as well.

To better catch overlapping range expressions, we now verify that the resulting ranges do not overlap (an operation which isn't too expensive). This fixes some plans from an index refactor.

Additionally, this also fixes a skipped test where the ranges were not overlapping but different than the brute force approach.