### PR TITLE
Remove the NewDefaultServer, which doesn't work for any included session implementation

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -19,14 +19,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 
 	sqle "github.com/dolthub/go-mysql-server"
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/server"
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -75,28 +73,12 @@ func main() {
 		Protocol: "tcp",
 		Address:  fmt.Sprintf("%s:%d", address, port),
 	}
-	s, err := server.NewServer(config, engine, sessionBuilder(pro), nil)
+	s, err := server.NewServer(config, engine, memory.NewSessionBuilder(pro), nil)
 	if err != nil {
 		panic(err)
 	}
 	if err = s.Start(); err != nil {
 		panic(err)
-	}
-}
-
-func sessionBuilder(pro *memory.DbProvider) server.SessionBuilder {
-	return func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, error) {
-		host := ""
-		user := ""
-		mysqlConnectionUser, ok := conn.UserData.(mysql_db.MysqlConnectionUser)
-		if ok {
-			host = mysqlConnectionUser.Host
-			user = mysqlConnectionUser.User
-		}
-
-		client := sql.Client{Address: host, User: user, Capabilities: conn.Capabilities}
-		baseSession := sql.NewBaseSessionWithClientServer(addr, client, conn.ConnectionID)
-		return memory.NewSession(baseSession, pro), nil
 	}
 }
 

--- a/memory/session.go
+++ b/memory/session.go
@@ -15,10 +15,13 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"github.com/dolthub/vitess/go/mysql"
 )
 
 type GlobalsMap = map[string]interface{}
@@ -48,6 +51,25 @@ func NewSession(baseSession *sql.BaseSession, provider sql.DatabaseProvider) *Se
 
 func SessionFromContext(ctx *sql.Context) *Session {
 	return ctx.Session.(*Session)
+}
+
+// NewSessionBuilder returns a session for the given in-memory database provider suitable to use in a test server
+// This can't be defined as server.SessionBuilder because importing it would create a circular dependency, 
+// but it's the same signature. 
+func NewSessionBuilder(pro *DbProvider) func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, error) {
+	return func(ctx context.Context, conn *mysql.Conn, addr string) (sql.Session, error) {
+		host := ""
+		user := ""
+		mysqlConnectionUser, ok := conn.UserData.(mysql_db.MysqlConnectionUser)
+		if ok {
+			host = mysqlConnectionUser.Host
+			user = mysqlConnectionUser.User
+		}
+
+		client := sql.Client{Address: host, User: user, Capabilities: conn.Capabilities}
+		baseSession := sql.NewBaseSessionWithClientServer(addr, client, conn.ConnectionID)
+		return NewSession(baseSession, pro), nil
+	}
 }
 
 type Transaction struct {

--- a/server/context.go
+++ b/server/context.go
@@ -34,19 +34,6 @@ type SessionBuilder func(ctx context.Context, conn *mysql.Conn, addr string) (sq
 // it can be disposed.
 type DoneFunc func()
 
-// DefaultSessionBuilder is a SessionBuilder that returns a base session.
-func DefaultSessionBuilder(ctx context.Context, c *mysql.Conn, addr string) (sql.Session, error) {
-	host := ""
-	user := ""
-	mysqlConnectionUser, ok := c.UserData.(mysql_db.MysqlConnectionUser)
-	if ok {
-		host = mysqlConnectionUser.Host
-		user = mysqlConnectionUser.User
-	}
-	client := sql.Client{Address: host, User: user, Capabilities: c.Capabilities}
-	return sql.NewBaseSessionWithClientServer(addr, client, c.ConnectionID), nil
-}
-
 // SessionManager is in charge of creating new sessions for the given
 // connections and keep track of which sessions are in each connection, so
 // they can be cancelled if the connection is closed.


### PR DESCRIPTION
Fixes https://github.com/dolthub/go-mysql-server/issues/2364

Added a `memory.NewSessionBuilder` method, now used in the example code.