### PR TITLE
Feature: `@@last_generated_uuid` system session variable

### DIFF
--- a/sql/expression/function/uuid_test.go
+++ b/sql/expression/function/uuid_test.go
@@ -32,6 +32,11 @@ func TestUUID(t *testing.T) {
 	// Generate a UUID and validate that is a legitimate uuid
 	uuidE := NewUUIDFunc()
 
+	// Assert that @@last_generated_uuid is initialized to NULL
+	lastGeneratedUuid, err := ctx.GetSessionVariable(ctx, "last_generated_uuid")
+	require.NoError(t, err)
+	require.Nil(t, lastGeneratedUuid)
+
 	result, err := uuidE.Eval(ctx, sql.Row{nil})
 	require.NoError(t, err)
 
@@ -39,9 +44,14 @@ func TestUUID(t *testing.T) {
 	_, err = uuid.Parse(myUUID)
 	require.NoError(t, err)
 
+	// Assert that @@last_generated_uuid has been set
+	lastGeneratedUuid, err = ctx.GetSessionVariable(ctx, "last_generated_uuid")
+	require.NoError(t, err)
+	require.Equal(t, myUUID, lastGeneratedUuid)
+
 	// validate that generated uuid is legitimate for IsUUID
 	val := NewIsUUID(uuidE)
-	require.Equal(t, int8(1), eval(t, val, sql.Row{nil}))
+	require.Equal(t, true, eval(t, val, sql.Row{nil}))
 
 	// Use a UUID regex as a sanity check
 	re2 := regexp.MustCompile(`\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b`)
@@ -55,14 +65,14 @@ func TestIsUUID(t *testing.T) {
 		value    interface{}
 		expected interface{}
 	}{
-		{"uuid form 1", types.LongText, "{12345678-1234-5678-1234-567812345678}", int8(1)},
-		{"uuid form 2", types.LongText, "12345678123456781234567812345678", int8(1)},
-		{"uuid form 3", types.LongText, "12345678-1234-5678-1234-567812345678", int8(1)},
+		{"uuid form 1", types.LongText, "{12345678-1234-5678-1234-567812345678}", true},
+		{"uuid form 2", types.LongText, "12345678123456781234567812345678", true},
+		{"uuid form 3", types.LongText, "12345678-1234-5678-1234-567812345678", true},
 		{"NULL", types.Null, nil, nil},
-		{"random int", types.Int8, 1, int8(0)},
-		{"random bool", types.Boolean, false, int8(0)},
-		{"random string", types.LongText, "12345678-dasd-fasdf8", int8(0)},
-		{"swapped uuid", types.LongText, "5678-1234-12345678-1234-567812345678", int8(0)},
+		{"random int", types.Int8, 1, false},
+		{"random bool", types.Boolean, false, false},
+		{"random string", types.LongText, "12345678-dasd-fasdf8", false},
+		{"swapped uuid", types.LongText, "5678-1234-12345678-1234-567812345678", false},
 	}
 
 	for _, tt := range testCases {

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -27,6 +27,7 @@ import (
 	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/sqltypes"
 )
 
 // TODO: Add from the following sources because MySQL likes to not have every variable on a single page:
@@ -1151,6 +1152,14 @@ var systemVars = map[string]sql.SystemVariable{
 		SetVarHintApplies: false,
 		Type:              types.NewSystemIntType("large_page_size", -9223372036854775808, 9223372036854775807, false),
 		Default:           int64(0),
+	},
+	"last_generated_uuid": {
+		Name:              "last_generated_uuid",
+		Scope:             sql.SystemVariableScope_Session,
+		Dynamic:           true,
+		SetVarHintApplies: false,
+		Type:              types.MustCreateStringWithDefaults(sqltypes.VarChar, 36),
+		Default:           nil,
 	},
 	"last_insert_id": {
 		Name:              "last_insert_id",

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -21,13 +21,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
-	"github.com/dolthub/vitess/go/sqltypes"
 )
 
 // TODO: Add from the following sources because MySQL likes to not have every variable on a single page:


### PR DESCRIPTION
Dolt [recommends customers prefer UUIDs over `auto_increment` values](https://www.dolthub.com/blog/2023-10-27-uuid-keys/) where possible. For `auto_increment` columns, the MySQL `last_insert_id()` function helps to retrieve the last generated ID, but there's not an analogue for UUIDs. This PR adds a new system session variable, `@@last_generated_uuid` that is populated each time the `UUID()` function is executed. Note that this is not a standard MySQL behavior. 

Customer request: https://github.com/dolthub/dolt/issues/7547