### PR TITLE
promote string lookup range types

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -6004,6 +6004,39 @@ where
 					{"ghi"},
 				},
 			},
+
+			{
+				Query: "select * from vt where v = cast('def' as char(6));",
+				Expected: []sql.Row{
+					{"def"},
+				},
+			},
+			{
+				Query: "select * from vt where v < cast('def' as char(6));",
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: "select * from vt where v > cast('def' as char(6));",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+			{
+				Query: "select * from vt where v <= cast('def' as char(6));",
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Query: "select * from vt where v >= cast('def' as char(6));",
+				Expected: []sql.Row{
+					{"def"},
+					{"ghi"},
+				},
+			},
 		},
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5898,7 +5898,7 @@ where
 		},
 	},
 	{
-		Name: "index lookup length shouldn't matter",
+		Name: "varchar primary key",
 		SetUpScript: []string{
 			"create table vt (v varchar(3) primary key);",
 			"insert into vt values ('abc'), ('def'), ('ghi');",
@@ -5999,6 +5999,115 @@ where
 			{
 				Skip:  true,
 				Query: `select * from vt where v >= 'def\0\0';`,
+				Expected: []sql.Row{
+					{"def"},
+					{"ghi"},
+				},
+			},
+		},
+	},
+	{
+		Name: "varbinary primary key",
+		SetUpScript: []string{
+			"create table vt (v varbinary(3) primary key);",
+			"insert into vt values ('abc'), ('def'), ('ghi');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select cast(v as char(3)) from vt where v = 'def';",
+				Expected: []sql.Row{
+					{"def"},
+				},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v < 'def';",
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v > 'def';",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v <= 'def';",
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v >= 'def';",
+				Expected: []sql.Row{
+					{"def"},
+					{"ghi"},
+				},
+			},
+
+			{
+				Query:    "select cast(v as char(3)) from vt where v = 'defdef';",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v < 'defdef';",
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v > 'defdef';",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v <= 'defdef';",
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Query: "select cast(v as char(3)) from vt where v >= 'defdef';",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+
+			// MySQL behavior around null bytes is strange
+			{
+				Skip:  true,
+				Query: `select cast(v as char(3)) from vt where v = 'def\0\0';`,
+				Expected: []sql.Row{
+					{"def"},
+				},
+			},
+			{
+				Skip:  true,
+				Query: `select cast(v as char(3)) from vt where v < 'def\0\0';`,
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: `select cast(v as char(3)) from vt where v > 'def\0\0';`,
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+			{
+				Query: `select cast(v as char(3)) from vt where v <= 'def\0\0';`,
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Skip:  true,
+				Query: `select cast(v as char(3)) from vt where v >= 'def\0\0';`,
 				Expected: []sql.Row{
 					{"def"},
 					{"ghi"},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5936,9 +5936,9 @@ where
 					{"ghi"},
 				},
 			},
-			
+
 			{
-				Query: "select * from vt where v = 'defdef';",
+				Query:    "select * from vt where v = 'defdef';",
 				Expected: []sql.Row{},
 			},
 			{
@@ -5968,17 +5968,16 @@ where
 				},
 			},
 
-
 			// MySQL behavior around null bytes is strange
 			{
-				Skip: true,
+				Skip:  true,
 				Query: `select * from vt where v = 'def\0\0';`,
 				Expected: []sql.Row{
 					{"def"},
 				},
 			},
 			{
-				Skip: true,
+				Skip:  true,
 				Query: `select * from vt where v < 'def\0\0';`,
 				Expected: []sql.Row{
 					{"abc"},
@@ -5998,7 +5997,7 @@ where
 				},
 			},
 			{
-				Skip: true,
+				Skip:  true,
 				Query: `select * from vt where v >= 'def\0\0';`,
 				Expected: []sql.Row{
 					{"def"},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5897,6 +5897,116 @@ where
 			},
 		},
 	},
+	{
+		Name: "index lookup length shouldn't matter",
+		SetUpScript: []string{
+			"create table vt (v varchar(3) primary key);",
+			"insert into vt values ('abc'), ('def'), ('ghi');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select * from vt where v = 'def';",
+				Expected: []sql.Row{
+					{"def"},
+				},
+			},
+			{
+				Query: "select * from vt where v < 'def';",
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: "select * from vt where v > 'def';",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+			{
+				Query: "select * from vt where v <= 'def';",
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Query: "select * from vt where v >= 'def';",
+				Expected: []sql.Row{
+					{"def"},
+					{"ghi"},
+				},
+			},
+			
+			{
+				Query: "select * from vt where v = 'defdef';",
+				Expected: []sql.Row{},
+			},
+			{
+				Query: "select * from vt where v < 'defdef';",
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Query: "select * from vt where v > 'defdef';",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+			{
+				Query: "select * from vt where v <= 'defdef';",
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Query: "select * from vt where v >= 'defdef';",
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+
+
+			// MySQL behavior around null bytes is strange
+			{
+				Skip: true,
+				Query: `select * from vt where v = 'def\0\0';`,
+				Expected: []sql.Row{
+					{"def"},
+				},
+			},
+			{
+				Skip: true,
+				Query: `select * from vt where v < 'def\0\0';`,
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: `select * from vt where v > 'def\0\0';`,
+				Expected: []sql.Row{
+					{"ghi"},
+				},
+			},
+			{
+				Query: `select * from vt where v <= 'def\0\0';`,
+				Expected: []sql.Row{
+					{"abc"},
+					{"def"},
+				},
+			},
+			{
+				Skip: true,
+				Query: `select * from vt where v >= 'def\0\0';`,
+				Expected: []sql.Row{
+					{"def"},
+					{"ghi"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -374,7 +374,11 @@ func (b *IndexBuilder) Ranges(ctx *Context) RangeCollection {
 		cets := b.idx.ColumnExpressionTypes()
 		emptyRange := make(Range, len(cets))
 		for i, cet := range cets {
-			emptyRange[i] = EmptyRangeColumnExpr(cet.Type.Promote())
+			typ := cet.Type
+			if _, ok := typ.(StringType); ok {
+				typ = typ.Promote()
+			}
+			emptyRange[i] = EmptyRangeColumnExpr(typ)
 		}
 		return RangeCollection{emptyRange}
 	}

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -44,8 +44,8 @@ func NewIndexBuilder(idx Index) *IndexBuilder {
 	colExprTypes := make(map[string]Type)
 	ranges := make(map[string][]RangeColumnExpr)
 	for _, cet := range idx.ColumnExpressionTypes() {
-		colExprTypes[strings.ToLower(cet.Expression)] = cet.Type
-		ranges[strings.ToLower(cet.Expression)] = []RangeColumnExpr{AllRangeColumnExpr(cet.Type)}
+		colExprTypes[strings.ToLower(cet.Expression)] = cet.Type.Promote()
+		ranges[strings.ToLower(cet.Expression)] = []RangeColumnExpr{AllRangeColumnExpr(cet.Type.Promote())}
 	}
 	return &IndexBuilder{
 		idx:          idx,
@@ -376,7 +376,7 @@ func (b *IndexBuilder) Ranges(ctx *Context) RangeCollection {
 		cets := b.idx.ColumnExpressionTypes()
 		emptyRange := make(Range, len(cets))
 		for i, cet := range cets {
-			emptyRange[i] = EmptyRangeColumnExpr(cet.Type)
+			emptyRange[i] = EmptyRangeColumnExpr(cet.Type.Promote())
 		}
 		return RangeCollection{emptyRange}
 	}
@@ -426,7 +426,7 @@ func (b *IndexBuilder) Ranges(ctx *Context) RangeCollection {
 		cets := b.idx.ColumnExpressionTypes()
 		emptyRange := make(Range, len(cets))
 		for i, cet := range cets {
-			emptyRange[i] = EmptyRangeColumnExpr(cet.Type)
+			emptyRange[i] = EmptyRangeColumnExpr(cet.Type.Promote())
 		}
 		return RangeCollection{emptyRange}
 	}

--- a/sql/range.go
+++ b/sql/range.go
@@ -223,6 +223,9 @@ func (rang Range) TryMerge(otherRange Range) (Range, bool, error) {
 			}
 		}
 	}
+	if indexToMerge == -1 {
+		return nil, false, fmt.Errorf("invalid index to merge")
+	}
 	mergedLastExpr, ok, err := rang[indexToMerge].TryUnion(otherRange[indexToMerge])
 	if err != nil || !ok {
 		return nil, false, err


### PR DESCRIPTION
When performing range lookups, we convert the key to the type of the column.
The conversion throws an error when the key doesn't fit within the type for the index.
The fix is to promote these (only for StringType) so the ranges fit.

There were issues with `type.Promote()` for all types.

Additionally, there are some inconsistencies with MySQL when performing these checks with NUL characters (`\0`). They are skipped tests for now.


related https://github.com/dolthub/dolt/issues/7588