### PR TITLE
Setting `Innodb_buffer_pool_pages_total` to 1, to avoid an issue with Datadog's collector

### DIFF
--- a/sql/variables/status_variables.go
+++ b/sql/variables/status_variables.go
@@ -1619,10 +1619,12 @@ var statusVars = map[string]sql.StatusVariable{
 		Default: int64(0),
 	},
 	"Innodb_buffer_pool_pages_total": &sql.MySQLStatusVariable{
-		Name:    "Innodb_buffer_pool_pages_total",
-		Scope:   sql.StatusVariableScope_Global,
-		Type:    types.NewSystemIntType("Innodb_buffer_pool_pages_total", 0, 0, false),
-		Default: int64(0),
+		Name:  "Innodb_buffer_pool_pages_total",
+		Scope: sql.StatusVariableScope_Global,
+		Type:  types.NewSystemIntType("Innodb_buffer_pool_pages_total", 0, 0, false),
+		// NOTE: Datadog errors out with a divide by zero error if this is zero,
+		//       so for now, we just report 1.
+		Default: int64(1),
 	},
 	"Innodb_buffer_pool_read_ahead": &sql.MySQLStatusVariable{
 		Name:    "Innodb_buffer_pool_read_ahead",


### PR DESCRIPTION
Datadog's metric collector errors out with a divide by zero error if the `Innodb_buffer_pool_pages_total` status variable is `0`; changing it to `1` avoids this and allows the agent to collect metrics from Dolt. 