### PR TITLE
Add `LazyJSONDocument`, which wraps a JSON string and only deserializes it if needed.

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -819,7 +819,10 @@ func widenJSONValues(val interface{}) sql.JSONWrapper {
 		js = types.MustJSON(str)
 	}
 
-	doc := js.ToInterface()
+	doc, err := js.ToInterface()
+	if err != nil {
+		panic(err)
+	}
 
 	if _, ok := js.(sql.Statistic); ok {
 		// avoid comparing time values in statistics

--- a/sql/expression/function/aggregation/json_agg.go
+++ b/sql/expression/function/aggregation/json_agg.go
@@ -159,7 +159,10 @@ func (j *jsonObjectBuffer) Update(ctx *sql.Context, row sql.Row) error {
 
 	// unwrap JSON values
 	if js, ok := val.(sql.JSONWrapper); ok {
-		val = js.ToInterface()
+		val, err = js.ToInterface()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Update the map.

--- a/sql/expression/function/aggregation/unary_agg_buffers.go
+++ b/sql/expression/function/aggregation/unary_agg_buffers.go
@@ -647,7 +647,10 @@ func (j *jsonArrayBuffer) Update(ctx *sql.Context, row sql.Row) error {
 
 	// unwrap JSON values
 	if js, ok := v.(sql.JSONWrapper); ok {
-		v = js.ToInterface()
+		v, err = js.ToInterface()
+		if err != nil {
+			return err
+		}
 	}
 
 	j.vals = append(j.vals, v)

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -1050,7 +1050,10 @@ func (a *WindowedJSONArrayAgg) aggregateVals(ctx *sql.Context, interval sql.Wind
 
 		// unwrap JSON values
 		if js, ok := v.(sql.JSONWrapper); ok {
-			v = js.ToInterface()
+			v, err = js.ToInterface()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		vals = append(vals, v)
@@ -1134,7 +1137,10 @@ func (a *WindowedJSONObjectAgg) aggregateVals(ctx *sql.Context, interval sql.Win
 
 		// unwrap JSON values
 		if js, ok := val.(sql.JSONWrapper); ok {
-			val = js.ToInterface()
+			val, err = js.ToInterface()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		// Update the map.

--- a/sql/expression/function/json/json_array.go
+++ b/sql/expression/function/json/json_array.go
@@ -113,7 +113,10 @@ func (j *JSONArray) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 		switch v := val.(type) {
 		case sql.JSONWrapper:
-			val = v.ToInterface()
+			val, err = v.ToInterface()
+			if err != nil {
+				return nil, err
+			}
 		case []byte:
 			val = string(v)
 		}

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -71,7 +71,11 @@ func getJSONDocumentFromRow(ctx *sql.Context, row sql.Row, json sql.Expression) 
 	doc, ok := converted.(types.JSONDocument)
 	if !ok {
 		// This should never happen, but just in case.
-		doc = types.JSONDocument{Val: js.(sql.JSONWrapper).ToInterface()}
+		val, err := js.(sql.JSONWrapper).ToInterface()
+		if err != nil {
+			return nil, err
+		}
+		doc = types.JSONDocument{Val: val}
 	}
 
 	return &doc, nil

--- a/sql/expression/function/json/json_contains.go
+++ b/sql/expression/function/json/json_contains.go
@@ -162,7 +162,15 @@ func (j *JSONContains) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 	}
 
 	// Now determine whether the candidate value exists in the target
-	return types.ContainsJSON(target.ToInterface(), candidate.ToInterface())
+	targetVal, err := target.ToInterface()
+	if err != nil {
+		return nil, err
+	}
+	candidateVal, err := candidate.ToInterface()
+	if err != nil {
+		return nil, err
+	}
+	return types.ContainsJSON(targetVal, candidateVal)
 }
 
 func (j *JSONContains) Children() []sql.Expression {

--- a/sql/expression/function/json/json_object.go
+++ b/sql/expression/function/json/json_object.go
@@ -109,7 +109,10 @@ func (j JSONObject) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			key = val.(string)
 		} else {
 			if json, ok := val.(sql.JSONWrapper); ok {
-				val = json.ToInterface()
+				val, err = json.ToInterface()
+				if err != nil {
+					return nil, err
+				}
 			}
 			obj[key] = val
 		}

--- a/sql/expression/function/json/json_value.go
+++ b/sql/expression/function/json/json_value.go
@@ -182,7 +182,7 @@ func GetJSONFromWrapperOrCoercibleString(js interface{}) (jsonData interface{}, 
 		}
 		return jsonData, nil
 	case sql.JSONWrapper:
-		return jsType.ToInterface(), nil
+		return jsType.ToInterface()
 	default:
 		return nil, InvalidJsonArgument.New()
 	}

--- a/sql/fulltext/fulltext.go
+++ b/sql/fulltext/fulltext.go
@@ -176,7 +176,7 @@ func writeHashedValue(h hash.Hash, val interface{}) (valIsNull bool, err error) 
 			return false, err
 		}
 	case *types.LazyJSONDocument:
-		str, err := val.JSONString()
+		str, err := types.StringifyJSON(val)
 		if err != nil {
 			return false, err
 		}

--- a/sql/fulltext/fulltext.go
+++ b/sql/fulltext/fulltext.go
@@ -175,6 +175,14 @@ func writeHashedValue(h hash.Hash, val interface{}) (valIsNull bool, err error) 
 		if _, err := h.Write([]byte(str)); err != nil {
 			return false, err
 		}
+	case *types.LazyJSONDocument:
+		str, err := val.JSONString()
+		if err != nil {
+			return false, err
+		}
+		if _, err := h.Write([]byte(str)); err != nil {
+			return false, err
+		}
 	case nil:
 		return true, nil
 	default:

--- a/sql/plan/histogram.go
+++ b/sql/plan/histogram.go
@@ -1,8 +1,8 @@
 package plan
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -58,9 +58,8 @@ func (u *UpdateHistogram) Resolved() bool {
 }
 
 func (u *UpdateHistogram) String() string {
-	statMap := u.stats.ToInterface()
-	statBytes, _ := json.Marshal(statMap)
-	return fmt.Sprintf("update histogram  %s.(%s) using %s", u.table, strings.Join(u.cols, ","), statBytes)
+	statString, _ := types.StringifyJSON(u.stats)
+	return fmt.Sprintf("update histogram  %s.(%s) using %s", u.table, strings.Join(u.cols, ","), statString)
 }
 
 func (u *UpdateHistogram) Schema() sql.Schema {

--- a/sql/plan/histogram.go
+++ b/sql/plan/histogram.go
@@ -59,8 +59,8 @@ func (u *UpdateHistogram) Resolved() bool {
 }
 
 func (u *UpdateHistogram) String() string {
-	statString, _ := types.StringifyJSON(u.stats)
-	return fmt.Sprintf("update histogram  %s.(%s) using %s", u.table, strings.Join(u.cols, ","), statString)
+	statBytes, _ := types.MarshallJson(u.stats)
+	return fmt.Sprintf("update histogram  %s.(%s) using %s", u.table, strings.Join(u.cols, ","), statBytes)
 }
 
 func (u *UpdateHistogram) Schema() sql.Schema {

--- a/sql/plan/histogram.go
+++ b/sql/plan/histogram.go
@@ -2,8 +2,9 @@ package plan
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/types"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/types"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/statistics.go
+++ b/sql/statistics.go
@@ -142,7 +142,7 @@ func (h Histogram) IsEmpty() bool {
 	return len(h) == 0
 }
 
-func (h Histogram) ToInterface() interface{} {
+func (h Histogram) ToInterface() (interface{}, error) {
 	ret := make([]interface{}, len(h))
 	for i, b := range h {
 		var upperBound Row
@@ -167,7 +167,7 @@ func (h Histogram) ToInterface() interface{} {
 			"upper_bound":    upperBound,
 		}
 	}
-	return ret
+	return ret, nil
 }
 
 func (h Histogram) DebugString() string {
@@ -216,5 +216,5 @@ type HistogramBucket interface {
 // by minimizing the need to unmarshall a JSONWrapper into a JSONDocument.
 type JSONWrapper interface {
 	// ToInterface converts a JSONWrapper to an interface{} of simple types
-	ToInterface() interface{}
+	ToInterface() (interface{}, error)
 }

--- a/sql/stats/statistic.go
+++ b/sql/stats/statistic.go
@@ -209,10 +209,15 @@ func (s *Statistic) IndexClass() sql.IndexClass {
 	return sql.IndexClass(s.IdxClass)
 }
 
-func (s *Statistic) ToInterface() interface{} {
+func (s *Statistic) ToInterface() (interface{}, error) {
 	typs := make([]string, len(s.Typs))
 	for i, t := range s.Typs {
 		typs[i] = t.String()
+	}
+
+	buckets, err := s.Histogram().ToInterface()
+	if err != nil {
+		return nil, err
 	}
 
 	return map[string]interface{}{
@@ -225,9 +230,9 @@ func (s *Statistic) ToInterface() interface{} {
 			"qualifier":      s.Qualifier().String(),
 			"columns":        s.Columns(),
 			"types:":         typs,
-			"buckets":        s.Histogram().ToInterface(),
+			"buckets":        buckets,
 		},
-	}
+	}, nil
 }
 
 func ParseTypeStrings(typs []string) ([]sql.Type, error) {

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"bytes"
 	"encoding/json"
 	"reflect"
 
@@ -138,24 +137,11 @@ func (t JsonType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 	}
 	js := jsVal.(sql.JSONWrapper)
 
-	var val []byte
-	switch j := js.(type) {
-	case JSONStringer:
-		str, err := j.JSONString()
-		if err != nil {
-			return sqltypes.NULL, err
-		}
-		val = AppendAndSliceString(dest, str)
-	default:
-		jsonBytes, err := MarshallJson(js)
-		if err != nil {
-			return sqltypes.NULL, err
-		}
-
-		jsonBytes = bytes.ReplaceAll(jsonBytes, []byte(",\""), []byte(", \""))
-		jsonBytes = bytes.ReplaceAll(jsonBytes, []byte("\":"), []byte("\": "))
-		val = AppendAndSliceBytes(dest, jsonBytes)
+	str, err := StringifyJSON(js)
+	if err != nil {
+		return sqltypes.NULL, err
 	}
+	val := AppendAndSliceString(dest, str)
 
 	return sqltypes.MakeTrusted(sqltypes.TypeJSON, val), nil
 }

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -147,7 +147,7 @@ func (t JsonType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 		}
 		val = AppendAndSliceString(dest, str)
 	default:
-		jsonBytes, err := json.Marshal(js.ToInterface())
+		jsonBytes, err := MarshallJson(js)
 		if err != nil {
 			return sqltypes.NULL, err
 		}

--- a/sql/types/json_test.go
+++ b/sql/types/json_test.go
@@ -212,6 +212,29 @@ func TestValuer(t *testing.T) {
 	require.Equal(t, `{"a": "one"}`, res)
 }
 
+func TestLazyJsonDocument(t *testing.T) {
+	testCases := []struct {
+		s    string
+		json interface{}
+	}{
+		{"\"1\"", "1"},
+		{"{\"a\": [1.0, null]}", map[string]any{"a": []any{1.0, nil}}},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.s, func(t *testing.T) {
+			doc := NewLazyJSONDocument([]byte(testCase.s))
+			val, err := doc.ToInterface()
+			require.NoError(t, err)
+			require.Equal(t, testCase.json, val)
+		})
+	}
+	t.Run("lazy docs only error when deserialized", func(t *testing.T) {
+		doc := NewLazyJSONDocument([]byte("not valid json"))
+		_, err := doc.ToInterface()
+		require.Error(t, err)
+	})
+}
+
 type JsonRoundtripTest struct {
 	desc     string
 	input    string

--- a/sql/types/json_test.go
+++ b/sql/types/json_test.go
@@ -217,8 +217,8 @@ func TestLazyJsonDocument(t *testing.T) {
 		s    string
 		json interface{}
 	}{
-		{"\"1\"", "1"},
-		{"{\"a\": [1.0, null]}", map[string]any{"a": []any{1.0, nil}}},
+		{`"1"`, "1"},
+		{`{"a": [1.0, null]}`, map[string]any{"a": []any{1.0, nil}}},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.s, func(t *testing.T) {

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -34,6 +34,33 @@ type JSONStringer interface {
 	JSONString() (string, error)
 }
 
+func MarshallJson(jsonWrapper sql.JSONWrapper) ([]byte, error) {
+	if stringer, ok := jsonWrapper.(JSONStringer); ok {
+		s, err := stringer.JSONString()
+		return []byte(s), err
+	}
+	val, err := jsonWrapper.ToInterface()
+	if err != nil {
+		return []byte{}, err
+	}
+	return json.Marshal(val)
+}
+
+func StringifyJSON(jsonWrapper sql.JSONWrapper) (string, error) {
+	if stringer, ok := jsonWrapper.(JSONStringer); ok {
+		return stringer.JSONString()
+	}
+	val, err := jsonWrapper.ToInterface()
+	if err != nil {
+		return "", err
+	}
+	bytes, err := json.Marshal(val)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
 type JsonObject = map[string]interface{}
 type JsonArray = []interface{}
 

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"bytes"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -43,13 +42,11 @@ func StringifyJSON(jsonWrapper sql.JSONWrapper) (string, error) {
 	if stringer, ok := jsonWrapper.(JSONStringer); ok {
 		return stringer.JSONString()
 	}
-	jsonBytes, err := MarshallJson(jsonWrapper)
+	val, err := jsonWrapper.ToInterface()
 	if err != nil {
 		return "", err
 	}
-	jsonBytes = bytes.ReplaceAll(jsonBytes, []byte(",\""), []byte(", \""))
-	jsonBytes = bytes.ReplaceAll(jsonBytes, []byte("\":"), []byte("\": "))
-	return string(jsonBytes), nil
+	return marshalToMySqlString(val)
 }
 
 // JSONBytes are values which can be represented as JSON.

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -16,18 +16,18 @@ package types
 
 import (
 	"database/sql/driver"
-
 	"encoding/json"
 	"fmt"
-	"github.com/dolthub/jsonpath"
-	"github.com/shopspring/decimal"
-	"golang.org/x/exp/maps"
 	"io"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/dolthub/jsonpath"
+	"github.com/shopspring/decimal"
+	"golang.org/x/exp/maps"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -133,6 +133,8 @@ func (doc JSONDocument) Extract(path string) (sql.JSONWrapper, error) {
 	return LookupJSONValue(doc, path)
 }
 
+// LazyJSONDocument is an implementation of sql.JSONWrapper that wraps a JSON string and defers deserializing
+// it unless needed. This is more efficient for queries that interact with JSON values but don't care about their structure.
 type LazyJSONDocument struct {
 	Bytes         []byte
 	interfaceFunc func() (interface{}, error)

--- a/sql/types/number.go
+++ b/sql/types/number.go
@@ -233,6 +233,7 @@ func (t NumberTypeImpl_) Compare(a interface{}, b interface{}) (int, error) {
 
 // Convert implements Type interface.
 func (t NumberTypeImpl_) Convert(v interface{}) (interface{}, sql.ConvertInRange, error) {
+	var err error
 	if v == nil {
 		return nil, sql.InRange, nil
 	}
@@ -242,7 +243,10 @@ func (t NumberTypeImpl_) Convert(v interface{}) (interface{}, sql.ConvertInRange
 	}
 
 	if jv, ok := v.(sql.JSONWrapper); ok {
-		v = jv.ToInterface()
+		v, err = jv.ToInterface()
+		if err != nil {
+			return nil, sql.OutOfRange, err
+		}
 	}
 
 	switch t.baseType {

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -15,7 +15,6 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -384,12 +383,11 @@ func ConvertToString(v interface{}, t sql.StringType) (string, error) {
 			return "", err
 		}
 	case sql.JSONWrapper:
-		jsonInterface := s.ToInterface()
-		jsonBytes, err := json.Marshal(jsonInterface)
+		jsonString, err := StringifyJSON(s)
 		if err != nil {
 			return "", err
 		}
-		val, err = strings.Unquote(string(jsonBytes))
+		val, err = strings.Unquote(jsonString)
 		if err != nil {
 			return "", err
 		}

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -16,20 +16,19 @@ package types
 
 import (
 	"fmt"
+	"gopkg.in/src-d/go-errors.v1"
 	"reflect"
 	"strconv"
 	strings2 "strings"
 	"time"
 	"unicode/utf8"
 
-	"github.com/dolthub/vitess/go/sqltypes"
-	"github.com/dolthub/vitess/go/vt/proto/query"
-	"github.com/shopspring/decimal"
-	"gopkg.in/src-d/go-errors.v1"
-
 	"github.com/dolthub/go-mysql-server/internal/strings"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/encodings"
+	"github.com/dolthub/vitess/go/sqltypes"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/shopspring/decimal"
 )
 
 const (
@@ -371,17 +370,6 @@ func ConvertToString(v interface{}, t sql.StringType) (string, error) {
 			return "", nil
 		}
 		val = s.Decimal.String()
-
-	case JSONStringer:
-		var err error
-		val, err = s.JSONString()
-		if err != nil {
-			return "", err
-		}
-		val, err = strings.Unquote(val)
-		if err != nil {
-			return "", err
-		}
 	case sql.JSONWrapper:
 		jsonString, err := StringifyJSON(s)
 		if err != nil {

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -16,19 +16,20 @@ package types
 
 import (
 	"fmt"
-	"gopkg.in/src-d/go-errors.v1"
 	"reflect"
 	"strconv"
 	strings2 "strings"
 	"time"
 	"unicode/utf8"
 
-	"github.com/dolthub/go-mysql-server/internal/strings"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/encodings"
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/shopspring/decimal"
+	"gopkg.in/src-d/go-errors.v1"
+
+	"github.com/dolthub/go-mysql-server/internal/strings"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/encodings"
 )
 
 const (

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -371,12 +371,21 @@ func ConvertToString(v interface{}, t sql.StringType) (string, error) {
 			return "", nil
 		}
 		val = s.Decimal.String()
-	case sql.JSONWrapper:
+	case JSONDocument:
 		jsonString, err := StringifyJSON(s)
 		if err != nil {
 			return "", err
 		}
 		val, err = strings.Unquote(jsonString)
+		if err != nil {
+			return "", err
+		}
+	case sql.JSONWrapper:
+		jsonBytes, err := MarshallJson(s)
+		if err != nil {
+			return "", err
+		}
+		val, err = strings.Unquote(string(jsonBytes))
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
This is the GMS side of https://github.com/dolthub/dolt/issues/7749

This is a new `JSONWrapper` implementation. It isn't used by the GMS in-memory storage, but it will be used in Dolt to speed up `SELECT` queries that don't care about the structure of the JSON.

A big difference between this and `JSONDocument` is that even after it de-serializes the JSON into a go value, it continues to keep the string in memory. This is good in cases where we would want to re-serialize the JSON later without changing it. (So statements like `SELECT json FROM table WHERE json->>"$.key" =  "foo";` will still be faster.) But with the downside of using more memory than `JSONDocument`)