### PR TITLE
Add net.Listener as server config option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/sys v0.12.0
 	golang.org/x/text v0.6.0
 	golang.org/x/tools v0.13.0
+	google.golang.org/grpc v1.53.0
 	gopkg.in/src-d/go-errors.v1 v1.0.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -39,7 +40,6 @@ require (
 	github.com/tetratelabs/wazero v1.1.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
-	google.golang.org/grpc v1.53.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )

--- a/server/server.go
+++ b/server/server.go
@@ -143,18 +143,21 @@ func newServerFromHandler(cfg Config, e *sqle.Engine, sm *SessionManager, handle
 		cfg.MaxConnections = 0
 	}
 
+	l := cfg.Listener
 	var unixSocketInUse error
+	if l == nil {
+		if portInUse(cfg.Address) {
+			unixSocketInUse = fmt.Errorf("Port %s already in use.", cfg.Address)
+		}
 
-	if portInUse(cfg.Address) {
-		unixSocketInUse = fmt.Errorf("Port %s already in use.", cfg.Address)
-	}
-
-	l, err := NewListener(cfg.Protocol, cfg.Address, cfg.Socket)
-	if err != nil {
-		if errors.Is(err, UnixSocketInUseError) {
-			unixSocketInUse = err
-		} else {
-			return nil, err
+		var err error
+		l, err = NewListener(cfg.Protocol, cfg.Address, cfg.Socket)
+		if err != nil {
+			if errors.Is(err, UnixSocketInUseError) {
+				unixSocketInUse = err
+			} else {
+				return nil, err
+			}
 		}
 	}
 

--- a/server/server_config.go
+++ b/server/server_config.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"crypto/tls"
+	"net"
 	"time"
 
 	"github.com/dolthub/vitess/go/mysql"
@@ -43,6 +44,9 @@ type Config struct {
 	Protocol string
 	// Address of the server.
 	Address string
+	// Custom listener for the mysql server. Use this if you don't want ports or unix sockets to be opened automatically.
+	// This can be useful in testing by using a pure go net.Conn implementation.
+	Listener net.Listener
 	// Tracer to use in the server. By default, a noop tracer will be used if
 	// no tracer is provided.
 	Tracer trace.Tracer

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -79,7 +79,7 @@ func TestSeverCustomListener(t *testing.T) {
 		}
 		time.Sleep(time.Second)
 	}
-	require.NoError(t, err)
+	require.NoError(t, pingErr)
 
 	_, err = db.Exec("CREATE TABLE table1 (id int)")
 	require.NoError(t, err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,94 @@
+package server_test
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"testing"
+
+	vsql "github.com/dolthub/vitess/go/mysql"
+	"github.com/go-sql-driver/mysql"
+
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/server"
+	gsql "github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// TestSeverCustomListener verifies a caller can provide their own net.Conn implementation for the server to use
+func TestSeverCustomListener(t *testing.T) {
+	dbName := "mydb"
+	// create a net.Conn thats based on a golang buffer
+	buffer := 1024
+	listener := bufconn.Listen(buffer)
+
+	// create the memory database
+	memdb := memory.NewDatabase(dbName)
+	pro := memory.NewDBProvider(memdb)
+	engine := sqle.NewDefault(pro)
+
+	// server config with custom listener
+	cfg := server.Config{Listener: listener}
+	// since we're using a memory db, we can't rely on server.DefaultSessionBuilder as it causes panics, so explicitly build a memorySessionBuilder
+	sessionBuilder := func(ctx context.Context, c *vsql.Conn, addr string) (gsql.Session, error) {
+		host := ""
+		user := ""
+		mysqlConnectionUser, ok := c.UserData.(mysql_db.MysqlConnectionUser)
+		if ok {
+			host = mysqlConnectionUser.Host
+			user = mysqlConnectionUser.User
+		}
+		client := gsql.Client{Address: host, User: user, Capabilities: c.Capabilities}
+		return memory.NewSession(gsql.NewBaseSessionWithClientServer(addr, client, c.ConnectionID), pro), nil
+	}
+	s, err := server.NewServer(cfg, engine, sessionBuilder, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		if err = s.Start(); err != nil {
+			panic(err)
+		}
+	}()
+
+	networkName := "testNetwork"
+	// wire up go-mysql-driver to the listener
+	mysql.RegisterDialContext(networkName, func(ctx context.Context, addr string) (net.Conn, error) {
+		return listener.DialContext(ctx)
+	})
+	driver, err := mysql.NewConnector(&mysql.Config{
+		DBName:               dbName,
+		Addr:                 "bufconn",
+		Net:                  networkName,
+		Passwd:               "",
+		User:                 "root",
+		AllowNativePasswords: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// open the db, ping it, and run some execs/queries
+	db := sql.OpenDB(driver)
+	err = db.Ping()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Exec("CREATE TABLE table1 (id int)")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	row := db.QueryRow("SHOW TABLES")
+	var tableName string
+	err = row.Scan(&tableName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tableName != "table1" {
+		t.Fatalf("expected to find table1, but got %s", tableName)
+	}
+}

--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -774,6 +774,7 @@ func (db *MySQLDb) AuthMethod(user, addr string) (string, error) {
 			} else {
 				return "", err
 			}
+		} else {
 			host = splitHost
 		}
 	}

--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -768,11 +767,15 @@ func (db *MySQLDb) AuthMethod(user, addr string) (string, error) {
 	if addr == "@" || addr == "" {
 		host = "localhost"
 	} else {
-		addrUrl, err := url.Parse(addr)
+		splitHost, _, err := net.SplitHostPort(addr)
 		if err != nil {
-			return "", err
+			if err.(*net.AddrError).Err == "missing port in address" {
+				host = addr
+			} else {
+				return "", err
+			}
+			host = splitHost
 		}
-		host = addrUrl.Hostname()
 	}
 
 	rd := db.Reader()
@@ -796,14 +799,18 @@ func (db *MySQLDb) Salt() ([]byte, error) {
 // ValidateHash implements the interface mysql.AuthServer. This is called when the method used is "mysql_native_password".
 func (db *MySQLDb) ValidateHash(salt []byte, user string, authResponse []byte, addr net.Addr) (mysql.Getter, error) {
 	var host string
+	var err error
 	if addr.Network() == "unix" {
 		host = "localhost"
 	} else {
-		addrUrl, err := url.Parse(addr.String())
+		host, _, err = net.SplitHostPort(addr.String())
 		if err != nil {
-			return nil, err
+			if err.(*net.AddrError).Err == "missing port in address" {
+				host = addr.String()
+			} else {
+				return nil, err
+			}
 		}
-		host = addrUrl.Hostname()
 	}
 
 	rd := db.Reader()
@@ -832,14 +839,18 @@ func (db *MySQLDb) ValidateHash(salt []byte, user string, authResponse []byte, a
 // Negotiate implements the interface mysql.AuthServer. This is called when the method used is not "mysql_native_password".
 func (db *MySQLDb) Negotiate(c *mysql.Conn, user string, addr net.Addr) (mysql.Getter, error) {
 	var host string
+	var err error
 	if addr.Network() == "unix" {
 		host = "localhost"
 	} else {
-		addrUrl, err := url.Parse(addr.String())
+		host, _, err = net.SplitHostPort(addr.String())
 		if err != nil {
-			return nil, err
+			if err.(*net.AddrError).Err == "missing port in address" {
+				host = addr.String()
+			} else {
+				return nil, err
+			}
 		}
-		host = addrUrl.Hostname()
 	}
 
 	rd := db.Reader()

--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -796,13 +796,16 @@ func (db *MySQLDb) Salt() ([]byte, error) {
 func (db *MySQLDb) ValidateHash(salt []byte, user string, authResponse []byte, addr net.Addr) (mysql.Getter, error) {
 	var host string
 	var err error
-	if addr.Network() == "unix" {
+	switch addr.Network() {
+	case "unix":
 		host = "localhost"
-	} else {
+	case "tcp", "udp":
 		host, _, err = net.SplitHostPort(addr.String())
 		if err != nil {
 			return nil, err
 		}
+	default:
+		host = addr.String()
 	}
 
 	rd := db.Reader()
@@ -832,13 +835,16 @@ func (db *MySQLDb) ValidateHash(salt []byte, user string, authResponse []byte, a
 func (db *MySQLDb) Negotiate(c *mysql.Conn, user string, addr net.Addr) (mysql.Getter, error) {
 	var host string
 	var err error
-	if addr.Network() == "unix" {
+	switch addr.Network() {
+	case "unix":
 		host = "localhost"
-	} else {
+	case "tcp", "udp":
 		host, _, err = net.SplitHostPort(addr.String())
 		if err != nil {
 			return nil, err
 		}
+	default:
+		host = addr.String()
 	}
 
 	rd := db.Reader()


### PR DESCRIPTION
Presently go-mysql-server is served by a `net.Listener` backed by a real port or socket. In some environments (like testing) we want to avoid the host's networking stack entirely. This changeset adds support for the caller to provide the `net.Listener`, which gives them full control over where the sever serves.

This opens the door for some cool workflows. For example, you can run the server using a buffer-based `net.Listener` implementation (which is what happens in the test that I added).

I landed on this solution while thinking through https://github.com/dolthub/go-mysql-server/issues/2314