### PR TITLE
Fixup index selection when prefix not complete

### DIFF
--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -11356,7 +11356,7 @@ WHERE
 			" │                           └─ columns: [id]\n" +
 			" │   END as M6T2N, mjr3d.GE5EL as GE5EL, mjr3d.F7A4Q as F7A4Q, mjr3d.CC4AX as CC4AX, mjr3d.SL76B as SL76B, aac.BTXC5 as YEBDJ, mjr3d.PSMU6]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [mjr3d.FJDP5, mjr3d.BJUF2, mjr3d.PSMU6, mjr3d.M22QN, mjr3d.GE5EL, mjr3d.F7A4Q, mjr3d.ESFVY, mjr3d.CC4AX, mjr3d.SL76B, mjr3d.QNI57, mjr3d.TDEIU, sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, mf.FTQLQ, mf.LUEVY, mf.M22QN, aac.id, aac.btxc5, aac.fhcyt, mf.FTQLQ as T4IBQ, CASE  WHEN (NOT(mjr3d.QNI57 IS NULL)) THEN Subquery\n" +
+			"     ├─ columns: [mjr3d.FJDP5, mjr3d.BJUF2, mjr3d.PSMU6, mjr3d.M22QN, mjr3d.GE5EL, mjr3d.F7A4Q, mjr3d.ESFVY, mjr3d.CC4AX, mjr3d.SL76B, mjr3d.QNI57, mjr3d.TDEIU, sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, mf.FTQLQ, mf.LUEVY, mf.M22QN, aac.id, aac.BTXC5, aac.FHCYT, mf.FTQLQ as T4IBQ, CASE  WHEN (NOT(mjr3d.QNI57 IS NULL)) THEN Subquery\n" +
 			"     │   ├─ cacheable: false\n" +
 			"     │   └─ Project\n" +
 			"     │       ├─ columns: [ei.M6T2N]\n" +
@@ -11705,7 +11705,7 @@ WHERE
 			" │                           └─ columns: [id]\n" +
 			" │   END as M6T2N, mjr3d.GE5EL as GE5EL, mjr3d.F7A4Q as F7A4Q, mjr3d.CC4AX as CC4AX, mjr3d.SL76B as SL76B, aac.BTXC5 as YEBDJ, mjr3d.PSMU6]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [mjr3d.FJDP5, mjr3d.BJUF2, mjr3d.PSMU6, mjr3d.M22QN, mjr3d.GE5EL, mjr3d.F7A4Q, mjr3d.ESFVY, mjr3d.CC4AX, mjr3d.SL76B, mjr3d.QNI57, mjr3d.TDEIU, sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, mf.FTQLQ, mf.LUEVY, mf.M22QN, aac.id, aac.btxc5, aac.fhcyt, mf.FTQLQ as T4IBQ, CASE  WHEN (NOT(mjr3d.QNI57 IS NULL)) THEN Subquery\n" +
+			"     ├─ columns: [mjr3d.FJDP5, mjr3d.BJUF2, mjr3d.PSMU6, mjr3d.M22QN, mjr3d.GE5EL, mjr3d.F7A4Q, mjr3d.ESFVY, mjr3d.CC4AX, mjr3d.SL76B, mjr3d.QNI57, mjr3d.TDEIU, sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, mf.FTQLQ, mf.LUEVY, mf.M22QN, aac.id, aac.BTXC5, aac.FHCYT, mf.FTQLQ as T4IBQ, CASE  WHEN (NOT(mjr3d.QNI57 IS NULL)) THEN Subquery\n" +
 			"     │   ├─ cacheable: false\n" +
 			"     │   └─ Project\n" +
 			"     │       ├─ columns: [ei.M6T2N]\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -8968,8 +8968,8 @@ inner join pq on true
 		Query: `SELECT a.* FROM mytable a WHERE a.s is not null`,
 		ExpectedPlan: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ index: [mytable.s,mytable.i]\n" +
+			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1,2)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -8978,14 +8978,14 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ index: [mytable.s,mytable.i]\n" +
+			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ index: [mytable.s,mytable.i]\n" +
+			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [i s]\n" +
 			"",
 	},
@@ -8996,8 +8996,8 @@ inner join pq on true
 			" └─ LookupJoin\n" +
 			"     ├─ TableAlias(a)\n" +
 			"     │   └─ IndexedTableAccess(mytable)\n" +
