### PR TITLE
[no-release-notes] Passing existing context to AsserErr functions

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -124,7 +124,7 @@ func TestScriptWithEngine(t *testing.T, e QueryEngine, harness Harness, script q
 				if assertion.ExpectedErr != nil {
 					AssertErr(t, e, harness, assertion.Query, assertion.ExpectedErr)
 				} else if assertion.ExpectedErrStr != "" {
-					AssertErr(t, e, harness, assertion.Query, nil, assertion.ExpectedErrStr)
+					AssertErrWithCtx(t, e, harness, ctx, assertion.Query, nil, assertion.ExpectedErrStr)
 				} else if assertion.ExpectedWarning != 0 {
 					AssertWarningAndTestQuery(t, e, nil, harness, assertion.Query,
 						assertion.Expected, nil, assertion.ExpectedWarning, assertion.ExpectedWarningsCount,
@@ -215,9 +215,9 @@ func TestScriptWithEnginePrepared(t *testing.T, e QueryEngine, harness Harness, 
 				ctx = th.NewSession()
 			}
 			if assertion.ExpectedErr != nil {
-				AssertErrPrepared(t, e, harness, assertion.Query, assertion.ExpectedErr)
+				AssertErrPreparedWithCtx(t, e, harness, ctx, assertion.Query, assertion.ExpectedErr)
 			} else if assertion.ExpectedErrStr != "" {
-				AssertErrPrepared(t, e, harness, assertion.Query, nil, assertion.ExpectedErrStr)
+				AssertErrPreparedWithCtx(t, e, harness, ctx, assertion.Query, nil, assertion.ExpectedErrStr)
 			} else if assertion.ExpectedWarning != 0 {
 				AssertWarningAndTestQuery(t, e, nil, harness, assertion.Query,
 					assertion.Expected, nil, assertion.ExpectedWarning, assertion.ExpectedWarningsCount,


### PR DESCRIPTION
Creating a new context when asserting an expected error can cause side effects. For example, in a test in https://github.com/dolthub/dolt/pull/7183, the current selected database was supposed to be empty, but because `AssertErr` was creating a new context automatically and that context had 'mydb' set as the selected database, the test wasn't running correctly. 