### PR TITLE
Bug fix: Allow JSON scalar comparison between int64 and float64

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7713,6 +7713,11 @@ Select * from (
 		Expected: []sql.Row{{true}},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/7656
+		Query:    "select json_contains(cast('[1, 2]' as json), cast(cast(1 as signed) as json));",
+		Expected: []sql.Row{{true}},
+	},
+	{
 		Query: "select one_pk.pk, one_pk.c1 from one_pk join two_pk on one_pk.c1 = two_pk.c1 order by two_pk.c1",
 		Expected: []sql.Row{
 			{0, 0},

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -276,6 +276,8 @@ func containsJSONNumber(a float64, b interface{}) (bool, error) {
 	switch b := b.(type) {
 	case float64:
 		return a == b, nil
+	case int64:
+		return a == float64(b), nil
 	default:
 		return false, nil
 	}


### PR DESCRIPTION
When comparing JSON values, numbers may be represented internally as an int64 or float64, but our comparison code wasn't casting an int64 to a float64 in order to compare it with a float64 value. 

Fixes https://github.com/dolthub/dolt/issues/7656