### PR TITLE
fix order by optimization

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8737,6 +8737,17 @@ from typestable`,
 			{3, "third row"},
 		},
 	},
+	{
+		Query:    "select * from one_pk_two_idx where v1 < 4 and v2 < 2 or v2 > 3 order by v1",
+		Expected: []sql.Row{
+			{0, 0, 0},
+			{1, 1, 1},
+			{4, 4, 4},
+			{5, 5, 5},
+			{6, 6, 6},
+			{7, 7, 7},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8756,7 +8756,7 @@ from typestable`,
 		},
 	},
 	{
-		Query:    "select * from one_pk_two_idx where v1 < 4 and v2 < 2 or v2 > 3 order by v1",
+		Query: "select * from one_pk_two_idx where v1 < 4 and v2 < 2 or v2 > 3 order by v1",
 		Expected: []sql.Row{
 			{0, 0, 0},
 			{1, 1, 1},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -12189,4 +12189,17 @@ order by x, y;
 			"                     └─ tableId: 0\n" +
 			"",
 	},
+	{
+		Query: "select * from one_pk_two_idx where v1 < 4 and v2 < 2 or v2 > 3 order by v1",
+		ExpectedPlan: "Sort(one_pk_two_idx.v1:1 ASC nullsFirst)\n" +
+			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
+			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
+			"     ├─ static: [{[NULL, ∞), (3, ∞)}, {(NULL, 4), (NULL, 2)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: one_pk_two_idx\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+	},
 }

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -297,7 +297,7 @@ func isValidSortFieldOrder(sfs sql.SortFields) bool {
 	return true
 }
 
-// hasOverlapping checks if the ranges in a RangeCollection that are part of the sortfield exprs are non-overlapping
+// hasOverlapping checks if the ranges in a RangeCollection that are part of the sortfield exprs are overlapping
 // This function assumes that the sort field exprs are a valid prefix of the index columns
 func hasOverlapping(sfExprs []sql.Expression, ranges sql.RangeCollection) bool {
 	for si := range sfExprs {

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -46,7 +46,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 
 		// if the resulting ranges are overlapping, we cannot drop the sort node
 		// it is possible we end up with blocks rows that intersect
-		if !isNonOverlapping(sfExprs, lookup.Ranges) {
+		if hasOverlapping(sfExprs, lookup.Ranges) {
 			return n, transform.SameTree, nil
 		}
 
@@ -297,19 +297,19 @@ func isValidSortFieldOrder(sfs sql.SortFields) bool {
 	return true
 }
 
-// isNonOverlapping checks if the ranges in a RangeCollection that are part of the sortfield exprs are non-overlapping
+// hasOverlapping checks if the ranges in a RangeCollection that are part of the sortfield exprs are non-overlapping
 // This function assumes that the sort field exprs are a valid prefix of the index columns
-func isNonOverlapping(sfExprs []sql.Expression, ranges sql.RangeCollection) bool {
+func hasOverlapping(sfExprs []sql.Expression, ranges sql.RangeCollection) bool {
 	for si := range sfExprs {
 		for ri := 0; ri < len(ranges)-1; ri++ {
 			for rj := ri + 1; rj < len(ranges); rj++ {
 				if _, overlaps, _ := ranges[ri][si].Overlaps(ranges[rj][si]); overlaps {
-					return false
+					return true
 				}
 			}
 		}
 	}
-	return true
+	return false
 }
 
 // getPKIndex returns the primary key index of an IndexAddressableTable


### PR DESCRIPTION
This hopefully fixes 24 sqllogictests.

We introduced an optimization where we would drop `Sort` nodes for queries that included `ORDER BY`s if there were `IndexLookup`s that were a matching prefix over the sortfields. The idea was that since indexes are already in order there was no need to sort.

However, there is a case when that isn't necessarily true. If the index is created from a filter over multiple columns, specifically when that filter contains an `OR` expression, it is possible to iterate over columns in a non-sorted order. During analysis, the filters are converted into several non-overlapping ranges; it is possible for a range expression in the range to overlap with another range's range expression, but for the two ranges to not overlap. It's clearer to look at the test.

We didn't catch this bug earlier, as it only affects queries in dolt. We iterate over rows in the in-memory tables in such a way that the rows will still appear in order.