### PR TITLE
optimize sql.HashOf

### DIFF
--- a/sql/cache_test.go
+++ b/sql/cache_test.go
@@ -177,3 +177,33 @@ func TestRowsCache(t *testing.T) {
 		require.True(freed)
 	})
 }
+
+func BenchmarkHashOf(b *testing.B) {
+	row := NewRow(1, "1")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sum, err := HashOf(row)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if sum != 11268758894040352165 {
+			b.Fatalf("got %v", sum)
+		}
+	}
+}
+
+func BenchmarkParallelHashOf(b *testing.B) {
+	row := NewRow(1, "1")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sum, err := HashOf(row)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if sum != 11268758894040352165 {
+				b.Fatalf("got %v", sum)
+			}
+		}
+	})
+}


### PR DESCRIPTION
* pool *xxhash.Digest objects
* use fmt.Fprintf to write to hash

benchmark stats

```
oos: linux
goarch: amd64
pkg: github.com/dolthub/go-mysql-server/sql
cpu: AMD Ryzen 9 7900 12-Core Processor
                  │     b1      │                 b2                  │
                  │   sec/op    │    sec/op     vs base               │
HashOf-24           79.65n ± 4%   70.86n ±  7%  -11.03% (p=0.002 n=6)
ParallelHashOf-24   10.47n ± 4%   11.85n ± 19%        ~ (p=0.368 n=6)
geomean             28.88n        28.98n         +0.32%

                  │     b1     │                   b2                   │
                  │    B/op    │    B/op     vs base                    │
HashOf-24           4.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
ParallelHashOf-24   4.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
geomean             4.000                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                  │     b1     │                   b2                   │
                  │ allocs/op  │ allocs/op   vs base                    │
HashOf-24           2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
ParallelHashOf-24   2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.002 n=6)
geomean             2.000                    ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```