### PR TITLE
use cached decimal type for casts

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6980,6 +6980,12 @@ Select * from (
 		},
 	},
 	{
+		Query: "SELECT CASE WHEN COUNT( * ) THEN 10.0 * CAST(1234 AS DATE) + CAST(82 AS CHAR) END;",
+		Expected: []sql.Row{
+			{nil},
+		},
+	},
+	{
 		Query:    "SELECT 2.0 + CAST(5 AS DECIMAL)",
 		Expected: []sql.Row{{"7.0"}},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6968,6 +6968,13 @@ Select * from (
 		},
 	},
 	{
+		Query: "SELECT CASE WHEN COUNT( * ) THEN 10 * CAST(-19 AS SIGNED ) + CAST(82 AS DECIMAL) END;",
+		Expected: []sql.Row{
+			{"-108"},
+		},
+	},
+
+	{
 		Query:    "SELECT 2.0 + CAST(5 AS DECIMAL)",
 		Expected: []sql.Row{{"7.0"}},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6973,7 +6973,12 @@ Select * from (
 			{"-108"},
 		},
 	},
-
+	{
+		Query: "SELECT CASE WHEN COUNT( * ) THEN 10.0 * CAST(2012 AS UNSIGNED) + CAST(82 AS CHAR) END;",
+		Expected: []sql.Row{
+			{20202.0},
+		},
+	},
 	{
 		Query:    "SELECT 2.0 + CAST(5 AS DECIMAL)",
 		Expected: []sql.Row{{"7.0"}},

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -390,12 +390,14 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 				}
 			}
 		case *Convert:
-			p, s := GetPrecisionAndScale(c.cachedDecimalType)
-			if whole := p - s; whole > maxWhole {
-				maxWhole = whole
-			}
-			if s > maxFrac {
-				maxFrac = s
+			if c.cachedDecimalType != nil {
+				p, s := GetPrecisionAndScale(c.cachedDecimalType)
+				if whole := p - s; whole > maxWhole {
+					maxWhole = whole
+				}
+				if s > maxFrac {
+					maxFrac = s
+				}
 			}
 		case *Literal:
 			if types.IsNumber(c.Type()) {

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -389,6 +389,14 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 					maxFrac = s
 				}
 			}
+		case *Convert:
+			p, s := GetPrecisionAndScale(c.cachedDecimalType)
+			if whole := p - s; whole > maxWhole {
+				maxWhole = whole
+			}
+			if s > maxFrac {
+				maxFrac = s
+			}
 		case *Literal:
 			if types.IsNumber(c.Type()) {
 				l, err := c.Eval(nil, nil)


### PR DESCRIPTION
Fixes a variety (hopefully 49) of SQLLogicTests involving `CASTS(... AS DECIMAL)`