### PR TITLE
fix panic in `VALUES` constructor

### DIFF
--- a/enginetest/queries/logic_test_scripts.go
+++ b/enginetest/queries/logic_test_scripts.go
@@ -150,7 +150,6 @@ var SQLLogicJoinTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				// Syntax error
-				Skip:  true,
 				Query: "INSERT INTO xy (VALUES ROW(1, 1))",
 				Expected: []sql.Row{
 					{types.NewOkResult(1)},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10626,6 +10626,10 @@ var ErrorQueries = []QueryErrorTest{
 		Query:          `select cot(0)`,
 		ExpectedErrStr: "DOUBLE out of range for COT",
 	},
+	{
+		Query: `SELECT * FROM (values row(1,2), row(1,2,3)) t`,
+		ExpectedErr: sql.ErrColValCountMismatch,
+	},
 }
 
 var BrokenErrorQueries = []QueryErrorTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10627,7 +10627,7 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErrStr: "DOUBLE out of range for COT",
 	},
 	{
-		Query: `SELECT * FROM (values row(1,2), row(1,2,3)) t`,
+		Query:       `SELECT * FROM (values row(1,2), row(1,2,3)) t`,
 		ExpectedErr: sql.ErrColValCountMismatch,
 	},
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240429213844-e8e1b4cd75c4
+	github.com/dolthub/vitess v0.0.0-20240514174629-05f258a461c6
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20230524105445-af7e7991c97e
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20240514174629-05f258a461c6
+	github.com/dolthub/vitess v0.0.0-20240514182535-00461f67afae
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240429213844-e8e1b4cd75c4 h1:OM5fvL/E58MUkxqqdiixNXBKMcomvnjBAWnPA2YIv7c=
-github.com/dolthub/vitess v0.0.0-20240429213844-e8e1b4cd75c4/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
+github.com/dolthub/vitess v0.0.0-20240514174629-05f258a461c6 h1:70nz+KpX5lZQKcoNgs+eqcaUuQeHNghz9El7L98rorY=
+github.com/dolthub/vitess v0.0.0-20240514174629-05f258a461c6/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240514174629-05f258a461c6 h1:70nz+KpX5lZQKcoNgs+eqcaUuQeHNghz9El7L98rorY=
-github.com/dolthub/vitess v0.0.0-20240514174629-05f258a461c6/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
+github.com/dolthub/vitess v0.0.0-20240514182535-00461f67afae h1:q3Fy11eAibKoO6t2c+GADn1qafVLPSwGE349DVSTngI=
+github.com/dolthub/vitess v0.0.0-20240514182535-00461f67afae/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -309,7 +309,7 @@ var (
 	// list with a different number of columns than the schema of the table.
 	ErrColumnCountMismatch = errors.NewKind("In definition of view, derived table or common table expression, SELECT list and column names list have different column counts")
 
-	// ErrColValCountMismatch is returned when the length of tuples in VALUES constructor.
+	// ErrColValCountMismatch is returned when not all rows in values constructor are of equal length.
 	ErrColValCountMismatch = errors.NewKind("Column count doesn't match value count at row %d")
 
 	// ErrUuidUnableToParse is returned when a UUID is unable to be parsed.

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -309,6 +309,9 @@ var (
 	// list with a different number of columns than the schema of the table.
 	ErrColumnCountMismatch = errors.NewKind("In definition of view, derived table or common table expression, SELECT list and column names list have different column counts")
 
+	// ErrColValCountMismatch is returned when the length of tuples in VALUES constructor.
+	ErrColValCountMismatch = errors.NewKind("Column count doesn't match value count at row %d")
+
 	// ErrUuidUnableToParse is returned when a UUID is unable to be parsed.
 	ErrUuidUnableToParse = errors.NewKind("unable to parse '%s' to UUID: %s")
 

--- a/sql/plan/values_derived_table.go
+++ b/sql/plan/values_derived_table.go
@@ -173,7 +173,6 @@ func getSchema(rows [][]sql.Expression) sql.Schema {
 					s[i].Nullable = val.IsNullable()
 				}
 			}
-
 		}
 	}
 

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -346,8 +346,16 @@ func (b *Builder) buildDataSource(inScope *scope, te ast.TableExpr) (outScope *s
 				// Parser should enforce this, but just to be safe
 				b.handleErr(sql.ErrUnsupportedSyntax.New("every derived table must have an alias"))
 			}
-			exprTuples := make([][]sql.Expression, len(e.Rows))
+			rowLen := len(e.Rows)
+			exprTuples := make([][]sql.Expression, rowLen)
+			var tupLen int
+			if rowLen > 0 {
+				tupLen = len(e.Rows[0])
+			}
 			for i, vt := range e.Rows {
+				if len(vt) != tupLen {
+					b.handleErr(sql.ErrColValCountMismatch.New(i + 1))
+				}
 				exprs := make([]sql.Expression, len(vt))
 				exprTuples[i] = exprs
 				for j, e := range vt {


### PR DESCRIPTION
When the number of rows in a `... VALUES ROW(...), ROW(...)` statement were not equal, we would throw a panic.
This PR also unskips some tests that are now fixed.

Companion PR: https://github.com/dolthub/dolt/issues/6849

fixes: https://github.com/dolthub/dolt/issues/6849