### PR TITLE
Optional integrator schema validation

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	sql2 "database/sql"
 	"fmt"
+	"github.com/dolthub/vitess/go/sqltypes"
 	"io"
 	"net"
 	"runtime"
@@ -979,6 +980,68 @@ func TestTimestampBindingsCanBeCompared(t *testing.T) {
 	err = db.QueryRow("SELECT COUNT(1) FROM mytable WHERE t > ?", t0).Scan(&count)
 	require.NoError(t, err)
 	require.Equal(t, 1, count)
+}
+
+// TestAlterTableWithBadSchema is a backwards compatibility test that
+// ensures tables made with old versions of the engine can be altered.
+func TestAlterTableWithBadSchema(t *testing.T) {
+	harness := enginetest.NewDefaultMemoryHarness()
+	pro := harness.Provider()
+	harness.NewDatabases("mydb")
+	ctx := harness.NewContext()
+	sqlDb, err := pro.Database(ctx, "mydb")
+	require.NoError(t, err)
+	db := sqlDb.(*memory.HistoryDatabase)
+
+	sch := sql.NewPrimaryKeySchema(sql.Schema{
+		{Name: "a", Type: types.MustCreateStringWithDefaults(sqltypes.VarChar, 16383), Source: "mytable"},
+		{Name: "b", Type: types.MustCreateStringWithDefaults(sqltypes.VarChar, 16383), Source: "mytable"},
+		{Name: "c", Type: types.MustCreateStringWithDefaults(sqltypes.VarChar, 16383), Source: "mytable"},
+	})
+
+	harness.NewTableAsOf(db, "mytable", sch, nil)
+	//err = db.CreateTable(harness.NewContext(), "mytable", sch, sql.Collation_Default, "")
+	//require.NoError(t, err)
+
+	engine, err := harness.NewEngine(t)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		q    string
+		err  bool
+	}{
+		{
+			name: "noop modify doesn't trigger validation",
+			q:    "alter table mytable rename column a to d",
+			err:  false,
+		},
+		{
+			name: "partial update with invalid final schema fails",
+			q:    "alter table mytable modify column a varchar(100), modify column b varchar(100)",
+			err:  true,
+		},
+		{
+			name: "update with invalid final schema succeeds",
+			q:    "alter table mytable modify column a varchar(100), modify column b varchar(100), modify column c varchar(100)",
+			err:  false,
+		},
+		{
+			name: "mixed update add with invalid final schema fails",
+			q:    "alter table mytable modify column a varchar(100), modify column b varchar(100), modify column c varchar(100), add column d varchar(max)",
+			err:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := harness.NewContext()
+			_, _, err := engine.Query(ctx, tt.q)
+			// errors should be analyze time, not execution time
+			if tt.err && err == nil {
+				t.Errorf("expected error: %s", tt.q)
+			}
+		})
+	}
 }
 
 func newDatabase() (*sql2.DB, func()) {

--- a/enginetest/mysqlshim/table.go
+++ b/enginetest/mysqlshim/table.go
@@ -46,6 +46,7 @@ var _ sql.CheckAlterableTable = Table{}
 var _ sql.CheckTable = Table{}
 var _ sql.StatisticsTable = Table{}
 var _ sql.PrimaryKeyAlterableTable = Table{}
+var _ sql.SchemaValidator = Table{}
 
 func (t Table) IndexedAccess(sql.IndexLookup) sql.IndexedTable {
 	panic("not implemented")
@@ -180,6 +181,10 @@ func (t Table) AddColumn(ctx *sql.Context, column *sql.Column, order *sql.Column
 // DropColumn implements the interface sql.AlterableTable.
 func (t Table) DropColumn(ctx *sql.Context, columnName string) error {
 	return t.db.shim.Exec(t.db.name, fmt.Sprintf("ALTER TABLE `%s` DROP COLUMN `%s`;", t.name, columnName))
+}
+
+func (t Table) ValidateSchema(sch sql.Schema) error {
+	return nil
 }
 
 // ModifyColumn implements the interface sql.AlterableTable.

--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -15,6 +15,7 @@
 package queries
 
 import (
+	"github.com/dolthub/go-mysql-server/sql/analyzer/analyzererrors"
 	"github.com/dolthub/vitess/go/mysql"
 
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -24,6 +25,26 @@ import (
 )
 
 var AlterTableScripts = []ScriptTest{
+	{
+		Name: "multi alter with invalid schemas",
+		SetUpScript: []string{
+			"CREATE TABLE t(a int primary key)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "alter table t add column b varchar(max)",
+				ExpectedErr: analyzererrors.ErrInvalidRowLength,
+			},
+			{
+				Query:       "alter table t add column b varchar(16000), add column c varchar(16000)",
+				ExpectedErr: analyzererrors.ErrInvalidRowLength,
+			},
+			{
+				Query:    "alter table t add column b varchar(16000), add column c varchar(10)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+		},
+	},
 	{
 		Name: "variety of alter column statements in a single statement",
 		SetUpScript: []string{

--- a/memory/table.go
+++ b/memory/table.go
@@ -1165,10 +1165,6 @@ func addColumnToSchema(ctx *sql.Context, data *TableData, newCol *sql.Column, or
 		}
 	}
 
-	if err := validateMaxRowLength(newSch.PhysicalSchema()); err != nil {
-		return 0, nil, err
-	}
-
 	for _, newSchCol := range newSch {
 		newDefault, _, _ := transform.Expr(newSchCol.Default, func(expr sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 			if expr, ok := expr.(*expression.GetField); ok {

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -155,6 +155,7 @@ func validateIdentifiers(name string, spec *plan.TableSpec) error {
 func resolveAlterColumn(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, sel RuleSelector) (sql.Node, transform.TreeIdentity, error) {
 	var sch sql.Schema
 	var indexes []string
+	var validator sql.SchemaValidator
 	keyedColumns := make(map[string]bool)
 	var err error
 	transform.Inspect(n, func(n sql.Node) bool {
@@ -163,16 +164,39 @@ func resolveAlterColumn(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.S
 		}
 		switch n := n.(type) {
 		case *plan.ModifyColumn:
+			if rt, ok := n.Table.(*plan.ResolvedTable); ok {
+				if at, ok := rt.UnwrappedDatabase().(sql.SchemaValidator); ok {
+					validator = at
+				}
+			}
 			keyedColumns, err = getTableIndexColumns(ctx, n.Table)
 			return false
 		case *plan.RenameColumn:
+			if rt, ok := n.Table.(*plan.ResolvedTable); ok {
+				if at, ok := rt.UnwrappedDatabase().(sql.SchemaValidator); ok {
+					validator = at
+				}
+			}
 			return false
 		case *plan.AddColumn:
+			if rt, ok := n.Table.(*plan.ResolvedTable); ok {
+				if at, ok := rt.UnwrappedDatabase().(sql.SchemaValidator); ok {
+					validator = at
+				}
+			}
 			keyedColumns, err = getTableIndexColumns(ctx, n.Table)
 			return false
 		case *plan.DropColumn:
+			if rt, ok := n.Table.(*plan.ResolvedTable); ok {
+				validator, _ = rt.UnwrappedDatabase().(sql.SchemaValidator)
+			}
 			return false
 		case *plan.AlterIndex:
+			if rt, ok := n.Table.(*plan.ResolvedTable); ok {
+				if at, ok := rt.UnwrappedDatabase().(sql.SchemaValidator); ok {
+					validator = at
+				}
+			}
 			indexes, err = getTableIndexNames(ctx, a, n.Table)
 		default:
 		}
@@ -291,6 +315,12 @@ func resolveAlterColumn(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.S
 
 	if err != nil {
 		return nil, transform.SameTree, err
+	}
+
+	if validator != nil {
+		if err := validator.ValidateSchema(sch); err != nil {
+			return nil, transform.SameTree, err
+		}
 	}
 
 	// We can't evaluate auto-increment until the end of the analysis, since we break adding a new auto-increment unique

--- a/sql/plan/resolved_table.go
+++ b/sql/plan/resolved_table.go
@@ -16,6 +16,7 @@ package plan
 
 import (
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/memory"
@@ -88,6 +89,13 @@ func (t *ResolvedTable) WrappedTable() sql.Table {
 }
 
 func (t *ResolvedTable) Database() sql.Database {
+	return t.SqlDatabase
+}
+
+func (t *ResolvedTable) UnwrappedDatabase() sql.Database {
+	if privDb, ok := t.SqlDatabase.(mysql_db.PrivilegedDatabase); ok {
+		return privDb.Unwrap()
+	}
 	return t.SqlDatabase
 }
 

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -393,18 +393,28 @@ type RewritableTable interface {
 	RewriteInserter(ctx *Context, oldSchema, newSchema PrimaryKeySchema, oldColumn, newColumn *Column, idxCols []IndexColumn) (RowInserter, error)
 }
 
-// AlterableTable should be implemented by tables that can receive ALTER TABLE statements to modify their schemas.
+// AlterableTable should be implemented by tables that can receive
+// ALTER TABLE statements to modify their schemas.
 type AlterableTable interface {
 	Table
 	UpdatableTable
 
-	// AddColumn adds a column to this table as given. If non-nil, order specifies where in the schema to add the column.
+	// AddColumn adds a column to this table as given. If non-nil, order
+	// specifies where in the schema to add the column.
 	AddColumn(ctx *Context, column *Column, order *ColumnOrder) error
 	// DropColumn drops the column with the name given.
 	DropColumn(ctx *Context, columnName string) error
-	// ModifyColumn modifies the column with the name given, replacing with the new column definition provided (which may
-	// include a name change). If non-nil, order specifies where in the schema to move the column.
+	// ModifyColumn modifies the column with the name given, replacing
+	// with the new column definition provided (which may include a name
+	// change). If non-nil, order specifies where in the schema to move
+	// the column.
 	ModifyColumn(ctx *Context, columnName string, column *Column, order *ColumnOrder) error
+}
+
+type SchemaValidator interface {
+	// ValidateSchema lets storage integrators validate whether they
+	// can serialize the given schema
+	ValidateSchema(Schema) error
 }
 
 // UnresolvedTable is a Table that is either unresolved or deferred for until an asOf resolution.


### PR DESCRIPTION
Move table schema validation so that we validate the accumulated result rather than sequential alters. 