### PR TITLE
fix show create database to actually show charset/collation

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -6267,6 +6267,41 @@ where
 			},
 		},
 	},
+	{
+		Name: "test show create database",
+		SetUpScript: []string{
+			"create database def_db;",
+			"create database latin1_db character set latin1;",
+			"create database bin_db charset binary;",
+			"create database mb3_db collate utf8mb3_general_ci;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show create database def_db",
+				Expected: []sql.Row{
+					{"def_db", "CREATE DATABASE `def_db` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin */"},
+				},
+			},
+			{
+				Query: "show create database latin1_db",
+				Expected: []sql.Row{
+					{"latin1_db", "CREATE DATABASE `latin1_db` /*!40100 DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci */"},
+				},
+			},
+			{
+				Query: "show create database bin_db",
+				Expected: []sql.Row{
+					{"bin_db", "CREATE DATABASE `bin_db` /*!40100 DEFAULT CHARACTER SET binary COLLATE binary */"},
+				},
+			},
+			{
+				Query: "show create database mb3_db",
+				Expected: []sql.Row{
+					{"mb3_db", "CREATE DATABASE `mb3_db` /*!40100 DEFAULT CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci */"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -1489,9 +1489,10 @@ func (b *Builder) buildDBDDL(inScope *scope, c *ast.DBDDL) (outScope *scope) {
 		}
 		for _, cc := range c.CharsetCollate {
 			ccType := strings.ToLower(cc.Type)
-			if ccType == "character set" {
+			switch ccType {
+			case "character set", "charset":
 				charsetStr = cc.Value
-			} else if ccType == "collate" {
+			case "collate":
 				collationStr = cc.Value
 			}
 		}

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -330,13 +330,19 @@ func (b *BaseBuilder) buildShowCreateDatabase(ctx *sql.Context, n *plan.ShowCrea
 		buf.WriteString("/*!32312 IF NOT EXISTS*/ ")
 	}
 
+	// TODO: grab collation from server?
+	collId := sql.Collation_Default
+	if collDb, ok := n.Database().(sql.CollatedDatabase); ok {
+		collId = collDb.GetCollation(ctx)
+	}
+
 	buf.WriteRune('`')
 	buf.WriteString(name)
 	buf.WriteRune('`')
 	buf.WriteString(fmt.Sprintf(
 		" /*!40100 DEFAULT CHARACTER SET %s COLLATE %s */",
-		sql.Collation_Default.CharacterSet().String(),
-		sql.Collation_Default.String(),
+		collId.CharacterSet().String(),
+		collId.String(),
 	))
 
 	return sql.RowsToRowIter(


### PR DESCRIPTION
This PR fixes the `SHOW CREATE DATABASE ...` statement to actually show the charset/collation that the db is under instead of always default. 
Additionally, this PR parses the `charset` database option, instead of ignoring it like before.

partially fixes: https://github.com/dolthub/dolt/issues/7651