### PR TITLE
Bug fix: Set non-boolean system variable enum values to 'ON' or 'OFF'

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3871,6 +3871,24 @@ func TestVariables(t *testing.T, harness Harness) {
 			Query:    "SELECT @@GLOBAL.select_into_buffer_size",
 			Expected: []sql.Row{{9002}},
 		},
+		{
+			// For boolean types, OFF/ON is converted
+			Query:    "SET @@GLOBAL.activate_all_roles_on_login = 'ON'",
+			Expected: []sql.Row{{}},
+		},
+		{
+			Query:    "SELECT @@GLOBAL.activate_all_roles_on_login",
+			Expected: []sql.Row{{1}},
+		},
+		{
+			// For non-boolean types, OFF/ON is not converted
+			Query:    "SET @@GLOBAL.delay_key_write = 'OFF'",
+			Expected: []sql.Row{{}},
+		},
+		{
+			Query:    "SELECT @@GLOBAL.delay_key_write",
+			Expected: []sql.Row{{"OFF"}},
+		},
 	} {
 		t.Run(assertion.Query, func(t *testing.T) {
 			TestQueryWithContext(t, ctx1, engine, harness, assertion.Query, assertion.Expected, nil, nil)

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -244,9 +244,13 @@ func (b *Builder) simplifySetExpr(name *ast.ColName, varScope ast.SetScope, val 
 			return nil, false
 		}
 
+		if sysVarType == nil {
+			return nil, false
+		}
+
 		// If we're targeting a boolean type (likely if we see an INT8 sys var),
 		// convert a few common string values to boolean values.
-		if sysVarType != nil && sysVarType.Type() == sqltypes.Int8 {
+		if sysVarType.Type() == sqltypes.Int8 {
 			switch strings.ToLower(setVal) {
 			case ast.KeywordString(ast.ON):
 				return expression.NewLiteral(true, types.Boolean), true
@@ -257,10 +261,6 @@ func (b *Builder) simplifySetExpr(name *ast.ColName, varScope ast.SetScope, val 
 			case ast.KeywordString(ast.FALSE):
 				return expression.NewLiteral(false, types.Boolean), true
 			}
-		}
-
-		if sysVarType == nil {
-			return nil, false
 		}
 
 		enum, _, err := sysVarType.Convert(setVal)

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/dolthub/vitess/go/sqltypes"
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -243,16 +244,19 @@ func (b *Builder) simplifySetExpr(name *ast.ColName, varScope ast.SetScope, val 
 			return nil, false
 		}
 
-		switch strings.ToLower(setVal) {
-		case ast.KeywordString(ast.ON):
-			return expression.NewLiteral(true, types.Boolean), true
-		case ast.KeywordString(ast.TRUE):
-			return expression.NewLiteral(true, types.Boolean), true
-		case ast.KeywordString(ast.OFF):
-			return expression.NewLiteral(false, types.Boolean), true
-		case ast.KeywordString(ast.FALSE):
-			return expression.NewLiteral(false, types.Boolean), true
-		default:
+		// If we're targeting a boolean type (likely if we see an INT8 sys var),
+		// convert a few common string values to boolean values.
+		if sysVarType != nil && sysVarType.Type() == sqltypes.Int8 {
+			switch strings.ToLower(setVal) {
+			case ast.KeywordString(ast.ON):
+				return expression.NewLiteral(true, types.Boolean), true
+			case ast.KeywordString(ast.TRUE):
+				return expression.NewLiteral(true, types.Boolean), true
+			case ast.KeywordString(ast.OFF):
+				return expression.NewLiteral(false, types.Boolean), true
+			case ast.KeywordString(ast.FALSE):
+				return expression.NewLiteral(false, types.Boolean), true
+			}
 		}
 
 		if sysVarType == nil {


### PR DESCRIPTION
We were automatically converting `ON` and `OFF` values to to `true` and `false` when setting a system variable, which made it impossible to set system variables to those enum values. For example:

```sql
SET @@GLOBAL.gtid_mode='ON';
Variable 'gtid_mode' can't be set to the value of 'true'
```