### PR TITLE
Allow `BLOB`/`JSON`/`TEXT` columns to have literal default values (MariaDB compatibility)

### DIFF
--- a/enginetest/queries/blob_queries.go
+++ b/enginetest/queries/blob_queries.go
@@ -187,20 +187,12 @@ var BlobErrors = []QueryErrorTest{
 		ExpectedErr: sql.ErrKeyTooLong,
 	},
 	{
-		Query:       "alter table blobt add column b2 blob default '1'",
-		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
-	},
-	{
 		Query:       "alter table textt add index tidx (t)",
 		ExpectedErr: sql.ErrInvalidBlobTextKey,
 	},
 	{
 		Query:       "alter table textt add index tidx (t(769))",
 		ExpectedErr: sql.ErrKeyTooLong,
-	},
-	{
-		Query:       "alter table textt add column t2 text default '1'",
-		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
 	},
 	{
 		Query:       "alter table textt add index tidx (i, t)",

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -9245,22 +9245,6 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: sql.ErrSyntaxError,
 	},
 	{
-		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, j JSON DEFAULT '{}');",
-		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
-	},
-	{
-		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, g GEOMETRY DEFAULT '');",
-		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
-	},
-	{
-		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, t TEXT DEFAULT '');",
-		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
-	},
-	{
-		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, b BLOB DEFAULT '');",
-		ExpectedErr: sql.ErrInvalidTextBlobColumnDefault,
-	},
-	{
 		Query:       "with a as (select * from a) select * from a",
 		ExpectedErr: sql.ErrTableNotFound,
 	},

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/information_schema"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
-	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // Resolving column defaults is a multi-phase process, with different analyzer rules for each phase.
@@ -232,18 +231,6 @@ func validateColumnDefault(ctx *sql.Context, col *sql.Column, e *expression.Wrap
 
 	if newDefault == nil {
 		return nil
-	}
-
-	// Some column types can only have a NULL for a literal default, must be an expression otherwise
-	isLiteralRestrictedType := types.IsTextBlob(col.Type) || types.IsJSON(col.Type) || types.IsGeometry(col.Type)
-	if isLiteralRestrictedType && newDefault.IsLiteral() {
-		lit, err := newDefault.Expr.Eval(ctx, nil)
-		if err != nil {
-			return err
-		}
-		if lit != nil {
-			return sql.ErrInvalidTextBlobColumnDefault.New()
-		}
 	}
 
 	var err error

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -134,9 +134,6 @@ var (
 	// ErrIncompatibleDefaultType is returned when a provided default cannot be coerced into the type of the column
 	ErrIncompatibleDefaultType = errors.NewKind("incompatible type for default value")
 
-	// ErrInvalidTextBlobColumnDefault is returned when a column of type text/blob (or related) has a literal default set.
-	ErrInvalidTextBlobColumnDefault = errors.NewKind("TEXT, BLOB, GEOMETRY, and JSON types may only have expression default values")
-
 	// ErrColumnDefaultDatetimeOnlyFunc is returned when a non datetime/timestamp column attempts to declare now/current_timestamp as a default value literal.
 	ErrColumnDefaultDatetimeOnlyFunc = errors.NewKind("only datetime/timestamp may declare default values of now()/current_timestamp() without surrounding parentheses")
 

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -93,7 +93,7 @@ func (lit *Literal) String() string {
 	case decimal.Decimal:
 		return litVal.StringFixed(litVal.Exponent() * -1)
 	case []byte:
-		return "BLOB"
+		return fmt.Sprintf("0x%X", litVal)
 	case nil:
 		return "NULL"
 	default:


### PR DESCRIPTION
Technically, MySQL does NOT allow `BLOB`/`JSON`/`TEXT` columns to have a literal default value, and requires them to be specified as an expression (i.e. wrapped in parens). We diverge from this behavior and allow it, for compatibility with MariaDB. 

While testing with a binary literal, I noticed that `SQLVal` was converting that value to "`BLOB`" instead of the actual binary content, so I fixed that one, too. 

Related to: https://github.com/dolthub/dolt/issues/7033

Dolt CI Checks: https://github.com/dolthub/dolt/pull/7036