### PR TITLE
Add type coercion to top-down fix expression types

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -497,7 +497,7 @@ func injectBindVarsAndPrepare(
 			case sqlparser.HexNum, sqlparser.HexVal:
 				return false, nil
 			}
-			expr := b.ConvertVal(n)
+			expr := b.ConvertVal(n, nil)
 			var val interface{}
 			if l, ok := expr.(*expression.Literal); ok {
 				val, _, err = expr.Type().Promote().Convert(l.Value())

--- a/enginetest/queries/imdb_plans.go
+++ b/enginetest/queries/imdb_plans.go
@@ -484,10 +484,10 @@ WHERE cn.country_code !='[pl]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 1950 (smallint)\n" +
+			"             │   │   └─ 1950 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2000 (smallint)\n" +
+			"             │       └─ 2000 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -1101,10 +1101,10 @@ WHERE cn.country_code = '[us]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2005 (smallint)\n" +
+			"             │   │   └─ 2005 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2008 (smallint)\n" +
+			"             │       └─ 2008 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -1416,10 +1416,10 @@ WHERE cn.country_code = '[us]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2000 (smallint)\n" +
+			"             │   │   └─ 2000 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -2893,10 +2893,10 @@ WHERE cn.country_code = '[us]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2005 (smallint)\n" +
+			"             │   │   └─ 2005 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -4715,10 +4715,10 @@ WHERE ci.note IN ('(writer)',
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2008 (smallint)\n" +
+			"             │   │   └─ 2008 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2014 (smallint)\n" +
+			"             │       └─ 2014 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -5050,10 +5050,10 @@ WHERE ci.note IN ('(voice)',
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2005 (smallint)\n" +
+			"             │   │   └─ 2005 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2009 (smallint)\n" +
+			"             │       └─ 2009 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -5247,10 +5247,10 @@ WHERE ci.note = '(voice)'
 			"             │   ├─ AND\n" +
 			"             │   │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   │   ├─ t.production_year:2\n" +
-			"             │   │   │   └─ 2007 (smallint)\n" +
+			"             │   │   │   └─ 2007 (int)\n" +
 			"             │   │   └─ LessThanOrEqual\n" +
 			"             │   │       ├─ t.production_year:2\n" +
-			"             │   │       └─ 2008 (smallint)\n" +
+			"             │   │       └─ 2008 (int)\n" +
 			"             │   └─ t.title LIKE '%Kung%Fu%Panda%'\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
@@ -5788,10 +5788,10 @@ WHERE ct.kind = 'production companies'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2005 (smallint)\n" +
+			"             │   │   └─ 2005 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -6687,10 +6687,10 @@ WHERE cn.country_code !='[pl]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 1950 (smallint)\n" +
+			"             │   │   └─ 1950 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2000 (smallint)\n" +
+			"             │       └─ 2000 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -6871,10 +6871,10 @@ WHERE cn.country_code !='[pl]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2000 (smallint)\n" +
+			"             │   │   └─ 2000 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -7062,10 +7062,10 @@ WHERE cn.country_code !='[pl]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 1950 (smallint)\n" +
+			"             │   │   └─ 1950 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -10506,10 +10506,10 @@ WHERE cct1.kind IN ('cast',
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 1950 (smallint)\n" +
+			"             │   │   └─ 1950 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2000 (smallint)\n" +
+			"             │       └─ 2000 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -11010,10 +11010,10 @@ WHERE cct1.kind = 'cast'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 1950 (smallint)\n" +
+			"             │   │   └─ 1950 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -12209,10 +12209,10 @@ WHERE cct1.kind ='cast'
 			"             │   │   │   └─ Shrek 2 (longtext)\n" +
 			"             │   │   └─ GreaterThanOrEqual\n" +
 			"             │   │       ├─ t.production_year:2\n" +
-			"             │   │       └─ 2000 (smallint)\n" +
+			"             │   │       └─ 2000 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -12541,10 +12541,10 @@ WHERE cct1.kind ='cast'
 			"             │   │   │   └─ Shrek 2 (longtext)\n" +
 			"             │   │   └─ GreaterThanOrEqual\n" +
 			"             │   │       ├─ t.production_year:2\n" +
-			"             │   │       └─ 2000 (smallint)\n" +
+			"             │   │       └─ 2000 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2005 (smallint)\n" +
+			"             │       └─ 2005 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -12871,10 +12871,10 @@ WHERE cct1.kind ='cast'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2000 (smallint)\n" +
+			"             │   │   └─ 2000 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -15083,10 +15083,10 @@ WHERE cn1.country_code = '[us]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t2.production_year:3\n" +
-			"             │   │   └─ 2005 (smallint)\n" +
+			"             │   │   └─ 2005 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t2.production_year:3\n" +
-			"             │       └─ 2008 (smallint)\n" +
+			"             │       └─ 2008 (int)\n" +
 			"             └─ TableAlias(t2)\n" +
 			"                 └─ Table\n" +
 			"                     ├─ name: title\n" +
@@ -15562,10 +15562,10 @@ WHERE cn1.country_code != '[us]'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t2.production_year:3\n" +
-			"             │   │   └─ 2000 (smallint)\n" +
+			"             │   │   └─ 2000 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t2.production_year:3\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t2)\n" +
 			"                 └─ Table\n" +
 			"                     ├─ name: title\n" +
@@ -16987,10 +16987,10 @@ WHERE an.name LIKE '%a%'
 			"         │   │       │   ├─ AND\n" +
 			"         │   │       │   │   ├─ GreaterThanOrEqual\n" +
 			"         │   │       │   │   │   ├─ n.name_pcode_cf:3\n" +
-			"         │   │       │   │   │   └─ A (longtext)\n" +
+			"         │   │       │   │   │   └─ A (varchar(5))\n" +
 			"         │   │       │   │   └─ LessThanOrEqual\n" +
 			"         │   │       │   │       ├─ n.name_pcode_cf:3\n" +
-			"         │   │       │   │       └─ F (longtext)\n" +
+			"         │   │       │   │       └─ F (varchar(5))\n" +
 			"         │   │       │   └─ Or\n" +
 			"         │   │       │       ├─ Eq\n" +
 			"         │   │       │       │   ├─ n.gender:2\n" +
@@ -17024,10 +17024,10 @@ WHERE an.name LIKE '%a%'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 1980 (smallint)\n" +
+			"             │   │   └─ 1980 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 1995 (smallint)\n" +
+			"             │       └─ 1995 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -17182,10 +17182,10 @@ WHERE an.name LIKE '%a%'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 1980 (smallint)\n" +
+			"             │   │   └─ 1980 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 1984 (smallint)\n" +
+			"             │       └─ 1984 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -17336,7 +17336,7 @@ WHERE an.name IS NOT NULL
 			"         │   │       │   │   │   └─ A (longtext)\n" +
 			"         │   │       │   │   └─ LessThanOrEqual\n" +
 			"         │   │       │   │       ├─ n.name_pcode_cf:3\n" +
-			"         │   │       │   │       └─ F (longtext)\n" +
+			"         │   │       │   │       └─ F (varchar(5))\n" +
 			"         │   │       │   └─ Or\n" +
 			"         │   │       │       ├─ Eq\n" +
 			"         │   │       │       │   ├─ n.gender:2\n" +
@@ -17369,10 +17369,10 @@ WHERE an.name IS NOT NULL
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:1\n" +
-			"             │   │   └─ 1980 (smallint)\n" +
+			"             │   │   └─ 1980 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:1\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -17635,10 +17635,10 @@ WHERE ci.note ='(voice: English version)'
 			"             │   ├─ AND\n" +
 			"             │   │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   │   ├─ t.production_year:2\n" +
-			"             │   │   │   └─ 2006 (smallint)\n" +
+			"             │   │   │   └─ 2006 (int)\n" +
 			"             │   │   └─ LessThanOrEqual\n" +
 			"             │   │       ├─ t.production_year:2\n" +
-			"             │   │       └─ 2007 (smallint)\n" +
+			"             │   │       └─ 2007 (int)\n" +
 			"             │   └─ Or\n" +
 			"             │       ├─ AND\n" +
 			"             │       │   ├─ GreaterThanOrEqual\n" +
@@ -18012,10 +18012,10 @@ WHERE ci.note IN ('(voice)',
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2005 (smallint)\n" +
+			"             │   │   └─ 2005 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2015 (smallint)\n" +
+			"             │       └─ 2015 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
@@ -18161,10 +18161,10 @@ WHERE ci.note = '(voice)'
 			"             ├─ AND\n" +
 			"             │   ├─ GreaterThanOrEqual\n" +
 			"             │   │   ├─ t.production_year:2\n" +
-			"             │   │   └─ 2007 (smallint)\n" +
+			"             │   │   └─ 2007 (int)\n" +
 			"             │   └─ LessThanOrEqual\n" +
 			"             │       ├─ t.production_year:2\n" +
-			"             │       └─ 2010 (smallint)\n" +
+			"             │       └─ 2010 (int)\n" +
 			"             └─ TableAlias(t)\n" +
 			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +

--- a/enginetest/queries/tpch_plans.go
+++ b/enginetest/queries/tpch_plans.go
@@ -458,10 +458,10 @@ where
 			"         │   │   └─ AND\n" +
 			"         │   │       ├─ GreaterThanOrEqual\n" +
 			"         │   │       │   ├─ lineitem.l_discount:2!null\n" +
-			"         │   │       │   └─ 0.05 (decimal(3,2))\n" +
+			"         │   │       │   └─ 0.05 (decimal(15,2))\n" +
 			"         │   │       └─ LessThanOrEqual\n" +
 			"         │   │           ├─ lineitem.l_discount:2!null\n" +
-			"         │   │           └─ 0.07 (decimal(3,2))\n" +
+			"         │   │           └─ 0.07 (decimal(15,2))\n" +
 			"         │   └─ LessThan\n" +
 			"         │       ├─ lineitem.l_quantity:0!null\n" +
 			"         │       └─ 24 (tinyint)\n" +
@@ -553,10 +553,10 @@ order by
 			"                             │   │   │   │   │   ├─ AND\n" +
 			"                             │   │   │   │   │   │   ├─ GreaterThanOrEqual\n" +
 			"                             │   │   │   │   │   │   │   ├─ lineitem.l_shipdate:4!null\n" +
-			"                             │   │   │   │   │   │   │   └─ 1995-01-01 (longtext)\n" +
+			"                             │   │   │   │   │   │   │   └─ 1995-01-01 00:00:00 +0000 UTC (date)\n" +
 			"                             │   │   │   │   │   │   └─ LessThanOrEqual\n" +
 			"                             │   │   │   │   │   │       ├─ lineitem.l_shipdate:4!null\n" +
-			"                             │   │   │   │   │   │       └─ 1996-12-31 (longtext)\n" +
+			"                             │   │   │   │   │   │       └─ 1996-12-31 00:00:00 +0000 UTC (date)\n" +
 			"                             │   │   │   │   │   └─ Table\n" +
 			"                             │   │   │   │   │       ├─ name: lineitem\n" +
 			"                             │   │   │   │   │       └─ columns: [l_orderkey l_suppkey l_extendedprice l_discount l_shipdate]\n" +
@@ -676,10 +676,10 @@ order by
 			"                         │   │   │   │   │       ├─ AND\n" +
 			"                         │   │   │   │   │       │   ├─ GreaterThanOrEqual\n" +
 			"                         │   │   │   │   │       │   │   ├─ orders.o_orderdate:2!null\n" +
-			"                         │   │   │   │   │       │   │   └─ 1995-01-01 (longtext)\n" +
+			"                         │   │   │   │   │       │   │   └─ 1995-01-01 00:00:00 +0000 UTC (date)\n" +
 			"                         │   │   │   │   │       │   └─ LessThanOrEqual\n" +
 			"                         │   │   │   │   │       │       ├─ orders.o_orderdate:2!null\n" +
-			"                         │   │   │   │   │       │       └─ 1996-12-31 (longtext)\n" +
+			"                         │   │   │   │   │       │       └─ 1996-12-31 00:00:00 +0000 UTC (date)\n" +
 			"                         │   │   │   │   │       └─ IndexedTableAccess(orders)\n" +
 			"                         │   │   │   │   │           ├─ index: [orders.O_ORDERKEY]\n" +
 			"                         │   │   │   │   │           ├─ keys: [lineitem.l_orderkey]\n" +
@@ -1612,7 +1612,7 @@ where
 			"         │   │   │   │   │       │   └─ 1 (tinyint)\n" +
 			"         │   │   │   │   │       └─ LessThanOrEqual\n" +
 			"         │   │   │   │   │           ├─ part.p_size:8!null\n" +
-			"         │   │   │   │   │           └─ 5 (tinyint)\n" +
+			"         │   │   │   │   │           └─ 5 (int)\n" +
 			"         │   │   │   │   └─ IN\n" +
 			"         │   │   │   │       ├─ left: lineitem.l_shipmode:5!null\n" +
 			"         │   │   │   │       └─ right: TUPLE(AIR (longtext), AIR REG (longtext))\n" +
@@ -1682,7 +1682,7 @@ where
 			"         │       │   │       │   └─ 1 (tinyint)\n" +
 			"         │       │   │       └─ LessThanOrEqual\n" +
 			"         │       │   │           ├─ part.p_size:8!null\n" +
-			"         │       │   │           └─ 15 (tinyint)\n" +
+			"         │       │   │           └─ 15 (int)\n" +
 			"         │       │   └─ IN\n" +
 			"         │       │       ├─ left: lineitem.l_shipmode:5!null\n" +
 			"         │       │       └─ right: TUPLE(AIR (longtext), AIR REG (longtext))\n" +

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -487,8 +487,6 @@ func newInsertSourceSelector(sel RuleSelector) RuleSelector {
 // Analyze applies the transformation rules to the node given. In the case of an error, the last successfully
 // transformed node is returned along with the error.
 func (a *Analyzer) Analyze(ctx *sql.Context, n sql.Node, scope *plan.Scope) (sql.Node, error) {
-	//a.Verbose = true
-	//a.Debug = true
 	n, _, err := a.analyzeWithSelector(ctx, n, scope, SelectAllBatches, DefaultRuleSelector)
 	return n, err
 }

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -55,6 +55,8 @@ func validateLimitAndOffset(ctx *sql.Context, a *Analyzer, n sql.Node, scope *pl
 					err = sql.ErrInvalidSyntax.New("negative limit")
 					return false
 				}
+			case *expression.CoerceInternal:
+
 			case *expression.BindVar:
 				return true
 			default:

--- a/sql/expression/convert_internal.go
+++ b/sql/expression/convert_internal.go
@@ -50,9 +50,6 @@ func (c *CoerceInternal) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 	if !inRange {
 		ctx.Warn(0, "coercion %s to %s failed, out of range", val, c.typ)
 	}
-	if ret == nil {
-		print(row, val)
-	}
 	return ret, nil
 }
 

--- a/sql/expression/convert_internal.go
+++ b/sql/expression/convert_internal.go
@@ -1,0 +1,70 @@
+package expression
+
+import (
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+func NewCoerceInternal(e sql.Expression, typ sql.Type) *CoerceInternal {
+	return &CoerceInternal{e: e, typ: typ}
+}
+
+type CoerceInternal struct {
+	e   sql.Expression
+	typ sql.Type
+}
+
+var _ sql.Expression = (*CoerceInternal)(nil)
+
+func (c *CoerceInternal) Resolved() bool {
+	return true
+}
+
+func (c *CoerceInternal) String() string {
+	return fmt.Sprintf("coerce(%s->%s)", c.e, c.typ)
+}
+
+func (c *CoerceInternal) Type() sql.Type {
+	return c.typ
+}
+
+func (c *CoerceInternal) IsNullable() bool {
+	return c.e.IsNullable()
+}
+
+func (c *CoerceInternal) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	val, err := c.e.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	ret, inRange, err := c.typ.Convert(val)
+	if err != nil {
+		switch c.typ {
+		case types.Boolean:
+			return false, nil
+		default:
+			return nil, err
+		}
+	}
+	if !inRange {
+		ctx.Warn(0, "coercion %s to %s failed, out of range", val, c.typ)
+	}
+	if ret == nil {
+		print(row, val)
+	}
+	return ret, nil
+}
+
+func (c *CoerceInternal) Children() []sql.Expression {
+	return []sql.Expression{c.e}
+}
+
+func (c *CoerceInternal) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(c, len(children), 1)
+	}
+	ret := *c
+	ret.e = children[0]
+	return &ret, nil
+}

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -140,7 +140,7 @@ func (b *Builder) buildGroupingCols(fromScope, projScope *scope, groupby ast.Gro
 				col = projScope.cols[intIdx-1]
 			}
 		default:
