### PR TITLE
use `@@session.collation_server` during `create database ...`

### DIFF
--- a/enginetest/queries/charset_collation_engine.go
+++ b/enginetest/queries/charset_collation_engine.go
@@ -453,6 +453,118 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 		},
 	},
 	{
+		Name: "setting charset/collation sets the other",
+		Queries: []CharsetCollationEngineTestQuery{
+			{
+				Query: "select @@session.character_set_connection, @@session.collation_connection;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "set @@session.character_set_connection = 'latin1';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@session.character_set_connection, @@session.collation_connection;",
+				Expected: []sql.Row{
+					{"latin1", "latin1_swedish_ci"},
+				},
+			},
+			{
+				Query: "set @@session.collation_connection = 'utf8mb4_0900_bin';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@session.character_set_connection, @@session.collation_connection;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Query: "select @@global.character_set_connection, @@global.collation_connection;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "set @@global.character_set_connection = 'latin1';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@global.character_set_connection, @@global.collation_connection;",
+				Expected: []sql.Row{
+					{"latin1", "latin1_swedish_ci"},
+				},
+			},
+			{
+				Query: "set @@global.collation_connection = 'utf8mb4_0900_bin';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@global.character_set_connection, @@global.collation_connection;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Query: "select @@session.character_set_server, @@session.collation_server;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "set @@session.character_set_server = 'latin1';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@session.character_set_server, @@session.collation_server;",
+				Expected: []sql.Row{
+					{"latin1", "latin1_swedish_ci"},
+				},
+			},
+			{
+				Query: "set @@session.collation_server = 'utf8mb4_0900_bin';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@session.character_set_server, @@session.collation_server;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Query: "select @@global.character_set_server, @@global.collation_server;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "set @@global.character_set_server = 'latin1';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@global.character_set_server, @@global.collation_server;",
+				Expected: []sql.Row{
+					{"latin1", "latin1_swedish_ci"},
+				},
+			},
+			{
+				Query: "set @@global.collation_server = 'utf8mb4_0900_bin';",
+				Expected: []sql.Row{{}},
+			},
+			{
+				Query: "select @@global.character_set_server, @@global.collation_server;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
 		Name: "ENUM collation handling",
 		SetUpScript: []string{
 			"CREATE TABLE test1 (pk BIGINT PRIMARY KEY, v1 ENUM('abc','def','ghi') COLLATE utf16_unicode_ci);",

--- a/enginetest/queries/charset_collation_engine.go
+++ b/enginetest/queries/charset_collation_engine.go
@@ -462,7 +462,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@session.character_set_connection = 'latin1';",
+				Query:    "set @@session.character_set_connection = 'latin1';",
 				Expected: []sql.Row{{}},
 			},
 			{
@@ -472,7 +472,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@session.collation_connection = 'utf8mb4_0900_bin';",
+				Query:    "set @@session.collation_connection = 'utf8mb4_0900_bin';",
 				Expected: []sql.Row{{}},
 			},
 			{
@@ -489,7 +489,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@global.character_set_connection = 'latin1';",
+				Query:    "set @@global.character_set_connection = 'latin1';",
 				Expected: []sql.Row{{}},
 			},
 			{
@@ -499,7 +499,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@global.collation_connection = 'utf8mb4_0900_bin';",
+				Query:    "set @@global.collation_connection = 'utf8mb4_0900_bin';",
 				Expected: []sql.Row{{}},
 			},
 			{
@@ -516,7 +516,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@session.character_set_server = 'latin1';",
+				Query:    "set @@session.character_set_server = 'latin1';",
 				Expected: []sql.Row{{}},
 			},
 			{
@@ -526,7 +526,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@session.collation_server = 'utf8mb4_0900_bin';",
+				Query:    "set @@session.collation_server = 'utf8mb4_0900_bin';",
 				Expected: []sql.Row{{}},
 			},
 			{
@@ -543,7 +543,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@global.character_set_server = 'latin1';",
+				Query:    "set @@global.character_set_server = 'latin1';",
 				Expected: []sql.Row{{}},
 			},
 			{
@@ -553,7 +553,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 				},
 			},
 			{
-				Query: "set @@global.collation_server = 'utf8mb4_0900_bin';",
+				Query:    "set @@global.collation_server = 'utf8mb4_0900_bin';",
 				Expected: []sql.Row{{}},
 			},
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -6302,6 +6302,33 @@ where
 			},
 		},
 	},
+	{
+		Name: "test create database with modified server variables",
+		SetUpScript: []string{
+			"set @@session.character_set_server = 'latin1';",
+			"create database latin1_db;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select @@global.character_set_server, @@global.collation_server;",
+				Expected: []sql.Row{
+					{"utf8mb4", "utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "select @@session.character_set_server, @@session.collation_server;",
+				Expected: []sql.Row{
+					{"latin1", "latin1_swedish_ci"},
+				},
+			},
+			{
+				Query: "show create database latin1_db",
+				Expected: []sql.Row{
+					{"latin1_db", "CREATE DATABASE `latin1_db` /*!40100 DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci */"},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -6322,6 +6322,7 @@ where
 				},
 			},
 			{
+				// Interestingly, session actually takes priority over global
 				Query: "show create database latin1_db",
 				Expected: []sql.Row{
 					{"latin1_db", "CREATE DATABASE `latin1_db` /*!40100 DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci */"},

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -1496,6 +1496,14 @@ func (b *Builder) buildDBDDL(inScope *scope, c *ast.DBDDL) (outScope *scope) {
 				collationStr = cc.Value
 			}
 		}
+		// TODO: ensure that collation and charset match when setting them
+		if len(charsetStr) == 0 && len(collationStr) == 0 {
+			collation, err := b.ctx.Session.GetSessionVariable(b.ctx, "collation_server")
+			if err != nil {
+				b.handleErr(err)
+			}
+			collationStr = collation.(string)
+		}
 		collation, err := sql.ParseCollation(charsetStr, collationStr, false)
 		if err != nil {
 			b.handleErr(err)

--- a/sql/session.go
+++ b/sql/session.go
@@ -38,6 +38,7 @@ const (
 const (
 	CurrentDBSessionVar              = "current_database"
 	AutoCommitSessionVar             = "autocommit"
+	// TODO: how does character set and collation get matched?
 	characterSetConnectionSysVarName = "character_set_connection"
 	characterSetResultsSysVarName    = "character_set_results"
 	collationConnectionSysVarName    = "collation_connection"

--- a/sql/session.go
+++ b/sql/session.go
@@ -36,8 +36,8 @@ const (
 )
 
 const (
-	CurrentDBSessionVar              = "current_database"
-	AutoCommitSessionVar             = "autocommit"
+	CurrentDBSessionVar  = "current_database"
+	AutoCommitSessionVar = "autocommit"
 	// TODO: how does character set and collation get matched?
 	characterSetConnectionSysVarName = "character_set_connection"
 	characterSetResultsSysVarName    = "character_set_results"


### PR DESCRIPTION
This PR makes it so `create database ...` actually reads the `@@session.collation_server` variable.
Additionally, this ensures that settings `@@character_set_server` sets `@@collation_server` and vice versa.

Interestingly, it seems like MySQL actually ignores the global scope of these system variables, and reads the session scope instead.

fixes https://github.com/dolthub/dolt/issues/7651