### PR TITLE
Update RangeTree MaxUpperBound when removing nodes

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4253,6 +4253,22 @@ CREATE TABLE tab3 (
 			},
 		},
 	},
+	{
+		Name: "Complex Filter Index Scan",
+		SetUpScript: []string{
+			"create table t (pk integer primary key, col0 integer, col1 float);",
+			"create index idx on t (col0, col1);",
+			"insert into t values (0, 22, 1.23);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select pk, col0 from t where (col0 in (73,69)) or col0 in (4,12,3,17,70,20) or (col0 in (39) or (col1 < 69.67));",
+				Expected: []sql.Row{
+					{0, 22},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/range_cut.go
+++ b/sql/range_cut.go
@@ -24,8 +24,6 @@ type RangeCut interface {
 	Compare(RangeCut, Type) (int, error)
 	// String returns the RangeCut as a string for display purposes.
 	String() string
-	// DebugString returns the RangeCut as a string for display purposes.
-	DebugString() string
 	// TypeAsLowerBound returns the bound type if the calling RangeCut is the lower bound of a range.
 	TypeAsLowerBound() RangeBoundType
 	// TypeAsUpperBound returns the bound type if the calling RangeCut is the upper bound of a range.
@@ -159,11 +157,6 @@ func (a Above) String() string {
 	return fmt.Sprintf("Above[%v]", a.Key)
 }
 
-// DebugString implements RangeCut.
-func (a Above) DebugString() string {
-	return fmt.Sprintf(">%v", a.Key)
-}
-
 // TypeAsLowerBound implements RangeCut.
 func (Above) TypeAsLowerBound() RangeBoundType {
 	return Open
@@ -190,11 +183,6 @@ func (AboveAll) Compare(c RangeCut, typ Type) (int, error) {
 // String implements RangeCut.
 func (AboveAll) String() string {
 	return "AboveAll"
-}
-
-// DebugString implements RangeCut.
-func (AboveAll) DebugString() string {
-	return "∞"
 }
 
 // TypeAsLowerBound implements RangeCut.
@@ -244,11 +232,6 @@ func (b Below) String() string {
 	return fmt.Sprintf("Below[%v]", b.Key)
 }
 
-// DebugString implements RangeCut.
-func (b Below) DebugString() string {
-	return fmt.Sprintf("<%v", b.Key)
-}
-
 // TypeAsLowerBound implements RangeCut.
 func (Below) TypeAsLowerBound() RangeBoundType {
 	return Closed
@@ -280,11 +263,6 @@ func (AboveNull) String() string {
 	return "AboveNull"
 }
 
-// DebugString implements RangeCut.
-func (AboveNull) DebugString() string {
-	return ">NULL"
-}
-
 // TypeAsLowerBound implements RangeCut.
 func (AboveNull) TypeAsLowerBound() RangeBoundType {
 	return Open
@@ -313,11 +291,6 @@ func (BelowNull) Compare(c RangeCut, typ Type) (int, error) {
 // String implements RangeCut.
 func (BelowNull) String() string {
 	return "BelowNull"
-}
-
-// DebugString implements RangeCut.
-func (BelowNull) DebugString() string {
-	return "<NULL"
 }
 
 // TypeAsLowerBound implements RangeCut.

--- a/sql/range_cut.go
+++ b/sql/range_cut.go
@@ -24,6 +24,8 @@ type RangeCut interface {
 	Compare(RangeCut, Type) (int, error)
 	// String returns the RangeCut as a string for display purposes.
 	String() string
+	// DebugString returns the RangeCut as a string for display purposes.
+	DebugString() string
 	// TypeAsLowerBound returns the bound type if the calling RangeCut is the lower bound of a range.
 	TypeAsLowerBound() RangeBoundType
 	// TypeAsUpperBound returns the bound type if the calling RangeCut is the upper bound of a range.
@@ -157,6 +159,11 @@ func (a Above) String() string {
 	return fmt.Sprintf("Above[%v]", a.Key)
 }
 
+// DebugString implements RangeCut.
+func (a Above) DebugString() string {
+	return fmt.Sprintf(">%v", a.Key)
+}
+
 // TypeAsLowerBound implements RangeCut.
 func (Above) TypeAsLowerBound() RangeBoundType {
 	return Open
@@ -183,6 +190,11 @@ func (AboveAll) Compare(c RangeCut, typ Type) (int, error) {
 // String implements RangeCut.
 func (AboveAll) String() string {
 	return "AboveAll"
+}
+
+// DebugString implements RangeCut.
+func (AboveAll) DebugString() string {
+	return "∞"
 }
 
 // TypeAsLowerBound implements RangeCut.
@@ -232,6 +244,11 @@ func (b Below) String() string {
 	return fmt.Sprintf("Below[%v]", b.Key)
 }
 
+// DebugString implements RangeCut.
+func (b Below) DebugString() string {
+	return fmt.Sprintf("<%v", b.Key)
+}
+
 // TypeAsLowerBound implements RangeCut.
 func (Below) TypeAsLowerBound() RangeBoundType {
 	return Closed
@@ -263,6 +280,11 @@ func (AboveNull) String() string {
 	return "AboveNull"
 }
 
+// DebugString implements RangeCut.
+func (AboveNull) DebugString() string {
+	return ">NULL"
+}
+
 // TypeAsLowerBound implements RangeCut.
 func (AboveNull) TypeAsLowerBound() RangeBoundType {
 	return Open
@@ -291,6 +313,11 @@ func (BelowNull) Compare(c RangeCut, typ Type) (int, error) {
 // String implements RangeCut.
 func (BelowNull) String() string {
 	return "BelowNull"
+}
+
+// DebugString implements RangeCut.
+func (BelowNull) DebugString() string {
+	return "<NULL"
 }
 
 // TypeAsLowerBound implements RangeCut.

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -411,7 +411,6 @@ func TestComplexRange(t *testing.T) {
 		ranges sql.RangeCollection
 	}{
 		{
-			skip: true,
 			// derived from sqllogictest/index/in/100/slt_good_1.test:12655
 			ranges: sql.RangeCollection{
 				r(
@@ -457,7 +456,6 @@ func TestComplexRange(t *testing.T) {
 			},
 		},
 		{
-			skip: true,
 			// derived from index query plan test
 			// `SELECT * FROM comp_index_t2 WHERE (((v1>25 AND v2 BETWEEN 23 AND 54) OR (v1<>40 AND v3>90)) OR (v1<>7 AND v4<=78));`
 			ranges: sql.RangeCollection{
@@ -494,7 +492,6 @@ func TestComplexRange(t *testing.T) {
 			},
 		},
 		{
-			skip: true,
 			ranges: sql.RangeCollection{
 				r(
 					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 0}, UpperBound: sql.Above{Key: 6}, Typ: types.Int16},

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -411,6 +411,7 @@ func TestComplexRange(t *testing.T) {
 		ranges sql.RangeCollection
 	}{
 		{
+			skip: true,
 			// derived from sqllogictest/index/in/100/slt_good_1.test:12655
 			ranges: sql.RangeCollection{
 				r(
@@ -456,6 +457,7 @@ func TestComplexRange(t *testing.T) {
 			},
 		},
 		{
+			skip: true,
 			// derived from index query plan test
 			// `SELECT * FROM comp_index_t2 WHERE (((v1>25 AND v2 BETWEEN 23 AND 54) OR (v1<>40 AND v3>90)) OR (v1<>7 AND v4<=78));`
 			ranges: sql.RangeCollection{
@@ -492,6 +494,7 @@ func TestComplexRange(t *testing.T) {
 			},
 		},
 		{
+			skip: true,
 			ranges: sql.RangeCollection{
 				r(
 					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 0}, UpperBound: sql.Above{Key: 6}, Typ: types.Int16},
@@ -517,6 +520,50 @@ func TestComplexRange(t *testing.T) {
 					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 4}, UpperBound: sql.Above{Key: 4}, Typ: types.Int16},
 					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 0}, UpperBound: sql.Above{Key: 6}, Typ: types.Int16},
 					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 1}, UpperBound: sql.Above{Key: 6}, Typ: types.Int16},
+				),
+			},
+		},
+		{
+			ranges: sql.RangeCollection{
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 69}, UpperBound: sql.Above{Key: 69}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 73}, UpperBound: sql.Above{Key: 73}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 12}, UpperBound: sql.Above{Key: 12}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 3}, UpperBound: sql.Above{Key: 3}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 17}, UpperBound: sql.Above{Key: 17}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 70}, UpperBound: sql.Above{Key: 70}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 20}, UpperBound: sql.Above{Key: 20}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 4}, UpperBound: sql.Above{Key: 4}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.Below{Key: 39}, UpperBound: sql.Above{Key: 39}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Float32},
+				),
+				r(
+					sql.RangeColumnExpr{LowerBound: sql.BelowNull{}, UpperBound: sql.AboveAll{}, Typ: types.Int32},
+					sql.RangeColumnExpr{LowerBound: sql.AboveNull{}, UpperBound: sql.Below{Key: 69.67}, Typ: types.Float32},
 				),
 			},
 		},

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -811,3 +811,325 @@ func and(expressions ...sql.Expression) sql.Expression {
 	}
 	return expression.NewAnd(expressions[0], and(expressions[1:]...))
 }
+
+func buildTestRangeTree(ranges []sql.Range) (*sql.RangeColumnExprTree, error) {
+	tree, err := sql.NewRangeColumnExprTree(ranges[0], []sql.Type{rangeType})
+	if err != nil {
+		return nil, err
+	}
+	for _, rng := range ranges[1:] {
+		err = tree.Insert(rng)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return tree, nil
+}
+
+func TestRangeTreeInsert(t *testing.T) {
+	tests := []struct{
+		name string
+		setupRngs []sql.Range
+		setupExp string
+		rng sql.Range
+		exp string
+	}{
+		{
+			name: "insert smallest",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 1\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 1\n" +
+				"",
+			rng: r(req(0)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 0\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"        └── [0, 0] max: >0 color: 1\n" +
+				"",
+		},
+		{
+			name: "insert largest",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 1\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 1\n" +
+				"",
+			rng: r(req(14)),
+			exp: "RangeColumnExprTree\n" +
+				"│       ┌── [14, 14] max: >14 color: 1\n" +
+				"│   ┌── [11, 11] max: >14 color: 0\n" +
+				"└── [7, 7] max: >14 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"",
+		},
+		{
+			name: "insert rebalance left child",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(0))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 0\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"        └── [0, 0] max: >0 color: 1\n" +
+				"",
+			rng: r(req(1)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 0\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    │   ┌── [3, 3] max: >3 color: 1\n" +
+				"    └── [1, 1] max: >3 color: 0\n" +
+				"        └── [0, 0] max: >0 color: 1\n" +
+				"",
+		},
+		{
+			name: "insert rebalance right child",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(12))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│       ┌── [12, 12] max: >12 color: 1\n" +
+				"│   ┌── [11, 11] max: >12 color: 0\n" +
+				"└── [7, 7] max: >12 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"",
+			rng: r(req(13)),
+			exp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [12, 12] max: >13 color: 0\n" +
+				"│   │   └── [11, 11] max: >11 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"",
+		},
+		{
+			name: "insert rebalance root from left",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(0)), r(req(1)), r(req(2)), r(req(4))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 0\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    │       ┌── [4, 4] max: >4 color: 1" +
+				"\n    │   ┌── [3, 3] max: >4 color: 0\n" +
+				"    │   │   └── [2, 2] max: >2 color: 1\n" +
+				"    └── [1, 1] max: >4 color: 1\n" +
+				"        └── [0, 0] max: >0 color: 0\n" +
+				"",
+			rng: r(req(5)),
+			exp: "RangeColumnExprTree\n" +
+				"│       ┌── [11, 11] max: >11 color: 0\n" +
+				"│   ┌── [7, 7] max: >11 color: 1\n" +
+				"│   │   │   ┌── [5, 5] max: >5 color: 1\n" +
+				"│   │   └── [4, 4] max: >5 color: 0\n" +
+				"└── [3, 3] max: >11 color: 0\n" +
+				"    │   ┌── [2, 2] max: >2 color: 0\n" +
+				"    └── [1, 1] max: >2 color: 1\n" +
+				"        └── [0, 0] max: >0 color: 0\n" +
+				"",
+		},
+		{
+			name: "insert rebalance root from right",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(8)), r(req(9)), r(req(10)), r(req(12))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│           ┌── [12, 12] max: >12 color: 1\n" +
+				"│       ┌── [11, 11] max: >12 color: 0\n" +
+				"│       │   └── [10, 10] max: >10 color: 1\n" +
+				"│   ┌── [9, 9] max: >12 color: 1\n" +
+				"│   │   └── [8, 8] max: >8 color: 0\n" +
+				"└── [7, 7] max: >12 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"",
+			rng: r(req(13)),
+			exp: "RangeColumnExprTree\n" +
+				"│           ┌── [13, 13] max: >13 color: 1\n" +
+				"│       ┌── [12, 12] max: >13 color: 0\n" +
+				"│   ┌── [11, 11] max: >13 color: 1\n" +
+				"│   │   └── [10, 10] max: >10 color: 0\n" +
+				"└── [9, 9] max: >13 color: 0\n" +
+				"    │   ┌── [8, 8] max: >8 color: 0\n" +
+				"    └── [7, 7] max: >8 color: 1\n" +
+				"        └── [3, 3] max: >3 color: 0\n" +
+				"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tree, err := buildTestRangeTree(test.setupRngs)
+			require.NoError(t, err)
+			assert.Equal(t, test.setupExp, tree.String())
+
+			err = tree.Insert(test.rng)
+			require.NoError(t, err)
+			assert.Equal(t, test.exp, tree.String())
+		})
+	}
+}
+
+func TestRangeTreeRemove(t *testing.T) {
+	tests := []struct{
+		name string
+		setupRngs []sql.Range
+		setupExp string
+		rng sql.Range
+		exp string
+	}{
+		{
+			name: "remove smallest",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+			rng: r(req(1)),
+			exp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"",
+		},
+		{
+			name: "remove largest",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+			rng: r(req(13)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+		},
+		{
+			name: "remove left parent",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+			rng: r(req(3)),
+			exp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [1, 1] max: >5 color: 0\n" +
+				"",
+		},
+		{
+			name: "remove right parent",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+			rng: r(req(11)),
+			exp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [9, 9] max: >13 color: 0\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+		},
+		{
+			name: "remove root",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+			rng: r(req(7)),
+			exp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [5, 5] max: >13 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+		},
+		{
+			name: "remove rotate left",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: >11 color: 0\n" +
+				"└── [7, 7] max: >11 color: 0\n" +
+				"    │   ┌── [5, 5] max: >5 color: 1\n" +
+				"    └── [3, 3] max: >5 color: 0\n" +
+				"        └── [1, 1] max: >1 color: 1\n" +
+				"",
+			rng: r(req(11)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── [7, 7] max: >7 color: 0\n" +
+				"│   │   └── [5, 5] max: >5 color: 1\n" +
+				"└── [3, 3] max: >7 color: 0\n" +
+				"    └── [1, 1] max: >1 color: 0\n" +
+				"",
+		},
+		{
+			name: "remove root",
+			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(9)), r(req(13))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│       ┌── [13, 13] max: >13 color: 1\n" +
+				"│   ┌── [11, 11] max: >13 color: 0\n" +
+				"│   │   └── [9, 9] max: >9 color: 1\n" +
+				"└── [7, 7] max: >13 color: 0\n" +
+				"    └── [3, 3] max: >3 color: 0\n" +
+				"",
+			rng: r(req(3)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── [13, 13] max: >13 color: 0\n" +
+				"└── [11, 11] max: >13 color: 0\n" +
+				"    │   ┌── [9, 9] max: >9 color: 1\n" +
+				"    └── [7, 7] max: >9 color: 0\n" +
+				"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tree, err := buildTestRangeTree(test.setupRngs)
+			require.NoError(t, err)
+			assert.Equal(t, test.setupExp, tree.String())
+
+			err = tree.Remove(test.rng)
+			require.NoError(t, err)
+			assert.Equal(t, test.exp, tree.String())
+		})
+	}
+}

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -950,6 +950,36 @@ func TestRangeTreeInsert(t *testing.T) {
 				"        └── [3, 3] max: Above[3] color: 0\n" +
 				"",
 		},
+		{
+			name:      "insert smallest",
+			setupRngs: []sql.Range{r(rcc(4, 6)), r(req(3)), r(req(11))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 1\n" +
+				"└── [4, 6] max: Above[11] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 1\n" +
+				"",
+			rng: r(req(0)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 0\n" +
+				"└── [4, 6] max: Above[11] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
+				"        └── [0, 0] max: Above[0] color: 1\n" +
+				"",
+		},
+		{
+			name:      "insert compare above and below",
+			setupRngs: []sql.Range{r(roo(4, 6)), r(req(4))},
+			setupExp: "RangeColumnExprTree\n" +
+				"└── (4, 6) max: Below[6] color: 0\n" +
+				"    └── [4, 4] max: Above[4] color: 1\n" +
+				"",
+			rng: r(req(6)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── [6, 6] max: Above[6] color: 1\n" +
+				"└── (4, 6) max: Above[6] color: 0\n" +
+				"    └── [4, 4] max: Above[4] color: 1\n" +
+				"",
+		},
 	}
 
 	for _, test := range tests {
@@ -1117,6 +1147,34 @@ func TestRangeTreeRemove(t *testing.T) {
 				"└── [11, 11] max: Above[13] color: 0\n" +
 				"    │   ┌── [9, 9] max: Above[9] color: 1\n" +
 				"    └── [7, 7] max: Above[9] color: 0\n" +
+				"",
+		},
+		{
+			name:      "remove ranges",
+			setupRngs: []sql.Range{r(roo(3, 5)), r(roo(1, 3)), r(roo(5, 7))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── (5, 7) max: Below[7] color: 1\n" +
+				"└── (3, 5) max: Below[7] color: 0\n" +
+				"    └── (1, 3) max: Below[3] color: 1\n" +
+				"",
+			rng: r(roo(1, 3)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── (5, 7) max: Below[7] color: 1\n" +
+				"└── (3, 5) max: Below[7] color: 0\n" +
+				"",
+		},
+		{
+			name:      "remove ranges",
+			setupRngs: []sql.Range{r(roo(3, 5)), r(roo(1, 3)), r(roo(5, 7))},
+			setupExp: "RangeColumnExprTree\n" +
+				"│   ┌── (5, 7) max: Below[7] color: 1\n" +
+				"└── (3, 5) max: Below[7] color: 0\n" +
+				"    └── (1, 3) max: Below[3] color: 1\n" +
+				"",
+			rng: r(roo(3, 5)),
+			exp: "RangeColumnExprTree\n" +
+				"│   ┌── (5, 7) max: Below[7] color: 1\n" +
+				"└── (1, 3) max: Below[7] color: 0\n" +
 				"",
 		},
 	}

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -827,15 +827,15 @@ func buildTestRangeTree(ranges []sql.Range) (*sql.RangeColumnExprTree, error) {
 }
 
 func TestRangeTreeInsert(t *testing.T) {
-	tests := []struct{
-		name string
+	tests := []struct {
+		name      string
 		setupRngs []sql.Range
-		setupExp string
-		rng sql.Range
-		exp string
+		setupExp  string
+		rng       sql.Range
+		exp       string
 	}{
 		{
-			name: "insert smallest",
+			name:      "insert smallest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│   ┌── [11, 11] max: >11 color: 1\n" +
@@ -851,7 +851,7 @@ func TestRangeTreeInsert(t *testing.T) {
 				"",
 		},
 		{
-			name: "insert largest",
+			name:      "insert largest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│   ┌── [11, 11] max: >11 color: 1\n" +
@@ -867,7 +867,7 @@ func TestRangeTreeInsert(t *testing.T) {
 				"",
 		},
 		{
-			name: "insert rebalance left child",
+			name:      "insert rebalance left child",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(0))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│   ┌── [11, 11] max: >11 color: 0\n" +
@@ -885,7 +885,7 @@ func TestRangeTreeInsert(t *testing.T) {
 				"",
 		},
 		{
-			name: "insert rebalance right child",
+			name:      "insert rebalance right child",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(12))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│       ┌── [12, 12] max: >12 color: 1\n" +
@@ -903,7 +903,7 @@ func TestRangeTreeInsert(t *testing.T) {
 				"",
 		},
 		{
-			name: "insert rebalance root from left",
+			name:      "insert rebalance root from left",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(0)), r(req(1)), r(req(2)), r(req(4))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│   ┌── [11, 11] max: >11 color: 0\n" +
@@ -927,7 +927,7 @@ func TestRangeTreeInsert(t *testing.T) {
 				"",
 		},
 		{
-			name: "insert rebalance root from right",
+			name:      "insert rebalance root from right",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(8)), r(req(9)), r(req(10)), r(req(12))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│           ┌── [12, 12] max: >12 color: 1\n" +
@@ -966,15 +966,15 @@ func TestRangeTreeInsert(t *testing.T) {
 }
 
 func TestRangeTreeRemove(t *testing.T) {
-	tests := []struct{
-		name string
+	tests := []struct {
+		name      string
 		setupRngs []sql.Range
-		setupExp string
-		rng sql.Range
-		exp string
+		setupExp  string
+		rng       sql.Range
+		exp       string
 	}{
 		{
-			name: "remove smallest",
+			name:      "remove smallest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│       ┌── [13, 13] max: >13 color: 1\n" +
@@ -996,7 +996,7 @@ func TestRangeTreeRemove(t *testing.T) {
 				"",
 		},
 		{
-			name: "remove largest",
+			name:      "remove largest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│       ┌── [13, 13] max: >13 color: 1\n" +
@@ -1018,7 +1018,7 @@ func TestRangeTreeRemove(t *testing.T) {
 				"",
 		},
 		{
-			name: "remove left parent",
+			name:      "remove left parent",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│       ┌── [13, 13] max: >13 color: 1\n" +
@@ -1040,7 +1040,7 @@ func TestRangeTreeRemove(t *testing.T) {
 				"",
 		},
 		{
-			name: "remove right parent",
+			name:      "remove right parent",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│       ┌── [13, 13] max: >13 color: 1\n" +
@@ -1062,7 +1062,7 @@ func TestRangeTreeRemove(t *testing.T) {
 				"",
 		},
 		{
-			name: "remove root",
+			name:      "remove root",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│       ┌── [13, 13] max: >13 color: 1\n" +
@@ -1084,7 +1084,7 @@ func TestRangeTreeRemove(t *testing.T) {
 				"",
 		},
 		{
-			name: "remove rotate left",
+			name:      "remove rotate left",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│   ┌── [11, 11] max: >11 color: 0\n" +
@@ -1102,7 +1102,7 @@ func TestRangeTreeRemove(t *testing.T) {
 				"",
 		},
 		{
-			name: "remove root",
+			name:      "remove root",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
 				"│       ┌── [13, 13] max: >13 color: 1\n" +

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -838,116 +838,116 @@ func TestRangeTreeInsert(t *testing.T) {
 			name:      "insert smallest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 1\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 1\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 1\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 1\n" +
 				"",
 			rng: r(req(0)),
 			exp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 0\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
-				"        └── [0, 0] max: >0 color: 1\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 0\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
+				"        └── [0, 0] max: Above[0] color: 1\n" +
 				"",
 		},
 		{
 			name:      "insert largest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 1\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 1\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 1\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 1\n" +
 				"",
 			rng: r(req(14)),
 			exp: "RangeColumnExprTree\n" +
-				"│       ┌── [14, 14] max: >14 color: 1\n" +
-				"│   ┌── [11, 11] max: >14 color: 0\n" +
-				"└── [7, 7] max: >14 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
+				"│       ┌── [14, 14] max: Above[14] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[14] color: 0\n" +
+				"└── [7, 7] max: Above[14] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
 				"",
 		},
 		{
 			name:      "insert rebalance left child",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(0))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 0\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
-				"        └── [0, 0] max: >0 color: 1\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 0\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
+				"        └── [0, 0] max: Above[0] color: 1\n" +
 				"",
 			rng: r(req(1)),
 			exp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 0\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    │   ┌── [3, 3] max: >3 color: 1\n" +
-				"    └── [1, 1] max: >3 color: 0\n" +
-				"        └── [0, 0] max: >0 color: 1\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 0\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    │   ┌── [3, 3] max: Above[3] color: 1\n" +
+				"    └── [1, 1] max: Above[3] color: 0\n" +
+				"        └── [0, 0] max: Above[0] color: 1\n" +
 				"",
 		},
 		{
 			name:      "insert rebalance right child",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(12))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│       ┌── [12, 12] max: >12 color: 1\n" +
-				"│   ┌── [11, 11] max: >12 color: 0\n" +
-				"└── [7, 7] max: >12 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
+				"│       ┌── [12, 12] max: Above[12] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[12] color: 0\n" +
+				"└── [7, 7] max: Above[12] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
 				"",
 			rng: r(req(13)),
 			exp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [12, 12] max: >13 color: 0\n" +
-				"│   │   └── [11, 11] max: >11 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [12, 12] max: Above[13] color: 0\n" +
+				"│   │   └── [11, 11] max: Above[11] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
 				"",
 		},
 		{
 			name:      "insert rebalance root from left",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(0)), r(req(1)), r(req(2)), r(req(4))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 0\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    │       ┌── [4, 4] max: >4 color: 1" +
-				"\n    │   ┌── [3, 3] max: >4 color: 0\n" +
-				"    │   │   └── [2, 2] max: >2 color: 1\n" +
-				"    └── [1, 1] max: >4 color: 1\n" +
-				"        └── [0, 0] max: >0 color: 0\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 0\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    │       ┌── [4, 4] max: Above[4] color: 1\n" +
+				"    │   ┌── [3, 3] max: Above[4] color: 0\n" +
+				"    │   │   └── [2, 2] max: Above[2] color: 1\n" +
+				"    └── [1, 1] max: Above[4] color: 1\n" +
+				"        └── [0, 0] max: Above[0] color: 0\n" +
 				"",
 			rng: r(req(5)),
 			exp: "RangeColumnExprTree\n" +
-				"│       ┌── [11, 11] max: >11 color: 0\n" +
-				"│   ┌── [7, 7] max: >11 color: 1\n" +
-				"│   │   │   ┌── [5, 5] max: >5 color: 1\n" +
-				"│   │   └── [4, 4] max: >5 color: 0\n" +
-				"└── [3, 3] max: >11 color: 0\n" +
-				"    │   ┌── [2, 2] max: >2 color: 0\n" +
-				"    └── [1, 1] max: >2 color: 1\n" +
-				"        └── [0, 0] max: >0 color: 0\n" +
+				"│       ┌── [11, 11] max: Above[11] color: 0\n" +
+				"│   ┌── [7, 7] max: Above[11] color: 1\n" +
+				"│   │   │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"│   │   └── [4, 4] max: Above[5] color: 0\n" +
+				"└── [3, 3] max: Above[11] color: 0\n" +
+				"    │   ┌── [2, 2] max: Above[2] color: 0\n" +
+				"    └── [1, 1] max: Above[2] color: 1\n" +
+				"        └── [0, 0] max: Above[0] color: 0\n" +
 				"",
 		},
 		{
 			name:      "insert rebalance root from right",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(8)), r(req(9)), r(req(10)), r(req(12))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│           ┌── [12, 12] max: >12 color: 1\n" +
-				"│       ┌── [11, 11] max: >12 color: 0\n" +
-				"│       │   └── [10, 10] max: >10 color: 1\n" +
-				"│   ┌── [9, 9] max: >12 color: 1\n" +
-				"│   │   └── [8, 8] max: >8 color: 0\n" +
-				"└── [7, 7] max: >12 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
+				"│           ┌── [12, 12] max: Above[12] color: 1\n" +
+				"│       ┌── [11, 11] max: Above[12] color: 0\n" +
+				"│       │   └── [10, 10] max: Above[10] color: 1\n" +
+				"│   ┌── [9, 9] max: Above[12] color: 1\n" +
+				"│   │   └── [8, 8] max: Above[8] color: 0\n" +
+				"└── [7, 7] max: Above[12] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
 				"",
 			rng: r(req(13)),
 			exp: "RangeColumnExprTree\n" +
-				"│           ┌── [13, 13] max: >13 color: 1\n" +
-				"│       ┌── [12, 12] max: >13 color: 0\n" +
-				"│   ┌── [11, 11] max: >13 color: 1\n" +
-				"│   │   └── [10, 10] max: >10 color: 0\n" +
-				"└── [9, 9] max: >13 color: 0\n" +
-				"    │   ┌── [8, 8] max: >8 color: 0\n" +
-				"    └── [7, 7] max: >8 color: 1\n" +
-				"        └── [3, 3] max: >3 color: 0\n" +
+				"│           ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│       ┌── [12, 12] max: Above[13] color: 0\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 1\n" +
+				"│   │   └── [10, 10] max: Above[10] color: 0\n" +
+				"└── [9, 9] max: Above[13] color: 0\n" +
+				"    │   ┌── [8, 8] max: Above[8] color: 0\n" +
+				"    └── [7, 7] max: Above[8] color: 1\n" +
+				"        └── [3, 3] max: Above[3] color: 0\n" +
 				"",
 		},
 	}
@@ -977,146 +977,146 @@ func TestRangeTreeRemove(t *testing.T) {
 			name:      "remove smallest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 			rng: r(req(1)),
 			exp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
 				"",
 		},
 		{
 			name:      "remove largest",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 			rng: r(req(13)),
 			exp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 		},
 		{
 			name:      "remove left parent",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 			rng: r(req(3)),
 			exp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [1, 1] max: >5 color: 0\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [1, 1] max: Above[5] color: 0\n" +
 				"",
 		},
 		{
 			name:      "remove right parent",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 			rng: r(req(11)),
 			exp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [9, 9] max: >13 color: 0\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [9, 9] max: Above[13] color: 0\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 		},
 		{
 			name:      "remove root",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 			rng: r(req(7)),
 			exp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [5, 5] max: >13 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [5, 5] max: Above[13] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 		},
 		{
 			name:      "remove rotate left",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(1)), r(req(5))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│   ┌── [11, 11] max: >11 color: 0\n" +
-				"└── [7, 7] max: >11 color: 0\n" +
-				"    │   ┌── [5, 5] max: >5 color: 1\n" +
-				"    └── [3, 3] max: >5 color: 0\n" +
-				"        └── [1, 1] max: >1 color: 1\n" +
+				"│   ┌── [11, 11] max: Above[11] color: 0\n" +
+				"└── [7, 7] max: Above[11] color: 0\n" +
+				"    │   ┌── [5, 5] max: Above[5] color: 1\n" +
+				"    └── [3, 3] max: Above[5] color: 0\n" +
+				"        └── [1, 1] max: Above[1] color: 1\n" +
 				"",
 			rng: r(req(11)),
 			exp: "RangeColumnExprTree\n" +
-				"│   ┌── [7, 7] max: >7 color: 0\n" +
-				"│   │   └── [5, 5] max: >5 color: 1\n" +
-				"└── [3, 3] max: >7 color: 0\n" +
-				"    └── [1, 1] max: >1 color: 0\n" +
+				"│   ┌── [7, 7] max: Above[7] color: 0\n" +
+				"│   │   └── [5, 5] max: Above[5] color: 1\n" +
+				"└── [3, 3] max: Above[7] color: 0\n" +
+				"    └── [1, 1] max: Above[1] color: 0\n" +
 				"",
 		},
 		{
 			name:      "remove root",
 			setupRngs: []sql.Range{r(req(7)), r(req(3)), r(req(11)), r(req(9)), r(req(13))},
 			setupExp: "RangeColumnExprTree\n" +
-				"│       ┌── [13, 13] max: >13 color: 1\n" +
-				"│   ┌── [11, 11] max: >13 color: 0\n" +
-				"│   │   └── [9, 9] max: >9 color: 1\n" +
-				"└── [7, 7] max: >13 color: 0\n" +
-				"    └── [3, 3] max: >3 color: 0\n" +
+				"│       ┌── [13, 13] max: Above[13] color: 1\n" +
+				"│   ┌── [11, 11] max: Above[13] color: 0\n" +
+				"│   │   └── [9, 9] max: Above[9] color: 1\n" +
+				"└── [7, 7] max: Above[13] color: 0\n" +
+				"    └── [3, 3] max: Above[3] color: 0\n" +
 				"",
 			rng: r(req(3)),
 			exp: "RangeColumnExprTree\n" +
-				"│   ┌── [13, 13] max: >13 color: 0\n" +
-				"└── [11, 11] max: >13 color: 0\n" +
-				"    │   ┌── [9, 9] max: >9 color: 1\n" +
-				"    └── [7, 7] max: >9 color: 0\n" +
+				"│   ┌── [13, 13] max: Above[13] color: 0\n" +
+				"└── [11, 11] max: Above[13] color: 0\n" +
+				"    │   ┌── [9, 9] max: Above[9] color: 1\n" +
+				"    └── [7, 7] max: Above[9] color: 0\n" +
 				"",
 		},
 	}

--- a/sql/range_tree.go
+++ b/sql/range_tree.go
@@ -336,7 +336,6 @@ func (tree *RangeColumnExprTree) remove(rang Range, colExprIdx int) error {
 		pred := node.Left.maximumNode()
 		node.LowerBound = pred.LowerBound
 		node.UpperBound = pred.UpperBound
-		node.MaxUpperbound = pred.MaxUpperbound
 		if pred.Inner != nil && pred.Inner.size > 0 {
 			node.Inner = pred.Inner
 		} else {
@@ -348,48 +347,37 @@ func (tree *RangeColumnExprTree) remove(rang Range, colExprIdx int) error {
 		if node.Right == nil {
 			child = node.Left
 		} else {
-			child = node.Right
+			child = node.Right // TODO: if node is being replaced by non-nil right child, no need to update max upperbound
 		}
 		if node.color == black {
 			node.color = child.nodeColor()
-			tree.removeBalance(node)
+			tree.removeBalance(node) // TODO: isn't this supposed to be called after?
 		}
 		tree.replaceNode(node, child)
 		if child != nil {
 			if node.Parent == nil {
 				child.color = black
-			} else {
-				parentMax, err := GetRangeCutMax(tree.typ, child.Parent.Left.maxUpperBound(), child.Parent.Right.maxUpperBound(), child.Parent.UpperBound)
-				if err != nil {
-					panic(err)
-				}
-				child.Parent.MaxUpperbound = parentMax
 			}
+		}
+
+		// propagate max upperbound updates up the tree
+		parent := node.Parent
+		for parent != nil {
+			// upperbound of left child has no impact on parent's upperbound
+			if child == parent.Left {
+				break
+			}
+			if child == nil {
+				parent.MaxUpperbound = parent.UpperBound
+			} else {
+				parent.MaxUpperbound = child.MaxUpperbound
+			}
+			child = parent
+			parent = parent.Parent
 		}
 	}
 	tree.size--
-	tree.CalcMaxUpperBound()
 	return nil
-}
-
-func (tree *RangeColumnExprTree) CalcMaxUpperBound() {
-	if tree == nil {
-		return
-	}
-	tree.root.calcMaxUpperbound()
-}
-
-func (node *rangeColumnExprTreeNode) calcMaxUpperbound() RangeCut {
-	if node == nil {
-		return nil
-	}
-	node.Inner.CalcMaxUpperBound()
-	node.Left.calcMaxUpperbound()
-	node.MaxUpperbound = node.Right.calcMaxUpperbound()
-	if node.MaxUpperbound == nil {
-		node.MaxUpperbound = node.UpperBound
-	}
-	return node.MaxUpperbound
 }
 
 // GetRangeCollection returns every Range that this tree contains.
@@ -484,7 +472,8 @@ func (node *rangeColumnExprTreeNode) string(prefix string, isTail bool, sb *stri
 		UpperBound: node.UpperBound,
 		Typ:        typ,
 	}.DebugString())
-	sb.WriteString(" " + node.MaxUpperbound.String())
+	sb.WriteString(fmt.Sprintf(" max: %s", node.MaxUpperbound.DebugString()))
+	sb.WriteString(fmt.Sprintf(" color: %d", node.color))
 	sb.WriteRune('\n')
 	if node.Left != nil {
 		newPrefix := prefix
@@ -543,16 +532,11 @@ func (tree *RangeColumnExprTree) rotateLeft(node *rangeColumnExprTreeNode) {
 	}
 	right.Left = node
 	node.Parent = right
-	nodeMax, err := GetRangeCutMax(tree.typ, node.Left.maxUpperBound(), node.Right.maxUpperBound(), node.UpperBound)
-	if err != nil {
-		panic(err)
+	if node.Right == nil { // TODO: right is always not nil?
+		node.MaxUpperbound = node.UpperBound
+	} else {
+		node.MaxUpperbound = node.Right.MaxUpperbound
 	}
-	node.MaxUpperbound = nodeMax
-	rightMax, err := GetRangeCutMax(tree.typ, node.UpperBound, right.UpperBound, right.Right.upperBound())
-	if err != nil {
-		panic(err)
-	}
-	right.MaxUpperbound = rightMax
 }
 
 // rotateRight performs a right rotation. This also updates the max upperbounds of each affected node.
@@ -565,19 +549,10 @@ func (tree *RangeColumnExprTree) rotateRight(node *rangeColumnExprTreeNode) {
 	}
 	left.Right = node
 	node.Parent = left
-	nodeMax, err := GetRangeCutMax(tree.typ, node.Left.maxUpperBound(), node.Right.maxUpperBound(), node.upperBound())
-	if err != nil {
-		panic(err)
-	}
-	node.MaxUpperbound = nodeMax
-	leftMax, err := GetRangeCutMax(tree.typ, node.UpperBound, left.UpperBound, left.Left.upperBound())
-	if err != nil {
-		panic(err)
-	}
-	left.MaxUpperbound = leftMax
+	left.MaxUpperbound = node.MaxUpperbound
 }
 
-// replaceNode replaces the old node with the new node.
+// replaceNode updates the parent to point to the new node, and the new node to point to the parent; it does not update the children
 func (tree *RangeColumnExprTree) replaceNode(old *rangeColumnExprTreeNode, new *rangeColumnExprTreeNode) {
 	if old.Parent == nil {
 		tree.root = new

--- a/sql/range_tree.go
+++ b/sql/range_tree.go
@@ -472,7 +472,7 @@ func (node *rangeColumnExprTreeNode) string(prefix string, isTail bool, sb *stri
 		UpperBound: node.UpperBound,
 		Typ:        typ,
 	}.DebugString())
-	sb.WriteString(fmt.Sprintf(" max: %s", node.MaxUpperbound.DebugString()))
+	sb.WriteString(fmt.Sprintf(" max: %s", node.MaxUpperbound.String()))
 	sb.WriteString(fmt.Sprintf(" color: %d", node.color))
 	sb.WriteRune('\n')
 	if node.Left != nil {

--- a/sql/range_tree.go
+++ b/sql/range_tree.go
@@ -368,7 +368,28 @@ func (tree *RangeColumnExprTree) remove(rang Range, colExprIdx int) error {
 		}
 	}
 	tree.size--
+	tree.CalcMaxUpperBound()
 	return nil
+}
+
+func (tree *RangeColumnExprTree) CalcMaxUpperBound() {
+	if tree == nil {
+		return
+	}
+	tree.root.calcMaxUpperbound()
+}
+
+func (node *rangeColumnExprTreeNode) calcMaxUpperbound() RangeCut {
+	if node == nil {
+		return nil
+	}
+	node.Inner.CalcMaxUpperBound()
+	node.Left.calcMaxUpperbound()
+	node.MaxUpperbound = node.Right.calcMaxUpperbound()
+	if node.MaxUpperbound == nil {
+		node.MaxUpperbound = node.UpperBound
+	}
+	return node.MaxUpperbound
 }
 
 // GetRangeCollection returns every Range that this tree contains.
@@ -463,6 +484,7 @@ func (node *rangeColumnExprTreeNode) string(prefix string, isTail bool, sb *stri
 		UpperBound: node.UpperBound,
 		Typ:        typ,
 	}.DebugString())
+	sb.WriteString(" " + node.MaxUpperbound.String())
 	sb.WriteRune('\n')
 	if node.Left != nil {
 		newPrefix := prefix

--- a/sql/range_tree.go
+++ b/sql/range_tree.go
@@ -532,7 +532,7 @@ func (tree *RangeColumnExprTree) rotateLeft(node *rangeColumnExprTreeNode) {
 	}
 	right.Left = node
 	node.Parent = right
-	if node.Right == nil { // TODO: right is always not nil?
+	if node.Right == nil {
 		node.MaxUpperbound = node.UpperBound
 	} else {
 		node.MaxUpperbound = node.Right.MaxUpperbound


### PR DESCRIPTION
Verification code from in the last RangeTree related PR caught some bad ranges in the sqllogictests.
The cause was not properly updating the MaxUpperBound in nodes for the rangetree when performing a remove operation, which led to missing connections when pruning ranges.

This also prints MaxUpperBound in the String/DebugString methods for easier debugging.