### PR TITLE
RangeHeapJoin should consistently sort NULL values before non-NULL values while managing its heap.

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -12165,7 +12165,7 @@ order by x, y;
 			"     │   │   └─ Table\n" +
 			"     │   │       ├─ name: xy\n" +
 			"     │   │       └─ columns: [x y]\n" +
-			"     │   └─ Sort(bigtable.n:1 ASC nullsLast)\n" +
+			"     │   └─ Sort(bigtable.n:1 ASC nullsFirst)\n" +
 			"     │       └─ ProcessTable\n" +
 			"     │           └─ Table\n" +
 			"     │               ├─ name: bigtable\n" +

--- a/sql/memo/exec_builder.go
+++ b/sql/memo/exec_builder.go
@@ -100,7 +100,7 @@ func (b *ExecBuilder) buildRangeHeap(sr *RangeHeap, children ...sql.Node) (ret s
 			sf := []sql.SortField{{
 				Column:       sortExpr,
 				Order:        sql.Ascending,
-				NullOrdering: sql.NullsLast, // Due to https://github.com/dolthub/go-mysql-server/issues/1903
+				NullOrdering: sql.NullsFirst,
 			}}
 			childNode = plan.NewSort(sf, n)
 		}
@@ -135,7 +135,7 @@ func (b *ExecBuilder) buildRangeHeapJoin(j *RangeHeapJoin, children ...sql.Node)
 		sf := []sql.SortField{{
 			Column:       sortExpr,
 			Order:        sql.Ascending,
-			NullOrdering: sql.NullsLast, // Due to https://github.com/dolthub/go-mysql-server/issues/1903
+			NullOrdering: sql.NullsFirst,
 		}}
 		left = plan.NewSort(sf, children[0])
 	}

--- a/sql/rowexec/range_heap_iter.go
+++ b/sql/rowexec/range_heap_iter.go
@@ -215,9 +215,6 @@ func (iter *rangeHeapJoinIter) Close(ctx *sql.Context) (err error) {
 	return err
 }
 
-type rangeHeapRowIterProvider struct {
-}
-
 func (iter *rangeHeapJoinIter) initializeHeap(ctx *sql.Context, builder sql.NodeExecBuilder, primaryRow sql.Row) (err error) {
 	iter.childRowIter, err = builder.Build(ctx, iter.rangeHeapPlan.Child, primaryRow)
 	if err != nil {
@@ -235,11 +232,10 @@ func (iter *rangeHeapJoinIter) initializeHeap(ctx *sql.Context, builder sql.Node
 }
 
 func (iter *rangeHeapJoinIter) getActiveRanges(ctx *sql.Context, _ sql.NodeExecBuilder, row sql.Row) (sql.RowIter, error) {
-
 	// Remove rows from the heap if we've advanced beyond their max value.
 	for iter.Len() > 0 {
 		maxValue := iter.Peek()
-		compareResult, err := iter.rangeHeapPlan.ComparisonType.Compare(row[iter.rangeHeapPlan.ValueColumnIndex], maxValue)
+		compareResult, err := compareNullsFirst(iter.rangeHeapPlan.ComparisonType, row[iter.rangeHeapPlan.ValueColumnIndex], maxValue)
 		if err != nil {
 			return nil, err
 		}
@@ -258,7 +254,7 @@ func (iter *rangeHeapJoinIter) getActiveRanges(ctx *sql.Context, _ sql.NodeExecB
 	// Advance the child iterator until we encounter a row whose min value is beyond the range.
 	for iter.pendingRow != nil {
 		minValue := iter.pendingRow[iter.rangeHeapPlan.MinColumnIndex]
-		compareResult, err := iter.rangeHeapPlan.ComparisonType.Compare(row[iter.rangeHeapPlan.ValueColumnIndex], minValue)
+		compareResult, err := compareNullsFirst(iter.rangeHeapPlan.ComparisonType, row[iter.rangeHeapPlan.ValueColumnIndex], minValue)
 		if err != nil {
 			return nil, err
 		}
@@ -289,13 +285,31 @@ func (iter *rangeHeapJoinIter) getActiveRanges(ctx *sql.Context, _ sql.NodeExecB
 	return sql.RowsToRowIter(iter.activeRanges...), nil
 }
 
+// When managing the heap, consider all NULLs to come before any non-NULLS.
+// This is consistent with the order received if either child node is an index.
+// Note: We could get the same behavior by simply excluding values and ranges containing NULL,
+// but this is forward compatible if we ever want to convert joins with null-safe conditions into RangeHeapJoins.
+func compareNullsFirst(comparisonType sql.Type, a, b interface{}) (int, error) {
+	if a == nil {
+		if b == nil {
+			return 0, nil
+		} else {
+			return -1, nil
+		}
+	}
+	if b == nil {
+		return 1, nil
+	}
+	return comparisonType.Compare(a, b)
+}
+
 func (iter rangeHeapJoinIter) Len() int { return len(iter.activeRanges) }
 
 func (iter *rangeHeapJoinIter) Less(i, j int) bool {
 	lhs := iter.activeRanges[i][iter.rangeHeapPlan.MaxColumnIndex]
 	rhs := iter.activeRanges[j][iter.rangeHeapPlan.MaxColumnIndex]
 	// compareResult will be 0 if lhs==rhs, -1 if lhs < rhs, and +1 if lhs > rhs.
-	compareResult, err := iter.rangeHeapPlan.ComparisonType.Compare(lhs, rhs)
+	compareResult, err := compareNullsFirst(iter.rangeHeapPlan.ComparisonType, lhs, rhs)
 	if iter.err == nil && err != nil {
 		iter.err = err
 	}


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/7260

This was ultimately caused by https://github.com/dolthub/go-mysql-server/issues/1903. I didn't think it was possible for that issue to cause user-facing problems, but I was wrong. Because of that issue, RangeHeapJoins considered all NULL values in its children iterators to come after all non-NULL values. However, if the child node was an index, then the child iterator would order its rows with the NULL values first. This causes the RangeHeapIterator to mismanage the heap and skip rows that should have been in the results.

I updated the range heap code to manually check for NULL values when manipulating the heap. I also updated the plan tests to include NULL values in the test tables, which should now catch this issue.