### PR TITLE
exit early when `IF NOT EXISTS` and table exists

### DIFF
--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -647,6 +647,84 @@ var CreateTableScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name:        "if not exists option blocks",
+		SetUpScript: []string{
+			"create table t1 (i int, index (i));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "show create table t1",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int,\n" +
+						"  KEY `i` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
+				},
+			},
+
+			{
+				Query:    "create table if not exists t1 (i int, index (i));",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "show create table t1",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int,\n" +
+						"  KEY `i` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
+				},
+			},
+
+			{
+				Query:    "create table if not exists t1 (i int, index notthesamename (i));",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "show create table t1",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int,\n" +
+						"  KEY `i` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
+				},
+			},
+
+			{
+				Query:    "create table if not exists t1 (i int primary key, foreign key (i) references t1(i));",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "show create table t1",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int,\n" +
+						"  KEY `i` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
+				},
+			},
+
+			{
+				Query:    "create table if not exists t1 (i int, check (i > 10));",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "show create table t1",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int,\n" +
+						"  KEY `i` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin",
+					},
+				},
+			},
+		},
+	},
 }
 
 var CreateTableAutoIncrementTests = []ScriptTest{

--- a/memory/table.go
+++ b/memory/table.go
@@ -1907,8 +1907,7 @@ func (t *Table) createIndex(data *TableData, name string, columns []sql.IndexCol
 		}
 	}
 	if data.indexes[name] != nil {
-		// TODO: extract a standard error type for this
-		return nil, fmt.Errorf("Error: index already exists")
+		return nil, sql.ErrDuplicateKey.New(name)
 	}
 
 	exprs := make([]sql.Expression, len(columns))

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -784,7 +784,7 @@ func validateReadOnlyTransaction(ctx *sql.Context, a *Analyzer, n sql.Node, scop
 			return false
 		case *plan.CreateTable:
 			// MySQL explicitly blocks the creation of temporary tables in a read only transaction.
-			if n.Temporary() == plan.IsTempTable {
+			if n.Temporary() {
 				valid = false
 			}
 

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -460,6 +460,9 @@ var (
 	// ErrForeignKeyDepthLimit is returned when the CASCADE depth limit has been reached.
 	ErrForeignKeyDepthLimit = errors.NewKind("Foreign key cascade delete/update exceeds max depth of 15.")
 
+	// ErrDuplicateKey is returned when a duplicate key is defined on a table.
+	ErrDuplicateKey = errors.NewKind("Duplicate key name '%s'")
+
 	// ErrDuplicateEntry is returns when a duplicate entry is placed on an index such as a UNIQUE or a Primary Key.
 	ErrDuplicateEntry = errors.NewKind("Duplicate entry for key '%s'")
 

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -226,7 +226,7 @@ func (b *Builder) buildCreateTable(inScope *scope, c *ast.DDL) (outScope *scope)
 
 		selectScope := b.buildSelectStmt(inScope, c.OptSelect.Select)
 
-		outScope.node = plan.NewCreateTableSelect(database, c.Table.Name.String(), selectScope.node, tableSpec, plan.IfNotExistsOption(c.IfNotExists), plan.TempTableOption(c.Temporary))
+		outScope.node = plan.NewCreateTableSelect(database, c.Table.Name.String(), selectScope.node, tableSpec, c.IfNotExists, c.Temporary)
 		return outScope
 	}
 
@@ -263,10 +263,10 @@ func (b *Builder) buildCreateTable(inScope *scope, c *ast.DDL) (outScope *scope)
 
 	if c.OptSelect != nil {
 		selectScope := b.buildSelectStmt(inScope, c.OptSelect.Select)
-		outScope.node = plan.NewCreateTableSelect(database, c.Table.Name.String(), selectScope.node, tableSpec, plan.IfNotExistsOption(c.IfNotExists), plan.TempTableOption(c.Temporary))
+		outScope.node = plan.NewCreateTableSelect(database, c.Table.Name.String(), selectScope.node, tableSpec, c.IfNotExists, c.Temporary)
 	} else {
 		outScope.node = plan.NewCreateTable(
-			database, c.Table.Name.String(), plan.IfNotExistsOption(c.IfNotExists), plan.TempTableOption(c.Temporary), tableSpec)
+			database, c.Table.Name.String(), c.IfNotExists, c.Temporary, tableSpec)
 	}
 
 	return
@@ -401,7 +401,7 @@ func (b *Builder) buildCreateTableLike(inScope *scope, ct *ast.DDL) *scope {
 	}
 	database := b.resolveDb(qualifier)
 
-	outScope.node = plan.NewCreateTable(database, newTableName, plan.IfNotExistsOption(ct.IfNotExists), plan.TempTableOption(ct.Temporary), tableSpec)
+	outScope.node = plan.NewCreateTable(database, newTableName, ct.IfNotExists, ct.Temporary, tableSpec)
 	return outScope
 }
 

