### PR TITLE
use entire lateral scope when indexing RangeHeapJoin

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8647,6 +8647,12 @@ from typestable`,
 		Query:    "select * from mytable where (i in (null, 0.8, 1.5, 2.999))",
 		Expected: []sql.Row{},
 	},
+	{
+		Query: "select * from (select 'k' as k) sq join bigtable on t = k join xy where x between n and n;",
+		Expected: []sql.Row{
+			{"k", "k", 1, 1, 0},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -12109,4 +12109,52 @@ order by x, y;
 			"         └─ tableId: 2\n" +
 			"",
 	},
+	{
+		Query: "select * from (select 'k' as k) sq join bigtable on t = k join xy where x between n and n;",
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [sq.k:0!null, bigtable.t:3!null, bigtable.n:4, xy.x:1!null, xy.y:2]\n" +
+			" └─ HashJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ bigtable.t:3!null\n" +
+			"     │   └─ sq.k:0!null\n" +
+			"     ├─ SubqueryAlias\n" +
+			"     │   ├─ name: sq\n" +
+			"     │   ├─ outerVisibility: false\n" +
+			"     │   ├─ isLateral: false\n" +
+			"     │   ├─ cacheable: true\n" +
+			"     │   ├─ colSet: (2)\n" +
+			"     │   ├─ tableId: 1\n" +
+			"     │   └─ Project\n" +
+			"     │       ├─ columns: [k (longtext) as k]\n" +
+			"     │       └─ Table\n" +
+			"     │           ├─ name: \n" +
+			"     │           ├─ columns: []\n" +
+			"     │           ├─ colSet: ()\n" +
+			"     │           └─ tableId: 0\n" +
+			"     └─ HashLookup\n" +
+			"         ├─ left-key: TUPLE(sq.k:0!null)\n" +
+			"         ├─ right-key: TUPLE(bigtable.t:2!null)\n" +
+			"         └─ RangeHeapJoin\n" +
+			"             ├─ AND\n" +
+			"             │   ├─ GreaterThanOrEqual\n" +
+			"             │   │   ├─ xy.x:1!null\n" +
+			"             │   │   └─ bigtable.n:4\n" +
+			"             │   └─ LessThanOrEqual\n" +
+			"             │       ├─ xy.x:1!null\n" +
+			"             │       └─ bigtable.n:4\n" +
+			"             ├─ IndexedTableAccess(xy)\n" +
+			"             │   ├─ index: [xy.x]\n" +
+			"             │   ├─ static: [{[NULL, ∞)}]\n" +
+			"             │   ├─ colSet: (5,6)\n" +
+			"             │   ├─ tableId: 3\n" +
+			"             │   └─ Table\n" +
+			"             │       ├─ name: xy\n" +
+			"             │       └─ columns: [x y]\n" +
+			"             └─ Sort(bigtable.n:1 ASC nullsLast)\n" +
+			"                 └─ ProcessTable\n" +
+			"                     └─ Table\n" +
+			"                         ├─ name: bigtable\n" +
+			"                         └─ columns: [t n]\n" +
+			"",
+	},
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4880,6 +4880,29 @@ CREATE TABLE tab3 (
 			},
 		},
 	},
+	{
+		Name: "subquery with range heap join",
+		SetUpScript: []string{
+			"create table a (i int primary key, start int, end int, name varchar(32));",
+			"insert into a values (1, 603000, 605001, 'test');",
+			"create table b (i int primary key);",
+			"insert into b values (600000), (605000), (608000);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select a.i from (select 'test' as name) sq join a on sq.name = a.name join b on b.i between a.start and a.end;",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "select * from (select 'test' as name, 1 as x, 2 as y, 3 as z) sq join a on sq.name = a.name join b on b.i between a.start and a.end;",
+				Expected: []sql.Row{
+					{"test", 1, 2, 3, 1, 603000, 605001, "test", 605000},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -259,9 +259,8 @@ func (s *idxScope) visitSelf(n sql.Node) error {
 			s.expressions = append(s.expressions, fixExprToScope(e, scopes...))
 		}
 	case *plan.RangeHeap:
-		siblingScope := s.lateralScopes[len(s.lateralScopes)-1]
 		// value indexes other side of join
-		newValue := fixExprToScope(n.ValueColumnGf, siblingScope)
+		newValue := fixExprToScope(n.ValueColumnGf, s.lateralScopes...)
 		// min/are this child
 		newMin := fixExprToScope(n.MinColumnGf, s.childScopes...)
 		newMax := fixExprToScope(n.MaxColumnGf, s.childScopes...)


### PR DESCRIPTION
`RangeHeapJoin`s looked at the lateral join scope when assigning indexes.
However, we never tested nested joins for this case, leading to https://github.com/dolthub/dolt/issues/7177

What made the error more apparent was the string in the left scope that would result in empty results when doing lookups into the right tables. The fix was to look at the whole lateral scope when indexing `RangeHeapJoin`s

fixes https://github.com/dolthub/dolt/issues/7177