### PR TITLE
Adding mapping to error code 1049 for `ErrDatabaseNotFound` errors

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -90,7 +90,12 @@ func (h *Handler) NewConnection(c *mysql.Conn) {
 }
 
 func (h *Handler) ComInitDB(c *mysql.Conn, schemaName string) error {
-	return h.sm.SetDB(c, schemaName)
+	err := h.sm.SetDB(c, schemaName)
+	if err != nil {
+		logrus.WithField("database", schemaName).Errorf("unable to process ComInitDB: %s", err.Error())
+		err = sql.CastSQLError(err)
+	}
+	return err
 }
 
 // ComPrepare parses, partially analyzes, and caches a prepared statement's plan

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -260,6 +260,11 @@ func TestHandlerErrors(t *testing.T) {
 			query:             "INSERT INTO `test`.`test_table` (`id`, `id`, `v`) VALUES (1, 2, 3)",
 			expectedErrorCode: mysql.ERFieldSpecifiedTwice,
 		},
+		{
+			name:              "use database that doesn't exist'",
+			query:             "USE does_not_exist_db;",
+			expectedErrorCode: mysql.ERBadDb,
+		},
 	}
 
 	handler.ComInitDB(dummyConn, "test")

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -936,6 +936,8 @@ func CastSQLError(err error) *mysql.SQLError {
 		code = mysql.ERNoSuchTable
 	case ErrDatabaseExists.Is(err):
 		code = mysql.ERDbCreateExists
+	case ErrDatabaseNotFound.Is(err):
+		code = mysql.ERBadDb
 	case ErrExpectedSingleRow.Is(err):
 		code = mysql.ERSubqueryNo1Row
 	case ErrInvalidOperandColumns.Is(err):


### PR DESCRIPTION
When a database doesn't exist, [MySQL returns error code 1049](https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_bad_db_error). This change adds a mapping to error code 1049 for `ErrDatabaseNotFound` errors, and updates our handler so that `ComInitDB` messages will map errors to MySQL error codes. 

This is needed because tooling (e.g. Pomelo EntityFramework MySQL library) can rely on this error code in application logic.

Related to https://github.com/dolthub/dolt/issues/7890