### PR TITLE
Implement `COM_RESET_CONNECTION`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813
+	github.com/dolthub/vitess v0.0.0-20240206204925-6acf16fa777c
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240129233432-aec9daef6af7
+	github.com/dolthub/vitess v0.0.0-20240202230207-9533f7101bba
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9X
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
 github.com/dolthub/vitess v0.0.0-20240129233432-aec9daef6af7 h1:AhmDCMtoEh2PwYsfblCaWIVvpHgDmWhz1YNNwl67vm4=
 github.com/dolthub/vitess v0.0.0-20240129233432-aec9daef6af7/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240202230207-9533f7101bba h1:NjNLn2/xzpJNfMlD3AxPTfspCrdO5ugB8TPmKZMNSfU=
+github.com/dolthub/vitess v0.0.0-20240202230207-9533f7101bba/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9X
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
 github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813 h1:tGwsoLAMFQ+7FDEyIWOIJ1Vc/nptbFi0Fh7SQahB8ro=
 github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240206204925-6acf16fa777c h1:Zt23BHsxvPHGfpHV9k/FcsHqWZjfybyQQux2OLpRni8=
+github.com/dolthub/vitess v0.0.0-20240206204925-6acf16fa777c/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/server/extension.go
+++ b/server/extension.go
@@ -167,8 +167,8 @@ func (ih *interceptorHandler) WarningCount(c *mysql.Conn) uint16 {
 	return ih.h.WarningCount(c)
 }
 
-func (ih *interceptorHandler) ComResetConnection(c *mysql.Conn) {
-	ih.h.ComResetConnection(c)
+func (ih *interceptorHandler) ComResetConnection(c *mysql.Conn) error {
+	return ih.h.ComResetConnection(c)
 }
 
 func (ih *interceptorHandler) ParserOptionsForConnection(c *mysql.Conn) (ast.ParserOptions, error) {

--- a/server/golden/proxy.go
+++ b/server/golden/proxy.go
@@ -149,8 +149,8 @@ func (h MySqlProxy) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, ca
 }
 
 // ComResetConnection implements mysql.Handler.
-func (h MySqlProxy) ComResetConnection(c *mysql.Conn) {
-	return
+func (h MySqlProxy) ComResetConnection(_ *mysql.Conn) error {
+	return nil
 }
 
 // ConnectionClosed implements mysql.Handler.

--- a/server/golden/validator.go
+++ b/server/golden/validator.go
@@ -81,8 +81,8 @@ func (v Validator) ComStmtExecute(c *mysql.Conn, prepare *mysql.PrepareData, cal
 	return fmt.Errorf("ComStmtExecute unsupported")
 }
 
-func (v Validator) ComResetConnection(c *mysql.Conn) {
-	return
+func (v Validator) ComResetConnection(_ *mysql.Conn) error {
+	return nil
 }
 
 // ConnectionClosed reports that a connection has been closed.


### PR DESCRIPTION
Implements the `COM_RESET_CONNECTION` command to allow a sql-server to clear session state on a connection so that it can be safely reused, for example, in connection pools. 

This matches MySQL's behavior, but customers may see a behavior change from this if they are relying on the old behavior. For example, if customers are relying on prepared statements to remain available in a session after it has been released to a connection pool and then reassigned to a new worker thread. The behavior now matches MySQL, where prepared statements, session vars, and user vars are all reset on a connection when the `COM_RESET_CONNECTION` command is executed on a connection.

Depends on https://github.com/dolthub/vitess/pull/308

Related to https://github.com/dolthub/dolt/issues/3921