### PR TITLE
remove delimiter before caching the prepared stmt

### DIFF
--- a/server/golden/proxy.go
+++ b/server/golden/proxy.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -232,11 +231,7 @@ func (h MySqlProxy) processQuery(
 		if ri != 0 && ri < len(query) {
 			remainder = query[ri:]
 			query = query[:ri]
-			query = strings.TrimSpace(query)
-			// trim spaces and empty statements
-			query = strings.TrimRightFunc(query, func(r rune) bool {
-				return r == ';' || unicode.IsSpace(r)
-			})
+			query = planbuilder.RemoveSpaceAndDelimiter(query, ';')
 		}
 	}
 


### PR DESCRIPTION
When using prepared statement, some create statements were being stored in the cache with delimiter at the end of it, which does not trimmed when executing the prepared statement. This causes consistency issue where in cases of storing a create statement, it will have the delimiter whereas running the same query without it being prepared statement trims before storing.