### PR TITLE
fix precision for `utc_timestamp`

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3732,7 +3732,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				// When the session's time zone is set to UTC, NOW() and UTC_TIMESTAMP() should return the same value
-				Query:    `select @@time_zone, NOW() = UTC_TIMESTAMP();`,
+				Query:    `select @@time_zone, NOW(6) = UTC_TIMESTAMP();`,
 				Expected: []sql.Row{{"+00:00", true}},
 			},
 			{
@@ -3746,7 +3746,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				// When the session's time zone is set to +2:00, NOW() should report two hours ahead of UTC_TIMESTAMP()
-				Query:    `select @@time_zone, TIMESTAMPDIFF(MINUTE, NOW(), UTC_TIMESTAMP());`,
+				Query:    `select @@time_zone, TIMESTAMPDIFF(MINUTE, NOW(6), UTC_TIMESTAMP());`,
 				Expected: []sql.Row{{"+02:00", -120}},
 			},
 			{

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -990,7 +990,7 @@ func (n *Now) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	nano := precision * (t.Nanosecond() / precision)
 
 	// Generate a new timestamp
-	tt := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), nano, t.Location())
+	tt := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), nano, time.UTC)
 
 	return tt, nil
 }

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -1099,7 +1099,8 @@ func (ut *UTCTimestamp) Children() []sql.Expression { return nil }
 func (ut *UTCTimestamp) Eval(ctx *sql.Context, _ sql.Row) (interface{}, error) {
 	t := ctx.QueryTime()
 	// TODO: UTC Timestamp needs to also handle precision arguments
-	tt := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, t.Location())
+	nano := 1000 * (t.Nanosecond() / 1000)
+	tt := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), nano, t.Location())
 	return tt.UTC(), nil
 }
 


### PR DESCRIPTION
The `UTC_TIMESTAMP()` function should take in an argument and round the milliseconds. For now, we stick to always returning the full precision (6 places)