### PR TITLE
Insert VALUES statements with subqueries index correctly

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -845,6 +845,10 @@ var InsertScripts = []ScriptTest{
 				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 1}}},
 			},
 			{
+				Query:       "INSERT INTO uv(v, x_id) VALUES ('test', (SELECT x FROM xy WHERE x > 0));",
+				ExpectedErr: sql.ErrExpectedSingleRow,
+			},
+			{
 				Query:    "select * from uv",
 				Expected: []sql.Row{{1, "test", 1}},
 			},

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -65,6 +65,12 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 		// TriggerExecutor has already been analyzed
 		if _, ok := insert.Source.(*plan.TriggerExecutor); !ok {
 			// Analyze the source of the insert independently
+			if _, ok := insert.Source.(*plan.Values); ok {
+				scope = scope.NewScope(plan.NewProject(
+					expression.SchemaToGetFields(insert.Source.Schema()[:len(insert.ColumnNames)]),
+					plan.NewSubqueryAlias("dummy", "", insert.Source),
+				))
+			}
 			source, _, err = a.analyzeWithSelector(ctx, insert.Source, scope, SelectAllBatches, newInsertSourceSelector(sel))
 			if err != nil {
 				return nil, transform.SameTree, err


### PR DESCRIPTION
fixes: https://github.com/dolthub/dolt/issues/7322

A couple things I noticed in the process of debugging this:
- We appear to inline inject an empty row when evaluating VALUES statements. Code comments suggest TRIGGERS are the reason for this. Most of the time this doesn't impact other value statements, and I think we've adapted VALUE expressions to use this pattern, but it shifts subquery expression indexes in a way that we were not accounting for. The change here updates subqueries in INSERT VALUES to expect this offset.
- We can't fix this during expression indexing at the INSERT level, because a second analysis of VALUES statements is necessary, for unclear reasons.
- We differentiate between INSERT VALUES and INSERT SELECTs, because INSERT SELECTs do not inject an offset row. In theory we could probably normalize these two cases and inject an empty row into insert select sources, but I ran into problems trying to implement the fix this way. 