### PR TITLE
fix dbName not being used in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ func main() {
 }
 
 func createTestDatabase() *memory.DbProvider {
-	db := memory.NewDatabase("mydb")
+	db := memory.NewDatabase(dbName)
 	db.BaseDatabase.EnablePrimaryKeyIndexes()
 
 	pro := memory.NewDBProvider(db)

--- a/_example/main.go
+++ b/_example/main.go
@@ -83,7 +83,7 @@ func main() {
 }
 
 func createTestDatabase() *memory.DbProvider {
-	db := memory.NewDatabase("mydb")
+	db := memory.NewDatabase(dbName)
 	db.BaseDatabase.EnablePrimaryKeyIndexes()
 
 	pro := memory.NewDBProvider(db)


### PR DESCRIPTION
This PR makes sure that `dbName` in the example is actually being used, instead of having a hardcoded "mydb" in `createTestDatabase`.

fixes #2402 