### PR TITLE
[no-release-notes] deleting unused regexes

### DIFF
--- a/sql/planbuilder/errors.go
+++ b/sql/planbuilder/errors.go
@@ -15,8 +15,6 @@
 package planbuilder
 
 import (
-	"regexp"
-
 	"gopkg.in/src-d/go-errors.v1"
 )
 
@@ -26,16 +24,6 @@ var (
 	errInvalidSortOrder = errors.NewKind("invalid sort order: %s")
 
 	ErrPrimaryKeyOnNullField = errors.NewKind("All parts of PRIMARY KEY must be NOT NULL")
-
-	// TODO: We parse table options in Vitess, but we return them to GMS as a single string, so GMS has to reparse
-	//       table options using these regexes. It would be cleaner for Vitess to parse them into structures so that
-	//       GMS could just pull out the data it needs, without having to regex it out from a single string. Because
-	//       of how the original quotes are lost and single quotes are always used, we also currently lose some info
-	//       about the original statement – notably, we can't parse comments that contain single quotes because Vitess
-	//       strips the original double quotes and sends the comment string to GMS wrapped in single quotes.
-	tableCharsetOptionRegex   = regexp.MustCompile(`(?i)(DEFAULT)?\s+CHARACTER\s+SET((\s*=?\s*)|\s+)([A-Za-z0-9_]+)`)
-	tableCollationOptionRegex = regexp.MustCompile(`(?i)(DEFAULT)?\s+COLLATE((\s*=?\s*)|\s+)([A-Za-z0-9_]+)`)
-	tableCommentOptionRegex   = regexp.MustCompile(`(?i)\s+COMMENT((\s*=?\s*)|\s+)('([^']+)')`)
 
 	// ErrUnionSchemasDifferentLength is returned when the two sides of a
 	// UNION do not have the same number of columns in their schemas.


### PR DESCRIPTION
This PR includes changes to parse table options in vitess
https://github.com/dolthub/go-mysql-server/pull/2401

As a result, these regexes are no longer needed.