### PR TITLE
don't use all caps for engines info table

### DIFF
--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -381,6 +381,32 @@ var InfoSchemaQueries = []QueryTest{
 		Expected: []sql.Row{
 			{"InnoDB", "DEFAULT", "Supports transactions, row-level locking, and foreign keys", "YES", "YES", "YES"},
 		},
+		ExpectedColumns: sql.Schema{
+			{
+				Name: "Engine",
+				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "Support",
+				Type: types.MustCreateString(sqltypes.VarChar, 8, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "Comment",
+				Type: types.MustCreateString(sqltypes.VarChar, 80, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "Transactions",
+				Type: types.MustCreateString(sqltypes.VarChar, 3, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "XA",
+				Type: types.MustCreateString(sqltypes.VarChar, 3, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "Savepoints",
+				Type: types.MustCreateString(sqltypes.VarChar, 3, sql.Collation_Information_Schema_Default),
+			},
+		},
 	},
 	{
 		Query: "SELECT * FROM information_schema.table_constraints ORDER BY table_name, constraint_type;",
@@ -454,6 +480,32 @@ var InfoSchemaQueries = []QueryTest{
 		Query: `SELECT * FROM information_schema.ENGINES ORDER BY engine`,
 		Expected: []sql.Row{
 			{"InnoDB", "DEFAULT", "Supports transactions, row-level locking, and foreign keys", "YES", "YES", "YES"},
+		},
+		ExpectedColumns: sql.Schema{
+			{
+				Name: "ENGINE",
+				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "SUPPORT",
+				Type: types.MustCreateString(sqltypes.VarChar, 8, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "COMMENT",
+				Type: types.MustCreateString(sqltypes.VarChar, 80, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "TRANSACTIONS",
+				Type: types.MustCreateString(sqltypes.VarChar, 3, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "XA",
+				Type: types.MustCreateString(sqltypes.VarChar, 3, sql.Collation_Information_Schema_Default),
+			},
+			{
+				Name: "SAVEPOINTS",
+				Type: types.MustCreateString(sqltypes.VarChar, 3, sql.Collation_Information_Schema_Default),
+			},
 		},
 	},
 	{

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -286,12 +286,12 @@ var enabledRolesSchema = Schema{
 }
 
 var enginesSchema = Schema{
-	{Name: "ENGINE", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
-	{Name: "SUPPORT", Type: types.MustCreateString(sqltypes.VarChar, 8, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
-	{Name: "COMMENT", Type: types.MustCreateString(sqltypes.VarChar, 80, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
-	{Name: "TRANSACTIONS", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
+	{Name: "Engine", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
+	{Name: "Support", Type: types.MustCreateString(sqltypes.VarChar, 8, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
+	{Name: "Comment", Type: types.MustCreateString(sqltypes.VarChar, 80, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
+	{Name: "Transactions", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
 	{Name: "XA", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
-	{Name: "SAVEPOINTS", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
+	{Name: "Savepoints", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
 }
 
 var eventsSchema = Schema{

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -286,12 +286,12 @@ var enabledRolesSchema = Schema{
 }
 
 var enginesSchema = Schema{
-	{Name: "Engine", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
-	{Name: "Support", Type: types.MustCreateString(sqltypes.VarChar, 8, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
-	{Name: "Comment", Type: types.MustCreateString(sqltypes.VarChar, 80, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
-	{Name: "Transactions", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
+	{Name: "ENGINE", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
+	{Name: "SUPPORT", Type: types.MustCreateString(sqltypes.VarChar, 8, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
+	{Name: "COMMENT", Type: types.MustCreateString(sqltypes.VarChar, 80, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: false, Source: EnginesTableName},
+	{Name: "TRANSACTIONS", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
 	{Name: "XA", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
-	{Name: "Savepoints", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
+	{Name: "SAVEPOINTS", Type: types.MustCreateString(sqltypes.VarChar, 3, Collation_Information_Schema_Default), Default: planbuilder.MustStringToColumnDefaultValue(NewEmptyContext(), `""`, types.LongText, false), Nullable: true, Source: EnginesTableName},
 }
 
 var eventsSchema = Schema{

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -815,7 +815,16 @@ func (b *Builder) buildShowCollation(inScope *scope, s *ast.Show) (outScope *sco
 
 func (b *Builder) buildShowEngines(inScope *scope, s *ast.Show) (outScope *scope) {
 	outScope = inScope.push()
-	infoSchemaSelect, _, _, err := b.Parse("select * from information_schema.engines", false)
+	infoSchemaSelect, _, _, err := b.Parse(`
+select
+    ENGINE as Engine,
+    SUPPORT as Support,
+    COMMENT as Comment,
+    TRANSACTIONS as Transactions,
+    XA as XA,
+    SAVEPOINTS as Savepoints
+from information_schema.engines
+`, false)
 	if err != nil {
 		b.handleErr(err)
 	}


### PR DESCRIPTION
Some clients rely on the correct casing of column names
For some reason, the casing is different when performing `SHOW ENGINES;` vs `select * from information_schema.engines;`

Fortunately, the way we do `SHOW ENGINES;` is actually a `SELECT ...` under the hood.
So the hacky fix is to just use an alias :)

related https://github.com/dolthub/dolt/issues/7574