### PR TITLE
Use Uint32 for SEQ_IN_INDEX in 'SHOW INDEXES' queries.

### DIFF
--- a/sql/plan/show_indexes.go
+++ b/sql/plan/show_indexes.go
@@ -75,7 +75,7 @@ func (n *ShowIndexes) Schema() sql.Schema {
 		&sql.Column{Name: "Table", Type: types.LongText},
 		&sql.Column{Name: "Non_unique", Type: types.Int32},
 		&sql.Column{Name: "Key_name", Type: types.LongText},
-		&sql.Column{Name: "Seq_in_index", Type: types.Int32},
+		&sql.Column{Name: "Seq_in_index", Type: types.Uint32},
 		&sql.Column{Name: "Column_name", Type: types.LongText, Nullable: true},
 		&sql.Column{Name: "Collation", Type: types.LongText, Nullable: true},
 		&sql.Column{Name: "Cardinality", Type: types.Int64},


### PR DESCRIPTION
This is seemingly the correct type for this field.

MySQL Connector/NET expects this for servers >8.0.1: https://github.com/mysql/mysql-connector-net/blob/8.4.0/MySQL.Data/src/SchemaProvider.cs#L298-L300

Fixes dolthub/go-mysql-server#2501