### PR TITLE
`charset` table option tests

### DIFF
--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -585,6 +585,61 @@ var CreateTableScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "table charset options",
+		SetUpScript: []string{
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    `create table t1 (i int) charset latin1`,
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    `show create table t1`,
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci"},
+				},
+			},
+			{
+				Query:    `create table t2 (i int) character set latin1`,
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    `show create table t2`,
+				Expected: []sql.Row{
+					{"t2", "CREATE TABLE `t2` (\n" +
+						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci"},
+				},
+			},
+			{
+				Query:    `create table t3 (i int) charset binary`,
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    `show create table t3`,
+				Expected: []sql.Row{
+					{"t3", "CREATE TABLE `t3` (\n" +
+						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=binary COLLATE=binary"},
+				},
+			},
+			{
+				Query:    `create table t4 (i int) character set binary`,
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    `show create table t4`,
+				Expected: []sql.Row{
+					{"t4", "CREATE TABLE `t4` (\n" +
+						"  `i` int\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=binary COLLATE=binary"},
+				},
+			},
+		},
+	},
 }
 
 var CreateTableAutoIncrementTests = []ScriptTest{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240307075619-7c834a45d284
+	github.com/dolthub/vitess v0.0.0-20240307173128-5f7f58927aec
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240228234620-13c0f62e6b4a
+	github.com/dolthub/vitess v0.0.0-20240307075619-7c834a45d284
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240228234620-13c0f62e6b4a h1:aXFMPhMpOYiyPo2wqgpPLjxqr8mvfxSW2wSpLpzboZ0=
-github.com/dolthub/vitess v0.0.0-20240228234620-13c0f62e6b4a/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240307075619-7c834a45d284 h1:INNybv/FYCHpyyATcVKf7oWgEsK9ZHZsAAlM2rca6A0=
+github.com/dolthub/vitess v0.0.0-20240307075619-7c834a45d284/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240307075619-7c834a45d284 h1:INNybv/FYCHpyyATcVKf7oWgEsK9ZHZsAAlM2rca6A0=
-github.com/dolthub/vitess v0.0.0-20240307075619-7c834a45d284/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240307173128-5f7f58927aec h1:H1tHx26oby26Ig8SkFLIu/L5w3bFhAHOONMhJc0iE4A=
+github.com/dolthub/vitess v0.0.0-20240307173128-5f7f58927aec/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=


### PR DESCRIPTION
In GMS, we reparse table options with a regular expression, but we only cover `CHARACTER SET` and not its synonym `CHARSET`.
As a result, we just ignore table options for `CHARSET`.

The fix is in https://github.com/dolthub/vitess/pull/315

TODO: maybe should just address [this TODO](https://github.com/dolthub/go-mysql-server/blob/main/sql/planbuilder/errors.go#L30) instead...

