### PR TITLE
prevent panic on triggers with declare statements

### DIFF
--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2204,6 +2204,46 @@ INSERT INTO t0 (v1, v2) VALUES (i, s); END;`,
 			},
 		},
 	},
+
+	{
+		Name: "Trigger with BLOCK and DECLARE",
+		SetUpScript: []string{
+			"create table t (i int primary key);",
+			"create trigger trig before insert on t for each row begin declare x int; select new.i + 10 into x; set new.i = x; end;",
+			//"create trigger trig before insert on t for each row begin declare x int; set x = new.i * 10; set new.i = x; end;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Skip: true,
+				Query:    "insert into t values (1);",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Skip: true,
+				Query:    "insert into t values (2);",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Skip: true,
+				Query: "select * from t;",
+				Expected: []sql.Row{
+					{10},
+				},
+			},
+			{
+				Skip: true,
+				Query: "select * from t;",
+				Expected: []sql.Row{
+					{20},
+				},
+			},
+		},
+	},
+
 }
 
 // RollbackTriggerTests are trigger tests that require rollback logic to work correctly

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2214,28 +2214,28 @@ INSERT INTO t0 (v1, v2) VALUES (i, s); END;`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Skip: true,
-				Query:    "insert into t values (1);",
+				Skip:  true,
+				Query: "insert into t values (1);",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
-				Skip: true,
-				Query:    "insert into t values (2);",
+				Skip:  true,
+				Query: "insert into t values (2);",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},
 				},
 			},
 			{
-				Skip: true,
+				Skip:  true,
 				Query: "select * from t;",
 				Expected: []sql.Row{
 					{10},
 				},
 			},
 			{
-				Skip: true,
+				Skip:  true,
 				Query: "select * from t;",
 				Expected: []sql.Row{
 					{20},
@@ -2243,7 +2243,6 @@ INSERT INTO t0 (v1, v2) VALUES (i, s); END;`,
 			},
 		},
 	},
-
 }
 
 // RollbackTriggerTests are trigger tests that require rollback logic to work correctly

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2206,40 +2206,18 @@ INSERT INTO t0 (v1, v2) VALUES (i, s); END;`,
 	},
 
 	{
-		Name: "Trigger with BLOCK and DECLARE",
+		Name: "delete me",
 		SetUpScript: []string{
 			"create table t (i int primary key);",
-			"create trigger trig before insert on t for each row begin declare x int; select new.i + 10 into x; set new.i = x; end;",
-			//"create trigger trig before insert on t for each row begin declare x int; set x = new.i * 10; set new.i = x; end;",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Skip:  true,
-				Query: "insert into t values (1);",
-				Expected: []sql.Row{
-					{types.NewOkResult(1)},
-				},
+				Query:    "create trigger trig1 before insert on t for each row begin declare x int; select new.i + 10 into x; set new.i = x; end;",
+				ExpectedErr: sql.ErrUnsupportedFeature,
 			},
 			{
-				Skip:  true,
-				Query: "insert into t values (2);",
-				Expected: []sql.Row{
-					{types.NewOkResult(1)},
-				},
-			},
-			{
-				Skip:  true,
-				Query: "select * from t;",
-				Expected: []sql.Row{
-					{10},
-				},
-			},
-			{
-				Skip:  true,
-				Query: "select * from t;",
-				Expected: []sql.Row{
-					{20},
-				},
+				Query:    "create trigger trig2 before insert on t for each row begin declare x int; set x = new.i * 10; set new.i = x; end;",
+				ExpectedErr: sql.ErrUnsupportedFeature,
 			},
 		},
 	},

--- a/sql/expression/procedurereference.go
+++ b/sql/expression/procedurereference.go
@@ -60,6 +60,9 @@ type ProcedureReferencable interface {
 
 // InitializeVariable sets the initial value for the variable.
 func (ppr *ProcedureReference) InitializeVariable(name string, sqlType sql.Type, val interface{}) error {
+	if ppr == nil || ppr.InnermostScope == nil {
+		return fmt.Errorf("cannot initialize variable `%s` in an empty procedure reference", name)
+	}
 	convertedVal, _, err := sqlType.Convert(val)
 	if err != nil {
 		return err
@@ -274,7 +277,7 @@ func NewProcedureParam(name string, typ sql.Type) *ProcedureParam {
 	return &ProcedureParam{
 		name: strings.ToLower(name),
 		typ:  typ,
-		pRef: NewProcedureReference(),
+		//pRef: NewProcedureReference(),
 	}
 }
 

--- a/sql/expression/procedurereference.go
+++ b/sql/expression/procedurereference.go
@@ -277,7 +277,6 @@ func NewProcedureParam(name string, typ sql.Type) *ProcedureParam {
 	return &ProcedureParam{
 		name: strings.ToLower(name),
 		typ:  typ,
-		//pRef: NewProcedureReference(),
 	}
 }
 

--- a/sql/expression/procedurereference.go
+++ b/sql/expression/procedurereference.go
@@ -271,7 +271,11 @@ var _ sql.CollationCoercible = (*ProcedureParam)(nil)
 
 // NewProcedureParam creates a new ProcedureParam expression.
 func NewProcedureParam(name string, typ sql.Type) *ProcedureParam {
-	return &ProcedureParam{name: strings.ToLower(name), typ: typ}
+	return &ProcedureParam{
+		name: strings.ToLower(name),
+		typ:  typ,
+		pRef: NewProcedureReference(),
+	}
 }
 
 // Children implements the sql.Expression interface.

--- a/sql/plan/declare_variables.go
+++ b/sql/plan/declare_variables.go
@@ -40,7 +40,6 @@ func NewDeclareVariables(names []string, typ sql.Type, defaultVal *sql.ColumnDef
 		Names:      names,
 		Type:       typ,
 		DefaultVal: defaultVal,
-		Pref:       expression.NewProcedureReference(),
 	}
 }
 

--- a/sql/plan/declare_variables.go
+++ b/sql/plan/declare_variables.go
@@ -40,6 +40,7 @@ func NewDeclareVariables(names []string, typ sql.Type, defaultVal *sql.ColumnDef
 		Names:      names,
 		Type:       typ,
 		DefaultVal: defaultVal,
+		Pref:       expression.NewProcedureReference(),
 	}
 }
 

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -108,6 +108,16 @@ func (b *Builder) buildCreateTrigger(inScope *scope, query string, c *ast.DDL) (
 		}
 	}
 
+	// TODO: https://github.com/dolthub/dolt/issues/7720
+	if block, isBEBlock := bodyScope.node.(*plan.BeginEndBlock); isBEBlock {
+		for _, child := range block.Children() {
+			if _, ok := child.(*plan.DeclareVariables); ok {
+				err := sql.ErrUnsupportedFeature.New("DECLARE in BEGIN END block")
+				b.handleErr(err)
+			}
+		}
+	}
+
 	outScope.node = plan.NewCreateTrigger(
 		db,
 		c.TriggerSpec.TrigName.Name.String(),


### PR DESCRIPTION
We're reusing a code from stored procedures to handle begin end blocks, but we're missing a lot of set up that prevents certain variables from being nil. Consequently, we panic in a couple places.

This PR fixes some of those panics, but reveals other problems we have in resolving/executing triggers of this format.


Partially addresses: https://github.com/dolthub/dolt/issues/7720


