### PR TITLE
[sql/planbuilder] Update join defaults are not prefixed, need individual table schemas to resolve

### DIFF
--- a/enginetest/queries/column_default_queries.go
+++ b/enginetest/queries/column_default_queries.go
@@ -21,7 +21,7 @@ import (
 
 var ColumnDefaultTests = []ScriptTest{
 	{
-		Name: "update join ambiguous column",
+		Name: "update join ambiguous default",
 		SetUpScript: []string{
 			"CREATE TABLE t1(name varchar(10) primary key, cnt int, hash varchar(100) NOT NULL DEFAULT (concat('id00',md5(name))))",
 			"INSERT INTO t1 (name, cnt) VALUES ('one', 1), ('two', 2)",
@@ -35,6 +35,24 @@ var ColumnDefaultTests = []ScriptTest{
 			{
 				Query:    "select name, cnt from t1",
 				Expected: []sql.Row{{"one", 2}, {"two", 3}},
+			},
+		},
+	},
+	{
+		Name: "update join ambiguous generated column",
+		SetUpScript: []string{
+			"CREATE TABLE t1 (x int primary key, y int generated always as (x + 1) virtual)",
+			"INSERT INTO t1 (x) values (1), (2), (3)",
+			"create view t2 as SELECT x, y from t1",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "update t1 n inner join t2 m on n.y = m.y set n.x =n.y where n.x = 3;",
+				Expected: []sql.Row{{newUpdateResult(1, 1)}},
+			},
+			{
+				Query:    "select * from t1",
+				Expected: []sql.Row{{1, 2}, {2, 3}, {4, 5}},
 			},
 		},
 	},

--- a/enginetest/queries/column_default_queries.go
+++ b/enginetest/queries/column_default_queries.go
@@ -21,6 +21,24 @@ import (
 
 var ColumnDefaultTests = []ScriptTest{
 	{
+		Name: "update join ambiguous column",
+		SetUpScript: []string{
+			"CREATE TABLE t1(name varchar(10) primary key, cnt int, hash varchar(100) NOT NULL DEFAULT (concat('id00',md5(name))))",
+			"INSERT INTO t1 (name, cnt) VALUES ('one', 1), ('two', 2)",
+			"create view t2 as SELECT name, cnt, hash from t1 where name in ('one', 'two')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "update t1 n inner join t2 m on n.name = m.name set n.cnt =m.cnt+1;",
+				Expected: []sql.Row{{newUpdateResult(2, 2)}},
+			},
+			{
+				Query:    "select name, cnt from t1",
+				Expected: []sql.Row{{"one", 2}, {"two", 3}},
+			},
+		},
+	},
+	{
 		Name: "Standard default literal",
 		SetUpScript: []string{
 			"CREATE TABLE t1(pk BIGINT PRIMARY KEY, v1 BIGINT DEFAULT 2)",

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -415,6 +415,7 @@ func (b *Builder) buildDelete(inScope *scope, d *ast.Delete) (outScope *scope) {
 func (b *Builder) buildUpdate(inScope *scope, u *ast.Update) (outScope *scope) {
 	outScope = b.buildFrom(inScope, u.TableExprs)
 
+	// default expressions only resolve to target table
 	updateExprs := b.assignmentExprsToExpressions(outScope, u.Exprs)
 
 	b.buildWhere(outScope, u.Where)


### PR DESCRIPTION
Updates need to resolve default expressions. The input definitions for update joins include the total join output columns. If two of those columns have the same name, the target table's unqualified default expression will throw an "ambiguous column" error. We partition the update join schemas/column definitions to sidestep the error.

The case where this is problematic is ALTER COLUMN expressions, where only the columns being modified are scoped for some reason. In those cases, I create a new scope with the source table schema to provide the full set of underlying column definitions. There is probably a whole class of virtual columns/column default bugs related to the way we resolve alter statements.