-			"     │       ├─ index: [mytable.s]\n" +
-			"     │       ├─ static: [{(NULL, ∞)}]\n" +
+			"     │       ├─ index: [mytable.s,mytable.i]\n" +
+			"     │       ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"     │       ├─ colSet: (1,2)\n" +
 			"     │       ├─ tableId: 1\n" +
 			"     │       └─ Table\n" +
@@ -9018,8 +9018,8 @@ inner join pq on true
 			" └─ LookupJoin (estimated cost=2.310 rows=1)\n" +
 			"     ├─ TableAlias(a)\n" +
 			"     │   └─ IndexedTableAccess(mytable)\n" +
-			"     │       ├─ index: [mytable.s]\n" +
-			"     │       ├─ filters: [{(NULL, ∞)}]\n" +
+			"     │       ├─ index: [mytable.s,mytable.i]\n" +
+			"     │       ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
@@ -9032,8 +9032,8 @@ inner join pq on true
 			" └─ LookupJoin (estimated cost=2.310 rows=1) (actual rows=0 loops=1)\n" +
 			"     ├─ TableAlias(a)\n" +
 			"     │   └─ IndexedTableAccess(mytable)\n" +
-			"     │       ├─ index: [mytable.s]\n" +
-			"     │       ├─ filters: [{(NULL, ∞)}]\n" +
+			"     │       ├─ index: [mytable.s,mytable.i]\n" +
+			"     │       ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
@@ -9057,8 +9057,8 @@ inner join pq on true
 			"     │           └─ columns: [s]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s]\n" +
-			"             ├─ static: [{(NULL, ∞)}]\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -9075,8 +9075,8 @@ inner join pq on true
 			"     │       └─ columns: [s]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -9089,8 +9089,8 @@ inner join pq on true
 			"     │       └─ columns: [s]\n" +
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -9106,8 +9106,8 @@ inner join pq on true
 			"     │   │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext), 4 (longtext))\n" +
 			"     │   └─ TableAlias(a)\n" +
 			"     │       └─ IndexedTableAccess(mytable)\n" +
-			"     │           ├─ index: [mytable.s]\n" +
-			"     │           ├─ static: [{(NULL, 1)}, {(1, 2)}, {(2, 3)}, {(3, 4)}, {(4, ∞)}]\n" +
+			"     │           ├─ index: [mytable.s,mytable.i]\n" +
+			"     │           ├─ static: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
 			"     │           ├─ colSet: (1,2)\n" +
 			"     │           ├─ tableId: 1\n" +
 			"     │           └─ Table\n" +
@@ -9130,8 +9130,8 @@ inner join pq on true
 			"     │   ├─ (NOT((a.s HASH IN ('1', '2', '3', '4'))))\n" +
 			"     │   └─ TableAlias(a)\n" +
 			"     │       └─ IndexedTableAccess(mytable)\n" +
-			"     │           ├─ index: [mytable.s]\n" +
-			"     │           ├─ filters: [{(NULL, 1)}, {(1, 2)}, {(2, 3)}, {(3, 4)}, {(4, ∞)}]\n" +
+			"     │           ├─ index: [mytable.s,mytable.i]\n" +
+			"     │           ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
 			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
@@ -9146,8 +9146,8 @@ inner join pq on true
 			"     │   ├─ (NOT((a.s HASH IN ('1', '2', '3', '4'))))\n" +
 			"     │   └─ TableAlias(a)\n" +
 			"     │       └─ IndexedTableAccess(mytable)\n" +
-			"     │           ├─ index: [mytable.s]\n" +
-			"     │           ├─ filters: [{(NULL, 1)}, {(1, 2)}, {(2, 3)}, {(3, 4)}, {(4, ∞)}]\n" +
+			"     │           ├─ index: [mytable.s,mytable.i]\n" +
+			"     │           ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
 			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
