### PR TITLE
Allow primary keys with `auto_increment` columns to be dropped when an appropriate index exists

### DIFF
--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -1332,38 +1332,6 @@ var AddDropPrimaryKeyScripts = []ScriptTest{
 		},
 	},
 	{
-		// In addition to using ALTER TABLE DROP PRIMARY KEY, MySQL also supports dropping a primary key by
-		// referring to it with the 'PRIMARY' name.
-		Name: "Drop auto-increment primary key as named index",
-		SetUpScript: []string{
-			"create table t (id int primary key AUTO_INCREMENT, c1 varchar(255));",
-			"insert into t (c1) values ('one');",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				// Without a supporting index, we should get an error
-				Query:       "DROP INDEX `PRIMARY` ON t;",
-				ExpectedErr: sql.ErrWrongAutoKey,
-			},
-			{
-				Query:    "ALTER TABLE t ADD UNIQUE KEY id (id);",
-				Expected: []sql.Row{{types.NewOkResult(0)}},
-			},
-			{
-				Query:    "DROP INDEX `PRIMARY` ON t;",
-				Expected: []sql.Row{{types.NewOkResult(0)}},
-			},
-			{
-				Query:    "show create table t;",
-				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `c1` varchar(255),\n  UNIQUE KEY `id` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
-			},
-			{
-				Query:    "SELECT * FROM t;",
-				Expected: []sql.Row{{1, "one"}},
-			},
-		},
-	},
-	{
 		Name: "Drop auto-increment primary key with supporting unique index",
 		SetUpScript: []string{
 			"create table t (id int primary key AUTO_INCREMENT, c1 varchar(255));",

--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -1357,8 +1357,12 @@ var AddDropPrimaryKeyScripts = []ScriptTest{
 				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `c1` varchar(255),\n  UNIQUE KEY `id` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
+				Query:    "insert into t (c1) values('two');",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 2}}},
+			},
+			{
 				Query:    "select * from t;",
-				Expected: []sql.Row{{1, "one"}},
+				Expected: []sql.Row{{1, "one"}, {2, "two"}},
 			},
 		},
 	},
@@ -1388,8 +1392,12 @@ var AddDropPrimaryKeyScripts = []ScriptTest{
 				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `c1` varchar(255),\n  KEY `id` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
+				Query:    "insert into t (c1) values('two');",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 2}}},
+			},
+			{
 				Query:    "select * from t;",
-				Expected: []sql.Row{{1, "one"}},
+				Expected: []sql.Row{{1, "one"}, {2, "two"}},
 			},
 		},
 	},
@@ -1423,8 +1431,12 @@ var AddDropPrimaryKeyScripts = []ScriptTest{
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
+				Query:    "insert into t (id2, c1) values(-2, 'two');",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 2}}},
+			},
+			{
 				Query:    "select * from t;",
-				Expected: []sql.Row{{1, -1, "one"}},
+				Expected: []sql.Row{{1, -1, "one"}, {2, -2, "two"}},
 			},
 			{
 				Query:    "show create table t;",

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -925,7 +925,7 @@ func getTableIndexColumns(ctx *sql.Context, table sql.Node) (map[string]bool, er
 }
 
 // getTableIndexNames returns the names of indexes associated with a table.
-func getTableIndexNames(ctx *sql.Context, a *Analyzer, table sql.Node) ([]string, error) {
+func getTableIndexNames(ctx *sql.Context, _ *Analyzer, table sql.Node) ([]string, error) {
 	ia, err := newIndexAnalyzerForNode(ctx, table)
 	if err != nil {
 		return nil, err
@@ -936,6 +936,10 @@ func getTableIndexNames(ctx *sql.Context, a *Analyzer, table sql.Node) ([]string
 
 	for i, index := range indexes {
 		names[i] = index.ID()
+	}
+
+	if hasPrimaryKeys(table.Schema()) {
+		names = append(names, "PRIMARY")
 	}
 
 	return names, nil

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -453,7 +453,7 @@ func (i *modifyColumnIter) Close(context *sql.Context) error {
 	return nil
 }
 
-// rewriteTable rewrites the table given if required or requested, and returns the whether it was rewritten
+// rewriteTable rewrites the table given if required or requested, and returns whether it was rewritten
 func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) (bool, error) {
 	oldColIdx := i.m.TargetSchema().IndexOfColName(i.m.Column())
 	if oldColIdx == -1 {


### PR DESCRIPTION
MySQL allows a primary key with an `auto_increment` column to be dropped as long as there is a secondary index that includes the `auto_increment` column as the first column in the index. ([MySQL Reference](https://dev.mysql.com/doc/refman/8.0/en/innodb-auto-increment-handling.html))

This PR also enables dropping a primary key by referencing it by it's ID (`PRIMARY`), in order to match MySQL's behavior, e.g. 
```
DROP INDEX `PRIMARY` ON t;
```

Related to https://github.com/dolthub/dolt/issues/7456