### PR TITLE
use SubStatementStr field in DDL for getting sub statement in CREATE VIEW

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240410183958-15cc912ab042
+	github.com/dolthub/vitess v0.0.0-20240412184125-91265873e1f1
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240410183958-15cc912ab042 h1:VxB3MyyVGp+Pr9fnkahIj2FXRfM5dpvdz1rV6ERCH1s=
-github.com/dolthub/vitess v0.0.0-20240410183958-15cc912ab042/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
+github.com/dolthub/vitess v0.0.0-20240412184125-91265873e1f1 h1:sPK3qu3yBbKBS8Bv9+tZlLiaM3VBV1y1qZLzplQIlHg=
+github.com/dolthub/vitess v0.0.0-20240412184125-91265873e1f1/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -448,8 +448,13 @@ func (b *Builder) buildAlterEvent(inScope *scope, query string, c *ast.DDL) (out
 
 func (b *Builder) buildCreateView(inScope *scope, query string, c *ast.DDL) (outScope *scope) {
 	outScope = inScope.push()
-
-	selectStr := query[c.SubStatementPositionStart:c.SubStatementPositionEnd]
+	selectStr := c.SubStatementStr
+	if selectStr == "" {
+		if c.SubStatementPositionEnd > len(query) {
+			b.handleErr(fmt.Errorf("unable to get sub statement"))
+		}
+		selectStr = query[c.SubStatementPositionStart:c.SubStatementPositionEnd]
+	}
 	stmt, _, err := ast.ParseOneWithOptions(selectStr, b.parserOpts)
 	if err != nil {
 		b.handleErr(err)


### PR DESCRIPTION
This PR allows using defined string for sub statement instead of slicing the original query. If this field is empty, then slice the original query to get the sub statement.