### PR TITLE
trim floats when hashing

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -813,6 +813,10 @@ var QueryTests = []QueryTest{
 		Expected: []sql.Row{{3}},
 	},
 	{
+		Query:    "SELECT count(*) from mytable WHERE (i IN (-''));",
+		Expected: []sql.Row{{0}},
+	},
+	{
 		Query:    "SELECT 1 % true",
 		Expected: []sql.Row{{"0"}},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4892,7 +4892,7 @@ CREATE TABLE tab3 (
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "select * from t where (b in (-''));",
+				Query: "select * from t where (b in (-''));",
 				Expected: []sql.Row{
 					{0},
 				},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4885,6 +4885,21 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "floats in tuple are properly hashed",
+		SetUpScript: []string{
+			"create table t (b bool);",
+			"insert into t values (false);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from t where (b in (-''));",
+				Expected: []sql.Row{
+					{0},
+				},
+			},
+		},
+	},
+	{
 		Name: "subquery with range heap join",
 		SetUpScript: []string{
 			"create table a (i int primary key, start int, end int, name varchar(32));",

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -16,6 +16,7 @@ package expression
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/cespare/xxhash/v2"
 
@@ -267,7 +268,24 @@ func hashOfSimple(ctx *sql.Context, i interface{}, t sql.Type) (uint64, error) {
 			return 0, err
 		}
 
-		if _, err := hash.Write([]byte(fmt.Sprintf("%v,", x))); err != nil {
+		// Remove trailing 0s from floats
+		var s string
+		switch v := x.(type) {
+		case float32:
+			s = strconv.FormatFloat(float64(v), 'f', -1, 32)
+			if s == "-0" {
+				s = "0"
+			}
+		case float64:
+			s = strconv.FormatFloat(v, 'f', -1, 64)
+			if s == "-0" {
+				s = "0"
+			}
+		default:
+			s = fmt.Sprintf("%v", v)
+		}
+
+		if _, err := hash.Write([]byte(fmt.Sprintf("%s,", s))); err != nil {
 			return 0, err
 		}
 		return hash.Sum64(), nil

--- a/sql/expression/in_test.go
+++ b/sql/expression/in_test.go
@@ -488,6 +488,36 @@ func TestHashInTuple(t *testing.T) {
 			result: false,
 		},
 		{
+			name: "right values contain zero floats that are equal to the left value",
+			left: expression.NewLiteral(0, types.Uint64),
+			right: expression.NewTuple(
+				expression.NewLiteral( 0.0, types.Float64),
+				expression.NewLiteral(1.23, types.Float64),
+			),
+			row:    nil,
+			result: true,
+		},
+		{
+			name: "right values contain floats that are equal to the left value",
+			left: expression.NewLiteral(1, types.Uint64),
+			right: expression.NewTuple(
+				expression.NewLiteral( 1.0, types.Float64),
+				expression.NewLiteral(1.23, types.Float64),
+			),
+			row:    nil,
+			result: true,
+		},
+		{
+			name: "right values contain decimals that are equal to the left value",
+			left: expression.NewLiteral(1, types.Uint64),
+			right: expression.NewTuple(
+				expression.NewLiteral( 1.0, types.MustCreateDecimalType(10, 5)),
+				expression.NewLiteral(1.23, types.MustCreateDecimalType(10, 5)),
+			),
+			row:    nil,
+			result: true,
+		},
+		{
 			name: "right values contain a different, coercible type, and left value is zero value",
 			left: expression.NewLiteral(0, types.Uint64),
 			right: expression.NewTuple(

--- a/sql/expression/in_test.go
+++ b/sql/expression/in_test.go
@@ -491,7 +491,7 @@ func TestHashInTuple(t *testing.T) {
 			name: "right values contain zero floats that are equal to the left value",
 			left: expression.NewLiteral(0, types.Uint64),
 			right: expression.NewTuple(
-				expression.NewLiteral( 0.0, types.Float64),
+				expression.NewLiteral(0.0, types.Float64),
 				expression.NewLiteral(1.23, types.Float64),
 			),
 			row:    nil,
@@ -501,7 +501,7 @@ func TestHashInTuple(t *testing.T) {
 			name: "right values contain floats that are equal to the left value",
 			left: expression.NewLiteral(1, types.Uint64),
 			right: expression.NewTuple(
-				expression.NewLiteral( 1.0, types.Float64),
+				expression.NewLiteral(1.0, types.Float64),
 				expression.NewLiteral(1.23, types.Float64),
 			),
 			row:    nil,
@@ -511,7 +511,7 @@ func TestHashInTuple(t *testing.T) {
 			name: "right values contain decimals that are equal to the left value",
 			left: expression.NewLiteral(1, types.Uint64),
 			right: expression.NewTuple(
-				expression.NewLiteral( 1.0, types.MustCreateDecimalType(10, 5)),
+				expression.NewLiteral(1.0, types.MustCreateDecimalType(10, 5)),
 				expression.NewLiteral(1.23, types.MustCreateDecimalType(10, 5)),
 			),
 			row:    nil,


### PR DESCRIPTION
`fmt.Sprintf("%v", x)` writes floats with a `x.0` which causes it to never equal hashed strings.
Initially, I wanted to always convert the LHS to the type in the RHS, but this is difficult when there are multiple types in the RHS

fixes https://github.com/dolthub/dolt/issues/7246