### PR TITLE
aliasExpr inputExpression case-insensitive check

### DIFF
--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -224,5 +224,5 @@ func selectExprNeedsAlias(e *ast.AliasedExpr, expr sql.Expression) bool {
 		}
 	})
 
-	return complex || strings.ToLower(e.InputExpression) != strings.ToLower(expr.String())
+	return complex || e.InputExpression != expr.String()
 }

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -181,7 +181,7 @@ func (b *Builder) selectExprToExpression(inScope *scope, se ast.SelectExpr) sql.
 		if selectExprNeedsAlias(e, expr) {
 			// if the input expression is the same as expression string, then it's referencable.
 			// E.g. "SLEEP(1)" is the same as "sleep(1)"
-			if strings.ToLower(e.InputExpression) == strings.ToLower(expr.String()) {
+			if strings.EqualFold(e.InputExpression, expr.String()) {
 				return expression.NewAlias(e.InputExpression, expr)
 			}
 			return expression.NewAlias(e.InputExpression, expr).AsUnreferencable()

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -219,5 +219,5 @@ func selectExprNeedsAlias(e *ast.AliasedExpr, expr sql.Expression) bool {
 		}
 	})
 
-	return complex || e.InputExpression != expr.String()
+	return complex || strings.ToLower(e.InputExpression) != strings.ToLower(expr.String())
 }

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -179,6 +179,11 @@ func (b *Builder) selectExprToExpression(inScope *scope, se ast.SelectExpr) sql.
 			return expression.NewAlias(e.As.String(), expr)
 		}
 		if selectExprNeedsAlias(e, expr) {
+			// if the input expression is the same as expression string, then it's referencable.
+			// E.g. "SLEEP(1)" is the same as "sleep(1)"
+			if strings.ToLower(e.InputExpression) == strings.ToLower(expr.String()) {
+				return expression.NewAlias(e.InputExpression, expr)
+			}
 			return expression.NewAlias(e.InputExpression, expr).AsUnreferencable()
 		}
 		return expr


### PR DESCRIPTION
This PR adds case-insensitive check for `aliasExpr.InputExpression` and `expr.String()` to determine the expr is referencable. 