### PR TITLE
[memory] force mutating the editAcc AutoInc because tableEditor is unreliable

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -122,6 +122,40 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "GMS issue 2369",
+		SetUpScript: []string{
+			`CREATE TABLE table1 (
+	id int NOT NULL AUTO_INCREMENT,
+	name text,
+	parentId int DEFAULT NULL,
+	PRIMARY KEY (id),
+	CONSTRAINT myConstraint FOREIGN KEY (parentId) REFERENCES table1 (id) ON DELETE CASCADE
+)`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "INSERT INTO table1 (name, parentId) VALUES ('tbl1 row 1', NULL);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 1}}},
+			},
+			{
+				Query:    "INSERT INTO table1 (name, parentId) VALUES ('tbl1 row 2', 1);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 2}}},
+			},
+			{
+				Query:    "INSERT INTO table1 (name, parentId) VALUES ('tbl1 row 3', NULL);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 3}}},
+			},
+			{
+				Query: "select * from table1",
+				Expected: []sql.Row{
+					{1, "tbl1 row 1", nil},
+					{2, "tbl1 row 2", 1},
+					{3, "tbl1 row 3", nil},
+				},
+			},
+		},
+	},
+	{
 		Name: "GMS issue 2349",
 		SetUpScript: []string{
 			"CREATE TABLE table1 (id int NOT NULL AUTO_INCREMENT primary key, name text)",

--- a/memory/table.go
+++ b/memory/table.go
@@ -971,6 +971,7 @@ func (t *Table) tableEditorForRewrite(ctx *sql.Context, oldSchema, newSchema sql
 	tableData := tableUnderEdit.data.truncate(normalizeSchemaForRewrite(newSchema))
 	tableUnderEdit.data = tableData
 
+	// TODO: |editedTableAnd| and |ea| should have the same tableData reference
 	uniqIdxCols, prefixLengths := tableData.indexColsForTableEditor()
 	var editor sql.TableEditor = &tableEditor{
 		editedTable:   tableUnderEdit,


### PR DESCRIPTION
I can't figure a clean way to get the insert editor's edit accumulator and table editor data in sync when a self-referential foreign key initializes the session editor during analysis. So I just forced us to mutate the edit accumulator's auto increment id, which should prevent bugs of the kind we've been seeing. Zach might have a better understanding of how this should work.

fixes: https://github.com/dolthub/go-mysql-server/issues/2369