### PR TITLE
Added the ExtendedType interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240206204925-6acf16fa777c
+	github.com/dolthub/vitess v0.0.0-20240207121055-c057d2347007
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15 h1:sfTETOpsrNJP
 github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813 h1:tGwsoLAMFQ+7FDEyIWOIJ1Vc/nptbFi0Fh7SQahB8ro=
-github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
-github.com/dolthub/vitess v0.0.0-20240206204925-6acf16fa777c h1:Zt23BHsxvPHGfpHV9k/FcsHqWZjfybyQQux2OLpRni8=
-github.com/dolthub/vitess v0.0.0-20240206204925-6acf16fa777c/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240207121055-c057d2347007 h1:MvFoe0FnHhxQLyp4Ldw0HRj1yu83YErbtbr7XxhaIFk=
+github.com/dolthub/vitess v0.0.0-20240207121055-c057d2347007/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -242,7 +242,12 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 			b.handleErr(err)
 		}
 		return ret
-
+	case ast.InjectedExpr:
+		if expr, ok := v.Expression.(sql.Expression); ok {
+			return expr
+		}
+		b.handleErr(fmt.Errorf("Injected expression is not a valid expression"))
+		return nil
 	case *ast.RangeCond:
 		val := b.buildScalar(inScope, v.Left)
 		lower := b.buildScalar(inScope, v.From)

--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -147,7 +147,9 @@ var ErrCharacterSetOnInvalidType = errors.NewKind("Only character columns, enums
 
 // ColumnTypeToType gets the column type using the column definition.
 func ColumnTypeToType(ct *sqlparser.ColumnType) (sql.Type, error) {
-
+	if resolvedType, ok := ct.ResolvedType.(sql.Type); ok {
+		return resolvedType, nil
+	}
 	sqlType := ct.SQLType()
 
 	if !allowsCharSet(sqlType) && len(ct.Charset) != 0 {

--- a/sql/types/extended.go
+++ b/sql/types/extended.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"encoding/hex"
+	"errors"
+
+	"github.com/dolthub/go-mysql-server/sql"
+)
+
+// ExtendedType is a serializable type that offers an extended interface for interacting with types in a wider context.
+type ExtendedType interface {
+	sql.Type
+	// SerializedCompare compares two byte slices that each represent a serialized value, without first deserializing
+	// the value. This should return the same result as the Compare function.
+	SerializedCompare(v1 []byte, v2 []byte) (int, error)
+	// SerializeValue converts the given value into a binary representation.
+	SerializeValue(val any) ([]byte, error)
+	// DeserializeValue converts a binary representation of a value into its canonical type.
+	DeserializeValue(val []byte) (any, error)
+	// FormatValue returns a string version of the value. Primarily intended for display.
+	FormatValue(val any) (string, error)
+	// MaxSerializedWidth returns the maximum size that the serialized value may represent.
+	MaxSerializedWidth() ExtendedTypeSerializedWidth
+}
+
+type ExtendedTypeSerializedWidth uint8
+
+const (
+	ExtendedTypeSerializedWidth_64K       ExtendedTypeSerializedWidth = iota // Represents a variably-sized value. The maximum number of bytes is (2^16)-1.
+	ExtendedTypeSerializedWidth_Unbounded                                    // Represents a variably-sized value. The maximum number of bytes is (2^64)-1, which is practically unbounded.
+)
+
+// ExtendedTypeSerializer is the function signature for the extended type serializer.
+type ExtendedTypeSerializer func(extendedType ExtendedType) ([]byte, error)
+
+// ExtendedTypeDeserializer is the function signature for the extended type deserializer.
+type ExtendedTypeDeserializer func(serializedType []byte) (ExtendedType, error)
+
+// extendedTypeDeserializer refers to the function that will handle deserialization of extended types.
+var extendedTypeDeserializer ExtendedTypeDeserializer = func(serializedType []byte) (ExtendedType, error) {
+	return nil, errors.New("placeholder extended type deserializer")
+}
+
+// extendedTypeSerializer refers to the function that will handle serialization of extended types.
+var extendedTypeSerializer ExtendedTypeSerializer = func(extendedType ExtendedType) ([]byte, error) {
+	return nil, errors.New("placeholder extended type serializer")
+}
+
+// SetExtendedTypeSerializers sets the handlers that are able to serialize and deserialize extended types.
+// It is recommended to set these from within an init function within the calling package.
+func SetExtendedTypeSerializers(serializer ExtendedTypeSerializer, deserializer ExtendedTypeDeserializer) {
+	extendedTypeSerializer = serializer
+	extendedTypeDeserializer = deserializer
+}
+
+// SerializeType serializes the given extended type into a byte slice.
+func SerializeType(typ ExtendedType) ([]byte, error) {
+	return extendedTypeSerializer(typ)
+}
+
+// SerializeTypeToString serializes the given extended type into a hex-encoded string.
+func SerializeTypeToString(typ ExtendedType) (string, error) {
+	serializedType, err := extendedTypeSerializer(typ)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(serializedType), nil
+}
+
+// DeserializeType deserializes a byte slice representing a serialized extended type.
+func DeserializeType(typ []byte) (ExtendedType, error) {
+	return extendedTypeDeserializer(typ)
+}
+
+// DeserializeTypeFromString deserializes a hex-encoded string representing a serialized extended type.
+func DeserializeTypeFromString(typ string) (ExtendedType, error) {
+	serializedType, err := hex.DecodeString(typ)
+	if err != nil {
+		return nil, err
+	}
+	return extendedTypeDeserializer(serializedType)
+}
+
+// IsExtendedType returns whether the given sql.Type is an ExtendedType.
+func IsExtendedType(typ sql.Type) bool {
+	_, ok := typ.(ExtendedType)
+	return ok
+}


### PR DESCRIPTION
This adds the `ExtendedType` interface, which is used within [DoltgreSQL](https://github.com/dolthub/doltgresql) to implement PostgreSQL types, as well as in [Dolt](https://github.com/dolthub/dolt) to properly handle the new type and value serialization.

Related PRs:
* https://github.com/dolthub/dolt/pull/7457
* https://github.com/dolthub/doltgresql/pull/120