### PR TITLE
Add `JsonIter` class for iterating over the key-value pairs of a JSON object.

### DIFF
--- a/sql/expression/function/json/json_array_append.go
+++ b/sql/expression/function/json/json_array_append.go
@@ -87,7 +87,7 @@ func (j JSONArrayAppend) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 
 	// Apply the path-value pairs to the document.
 	for _, pair := range pairs {
-		doc, _, err = doc.ArrayAppend(ctx, pair.path, pair.val)
+		doc, _, err = doc.ArrayAppend(pair.path, pair.val)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/expression/function/json/json_array_insert.go
+++ b/sql/expression/function/json/json_array_insert.go
@@ -89,7 +89,7 @@ func (j JSONArrayInsert) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 
 	// Apply the path-value pairs to the document.
 	for _, pair := range pairs {
-		doc, _, err = doc.ArrayInsert(ctx, pair.path, pair.val)
+		doc, _, err = doc.ArrayInsert(pair.path, pair.val)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/expression/function/json/json_insert.go
+++ b/sql/expression/function/json/json_insert.go
@@ -94,7 +94,7 @@ func (j JSONInsert) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// Apply the path-value pairs to the document.
 	for _, pair := range pairs {
-		doc, _, err = doc.Insert(ctx, pair.path, pair.val)
+		doc, _, err = doc.Insert(pair.path, pair.val)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/expression/function/json/json_remove.go
+++ b/sql/expression/function/json/json_remove.go
@@ -122,7 +122,7 @@ func (j JSONRemove) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		if _, ok := path.(string); !ok {
 			return nil, fmt.Errorf("Invalid JSON path expression")
 		}
-		doc, _, err = doc.Remove(ctx, path.(string))
+		doc, _, err = doc.Remove(path.(string))
 		if err != nil {
 			return nil, err
 		}

--- a/sql/expression/function/json/json_replace.go
+++ b/sql/expression/function/json/json_replace.go
@@ -89,7 +89,7 @@ func (j JSONReplace) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// Apply the path-value pairs to the document.
 	for _, pair := range pairs {
-		doc, _, err = doc.Replace(ctx, pair.path, pair.val)
+		doc, _, err = doc.Replace(pair.path, pair.val)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/expression/function/json/json_set.go
+++ b/sql/expression/function/json/json_set.go
@@ -130,7 +130,7 @@ func (j *JSONSet) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// Apply the path-value pairs to the document.
 	for _, pair := range pairs {
-		doc, _, err = doc.Set(ctx, pair.path, pair.val)
+		doc, _, err = doc.Set(pair.path, pair.val)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/types/json_test.go
+++ b/sql/types/json_test.go
@@ -585,7 +585,7 @@ func TestJsonSet(t *testing.T) {
 		t.Run("JSON set: "+test.desc, func(t *testing.T) {
 			doc := MustJSON(test.doc)
 			val := MustJSON(test.value)
-			res, changed, err := doc.Set(sql.NewEmptyContext(), test.path, val)
+			res, changed, err := doc.Set(test.path, val)
 			require.NoError(t, err)
 			assert.Equal(t, MustJSON(test.resultVal), res)
 			assert.Equal(t, test.changed, changed)
@@ -768,7 +768,7 @@ func TestJsonInsert(t *testing.T) {
 		t.Run("JSON insert: "+test.desc, func(t *testing.T) {
 			doc := MustJSON(test.doc)
 			val := MustJSON(test.value)
-			res, changed, err := doc.Insert(sql.NewEmptyContext(), test.path, val)
+			res, changed, err := doc.Insert(test.path, val)
 			require.NoError(t, err)
 			assert.Equal(t, MustJSON(test.resultVal), res)
 			assert.Equal(t, test.changed, changed)
@@ -863,7 +863,7 @@ func TestJsonRemove(t *testing.T) {
 	for _, test := range JsonRemoveTests {
 		t.Run("JSON remove: "+test.desc, func(t *testing.T) {
 			doc := MustJSON(test.doc)
-			res, changed, err := doc.Remove(sql.NewEmptyContext(), test.path)
+			res, changed, err := doc.Remove(test.path)
 			require.NoError(t, err)
 			assert.Equal(t, MustJSON(test.resultVal), res)
 			assert.Equal(t, test.changed, changed)
@@ -1029,7 +1029,7 @@ func TestJsonReplace(t *testing.T) {
 		t.Run("JSON replace: "+test.desc, func(t *testing.T) {
 			doc := MustJSON(test.doc)
 			val := MustJSON(test.value)
-			res, changed, err := doc.Replace(sql.NewEmptyContext(), test.path, val)
+			res, changed, err := doc.Replace(test.path, val)
 			require.NoError(t, err)
 			assert.Equal(t, MustJSON(test.resultVal), res)
 			assert.Equal(t, test.changed, changed)
@@ -1117,7 +1117,7 @@ func TestJsonArrayAppend(t *testing.T) {
 		t.Run("JSON array append: "+test.desc, func(t *testing.T) {
 			doc := MustJSON(test.doc)
 			val := MustJSON(test.value)
-			res, changed, err := doc.ArrayAppend(sql.NewEmptyContext(), test.path, val)
+			res, changed, err := doc.ArrayAppend(test.path, val)
 			require.NoError(t, err)
 			assert.Equal(t, MustJSON(test.resultVal), res)
 			assert.Equal(t, test.changed, changed)
@@ -1195,7 +1195,7 @@ func TestJsonArrayInsert(t *testing.T) {
 		t.Run("JSON array insert: "+test.desc, func(t *testing.T) {
 			doc := MustJSON(test.doc)
 			val := MustJSON(test.value)
-			res, changed, err := doc.ArrayInsert(sql.NewEmptyContext(), test.path, val)
+			res, changed, err := doc.ArrayInsert(test.path, val)
 			require.NoError(t, err)
 			assert.Equal(t, MustJSON(test.resultVal), res)
 			assert.Equal(t, test.changed, changed)
@@ -1263,7 +1263,7 @@ func TestJsonPathErrors(t *testing.T) {
 
 	for _, test := range JsonPathParseErrTests {
 		t.Run("JSON Path: "+test.desc, func(t *testing.T) {
-			_, changed, err := doc.Set(sql.NewEmptyContext(), test.path, MustJSON(`{"a": 42}`))
+			_, changed, err := doc.Set(test.path, MustJSON(`{"a": 42}`))
 			assert.Equal(t, false, changed)
 			require.Error(t, err)
 			assert.Equal(t, test.expectErrStr, err.Error())
@@ -1296,7 +1296,7 @@ func TestJsonInsertErrors(t *testing.T) {
 
 	for _, test := range JsonArrayInsertErrors {
 		t.Run("JSON Path: "+test.desc, func(t *testing.T) {
-			_, changed, err := doc.ArrayInsert(sql.NewEmptyContext(), test.path, MustJSON(`{"a": 42}`))
+			_, changed, err := doc.ArrayInsert(test.path, MustJSON(`{"a": 42}`))
 			assert.Equal(t, false, changed)
 			require.Error(t, err)
 			assert.Equal(t, test.expectErrStr, err.Error())
@@ -1308,7 +1308,7 @@ func TestRemoveRoot(t *testing.T) {
 	// Fairly special case situation which doesn't mesh with our other tests. MySQL returns a specfic message when you
 	// attempt to remove the root document.
 	doc := MustJSON(`{"a": 1, "b": 2}`)
-	_, changed, err := doc.Remove(sql.NewEmptyContext(), "$")
+	_, changed, err := doc.Remove("$")
 
 	require.Error(t, err)
 	assert.Equal(t, "The path expression '$' is not allowed in this context.", err.Error())

--- a/sql/types/json_test.go
+++ b/sql/types/json_test.go
@@ -471,6 +471,14 @@ var JsonSetTests = []JsonMutationTest{
 		changed:   true,
 	},
 	{
+		desc:      "object field name can contain escaped quotes",
+		doc:       `{"\"a\"": {}}`,
+		path:      `$."\"a\""`,
+		value:     `42`,
+		resultVal: `{"\"a\"": 42 }`,
+		changed:   true,
+	},
+	{
 		desc:      "Object field can be set to null",
 		doc:       `{"a": {}}`,
 		path:      `$."a"`,
@@ -734,6 +742,14 @@ var JsonInsertTests = []JsonMutationTest{
 		path:      `$."a"`,
 		value:     `42`,
 		resultVal: `{"a": {} }`,
+		changed:   false,
+	},
+	{
+		desc:      "object field name can contain escaped quotes",
+		doc:       `{"\"a\"": {}}`,
+		path:      `$."\"a\""`,
+		value:     `42`,
+		resultVal: `{"\"a\"": {} }`,
 		changed:   false,
 	},
 	{

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -37,19 +37,19 @@ type JsonArray = []interface{}
 type MutableJSON interface {
 	// Insert Adds the value at the given path, only if it is not present. Updated value returned, and bool indicating if
 	// a change was made.
-	Insert(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error)
+	Insert(path string, val sql.JSONWrapper) (MutableJSON, bool, error)
 	// Remove the value at the given path. Updated value returned, and bool indicating if a change was made.
-	Remove(ctx *sql.Context, path string) (MutableJSON, bool, error)
+	Remove(path string) (MutableJSON, bool, error)
 	// Set the value at the given path. Updated value returned, and bool indicating if a change was made.
-	Set(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error)
+	Set(path string, val sql.JSONWrapper) (MutableJSON, bool, error)
 	// Replace the value at the given path with the new value. If the path does not exist, no modification is made.
-	Replace(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error)
+	Replace(path string, val sql.JSONWrapper) (MutableJSON, bool, error)
 	// ArrayInsert inserts into the array object referenced by the given path. If the path does not exist, no modification is made.
-	ArrayInsert(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error)
+	ArrayInsert(path string, val sql.JSONWrapper) (MutableJSON, bool, error)
 	// ArrayAppend appends to an  array object referenced by the given path. If the path does not exist, no modification is made,
 	// or if the path exists and is not an array, the element will be converted into an array and the element will be
 	// appended to it.
-	ArrayAppend(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error)
+	ArrayAppend(path string, val sql.JSONWrapper) (MutableJSON, bool, error)
 }
 
 type JSONDocument struct {
@@ -546,36 +546,36 @@ func jsonObjectDeterministicOrder(a, b JsonObject, inter []string) (int, error) 
 	return strings.Compare(aa, bb), nil
 }
 
-func (doc JSONDocument) Insert(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
+func (doc JSONDocument) Insert(path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
 	path = strings.TrimSpace(path)
-	return doc.unwrapAndExecute(ctx, path, val, INSERT)
+	return doc.unwrapAndExecute(path, val, INSERT)
 }
 
-func (doc JSONDocument) Remove(ctx *sql.Context, path string) (MutableJSON, bool, error) {
+func (doc JSONDocument) Remove(path string) (MutableJSON, bool, error) {
 	path = strings.TrimSpace(path)
 	if path == "$" {
 		return nil, false, fmt.Errorf("The path expression '$' is not allowed in this context.")
 	}
 
-	return doc.unwrapAndExecute(ctx, path, nil, REMOVE)
+	return doc.unwrapAndExecute(path, nil, REMOVE)
 }
 
-func (doc JSONDocument) Set(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
+func (doc JSONDocument) Set(path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
 	path = strings.TrimSpace(path)
-	return doc.unwrapAndExecute(ctx, path, val, SET)
+	return doc.unwrapAndExecute(path, val, SET)
 }
 
-func (doc JSONDocument) Replace(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
+func (doc JSONDocument) Replace(path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
 	path = strings.TrimSpace(path)
-	return doc.unwrapAndExecute(ctx, path, val, REPLACE)
+	return doc.unwrapAndExecute(path, val, REPLACE)
 }
 
-func (doc JSONDocument) ArrayAppend(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
+func (doc JSONDocument) ArrayAppend(path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
 	path = strings.TrimSpace(path)
-	return doc.unwrapAndExecute(ctx, path, val, ARRAY_APPEND)
+	return doc.unwrapAndExecute(path, val, ARRAY_APPEND)
 }
 
-func (doc JSONDocument) ArrayInsert(ctx *sql.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
+func (doc JSONDocument) ArrayInsert(path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
 	path = strings.TrimSpace(path)
 
 	if path == "$" {
@@ -583,7 +583,7 @@ func (doc JSONDocument) ArrayInsert(ctx *sql.Context, path string, val sql.JSONW
 		return nil, false, fmt.Errorf("Path expression is not a path to a cell in an array: $")
 	}
 
-	return doc.unwrapAndExecute(ctx, path, val, ARRAY_INSERT)
+	return doc.unwrapAndExecute(path, val, ARRAY_INSERT)
 }
 
 const (
@@ -597,7 +597,7 @@ const (
 
 // unwrapAndExecute unwraps the JSONDocument and executes the given path on the unwrapped value. The path string passed
 // in at this point should be unmodified.
-func (doc JSONDocument) unwrapAndExecute(ctx *sql.Context, path string, val sql.JSONWrapper, mode int) (MutableJSON, bool, error) {
+func (doc JSONDocument) unwrapAndExecute(path string, val sql.JSONWrapper, mode int) (MutableJSON, bool, error) {
 	if path == "" {
 		return nil, false, fmt.Errorf("Invalid JSON path expression. Empty path")
 	}

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -942,3 +942,36 @@ func parseIndex(indexStr string, lastIndex int, cursor *int) (*parseIndexResult,
 
 	return &parseIndexResult{index: val, overflow: overflow}, nil
 }
+
+type JSONIter struct {
+	doc  *JsonObject
+	keys []string
+	idx  int
+}
+
+func NewJSONIter(json JsonObject) JSONIter {
+	json = maps.Clone(json)
+	keys := maps.Keys(json)
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+	return JSONIter{
+		doc:  &json,
+		keys: keys,
+		idx:  0,
+	}
+}
+
+func (iter *JSONIter) Next() (key string, value interface{}, err error) {
+	if iter.idx >= len(iter.keys) {
+		return "", nil, io.EOF
+	}
+	key = iter.keys[iter.idx]
+	iter.idx++
+	value = (*iter.doc)[key]
+	return key, value, nil
+}
+
+func (iter *JSONIter) HasNext() bool {
+	return iter.idx < len(iter.keys)
+}

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -17,6 +17,8 @@ package types
 import (
 	"database/sql/driver"
 	"fmt"
+	"golang.org/x/exp/maps"
+	"io"
 	"regexp"
 	"sort"
 	"strconv"

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -17,7 +17,6 @@ package types
 import (
 	"database/sql/driver"
 	"fmt"
-	"golang.org/x/exp/maps"
 	"io"
 	"regexp"
 	"sort"
@@ -25,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/dolthub/jsonpath"
+	"golang.org/x/exp/maps"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )


### PR DESCRIPTION
This is the GMS side of automating JSON merging in Dolt: just some type aliases and a simple iterator for getting the keys in a JSON object in a deterministic order.

It's worth pointing out that currently Dolt stores JSON in a normalized form by sorting keys by length, but the iterator here uses a simple lexicographic order instead. This difference doesn't really matter at the moment because we unmarshall the entire object into a go map no matter what. But Dolt needs to be aware of the ordering used in order to correctly compute three-way diffs.