### PR TITLE
implement `sql_mode = 'NO_AUTO_VALUE_ON_ZERO'`

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1266,6 +1266,89 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "sql_mode=NO_AUTO_VALUE_ON_ZERO",
+		SetUpScript: []string{
+			"set @old_sql_mode=@@sql_mode",
+			"set @@sql_mode='NO_AUTO_VALUE_ON_ZERO'",
+			"create table auto (i int auto_increment, index (i))",
+			"create table auto_pk (i int auto_increment primary key)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select auto_increment from information_schema.tables where table_name='auto' and table_schema=database()",
+				Expected: []sql.Row{
+					{nil},
+				},
+			},
+			{
+				Query: "insert into auto values (0), (0), (1-1)",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 3, InsertID: 0}},
+				},
+			},
+			{
+				Query: "select * from auto order by i",
+				Expected: []sql.Row{
+					{0},
+					{0},
+					{0},
+				},
+			},
+			{
+				Query: "select auto_increment from information_schema.tables where table_name='auto' and table_schema=database()",
+				Expected: []sql.Row{
+					{nil},
+				},
+			},
+			{
+				Query: "insert into auto values (1)",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1, InsertID: 1}},
+				},
+			},
+			{
+				Query: "select auto_increment from information_schema.tables where table_name='auto' and table_schema=database()",
+				Expected: []sql.Row{
+					{uint64(2)},
+				},
+			},
+
+			{
+				Query: "select auto_increment from information_schema.tables where table_name='auto_pk' and table_schema=database()",
+				Expected: []sql.Row{
+					{nil},
+				},
+			},
+			{
+				Query: "insert into auto_pk values (0), (1), (NULL), ()",
+				Expected: []sql.Row{
+					{types.NewOkResult(4)},
+				},
+			},
+			{
+				Query: "select * from auto_pk",
+				Expected: []sql.Row{
+					{0},
+					{1},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query: "select auto_increment from information_schema.tables where table_name='auto_pk' and table_schema=database()",
+				Expected: []sql.Row{
+					{uint64(4)},
+				},
+			},
+
+			{
+				// restore old sql_mode just in case
+				SkipResultsCheck: true,
+				Query: "set @@sql_mode=@old_sql_mode",
+			},
+		},
+	},
+	{
 		Name: "explicit DEFAULT",
 		SetUpScript: []string{
 			"CREATE TABLE t1(id int DEFAULT '2', dt datetime DEFAULT now());",

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1344,7 +1344,7 @@ var InsertScripts = []ScriptTest{
 			{
 				// restore old sql_mode just in case
 				SkipResultsCheck: true,
-				Query: "set @@sql_mode=@old_sql_mode",
+				Query:            "set @@sql_mode=@old_sql_mode",
 			},
 		},
 	},

--- a/sql/analyzer/validation_rules.go
+++ b/sql/analyzer/validation_rules.go
@@ -254,9 +254,7 @@ func validateGroupBy(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 	defer span.End()
 
 	// only enforce strict group by when this variable is set
-	if isStrict, err := checkSqlMode(ctx, "ONLY_FULL_GROUP_BY"); err != nil {
-		return n, transform.SameTree, err
-	} else if !isStrict {
+	if !sql.LoadSqlMode(ctx).ModeEnabled(sql.OnlyFullGroupBy) {
 		return n, transform.SameTree, nil
 	}
 

--- a/sql/sql_mode.go
+++ b/sql/sql_mode.go
@@ -21,7 +21,16 @@ import (
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 )
 
-const SqlModeSessionVar = "SQL_MODE"
+const (
+	SqlModeSessionVar = "SQL_MODE"
+
+	ANSI = "ANSI"
+	ANSIQuotes = "ANSI_QUOTES"
+	OnlyFullGroupBy = "ONLY_FULL_GROUP_BY"
+	NoAutoValueOnZero = "NO_AUTO_VALUE_ON_ZERO"
+	NoEngineSubstitution = "NO_ENGINE_SUBSTITUTION"
+	StrictTransTables = "STRICT_TRANS_TABLES"
+)
 
 // SqlMode encodes the SQL mode string and provides methods for querying the enabled modes.
 type SqlMode struct {
@@ -67,7 +76,7 @@ func NewSqlModeFromString(sqlModeString string) *SqlMode {
 // AnsiQuotes returns true if the ANSI_QUOTES SQL mode is enabled. Note that the ANSI mode is a compound mode that
 // includes ANSI_QUOTES and other options, so if ANSI or ANSI_QUOTES is enabled, this function will return true.
 func (s *SqlMode) AnsiQuotes() bool {
-	return s.ModeEnabled("ansi_quotes") || s.ModeEnabled("ansi")
+	return s.ModeEnabled(ANSIQuotes) || s.ModeEnabled(ANSI)
 }
 
 // ModeEnabled returns true if |mode| was explicitly specified in the SQL_MODE string that was used to

--- a/sql/sql_mode.go
+++ b/sql/sql_mode.go
@@ -24,12 +24,12 @@ import (
 const (
 	SqlModeSessionVar = "SQL_MODE"
 
-	ANSI = "ANSI"
-	ANSIQuotes = "ANSI_QUOTES"
-	OnlyFullGroupBy = "ONLY_FULL_GROUP_BY"
-	NoAutoValueOnZero = "NO_AUTO_VALUE_ON_ZERO"
+	ANSI                 = "ANSI"
+	ANSIQuotes           = "ANSI_QUOTES"
+	OnlyFullGroupBy      = "ONLY_FULL_GROUP_BY"
+	NoAutoValueOnZero    = "NO_AUTO_VALUE_ON_ZERO"
 	NoEngineSubstitution = "NO_ENGINE_SUBSTITUTION"
-	StrictTransTables = "STRICT_TRANS_TABLES"
+	StrictTransTables    = "STRICT_TRANS_TABLES"
 )
 
 // SqlMode encodes the SQL mode string and provides methods for querying the enabled modes.


### PR DESCRIPTION
This PR implements the sql_mode NO_AUTO_VALUE_ON_ZERO.
This makes it so that 0 values (not NULL) do not increment the auto_increment counter.

MySQL Docs: https://dev.mysql.com/doc/refman/8.3/en/example-auto-increment.html

fixes https://github.com/dolthub/dolt/issues/7600