### PR TITLE
Improve IN_SUBQUERY table disambiguation

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -765,6 +765,14 @@ var SpatialQueryTests = []QueryTest{
 
 var QueryTests = []QueryTest{
 	{
+		Query:    "select x from xy where y in (select xy.x from xy join (select t2.y from xy t2 where exists (select t3.y from xy t3 where t3.y = xy.x)) t1) order by 1;",
+		Expected: []sql.Row{{0}, {1}, {2}, {3}},
+	},
+	{
+		Query:    "select x from xy where y in (select x from xy where x in (select y from xy)) order by 1;",
+		Expected: []sql.Row{{0}, {1}, {2}, {3}},
+	},
+	{
 		Query:    "SELECT 1 WHERE ((1 IN (NULL >= 1)) IS NULL);",
 		Expected: []sql.Row{{1}},
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -18,6 +18,141 @@ package queries
 
 var PlanTests = []QueryPlanTest{
 	{
+		Query: `select x from xy where y in (select x from xy where exists (select y from xy t1 where t1.y = xy.x));`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [xy.x:1!null]\n" +
+			" └─ LookupJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ xy.y:2\n" +
+			"     │   └─ xy_1.x:0!null\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ Project\n" +
+			"     │       ├─ columns: [xy_1.x:0!null]\n" +
+			"     │       └─ SemiLookupJoin\n" +
+			"     │           ├─ TableAlias(xy_1)\n" +
+			"     │           │   └─ ProcessTable\n" +
+			"     │           │       └─ Table\n" +
+			"     │           │           ├─ name: xy\n" +
+			"     │           │           └─ columns: [x y]\n" +
+			"     │           └─ TableAlias(t1)\n" +
+			"     │               └─ IndexedTableAccess(xy)\n" +
+			"     │                   ├─ index: [xy.y]\n" +
+			"     │                   ├─ keys: [xy.x:3!null]\n" +
+			"     │                   ├─ colSet: (5,6)\n" +
+			"     │                   ├─ tableId: 3\n" +
+			"     │                   └─ Table\n" +
+			"     │                       ├─ name: xy\n" +
+			"     │                       └─ columns: [x y]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
+			"         ├─ index: [xy.y]\n" +
+			"         ├─ keys: [xy_1.x:0!null]\n" +
+			"         ├─ colSet: (1,2)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: xy\n" +
+			"             └─ columns: [x y]\n" +
+			"",
+	},
+	{
+		Query: `select x from xy where y in (select xy.x from xy join (select t2.y from xy t2 where exists (select t3.y from xy t3 where t3.y = xy.x)) t1);`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [xy.x:0!null]\n" +
+			" └─ Filter\n" +
+			"     ├─ InSubquery\n" +
+			"     │   ├─ left: xy.y:1\n" +
+			"     │   └─ right: Subquery\n" +
+			"     │       ├─ cacheable: false\n" +
+			"     │       ├─ alias-string: select xy.x from xy join (select t2.y from xy as t2 where exists (select t3.y from xy as t3 where t3.y = xy.x)) as t1\n" +
+			"     │       └─ Project\n" +
+			"     │           ├─ columns: [xy.x:3!null]\n" +
+			"     │           └─ CrossHashJoin\n" +
+			"     │               ├─ SubqueryAlias\n" +
+			"     │               │   ├─ name: t1\n" +
+			"     │               │   ├─ outerVisibility: true\n" +
+			"     │               │   ├─ isLateral: false\n" +
+			"     │               │   ├─ cacheable: false\n" +
+			"     │               │   ├─ colSet: (9)\n" +
+			"     │               │   ├─ tableId: 5\n" +
+			"     │               │   └─ Project\n" +
+			"     │               │       ├─ columns: [t2.y:3]\n" +
+			"     │               │       └─ Filter\n" +
+			"     │               │           ├─ EXISTS Subquery\n" +
+			"     │               │           │   ├─ cacheable: false\n" +
+			"     │               │           │   ├─ alias-string: select t3.y from xy as t3 where t3.y = xy.x\n" +
+			"     │               │           │   └─ Project\n" +
+			"     │               │           │       ├─ columns: [t3.y:5]\n" +
+			"     │               │           │       └─ Filter\n" +
+			"     │               │           │           ├─ Eq\n" +
+			"     │               │           │           │   ├─ t3.y:5\n" +
+			"     │               │           │           │   └─ xy.x:0!null\n" +
+			"     │               │           │           └─ TableAlias(t3)\n" +
+			"     │               │           │               └─ IndexedTableAccess(xy)\n" +
+			"     │               │           │                   ├─ index: [xy.y]\n" +
+			"     │               │           │                   ├─ keys: [xy.x:0!null]\n" +
+			"     │               │           │                   ├─ colSet: (7,8)\n" +
+			"     │               │           │                   ├─ tableId: 4\n" +
+			"     │               │           │                   └─ Table\n" +
+			"     │               │           │                       ├─ name: xy\n" +
+			"     │               │           │                       └─ columns: [x y]\n" +
+			"     │               │           └─ TableAlias(t2)\n" +
+			"     │               │               └─ Table\n" +
+			"     │               │                   ├─ name: xy\n" +
+			"     │               │                   ├─ columns: [x y]\n" +
+			"     │               │                   ├─ colSet: (5,6)\n" +
+			"     │               │                   └─ tableId: 3\n" +
+			"     │               └─ HashLookup\n" +
+			"     │                   ├─ left-key: TUPLE()\n" +
+			"     │                   ├─ right-key: TUPLE()\n" +
+			"     │                   └─ Table\n" +
+			"     │                       ├─ name: xy\n" +
+			"     │                       ├─ columns: [x]\n" +
+			"     │                       ├─ colSet: (3,4)\n" +
+			"     │                       └─ tableId: 2\n" +
+			"     └─ ProcessTable\n" +
+			"         └─ Table\n" +
+			"             ├─ name: xy\n" +
+			"             └─ columns: [x y]\n" +
+			"",
+	},
+	{
+		Query: `select x from xy where y in (select x from xy where x in (select y from xy));`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [xy.x:1!null]\n" +
+			" └─ LookupJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ xy.y:2\n" +
+			"     │   └─ xy_1.x:0!null\n" +
+			"     ├─ Distinct\n" +
+			"     │   └─ Project\n" +
+			"     │       ├─ columns: [xy_1.x:0!null]\n" +
+			"     │       └─ SemiLookupJoin\n" +
+			"     │           ├─ TableAlias(xy_1)\n" +
+			"     │           │   └─ ProcessTable\n" +
+			"     │           │       └─ Table\n" +
+			"     │           │           ├─ name: xy\n" +
+			"     │           │           └─ columns: [x y]\n" +
+			"     │           └─ Project\n" +
+			"     │               ├─ columns: [xy_2.y:1]\n" +
+			"     │               └─ TableAlias(xy_2)\n" +
+			"     │                   └─ IndexedTableAccess(xy)\n" +
+			"     │                       ├─ index: [xy.y]\n" +
+			"     │                       ├─ keys: [xy_1.x:0!null]\n" +
+			"     │                       ├─ colSet: (5,6)\n" +
+			"     │                       ├─ tableId: 3\n" +
+			"     │                       └─ Table\n" +
+			"     │                           ├─ name: xy\n" +
+			"     │                           └─ columns: [x y]\n" +
+			"     └─ IndexedTableAccess(xy)\n" +
+			"         ├─ index: [xy.y]\n" +
+			"         ├─ keys: [xy_1.x:0!null]\n" +
+			"         ├─ colSet: (1,2)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: xy\n" +
+			"             └─ columns: [x y]\n" +
+			"",
+	},
+	{
 		Query: `select * from xy join uv on (x = u and u  > 0) where u < 2`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [xy.x:2!null, xy.y:3, uv.u:0!null, uv.v:1]\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -18,42 +18,6 @@ package queries
 
 var PlanTests = []QueryPlanTest{
 	{
-		Query: `select x from xy where y in (select x from xy where exists (select y from xy t1 where t1.y = xy.x));`,
-		ExpectedPlan: "Project\n" +
-			" ├─ columns: [xy.x:1!null]\n" +
-			" └─ LookupJoin\n" +
-			"     ├─ Eq\n" +
-			"     │   ├─ xy.y:2\n" +
-			"     │   └─ xy_1.x:0!null\n" +
-			"     ├─ Distinct\n" +
-			"     │   └─ Project\n" +
-			"     │       ├─ columns: [xy_1.x:0!null]\n" +
-			"     │       └─ SemiLookupJoin\n" +
-			"     │           ├─ TableAlias(xy_1)\n" +
-			"     │           │   └─ ProcessTable\n" +
-			"     │           │       └─ Table\n" +
-			"     │           │           ├─ name: xy\n" +
-			"     │           │           └─ columns: [x y]\n" +
-			"     │           └─ TableAlias(t1)\n" +
-			"     │               └─ IndexedTableAccess(xy)\n" +
-			"     │                   ├─ index: [xy.y]\n" +
-			"     │                   ├─ keys: [xy.x:3!null]\n" +
-			"     │                   ├─ colSet: (5,6)\n" +
-			"     │                   ├─ tableId: 3\n" +
-			"     │                   └─ Table\n" +
-			"     │                       ├─ name: xy\n" +
-			"     │                       └─ columns: [x y]\n" +
-			"     └─ IndexedTableAccess(xy)\n" +
-			"         ├─ index: [xy.y]\n" +
-			"         ├─ keys: [xy_1.x:0!null]\n" +
-			"         ├─ colSet: (1,2)\n" +
-			"         ├─ tableId: 1\n" +
-			"         └─ Table\n" +
-			"             ├─ name: xy\n" +
-			"             └─ columns: [x y]\n" +
-			"",
-	},
-	{
 		Query: `select x from xy where y in (select xy.x from xy join (select t2.y from xy t2 where exists (select t3.y from xy t3 where t3.y = xy.x)) t1);`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [xy.x:0!null]\n" +

--- a/sql/analyzer/unnest_insubqueries.go
+++ b/sql/analyzer/unnest_insubqueries.go
@@ -181,6 +181,8 @@ func unnestInSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.S
 	return ret, transform.TreeIdentity(!unnested), nil
 }
 
+// returns an updated sql.Node with aliases de-duplicated, and an
+// updated alias mapping with new conflicts and tables added.
 func disambiguateTables(used map[string]int, n sql.Node) (sql.Node, map[string]int, error) {
 	rename := make(map[sql.TableId]string)
 	n, _, err := transform.NodeWithCtx(n, nil, func(c transform.Context) (sql.Node, transform.TreeIdentity, error) {


### PR DESCRIPTION
When unnesting and IN_SUBQUERY into a parent scope with a table name clash, rename the child table and update its references to the new name. Prevent EXISTS subqueries from unnesting if it doesn't full decorrelate the child scope.