### PR TITLE
adding `@@server_uuid` system variable

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8923,7 +8923,7 @@ from typestable`,
 	{
 		Query: "select length(@@server_uuid)",
 		Expected: []sql.Row{
-			{"36"},
+			{36},
 		},
 	},
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -8920,6 +8920,12 @@ from typestable`,
 			{"1.5000"},
 		},
 	},
+	{
+		Query: "select length(@@server_uuid)",
+		Expected: []sql.Row{
+			{"36"},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	gmstime "github.com/dolthub/go-mysql-server/internal/time"
@@ -2129,6 +2130,14 @@ var systemVars = map[string]sql.SystemVariable{
 		SetVarHintApplies: false,
 		Type:              types.Uint32,
 		Default:           uint32(0),
+	},
+	"server_uuid": {
+		Name:              "server_uuid",
+		Scope:             sql.SystemVariableScope_Persist,
+		Dynamic:           false,
+		SetVarHintApplies: false,
+		Type:              types.Blob,
+		Default:           uuid.New().String(),
 	},
 	"session_track_gtids": {
 		Name:              "session_track_gtids",

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -2136,7 +2136,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Scope:             sql.SystemVariableScope_Persist,
 		Dynamic:           false,
 		SetVarHintApplies: false,
-		Type:              types.Blob,
+		Type:              types.Text,
 		Default:           uuid.New().String(),
 	},
 	"session_track_gtids": {


### PR DESCRIPTION
This PR adds support for the `@@server_uuid` system variable.
However, this just generates a random UUID on server start, and does not persist it to a file.

MySQL Docs:
https://dev.mysql.com/doc/refman/8.0/en/replication-options.html#sysvar_server_uuid

Fixes https://github.com/dolthub/dolt/issues/7431