### PR TITLE
[planbuilder] Limit allows unsigned ints

### DIFF
--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1159,6 +1159,7 @@ END;`,
 			"create table t (i int primary key);",
 			"insert into t values (0), (1), (2), (3)",
 			"CREATE PROCEDURE limited(the_limit int, the_offset bigint) SELECT * FROM t LIMIT the_limit OFFSET the_offset",
+			"CREATE PROCEDURE limited_uns(the_limit int unsigned, the_offset bigint unsigned) SELECT * FROM t LIMIT the_limit OFFSET the_offset",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1171,6 +1172,10 @@ END;`,
 			},
 			{
 				Query:    "call limited(2,2)",
+				Expected: []sql.Row{{2}, {3}},
+			},
+			{
+				Query:    "call limited_uns(2,2)",
 				Expected: []sql.Row{{2}, {3}},
 			},
 			{

--- a/sql/planbuilder/select.go
+++ b/sql/planbuilder/select.go
@@ -157,7 +157,7 @@ func (b *Builder) buildLimitVal(inScope *scope, e ast.Expr) sql.Expression {
 			if col, ok := inScope.proc.GetVar(e.String()); ok {
 				// proc param is OK
 				if pp, ok := col.scalarGf().(*expression.ProcedureParam); ok {
-					if !pp.Type().Promote().Equals(types.Int64) {
+					if !pp.Type().Promote().Equals(types.Int64) && !pp.Type().Promote().Equals(types.Uint64) {
 						err := fmt.Errorf("the variable '%s' has a non-integer based type: %s", pp.Name(), pp.Type().String())
 						b.handleErr(err)
 					}


### PR DESCRIPTION
Parameterizing limits in stored procedures exposed a bug where we weren't accepting unsigned ints in LIMIT/OFFSET. This is only possible in prepared or stored procedure contexts afaik.