### PR TITLE
fix type conversion in Between expressions

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4924,6 +4924,31 @@ CREATE TABLE tab3 (
 			},
 		},
 	},
+	{
+		Name: "between type conversion",
+		SetUpScript: []string{
+			"create table t0(c0 bool);",
+            "create table t1(c1 bool);",
+            "insert into t0 (c0) values (1);",
+            "insert into t1 (c1) values (false), (true);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SELECT t0.c0, t1.c1 FROM t0 LEFT  JOIN t1 ON true;",
+				Expected: []sql.Row{
+					{1, 0},
+					{1, 1},
+				},
+			},
+			{
+				Query: "SELECT t0.c0, t1.c1 FROM t0 LEFT  JOIN t1 ON ('a' NOT BETWEEN false AND false) WHERE 1 UNION ALL SELECT t0.c0, t1.c1 FROM t0 LEFT  JOIN t1 ON ('a' NOT BETWEEN false AND false) WHERE (NOT 1) UNION ALL SELECT t0.c0, t1.c1 FROM t0 LEFT  JOIN t1 ON ('a' NOT BETWEEN false AND false) WHERE (1 IS NULL);",
+				Expected: []sql.Row{
+					{1, nil},
+				},
+			},
+		},
+	},
+
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/expression/between.go
+++ b/sql/expression/between.go
@@ -69,76 +69,9 @@ func (b *Between) Resolved() bool {
 
 // Eval implements the Expression interface.
 func (b *Between) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	typ := b.Val.Type().Promote()
-
-	val, err := b.Val.Eval(ctx, row)
-	if err != nil {
-		return nil, err
-	}
-
-	if val == nil {
-		return nil, nil
-	}
-
-	val, _, err = typ.Convert(val)
-	if err != nil {
-		return nil, err
-	}
-
-	lower, err := b.Lower.Eval(ctx, row)
-	if err != nil {
-		return nil, err
-	}
-
-	if lower != nil {
-		lower, _, err = typ.Convert(lower)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	upper, err := b.Upper.Eval(ctx, row)
-	if err != nil {
-		return nil, err
-	}
-
-	if upper != nil {
-		upper, _, err = typ.Convert(upper)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if lower == nil && upper == nil {
-		return nil, nil
-	}
-
-	cmpLower, err := typ.Compare(val, lower)
-	if err != nil {
-		return nil, err
-	}
-
-	cmpUpper, err := typ.Compare(val, upper)
-	if err != nil {
-		return nil, err
-	}
-
-	if lower != nil && upper == nil {
-		if cmpLower >= 0 {
-			return nil, nil
-		} else {
-			return false, nil
-		}
-	}
-	if upper != nil && lower == nil {
-		if cmpUpper <= 0 {
-			return nil, nil
-		} else {
-			return false, nil
-		}
-	}
-
-	return cmpLower >= 0 && cmpUpper <= 0, nil
+	// TODO: Delete Between expression entirely?
+	// Reuse type conversion logic in comparison expressions by creating a logically equivalent expression
+	return NewAnd(NewLessThanOrEqual(b.Lower, b.Val), NewGreaterThanOrEqual(b.Upper, b.Val)).Eval(ctx, row)
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/between_test.go
+++ b/sql/expression/between_test.go
@@ -46,8 +46,10 @@ func TestBetween(t *testing.T) {
 		{"val is between lower and upper", sql.NewRow(2, 1, 3), true, false},
 		{"val is less than lower", sql.NewRow(0, 1, 3), false, false},
 		{"val is more than upper", sql.NewRow(4, 1, 3), false, false},
-		{"val type is different than lower", sql.NewRow(4, "lower", 3), false, true},
-		{"val type is different than upper", sql.NewRow(4, 1, "upper"), false, true},
+		{"val type is different than lower", sql.NewRow(4, "lower", 3), false, false},
+		{"val type is different than upper", sql.NewRow(4, 1, "upper"), false, false},
+		{"val type is different than lower", sql.NewRow(2, "lower", 3), true, false},
+		{"val type is different than upper", sql.NewRow(0, 0, "upper"), true, false},
 	}
 
 	for _, tt := range testCases {

--- a/sql/expression/between_test.go
+++ b/sql/expression/between_test.go
@@ -191,8 +191,10 @@ func TestNotBetween(t *testing.T) {
 		{"val is between lower and upper", sql.NewRow(2, 1, 3), false, false},
 		{"val is less than lower", sql.NewRow(0, 1, 3), true, false},
 		{"val is more than upper", sql.NewRow(4, 1, 3), true, false},
-		{"val type is different than lower", sql.NewRow(4, "lower", 3), true, true},
-		{"val type is different than upper", sql.NewRow(4, 1, "upper"), true, true},
+		{"val type is different than lower", sql.NewRow(4, "lower", 3), true, false},
+		{"val type is different than upper", sql.NewRow(4, 1, "upper"), true, false},
+		{"val type is different than lower", sql.NewRow(2, "lower", 3), false, false},
+		{"val type is different than upper", sql.NewRow(0, 0, "upper"), false, false},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
Replace the logic in `Between.Eval()` with a logically equivalent `AND` statement to reuse the type conversion logic in `comparison.go`

fixes https://github.com/dolthub/dolt/issues/7229