--- a/sql/rowexec/ddl_test.go
+++ b/sql/rowexec/ddl_test.go
@@ -42,7 +42,7 @@ func TestCreateTable(t *testing.T) {
 	})
 
 	ctx := newContext(pro)
-	require.NoError(createTable(t, ctx, db, "testTable", s, plan.IfNotExistsAbsent, plan.IsTempTableAbsent))
+	require.NoError(createTable(t, ctx, db, "testTable", s, false, false))
 
 	tables = db.Tables()
 
@@ -55,8 +55,8 @@ func TestCreateTable(t *testing.T) {
 		require.Equal("testTable", s.Source)
 	}
 
-	require.Error(createTable(t, ctx, db, "testTable", s, plan.IfNotExistsAbsent, plan.IsTempTableAbsent))
-	require.NoError(createTable(t, ctx, db, "testTable", s, plan.IfNotExists, plan.IsTempTableAbsent))
+	require.Error(createTable(t, ctx, db, "testTable", s, false, false))
+	require.NoError(createTable(t, ctx, db, "testTable", s, true, false))
 }
 
 func TestDropTable(t *testing.T) {
@@ -108,7 +108,7 @@ func TestDropTable(t *testing.T) {
 	require.False(ok)
 }
 
-func createTable(t *testing.T, ctx *sql.Context, db sql.Database, name string, schema sql.PrimaryKeySchema, ifNotExists plan.IfNotExistsOption, temporary plan.TempTableOption) error {
+func createTable(t *testing.T, ctx *sql.Context, db sql.Database, name string, schema sql.PrimaryKeySchema, ifNotExists, temporary bool) error {
 	c := plan.NewCreateTable(db, name, ifNotExists, temporary, &plan.TableSpec{Schema: schema})
 
 	rows, err := DefaultBuilder.Build(ctx, c, nil)

--- a/sql/rowexec/ddl_test.go
+++ b/sql/rowexec/ddl_test.go
@@ -71,9 +71,9 @@ func TestDropTable(t *testing.T) {
 		{Name: "c2", Type: types.Int32},
 	})
 
-	require.NoError(createTable(t, ctx, db, "testTable1", s, plan.IfNotExistsAbsent, plan.IsTempTableAbsent))
-	require.NoError(createTable(t, ctx, db, "testTable2", s, plan.IfNotExistsAbsent, plan.IsTempTableAbsent))
-	require.NoError(createTable(t, ctx, db, "testTable3", s, plan.IfNotExistsAbsent, plan.IsTempTableAbsent))
+	require.NoError(createTable(t, ctx, db, "testTable1", s, false, false))
+	require.NoError(createTable(t, ctx, db, "testTable2", s, false, false))
+	require.NoError(createTable(t, ctx, db, "testTable3", s, false, false))
 
 	d := plan.NewDropTable([]sql.Node{
 		plan.NewResolvedTable(memory.NewTable(db.BaseDatabase, "testTable1", s, db.GetForeignKeyCollection()), db, nil),


### PR DESCRIPTION
This PR addresses various issues related to `CREATE TABLE IF NOT EXISTS ...` queries.

Before, we simply ignored the table exists error, and continued creating indexes, foreign keys, and checks.
This led to errors when attempting to create indexes/foreign keys/checks that already exists.
Additionally, it would errorneously create indexes/foreng keys/checks that did exist.

The correct behavior is to do nothing if `IF NOT EXISTS` is specified and the table exists.

Also this contains some refactors and simplifications.

fixes https://github.com/dolthub/dolt/issues/7602