### PR TITLE
fix IN_SUBQUERY projection bugs

### DIFF
--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -21,6 +21,37 @@ import (
 
 var ViewScripts = []ScriptTest{
 	{
+		Name: "view of join with projections",
+		SetUpScript: []string{
+			`
+CREATE TABLE tab1 (
+  pk int NOT NULL,
+  col0 int,
+  col1 float,
+  col2 text,
+  col3 int,
+  col4 float,
+  col5 text,
+  PRIMARY KEY (pk),
+  KEY idx_tab1_0 (col0),
+  KEY idx_tab1_1 (col1),
+  KEY idx_tab1_3 (col3),
+  KEY idx_tab1_4 (col4)
+)`,
+			"insert into tab1 values (6, 0, 52.14, 'jxmel', 22, 2.27, 'pzxbn')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "CREATE VIEW view_2_tab1_157 AS SELECT pk, col0 FROM tab1 WHERE NOT ((col0 IN (SELECT col3 FROM tab1 WHERE ((col0 IS NULL) OR col3 > 5 OR col3 <= 50 OR col1 < 83.11))) OR col0 > 75)",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select pk, col0 from view_2_tab1_157",
+				Expected: []sql.Row{{6, 0}},
+			},
+		},
+	},
+	{
 		Name: "view with expression name",
 		SetUpScript: []string{
 			`create view v as select 2+2`,

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -385,6 +385,7 @@ func convertSemiToInnerJoin(a *Analyzer, m *memo.Memo) error {
 				}
 			}
 			if srcNode == nil {
+				break
 				return fmt.Errorf("table for column not found: %d", colId)
 			}
 
@@ -480,7 +481,10 @@ func convertAntiToLeftJoin(m *memo.Memo) error {
 				}
 			}
 			if srcNode == nil {
-				return fmt.Errorf("table for column not found: %d", colId)
+				//return fmt.Errorf("table for column not found: %d", colId)
+				//col := srcNode.Schema()[colId]
+				//projections = append(projections, expression.NewGetFieldWithTable(int(colId), int(srcNode.Id()), col.Type, col.DatabaseSource, col.Source, col.Name, col.Nullable))
+				break
 			}
 
 			sch := srcNode.Schema()

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -481,9 +481,6 @@ func convertAntiToLeftJoin(m *memo.Memo) error {
 				}
 			}
 			if srcNode == nil {
-				//return fmt.Errorf("table for column not found: %d", colId)
-				//col := srcNode.Schema()[colId]
-				//projections = append(projections, expression.NewGetFieldWithTable(int(colId), int(srcNode.Id()), col.Type, col.DatabaseSource, col.Source, col.Name, col.Nullable))
 				break
 			}
 

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -50,6 +50,8 @@ func newRelProps(rel RelExpr) *relProps {
 	switch r := rel.(type) {
 	case *Max1Row:
 		p.populateFds()
+	case *EmptyTable:
+		p.outputCols = r.TableIdNode().Columns()
 	case SourceRel:
 		n := r.TableIdNode()
 		if len(n.Schema()) == n.Columns().Len() {

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -51,6 +51,14 @@ func newRelProps(rel RelExpr) *relProps {
 	case *Max1Row:
 		p.populateFds()
 	case *EmptyTable:
+		if r.TableIdNode().Columns().Len() > 0 {
+			p.outputCols = r.TableIdNode().Columns()
+			p.populateFds()
+			p.populateOutputTables()
+			p.populateInputTables()
+			return p
+		}
+	case *SetOp:
 	case SourceRel:
 		n := r.TableIdNode()
 		if len(n.Schema()) == n.Columns().Len() {

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -51,7 +51,6 @@ func newRelProps(rel RelExpr) *relProps {
 	case *Max1Row:
 		p.populateFds()
 	case *EmptyTable:
-		p.outputCols = r.TableIdNode().Columns()
 	case SourceRel:
 		n := r.TableIdNode()
 		if len(n.Schema()) == n.Columns().Len() {
@@ -112,6 +111,8 @@ func (p *relProps) populateFds() {
 		all := rel.Child.RelProps.FuncDeps().All()
 		notNull := rel.Child.RelProps.FuncDeps().NotNull()
 		fds = sql.NewMax1RowFDs(all, notNull)
+	case *EmptyTable:
+		fds = &sql.FuncDepSet{}
 	case SourceRel:
 		n := rel.TableIdNode()
 		all := n.Columns()

--- a/sql/memo/rel_props_test.go
+++ b/sql/memo/rel_props_test.go
@@ -79,8 +79,9 @@ func TestPopulateFDs(t *testing.T) {
 						{Name: "z", Source: "t", Type: types.Int64, Nullable: false},
 					}).(*plan.EmptyTable).WithId(1).WithColumns(sql.NewColSet(1, 2, 3)).(*plan.EmptyTable),
 			},
-			all:     sql.NewColSet(1, 2, 3),
-			notNull: sql.NewColSet(1, 2, 3),
+			// planning ignores empty tables for now
+			all:     sql.NewColSet(),
+			notNull: sql.NewColSet(),
 		},
 		{
 			name: "max1Row",


### PR DESCRIPTION
Correctness regression fix. With a bit more work this could probably be a smaller query:

```sql
CREATE VIEW view_2_tab1_157 AS SELECT pk, col0 FROM tab1 WHERE NOT ((col0 IN (SELECT col3 FROM tab1 WHERE ((col0 IS NULL) OR col3 > 5 OR col3 <= 50 OR col1 < 83.11))) OR col0 > 75);
```

The CREATE panicked because the top-level projections get pushed into the source node, and my recent refactors failed to map projections onto the reported table output column sets.