### PR TITLE
Add support for the `ALTER USER` statement to change account passwords

### DIFF
--- a/enginetest/queries/priv_auth_queries.go
+++ b/enginetest/queries/priv_auth_queries.go
@@ -2208,6 +2208,12 @@ var ServerAuthTests = []ServerAuthenticationTest{
 				Password:    "",
 				Query:       "ALTER USER IF EXISTS nobody@localhost IDENTIFIED BY 'password';",
 				ExpectedErr: false,
+			}, {
+				Username:       "root",
+				Password:       "",
+				Query:          "ALTER USER nobody@localhost IDENTIFIED BY 'password';",
+				ExpectedErr:    true,
+				ExpectedErrStr: "Error 1105 (HY000): Operation ALTER USER failed for 'nobody'@'localhost'",
 			},
 
 			// RANDOM PASSWORD is not supported yet, so an error should be returned

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -644,6 +644,9 @@ var (
 	// ErrUserCreationFailure is returned when attempting to create a user and it fails for any reason.
 	ErrUserCreationFailure = errors.NewKind("Operation CREATE USER failed for %s")
 
+	// ErrUserAlterFailure is returned when attempting to alter a user and it fails for any reason.
+	ErrUserAlterFailure = errors.NewKind("Operation ALTER USER failed for %s")
+
 	// ErrRoleCreationFailure is returned when attempting to create a role and it fails for any reason.
 	ErrRoleCreationFailure = errors.NewKind("Operation CREATE ROLE failed for %s")
 

--- a/sql/plan/alter_user.go
+++ b/sql/plan/alter_user.go
@@ -39,11 +39,11 @@ func (a *AlterUser) Schema() sql.Schema {
 
 // String implements the interface sql.Node.
 func (a *AlterUser) String() string {
-	ifNotExists := ""
+	ifExists := ""
 	if a.IfExists {
-		ifNotExists = "IfExists: "
+		ifExists = "IfExists: "
 	}
-	return fmt.Sprintf("AlterUser(%s%s)", ifNotExists, a.User.String(""))
+	return fmt.Sprintf("AlterUser(%s%s)", ifExists, a.User.String(""))
 }
 
 // Database implements the interface sql.Databaser.

--- a/sql/plan/alter_user.go
+++ b/sql/plan/alter_user.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"fmt"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// AlterUser represents the statement ALTER USER.
+type AlterUser struct {
+	IfExists bool
+	User     AuthenticatedUser
+	MySQLDb  sql.Database
+}
+
+var _ sql.Node = (*AlterUser)(nil)
+var _ sql.Databaser = (*AlterUser)(nil)
+var _ sql.CollationCoercible = (*AlterUser)(nil)
+
+// Schema implements the interface sql.Node.
+func (a *AlterUser) Schema() sql.Schema {
+	return types.OkResultSchema
+}
+
+// String implements the interface sql.Node.
+func (a *AlterUser) String() string {
+	ifNotExists := ""
+	if a.IfExists {
+		ifNotExists = "IfExists: "
+	}
+	return fmt.Sprintf("AlterUser(%s%s)", ifNotExists, a.User.String(""))
+}
+
+// Database implements the interface sql.Databaser.
+func (a *AlterUser) Database() sql.Database {
+	return a.MySQLDb
+}
+
+// WithDatabase implements the interface sql.Databaser.
+func (a *AlterUser) WithDatabase(db sql.Database) (sql.Node, error) {
+	aa := *a
+	aa.MySQLDb = db
+	return &aa, nil
+}
+
+// Resolved implements the interface sql.Node.
+func (a *AlterUser) Resolved() bool {
+	_, ok := a.MySQLDb.(sql.UnresolvedDatabase)
+	return !ok
+}
+
+// IsReadOnly implements the interface sql.Node.
+func (a *AlterUser) IsReadOnly() bool {
+	return false
+}
+
+// Children implements the interface sql.Node.
+func (a *AlterUser) Children() []sql.Node {
+	return nil
+}
+
+// WithChildren implements the interface sql.Node.
+func (a *AlterUser) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(a, len(children), 0)
+	}
+	return a, nil
+}
+
+// CheckPrivileges implements the interface sql.Node.
+func (a *AlterUser) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
+	// From the MySQL reference on ALTER USER:
+	// https://dev.mysql.com/doc/refman/8.0/en/alter-user.html
+	// ALTER USER generally requires either the global `CREATE USER` privilege, or the `UPDATE` privilege
+	// for the `mysql` system schema.
+	if opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(
+		sql.PrivilegeCheckSubject{Database: "mysql"}, sql.PrivilegeType_Update)) {
+		return true
+	} else if opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(
+		sql.PrivilegeCheckSubject{}, sql.PrivilegeType_CreateUser)) {
+		return true
+	}
+
+	// There are several exceptions to the general privilege requirements. Currently, the only relevant one is
+	// that any client who connects to the server using a non-anonymous account can change the password for that account.
+	authenticatedUser := ctx.Session.Client()
+	if a.User.Name == authenticatedUser.User {
+		return true
+	}
+
+	return false
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (a *AlterUser) CollationCoercibility(_ *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -304,6 +304,25 @@ func (b *Builder) buildEventScheduleTimeSpec(inScope *scope, spec *ast.EventSche
 	return ts, intervals
 }
 
+func (b *Builder) buildAlterUser(inScope *scope, _ string, c *ast.DDL) (outScope *scope) {
+	database := b.resolveDb("mysql")
+	accountWithAuth := ast.AccountWithAuth{AccountName: c.User, Auth1: c.Authentication}
+	user := b.buildAuthenticatedUser(accountWithAuth)
+
+	if c.Authentication.RandomPassword {
+		b.handleErr(fmt.Errorf("random password generation is not currently supported; " +
+			"you can request support at https://github.com/dolthub/dolt/issues/new"))
+	}
+
+	outScope = inScope.push()
+	outScope.node = &plan.AlterUser{
+		IfExists: c.IfExists,
+		User:     user,
+		MySQLDb:  database,
+	}
+	return outScope
+}
+
 func (b *Builder) buildAlterEvent(inScope *scope, query string, c *ast.DDL) (outScope *scope) {
 	eventSpec := c.EventSpec
 

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -137,6 +137,8 @@ func (b *Builder) buildDDL(inScope *scope, query string, c *ast.DDL) (outScope *
 	case ast.AlterStr:
 		if c.EventSpec != nil {
 			return b.buildAlterEvent(inScope, query, c)
+		} else if !c.User.IsEmpty() {
+			return b.buildAlterUser(inScope, query, c)
 		}
 		b.handleErr(sql.ErrUnsupportedFeature.New(ast.String(c)))
 	case ast.RenameStr:

--- a/sql/planbuilder/priv.go
+++ b/sql/planbuilder/priv.go
@@ -175,7 +175,7 @@ func (b *Builder) buildCreateUser(inScope *scope, n *ast.CreateUser) (outScope *
 	outScope = inScope.push()
 	authUsers := make([]plan.AuthenticatedUser, len(n.Users))
 	for i, user := range n.Users {
-		if user.Auth1.RandomPassword {
+		if user.Auth1 != nil && user.Auth1.RandomPassword {
 			b.handleErr(fmt.Errorf("random password generation is not currently supported; " +
 				"you can request support at https://github.com/dolthub/dolt/issues/new"))
 		}

--- a/sql/planbuilder/priv.go
+++ b/sql/planbuilder/priv.go
@@ -162,6 +162,7 @@ func (b *Builder) buildAuthenticatedUser(user ast.AccountWithAuth) plan.Authenti
 			authUser.Auth1 = plan.NewDefaultAuthentication(user.Auth1.Password)
 		}
 	}
+	// We do not support Auth2, Auth3, or AuthInitial, so error out if they are set, since nothing reads them
 	if user.Auth2 != nil || user.Auth3 != nil || user.AuthInitial != nil {
 		err := fmt.Errorf(`multi-factor authentication is not yet supported`)
 		b.handleErr(err)

--- a/sql/rowexec/node_builder.gen.go
+++ b/sql/rowexec/node_builder.gen.go
@@ -185,6 +185,8 @@ func (b *BaseBuilder) buildNodeExec(ctx *sql.Context, n sql.Node, row sql.Row) (
 		return b.buildDeferredAsOfTable(ctx, n, row)
 	case *plan.CreateUser:
 		return b.buildCreateUser(ctx, n, row)
+	case *plan.AlterUser:
+		return b.buildAlterUser(ctx, n, row)
 	case *plan.DropView:
 		return b.buildDropView(ctx, n, row)
 	case *plan.GroupBy:


### PR DESCRIPTION
Adds basic support for the `ALTER USER` statement, so that users can change passwords. All users are allowed to change their own password; changing another user's password requires the `CREATE USER` privilege or the `UPDATE` privilege on the `mysql` database.

[MySQL reference docs for `ALTER USER`](https://dev.mysql.com/doc/refman/8.0/en/alter-user.html)

Related to: https://github.com/dolthub/dolt/issues/7348