### PR TITLE
remap `straight join` to `inner join`

### DIFF
--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -1693,6 +1693,26 @@ join uv d on d.u = c.x`,
 			},
 		},
 	},
+	{
+		name: "straight_join is inner join",
+		setup: []string{
+			"create table t1 (i int)",
+			"create table t2 (j int)",
+			"insert into t1 values (1), (2), (3)",
+			"insert into t2 values (2), (3), (4)",
+		},
+		tests: []JoinPlanTest{
+			{
+				// Test that a RangeHeapJoin won't be chosen over a LookupJoin with a multiple-column index.
+				q:     "select * from t1 straight_join t2 on i = j",
+				types: []plan.JoinType{plan.JoinTypeInner},
+				exp: []sql.Row{
+					{2, 2},
+					{3, 3},
+				},
+			},
+		},
+	},
 }
 
 func TestJoinPlanning(t *testing.T, harness Harness) {

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -140,6 +140,9 @@ func (b *Builder) buildJoin(inScope *scope, te *ast.JoinTableExpr) (outScope *sc
 		}
 	case ast.FullOuterJoinStr:
 		op = plan.JoinTypeFullOuter
+	case ast.StraightJoinStr:
+		// TODO: eventually we should support straight joins
+		op = plan.JoinTypeInner
 	default:
 		b.handleErr(fmt.Errorf("unknown join type: %s", te.Join))
 	}


### PR DESCRIPTION
This PR temporarily remaps `STRAIGHT_JOIN` operator to `INNER_JOIN` operator.

fixes https://github.com/dolthub/dolt/issues/7580