### PR TITLE
Add source table and database to field metadata in wire responses

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -625,6 +625,9 @@ func schemaToFields(ctx *sql.Context, s sql.Schema) []*query.Field {
 		fields[i] = &query.Field{
 			Name:         c.Name,
 			OrgName:      c.Name,
+			Table:        c.Source,
+			OrgTable:     c.Source,
+			Database:     c.DatabaseSource,
 			Type:         c.Type.Type(),
 			Charset:      charset,
 			ColumnLength: c.Type.MaxTextResponseByteLength(ctx),

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -257,7 +257,7 @@ func TestHandlerComPrepare(t *testing.T) {
 			name:      "select statement returns non-nil schema",
 			statement: "select c1 from test where c1 > ?",
 			expected: []*query.Field{
-				{Name: "c1", OrgName: "c1", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
+				{Name: "c1", OrgName: "c1", Table: "test", OrgTable: "test", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
 			},
 		},
 		{
@@ -324,7 +324,7 @@ func TestHandlerComPrepareExecute(t *testing.T) {
 				},
 			},
 			schema: []*query.Field{
-				{Name: "c1", OrgName: "c1", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
+				{Name: "c1", OrgName: "c1", Table: "test", OrgTable: "test", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
 			},
 			expected: []sql.Row{
 				{0}, {1}, {2}, {3}, {4},
@@ -402,7 +402,7 @@ func TestHandlerComPrepareExecuteWithPreparedDisabled(t *testing.T) {
 				},
 			},
 			schema: []*query.Field{
-				{Name: "c1", OrgName: "c1", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
+				{Name: "c1", OrgName: "c1", Table: "test", OrgTable: "test", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
 			},
 			expected: []sql.Row{
 				{0}, {1}, {2}, {3}, {4},
@@ -608,112 +608,112 @@ func TestSchemaToFields(t *testing.T) {
 
 	schema := sql.Schema{
 		// Blob, Text, and JSON Types
-		{Name: "tinyblob", Type: types.TinyBlob},
-		{Name: "blob", Type: types.Blob},
-		{Name: "mediumblob", Type: types.MediumBlob},
-		{Name: "longblob", Type: types.LongBlob},
-		{Name: "tinytext", Type: types.TinyText},
-		{Name: "text", Type: types.Text},
-		{Name: "mediumtext", Type: types.MediumText},
-		{Name: "longtext", Type: types.LongText},
-		{Name: "json", Type: types.JSON},
+		{Name: "tinyblob", Source: "table1", DatabaseSource: "db1", Type: types.TinyBlob},
+		{Name: "blob", Source: "table1", DatabaseSource: "db1", Type: types.Blob},
+		{Name: "mediumblob", Source: "table1", DatabaseSource: "db1", Type: types.MediumBlob},
+		{Name: "longblob", Source: "table1", DatabaseSource: "db1", Type: types.LongBlob},
+		{Name: "tinytext", Source: "table1", DatabaseSource: "db1", Type: types.TinyText},
+		{Name: "text", Source: "table1", DatabaseSource: "db1", Type: types.Text},
+		{Name: "mediumtext", Source: "table1", DatabaseSource: "db1", Type: types.MediumText},
+		{Name: "longtext", Source: "table1", DatabaseSource: "db1", Type: types.LongText},
+		{Name: "json", Source: "table1", DatabaseSource: "db1", Type: types.JSON},
 
 		// Geometry Types
-		{Name: "geometry", Type: types.GeometryType{}},
-		{Name: "point", Type: types.PointType{}},
-		{Name: "polygon", Type: types.PolygonType{}},
-		{Name: "linestring", Type: types.LineStringType{}},
+		{Name: "geometry", Source: "table1", DatabaseSource: "db1", Type: types.GeometryType{}},
+		{Name: "point", Source: "table1", DatabaseSource: "db1", Type: types.PointType{}},
+		{Name: "polygon", Source: "table1", DatabaseSource: "db1", Type: types.PolygonType{}},
+		{Name: "linestring", Source: "table1", DatabaseSource: "db1", Type: types.LineStringType{}},
 
 		// Integer Types
-		{Name: "uint8", Type: types.Uint8},
-		{Name: "int8", Type: types.Int8},
-		{Name: "uint16", Type: types.Uint16},
-		{Name: "int16", Type: types.Int16},
-		{Name: "uint24", Type: types.Uint24},
-		{Name: "int24", Type: types.Int24},
-		{Name: "uint32", Type: types.Uint32},
-		{Name: "int32", Type: types.Int32},
-		{Name: "uint64", Type: types.Uint64},
-		{Name: "int64", Type: types.Int64},
+		{Name: "uint8", Source: "table1", DatabaseSource: "db1", Type: types.Uint8},
+		{Name: "int8", Source: "table1", DatabaseSource: "db1", Type: types.Int8},
+		{Name: "uint16", Source: "table1", DatabaseSource: "db1", Type: types.Uint16},
+		{Name: "int16", Source: "table1", DatabaseSource: "db1", Type: types.Int16},
+		{Name: "uint24", Source: "table1", DatabaseSource: "db1", Type: types.Uint24},
+		{Name: "int24", Source: "table1", DatabaseSource: "db1", Type: types.Int24},
+		{Name: "uint32", Source: "table1", DatabaseSource: "db1", Type: types.Uint32},
+		{Name: "int32", Source: "table1", DatabaseSource: "db1", Type: types.Int32},
+		{Name: "uint64", Source: "table1", DatabaseSource: "db1", Type: types.Uint64},
+		{Name: "int64", Source: "table1", DatabaseSource: "db1", Type: types.Int64},
 
 		// Floating Point and Decimal Types
-		{Name: "float32", Type: types.Float32},
-		{Name: "float64", Type: types.Float64},
-		{Name: "decimal10_0", Type: types.MustCreateDecimalType(10, 0)},
-		{Name: "decimal60_30", Type: types.MustCreateDecimalType(60, 30)},
+		{Name: "float32", Source: "table1", DatabaseSource: "db1", Type: types.Float32},
+		{Name: "float64", Source: "table1", DatabaseSource: "db1", Type: types.Float64},
+		{Name: "decimal10_0", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateDecimalType(10, 0)},
+		{Name: "decimal60_30", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateDecimalType(60, 30)},
 
 		// Char, Binary, and Bit Types
-		{Name: "varchar50", Type: types.MustCreateString(sqltypes.VarChar, 50, sql.Collation_Default)},
-		{Name: "varbinary12345", Type: types.MustCreateBinary(sqltypes.VarBinary, 12345)},
-		{Name: "binary123", Type: types.MustCreateBinary(sqltypes.Binary, 123)},
-		{Name: "char123", Type: types.MustCreateString(sqltypes.Char, 123, sql.Collation_Default)},
-		{Name: "bit12", Type: types.MustCreateBitType(12)},
+		{Name: "varchar50", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateString(sqltypes.VarChar, 50, sql.Collation_Default)},
+		{Name: "varbinary12345", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateBinary(sqltypes.VarBinary, 12345)},
+		{Name: "binary123", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateBinary(sqltypes.Binary, 123)},
+		{Name: "char123", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateString(sqltypes.Char, 123, sql.Collation_Default)},
+		{Name: "bit12", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateBitType(12)},
 
 		// Dates
-		{Name: "datetime", Type: types.MustCreateDatetimeType(sqltypes.Datetime, 0)},
-		{Name: "timestamp", Type: types.MustCreateDatetimeType(sqltypes.Timestamp, 0)},
-		{Name: "date", Type: types.MustCreateDatetimeType(sqltypes.Date, 0)},
-		{Name: "time", Type: types.Time},
-		{Name: "year", Type: types.Year},
+		{Name: "datetime", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateDatetimeType(sqltypes.Datetime, 0)},
+		{Name: "timestamp", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateDatetimeType(sqltypes.Timestamp, 0)},
+		{Name: "date", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateDatetimeType(sqltypes.Date, 0)},
+		{Name: "time", Source: "table1", DatabaseSource: "db1", Type: types.Time},
+		{Name: "year", Source: "table1", DatabaseSource: "db1", Type: types.Year},
 
 		// Set and Enum Types
-		{Name: "set", Type: types.MustCreateSetType([]string{"one", "two", "three", "four"}, sql.Collation_Default)},
-		{Name: "enum", Type: types.MustCreateEnumType([]string{"one", "two", "three", "four"}, sql.Collation_Default)},
+		{Name: "set", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateSetType([]string{"one", "two", "three", "four"}, sql.Collation_Default)},
+		{Name: "enum", Source: "table1", DatabaseSource: "db1", Type: types.MustCreateEnumType([]string{"one", "two", "three", "four"}, sql.Collation_Default)},
 	}
 
 	expected := []*query.Field{
 		// Blob, Text, and JSON Types
-		{Name: "tinyblob", OrgName: "tinyblob", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 255},
-		{Name: "blob", OrgName: "blob", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 65_535},
-		{Name: "mediumblob", OrgName: "mediumblob", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 16_777_215},
-		{Name: "longblob", OrgName: "longblob", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
-		{Name: "tinytext", OrgName: "tinytext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 1020},
-		{Name: "text", OrgName: "text", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 262_140},
-		{Name: "mediumtext", OrgName: "mediumtext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 67_108_860},
-		{Name: "longtext", OrgName: "longtext", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
-		{Name: "json", OrgName: "json", Type: query.Type_JSON, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "tinyblob", OrgName: "tinyblob", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 255},
+		{Name: "blob", OrgName: "blob", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 65_535},
+		{Name: "mediumblob", OrgName: "mediumblob", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 16_777_215},
+		{Name: "longblob", OrgName: "longblob", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BLOB, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "tinytext", OrgName: "tinytext", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 1020},
+		{Name: "text", OrgName: "text", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 262_140},
+		{Name: "mediumtext", OrgName: "mediumtext", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 67_108_860},
+		{Name: "longtext", OrgName: "longtext", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_TEXT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4_294_967_295},
+		{Name: "json", OrgName: "json", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_JSON, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
 
 		// Geometry Types
-		{Name: "geometry", OrgName: "geometry", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
-		{Name: "point", OrgName: "point", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
-		{Name: "polygon", OrgName: "polygon", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
-		{Name: "linestring", OrgName: "linestring", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "geometry", OrgName: "geometry", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "point", OrgName: "point", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "polygon", OrgName: "polygon", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
+		{Name: "linestring", OrgName: "linestring", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_GEOMETRY, Charset: mysql.CharacterSetBinary, ColumnLength: 4_294_967_295},
 
 		// Integer Types
-		{Name: "uint8", OrgName: "uint8", Type: query.Type_UINT8, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 3},
-		{Name: "int8", OrgName: "int8", Type: query.Type_INT8, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4},
-		{Name: "uint16", OrgName: "uint16", Type: query.Type_UINT16, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 5},
-		{Name: "int16", OrgName: "int16", Type: query.Type_INT16, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 6},
-		{Name: "uint24", OrgName: "uint24", Type: query.Type_UINT24, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 8},
-		{Name: "int24", OrgName: "int24", Type: query.Type_INT24, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 9},
-		{Name: "uint32", OrgName: "uint32", Type: query.Type_UINT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 10},
-		{Name: "int32", OrgName: "int32", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
-		{Name: "uint64", OrgName: "uint64", Type: query.Type_UINT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
-		{Name: "int64", OrgName: "int64", Type: query.Type_INT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
+		{Name: "uint8", OrgName: "uint8", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_UINT8, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 3},
+		{Name: "int8", OrgName: "int8", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_INT8, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4},
+		{Name: "uint16", OrgName: "uint16", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_UINT16, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 5},
+		{Name: "int16", OrgName: "int16", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_INT16, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 6},
+		{Name: "uint24", OrgName: "uint24", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_UINT24, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 8},
+		{Name: "int24", OrgName: "int24", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_INT24, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 9},
+		{Name: "uint32", OrgName: "uint32", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_UINT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 10},
+		{Name: "int32", OrgName: "int32", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_INT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11},
+		{Name: "uint64", OrgName: "uint64", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_UINT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
+		{Name: "int64", OrgName: "int64", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_INT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
 
 		// Floating Point and Decimal Types
-		{Name: "float32", OrgName: "float32", Type: query.Type_FLOAT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 12},
-		{Name: "float64", OrgName: "float64", Type: query.Type_FLOAT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 22},
-		{Name: "decimal10_0", OrgName: "decimal10_0", Type: query.Type_DECIMAL, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11, Decimals: 0},
-		{Name: "decimal60_30", OrgName: "decimal60_30", Type: query.Type_DECIMAL, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 62, Decimals: 30},
+		{Name: "float32", OrgName: "float32", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_FLOAT32, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 12},
+		{Name: "float64", OrgName: "float64", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_FLOAT64, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 22},
+		{Name: "decimal10_0", OrgName: "decimal10_0", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_DECIMAL, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 11, Decimals: 0},
+		{Name: "decimal60_30", OrgName: "decimal60_30", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_DECIMAL, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 62, Decimals: 30},
 
 		// Char, Binary, and Bit Types
-		{Name: "varchar50", OrgName: "varchar50", Type: query.Type_VARCHAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 50 * 4},
-		{Name: "varbinary12345", OrgName: "varbinary12345", Type: query.Type_VARBINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 12345},
-		{Name: "binary123", OrgName: "binary123", Type: query.Type_BINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 123},
-		{Name: "char123", OrgName: "char123", Type: query.Type_CHAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 123 * 4},
-		{Name: "bit12", OrgName: "bit12", Type: query.Type_BIT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 12},
+		{Name: "varchar50", OrgName: "varchar50", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_VARCHAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 50 * 4},
+		{Name: "varbinary12345", OrgName: "varbinary12345", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_VARBINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 12345},
+		{Name: "binary123", OrgName: "binary123", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 123},
+		{Name: "char123", OrgName: "char123", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_CHAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 123 * 4},
+		{Name: "bit12", OrgName: "bit12", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BIT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 12},
 
 		// Dates
-		{Name: "datetime", OrgName: "datetime", Type: query.Type_DATETIME, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 26},
-		{Name: "timestamp", OrgName: "timestamp", Type: query.Type_TIMESTAMP, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 26},
-		{Name: "date", OrgName: "date", Type: query.Type_DATE, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 10},
-		{Name: "time", OrgName: "time", Type: query.Type_TIME, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 17},
-		{Name: "year", OrgName: "year", Type: query.Type_YEAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4},
+		{Name: "datetime", OrgName: "datetime", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_DATETIME, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 26},
+		{Name: "timestamp", OrgName: "timestamp", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_TIMESTAMP, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 26},
+		{Name: "date", OrgName: "date", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_DATE, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 10},
+		{Name: "time", OrgName: "time", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_TIME, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 17},
+		{Name: "year", OrgName: "year", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_YEAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 4},
 
 		// Set and Enum Types
-		{Name: "set", OrgName: "set", Type: query.Type_SET, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 72},
-		{Name: "enum", OrgName: "enum", Type: query.Type_ENUM, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
+		{Name: "set", OrgName: "set", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_SET, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 72},
+		{Name: "enum", OrgName: "enum", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_ENUM, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 20},
 	}
 
 	require.Equal(len(schema), len(expected))


### PR DESCRIPTION
The field metadata messages we were sending back for a result set did not include the source table and source database for fields. This caused a behavior difference from MySQL where the table-qualified column name (e.g. `table1.ID`) would not work with Dolt when using the MySQL Java Connector library. See https://github.com/dolthub/dolt/issues/7247 for more details. 

Updates to unit tests for the `schemaToFields` code are in this PR, and I'll follow up with a PR in the Dolt repo that updates our MySQL Connector library integration tests to add coverage for the table-qualified column name. 