### PR TITLE
fix special case for `now()` string

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5553,6 +5553,31 @@ where
 			},
 		},
 	},
+	{
+		Name: "preserve now()",
+		SetUpScript: []string{
+			"create table t1 (i int default (cast(now() as signed)));",
+			"create table t2 (i int default (cast(current_timestamp(6) as signed)));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int DEFAULT (convert(NOW(), signed))\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "show create table t2",
+				Expected: []sql.Row{
+					{"t2", "CREATE TABLE `t2` (\n" +
+						"  `i` int DEFAULT (convert(NOW(6), signed))\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/columndefault.go
+++ b/sql/columndefault.go
@@ -16,7 +16,6 @@ package sql
 
 import (
 	"fmt"
-	"strings"
 )
 
 // ColumnDefaultValue is an expression representing the default value of a column. May represent both a default literal
@@ -151,11 +150,21 @@ func (e *ColumnDefaultValue) String() string {
 	}
 
 	// There's a special case for NOW()
-	if str == "NOW()" || str == "NOW(0)" {
+	switch str {
+	case "NOW()", "NOW(0)":
 		return "CURRENT_TIMESTAMP"
-	}
-	if strings.Contains(str, "NOW(") {
-		return strings.Replace(str, "NOW(", "CURRENT_TIMESTAMP(", 1)
+	case "NOW(1)":
+		return "CURRENT_TIMESTAMP(1)"
+	case "NOW(2)":
+		return "CURRENT_TIMESTAMP(2)"
+	case "NOW(3)":
+		return "CURRENT_TIMESTAMP(3)"
+	case "NOW(4)":
+		return "CURRENT_TIMESTAMP(4)"
+	case "NOW(5)":
+		return "CURRENT_TIMESTAMP(5)"
+	case "NOW(6)":
+		return "CURRENT_TIMESTAMP(6)"
 	}
 	return fmt.Sprintf("(%s)", str)
 }


### PR DESCRIPTION
The BATS tests `import-mysqldump.bats` was failing due to a recent string replace case added by https://github.com/dolthub/go-mysql-server/pull/2357.

I didn't account for when `NOW()` would be used with other functions inside a `DEFAULT` column expression, and was replacing the `"NOW("` with `"CURRENT_TIMESTAMP("`. This was causing problems as we reparse ColumnDefaultExprs, resulting in unparenthesized default expressions, which threw an error.