### PR TITLE
match range key with range type

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25933,4 +25933,21 @@ order by x, y;
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
+	{
+		Query: `SELECT /*+ LOOKUP_JOIN(xy,mytable) JOIN_ORDER(xy,mytable) */ * FROM xy INNER JOIN mytable ON ((xy.x)=(mytable.s));`,
+		ExpectedPlan: "LookupJoin\n" +
+			" ├─ ProcessTable\n" +
+			" │   └─ Table\n" +
+			" │       ├─ name: xy\n" +
+			" │       └─ columns: [x y]\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
+			"     ├─ index: [mytable.s]\n" +
+			"     ├─ keys: [xy.x:0!null]\n" +
+			"     ├─ colSet: (3,4)\n" +
+			"     ├─ tableId: 2\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: [i s]\n" +
+			"",
+	},
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5241,6 +5241,43 @@ CREATE TABLE tab3 (
 			},
 		},
 	},
+	{
+		Name: "range query convert int to string zero value",
+		SetUpScript: []string{
+			`CREATE TABLE t0(c0 VARCHAR(500));`,
+			`INSERT INTO t0(c0) VALUES ('a');`,
+			`INSERT INTO t0(c0) VALUES ('1');`,
+			`CREATE TABLE t1(c0 INTEGER, PRIMARY KEY(c0));`,
+			`INSERT INTO t1(c0) VALUES (0);`,
+			`INSERT INTO t1(c0) VALUES (1);`,
+			`INSERT INTO t1(c0) VALUES (2);`,
+
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "SELECT /*+ LOOKUP_JOIN(t0,t1) JOIN_ORDER(t0,t1) */ * FROM t1 INNER  JOIN t0 ON ((t0.c0)=(t1.c0));",
+				Expected: []sql.Row{
+					{0, "a"},
+					{1, "1"},
+				},
+			},
+			{
+				Query:    "INSERT INTO t0(c0) VALUES ('2abc');",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Skip: true,
+				Query:    "SELECT /*+ LOOKUP_JOIN(t0,t1) JOIN_ORDER(t0,t1) */ * FROM t1 INNER  JOIN t0 ON ((t0.c0)=(t1.c0));",
+				Expected: []sql.Row{
+					{0, "a"},
+					{1, "1"},
+					{2, "2abc"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5251,25 +5251,24 @@ CREATE TABLE tab3 (
 			`INSERT INTO t1(c0) VALUES (0);`,
 			`INSERT INTO t1(c0) VALUES (1);`,
 			`INSERT INTO t1(c0) VALUES (2);`,
-
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "SELECT /*+ LOOKUP_JOIN(t0,t1) JOIN_ORDER(t0,t1) */ * FROM t1 INNER  JOIN t0 ON ((t0.c0)=(t1.c0));",
+				Query: "SELECT /*+ LOOKUP_JOIN(t0,t1) JOIN_ORDER(t0,t1) */ * FROM t1 INNER  JOIN t0 ON ((t0.c0)=(t1.c0));",
 				Expected: []sql.Row{
 					{0, "a"},
 					{1, "1"},
 				},
 			},
 			{
-				Query:    "INSERT INTO t0(c0) VALUES ('2abc');",
+				Query: "INSERT INTO t0(c0) VALUES ('2abc');",
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
 			},
 			{
-				Skip: true,
-				Query:    "SELECT /*+ LOOKUP_JOIN(t0,t1) JOIN_ORDER(t0,t1) */ * FROM t1 INNER  JOIN t0 ON ((t0.c0)=(t1.c0));",
+				Skip:  true,
+				Query: "SELECT /*+ LOOKUP_JOIN(t0,t1) JOIN_ORDER(t0,t1) */ * FROM t1 INNER  JOIN t0 ON ((t0.c0)=(t1.c0));",
 				Expected: []sql.Row{
 					{0, "a"},
 					{1, "1"},

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -559,14 +559,27 @@ func (lb *LookupBuilder) GetLookup(key lookupBuilderKey) (sql.IndexLookup, error
 		if lb.matchesNullMask[i] {
 			if key[i] == nil {
 				lb.rang[i] = sql.NullRangeColumnExpr(lb.cets[i].Type)
-
 			} else {
-				lb.rang[i].LowerBound = sql.Below{Key: key[i]}
-				lb.rang[i].UpperBound = sql.Above{Key: key[i]}
+				// TODO: convert the key to range type; ignore errors?
+				k, _, err := lb.rang[i].Typ.Convert(key[i])
+				if err != nil {
+					// TODO: throw warning, and this should truncate for strings
+					err = nil
+					k = lb.rang[i].Typ.Zero()
+				}
+				lb.rang[i].LowerBound = sql.Below{Key: k}
+				lb.rang[i].UpperBound = sql.Above{Key: k}
 			}
 		} else {
-			lb.rang[i].LowerBound = sql.Below{Key: key[i]}
-			lb.rang[i].UpperBound = sql.Above{Key: key[i]}
+			// TODO: convert the key to range type; ignore errors?
+			k, _, err := lb.rang[i].Typ.Convert(key[i])
+			if err != nil {
+				// TODO: throw warning, and this should truncate for strings
+				err = nil
+				k = lb.rang[i].Typ.Zero()
+			}
+			lb.rang[i].LowerBound = sql.Below{Key: k}
+			lb.rang[i].UpperBound = sql.Above{Key: k}
 		}
 	}
 

--- a/sql/plan/indexed_table_access.go
+++ b/sql/plan/indexed_table_access.go
@@ -560,7 +560,6 @@ func (lb *LookupBuilder) GetLookup(key lookupBuilderKey) (sql.IndexLookup, error
 			if key[i] == nil {
 				lb.rang[i] = sql.NullRangeColumnExpr(lb.cets[i].Type)
 			} else {
-				// TODO: convert the key to range type; ignore errors?
 				k, _, err := lb.rang[i].Typ.Convert(key[i])
 				if err != nil {
 					// TODO: throw warning, and this should truncate for strings
@@ -571,7 +570,6 @@ func (lb *LookupBuilder) GetLookup(key lookupBuilderKey) (sql.IndexLookup, error
 				lb.rang[i].UpperBound = sql.Above{Key: k}
 			}
 		} else {
-			// TODO: convert the key to range type; ignore errors?
 			k, _, err := lb.rang[i].Typ.Convert(key[i])
 			if err != nil {
 				// TODO: throw warning, and this should truncate for strings


### PR DESCRIPTION
Creating lookups when comparing columns of different types were causing problems.
Especially, if one of the types is a string.

This is not a perfect fix as we don't do truncation yet, but it will stop panics.


Reused solution from this PR:
https://github.com/dolthub/go-mysql-server/pull/2177

It fixes the test case in this issue, but a skipped test is added for missing truncation functionality.
https://github.com/dolthub/dolt/issues/7371