### PR TITLE
Avoid escaping HTML when Marshalling JSON

### DIFF
--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
@@ -54,6 +55,21 @@ type JSONBytes interface {
 	GetBytes() ([]byte, error)
 }
 
+func MarshallJsonValue(value interface{}) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	// Prevents special characters like <, >, or & from being escaped.
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(value)
+	if err != nil {
+		return nil, err
+	}
+	// json.Encoder appends a newline character so we trim it.
+	// SELECT cast('6\n' as JSON) returns only 6 in MySQL.
+	out := bytes.TrimRight(buffer.Bytes(), "\n")
+	return out, err
+}
+
 // JSONBytes returns or generates a byte array for the JSON representation of the underlying sql.JSONWrapper
 func MarshallJson(jsonWrapper sql.JSONWrapper) ([]byte, error) {
 	if bytes, ok := jsonWrapper.(JSONBytes); ok {
@@ -63,7 +79,7 @@ func MarshallJson(jsonWrapper sql.JSONWrapper) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
-	return json.Marshal(val)
+	return MarshallJsonValue(val)
 }
 
 type JsonObject = map[string]interface{}


### PR DESCRIPTION
Due to a misconfiguration, HTML characters were being escaped when marshaling JSON. This is unnecessary, and since we now potentially display marshalled JSON to the user, we shouldn't be doing this.