### PR TITLE
Fix External Index Creation

### DIFF
--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -995,6 +995,7 @@ func (b *Builder) buildExternalCreateIndex(inScope *scope, ddl *ast.DDL) (outSco
 		config,
 	)
 	createIndex.Catalog = b.cat
+	outScope.node = createIndex
 	return
 }
 


### PR DESCRIPTION
Fixes regression introduced by 9b9301f8c4709d2d32982068322662643e02f231

Currently

```sql
CREATE INDEX foo USING driver table (column)
```

creates a table scan if driver is not "", "btree" or "hash".

The regression is caused by the change:
```diff

-	outScope.node = plan.NewCreateIndex(
+	createIndex := plan.NewCreateIndex(
		ddl.IndexSpec.ToName.String(),
		table,
		cols,
		ddl.IndexSpec.Using.Lowered(),
		config,
	)
+	createIndex.Catalog = b.cat
	return
```