### PR TITLE
implementing `bit_count()` function

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8818,6 +8818,14 @@ from typestable`,
 			{"6.141592653589793"},
 		},
 	},
+	{
+		Query: "select bit_count(i), bit_count(-20 * i) from mytable;",
+		Expected: []sql.Row{
+			{1, 61},
+			{1, 60},
+			{2, 59},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8826,6 +8826,12 @@ from typestable`,
 			{2, 59},
 		},
 	},
+	{
+		Query: "select bit_count(binary 123456878901234567890);",
+		Expected: []sql.Row{
+			{73},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/expression/function/bit_count.go
+++ b/sql/expression/function/bit_count.go
@@ -69,8 +69,8 @@ func (b *BitCount) WithChildren(children ...sql.Expression) (sql.Expression, err
 func countBits(n uint64) int32 {
 	var res int32
 	for n != 0 {
-		res += int32(n & 1)
-		n >>= 1
+		res++
+		n &= n - 1
 	}
 	return res
 }

--- a/sql/expression/function/bit_count.go
+++ b/sql/expression/function/bit_count.go
@@ -16,8 +16,9 @@ package function
 
 import (
 	"fmt"
-			"github.com/dolthub/go-mysql-server/sql"
-		"github.com/dolthub/go-mysql-server/sql/types"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // BitCount returns the smallest integer value not less than X.

--- a/sql/expression/function/bit_count.go
+++ b/sql/expression/function/bit_count.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+			"github.com/dolthub/go-mysql-server/sql"
+		"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// BitCount returns the smallest integer value not less than X.
+type BitCount struct {
+	*UnaryFunc
+}
+
+var _ sql.FunctionExpression = (*BitCount)(nil)
+var _ sql.CollationCoercible = (*BitCount)(nil)
+
+// NewBitCount creates a new Ceil expression.
+func NewBitCount(arg sql.Expression) sql.Expression {
+	return &BitCount{NewUnaryFunc(arg, "BIT_COUNT", types.Int32)}
+}
+
+// FunctionName implements sql.FunctionExpression
+func (b *BitCount) FunctionName() string {
+	return "bit_count"
+}
+
+// Description implements sql.FunctionExpression
+func (b *BitCount) Description() string {
+	return "returns the number of bits that are set."
+}
+
+// Type implements the Expression interface.
+func (b *BitCount) Type() sql.Type {
+	return types.Int32
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (b *BitCount) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+func (b *BitCount) String() string {
+	return fmt.Sprintf("%s(%s)", b.FunctionName(), b.Child)
+}
+
+// WithChildren implements the Expression interface.
+func (b *BitCount) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(b, len(children), 1)
+	}
+	return NewBitCount(children[0]), nil
+}
+
+// Eval implements the Expression interface.
+func (b *BitCount) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	child, err := b.Child.Eval(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+
+	if child == nil {
+		return nil, nil
+	}
+
+	num, _, err := types.Int64.Convert(child)
+	if err != nil {
+		return nil, err
+	}
+
+	n := num.(int64)
+	var res int32
+	for n != 0 {
+		res += int32(n & 1)
+		n >>= 1
+	}
+
+	return res, nil
+}

--- a/sql/expression/function/bit_count_test.go
+++ b/sql/expression/function/bit_count_test.go
@@ -1,0 +1,162 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+func TestBitCount(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  sql.Expression
+		exp  interface{}
+		err  bool
+		skip bool
+	}{
+		{
+			name: "null argument",
+			arg:  nil,
+			exp:  nil,
+			err:  false,
+		},
+		{
+			name: "zero",
+			arg:  expression.NewLiteral(int64(0), types.Int64),
+			exp:  int32(0),
+			err:  false,
+		},
+		{
+			name: "one",
+			arg:  expression.NewLiteral(int64(1), types.Int64),
+			exp:  int32(1),
+			err:  false,
+		},
+		{
+			name: "ten",
+			arg:  expression.NewLiteral(int64(10), types.Int64),
+			exp:  int32(2),
+			err:  false,
+		},
+		{
+			name: "negative",
+			arg:  expression.NewLiteral(int64(-1), types.Int64),
+			exp:  int32(64),
+			err:  false,
+		},
+		{
+			name: "float32 rounds down",
+			arg:  expression.NewLiteral(float32(1.1), types.Float32),
+			exp:  int32(1),
+			err:  false,
+		},
+		{
+			name: "float64 rounds down",
+			arg:  expression.NewLiteral(1.1, types.Float64),
+			exp:  int32(1),
+			err:  false,
+		},
+		{
+			name: "decimal rounds down",
+			arg:  expression.NewLiteral(decimal.NewFromFloat(1.1), types.DecimalType_{}),
+			exp:  int32(1),
+			err:  false,
+		},
+		{
+			name: "float32 rounds up",
+			arg:  expression.NewLiteral(float32(2.99), types.Float32),
+			exp:  int32(2),
+			err:  false,
+		},
+		{
+			name: "float64 rounds up",
+			arg:  expression.NewLiteral(2.99, types.Float64),
+			exp:  int32(2),
+			err:  false,
+		},
+		{
+			name: "decimal rounds up",
+			arg:  expression.NewLiteral(decimal.NewFromFloat(2.99), types.DecimalType_{}),
+			exp:  int32(2),
+			err:  false,
+		},
+		{
+			name: "negative float32",
+			arg:  expression.NewLiteral(float32(-12.34), types.Float32),
+			exp:  int32(61),
+			err:  false,
+		},
+		{
+			name: "negative float64",
+			arg:  expression.NewLiteral(-12.34, types.Float64),
+			exp:  int32(61),
+			err:  false,
+		},
+		{
+			name: "negative decimal",
+			arg:  expression.NewLiteral(decimal.NewFromFloat(-12.34), types.DecimalType_{}),
+			exp:  int32(61),
+			err:  false,
+		},
+		{
+			name: "string is 0",
+			arg:  expression.NewLiteral("notanumber", types.Text),
+			exp:  int32(0),
+			err:  false,
+		},
+		{
+			name: "numerical string",
+			arg:  expression.NewLiteral("15", types.Text),
+			exp:  int32(4),
+			err:  false,
+		},
+		{
+			// we don't do truncation yet
+			// https://github.com/dolthub/dolt/issues/7302
+			name: "scientific string is truncated",
+			arg:  expression.NewLiteral("1e1", types.Text),
+			exp:  int32(1),
+			err:  false,
+			skip: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.skip {
+				t.Skip()
+			}
+
+			ctx := sql.NewEmptyContext()
+			f := NewBitCount(tt.arg)
+
+			res, err := f.Eval(ctx, nil)
+			if tt.err {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.exp, res)
+		})
+	}
+}

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -43,6 +43,7 @@ var BuiltIns = []sql.Function{
 	sql.Function1{Name: "bin", Fn: NewBin},
 	sql.FunctionN{Name: "bin_to_uuid", Fn: NewBinToUUID},
 	sql.Function1{Name: "bit_and", Fn: func(e sql.Expression) sql.Expression { return aggregation.NewBitAnd(e) }},
+	sql.Function1{Name: "bit_count", Fn: NewBitCount},
 	sql.Function1{Name: "bit_length", Fn: NewBitlength},
 	sql.Function1{Name: "bit_or", Fn: func(e sql.Expression) sql.Expression { return aggregation.NewBitOr(e) }},
 	sql.Function1{Name: "bit_xor", Fn: func(e sql.Expression) sql.Expression { return aggregation.NewBitXor(e) }},


### PR DESCRIPTION
This PR implements the `BIT_COUNT()` function, which counts the number of 1s in the binary representation of the integer argument.

MySQL Docs: https://dev.mysql.com/doc/refman/8.0/en/bit-functions.html#function_bit-count