### PR TITLE
Update README with latest sample code from _example/main.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,35 @@ directory](_example/main.go), also reproduced below.
 package main
 
 import (
+	"context"
 	"fmt"
 	"time"
+
+	"github.com/dolthub/vitess/go/mysql"
+	"github.com/dolthub/vitess/go/vt/proto/query"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
+
+// This is an example of how to implement a MySQL server.
+// After running the example, you may connect to it using the following:
+//
+// > mysql --host=localhost --port=3306 --user=root mydb --execute="SELECT * FROM mytable;"
+// +----------+-------------------+-------------------------------+----------------------------+
+// | name     | email             | phone_numbers                 | created_at                 |
+// +----------+-------------------+-------------------------------+----------------------------+
+// | Jane Deo | janedeo@gmail.com | ["556-565-566","777-777-777"] | 2022-11-01 12:00:00.000001 |
+// | Jane Doe | jane@doe.com      | []                            | 2022-11-01 12:00:00.000001 |
+// | John Doe | john@doe.com      | ["555-555-555"]               | 2022-11-01 12:00:00.000001 |
+// | John Doe | johnalt@doe.com   | []                            | 2022-11-01 12:00:00.000001 |
+// +----------+-------------------+-------------------------------+----------------------------+
+//
+// The included MySQL client is used in this example, however any MySQL-compatible client will work.
 
 var (
 	dbName    = "mydb"
@@ -85,51 +105,74 @@ var (
 )
 
 func main() {
-	ctx := sql.NewEmptyContext()
-	engine := sqle.NewDefault(
-		memory.NewDBProvider(
-			createTestDatabase(ctx),
-		))
+    pro := createTestDatabase()
+    engine := sqle.NewDefault(pro)
+    
+    session := memory.NewSession(sql.NewBaseSession(), pro)
+    ctx := sql.NewContext(context.Background(), sql.WithSession(session))
+    ctx.SetCurrentDatabase("test")
+    
+    // This variable may be found in the "users_example.go" file. Please refer to that file for a walkthrough on how to
+    // set up the "mysql" database to allow user creation and user checking when establishing connections. This is set
+    // to false for this example, but feel free to play around with it and see how it works.
+    if enableUsers {
+        if err := enableUserAccounts(ctx, engine); err != nil {
+            panic(err)
+        }
+    }
 
-	// This variable may be found in the "users_example.go" file. Please refer to that file for a walkthrough on how to
-	// set up the "mysql" database to allow user creation and user checking when establishing connections. This is set
-	// to false for this example, but feel free to play around with it and see how it works.
-	if enableUsers {
-		if err := enableUserAccounts(ctx, engine); err != nil {
-			panic(err)
-		}
-	}
-
-	config := server.Config{
-		Protocol: "tcp",
-		Address:  fmt.Sprintf("%s:%d", address, port),
-	}
-	s, err := server.NewDefaultServer(config, engine)
-	if err != nil {
-		panic(err)
-	}
-	if err = s.Start(); err != nil {
-		panic(err)
-	}
+    config := server.Config{
+        Protocol: "tcp",
+        Address:  fmt.Sprintf("%s:%d", address, port),
+    }
+    s, err := server.NewServer(config, engine, sessionBuilder(pro), nil)
+    if err != nil {
+        panic(err)
+    }
+    if err = s.Start(); err != nil {
+        panic(err)
+    }
 }
 
-func createTestDatabase(ctx *sql.Context) *memory.Database {
-	db := memory.NewDatabase(dbName)
-	db.EnablePrimaryKeyIndexes()
-	table := memory.NewTable(tableName, sql.NewPrimaryKeySchema(sql.Schema{
-		{Name: "name", Type: types.Text, Nullable: false, Source: tableName, PrimaryKey: true},
-		{Name: "email", Type: types.Text, Nullable: false, Source: tableName, PrimaryKey: true},
-		{Name: "phone_numbers", Type: types.JSON, Nullable: false, Source: tableName},
-		{Name: "created_at", Type: types.Datetime, Nullable: false, Source: tableName},
-	}), db.GetForeignKeyCollection())
-	db.AddTable(tableName, table)
+func sessionBuilder(pro *memory.DbProvider) server.SessionBuilder {
+    return func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, error) {
+        host := ""
+        user := ""
+        mysqlConnectionUser, ok := conn.UserData.(mysql_db.MysqlConnectionUser)
+        if ok {
+            host = mysqlConnectionUser.Host
+            user = mysqlConnectionUser.User
+        }
 
-	creationTime := time.Unix(0, 1667304000000001000).UTC()
-	_ = table.Insert(ctx, sql.NewRow("Jane Deo", "janedeo@gmail.com", types.MustJSON(`["556-565-566", "777-777-777"]`), creationTime))
-	_ = table.Insert(ctx, sql.NewRow("Jane Doe", "jane@doe.com", types.MustJSON(`[]`), creationTime))
-	_ = table.Insert(ctx, sql.NewRow("John Doe", "john@doe.com", types.MustJSON(`["555-555-555"]`), creationTime))
-	_ = table.Insert(ctx, sql.NewRow("John Doe", "johnalt@doe.com", types.MustJSON(`[]`), creationTime))
-	return db
+        client := sql.Client{Address: host, User: user, Capabilities: conn.Capabilities}
+        baseSession := sql.NewBaseSessionWithClientServer(addr, client, conn.ConnectionID)
+        return memory.NewSession(baseSession, pro), nil
+    }
+}
+
+func createTestDatabase() *memory.DbProvider {
+    db := memory.NewDatabase("mydb")
+    db.BaseDatabase.EnablePrimaryKeyIndexes()
+    
+    pro := memory.NewDBProvider(db)
+    session := memory.NewSession(sql.NewBaseSession(), pro)
+    ctx := sql.NewContext(context.Background(), sql.WithSession(session))
+    
+    table := memory.NewTable(db, tableName, sql.NewPrimaryKeySchema(sql.Schema{
+    {Name: "name", Type: types.Text, Nullable: false, Source: tableName, PrimaryKey: true},
+    {Name: "email", Type: types.Text, Nullable: false, Source: tableName, PrimaryKey: true},
+    {Name: "phone_numbers", Type: types.JSON, Nullable: false, Source: tableName},
+    {Name: "created_at", Type: types.MustCreateDatetimeType(query.Type_DATETIME, 6), Nullable: false, Source: tableName},
+    }), db.GetForeignKeyCollection())
+    db.AddTable(tableName, table)
+    
+    creationTime := time.Unix(0, 1667304000000001000).UTC()
+    _ = table.Insert(ctx, sql.NewRow("Jane Deo", "janedeo@gmail.com", types.MustJSON(`["556-565-566", "777-777-777"]`), creationTime))
+    _ = table.Insert(ctx, sql.NewRow("Jane Doe", "jane@doe.com", types.MustJSON(`[]`), creationTime))
+    _ = table.Insert(ctx, sql.NewRow("John Doe", "john@doe.com", types.MustJSON(`["555-555-555"]`), creationTime))
+    _ = table.Insert(ctx, sql.NewRow("John Doe", "johnalt@doe.com", types.MustJSON(`[]`), creationTime))
+    
+    return pro
 }
 ```
 


### PR DESCRIPTION
The latest release of `go-mysql-server` requires a different way of instantiating the database server. Notably, a function that provides sessions must now be provided. 

This change updates our README with the latest working example code from `_example/main.go`.

Related to https://github.com/dolthub/go-mysql-server/issues/2364