### PR TITLE
guard `ctx.Span` again

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8647,6 +8647,14 @@ from typestable`,
 		Query:    "select * from mytable where (i in (null, 0.8, 1.5, 2.999))",
 		Expected: []sql.Row{},
 	},
+	{
+		Query: "select * from mytable where (i BETWEEN (CASE 1 WHEN 2 THEN 1.0 ELSE (1||2) END) AND i)",
+		Expected: []sql.Row{
+			{1, "first row"},
+			{2, "second row"},
+			{3, "third row"},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/session.go
+++ b/sql/session.go
@@ -373,6 +373,10 @@ func (c *Context) Span(
 	opName string,
 	opts ...trace.SpanStartOption,
 ) (trace.Span, *Context) {
+	if c == nil {
+		return noopSpan, nil
+	}
+
 	if c.tracer == NoopTracer {
 		return noopSpan, c
 	}

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -168,6 +168,12 @@ func (t DecimalType_) ConvertToNullDecimal(v interface{}) (decimal.NullDecimal, 
 	var res decimal.Decimal
 
 	switch value := v.(type) {
+	case bool:
+		if value {
+			return t.ConvertToNullDecimal(decimal.NewFromInt(1))
+		} else {
+			return t.ConvertToNullDecimal(decimal.NewFromInt(0))
+		}
 	case int:
 		return t.ConvertToNullDecimal(int64(value))
 	case uint:

--- a/sql/types/decimal_test.go
+++ b/sql/types/decimal_test.go
@@ -284,6 +284,8 @@ func TestDecimalConvert(t *testing.T) {
 		expectedErr bool
 	}{
 		{1, 0, nil, nil, false},
+		{1, 0, true, "1", false},
+		{1, 0, false, "0", false},
 		{1, 0, byte(0), "0", false},
 		{1, 0, int8(3), "3", false},
 		{1, 0, "-3.7e0", "-4", false},


### PR DESCRIPTION
https://github.com/dolthub/go-mysql-server/pull/2203 again, because it was overwritten

fixes https://github.com/dolthub/dolt/issues/7182 again