### PR TITLE
fix `NOT` expression in conjunction with `WHERE EXISTS(<subquery>)`

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -850,6 +850,16 @@ where u in (select * from rec);`,
 				},
 			},
 			{
+				q:     "select * from xy where not exists (select * from empty_tbl) and x is not null order by x",
+				types: []plan.JoinType{plan.JoinTypeLeftOuter},
+				exp: []sql.Row{
+					{0, 2},
+					{1, 0},
+					{2, 1},
+					{3, 3},
+				},
+			},
+			{
 				q:     "select /*+ MERGE_JOIN(xy,uv) */ * from xy where x not in (select u from uv WHERE u = 2) order by x",
 				types: []plan.JoinType{plan.JoinTypeLeftOuterMerge},
 				exp: []sql.Row{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7668,6 +7668,14 @@ Select * from (
 		},
 	},
 	{
+		Query: `SELECT i FROM mytable WHERE EXISTS (SELECT 1 from mytable) AND i IS NOT NULL;`,
+		Expected: []sql.Row{
+			{1},
+			{2},
+			{3},
+		},
+	},
+	{
 		Query:    `SELECT * FROM two_pk WHERE EXISTS (SELECT pk FROM one_pk WHERE pk > 4)`,
 		Expected: []sql.Row{},
 	},

--- a/sql/analyzer/unnest_exists_subqueries.go
+++ b/sql/analyzer/unnest_exists_subqueries.go
@@ -119,13 +119,8 @@ func unnestExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, fil
 		var s *hoistSubquery
 		var err error
 
-		joinType := plan.JoinTypeSemi
-		if not, ok := f.(*expression.Not); ok {
-			f = not.Child
-			joinType = plan.JoinTypeAnti
-		}
-
 		// match subquery expression
+		joinType := plan.JoinTypeSemi
 		var sq *plan.Subquery
 		switch e := f.(type) {
 		case *plan.ExistsSubquery:
@@ -133,6 +128,7 @@ func unnestExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, fil
 		case *expression.Not:
 			if esq, ok := e.Child.(*plan.ExistsSubquery); ok {
 				sq = esq.Query
+				joinType = plan.JoinTypeAnti
 			}
 		default:
 		}


### PR DESCRIPTION
The analyzer rule `unnest_exists_subqueries` was accidentally dropping `NOT` expressions when hoisting subqueries from `WHERE EXISTS...` clauses.

This should fix 8 sqllogictests.
Correctness: https://github.com/dolthub/dolt/pull/7510