### PR TITLE
Correctly provide stats for TableAlias

### DIFF
--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -374,7 +374,13 @@ func statsForRel(rel RelExpr) sql.Statistic {
 		stat = &stats.Statistic{RowCnt: 10}
 
 	case SourceRel:
-		if tn, ok := rel.TableIdNode().(sql.TableNode); ok {
+		var tn sql.TableNode
+		if ta, ok := rel.(*TableAlias); ok {
+			tn, _ = ta.Table.Child.(sql.TableNode)
+		} else {
+			tn, _ = rel.TableIdNode().(sql.TableNode)
+		}
+		if tn != nil {
 			if prov := rel.Group().m.StatsProvider(); prov != nil {
 				if card, err := prov.RowCount(rel.Group().m.Ctx, tn.Database().Name(), tn.Name()); err == nil {
 					stat = &stats.Statistic{RowCnt: card}

--- a/sql/plan/tablealias.go
+++ b/sql/plan/tablealias.go
@@ -27,6 +27,7 @@ type TableAlias struct {
 	cols    sql.ColSet
 }
 
+var _ TableIdNode = (*TableAlias)(nil)
 var _ sql.RenameableNode = (*TableAlias)(nil)
 var _ sql.CommentedNode = (*TableAlias)(nil)
 var _ sql.CollationCoercible = (*TableAlias)(nil)


### PR DESCRIPTION
`plan.TableAlias` does not implement `sql.TableNode`, so the replaced line would always fail to cast when the input expression is a table alias, resulting in an inability to use the stats from the underlying table.

An alternate fix would be to make `plan.TableAlias` implement `sql.TableNode`, but this is only possible if the child of `TableAlias` is guaranteed to be a `sql.TableNode`, which isn't currently the case because the child can also be a recursive CTE.

Note that this means that CTE expressions still may not be able to leverage stats. But getting stats from a recursive CTE seems like a hard problem anyway.

(Perhaps we should be using `SubqueryAlias` instead of `TableAlias` for storing an aliased reference to a recursive CTE.)