### PR TITLE
Stored procedures can use params as LIMIT,OFFSET

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2837,6 +2837,28 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "issue 7458: proc params as limit values",
+		SetUpScript: []string{
+			"create table t (i int primary key);",
+			"insert into t values (0), (1), (2), (3)",
+			"CREATE PROCEDURE limited(the_limit INT, the_offset INT) SELECT * FROM t LIMIT the_limit OFFSET the_offset",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "call limited(1,0)",
+				Expected: []sql.Row{{0}},
+			},
+			{
+				Query:    "call limited(2,0)",
+				Expected: []sql.Row{{0}, {1}},
+			},
+			{
+				Query:    "call limited(2,2)",
+				Expected: []sql.Row{{2}, {3}},
+			},
+		},
+	},
+	{
 		Name: "failed conversion shows warning",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2837,28 +2837,6 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
-		Name: "issue 7458: proc params as limit values",
-		SetUpScript: []string{
-			"create table t (i int primary key);",
-			"insert into t values (0), (1), (2), (3)",
-			"CREATE PROCEDURE limited(the_limit INT, the_offset INT) SELECT * FROM t LIMIT the_limit OFFSET the_offset",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:    "call limited(1,0)",
-				Expected: []sql.Row{{0}},
-			},
-			{
-				Query:    "call limited(2,0)",
-				Expected: []sql.Row{{0}, {1}},
-			},
-			{
-				Query:    "call limited(2,2)",
-				Expected: []sql.Row{{2}, {3}},
-			},
-		},
-	},
-	{
 		Name: "failed conversion shows warning",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240129233432-aec9daef6af7
+	github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15 h1:sfTETOpsrNJP
 github.com/dolthub/jsonpath v0.0.2-0.20240201003050-392940944c15/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240129233432-aec9daef6af7 h1:AhmDCMtoEh2PwYsfblCaWIVvpHgDmWhz1YNNwl67vm4=
-github.com/dolthub/vitess v0.0.0-20240129233432-aec9daef6af7/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813 h1:tGwsoLAMFQ+7FDEyIWOIJ1Vc/nptbFi0Fh7SQahB8ro=
+github.com/dolthub/vitess v0.0.0-20240205203605-9e6c6d650813/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/analyzer/resolve_external_stored_procedures.go
+++ b/sql/analyzer/resolve_external_stored_procedures.go
@@ -131,7 +131,7 @@ func resolveExternalStoredProcedure(_ *sql.Context, externalProcedure sql.Extern
 				Type:      sqlType,
 				Variadic:  paramIsVariadic,
 			}
-			paramReferences[i] = expression.NewProcedureParam(paramName)
+			paramReferences[i] = expression.NewProcedureParam(paramName, sqlType)
 		} else if sqlType, ok = externalStoredProcedurePointerTypes[funcParamType]; ok {
 			paramDefinitions[i] = plan.ProcedureParam{
 				Direction: plan.ProcedureParamDirection_Inout,
@@ -139,7 +139,7 @@ func resolveExternalStoredProcedure(_ *sql.Context, externalProcedure sql.Extern
 				Type:      sqlType,
 				Variadic:  paramIsVariadic,
 			}
-			paramReferences[i] = expression.NewProcedureParam(paramName)
+			paramReferences[i] = expression.NewProcedureParam(paramName, sqlType)
 		} else {
 			return nil, sql.ErrExternalProcedureInvalidParamType.New(funcParamType.String())
 		}

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -55,7 +55,7 @@ func validateLimitAndOffset(ctx *sql.Context, a *Analyzer, n sql.Node, scope *pl
 					err = sql.ErrInvalidSyntax.New("negative limit")
 					return false
 				}
-			case *expression.BindVar:
+			case *expression.BindVar, *expression.ProcedureParam:
 				return true
 			default:
 				err = sql.ErrInvalidType.New(e.Type().String())
@@ -81,7 +81,7 @@ func validateLimitAndOffset(ctx *sql.Context, a *Analyzer, n sql.Node, scope *pl
 					err = sql.ErrInvalidSyntax.New("negative offset")
 					return false
 				}
-			case *expression.BindVar:
+			case *expression.BindVar, *expression.ProcedureParam:
 				return true
 			default:
 				err = sql.ErrInvalidType.New(e.Type().String())

--- a/sql/expression/procedurereference.go
+++ b/sql/expression/procedurereference.go
@@ -259,6 +259,7 @@ func NewProcedureReference() *ProcedureReference {
 type ProcedureParam struct {
 	name       string
 	pRef       *ProcedureReference
+	typ        sql.Type
 	hasBeenSet bool
 }
 
@@ -266,8 +267,8 @@ var _ sql.Expression = (*ProcedureParam)(nil)
 var _ sql.CollationCoercible = (*ProcedureParam)(nil)
 
 // NewProcedureParam creates a new ProcedureParam expression.
-func NewProcedureParam(name string) *ProcedureParam {
-	return &ProcedureParam{name: strings.ToLower(name)}
+func NewProcedureParam(name string, typ sql.Type) *ProcedureParam {
+	return &ProcedureParam{name: strings.ToLower(name), typ: typ}
 }
 
 // Children implements the sql.Expression interface.
@@ -287,7 +288,7 @@ func (*ProcedureParam) IsNullable() bool {
 
 // Type implements the sql.Expression interface.
 func (pp *ProcedureParam) Type() sql.Type {
-	return pp.pRef.GetVariableType(pp.name)
+	return pp.typ
 }
 
 // CollationCoercibility implements the sql.CollationCoercible interface.

--- a/sql/plan/procedure.go
+++ b/sql/plan/procedure.go
@@ -210,7 +210,7 @@ func (p *Procedure) ExtendVariadic(ctx *sql.Context, length int) *Procedure {
 					Type:      variadicParam.Type,
 					Variadic:  variadicParam.Variadic,
 				}
-				newParams[i] = expression.NewProcedureParam(paramName)
+				newParams[i] = expression.NewProcedureParam(paramName, variadicParam.Type)
 			}
 		}
 	}

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -196,7 +196,7 @@ func (b *Builder) buildCreateProcedure(inScope *scope, query string, c *ast.DDL)
 		// populate inScope with the procedure parameters. this will be
 		// subject maybe a bug where an inner procedure has access to
 		// outer procedure parameters.
-		inScope.proc.AddVar(expression.NewProcedureParam(strings.ToLower(p.Name)))
+		inScope.proc.AddVar(expression.NewProcedureParam(strings.ToLower(p.Name), p.Type))
 	}
 	bodyStr := strings.TrimSpace(query[c.SubStatementPositionStart:c.SubStatementPositionEnd])
 

