### PR TITLE
fix `binary` cast to maintain length

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -4913,8 +4913,8 @@ Select * from (
 		Expected: []sql.Row{{"10.56789"}},
 	},
 	{
-		Query:    "SELECT CAST('abcdef' as BINARY(30));",
-		Expected: []sql.Row{{[]byte("abcdef")}},
+		Query:    "SELECT CAST('abcdef' as BINARY(10));",
+		Expected: []sql.Row{{[]byte("abcdef\x00\x00\x00\x00")}},
 	},
 	{
 		Query:    `SELECT CONVERT(10.12345, DECIMAL(4,2))`,

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5877,7 +5877,6 @@ where
 					{"ghi"},
 				},
 			},
-
 			{
 				Query: "select cast(b as char(3)) from tt where b < cast('def' as binary(10));",
 				Expected: []sql.Row{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5850,6 +5850,54 @@ where
 			},
 		},
 	},
+	{
+		Name: "binary type primary key",
+		SetUpScript: []string{
+			"create table t (b binary(3) primary key);",
+			"insert into t values ('abc'), ('def'), ('ghi');",
+			"create table tt (b binary(10) primary key);",
+			"insert into tt values ('abc'), ('def'), ('ghi');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select cast(b as char) from t where b < cast('def' as binary(3));",
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: "select cast(b as char) from t where b = cast('def' as binary(3));",
+				Expected: []sql.Row{
+					{"def"},
+				},
+			},
+			{
+				Query: "select cast(b as char) from t where b > cast('def' as binary(3));",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+
+			{
+				Query: "select cast(b as char(3)) from tt where b < cast('def' as binary(10));",
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: "select cast(b as char(3)) from tt where b = cast('def' as binary(10));",
+				Expected: []sql.Row{
+					{"def"},
+				},
+			},
+			{
+				Query: "select cast(b as char(3)) from tt where b > cast('def' as binary(10));",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -348,6 +348,11 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 				if !isEvaluable(e) {
 					return e, transform.SameTree, nil
 				}
+				if conv, ok := e.(*expression.Convert); ok {
+					if types.IsBinaryType(conv.Type()) {
+						return e, transform.SameTree, nil
+					}
+				}
 
 				// All other expressions types can be evaluated once and turned into literals for the rest of query execution
 				val, err := e.Eval(ctx, nil)

--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -298,6 +298,9 @@ func convertValue(val interface{}, castTo string, originType sql.Type, typeLengt
 			}
 			b = encodedBytes
 		}
+		if bb, ok := b.([]byte); ok && len(bb) < typeLength {
+			b = append(bb, make([]byte, typeLength-len(bb))...)
+		}
 		return truncateConvertedValue(b, typeLength)
 	case ConvertToChar, ConvertToNChar:
 		s, _, err := types.LongText.Convert(val)


### PR DESCRIPTION
We were improperly dropping `CAST` node during comparison.

It might be fine in many cases, but it is definitely not for comparing `BINARY` column types.