### PR TITLE
allow tables with self referential foreign keys to be dropped

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -346,6 +346,18 @@ var ForeignKeyTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "DROP SELF REFERENCED TABLE",
+		SetUpScript: []string{
+			"create table t ( i int primary key, j int, index(j), foreign key (j) references t(i));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "DROP TABLE t;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+		},
+	},
+	{
 		Name: "Indexes used by foreign keys can't be dropped",
 		SetUpScript: []string{
 			"ALTER TABLE child ADD INDEX v1 (v1);",

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -184,8 +184,11 @@ func (b *BaseBuilder) buildDropTable(ctx *sql.Context, n *plan.DropTable, row sq
 				if err != nil {
 					return nil, err
 				}
-				if len(parentFks) > 0 {
-					return nil, sql.ErrForeignKeyDropTable.New(fkTable.Name(), parentFks[0].Name)
+				for i, fk := range parentFks {
+					// ignore self referential foreign keys
+					if fk.Table != fk.ParentTable {
+						return nil, sql.ErrForeignKeyDropTable.New(fkTable.Name(), parentFks[i].Name)
+					}
 				}
 			}
 			fks, err := fkTable.GetDeclaredForeignKeys(ctx)


### PR DESCRIPTION
Our logic for preventing `DROP`s on a table if that table was referenced in a `FOREIGN KEY` did not account for when the table was self referencing. This PR fixes that and closes the gap in our testing for this area.

fixes https://github.com/dolthub/dolt/issues/7418