### PR TITLE
Fixing the default value for the `binlog_checksum` system variable

### DIFF
--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -388,7 +388,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("binlog_checksum"),
-		Default:           "NONE", // TODO: MySQL's default is CRC32
+		Default:           "CRC32",
 	},
 	"binlog_gtid_simple_recovery": &sql.MysqlSystemVariable{
 		Name:              "binlog_gtid_simple_recovery",


### PR DESCRIPTION
Small change to make the default value of the global `binlog_checksum` system variable match MySQL's default value (i.e. "CRC32").