### PR TITLE
Implement fmt.Stringer for JsonDocument.

### DIFF
--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -71,7 +71,7 @@ func (doc JSONDocument) JSONString() (string, error) {
 func (doc JSONDocument) String() string {
 	result, err := doc.JSONString()
 	if err != nil {
-		return fmt.Sprintf("(Error marshalling JSON: %s)", err.Error())
+		return fmt.Sprintf("(Error marshalling JSON: %s, %s)", doc.Val, err.Error())
 	}
 	return result
 }

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -67,6 +67,15 @@ func (doc JSONDocument) JSONString() (string, error) {
 	return marshalToMySqlString(doc.Val)
 }
 
+// JSONDocument implements the fmt.Stringer interface.
+func (doc JSONDocument) String() string {
+	result, err := doc.JSONString()
+	if err != nil {
+		return fmt.Sprintf("(Error marshalling JSON: %s)", err.Error())
+	}
+	return result
+}
+
 var _ sql.JSONWrapper = JSONDocument{}
 var _ MutableJSON = JSONDocument{}
 


### PR DESCRIPTION
GMS side of an upcoming Dolt PR.

I'm improving error handling in schema merge tests by having the tests print the de-serialized values in incorrect tables instead of just their bytes. Since table values are passed around as an `interface{}`, it seems reasonable to have them implement Stringer.