-			expr := b.buildScalar(fromScope, e)
+			expr := b.buildScalar(fromScope, e, nil)
 			col = scopeColumn{
 				tableId:  sql.TableID{},
 				col:      expr.String(),
@@ -592,7 +592,7 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 	var sortFields sql.SortFields
 	for _, c := range def.OrderBy {
 		// resolve col in fromScope
-		e := b.buildScalar(fromScope, c.Expr)
+		e := b.buildScalar(fromScope, c.Expr, nil)
 		so := sql.Ascending
 		if c.Direction == ast.DescScr {
 			so = sql.Descending
@@ -606,7 +606,7 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 
 	partitions := make([]sql.Expression, len(def.PartitionBy))
 	for i, expr := range def.PartitionBy {
-		partitions[i] = b.buildScalar(fromScope, expr)
+		partitions[i] = b.buildScalar(fromScope, expr, nil)
 	}
 
 	frame := b.NewFrame(fromScope, def.Frame)
@@ -774,7 +774,7 @@ func (b *Builder) buildHaving(fromScope, projScope, outScope *scope, having *ast
 		}
 	}
 	havingScope.groupBy = fromScope.groupBy
-	h := b.buildScalar(havingScope, having.Expr)
+	h := b.buildScalar(havingScope, having.Expr, types.Boolean)
 	outScope.node = plan.NewHaving(h, outScope.node)
 	return
 }

--- a/sql/planbuilder/analyze.go
+++ b/sql/planbuilder/analyze.go
@@ -17,6 +17,7 @@ package planbuilder
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"strings"
 
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
@@ -119,10 +120,10 @@ func (b *Builder) buildAnalyzeTables(inScope *scope, n *ast.Analyze, query strin
 	return
 }
 
-func (b *Builder) buildAnalyzeUpdate(inScope *scope, n *ast.Analyze, dbName, tableName string, sch sql.Schema, columns []string, types []sql.Type) (outScope *scope) {
+func (b *Builder) buildAnalyzeUpdate(inScope *scope, n *ast.Analyze, dbName, tableName string, sch sql.Schema, columns []string, typs []sql.Type) (outScope *scope) {
 	outScope = inScope.push()
 	statistic := new(stats.Statistic)
-	using := b.buildScalar(inScope, n.Using)
+	using := b.buildScalar(inScope, n.Using, types.Text)
 	if l, ok := using.(*expression.Literal); ok {
 		if typ, ok := l.Type().(sql.StringType); ok {
 			val, _, err := typ.Convert(l.Value())
@@ -149,7 +150,7 @@ func (b *Builder) buildAnalyzeUpdate(inScope *scope, n *ast.Analyze, dbName, tab
 	}
 	statistic.SetQualifier(sql.NewStatQualifier(dbName, tableName, indexName))
 	statistic.SetColumns(columns)
-	statistic.SetTypes(types)
+	statistic.SetTypes(typs)
 
 	statCols := sql.NewFastIntSet()
 	for _, c := range columns {

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -292,7 +292,7 @@ func (b *Builder) buildCreateEvent(inScope *scope, query string, c *ast.DDL) (ou
 }
 
 func (b *Builder) buildEventScheduleTimeSpec(inScope *scope, spec *ast.EventScheduleTimeSpec) (sql.Expression, []sql.Expression) {
-	ts := b.buildScalar(inScope, spec.EventTimestamp)
+	ts := b.buildScalar(inScope, spec.EventTimestamp, nil)
 	if len(spec.EventIntervals) == 0 {
 		return ts, nil
 	}

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -703,7 +703,7 @@ func (b *Builder) convertConstraintDefinition(inScope *scope, cd *ast.Constraint
 	} else if chConstraint, ok := cd.Details.(*ast.CheckConstraintDefinition); ok {
 		var c sql.Expression
 		if chConstraint.Expr != nil {
-			c = b.buildScalar(inScope, chConstraint.Expr)
+			c = b.buildScalar(inScope, chConstraint.Expr, nil)
 		}
 
 		return &sql.CheckConstraint{
@@ -910,7 +910,7 @@ func (b *Builder) buildDefaultExpression(inScope *scope, defaultExpr ast.Expr) *
 	if defaultExpr == nil {
 		return nil
 	}
-	parsedExpr := b.buildScalar(inScope, defaultExpr)
+	parsedExpr := b.buildScalar(inScope, defaultExpr, nil)
 
 	// Function expressions must be enclosed in parentheses (except for current_timestamp() and now())
 	_, isParenthesized := defaultExpr.(*ast.ParenExpr)
@@ -1274,7 +1274,7 @@ func (b *Builder) convertDefaultExpression(inScope *scope, defaultExpr ast.Expr,
 	if defaultExpr == nil {
 		return nil
 	}
-	resExpr := b.buildScalar(inScope, defaultExpr)
+	resExpr := b.buildScalar(inScope, defaultExpr, nil)
 
 	// Function expressions must be enclosed in parentheses (except for current_timestamp() and now())
 	_, isParenthesized := defaultExpr.(*ast.ParenExpr)

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -16,7 +16,6 @@ package planbuilder
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/transform"
 	"strconv"
 	"strings"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
 	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -125,7 +125,7 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 			// track order by col
 			// replace aggregations with refs
 			// pick up auxiliary cols
-			expr := b.buildScalar(fromScope, e)
+			expr := b.buildScalar(fromScope, e, nil)
 			_, ok := outScope.getExpr(expr.String(), true)
 			if ok {
 				continue

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -779,7 +779,7 @@ Project
  ├─ columns: [xy.x:1!null, sum(xy.x):4!null as sum(x)]
  └─ Sort(xy.x:1!null ASC nullsFirst)
      └─ Having
-         ├─ (xy.x:1!null + xy.y:2!null)
+         ├─ coerce((xy.x + xy.y)->tinyint(1))
          └─ GroupBy
              ├─ select: SUM(xy.x:1!null), xy.x:1!null, xy.y:2!null
              ├─ group: xy.x:1!null

--- a/sql/planbuilder/proc.go
+++ b/sql/planbuilder/proc.go
@@ -214,7 +214,7 @@ func (b *Builder) buildCaseStatement(inScope *scope, n *ast.CaseStatement) (outS
 		outScope.node = plan.NewCaseStatement(nil, ifConditionals, elseBlock)
 		return outScope
 	} else {
-		caseExpr := b.buildScalar(inScope, n.Expr)
+		caseExpr := b.buildScalar(inScope, n.Expr, nil)
 		outScope.node = plan.NewCaseStatement(caseExpr, ifConditionals, elseBlock)
 		return outScope
 	}
@@ -223,7 +223,7 @@ func (b *Builder) buildCaseStatement(inScope *scope, n *ast.CaseStatement) (outS
 func (b *Builder) buildIfConditional(inScope *scope, n ast.IfStatementCondition) (outScope *scope) {
 	outScope = inScope.push()
 	block := b.buildBlock(inScope, n.Statements)
-	condition := b.buildScalar(inScope, n.Expr)
+	condition := b.buildScalar(inScope, n.Expr, types.Boolean)
 	outScope.node = plan.NewIfConditional(condition, block)
 	return outScope
 }
@@ -232,7 +232,7 @@ func (b *Builder) buildCall(inScope *scope, c *ast.Call) (outScope *scope) {
 	outScope = inScope.push()
 	params := make([]sql.Expression, len(c.Params))
 	for i, param := range c.Params {
-		expr := b.buildScalar(inScope, param)
+		expr := b.buildScalar(inScope, param, nil)
 		params[i] = expr
 	}
 
@@ -453,7 +453,7 @@ func (b *Builder) buildRepeat(inScope *scope, repeat *ast.Repeat) (outScope *sco
 	outScope.initProc()
 	outScope.proc.AddLabel(repeat.Label, true)
 	block := b.buildBlock(outScope, repeat.Statements)
-	expr := b.buildScalar(inScope, repeat.Condition)
+	expr := b.buildScalar(inScope, repeat.Condition, nil)
 	outScope.node = plan.NewRepeat(repeat.Label, expr, block)
 	return outScope
 }
@@ -463,7 +463,7 @@ func (b *Builder) buildWhile(inScope *scope, while *ast.While) (outScope *scope)
 	outScope.initProc()
 	outScope.proc.AddLabel(while.Label, true)
 	block := b.buildBlock(outScope, while.Statements)
-	expr := b.buildScalar(inScope, while.Condition)
+	expr := b.buildScalar(inScope, while.Condition, types.Boolean)
 	outScope.node = plan.NewWhile(while.Label, expr, block)
 	return outScope
 }

--- a/sql/planbuilder/process.go
+++ b/sql/planbuilder/process.go
@@ -55,7 +55,7 @@ func (b *Builder) getInt64Value(inScope *scope, expr ast.Expr, errStr string) in
 // getInt64Literal returns an int64 *expression.Literal for the value given, or an unsupported error with the string
 // given if the expression doesn't represent an integer literal.
 func (b *Builder) getInt64Literal(inScope *scope, expr ast.Expr, errStr string) *expression.Literal {
-	e := b.buildScalar(inScope, expr)
+	e := b.buildScalar(inScope, expr, nil)
 
 	switch e := e.(type) {
 	case *expression.Literal:

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -169,7 +169,7 @@ func (b *Builder) selectExprToExpression(inScope *scope, se ast.SelectExpr) sql.
 		}
 		return expression.NewQualifiedStar(strings.ToLower(e.TableName.Name.String()))
 	case *ast.AliasedExpr:
-		expr := b.buildScalar(inScope, e.Expr)
+		expr := b.buildScalar(inScope, e.Expr, nil)
 		if !e.As.IsEmpty() {
 			return expression.NewAlias(e.As.String(), expr)
 		}

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -80,7 +80,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr, coerce sql.Type) sql.E
 		return expression.NewNot(c)
 	case *ast.SQLVal:
 		val := b.ConvertVal(v, nil)
-		if coerce != nil && val.Type() != coerce {
+		if coerce != nil && val.Type().Promote() != coerce {
 			val = expression.NewCoerceInternal(val, coerce)
 		}
 		return val
@@ -260,7 +260,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr, coerce sql.Type) sql.E
 		return expression.NewInterval(e, v.Unit)
 	case *ast.CollateExpr:
 		// handleCollateExpr is meant to handle generic text-returning expressions that should be reinterpreted as a different collation.
-		innerExpr := b.buildScalar(inScope, v.Expr, types.Text)
+		innerExpr := b.buildScalar(inScope, v.Expr, nil)
 		//TODO: rename this from Charset to Collation
 		collation, err := sql.ParseCollation(nil, &v.Charset, false)
 		if err != nil {
@@ -593,7 +593,7 @@ func (b *Builder) buildCaseExpr(inScope *scope, e *ast.CaseExpr) sql.Expression 
 	var branches []expression.CaseBranch
 	for _, w := range e.Whens {
 		var cond sql.Expression
-		cond = b.buildScalar(inScope, w.Cond, types.Boolean)
+		cond = b.buildScalar(inScope, w.Cond, nil)
 
 		var val sql.Expression
 		val = b.buildScalar(inScope, w.Val, nil)

--- a/sql/planbuilder/select.go
+++ b/sql/planbuilder/select.go
@@ -126,21 +126,21 @@ func (b *Builder) buildSelect(inScope *scope, s *ast.Select) (outScope *scope) {
 
 func (b *Builder) buildLimit(inScope *scope, limit *ast.Limit) sql.Expression {
 	if limit != nil {
-		l := b.buildScalar(inScope, limit.Rowcount)
-		return b.typeCoerceLiteral(l)
+		l := b.buildScalar(inScope, limit.Rowcount, nil)
+		return b.typeCoerceLiteral(l, types.Int64)
 	}
 	return nil
 }
 
-func (b *Builder) typeCoerceLiteral(e sql.Expression) sql.Expression {
+func (b *Builder) typeCoerceLiteral(e sql.Expression, typ sql.Type) sql.Expression {
 	// todo this should be in a module that can generically coerce to a type or type class
 	switch e := e.(type) {
 	case *expression.Literal:
-		val, _, err := types.Int64.Convert(e.Value())
+		val, _, err := typ.Convert(e.Value())
 		if err != nil {
 			err = fmt.Errorf("%s: %w", err.Error(), sql.ErrInvalidTypeForLimit.New(types.Int64, e.Type()))
 		}
-		return expression.NewLiteral(val, types.Int64)
+		return expression.NewLiteral(val, typ)
 	case *expression.BindVar:
 		return e
 	default:
@@ -152,8 +152,8 @@ func (b *Builder) typeCoerceLiteral(e sql.Expression) sql.Expression {
 
 func (b *Builder) buildOffset(inScope *scope, limit *ast.Limit) sql.Expression {
 	if limit != nil && limit.Offset != nil {
-		rowCount := b.buildScalar(inScope, limit.Offset)
-		rowCount = b.typeCoerceLiteral(rowCount)
+		rowCount := b.buildScalar(inScope, limit.Offset, nil)
+		rowCount = b.typeCoerceLiteral(rowCount, types.Int64)
 		// Check if offset starts at 0, if so, we can just remove the offset node.
 		// Only cast to int8, as a larger int type just means a non-zero offset.
 		if val, err := rowCount.Eval(b.ctx, nil); err == nil {

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -153,7 +153,7 @@ func (b *Builder) setExprsToExpressions(inScope *scope, e ast.SetVarExprs) []sql
 		sysVarType, _ := setVar.Type().(sql.SystemVariableType)
 		innerExpr, ok := b.simplifySetExpr(setExpr.Name, setScope, setExpr.Expr, sysVarType)
 		if !ok {
-			innerExpr = b.buildScalar(inScope, setExpr.Expr)
+			innerExpr = b.buildScalar(inScope, setExpr.Expr, nil)
 		}
 
 		res[i] = expression.NewSetField(setVar, innerExpr)

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -205,7 +205,7 @@ func (b *Builder) buildShowAllTriggers(inScope *scope, s *ast.Show) (outScope *s
 		dbName = s.ShowTablesOpt.DbName
 		if s.ShowTablesOpt.Filter != nil {
 			if s.ShowTablesOpt.Filter.Filter != nil {
-				filter = b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter)
+				filter = b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter, nil)
 			} else if s.ShowTablesOpt.Filter.Like != "" {
 				filter = expression.NewLike(
 					expression.NewGetField(2, types.LongText, "Table", false),
@@ -273,7 +273,7 @@ func (b *Builder) buildShowAllEvents(inScope *scope, s *ast.Show) (outScope *sco
 		dbName = s.ShowTablesOpt.DbName
 		if s.ShowTablesOpt.Filter != nil {
 			if s.ShowTablesOpt.Filter.Filter != nil {
-				filter = b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter)
+				filter = b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter, nil)
 			} else if s.ShowTablesOpt.Filter.Like != "" {
 				filter = expression.NewLike(
 					expression.NewGetField(1, types.LongText, "name", false),
@@ -332,7 +332,7 @@ func (b *Builder) buildShowProcedureStatus(inScope *scope, s *ast.Show) (outScop
 	}
 	if s.Filter != nil {
 		if s.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.Filter.Filter)
+			filter = b.buildScalar(outScope, s.Filter.Filter, nil)
 		} else if s.Filter.Like != "" {
 			filter = expression.NewLike(
 				expression.NewGetField(1, types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default), "Name", false),
@@ -366,7 +366,7 @@ func (b *Builder) buildShowFunctionStatus(inScope *scope, s *ast.Show) (outScope
 
 	if s.Filter != nil {
 		if s.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.Filter.Filter)
+			filter = b.buildScalar(outScope, s.Filter.Filter, nil)
 		} else if s.Filter.Like != "" {
 			filter = expression.NewLike(
 				expression.NewGetField(1, types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default), "Name", false),
@@ -411,7 +411,7 @@ func (b *Builder) buildShowTableStatus(inScope *scope, s *ast.Show) (outScope *s
 	var filter sql.Expression
 	if s.Filter != nil {
 		if s.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.Filter.Filter)
+			filter = b.buildScalar(outScope, s.Filter.Filter, types.Boolean)
 		} else if s.Filter.Like != "" {
 			filter = expression.NewLike(
 				expression.NewGetField(0, types.LongText, "Name", false),
@@ -508,7 +508,7 @@ func (b *Builder) buildShowVariables(inScope *scope, s *ast.Show) (outScope *sco
 	var like sql.Expression
 	if s.Filter != nil {
 		if s.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.Filter.Filter)
+			filter = b.buildScalar(outScope, s.Filter.Filter, types.Boolean)
 		}
 		if s.Filter.Like != "" {
 			like = expression.NewLike(
@@ -582,7 +582,7 @@ func (b *Builder) buildAsOfExpr(inScope *scope, time ast.Expr) sql.Expression {
 		}
 	default:
 	}
-	return b.buildScalar(b.newScope(), time)
+	return b.buildScalar(b.newScope(), time, nil)
 }
 
 func (b *Builder) buildShowAllTables(inScope *scope, s *ast.Show) (outScope *scope) {
@@ -610,7 +610,7 @@ func (b *Builder) buildShowAllTables(inScope *scope, s *ast.Show) (outScope *sco
 
 	if s.ShowTablesOpt.Filter != nil {
 		if s.ShowTablesOpt.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter)
+			filter = b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter, types.Boolean)
 		} else if s.ShowTablesOpt.Filter.Like != "" {
 			filter = expression.NewLike(
 				expression.NewGetField(0, types.LongText, fmt.Sprintf("Tables_in_%s", dbName), false),
@@ -639,7 +639,7 @@ func (b *Builder) buildShowAllDatabases(inScope *scope, s *ast.Show) (outScope *
 	var filter sql.Expression
 	if s.Filter != nil {
 		if s.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.Filter.Filter)
+			filter = b.buildScalar(outScope, s.Filter.Filter, types.Boolean)
 		} else if s.Filter.Like != "" {
 			filter = expression.NewLike(
 				expression.NewGetField(0, types.LongText, "Database", false),
@@ -721,7 +721,7 @@ func (b *Builder) buildShowAllColumns(inScope *scope, s *ast.Show) (outScope *sc
 		}
 
 		if s.ShowTablesOpt.Filter.Filter != nil {
-			filter := b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter)
+			filter := b.buildScalar(outScope, s.ShowTablesOpt.Filter.Filter, types.Boolean)
 			node = plan.NewFilter(filter, node)
 		}
 	}
@@ -740,10 +740,10 @@ func (b *Builder) buildShowWarnings(inScope *scope, s *ast.Show) (outScope *scop
 	node = plan.ShowWarnings(b.ctx.Session.Warnings())
 	if s.Limit != nil {
 		if s.Limit.Offset != nil {
-			offset := b.buildScalar(inScope, s.Limit.Offset)
+			offset := b.buildScalar(inScope, s.Limit.Offset, nil)
 			node = plan.NewOffset(offset, node)
 		}
-		limit := b.buildScalar(inScope, s.Limit.Rowcount)
+		limit := b.buildScalar(inScope, s.Limit.Rowcount, nil)
 		node = plan.NewLimit(limit, node)
 	}
 
@@ -772,7 +772,7 @@ func (b *Builder) buildShowCollation(inScope *scope, s *ast.Show) (outScope *sco
 	}
 
 	if s.ShowCollationFilterOpt != nil {
-		filterExpr := b.buildScalar(outScope, s.ShowCollationFilterOpt)
+		filterExpr := b.buildScalar(outScope, s.ShowCollationFilterOpt, nil)
 		// TODO: once collations are properly implemented, we should better be able to handle utf8 -> utf8mb3 comparisons as they're aliases
 		filterExpr, _, _ = transform.Expr(filterExpr, func(expr sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if exprLiteral, ok := expr.(*expression.Literal); ok {
@@ -828,7 +828,7 @@ func (b *Builder) buildShowStatus(inScope *scope, s *ast.Show) (outScope *scope)
 				nil,
 			)
 		} else if s.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.Filter.Filter)
+			filter = b.buildScalar(outScope, s.Filter.Filter, types.Boolean)
 		}
 	}
 
@@ -855,7 +855,7 @@ func (b *Builder) buildShowCharset(inScope *scope, s *ast.Show) (outScope *scope
 	var filter sql.Expression
 	if s.Filter != nil {
 		if s.Filter.Filter != nil {
-			filter = b.buildScalar(outScope, s.Filter.Filter)
+			filter = b.buildScalar(outScope, s.Filter.Filter, types.Boolean)
 		} else if s.Filter.Like != "" {
 			filter = expression.NewLike(
 				expression.NewGetField(0, types.MustCreateStringWithDefaults(sqltypes.VarChar, 64), "Charset", false),

--- a/sql/planbuilder/window_frame_factory.go
+++ b/sql/planbuilder/window_frame_factory.go
@@ -12,28 +12,28 @@ func (b *Builder) getFrameStartNPreceding(inScope *scope, frame *ast.Frame) sql.
 	if frame == nil || frame.Extent.Start.Type != ast.ExprPreceding {
 		return nil
 	}
-	return b.buildScalar(inScope, frame.Extent.Start.Expr)
+	return b.buildScalar(inScope, frame.Extent.Start.Expr, nil)
 }
 
 func (b *Builder) getFrameEndNPreceding(inScope *scope, frame *ast.Frame) sql.Expression {
 	if frame == nil || frame.Extent.End == nil || frame.Extent.End.Type != ast.ExprPreceding {
 		return nil
 	}
-	return b.buildScalar(inScope, frame.Extent.End.Expr)
+	return b.buildScalar(inScope, frame.Extent.End.Expr, nil)
 }
 
 func (b *Builder) getFrameStartNFollowing(inScope *scope, frame *ast.Frame) sql.Expression {
 	if frame == nil || frame.Extent.Start.Type != ast.ExprFollowing {
 		return nil
 	}
-	return b.buildScalar(inScope, frame.Extent.Start.Expr)
+	return b.buildScalar(inScope, frame.Extent.Start.Expr, nil)
 }
 
 func (b *Builder) getFrameEndNFollowing(inScope *scope, frame *ast.Frame) sql.Expression {
 	if frame == nil || frame.Extent.End == nil || frame.Extent.End.Type != ast.ExprFollowing {
 		return nil
 	}
-	return b.buildScalar(inScope, frame.Extent.End.Expr)
+	return b.buildScalar(inScope, frame.Extent.End.Expr, nil)
 }
 
 func (b *Builder) getFrameStartCurrentRow(_ *scope, frame *ast.Frame) bool {

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -530,12 +530,12 @@ func (b *BaseBuilder) buildShowVariables(ctx *sql.Context, n *plan.ShowVariables
 			if err != nil {
 				return nil, err
 			}
-			res, _, err = types.Boolean.Convert(res)
+			res2, _, err := types.Boolean.Convert(res)
 			if err != nil {
 				ctx.Warn(1292, err.Error())
 				continue
 			}
-			if res.(int8) == 0 {
+			if res2.(int8) == 0 {
 				continue
 			}
 		}

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -530,12 +530,12 @@ func (b *BaseBuilder) buildShowVariables(ctx *sql.Context, n *plan.ShowVariables
 			if err != nil {
 				return nil, err
 			}
-			res2, _, err := types.Boolean.Convert(res)
+			res, _, err = types.Boolean.Convert(res)
 			if err != nil {
 				ctx.Warn(1292, err.Error())
 				continue
 			}
-			if res2.(int8) == 0 {
+			if res.(int8) == 0 {
 				continue
 			}
 		}


### PR DESCRIPTION
Setup an outline for how top-down hinting can help type coerce expressions that otherwise lack the context to know what types they need to be. The benefits of this compared to type casting within individual expression Evals:
- Controlling types upfront should aid correctness, for example for aggregation functions that return different types depending on the context, or INSERTs/UPDATEs that expect specific type inputs, or bindvar substitution
- Adding type casts while we have info at the AST layer should generalize to more expression types than adding type casts in individual execution functions
- Front-loading type information should make validation easier to add at binding, which is preferable to after analysis and is probably easier than doing another tree walk

fixes: https://github.com/dolthub/dolt/issues/7018