### PR TITLE
SQLEXCEPTION proc handler

### DIFF
--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1271,7 +1271,7 @@ END;`,
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "CALL eof();",
-				Expected: []sql.Row{{7}},
+				Expected: []sql.Row{},
 			},
 			{
 				Query:    "CALL duplicate_key();",

--- a/sql/expression/procedurereference.go
+++ b/sql/expression/procedurereference.go
@@ -423,7 +423,7 @@ const (
 
 func (c *HandlerCondition) Matches(err error) bool {
 	if errors.Is(err, FetchEOF) {
-		return c.Type == HandlerConditionNotFound || c.Type == HandlerConditionSqlException
+		return c.Type == HandlerConditionNotFound
 	} else {
 		return c.Type == HandlerConditionSqlException
 	}

--- a/sql/rowexec/other.go
+++ b/sql/rowexec/other.go
@@ -71,7 +71,7 @@ func (b *BaseBuilder) buildDeallocateQuery(ctx *sql.Context, n *plan.DeallocateQ
 func (b *BaseBuilder) buildFetch(ctx *sql.Context, n *plan.Fetch, row sql.Row) (sql.RowIter, error) {
 	row, sch, err := n.Pref.FetchCursor(ctx, n.Name)
 	if err == io.EOF {
-		return sql.RowsToRowIter(), expression.ProcedureBlockExitError(0)
+		return sql.RowsToRowIter(), expression.FetchEOF
 	} else if err != nil {
 		return nil, err
 	}

--- a/sql/rowexec/proc_iters.go
+++ b/sql/rowexec/proc_iters.go
@@ -76,9 +76,7 @@ func (b *beginEndIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 	row, err := b.rowIter.Next(ctx)
 	if err != nil {
-		if errors.Is(err, expression.FetchEOF) {
-			err = io.EOF
-		} else if controlFlow, ok := err.(loopError); ok && strings.ToLower(controlFlow.Label) == strings.ToLower(b.Label) {
+		if controlFlow, ok := err.(loopError); ok && strings.ToLower(controlFlow.Label) == strings.ToLower(b.Label) {
 			if controlFlow.IsExit {
 				err = nil
 			} else {
@@ -87,6 +85,9 @@ func (b *beginEndIter) Next(ctx *sql.Context) (sql.Row, error) {
 		}
 		if nErr := b.Pref.PopScope(ctx); nErr != nil && err == io.EOF {
 			err = nErr
+		}
+		if errors.Is(err, expression.FetchEOF) {
+			err = io.EOF
 		}
 		return nil, err
 	}

--- a/sql/rowexec/proc_iters.go
+++ b/sql/rowexec/proc_iters.go
@@ -15,6 +15,7 @@
 package rowexec
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -75,7 +76,7 @@ func (b *beginEndIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 	row, err := b.rowIter.Next(ctx)
 	if err != nil {
-		if exitErr, ok := err.(expression.ProcedureBlockExitError); ok && b.Pref.CurrentHeight() == int(exitErr) {
+		if errors.Is(err, expression.FetchEOF) {
 			err = io.EOF
 		} else if controlFlow, ok := err.(loopError); ok && strings.ToLower(controlFlow.Label) == strings.ToLower(b.Label) {
 			if controlFlow.IsExit {

--- a/sql/rowexec/rel_iters.go
+++ b/sql/rowexec/rel_iters.go
@@ -762,7 +762,7 @@ var _ sql.RowIter = (*declareHandlerIter)(nil)
 
 // Next implements the interface sql.RowIter.
 func (d *declareHandlerIter) Next(ctx *sql.Context) (sql.Row, error) {
-	d.Pref.InitializeHandler(d.Statement, d.Action == plan.DeclareHandlerAction_Exit)
+	d.Pref.InitializeHandler(d.Statement, d.Action, d.Condition)
 	return nil, io.EOF
 }
 


### PR DESCRIPTION
We originally supported one type of procedure handler, `NOT FOUND`, which explicitly checked for an error when fetching from a cursor io.EOFs. The implementation for that handler would walk the entire BEGIN/END scope stack inside the Fetch call looking for a handler, execute the handler body, and then embed the scope height into a special return error. The error walked back up the callstack looking for the BEGIN/END block embedded in the error message.

This PR:

1) Refactors handlers to coordinate message passing in a centralized way. No metadata is embedded in `FetchEOF`, because each scope will explicitly compare its handlers to errors raised during execution within its BEGIN/END bounds. (`FetchEOF` is important because we differentiate between 3 different types of `io.EOF` in procedure loops).

2) Add type/object support for representing specific signal handers.

3) Add `SQLEXCEPTION` signal handling, which will trigger for any error type (other than io.EOF) that bubbles up during a `BeginEndIter`'s execution.

re: https://github.com/dolthub/dolt/issues/7454

Another thing I noticed is that some of our tests return nil for empty stored procedures when mysql returns `ERROR 1329 (02000): No data - zero rows fetched, selected, or processed`. https://github.com/dolthub/dolt/issues/new