### PR TITLE
fix panic in math funcs

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8548,6 +8548,18 @@ from typestable`,
 			{3, "third row"},
 		},
 	},
+	{
+		Query: "select sqrt(-1) + 1",
+		Expected: []sql.Row{
+			{nil},
+		},
+	},
+	{
+		Query: "select sqrt(-1) + 1",
+		Expected: []sql.Row{
+			{nil},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/expression/function/logarithm.go
+++ b/sql/expression/function/logarithm.go
@@ -133,7 +133,7 @@ func (l *LogBase) Eval(
 	if err != nil {
 		return nil, sql.ErrInvalidType.New(reflect.TypeOf(v))
 	}
-	return computeLog(val.(float64), l.base)
+	return computeLog(ctx, val.(float64), l.base)
 }
 
 // Log is a function that returns the natural logarithm of a value.
@@ -231,15 +231,17 @@ func (l *Log) Eval(
 	}
 
 	// rhs becomes value, lhs becomes base
-	return computeLog(rhs.(float64), lhs.(float64))
+	return computeLog(ctx, rhs.(float64), lhs.(float64))
 }
 
-func computeLog(v float64, base float64) (float64, error) {
+func computeLog(ctx *sql.Context, v float64, base float64) (interface{}, error) {
 	if v <= 0 {
-		return float64(0), ErrInvalidArgumentForLogarithm.New(v)
+		ctx.Warn(3020, ErrInvalidArgumentForLogarithm.New(v).Error())
+		return nil, nil
 	}
 	if base == float64(1) || base <= float64(0) {
-		return float64(0), ErrInvalidArgumentForLogarithm.New(base)
+		ctx.Warn(3020, ErrInvalidArgumentForLogarithm.New(base).Error())
+		return nil, nil
 	}
 	switch base {
 	case float64(2):

--- a/sql/expression/function/logarithm_test.go
+++ b/sql/expression/function/logarithm_test.go
@@ -37,8 +37,9 @@ func TestLn(t *testing.T) {
 		expected interface{}
 		err      *errors.Kind
 	}{
-		{"Input value is zero", types.Float64, sql.NewRow(0), nil, ErrInvalidArgumentForLogarithm},
-		{"Input value is negative", types.Float64, sql.NewRow(-1), nil, ErrInvalidArgumentForLogarithm},
+		{"Input value is null", types.Float64, sql.NewRow(nil), nil, nil},
+		{"Input value is zero", types.Float64, sql.NewRow(0), nil, nil},
+		{"Input value is negative", types.Float64, sql.NewRow(-1), nil, nil},
 		{"Input value is valid string", types.Float64, sql.NewRow("2"), float64(0.6931471805599453), nil},
 		{"Input value is invalid string", types.Float64, sql.NewRow("aaa"), nil, sql.ErrInvalidType},
 		{"Input value is valid float64", types.Float64, sql.NewRow(3), float64(1.0986122886681096), nil},
@@ -48,7 +49,7 @@ func TestLn(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		f := NewLogBaseFunc(math.E)(expression.NewGetField(0, tt.rowType, "", false))
+		f := NewLogBaseFunc(math.E)(expression.NewGetField(0, tt.rowType, "", true))
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
 			require := require.New(t)
@@ -56,20 +57,16 @@ func TestLn(t *testing.T) {
 			if tt.err != nil {
 				require.Error(err)
 				require.True(tt.err.Is(err))
+			} else if tt.expected == nil {
+				require.NoError(err)
+				require.Nil(result)
+				require.True(f.IsNullable())
 			} else {
 				require.NoError(err)
 				require.InEpsilonf(tt.expected, result, epsilon, fmt.Sprintf("Actual is: %v", result))
 			}
 		})
 	}
-
-	// Test Nil
-	f := NewLogBaseFunc(math.E)(expression.NewGetField(0, types.Float64, "", true))
-	require := require.New(t)
-	result, err := f.Eval(sql.NewEmptyContext(), sql.NewRow(nil))
-	require.NoError(err)
-	require.Nil(result)
-	require.True(f.IsNullable())
 }
 
 func TestLog2(t *testing.T) {
@@ -80,8 +77,9 @@ func TestLog2(t *testing.T) {
 		expected interface{}
 		err      *errors.Kind
 	}{
-		{"Input value is zero", types.Float64, sql.NewRow(0), nil, ErrInvalidArgumentForLogarithm},
-		{"Input value is negative", types.Float64, sql.NewRow(-1), nil, ErrInvalidArgumentForLogarithm},
+		{"Input value is null", types.Float64, sql.NewRow(nil), nil, nil},
+		{"Input value is zero", types.Float64, sql.NewRow(0), nil, nil},
+		{"Input value is negative", types.Float64, sql.NewRow(-1), nil, nil},
 		{"Input value is valid string", types.Float64, sql.NewRow("2"), float64(1), nil},
 		{"Input value is invalid string", types.Float64, sql.NewRow("aaa"), nil, sql.ErrInvalidType},
 		{"Input value is valid float64", types.Float64, sql.NewRow(3), float64(1.5849625007211563), nil},
@@ -91,7 +89,7 @@ func TestLog2(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		f := NewLogBaseFunc(float64(2))(expression.NewGetField(0, tt.rowType, "", false))
+		f := NewLogBaseFunc(float64(2))(expression.NewGetField(0, tt.rowType, "", true))
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
 			require := require.New(t)
@@ -99,20 +97,16 @@ func TestLog2(t *testing.T) {
 			if tt.err != nil {
 				require.Error(err)
 				require.True(tt.err.Is(err))
+			} else if tt.expected == nil {
+				require.NoError(err)
+				require.Nil(result)
+				require.True(f.IsNullable())
 			} else {
 				require.NoError(err)
 				require.InEpsilonf(tt.expected, result, epsilon, fmt.Sprintf("Actual is: %v", result))
 			}
 		})
 	}
-
-	// Test Nil
-	f := NewLogBaseFunc(float64(2))(expression.NewGetField(0, types.Float64, "", true))
-	require := require.New(t)
-	result, err := f.Eval(sql.NewEmptyContext(), sql.NewRow(nil))
-	require.NoError(err)
-	require.Nil(result)
-	require.True(f.IsNullable())
 }
 
 func TestLog10(t *testing.T) {
@@ -123,8 +117,9 @@ func TestLog10(t *testing.T) {
 		expected interface{}
 		err      *errors.Kind
 	}{
-		{"Input value is zero", types.Float64, sql.NewRow(0), nil, ErrInvalidArgumentForLogarithm},
-		{"Input value is negative", types.Float64, sql.NewRow(-1), nil, ErrInvalidArgumentForLogarithm},
+		{"Input value is null", types.Float64, sql.NewRow(0), nil, nil},
+		{"Input value is zero", types.Float64, sql.NewRow(0), nil, nil},
+		{"Input value is negative", types.Float64, sql.NewRow(-1), nil, nil},
 		{"Input value is valid string", types.Float64, sql.NewRow("2"), float64(0.3010299956639812), nil},
 		{"Input value is invalid string", types.Float64, sql.NewRow("aaa"), nil, sql.ErrInvalidType},
 		{"Input value is valid float64", types.Float64, sql.NewRow(3), float64(0.4771212547196624), nil},
@@ -134,7 +129,7 @@ func TestLog10(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		f := NewLogBaseFunc(float64(10))(expression.NewGetField(0, tt.rowType, "", false))
+		f := NewLogBaseFunc(float64(10))(expression.NewGetField(0, tt.rowType, "", true))
 		t.Run(tt.name, func(t *testing.T) {
 			t.Helper()
 			require := require.New(t)
@@ -142,20 +137,16 @@ func TestLog10(t *testing.T) {
 			if tt.err != nil {
 				require.Error(err)
 				require.True(tt.err.Is(err))
+			} else if tt.expected == nil {
+				require.NoError(err)
+				require.Nil(result)
+				require.True(f.IsNullable())
 			} else {
 				require.NoError(err)
 				require.InEpsilonf(tt.expected, result, epsilon, fmt.Sprintf("Actual is: %v", result))
 			}
 		})
 	}
-
-	// Test Nil
-	f := NewLogBaseFunc(float64(10))(expression.NewGetField(0, types.Float64, "", true))
-	require := require.New(t)
-	result, err := f.Eval(sql.NewEmptyContext(), sql.NewRow(nil))
-	require.NoError(err)
-	require.Nil(result)
-	require.True(f.IsNullable())
 }
 
 func TestLogInvalidArguments(t *testing.T) {
@@ -177,14 +168,16 @@ func TestLog(t *testing.T) {
 		expected interface{}
 		err      *errors.Kind
 	}{
-		{"Input base is 1", []sql.Expression{expression.NewLiteral(float64(1), types.Float64), expression.NewLiteral(float64(10), types.Float64)}, nil, ErrInvalidArgumentForLogarithm},
-		{"Input base is zero", []sql.Expression{expression.NewLiteral(float64(0), types.Float64), expression.NewLiteral(float64(10), types.Float64)}, nil, ErrInvalidArgumentForLogarithm},
-		{"Input base is negative", []sql.Expression{expression.NewLiteral(float64(-5), types.Float64), expression.NewLiteral(float64(10), types.Float64)}, nil, ErrInvalidArgumentForLogarithm},
+		{"Input base is 1", []sql.Expression{expression.NewLiteral(float64(1), types.Float64), expression.NewLiteral(float64(10), types.Float64)}, nil, nil},
+		{"Input base is nil", []sql.Expression{expression.NewLiteral(nil, types.Float64), expression.NewLiteral(float64(10), types.Float64)}, nil, nil},
+		{"Input base is zero", []sql.Expression{expression.NewLiteral(float64(0), types.Float64), expression.NewLiteral(float64(10), types.Float64)}, nil, nil},
+		{"Input base is negative", []sql.Expression{expression.NewLiteral(float64(-5), types.Float64), expression.NewLiteral(float64(10), types.Float64)}, nil, nil},
 		{"Input base is valid string", []sql.Expression{expression.NewLiteral("4", types.LongText), expression.NewLiteral(float64(10), types.Float64)}, float64(1.6609640474436813), nil},
 		{"Input base is invalid string", []sql.Expression{expression.NewLiteral("bbb", types.LongText), expression.NewLiteral(float64(10), types.Float64)}, nil, sql.ErrInvalidType},
 
-		{"Input value is zero", []sql.Expression{expression.NewLiteral(float64(0), types.Float64)}, nil, ErrInvalidArgumentForLogarithm},
-		{"Input value is negative", []sql.Expression{expression.NewLiteral(float64(-9), types.Float64)}, nil, ErrInvalidArgumentForLogarithm},
+		{"Input value is null", []sql.Expression{expression.NewLiteral(nil, types.Float64)}, nil, nil},
+		{"Input value is zero", []sql.Expression{expression.NewLiteral(float64(0), types.Float64)}, nil, nil},
+		{"Input value is negative", []sql.Expression{expression.NewLiteral(float64(-9), types.Float64)}, nil, nil},
 		{"Input value is valid string", []sql.Expression{expression.NewLiteral("7", types.LongText)}, float64(1.9459101490553132), nil},
 		{"Input value is invalid string", []sql.Expression{expression.NewLiteral("766j", types.LongText)}, nil, sql.ErrInvalidType},
 
@@ -208,18 +201,13 @@ func TestLog(t *testing.T) {
 			if tt.err != nil {
 				require.Error(err)
 				require.True(tt.err.Is(err))
+			} else if tt.expected == nil {
+				require.NoError(err)
+				require.Nil(result)
 			} else {
 				require.NoError(err)
 				require.InEpsilonf(tt.expected, result, epsilon, fmt.Sprintf("Actual is: %v", result))
 			}
 		})
 	}
-
-	// Test Nil
-	f, _ := NewLog(expression.NewLiteral(nil, types.Float64))
-	require := require.New(t)
-	result, err := f.Eval(sql.NewEmptyContext(), nil)
-	require.NoError(err)
-	require.Nil(result)
-	require.True(f.IsNullable())
 }

--- a/sql/expression/function/sqrt_power.go
+++ b/sql/expression/function/sqrt_power.go
@@ -90,7 +90,12 @@ func (s *Sqrt) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
-	return math.Sqrt(child.(float64)), nil
+	res := math.Sqrt(child.(float64))
+	if math.IsNaN(res) || math.IsInf(res, 0) {
+		return nil, nil
+	}
+
+	return res, nil
 }
 
 // Power is a function that returns value of X raised to the power of Y.
@@ -174,5 +179,10 @@ func (p *Power) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
-	return math.Pow(left.(float64), right.(float64)), nil
+	res := math.Pow(left.(float64), right.(float64))
+	if math.IsNaN(res) || math.IsInf(res, 0) {
+		return nil, nil
+	}
+
+	return res, nil
 }

--- a/sql/expression/function/sqrt_power_test.go
+++ b/sql/expression/function/sqrt_power_test.go
@@ -40,6 +40,7 @@ func TestSqrt(t *testing.T) {
 		{"valid string", sql.NewRow("9"), float64(3), false},
 		{"number is zero", sql.NewRow(0), float64(0), false},
 		{"positive number", sql.NewRow(8), float64(2.8284271247461903), false},
+		{"negative number", sql.NewRow(-1), nil, false},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -56,16 +57,6 @@ func TestSqrt(t *testing.T) {
 			}
 		})
 	}
-
-	// Test negative number
-	f = NewSqrt(
-		expression.NewGetField(0, types.Float64, "n", false),
-	)
-	require := require.New(t)
-	v, err := f.Eval(sql.NewEmptyContext(), []interface{}{float64(-4)})
-	require.NoError(err)
-	require.IsType(float64(0), v)
-	require.True(math.IsNaN(v.(float64)))
 }
 
 func TestPower(t *testing.T) {
@@ -87,6 +78,8 @@ func TestPower(t *testing.T) {
 		{"Exp is negative", types.Float64, sql.NewRow(2, -2), float64(0.25), false},
 		{"Base and exp are invalid strings", types.Float64, sql.NewRow("a", "b"), nil, true},
 		{"Base and exp are valid strings", types.Float64, sql.NewRow("2", "2"), float64(4), false},
+		{"positive inf", types.Float64, sql.NewRow(2, math.Inf(1)), nil, false},
+		{"negative inf", types.Float64, sql.NewRow(2, math.Inf(1)), nil, false},
 	}
 	for _, tt := range testCases {
 		f := NewPower(
@@ -107,20 +100,4 @@ func TestPower(t *testing.T) {
 			}
 		})
 	}
-
-	// Test inf numbers
-	f := NewPower(
-		expression.NewGetField(0, types.Float64, "", false),
-		expression.NewGetField(1, types.Float64, "", false),
-	)
-	require := require.New(t)
-	v, err := f.Eval(sql.NewEmptyContext(), sql.NewRow(2, math.Inf(1)))
-	require.NoError(err)
-	require.IsType(float64(0), v)
-	require.True(math.IsInf(v.(float64), 1))
-
-	v, err = f.Eval(sql.NewEmptyContext(), sql.NewRow(math.Inf(1), 2))
-	require.NoError(err)
-	require.IsType(float64(0), v)
-	require.True(math.IsInf(v.(float64), 1))
 }


### PR DESCRIPTION
fixes https://github.com/dolthub/dolt/issues/7060

Additionally, fixes `POW()` to not have the same panic and returns warnings instead of errors for certain inputs to `LOG()`.