### PR TITLE
Adding system variable `innodb_autoinc_lock_mode`

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5559,6 +5559,7 @@ Select * from (
 		Expected: []sql.Row{
 			{"block_encryption_mode", "aes-128-ecb"},
 			{"gtid_mode", "OFF"},
+			{"innodb_autoinc_lock_mode", int64(2)},
 			{"offline_mode", int64(0)},
 			{"pseudo_slave_mode", int64(0)},
 			{"rbr_exec_mode", "STRICT"},

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -352,6 +352,33 @@ var VariableQueries = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "innodb autoinc lock mode",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `select @@innodb_autoinc_lock_mode;`,
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query: `select @@global.innodb_autoinc_lock_mode;`,
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Skip: true,
+				Query: `select @@session.innodb_autoinc_lock_mode;`,
+				ExpectedErr: sql.ErrSystemVariableGlobalOnly,
+			},
+			{
+				Query: `set @@innodb_autoinc_lock_mode = 1;`,
+				ExpectedErr: sql.ErrSystemVariableReadOnly,
+			},
+		},
+	},
 	// User variables
 	{
 		Name: "set user var",

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -353,7 +353,7 @@ var VariableQueries = []ScriptTest{
 		},
 	},
 	{
-		Name: "innodb autoinc lock mode",
+		Name:        "innodb autoinc lock mode",
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -369,12 +369,12 @@ var VariableQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip: true,
-				Query: `select @@session.innodb_autoinc_lock_mode;`,
+				Skip:        true,
+				Query:       `select @@session.innodb_autoinc_lock_mode;`,
 				ExpectedErr: sql.ErrSystemVariableGlobalOnly,
 			},
 			{
-				Query: `set @@innodb_autoinc_lock_mode = 1;`,
+				Query:       `set @@innodb_autoinc_lock_mode = 1;`,
 				ExpectedErr: sql.ErrSystemVariableReadOnly,
 			},
 		},

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -1023,8 +1023,8 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		// TODO: lower bound should be 0: https://github.com/dolthub/dolt/issues/7634
-		Type:              types.NewSystemIntType("innodb_autoinc_lock_mode", 2, 2, false),
-		Default:           int64(2),
+		Type:    types.NewSystemIntType("innodb_autoinc_lock_mode", 2, 2, false),
+		Default: int64(2),
 	},
 	// Row locking is currently not supported. This variable is provided for 3p tools, and we always return the
 	// Lowest value allowed by MySQL, which is 1. If you attempt to set this value to anything other than 1, errors ensue.

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -1017,6 +1017,15 @@ var systemVars = map[string]sql.SystemVariable{
 		Type:              types.NewSystemBoolType("inmemory_joins"),
 		Default:           int8(0),
 	},
+	"innodb_autoinc_lock_mode": &sql.MysqlSystemVariable{
+		Name:              "innodb_autoinc_lock_mode",
+		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Global),
+		Dynamic:           false,
+		SetVarHintApplies: false,
+		// TODO: lower bound should be 0: https://github.com/dolthub/dolt/issues/7634
+		Type:              types.NewSystemIntType("innodb_autoinc_lock_mode", 2, 2, false),
+		Default:           int64(2),
+	},
 	// Row locking is currently not supported. This variable is provided for 3p tools, and we always return the
 	// Lowest value allowed by MySQL, which is 1. If you attempt to set this value to anything other than 1, errors ensue.
 	"innodb_lock_wait_timeout": &sql.MysqlSystemVariable{

--- a/sql/variables/system_variables_test.go
+++ b/sql/variables/system_variables_test.go
@@ -51,6 +51,8 @@ var newUnknown = &sql.MysqlSystemVariable{
 }
 
 func TestInitSystemVars(t *testing.T) {
+	defer InitSystemVariables()
+
 	tests := []struct {
 		varName string
 		varVal  interface{}
@@ -87,6 +89,8 @@ func TestInitSystemVars(t *testing.T) {
 }
 
 func TestInitSystemVariablesWithDefaults(t *testing.T) {
+	defer InitSystemVariables()
+
 	tests := []struct {
 		name             string
 		persistedGlobals []sql.SystemVariable


### PR DESCRIPTION
We currently only support `innodb_autoinc_lock_mode = 2`, not `0` or `1`.

MySQL Docs:
https://dev.mysql.com/doc/refman/8.0/en/innodb-auto-increment-handling.html

related: https://github.com/dolthub/dolt/issues/7634