### PR TITLE
[no-release-notes] Ensure the injected bind variables in tests use the same byte values as the variables they replace, in order to be parsed the same.

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -532,6 +532,12 @@ func injectBindVarsAndPrepare(
 				skipTypeConv = true
 				return false, nil
 			}
+
+			// Ensure that the bind variable has the same byte sequence as the original value.
+			// This is important to ensure that it will get parsed the same way.
+			// (Example: the value "1e-1" should be parsed as the float 0.1, not as a decimal value.)
+			bindVar.Value = n.Val
+
 			varName := fmt.Sprintf("v%d", bindCnt+1)
 			bindVars[varName] = bindVar
 			n.Type = sqlparser.ValArg

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -815,6 +815,11 @@ func TestJsonScripts(t *testing.T) {
 	enginetest.TestJsonScripts(t, enginetest.NewDefaultMemoryHarness(), skippedTests)
 }
 
+func TestJsonScriptsPrepared(t *testing.T) {
+	var skippedTests []string = nil
+	enginetest.TestJsonScriptsPrepared(t, enginetest.NewDefaultMemoryHarness(), skippedTests)
+}
+
 func TestShowTableStatus(t *testing.T) {
 	enginetest.TestShowTableStatus(t, enginetest.NewDefaultMemoryHarness())
 }


### PR DESCRIPTION
This fixes an issue with prepared tests where a value like "1e-1" would be correctly parsed as a float, but when it gets replaced with an injected bind variable, the bind variable would have the byte sequence "0.1", causing it to then get parsed as a decimal.