### PR TITLE
Add logging for `COM_RESET_CONNECTION` command

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -131,6 +131,8 @@ func (h *Handler) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, call
 }
 
 func (h *Handler) ComResetConnection(c *mysql.Conn) {
+	logrus.WithField("connectionId", c.ConnectionID).Debug("COM_RESET_CONNECTION command received")
+
 	// TODO: handle reset logic
 }
 


### PR DESCRIPTION
Adding debug logging to see when clients are sending this command, even though we don't implement it yet. For example, ORMs may send this command when returning a connection to a connection pool, so it may be helpful to implement this command and clear out session state in that case. 