### PR TITLE
[stats] costed index scan perf

### DIFF
--- a/enginetest/queries/stats_queries.go
+++ b/enginetest/queries/stats_queries.go
@@ -35,7 +35,7 @@ var StatisticsQueries = []ScriptTest{
 				SkipResultCheckOnServerEngine: true, // the non-interface types are not identified over the wire result
 				Query:                         "SELECT * FROM information_schema.column_statistics",
 				Expected: []sql.Row{
-					{"mydb", "t", "i", stats.NewStatistic(3, 3, 0, 24, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Int64}, []*stats.Bucket{
+					{"mydb", "t", "i", stats.NewStatistic(3, 3, 0, 24, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Int64}, []sql.HistogramBucket{
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(1)}, nil, nil),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(2)}, nil, nil),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(3)}, nil, nil),
@@ -60,7 +60,7 @@ var StatisticsQueries = []ScriptTest{
 				SkipResultCheckOnServerEngine: true, // the non-interface types are not identified over the wire result
 				Query:                         "SELECT * FROM information_schema.column_statistics",
 				Expected: []sql.Row{
-					{"mydb", "t", "i", stats.NewStatistic(40, 40, 1, 0, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Int64}, []*stats.Bucket{
+					{"mydb", "t", "i", stats.NewStatistic(40, 40, 1, 0, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Int64}, []sql.HistogramBucket{
 						stats.NewHistogramBucket(20, 20, 0, 1, sql.Row{float64(50)}, nil, nil),
 						stats.NewHistogramBucket(20, 20, 0, 1, sql.Row{float64(80)}, nil, nil),
 					}, sql.IndexClassDefault, nil),
@@ -89,13 +89,13 @@ var StatisticsQueries = []ScriptTest{
 				SkipResultCheckOnServerEngine: true, // the non-interface types are not identified over the wire result
 				Query:                         "SELECT * FROM information_schema.column_statistics",
 				Expected: []sql.Row{
-					{"mydb", "t", "i", stats.NewStatistic(3, 3, 0, 48, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Int64}, []*stats.Bucket{
+					{"mydb", "t", "i", stats.NewStatistic(3, 3, 0, 48, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Int64}, []sql.HistogramBucket{
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(1)}, nil, []sql.Row{}),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(2)}, nil, []sql.Row{}),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(3)}, nil, []sql.Row{}),
 					}, sql.IndexClassDefault, nil),
 					},
-					{"mydb", "t", "j", stats.NewStatistic(3, 3, 0, 48, time.Now(), sql.NewStatQualifier("mydb", "t", "j"), []string{"j"}, []sql.Type{types.Int64}, []*stats.Bucket{
+					{"mydb", "t", "j", stats.NewStatistic(3, 3, 0, 48, time.Now(), sql.NewStatQualifier("mydb", "t", "j"), []string{"j"}, []sql.Type{types.Int64}, []sql.HistogramBucket{
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(4)}, nil, []sql.Row{}),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(5)}, nil, []sql.Row{}),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{int64(6)}, nil, []sql.Row{}),
@@ -117,7 +117,7 @@ var StatisticsQueries = []ScriptTest{
 				SkipResultCheckOnServerEngine: true, // the non-interface types are not identified over the wire result
 				Query:                         "SELECT * FROM information_schema.column_statistics",
 				Expected: []sql.Row{
-					{"mydb", "t", "i", stats.NewStatistic(4, 4, 0, 32, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Float64}, []*stats.Bucket{
+					{"mydb", "t", "i", stats.NewStatistic(4, 4, 0, 32, time.Now(), sql.NewStatQualifier("mydb", "t", "primary"), []string{"i"}, []sql.Type{types.Float64}, []sql.HistogramBucket{
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{float64(1.25)}, nil, []sql.Row{}),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{float64(7.5)}, nil, []sql.Row{}),
 						stats.NewHistogramBucket(1, 1, 0, 1, sql.Row{float64(10.5)}, nil, []sql.Row{}),

--- a/memory/stats.go
+++ b/memory/stats.go
@@ -139,7 +139,7 @@ func (s *StatsProv) estimateStats(ctx *sql.Context, table sql.Table, keys map[st
 		}
 		offset := len(keyVals) / bucketCnt
 		perBucket := int(rowCount) / bucketCnt
-		buckets := make([]*stats.Bucket, bucketCnt)
+		buckets := make([]sql.HistogramBucket, bucketCnt)
 		for i := range buckets {
 			var upperBound []interface{}
 			for _, v := range keyVals[i*offset] {

--- a/sql/stats/filter.go
+++ b/sql/stats/filter.go
@@ -251,7 +251,7 @@ func PrefixLte(buckets []sql.HistogramBucket, types []sql.Type, val interface{})
 	return PrefixIsNotNull(ret)
 }
 
-func PrefixLteHist(h sql.Histogram, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
+func PrefixLteHist(h []sql.HistogramBucket, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
 	var searchErr error
 	idx := sort.Search(len(h), func(i int) bool {
 		// lowest index that func is true
@@ -265,7 +265,7 @@ func PrefixLteHist(h sql.Histogram, target sql.Row, cmp func(sql.Row, sql.Row) (
 	return idx, searchErr
 }
 
-func PrefixLtHist(h sql.Histogram, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
+func PrefixLtHist(h []sql.HistogramBucket, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
 	var searchErr error
 	idx := sort.Search(len(h), func(i int) bool {
 		// lowest index that func is true
@@ -279,7 +279,7 @@ func PrefixLtHist(h sql.Histogram, target sql.Row, cmp func(sql.Row, sql.Row) (i
 	return idx, searchErr
 }
 
-func PrefixGtHist(h sql.Histogram, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
+func PrefixGtHist(h []sql.HistogramBucket, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
 	var searchErr error
 	idx := sort.Search(len(h), func(i int) bool {
 		// lowest index that func is true
@@ -294,7 +294,7 @@ func PrefixGtHist(h sql.Histogram, target sql.Row, cmp func(sql.Row, sql.Row) (i
 	return idx, searchErr
 }
 
-func PrefixGteHist(h sql.Histogram, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
+func PrefixGteHist(h []sql.HistogramBucket, target sql.Row, cmp func(sql.Row, sql.Row) (int, error)) (int, error) {
 	var searchErr error
 	idx := sort.Search(len(h), func(i int) bool {
 		// lowest index that func is true

--- a/sql/stats/filter_test.go
+++ b/sql/stats/filter_test.go
@@ -27,63 +27,63 @@ import (
 var xFds = sql.NewTablescanFDs(sql.NewColSet(1, 2, 3), []sql.ColSet{sql.NewColSet(1)}, nil, sql.NewColSet(1, 2, 3))
 
 // NULL, 0,5,10,15,20, 5 row buckets of duplicates, two buckets for each value
-var x1Stat = &Statistic{Hist: buckets_x_1, Typs: []sql.Type{types.Int64}, fds: xFds, colSet: sql.NewColSet(1)}
-var buckets_x_1 = []*Bucket{
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{5}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{5}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{10}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{10}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{15}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{15}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{20}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{20}, BoundCnt: 5},
+var x1Stat = &Statistic{Hist: buckets_x_1, Typs: []sql.Type{types.Int64}, Fds: xFds, Colset: sql.NewColSet(1)}
+var buckets_x_1 = sql.Histogram{
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{5}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{5}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{10}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{10}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{15}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{15}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{20}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{20}, BoundCnt: 5},
 }
 
 // staggered buckets, 2 vals per, half is last bound half is current bound
-var x2Stat = &Statistic{Hist: buckets_x_2, Typs: []sql.Type{types.Int64}, fds: xFds, colSet: sql.NewColSet(1)}
-var buckets_x_2 = []*Bucket{
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 3, BoundVal: []interface{}{5}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{10}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{15}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{20}, BoundCnt: 2},
+var x2Stat = &Statistic{Hist: buckets_x_2, Typs: []sql.Type{types.Int64}, Fds: xFds, Colset: sql.NewColSet(1)}
+var buckets_x_2 = sql.Histogram{
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 3, BoundVal: []interface{}{5}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{10}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{15}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{20}, BoundCnt: 2},
 }
 
 var xyFds = sql.NewTablescanFDs(sql.NewColSet(1, 2, 3), []sql.ColSet{sql.NewColSet(1, 2)}, nil, sql.NewColSet(1, 2, 3))
 
-var xy1Stat = &Statistic{Hist: buckets_xy_1, Typs: []sql.Type{types.Int64, types.Int64}, fds: xyFds, colSet: sql.NewColSet(1, 2)}
+var xy1Stat = &Statistic{Hist: buckets_xy_1, Typs: []sql.Type{types.Int64, types.Int64}, Fds: xyFds, Colset: sql.NewColSet(1, 2)}
 
-var buckets_xy_1 = []*Bucket{
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 1}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 1}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 4}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 4}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{1, nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{1, nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{1, 1}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{1, 1}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{1, 3}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{3, 3}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{3, 3}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{4, 3}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{4, 3}, BoundCnt: 5},
+var buckets_xy_1 = sql.Histogram{
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 1}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 1}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 4}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, 4}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{1, nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{1, nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{1, 1}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{1, 1}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{1, 3}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{3, 3}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{3, 3}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{4, 3}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 0, BoundVal: []interface{}{4, 3}, BoundCnt: 5},
 }
 
-var xy2Stat = &Statistic{Hist: buckets_xy_2, Typs: []sql.Type{types.Int64, types.Int64}, fds: xyFds, colSet: sql.NewColSet(1, 2)}
+var xy2Stat = &Statistic{Hist: buckets_xy_2, Typs: []sql.Type{types.Int64, types.Int64}, Fds: xyFds, Colset: sql.NewColSet(1, 2)}
 
-var buckets_xy_2 = []*Bucket{
-	{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, nil}, BoundCnt: 5},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 5, BoundVal: []interface{}{nil, 1}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 5, BoundVal: []interface{}{nil, 4}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 5, BoundVal: []interface{}{1, nil}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{1, 1}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{1, 3}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{2, 3}, BoundCnt: 2},
-	{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{3, 3}, BoundCnt: 2},
+var buckets_xy_2 = sql.Histogram{
+	&Bucket{RowCnt: 5, DistinctCnt: 1, NullCnt: 5, BoundVal: []interface{}{nil, nil}, BoundCnt: 5},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 5, BoundVal: []interface{}{nil, 1}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 5, BoundVal: []interface{}{nil, 4}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 5, BoundVal: []interface{}{1, nil}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{1, 1}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{1, 3}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{2, 3}, BoundCnt: 2},
+	&Bucket{RowCnt: 5, DistinctCnt: 2, NullCnt: 0, BoundVal: []interface{}{3, 3}, BoundCnt: 2},
 }
 
 func TestPrefixKey(t *testing.T) {
@@ -605,12 +605,12 @@ func TestPrefixIsNull(t *testing.T) {
 			cols.AddRange(1, len(tt.typs))
 			colset := sql.NewColSetFromIntSet(cols)
 			fds := sql.NewTablescanFDs(colset, []sql.ColSet{colset}, nil, colset)
-			var buckets []*Bucket
+			var buckets []sql.HistogramBucket
 			for _, v := range tt.vals {
 				buckets = append(buckets, &Bucket{BoundVal: v})
 			}
 
-			statistic := &Statistic{Hist: buckets, Typs: tt.typs, fds: fds, colSet: colset}
+			statistic := &Statistic{Hist: buckets, Typs: tt.typs, Fds: fds, Colset: colset}
 
 			res, err := PrefixIsNull(statistic.Histogram())
 			require.NoError(t, err)
@@ -647,12 +647,12 @@ func TestPrefixIsNotNull(t *testing.T) {
 		colset := sql.NewColSetFromIntSet(cols)
 		fds := sql.NewTablescanFDs(colset, []sql.ColSet{colset}, nil, colset)
 
-		var buckets []*Bucket
+		var buckets []sql.HistogramBucket
 		for _, v := range tt.vals {
 			buckets = append(buckets, &Bucket{BoundVal: v})
 		}
 
-		statistic := &Statistic{Hist: buckets, Typs: tt.typs, fds: fds, colSet: colset}
+		statistic := &Statistic{Hist: buckets, Typs: tt.typs, Fds: fds, Colset: colset}
 
 		t.Run(fmt.Sprintf("is not null bound: %#v", tt.vals), func(t *testing.T) {
 			res, err := PrefixIsNotNull(statistic.Histogram())
@@ -707,12 +707,12 @@ func TestPrefixGt(t *testing.T) {
 		colset := sql.NewColSetFromIntSet(cols)
 		fds := sql.NewTablescanFDs(colset, []sql.ColSet{colset}, nil, colset)
 
-		var buckets []*Bucket
+		var buckets []sql.HistogramBucket
 		for _, v := range tt.vals {
 			buckets = append(buckets, &Bucket{BoundVal: v})
 		}
 
-		statistic := &Statistic{Hist: buckets, Typs: tt.typs, fds: fds, colSet: colset}
+		statistic := &Statistic{Hist: buckets, Typs: tt.typs, Fds: fds, Colset: colset}
 
 		t.Run(fmt.Sprintf("GT bound: %d", tt.key), func(t *testing.T) {
 			res, err := PrefixGt(statistic.Histogram(), statistic.Types(), tt.key)
@@ -766,12 +766,12 @@ func TestPrefixGte(t *testing.T) {
 		colset := sql.NewColSetFromIntSet(cols)
 		fds := sql.NewTablescanFDs(colset, []sql.ColSet{colset}, nil, colset)
 
-		var buckets []*Bucket
+		var buckets []sql.HistogramBucket
 		for _, v := range tt.vals {
 			buckets = append(buckets, &Bucket{BoundVal: v})
 		}
 
-		statistic := &Statistic{Hist: buckets, Typs: tt.typs, fds: fds, colSet: colset}
+		statistic := &Statistic{Hist: buckets, Typs: tt.typs, Fds: fds, Colset: colset}
 
 		t.Run(fmt.Sprintf("GTE bound: %v", tt.key), func(t *testing.T) {
 			res, err := PrefixGte(statistic.Histogram(), statistic.Types(), tt.key)
@@ -839,12 +839,12 @@ func TestPrefixLt(t *testing.T) {
 		colset := sql.NewColSetFromIntSet(cols)
 		fds := sql.NewTablescanFDs(colset, []sql.ColSet{colset}, nil, colset)
 
-		var buckets []*Bucket
+		var buckets []sql.HistogramBucket
 		for _, v := range tt.vals {
 			buckets = append(buckets, &Bucket{BoundVal: v})
 		}
 
-		statistic := &Statistic{Hist: buckets, Typs: tt.typs, fds: fds, colSet: colset}
+		statistic := &Statistic{Hist: buckets, Typs: tt.typs, Fds: fds, Colset: colset}
 
 		t.Run(fmt.Sprintf("LT bound: %v", tt.key), func(t *testing.T) {
 
@@ -913,12 +913,12 @@ func TestPrefixLte(t *testing.T) {
 		colset := sql.NewColSetFromIntSet(cols)
 		fds := sql.NewTablescanFDs(colset, []sql.ColSet{colset}, nil, colset)
 
-		var buckets []*Bucket
+		var buckets []sql.HistogramBucket
 		for _, v := range tt.vals {
 			buckets = append(buckets, &Bucket{BoundVal: v})
 		}
 
-		statistic := &Statistic{Hist: buckets, Typs: tt.typs, fds: fds, colSet: colset}
+		statistic := &Statistic{Hist: buckets, Typs: tt.typs, Fds: fds, Colset: colset}
 
 		t.Run(fmt.Sprintf("LTE bound: %v", tt.key), func(t *testing.T) {
 			res, err := PrefixLte(statistic.Histogram(), statistic.Types(), tt.key)
@@ -945,7 +945,7 @@ func TestUpdateCounts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		buckets := make([]*Bucket, len(tt.vals))
+		buckets := make([]sql.HistogramBucket, len(tt.vals))
 		for i := range buckets {
 			buckets[i] = &Bucket{RowCnt: tt.vals[i], DistinctCnt: tt.vals[i], NullCnt: tt.vals[i]}
 		}

--- a/sql/stats/helper.go
+++ b/sql/stats/helper.go
@@ -41,7 +41,7 @@ func InterpolateNewCounts(from, to sql.Statistic) sql.Statistic {
 
 	filterSelectivity := float64(to.DistinctCount()) / float64(from.DistinctCount())
 
-	newHist := make([]*Bucket, len(from.Histogram()))
+	newHist := make([]sql.HistogramBucket, len(from.Histogram()))
 	for i, h := range from.Histogram() {
 		newMcvs := make([]uint64, len(h.McvCounts()))
 		for i, cnt := range h.McvCounts() {

--- a/sql/stats/join.go
+++ b/sql/stats/join.go
@@ -87,8 +87,8 @@ func Join(s1, s2 sql.Statistic, prefixCnt int, debug bool) (sql.Statistic, error
 // buckets to estimate the join cardinality. Most common values (mcvs) adjust
 // the estimates to account for outlier keys that are a disproportionately
 // high fraction of the index.
-func joinAlignedStats(left, right sql.Histogram, cmp func(sql.Row, sql.Row) (int, error)) ([]*Bucket, error) {
-	var newBuckets []*Bucket
+func joinAlignedStats(left, right []sql.HistogramBucket, cmp func(sql.Row, sql.Row) (int, error)) ([]sql.HistogramBucket, error) {
+	var newBuckets []sql.HistogramBucket
 	newCnt := uint64(0)
 	for i := range left {
 		l := left[i]
@@ -176,8 +176,8 @@ func AlignBuckets(h1, h2 sql.Histogram, lBound1, lBound2 sql.Row, s1Types, s2Typ
 
 	var leftRes sql.Histogram
 	var rightRes sql.Histogram
-	var leftStack []sql.HistogramBucket
-	var rightStack []sql.HistogramBucket
+	var leftStack sql.Histogram
+	var rightStack sql.Histogram
 	var nextL sql.HistogramBucket
 	var nextR sql.HistogramBucket
 	var keyCmp int
@@ -512,7 +512,7 @@ func mergeMcvs(mcvs1, mcvs2 []sql.Row, mcvCnts1, mcvCnts2 []uint64, cmp func(sql
 
 // mergeOverlappingBuckets folds bins with one element into the previous
 // bucket when the bound keys match.
-func mergeOverlappingBuckets(h sql.Histogram, types []sql.Type) (sql.Histogram, error) {
+func mergeOverlappingBuckets(h []sql.HistogramBucket, types []sql.Type) ([]sql.HistogramBucket, error) {
 	cmp := func(l, r sql.Row) (int, error) {
 		for i := 0; i < len(types); i++ {
 			cmp, err := types[i].Compare(l[i], r[i])


### PR DESCRIPTION
Histogram copying is expensive. Instead pass and mutate references. We have to use a different struct type to load stats from JSON in order to support histogram interface generalization.

related Dolt-side: https://github.com/dolthub/dolt/pull/7666