### PR TITLE
Fix decimal parsing bug

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -148,6 +148,21 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "update exponential parsing",
+		SetUpScript: []string{
+			"create table a (a int primary key, b double);",
+			"insert into a values (0, 0.0),(1, 1.0)",
+			"update a set b = 5.0E-5 where a = 0",
+			"update a set b = 5.0e-5 where a = 1",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from a",
+				Expected: []sql.Row{{0, .00005}, {1, .00005}},
+			},
+		},
+	},
+	{
 		Name: "set op schema merge",
 		SetUpScript: []string{
 			"create table `left` (i int primary key, j mediumint, k varchar(20));",

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -690,7 +690,7 @@ func (b *Builder) ConvertVal(v *ast.SQLVal) sql.Expression {
 		return b.convertInt(string(v.Val), 10)
 	case ast.FloatVal:
 		// any float value is parsed as decimal except when the value has scientific notation
-		ogVal := string(v.Val)
+		ogVal := strings.ToLower(string(v.Val))
 		if strings.Contains(ogVal, "e") {
 			val, err := strconv.ParseFloat(string(v.Val), 64)
 			if err != nil {


### PR DESCRIPTION
Decimals with capitalized exponential 'E' were incorrectly bound to literals, losing precision in some cases.

```sql
select 5.0E-5; // -> 0.0001
```