### PR TITLE
Improve handling of unsigned and decimal types in JSON

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1698,9 +1698,14 @@ func TestComplexIndexQueriesPrepared(t *testing.T, harness Harness) {
 	}
 }
 
-func TestJsonScriptsPrepared(t *testing.T, harness Harness) {
+func TestJsonScriptsPrepared(t *testing.T, harness Harness, skippedTests []string) {
 	harness.Setup(setup.MydbData)
 	for _, script := range queries.JsonScripts {
+		for _, skippedTest := range skippedTests {
+			if strings.Contains(script.Name, skippedTest) {
+				t.Skip()
+			}
+		}
 		TestScriptPrepared(t, harness, script)
 	}
 }
@@ -4638,8 +4643,13 @@ func TestNullRanges(t *testing.T, harness Harness) {
 	}
 }
 
-func TestJsonScripts(t *testing.T, harness Harness) {
+func TestJsonScripts(t *testing.T, harness Harness, skippedTests []string) {
 	for _, script := range queries.JsonScripts {
+		for _, skippedTest := range skippedTests {
+			if strings.Contains(script.Name, skippedTest) {
+				t.Skip()
+			}
+		}
 		TestScript(t, harness, script)
 	}
 }

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -807,7 +807,8 @@ func TestDateParse(t *testing.T) {
 }
 
 func TestJsonScripts(t *testing.T) {
-	enginetest.TestJsonScripts(t, enginetest.NewDefaultMemoryHarness())
+	var skippedTests []string = nil
+	enginetest.TestJsonScripts(t, enginetest.NewDefaultMemoryHarness(), skippedTests)
 }
 
 func TestShowTableStatus(t *testing.T) {

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -15,8 +15,9 @@
 package queries
 
 import (
-	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
+
+	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -15,9 +15,10 @@
 package queries
 
 import (
-	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/shopspring/decimal"
+
+	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -71,7 +71,7 @@ var JsonScripts = []ScriptTest{
 		},
 	},
 	{
-		Name: "types survive round trips into tables",
+		Name: "types survive round-trip into tables",
 		SetUpScript: []string{
 			"CREATE TABLE xy (x bigint primary key, y JSON)",
 			`INSERT INTO xy VALUES (0, CAST(CAST(1.2 AS DECIMAL) AS JSON));`,

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -15,10 +15,8 @@
 package queries
 
 import (
-	querypb "github.com/dolthub/vitess/go/vt/proto/query"
-	"github.com/shopspring/decimal"
-
 	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
+	querypb "github.com/dolthub/vitess/go/vt/proto/query"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -108,9 +106,9 @@ var JsonScripts = []ScriptTest{
 		Name: "json_object preserves types",
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select JSON_OBJECT('a', CAST(12.34 AS DECIMAL(4, 2)));",
+				Query: `select JSON_TYPE(JSON_EXTRACT(JSON_OBJECT('a', CAST(12.34 AS DECIMAL(4, 2))), "$.a"));`,
 				Expected: []sql.Row{
-					{types.JSONDocument{Val: map[string]interface{}{"a": decimal.New(1234, -2)}}},
+					{"DECIMAL"},
 				},
 			},
 		},

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -146,7 +146,7 @@ var JsonScripts = []ScriptTest{
 		},
 	},
 	{
-		Name: "unsigned tinyint survives round-trip into table",
+		Name: "unsigned tinyint is still unsigned after round-trip into table",
 		SetUpScript: []string{
 			"CREATE TABLE xy (x bigint primary key, y JSON, z tinyint unsigned)",
 			`INSERT INTO xy VALUES (0, null, 0);`,

--- a/enginetest/server_engine_test.go
+++ b/enginetest/server_engine_test.go
@@ -97,8 +97,6 @@ func TestServerPreparedStatements(t *testing.T) {
 		{
 			name: "read json-wrapped decimal values",
 			setup: []string{
-				"create database test_db;",
-				"use test_db;",
 				"create table json_tbl (id int primary key, j json);",
 				"insert into json_tbl values (0, cast(213.4 as json));",
 				`insert into json_tbl values (1, cast("213.4" as json));`,
@@ -158,8 +156,6 @@ func TestServerPreparedStatements(t *testing.T) {
 		{
 			name: "prepared inserts with big ints",
 			setup: []string{
-				"create database test_db;",
-				"use test_db;",
 				"create table signed_tbl (i bigint signed);",
 				"create table unsigned_tbl (i bigint unsigned);",
 			},
@@ -287,7 +283,14 @@ func TestServerPreparedStatements(t *testing.T) {
 			require.NoError(t, cerr)
 			defer conn.Close()
 
-			for _, stmt := range test.setup {
+			commonSetup := []string{
+				"create database test_db;",
+				"use test_db;",
+			}
+			commonTeardown := []string{
+				"drop database test_db",
+			}
+			for _, stmt := range append(commonSetup, test.setup...) {
 				_, err := conn.Exec(stmt)
 				require.NoError(t, err)
 			}
@@ -317,6 +320,10 @@ func TestServerPreparedStatements(t *testing.T) {
 					require.NoError(t, err)
 					require.True(t, ok)
 				})
+			}
+			for _, stmt := range append(commonTeardown) {
+				_, err := conn.Exec(stmt)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/sql/expression/function/json/json_type.go
+++ b/sql/expression/function/json/json_type.go
@@ -16,11 +16,11 @@ package json
 
 import (
 	"fmt"
-	"math"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/shopspring/decimal"
+	"math"
 )
 
 // JSONType (json_val)
@@ -91,6 +91,10 @@ func (j JSONType) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return "NULL", nil
 	case bool:
 		return "BOOLEAN", nil
+	case int64:
+		return "INTEGER", nil
+	case uint64:
+		return "UNSIGNED INTEGER", nil
 	case float64:
 		if conv, ok := j.JSON.(*expression.Convert); ok {
 			typ := conv.Child.Type()
@@ -108,9 +112,6 @@ func (j JSONType) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	case string:
 		if conv, ok := j.JSON.(*expression.Convert); ok {
 			typ := conv.Child.Type()
-			if types.IsDecimal(typ) {
-				return "DECIMAL", nil
-			}
 			if types.IsDatetimeType(typ) {
 				return "DATETIME", nil
 			}
@@ -126,6 +127,8 @@ func (j JSONType) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return "ARRAY", nil
 	case map[string]interface{}:
 		return "OBJECT", nil
+	case decimal.Decimal:
+		return "DECIMAL", nil
 	default:
 		return "OPAQUE", nil
 	}

--- a/sql/expression/function/json/json_type.go
+++ b/sql/expression/function/json/json_type.go
@@ -16,11 +16,13 @@ package json
 
 import (
 	"fmt"
+	"math"
+
+	"github.com/shopspring/decimal"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
-	"github.com/shopspring/decimal"
-	"math"
 )
 
 // JSONType (json_val)

--- a/sql/expression/function/json/json_type_test.go
+++ b/sql/expression/function/json/json_type_test.go
@@ -16,15 +16,15 @@ package json
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/types"
-	"github.com/shopspring/decimal"
 	"strings"
 	"testing"
 
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 func TestJSONType(t *testing.T) {

--- a/sql/expression/function/json/json_type_test.go
+++ b/sql/expression/function/json/json_type_test.go
@@ -16,6 +16,8 @@ package json
 
 import (
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/shopspring/decimal"
 	"strings"
 	"testing"
 
@@ -54,6 +56,16 @@ func TestJSONType(t *testing.T) {
 		{
 			f:   f1,
 			row: sql.Row{1},
+			err: true,
+		},
+		{
+			f:   f1,
+			row: sql.Row{1.5},
+			err: true,
+		},
+		{
+			f:   f1,
+			row: sql.Row{decimal.New(15, -1)},
 			err: true,
 		},
 
@@ -103,6 +115,47 @@ func TestJSONType(t *testing.T) {
 		{
 			f:   f1,
 			row: sql.Row{`{"aa": 1, "bb": 2, "c": 3}`},
+			exp: "OBJECT",
+		},
+
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{nil}},
+			exp: "NULL",
+		},
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{uint64(1)}},
+			exp: "UNSIGNED INTEGER",
+		},
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{int64(1)}},
+			exp: "INTEGER",
+		},
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{true}},
+			exp: "BOOLEAN",
+		},
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{123.456}},
+			exp: "DOUBLE",
+		},
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{decimal.New(123456, -3)}},
+			exp: "DECIMAL",
+		},
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{[]interface{}{}}},
+			exp: "ARRAY",
+		},
+		{
+			f:   f1,
+			row: sql.Row{types.JSONDocument{map[string]interface{}{}}},
 			exp: "OBJECT",
 		},
 	}

--- a/sql/expression/function/json/json_value.go
+++ b/sql/expression/function/json/json_value.go
@@ -17,11 +17,11 @@ package json
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/src-d/go-errors.v1"
 	"strings"
 
 	"github.com/dolthub/jsonpath"
 	"github.com/dolthub/vitess/go/sqltypes"
+	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"

--- a/sql/expression/function/json/json_value.go
+++ b/sql/expression/function/json/json_value.go
@@ -96,7 +96,7 @@ func (j *JsonValue) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	jsonData, err := GetJSONOrCoercibleString(js)
+	jsonData, err := GetJSONFromWrapperOrCoercibleString(js)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,11 @@ func (j *JsonValue) String() string {
 
 var InvalidJsonArgument = errors.NewKind("invalid data type for JSON data in argument 1 to function json_value; a JSON string or JSON type is required")
 
-func GetJSONOrCoercibleString(js interface{}) (jsonData interface{}, err error) {
+// GetJSONFromWrapperOrCoercibleString takes a valid argument for JSON functions (either a JSON wrapper type or a string)
+// and unwraps the JSON, or coerces the string into JSON. The return value can return any type that can be stored in
+// a JSON column, not just maps. For a complete list, see
+// https://dev.mysql.com/doc/refman/8.3/en/json-attribute-functions.html#function_json-type
+func GetJSONFromWrapperOrCoercibleString(js interface{}) (jsonData interface{}, err error) {
 	// The first parameter can be either JSON or a string.
 	switch jsType := js.(type) {
 	case string:

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -189,7 +189,7 @@ func (b *BaseBuilder) buildJSONTable(ctx *sql.Context, n *plan.JSONTable, row sq
 		return &jsonTableRowIter{}, nil
 	}
 
-	jsonData, err := json.GetJSONOrCoercibleString(data)
+	jsonData, err := json.GetJSONFromWrapperOrCoercibleString(data)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -17,7 +17,6 @@ package rowexec
 import (
 	"errors"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -32,6 +31,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -15,9 +15,9 @@
 package rowexec
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -185,25 +185,15 @@ func (b *BaseBuilder) buildJSONTable(ctx *sql.Context, n *plan.JSONTable, row sq
 		return nil, err
 	}
 
-	if jd, ok := data.(types.JSONDocument); ok {
-		data, err = jd.JSONString()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	strData, _, err := types.LongBlob.Convert(data)
-	if err != nil {
-		return nil, fmt.Errorf("invalid data type for JSON data in argument 1 to function json_table; a JSON string or JSON type is required")
-	}
-	if strData == nil {
+	if data == nil {
 		return &jsonTableRowIter{}, nil
 	}
 
-	var jsonData interface{}
-	if err = json.Unmarshal(strData.([]byte), &jsonData); err != nil {
+	jsonData, err := json.GetJSONOrCoercibleString(data)
+	if err != nil {
 		return nil, err
 	}
+
 	jsonPathData, err := jsonpath.JsonPathLookup(jsonData, n.RootPath)
 	if err != nil {
 		jsonPathData = []interface{}{}

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -17,11 +17,11 @@ package types
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/shopspring/decimal"
 	"reflect"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -84,6 +84,10 @@ func (t JsonType) Convert(v interface{}) (doc interface{}, inRange sql.ConvertIn
 		return JSONDocument{Val: uint64(v)}, sql.InRange, nil
 	case uint64:
 		return JSONDocument{Val: v}, sql.InRange, nil
+	case float32:
+		return JSONDocument{Val: float64(v)}, sql.InRange, nil
+	case float64:
+		return JSONDocument{Val: v}, sql.InRange, nil
 	case decimal.Decimal:
 		return JSONDocument{Val: v}, sql.InRange, nil
 	default:

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -17,6 +17,7 @@ package types
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/shopspring/decimal"
 	"reflect"
 
 	"github.com/dolthub/vitess/go/sqltypes"
@@ -67,6 +68,24 @@ func (t JsonType) Convert(v interface{}) (doc interface{}, inRange sql.ConvertIn
 		if err != nil {
 			return nil, sql.OutOfRange, sql.ErrInvalidJson.New(err.Error())
 		}
+	case int8:
+		return JSONDocument{Val: int64(v)}, sql.InRange, nil
+	case int16:
+		return JSONDocument{Val: int64(v)}, sql.InRange, nil
+	case int32:
+		return JSONDocument{Val: int64(v)}, sql.InRange, nil
+	case int64:
+		return JSONDocument{Val: v}, sql.InRange, nil
+	case uint8:
+		return JSONDocument{Val: uint64(v)}, sql.InRange, nil
+	case uint16:
+		return JSONDocument{Val: uint64(v)}, sql.InRange, nil
+	case uint32:
+		return JSONDocument{Val: uint64(v)}, sql.InRange, nil
+	case uint64:
+		return JSONDocument{Val: v}, sql.InRange, nil
+	case decimal.Decimal:
+		return JSONDocument{Val: v}, sql.InRange, nil
 	default:
 		// if |v| can be marshalled, it contains
 		// a valid JSON document representation

--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/shopspring/decimal"
 	"io"
 	"reflect"
 	"sort"
@@ -314,6 +315,7 @@ func writeMarshalledValue(writer io.Writer, val interface{}) error {
 		writer.Write([]byte{'"'})
 		return nil
 	case json.Marshaler:
+		decimal.MarshalJSONWithoutQuotes = true
 		bytes, err := val.MarshalJSON()
 		if err != nil {
 			return err

--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -3,12 +3,13 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/shopspring/decimal"
 	"io"
 	"reflect"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 var isEscaped = [256]bool{}

--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -31,6 +31,8 @@ func init() {
 	escapeSeq[uint8('\t')] = []byte("\\t")
 	escapeSeq[uint8('"')] = []byte("\\\"")
 	escapeSeq[uint8('\\')] = []byte("\\\\")
+
+	decimal.MarshalJSONWithoutQuotes = true
 }
 
 type NoCopyBuilder struct {


### PR DESCRIPTION
Fixes https://github.com/dolthub/go-mysql-server/issues/2391

MySQL's JSON type differs from standard JSON in some important ways. It supports types not supported in standard JSON, such as separate types for integers and floats, an unsigned int type, and a decimal type.

Prior to this PR, we would convert values to JSON by using the `encodings/json` package to marshall the value to a JSON string and then unmarshall it to a go map. This is not only slow, but it's incorrect for these additional types.

The main purpose of this PR is to add special handling for these types that allow them to be stored in JSON documents. We also avoid generating and parsing JSON in places where it's not actually necessary, and fix bugs where decimals get incorrectly converted into strings, or unsigned ints get converted into signed ints. 

Finally, this fixes an issue where we send incorrect bytes for JSON-wrapped decimal values along the wire.