### PR TITLE
Adding test for preparing `time.Time` types

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -623,7 +623,7 @@ func (e *Engine) bindExecuteQueryNode(ctx *sql.Context, query string, eq *plan.E
 			}
 			bindings[fmt.Sprintf("v%d", i+1)], err = sqltypes.BuildBindVariable(val)
 			if err != nil {
-				return nil, nil
+				return nil, err
 			}
 		} else {
 			bindings[fmt.Sprintf("v%d", i)] = sqltypes.StringBindVariable(name.String())

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7035,6 +7035,15 @@ var PreparedScriptTests = []ScriptTest{
 					{types.NewOkResult(1)},
 				},
 			},
+			{
+				// TODO: should also select t when we fix that
+				Query: "select d, dt, ts from t",
+				Expected: []sql.Row{
+					{time.Date(2001, time.February, 3, 0, 0, 0, 0, time.UTC), nil, nil},
+					{nil, time.Date(2001, time.February, 3, 12, 34, 56, 0, time.UTC), nil},
+					{nil, nil, time.Date(2001, time.February, 3, 12, 34, 56, 0, time.UTC)},
+				},
+			},
 		},
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7011,30 +7011,30 @@ var PreparedScriptTests = []ScriptTest{
 			},
 			{
 				SkipResultCheckOnServerEngine: true,
-				Query: "execute sd using @d;",
+				Query:                         "execute sd using @d;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
 				SkipResultCheckOnServerEngine: true,
-				Query: "execute sdt using @dt;",
+				Query:                         "execute sdt using @dt;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
 				// types.Timespan not supported as bindvar
-				Skip:  true,
+				Skip:                          true,
 				SkipResultCheckOnServerEngine: true,
-				Query: "execute st using @t;",
+				Query:                         "execute st using @t;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
 				SkipResultCheckOnServerEngine: true,
-				Query: "execute sts using @ts;",
+				Query:                         "execute sts using @ts;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -6969,6 +6969,75 @@ var PreparedScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "prepare with time type binding",
+		SetUpScript: []string{
+			"create table t (d date, dt datetime, t time, ts timestamp);",
+			"set @d = date('2001-02-03');",
+			"set @dt = datetime('2001-02-03 12:34:56');",
+			"set @t = time('12:34:56');",
+			"set @ts = timestamp('2001-02-03 12:34:56');",
+			"prepare s from 'select ?';",
+			"prepare sd from 'insert into t(d) values(?)';",
+			"prepare sdt from 'insert into t(dt) values(?)';",
+			"prepare st from 'insert into t(t) values(?)';",
+			"prepare sts from 'insert into t(ts) values(?)';",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "execute s using @d;",
+				Expected: []sql.Row{
+					{"2001-02-03"},
+				},
+			},
+			{
+				Query: "execute s using @dt;",
+				Expected: []sql.Row{
+					{"2001-02-03 12:34:56 +0000 UTC"},
+				},
+			},
+			{
+				// types.Timespan not supported as bindvar
+				Skip: true,
+				Query: "execute s using @t;",
+				Expected: []sql.Row{
+					{"12:34:56"},
+				},
+			},
+			{
+				Query: "execute s using @ts;",
+				Expected: []sql.Row{
+					{"2001-02-03 12:34:56 +0000 UTC"},
+				},
+			},
+			{
+				Query: "execute sd using @d;",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "execute sdt using @dt;",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				// types.Timespan not supported as bindvar
+				Skip: true,
+				Query: "execute st using @t;",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "execute sts using @ts;",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+		},
+	},
+	{
 		Name: "prepare insert",
 		SetUpScript: []string{
 			"set @a = 123",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7073,6 +7073,8 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
+				// TODO: server engine busted?
+				SkipResultCheckOnServerEngine: true,
 				Query: "select * from t",
 				Expected: []sql.Row{
 					{"123.45"},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7060,22 +7060,23 @@ var PreparedScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
+				Skip: true,
 				Query: "execute s using @d;",
 				Expected: []sql.Row{
 					{"123.45"},
 				},
 			},
 			{
+				Skip: true,
 				SkipResultCheckOnServerEngine: true,
-				Query:                         "execute sd using @d;",
+				Query: "execute sd using @d;",
 				Expected: []sql.Row{
 					{"123.45"},
 				},
 			},
 			{
-				// TODO: server engine busted?
-				SkipResultCheckOnServerEngine: true,
-				Query:                         "select * from t",
+				Skip: true,
+				Query: "select * from t",
 				Expected: []sql.Row{
 					{"123.45"},
 				},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7054,7 +7054,7 @@ var PreparedScriptTests = []ScriptTest{
 		Name: "prepare with decimal type binding",
 		SetUpScript: []string{
 			"create table t (d decimal);",
-			"set @d = cast(123.45 as Decimal);",
+			"set @d = cast(123.45 as Decimal(5,2));",
 			"prepare s from 'select ?';",
 			"prepare sd from 'insert into t values(?)';",
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7010,12 +7010,14 @@ var PreparedScriptTests = []ScriptTest{
 				},
 			},
 			{
+				SkipResultCheckOnServerEngine: true,
 				Query: "execute sd using @d;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
+				SkipResultCheckOnServerEngine: true,
 				Query: "execute sdt using @dt;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
@@ -7024,12 +7026,14 @@ var PreparedScriptTests = []ScriptTest{
 			{
 				// types.Timespan not supported as bindvar
 				Skip: true,
+				SkipResultCheckOnServerEngine: true,
 				Query: "execute st using @t;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
+				SkipResultCheckOnServerEngine: true,
 				Query: "execute sts using @ts;",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7075,7 +7075,7 @@ var PreparedScriptTests = []ScriptTest{
 			{
 				// TODO: server engine busted?
 				SkipResultCheckOnServerEngine: true,
-				Query: "select * from t",
+				Query:                         "select * from t",
 				Expected: []sql.Row{
 					{"123.45"},
 				},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7051,6 +7051,36 @@ var PreparedScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "prepare with decimal type binding",
+		SetUpScript: []string{
+			"create table t (d decimal);",
+			"set @d = cast(123.45 as Decimal);",
+			"prepare s from 'select ?';",
+			"prepare sd from 'insert into t values(?)';",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "execute s using @d;",
+				Expected: []sql.Row{
+					{"123.45"},
+				},
+			},
+			{
+				SkipResultCheckOnServerEngine: true,
+				Query: "execute sd using @d;",
+				Expected: []sql.Row{
+					{"123.45"},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{"123.45"},
+				},
+			},
+		},
+	},
+	{
 		Name: "prepare insert",
 		SetUpScript: []string{
 			"set @a = 123",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240325235243-65f4774a8706
+	github.com/dolthub/vitess v0.0.0-20240329174652-793079af6e34
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240329213029-ba711b142ceb
+	github.com/dolthub/vitess v0.0.0-20240329220943-04e0d9e0dcf3
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2
@@ -42,5 +42,7 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )
+
+replace github.com/dolthub/vitess => ../vitess
 
 go 1.22

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240329174652-793079af6e34
+	github.com/dolthub/vitess v0.0.0-20240329211246-17daf8f07820
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2
@@ -15,7 +15,7 @@ require (
 	github.com/lestrrat-go/strftime v1.0.4
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
-	github.com/shopspring/decimal v1.2.0
+	github.com/shopspring/decimal v1.3.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/otel v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240329211246-17daf8f07820
+	github.com/dolthub/vitess v0.0.0-20240329213029-ba711b142ceb
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240329220943-04e0d9e0dcf3
+	github.com/dolthub/vitess v0.0.0-20240329223145-3e53a7bee1da
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,4 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )
 
-replace github.com/dolthub/vitess => ../vitess
-
 go 1.22

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240325235243-65f4774a8706 h1:nlmIlkMuCXzp/h5hoKh4mWW5ePqRlhwlJJQRLMtN3B4=
-github.com/dolthub/vitess v0.0.0-20240325235243-65f4774a8706/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240329174652-793079af6e34 h1:FxNpCc9c0IDVasfXT8NPav/RUb/gGtGNXjvyfDQxH/8=
+github.com/dolthub/vitess v0.0.0-20240329174652-793079af6e34/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240329211246-17daf8f07820 h1:pt0Rt1TiGi41XYVOMXKHJ/JoxNDCAzK2rZYFUJckHes=
-github.com/dolthub/vitess v0.0.0-20240329211246-17daf8f07820/go.mod h1:Td2nYCFY254M1ewOUxZMmIbeDowyimBu6sU6zryUlJU=
+github.com/dolthub/vitess v0.0.0-20240329213029-ba711b142ceb h1:+5I052Hhw8wG4i7dfMpDDtPUvCA4vCc3JRLiXhZV2Bw=
+github.com/dolthub/vitess v0.0.0-20240329213029-ba711b142ceb/go.mod h1:Xy89nzEyIwlMCiFWOJPmlnORpDFz5wFgEdYGfUwbIQ0=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
+github.com/dolthub/vitess v0.0.0-20240329220943-04e0d9e0dcf3 h1:gzlMfGaN0vj+M2Tkv9pREGDMOpBCNFt8C4gWKSx2ew4=
+github.com/dolthub/vitess v0.0.0-20240329220943-04e0d9e0dcf3/go.mod h1:Xy89nzEyIwlMCiFWOJPmlnORpDFz5wFgEdYGfUwbIQ0=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240329174652-793079af6e34 h1:FxNpCc9c0IDVasfXT8NPav/RUb/gGtGNXjvyfDQxH/8=
-github.com/dolthub/vitess v0.0.0-20240329174652-793079af6e34/go.mod h1:IwjNXSQPymrja5pVqmfnYdcy7Uv7eNJNBPK/MEh9OOw=
+github.com/dolthub/vitess v0.0.0-20240329211246-17daf8f07820 h1:pt0Rt1TiGi41XYVOMXKHJ/JoxNDCAzK2rZYFUJckHes=
+github.com/dolthub/vitess v0.0.0-20240329211246-17daf8f07820/go.mod h1:Td2nYCFY254M1ewOUxZMmIbeDowyimBu6sU6zryUlJU=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -268,8 +268,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
-github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
-github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9X
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
 github.com/dolthub/vitess v0.0.0-20240329220943-04e0d9e0dcf3 h1:gzlMfGaN0vj+M2Tkv9pREGDMOpBCNFt8C4gWKSx2ew4=
 github.com/dolthub/vitess v0.0.0-20240329220943-04e0d9e0dcf3/go.mod h1:Xy89nzEyIwlMCiFWOJPmlnORpDFz5wFgEdYGfUwbIQ0=
+github.com/dolthub/vitess v0.0.0-20240329223145-3e53a7bee1da h1:EZJqfIEHLV/eRtlxMhep2Jj/JpHSnZBiKFFLFbnmsSo=
+github.com/dolthub/vitess v0.0.0-20240329223145-3e53a7bee1da/go.mod h1:Xy89nzEyIwlMCiFWOJPmlnORpDFz5wFgEdYGfUwbIQ0=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240329213029-ba711b142ceb h1:+5I052Hhw8wG4i7dfMpDDtPUvCA4vCc3JRLiXhZV2Bw=
-github.com/dolthub/vitess v0.0.0-20240329213029-ba711b142ceb/go.mod h1:Xy89nzEyIwlMCiFWOJPmlnORpDFz5wFgEdYGfUwbIQ0=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=


### PR DESCRIPTION
This PR adds tests for using `time.Time`, some tests have to be skipped because we don't support Timespan correctly.

companion pr: ~~https://github.com/dolthub/vitess/pull/327~~ https://github.com/dolthub/vitess/pull/328

test for https://github.com/dolthub/dolt/issues/7665