--- a/sql/planbuilder/proc.go
+++ b/sql/planbuilder/proc.go
@@ -324,7 +324,7 @@ func (b *Builder) buildDeclareVariables(inScope *scope, d *ast.Declare) (outScop
 	for i, variable := range dVars.Names {
 		varName := strings.ToLower(variable.String())
 		names[i] = varName
-		param := expression.NewProcedureParam(varName)
+		param := expression.NewProcedureParam(varName, typ)
 		inScope.proc.AddVar(param)
 		inScope.newColumn(scopeColumn{col: varName, typ: typ, scalar: param})
 	}

--- a/sql/planbuilder/select.go
+++ b/sql/planbuilder/select.go
@@ -126,20 +126,50 @@ func (b *Builder) buildSelect(inScope *scope, s *ast.Select) (outScope *scope) {
 
 func (b *Builder) buildLimit(inScope *scope, limit *ast.Limit) sql.Expression {
 	if limit != nil {
-		switch e := limit.Rowcount.(type) {
-		case *ast.ColName:
-			if inScope.procActive() {
-				if col, ok := inScope.proc.GetVar(e.String()); ok {
-					// proc param is OK
-					return col.scalarGf()
+		return b.buildLimitVal(inScope, limit.Rowcount)
+	}
+	return nil
+}
+
+func (b *Builder) buildOffset(inScope *scope, limit *ast.Limit) sql.Expression {
+	if limit != nil && limit.Offset != nil {
+		e := b.buildLimitVal(inScope, limit.Offset)
+		if lit, ok := e.(*expression.Literal); ok {
+			// Check if offset starts at 0, if so, we can just remove the offset node.
+			// Only cast to int8, as a larger int type just means a non-zero offset.
+			if val, err := lit.Eval(b.ctx, nil); err == nil {
+				if v, ok := val.(int64); ok && v == 0 {
+					return nil
 				}
 			}
-			err := fmt.Errorf("limit expression expected to be numeric or prodecure parameter, found invalid column: %s", e.String())
-			b.handleErr(err)
-		default:
-			l := b.buildScalar(inScope, limit.Rowcount)
-			return b.typeCoerceLiteral(l)
 		}
+		return e
+	}
+	return nil
+}
+
+// buildLimitVal resolves a literal numeric type or a numeric
+// prodecure parameter
+func (b *Builder) buildLimitVal(inScope *scope, e ast.Expr) sql.Expression {
+	switch e := e.(type) {
+	case *ast.ColName:
+		if inScope.procActive() {
+			if col, ok := inScope.proc.GetVar(e.String()); ok {
+				// proc param is OK
+				if pp, ok := col.scalarGf().(*expression.ProcedureParam); ok {
+					if !pp.Type().Promote().Equals(types.Int64) {
+						err := fmt.Errorf("the variable '%s' has a non-integer based type: %s", pp.Name(), pp.Type().String())
+						b.handleErr(err)
+					}
+					return pp
+				}
+			}
+		}
+		err := fmt.Errorf("limit expression expected to be numeric or prodecure parameter, found invalid column: %s", e.String())
+		b.handleErr(err)
+	default:
+		l := b.buildScalar(inScope, e)
+		return b.typeCoerceLiteral(l)
 	}
 	return nil
 }
@@ -158,34 +188,6 @@ func (b *Builder) typeCoerceLiteral(e sql.Expression) sql.Expression {
 	default:
 		err := sql.ErrInvalidTypeForLimit.New(expression.Literal{}, e)
 		b.handleErr(err)
-	}
-	return nil
-}
-
-func (b *Builder) buildOffset(inScope *scope, limit *ast.Limit) sql.Expression {
-	if limit != nil && limit.Offset != nil {
-		switch e := limit.Offset.(type) {
-		case *ast.ColName:
-			if inScope.procActive() {
-				if col, ok := inScope.proc.GetVar(e.String()); ok {
-					// proc param is OK
-					return col.scalarGf()
-				}
-			}
-			err := fmt.Errorf("offset expression expected to be numeric or prodecure parameter, found invalid column: %s", e.String())
-			b.handleErr(err)
-		default:
-			rowCount := b.buildScalar(inScope, limit.Offset)
-			rowCount = b.typeCoerceLiteral(rowCount)
-			// Check if offset starts at 0, if so, we can just remove the offset node.
-			// Only cast to int8, as a larger int type just means a non-zero offset.
-			if val, err := rowCount.Eval(b.ctx, nil); err == nil {
-				if v, ok := val.(int64); ok && v == 0 {
-					return nil
-				}
-			}
-			return rowCount
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
fixes: https://github.com/dolthub/dolt/issues/7458

Fixes procedure param types in the process.

Testing against mysql it doesn't seem like subqueries or regular column types are valid as LIMIT values in any case other than procedure parameters. I still need to test whether trigger columns can be used in LIMIT,OFFSET, but that seems like a separate problem.
