### PR TITLE
Fix `HASH IN <tuple>` when comparing against collated string types

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4889,10 +4889,31 @@ CREATE TABLE tab3 (
 		SetUpScript: []string{
 			"create table t (b bool);",
 			"insert into t values (false);",
+			"create table t_idx (b bool);",
+			"create index idx on t_idx(b);",
+			"insert into t_idx values (false);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
 				Query: "select * from t where (b in (-''));",
+				Expected: []sql.Row{
+					{0},
+				},
+			},
+			{
+				Query: "select * from t where (b in (false/'1'));",
+				Expected: []sql.Row{
+					{0},
+				},
+			},
+			{
+				Query: "select * from t_idx where (b in (-''));",
+				Expected: []sql.Row{
+					{0},
+				},
+			},
+			{
+				Query: "select * from t_idx where (b in (false/'1'));",
 				Expected: []sql.Row{
 					{0},
 				},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4921,6 +4921,42 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "strings in tuple are properly hashed",
+		SetUpScript: []string{
+			"create table t (v varchar(100));",
+			"insert into t values (false);",
+			"create table t_idx (v varchar(100));",
+			"create index idx on t_idx(v);",
+			"insert into t_idx values (false);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from t where (v in (-''));",
+				Expected: []sql.Row{
+					{"0"},
+				},
+			},
+			{
+				Query: "select * from t where (v in (false/'1'));",
+				Expected: []sql.Row{
+					{"0"},
+				},
+			},
+			{
+				Query: "select * from t_idx where (v in (-''));",
+				Expected: []sql.Row{
+					{"0"},
+				},
+			},
+			{
+				Query: "select * from t_idx where (v in (false/'1'));",
+				Expected: []sql.Row{
+					{"0"},
+				},
+			},
+		},
+	},
+	{
 		Name: "subquery with range heap join",
 		SetUpScript: []string{
 			"create table a (i int primary key, start int, end int, name varchar(32));",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4957,6 +4957,38 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "strings vs decimals with trailing 0s in IN exprs",
+		SetUpScript: []string{
+			"create table t (v varchar(100));",
+			"insert into t values ('0'), ('0.0'), ('123'), ('123.0');",
+			"create table t_idx (v varchar(100));",
+			"create index idx on t_idx(v);",
+			"insert into t_idx values ('0'), ('0.0'), ('123'), ('123.0');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Skip: true,
+				Query: "select * from t where (v in (0.0, 123));",
+				Expected: []sql.Row{
+					{"0"},
+					{"0.0"},
+					{"123"},
+					{"123.0"},
+				},
+			},
+			{
+				Skip: true,
+				Query: "select * from t_idx where (v in (0.0, 123));",
+				Expected: []sql.Row{
+					{"0"},
+					{"0.0"},
+					{"123"},
+					{"123.0"},
+				},
+			},
+		},
+	},
+	{
 		Name: "subquery with range heap join",
 		SetUpScript: []string{
 			"create table a (i int primary key, start int, end int, name varchar(32));",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -4967,7 +4967,7 @@ CREATE TABLE tab3 (
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Skip: true,
+				Skip:  true,
 				Query: "select * from t where (v in (0.0, 123));",
 				Expected: []sql.Row{
 					{"0"},
@@ -4977,7 +4977,7 @@ CREATE TABLE tab3 (
 				},
 			},
 			{
-				Skip: true,
+				Skip:  true,
 				Query: "select * from t_idx where (v in (0.0, 123));",
 				Expected: []sql.Row{
 					{"0"},

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -284,9 +284,6 @@ func hashOfSimple(ctx *sql.Context, i interface{}, t sql.Type) (uint64, error) {
 		}
 	}
 
-	// Append comma
-	str += ","
-
 	// Collated strings that are equivalent may have different runes, so we must make them hash to the same value
 	return coll.HashToUint(str)
 }

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -18,8 +18,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cespare/xxhash/v2"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -250,46 +248,47 @@ func hashOfSimple(ctx *sql.Context, i interface{}, t sql.Type) (uint64, error) {
 		return 0, nil
 	}
 
-	// Collated strings that are equivalent may have different runes, so we must make them hash to the same value
+	var str string
+	coll := sql.Collation_Default
 	if types.IsTextOnly(t) {
-		if str, ok := i.(string); ok {
-			return t.(sql.StringType).Collation().HashToUint(str)
+		coll = t.(sql.StringType).Collation()
+		if s, ok := i.(string); ok {
+			str = s
 		} else {
 			converted, err := convertOrTruncate(ctx, i, t)
 			if err != nil {
 				return 0, err
 			}
-			return t.(sql.StringType).Collation().HashToUint(converted.(string))
+			str = converted.(string)
 		}
 	} else {
-		hash := xxhash.New()
 		x, err := convertOrTruncate(ctx, i, t.Promote())
 		if err != nil {
 			return 0, err
 		}
 
 		// Remove trailing 0s from floats
-		var s string
 		switch v := x.(type) {
 		case float32:
-			s = strconv.FormatFloat(float64(v), 'f', -1, 32)
-			if s == "-0" {
-				s = "0"
+			str = strconv.FormatFloat(float64(v), 'f', -1, 32)
+			if str == "-0" {
+				str = "0"
 			}
 		case float64:
-			s = strconv.FormatFloat(v, 'f', -1, 64)
-			if s == "-0" {
-				s = "0"
+			str = strconv.FormatFloat(v, 'f', -1, 64)
+			if str == "-0" {
+				str = "0"
 			}
 		default:
-			s = fmt.Sprintf("%v", v)
+			str = fmt.Sprintf("%v", v)
 		}
-
-		if _, err := hash.Write([]byte(fmt.Sprintf("%s,", s))); err != nil {
-			return 0, err
-		}
-		return hash.Sum64(), nil
 	}
+
+	// Append comma
+	str += ","
+
+	// Collated strings that are equivalent may have different runes, so we must make them hash to the same value
+	return coll.HashToUint(str)
 }
 
 // Eval implements the Expression interface.

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -330,8 +330,14 @@ func ConvertToString(v interface{}, t sql.StringType) (string, error) {
 		}
 	case float64:
 		val = strconv.FormatFloat(s, 'f', -1, 64)
+		if val == "-0" {
+			val = "0"
+		}
 	case float32:
 		val = strconv.FormatFloat(float64(s), 'f', -1, 32)
+		if val == "-0" {
+			val = "0"
+		}
 	case int:
 		val = strconv.FormatInt(int64(s), 10)
 	case int8:


### PR DESCRIPTION
This PR changes the `HASH IN` to always use a collation to hash the values in the case that we compare a numerical type against a collated string type. 

fixes https://github.com/dolthub/dolt/issues/7338