### PR TITLE
fix decimal out of bounds in case statement

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8737,6 +8737,12 @@ from typestable`,
 			{3, "third row"},
 		},
 	},
+	{
+		Query: "select case when 1 then 59 + 81 / 1 end;",
+		Expected: []sql.Row{
+			{"140.0000"},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8755,7 +8755,6 @@ from typestable`,
 			{"12.0000"},
 		},
 	},
-
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8743,6 +8743,19 @@ from typestable`,
 			{"140.0000"},
 		},
 	},
+	{
+		Query: "select case 1 when 2 then null else (6 * 2) / 1 end;",
+		Expected: []sql.Row{
+			{"12.0000"},
+		},
+	},
+	{
+		Query: "select case 1 when 1 then (6 * 2) / 1 when 2 then null else null end;",
+		Expected: []sql.Row{
+			{"12.0000"},
+		},
+	},
+
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/expression/case.go
+++ b/sql/expression/case.go
@@ -180,8 +180,10 @@ func (c *Case) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			ret, _, err := t.Convert(bval)
-			return ret, err
+			if ret, _, err := t.Convert(bval); err == nil {
+				return ret, nil
+			}
+			return bval, nil
 		}
 	}
 
@@ -190,8 +192,10 @@ func (c *Case) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		ret, _, err := t.Convert(val)
-		return ret, err
+		if ret, _, err := t.Convert(val); err == nil {
+			return ret, nil
+		}
+		return val, nil
 
 	}
 

--- a/sql/expression/case.go
+++ b/sql/expression/case.go
@@ -180,6 +180,8 @@ func (c *Case) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
+			// When unable to convert to the type of the case, return the original value
+			// A common error here is "Out of bounds value for decimal type"
 			if ret, _, err := t.Convert(bval); err == nil {
 				return ret, nil
 			}
@@ -192,6 +194,8 @@ func (c *Case) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+		// When unable to convert to the type of the case, return the original value
+		// A common error here is "Out of bounds value for decimal type"
 		if ret, _, err := t.Convert(val); err == nil {
 			return ret, nil
 		}

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -388,6 +388,9 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 				if s > maxFrac {
 					maxFrac = s
 				}
+				if maxWhole == 2 {
+					print()
+				}
 			}
 		case *Convert:
 			if c.cachedDecimalType != nil {
@@ -397,6 +400,9 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 				}
 				if s > maxFrac {
 					maxFrac = s
+				}
+				if maxWhole == 2 {
+					print()
 				}
 			}
 		case *Literal:
@@ -411,6 +417,9 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 						maxFrac = s
 					}
 				}
+			}
+			if maxWhole == 2 {
+				print()
 			}
 		}
 		return true

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -388,9 +388,6 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 				if s > maxFrac {
 					maxFrac = s
 				}
-				if maxWhole == 2 {
-					print()
-				}
 			}
 		case *Convert:
 			if c.cachedDecimalType != nil {
@@ -400,9 +397,6 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 				}
 				if s > maxFrac {
 					maxFrac = s
-				}
-				if maxWhole == 2 {
-					print()
 				}
 			}
 		case *Literal:
@@ -417,9 +411,6 @@ func getFloatOrMaxDecimalType(e sql.Expression, treatIntsAsFloats bool) sql.Type
 						maxFrac = s
 					}
 				}
-			}
-			if maxWhole == 2 {
-				print()
 			}
 		}
 		return true


### PR DESCRIPTION
We are failing 42 sqllogictest with the same error: `Out of bounds value for decimal type`.

This is caused by Case performing a `convert` to a decimal type that had a bad `exclusiveUpperBound`.
MySQL has specific rules about the precision , scale, and conversion of decimals, and it is difficult to match their behavior exactly.
Fortunately, the result is correct before the conversion, so the fix here is to just use the result, and not convert.

This is somewhat of a bandaid fix; decimal type is an area that needs more improvement in general.

Fixes https://github.com/dolthub/dolt/issues/7079