@@ -19578,16 +19578,12 @@ inner join pq on true
 	{
 		Query: `SELECT * from one_pk_three_idx where pk < 1 and v1 = 1 and v2 = 1`,
 		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ Eq\n" +
-			" │   │   ├─ one_pk_three_idx.v1:1\n" +
-			" │   │   └─ 1 (tinyint)\n" +
-			" │   └─ Eq\n" +
-			" │       ├─ one_pk_three_idx.v2:2\n" +
-			" │       └─ 1 (tinyint)\n" +
+			" ├─ LessThan\n" +
+			" │   ├─ one_pk_three_idx.pk:0!null\n" +
+			" │   └─ 1 (tinyint)\n" +
 			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
-			"     ├─ index: [one_pk_three_idx.pk]\n" +
-			"     ├─ static: [{(NULL, 1)}]\n" +
+			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-4)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -19595,17 +19591,17 @@ inner join pq on true
 			"         └─ columns: [pk v1 v2 v3]\n" +
 			"",
 		ExpectedEstimates: "Filter\n" +
-			" ├─ ((one_pk_three_idx.v1 = 1) AND (one_pk_three_idx.v2 = 1))\n" +
+			" ├─ (one_pk_three_idx.pk < 1)\n" +
 			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
-			"     ├─ index: [one_pk_three_idx.pk]\n" +
-			"     ├─ filters: [{(NULL, 1)}]\n" +
+			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((one_pk_three_idx.v1 = 1) AND (one_pk_three_idx.v2 = 1))\n" +
+			" ├─ (one_pk_three_idx.pk < 1)\n" +
 			" └─ IndexedTableAccess(one_pk_three_idx)\n" +
-			"     ├─ index: [one_pk_three_idx.pk]\n" +
-			"     ├─ filters: [{(NULL, 1)}]\n" +
+			"     ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
@@ -25634,6 +25630,18 @@ order by x, y;
 			"     └─ Table\n" +
 			"         ├─ name: one_pk_two_idx\n" +
 			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Sort(one_pk_two_idx.v1 ASC)\n" +
+			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
+			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
+			"     ├─ filters: [{[NULL, ∞), (3, ∞)}, {(NULL, 4), (NULL, 2)}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Sort(one_pk_two_idx.v1 ASC)\n" +
+			" └─ IndexedTableAccess(one_pk_two_idx)\n" +
+			"     ├─ index: [one_pk_two_idx.v1,one_pk_two_idx.v2]\n" +
+			"     ├─ filters: [{[NULL, ∞), (3, ∞)}, {(NULL, 4), (NULL, 2)}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -122,6 +122,31 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "missing indexes",
+		SetUpScript: []string{
+			`
+create table t (
+  id varchar(500),
+  from_ varchar(500),
+  to_ varchar(500),
+  key (to_, from_),
+  Primary key (id, from_, to_)
+);`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:           "select * from t where to_ = 'L1' and from_ = 'L2'",
+				Expected:        []sql.Row{},
+				ExpectedIndexes: []string{"to_from_"},
+			},
+			{
+				Query:           "select * from t where BIN_TO_UUID(id) = '0' and  to_ = 'L1' and from_ = 'L2'",
+				Expected:        []sql.Row{},
+				ExpectedIndexes: []string{"to_from_"},
+			},
+		},
+	},
+	{
 		Name: "correctness test indexes",
 		SetUpScript: []string{
 			`

--- a/enginetest/queries/stats_queries.go
+++ b/enginetest/queries/stats_queries.go
@@ -178,6 +178,8 @@ type StatsPlanTest struct {
 
 var StatsIndexTests = []ScriptTest{
 	{
+		// todo deprecate: this is wrong, full prefix match is preferable
+		// if not index statistics should be used to indicate
 		Name: "choose range over full prefix match",
 		SetUpScript: []string{
 			"create table xy (x int, y int, z varchar(36) default(uuid()), w varchar(10), key (z), key (y,w), key(x,y))",
@@ -236,7 +238,7 @@ analyze table xy update histogram on (x,y) using data
 			{
 				Query:           "select * from xy where x > 4 and y = 1 and w = 'a'",
 				Expected:        []sql.Row{},
-				ExpectedIndexes: []string{"xy"},
+				ExpectedIndexes: []string{"yw"},
 			},
 		},
 	},


### PR DESCRIPTION
Consider a query `SELECT * from t where b = 1 and c = 1` and two indexes, `(a,b,c)` and `(b,c)`. We want to use the `(b,c)` index as a lookup, because `(a,b,c)` will be disjoint on an `(b,c)` key. This PR fixes index costing to record and prefer non-zero prefix matches. We only differentiate zero and non-zero cases here because it is easier and I think pretty reliable.