### PR TITLE
improve `DESCRIBE` columns and auto_increment bugs

### DIFF
--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -716,7 +716,7 @@ var AlterTableScripts = []ScriptTest{
 				Query: "describe test",
 				Expected: []sql.Row{
 					{"pk", "int", "NO", "PRI", nil, ""},
-					{"uk", "int", "YES", "UNI", nil, "auto_increment"},
+					{"uk", "int", "NO", "UNI", nil, "auto_increment"},
 				},
 			},
 		},
@@ -745,7 +745,7 @@ var AlterTableScripts = []ScriptTest{
 				Query: "describe test",
 				Expected: []sql.Row{
 					{"pk", "int", "NO", "PRI", nil, ""},
-					{"mk", "int", "YES", "MUL", nil, "auto_increment"},
+					{"mk", "int", "NO", "MUL", nil, "auto_increment"},
 				},
 			},
 		},
@@ -1083,7 +1083,7 @@ var AlterTableAddAutoIncrementScripts = []ScriptTest{
 					"CREATE TABLE `t1` (\n" +
 						"  `i` bigint NOT NULL,\n" +
 						"  `s` varchar(20),\n" +
-						"  `j` int AUTO_INCREMENT,\n" +
+						"  `j` int NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`),\n" +
 						"  UNIQUE KEY `j` (`j`)\n" +
 						") ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -44,7 +44,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `create table floattypedefs (a float(10), b float(10, 2), c double(10, 2))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE floattypedefs",
-		ExpectedSelect:      []sql.Row{sql.Row{"floattypedefs", "CREATE TABLE `floattypedefs` (\n  `a` float,\n  `b` float,\n  `c` double\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"floattypedefs", "CREATE TABLE `floattypedefs` (\n  `a` float,\n  `b` float,\n  `c` double\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, b TEXT, c DATE, d TIMESTAMP, e VARCHAR(20), f BLOB NOT NULL, b1 BOOL, b2 BOOLEAN NOT NULL, g DATETIME, h CHAR(40))`,
@@ -56,7 +56,7 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER NOT NULL PRIMARY KEY, b VARCHAR(10) NOT NULL)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10) NOT NULL,\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10) NOT NULL,\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, b TEXT NOT NULL COMMENT 'comment', c bool, primary key (a))`,
@@ -68,13 +68,13 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER, create_time timestamp(6) NOT NULL DEFAULT NOW(6), primary key (a))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `create_time` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `create_time` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 LIKE mytable`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` bigint NOT NULL,\n  `s` varchar(20) NOT NULL COMMENT 'column s',\n  PRIMARY KEY (`i`),\n  KEY `idx_si` (`s`,`i`),\n  KEY `mytable_i_s` (`i`,`s`),\n  UNIQUE KEY `mytable_s` (`s`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` bigint NOT NULL,\n  `s` varchar(20) NOT NULL COMMENT 'column s',\n  PRIMARY KEY (`i`),\n  KEY `idx_si` (`s`,`i`),\n  KEY `mytable_i_s` (`i`,`s`),\n  UNIQUE KEY `mytable_s` (`s`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery: `CREATE TABLE t1 (
@@ -84,61 +84,61 @@ var CreateTableQueries = []WriteQueryTest{
 			)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `pk` bigint NOT NULL,\n  `v1` bigint DEFAULT (2) COMMENT 'hi there',\n  PRIMARY KEY (`pk`),\n  KEY `idx_v1` (`v1`) COMMENT 'index here'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` bigint NOT NULL,\n  `v1` bigint DEFAULT (2) COMMENT 'hi there',\n  PRIMARY KEY (`pk`),\n  KEY `idx_v1` (`v1`) COMMENT 'index here'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `create table t1 like foo.othertable`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `text` varchar(20) NOT NULL,\n  `number` mediumint,\n  PRIMARY KEY (`text`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `text` varchar(20) NOT NULL,\n  `number` mediumint,\n  PRIMARY KEY (`text`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER NOT NULL PRIMARY KEY, b VARCHAR(10) UNIQUE)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10),\n  PRIMARY KEY (`a`),\n  UNIQUE KEY `b` (`b`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10),\n  PRIMARY KEY (`a`),\n  UNIQUE KEY `b` (`b`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (a INTEGER NOT NULL PRIMARY KEY, b VARCHAR(10) UNIQUE KEY)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10),\n  PRIMARY KEY (`a`),\n  UNIQUE KEY `b` (`b`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10),\n  PRIMARY KEY (`a`),\n  UNIQUE KEY `b` (`b`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 SELECT * from mytable`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(3)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` bigint NOT NULL,\n  `s` varchar(20) NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` bigint NOT NULL,\n  `s` varchar(20) NOT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE mydb.t1 (a INTEGER NOT NULL PRIMARY KEY, b VARCHAR(10) NOT NULL)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE mydb.t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10) NOT NULL,\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `a` int NOT NULL,\n  `b` varchar(10) NOT NULL,\n  PRIMARY KEY (`a`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (i int primary key, j int auto_increment unique)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int AUTO_INCREMENT,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (i int primary key, j int auto_increment, index (j))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int AUTO_INCREMENT,\n  PRIMARY KEY (`i`),\n  KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`i`),\n  KEY `j` (`j`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (i int primary key, j int auto_increment, k int, unique(j,k))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `jk` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `jk` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (i int primary key, j int auto_increment, k int, index (j,k))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  KEY `jk` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  KEY `jk` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery: `CREATE TABLE t1 (
@@ -150,7 +150,7 @@ var CreateTableQueries = []WriteQueryTest{
 		)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `pk` int NOT NULL,\n  `col1` blob DEFAULT ('abc'),\n  `col2` json DEFAULT (json_object('a',1)),\n  `col3` text DEFAULT ('abc'),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` int NOT NULL,\n  `col1` blob DEFAULT ('abc'),\n  `col2` json DEFAULT (json_object('a',1)),\n  `col3` text DEFAULT ('abc'),\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery: `CREATE TABLE td (
@@ -165,7 +165,7 @@ var CreateTableQueries = []WriteQueryTest{
 		)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE td",
-		ExpectedSelect:      []sql.Row{sql.Row{"td", "CREATE TABLE `td` (\n  `pk` int NOT NULL,\n  `col2` int NOT NULL DEFAULT '2',\n  `col3` double NOT NULL DEFAULT (round(-1.58,0)),\n  `col4` varchar(10) DEFAULT 'new row',\n  `col5` float DEFAULT '33.33',\n  `col6` int DEFAULT NULL,\n  `col7` timestamp DEFAULT CURRENT_TIMESTAMP,\n  `col8` bigint DEFAULT CURRENT_TIMESTAMP,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"td", "CREATE TABLE `td` (\n  `pk` int NOT NULL,\n  `col2` int NOT NULL DEFAULT '2',\n  `col3` double NOT NULL DEFAULT (round(-1.58,0)),\n  `col4` varchar(10) DEFAULT 'new row',\n  `col5` float DEFAULT '33.33',\n  `col6` int DEFAULT NULL,\n  `col7` timestamp DEFAULT CURRENT_TIMESTAMP,\n  `col8` bigint DEFAULT CURRENT_TIMESTAMP,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `create table t1 (i int primary key, b1 blob, b2 blob, index(b1(123), b2(456)))`,
@@ -244,31 +244,31 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 (pk varchar(10) primary key collate binary)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `SHOW CREATE TABLE t1`,
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (pk varchar(10) primary key charset binary)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `SHOW CREATE TABLE t1`,
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (pk varchar(10) primary key character set binary)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `SHOW CREATE TABLE t1`,
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (pk varchar(10) primary key charset binary collate binary)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `SHOW CREATE TABLE t1`,
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (pk varchar(10) primary key character set binary collate binary)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `SHOW CREATE TABLE t1`,
-		ExpectedSelect:      []sql.Row{sql.Row{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` varbinary(10) NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 }
 
@@ -963,7 +963,7 @@ var CreateTableAutoIncrementTests = []ScriptTest{
 				Query: "show create table t1",
 				Expected: []sql.Row{{"t1",
 					"CREATE TABLE `t1` (\n" +
-						"  `a` int AUTO_INCREMENT,\n" +
+						"  `a` int NOT NULL AUTO_INCREMENT,\n" +
 						"  `b` int NOT NULL,\n" +
 						"  PRIMARY KEY (`b`),\n" +
 						"  UNIQUE KEY `a` (`a`)\n" +
@@ -998,7 +998,7 @@ var CreateTableAutoIncrementTests = []ScriptTest{
 				Query: "show create table t1",
 				Expected: []sql.Row{{"t1",
 					"CREATE TABLE `t1` (\n" +
-						"  `a` int AUTO_INCREMENT,\n" +
+						"  `a` int NOT NULL AUTO_INCREMENT,\n" +
 						"  `b` int NOT NULL,\n" +
 						"  PRIMARY KEY (`b`),\n" +
 						"  UNIQUE KEY `a` (`a`)\n" +

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3144,6 +3144,132 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "describe and show columns with various keys and constraints",
+		SetUpScript: []string{
+			"create table t1 (i int not null, unique key (i));",
+			"create table t2 (i int not null, j int not null, unique key (j), unique key(i));",
+			"create table t3 (i int not null, j int, unique key (i, j));",
+			"create table t4 (i int not null, j int primary key, unique key (i));",
+			"create table t5 (i int not null, j int not null, unique key (j, i), unique key (i));",
+			"create table t6 (i int not null, j int not null, unique key (i), unique key (j, i));",
+			"create table t7 (pk int primary key, i int, j int not null, unique key (i), unique key (j, i));",
+			"create table t8 (pk int primary key, i int, j int, k int, unique key (i, j, k), unique key (i), unique key (j), unique key(k));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show create table t1;",
+				Expected: []sql.Row{
+					{"t1", "CREATE TABLE `t1` (\n" +
+						"  `i` int NOT NULL,\n" +
+						"  UNIQUE KEY `i` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "describe t1;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "PRI", nil, ""},
+				},
+			},
+			{
+				Query: "show columns from t1;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "PRI", nil, ""},
+				},
+			},
+			{
+				Skip: true, // supposed to be the first index defined, not in order of columns
+				Query: "describe t2;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "UNI", nil, ""},
+					{"j", "int", "NO", "PRI", nil, ""},
+				},
+			},
+			{
+				Query: "describe t3;",
+				Expected: []sql.Row{
+					{"i", "int", "NO",  "MUL", nil, ""},
+					{"j", "int", "YES", "",    nil, ""},
+				},
+			},
+			{
+				Query: "describe t4;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "UNI", nil, ""},
+					{"j", "int", "NO", "PRI", nil, ""},
+				},
+			},
+			{
+				// TODO: the order of indexes retrieved is not guaranteed...
+				Skip: true,
+				Query: "describe t5;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "PRI", nil, ""},
+					{"j", "int", "NO", "PRI", nil, ""},
+				},
+			},
+			{
+				Query: "describe t6;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "PRI", nil, ""},
+					{"j", "int", "NO", "MUL", nil, ""},
+				},
+			},
+			{
+				Query: "describe t7;",
+				Expected: []sql.Row{
+					{"pk", "int", "NO",  "PRI", nil, ""},
+					{"i",  "int", "YES", "UNI", nil, ""},
+					{"j",  "int", "NO",  "MUL", nil, ""},
+				},
+			},
+			{
+				Skip: true, // for some reason MUL takes priority over UNI for i
+				Query: "describe t8;",
+				Expected: []sql.Row{
+					{"pk", "int", "NO",  "PRI", nil, ""},
+					{"i",  "int", "YES", "MUL", nil, ""},
+					{"j",  "int", "YES", "UNI", nil, ""},
+					{"k",  "int", "YES", "UNI", nil, ""},
+				},
+			},
+		},
+	},
+	{
+		Name: "ALTER TABLE MODIFY column with multiple UNIQUE KEYS",
+		SetUpScript: []string{
+			"CREATE table test (pk int primary key, uk1 int, uk2 int, unique(uk1, uk2))",
+			"ALTER TABLE `test` MODIFY column uk1 int auto_increment",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "describe test",
+				Expected: []sql.Row{
+					{"pk", "int", "NO", "PRI", nil, ""},
+					{"uk1", "int", "NO", "MUL", nil, "auto_increment"},
+					{"uk2", "int", "YES", "", nil, ""},
+				},
+			},
+		},
+	},
+	{
+		Name: "ALTER TABLE MODIFY column with multiple KEYS",
+		SetUpScript: []string{
+			"CREATE table test (pk int primary key, mk1 int, mk2 int, index(mk1, mk2))",
+			"ALTER TABLE `test` MODIFY column mk1 int auto_increment",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "describe test",
+				Expected: []sql.Row{
+					{"pk", "int", "NO", "PRI", nil, ""},
+					{"mk1", "int", "NO", "MUL", nil, "auto_increment"},
+					{"mk2", "int", "YES", "", nil, ""},
+				},
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/3065
 		Name: "join index lookups do not handle filters",
 		SetUpScript: []string{
@@ -7413,40 +7539,6 @@ var PreparedScriptTests = []ScriptTest{
 }
 
 var BrokenScriptTests = []ScriptTest{
-	{
-		Name: "ALTER TABLE MODIFY column with multiple UNIQUE KEYS",
-		SetUpScript: []string{
-			"CREATE table test (pk int primary key, uk1 int, uk2 int, unique(uk1, uk2))",
-			"ALTER TABLE `test` MODIFY column uk1 int auto_increment",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query: "describe test",
-				Expected: []sql.Row{
-					{"pk", "int", "NO", "PRI", nil, ""},
-					{"uk1", "int", "NO", "MUL", nil, "auto_increment"},
-					{"uk1", "int", "YES", "", nil, ""},
-				},
-			},
-		},
-	},
-	{
-		Name: "ALTER TABLE MODIFY column with multiple KEYS",
-		SetUpScript: []string{
-			"CREATE table test (pk int primary key, mk1 int, mk2 int, index(mk1, mk2))",
-			"ALTER TABLE `test` MODIFY column mk1 int auto_increment",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query: "describe test",
-				Expected: []sql.Row{
-					{"pk", "int", "NO", "PRI", nil, ""},
-					{"mk1", "int", "NO", "MUL", nil, "auto_increment"},
-					{"mk1", "int", "YES", "", nil, ""},
-				},
-			},
-		},
-	},
 	{
 		Name: "ALTER TABLE RENAME on a column when another column has a default dependency on it",
 		SetUpScript: []string{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3178,7 +3178,7 @@ CREATE TABLE tab3 (
 				},
 			},
 			{
-				Skip: true, // supposed to be the first index defined, not in order of columns
+				Skip:  true, // supposed to be the first index defined, not in order of columns
 				Query: "describe t2;",
 				Expected: []sql.Row{
 					{"i", "int", "NO", "UNI", nil, ""},
@@ -3188,8 +3188,8 @@ CREATE TABLE tab3 (
 			{
 				Query: "describe t3;",
 				Expected: []sql.Row{
-					{"i", "int", "NO",  "MUL", nil, ""},
-					{"j", "int", "YES", "",    nil, ""},
+					{"i", "int", "NO", "MUL", nil, ""},
+					{"j", "int", "YES", "", nil, ""},
 				},
 			},
 			{
@@ -3201,7 +3201,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				// TODO: the order of indexes retrieved is not guaranteed...
-				Skip: true,
+				Skip:  true,
 				Query: "describe t5;",
 				Expected: []sql.Row{
 					{"i", "int", "NO", "PRI", nil, ""},
@@ -3218,19 +3218,19 @@ CREATE TABLE tab3 (
 			{
 				Query: "describe t7;",
 				Expected: []sql.Row{
-					{"pk", "int", "NO",  "PRI", nil, ""},
-					{"i",  "int", "YES", "UNI", nil, ""},
-					{"j",  "int", "NO",  "MUL", nil, ""},
+					{"pk", "int", "NO", "PRI", nil, ""},
+					{"i", "int", "YES", "UNI", nil, ""},
+					{"j", "int", "NO", "MUL", nil, ""},
 				},
 			},
 			{
-				Skip: true, // for some reason MUL takes priority over UNI for i
+				Skip:  true, // for some reason MUL takes priority over UNI for i
 				Query: "describe t8;",
 				Expected: []sql.Row{
-					{"pk", "int", "NO",  "PRI", nil, ""},
-					{"i",  "int", "YES", "MUL", nil, ""},
-					{"j",  "int", "YES", "UNI", nil, ""},
-					{"k",  "int", "YES", "UNI", nil, ""},
+					{"pk", "int", "NO", "PRI", nil, ""},
+					{"i", "int", "YES", "MUL", nil, ""},
+					{"j", "int", "YES", "UNI", nil, ""},
+					{"k", "int", "YES", "UNI", nil, ""},
 				},
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3200,7 +3200,8 @@ CREATE TABLE tab3 (
 				},
 			},
 			{
-				// TODO: the order of indexes retrieved is not guaranteed...
+				// MySQL reads indexes in the order that they were created, while we sort by idx name
+				// https://github.com/dolthub/dolt/issues/2289
 				Skip:  true,
 				Query: "describe t5;",
 				Expected: []sql.Row{

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -554,7 +554,7 @@ func allTableCols(rel SourceRel) sql.Schema {
 			Type:           c.Type,
 			Default:        c.Default,
 			AutoIncrement:  c.AutoIncrement,
-			Nullable:       c.Nullable,
+			Nullable:       c.Nullable && !c.AutoIncrement,
 			Source:         rel.Name(),
 			DatabaseSource: c.DatabaseSource,
 			PrimaryKey:     c.PrimaryKey,

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -1332,7 +1332,7 @@ func (b *Builder) columnDefinitionToColumn(inScope *scope, cd *ast.ColumnDefinit
 		Name:          cd.Name.String(),
 		Type:          internalTyp,
 		AutoIncrement: bool(cd.Type.Autoincrement),
-		Nullable:      nullable,
+		Nullable:      nullable && !bool(cd.Type.Autoincrement),
 		PrimaryKey:    isPkey,
 		Comment:       comment,
 		Extra:         extra,

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -437,7 +437,6 @@ func (b *BaseBuilder) buildShowCreateTrigger(ctx *sql.Context, n *plan.ShowCreat
 func (b *BaseBuilder) buildShowColumns(ctx *sql.Context, n *plan.ShowColumns, row sql.Row) (sql.RowIter, error) {
 	span, _ := ctx.Span("plan.ShowColumns")
 
-	var hasPrimary bool
 	schema := n.TargetSchema()
 	var rows = make([]sql.Row, len(schema))
 	for i, col := range schema {
@@ -461,13 +460,11 @@ func (b *BaseBuilder) buildShowColumns(ctx *sql.Context, n *plan.ShowColumns, ro
 		case *plan.ResolvedTable:
 			if col.PrimaryKey {
 				key = "PRI"
-				hasPrimary = true
-			} else if !hasPrimary && isFirstColInUniqueKeyNotNull(n, col, table) {
+			} else if isPriCol(n, col, table) {
 				key = "PRI"
-				hasPrimary = true
-			} else if isFirstColInUniqueKey(n, col, table) {
+			} else if isUnqCol(n, col, table) {
 				key = "UNI"
-			} else if isFirstColInNonUniqueKey(n, col, table) {
+			} else if isMulCol(n, col, table) {
 				key = "MUL"
 			}
 		case *plan.SubqueryAlias:

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -260,6 +260,30 @@ func (i *showIndexesIter) Next(ctx *sql.Context) (sql.Row, error) {
 	), nil
 }
 
+func isFirstColInUniqueKeyNotNull(s *plan.ShowColumns, col *sql.Column, table sql.Table) bool {
+	for _, idx := range s.Indexes {
+		if !idx.IsUnique() {
+			continue
+		}
+
+		firstIndexCol := plan.GetColumnFromIndexExpr(idx.Expressions()[0], table)
+		if firstIndexCol == nil || firstIndexCol.Name != col.Name {
+			continue
+		}
+
+		for _, expr := range idx.Expressions() {
+			idxCol := plan.GetColumnFromIndexExpr(expr, table)
+			if idxCol == nil || idxCol.Nullable {
+				continue
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
 func isFirstColInUniqueKey(s *plan.ShowColumns, col *sql.Column, table sql.Table) bool {
 	for _, idx := range s.Indexes {
 		if !idx.IsUnique() {

--- a/sql/rowexec/showcolumns_test.go
+++ b/sql/rowexec/showcolumns_test.go
@@ -109,7 +109,7 @@ func TestShowColumnsWithIndexes(t *testing.T) {
 
 	expected := []sql.Row{
 		{"a", "text", "NO", "PRI", nil, ""},
-		{"b", "bigint", "YES", "UNI", nil, ""},
+		{"b", "bigint", "YES", "MUL", nil, ""},
 		{"c", "bigint", "NO", "", "1", ""},
 		{"d", "bigint", "YES", "MUL", nil, ""},
 		{"e", "bigint", "NO", "", "1", ""},


### PR DESCRIPTION
This PR makes it so our DESCRIBE statement is more correct when there are unique keys.
There's an edge case we miss:
```sql
create table t (i int not null, j int not null, unique key (j), unique key (i));
describe t;
```

In MySQL, `UNIQUE KEY j` is created before `UNIQUE KEY i`, so describe makes `j` as `PRI`.
In Dolt, we store indexes in a map and return them in order of index name, so we mark `i` as `PRI`.
There are skipped tests for this

Additionally, this adds the `NOT NULL` constraint to columns that are marked `AUTO_INCREMENT`.

partially addresses: https://github.com/dolthub/dolt/issues/2289