### PR TITLE
[no-release-notes] Move Json test cases into non-test file so Dolt can depend on them.

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -933,4 +933,19 @@ var JsonScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "json mutations don't modify objects that could be seen by other expressions",
+		SetUpScript: []string{
+			"create table t (pk int primary key, col1 json);",
+			"insert into t values (1, '{}');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select pk, json_insert(col1, '$.x', 1), json_insert(col1, '$.y', 2) from t order by pk;",
+				Expected: []sql.Row{
+					{1, types.MustJSON("{\"x\":1}"), types.MustJSON("{\"y\":2}")},
+				},
+			},
+		},
+	},
 }

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -42,15 +42,10 @@ func getMutableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (type
 		return nil, err
 	}
 
-	val, err := doc.ToInterface()
-	if err != nil {
-		return nil, err
-	}
-	mutable := types.DeepCopyJson(val)
-	return types.JSONDocument{Val: mutable}, nil
+	return mutableJsonDoc(doc)
 }
 
-// getSearchableJSONVal returns a SearchableJSONValue from the given row and expression. The underling value is not copied
+// getSearchableJSONVal returns a SearchableJSONValue from the given row and expression. The underlying value is not copied
 // so it is intended to be used for read-only operations.
 // nil will be returned only if the inputs are nil. This will not return an error, so callers must check.
 func getSearchableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (sql.JSONWrapper, error) {
@@ -94,6 +89,23 @@ func getJsonFunctionError(functionName string, argumentPosition int, err error) 
 		return sql.ErrInvalidJSONText.New(argumentPosition, functionName, string(ij))
 	}
 	return err
+}
+
+// mutableJsonDoc returns a copy of |wrapper| that can be safely mutated.
+func mutableJsonDoc(wrapper sql.JSONWrapper) (types.MutableJSON, error) {
+	// Call Clone() even if |wrapper| isn't mutable. This is because some implementations (like LazyJsonDocument)
+	// cache and reuse the result of ToInterface(), and mutating this map may cause unintended behavior.
+	clonedJsonWrapper := wrapper.Clone()
+
+	if mutable, ok := clonedJsonWrapper.(types.MutableJSON); ok {
+		return mutable, nil
+	}
+
+	val, err := clonedJsonWrapper.ToInterface()
+	if err != nil {
+		return nil, err
+	}
+	return &types.JSONDocument{Val: val}, nil
 }
 
 // pathValPair is a helper struct for use by functions which take json paths paired with a json value. eg. JSON_SET, JSON_INSERT, etc.

--- a/sql/statistics.go
+++ b/sql/statistics.go
@@ -142,6 +142,10 @@ func (h Histogram) IsEmpty() bool {
 	return len(h) == 0
 }
 
+func (h Histogram) Clone() JSONWrapper {
+	return h
+}
+
 func (h Histogram) ToInterface() (interface{}, error) {
 	ret := make([]interface{}, len(h))
 	for i, b := range h {
@@ -215,6 +219,8 @@ type HistogramBucket interface {
 // The query engine can utilize these optimized access methods improve performance
 // by minimizing the need to unmarshall a JSONWrapper into a JSONDocument.
 type JSONWrapper interface {
+	// Clone creates a new value that can be mutated without affecting the original.
+	Clone() JSONWrapper
 	// ToInterface converts a JSONWrapper to an interface{} of simple types
 	ToInterface() (interface{}, error)
 }

--- a/sql/stats/statistic.go
+++ b/sql/stats/statistic.go
@@ -209,6 +209,10 @@ func (s *Statistic) IndexClass() sql.IndexClass {
 	return sql.IndexClass(s.IdxClass)
 }
 
+func (s *Statistic) Clone() sql.JSONWrapper {
+	return s
+}
+
 func (s *Statistic) ToInterface() (interface{}, error) {
 	typs := make([]string, len(s.Typs))
 	for i, t := range s.Typs {

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -135,7 +135,7 @@ func (t JsonType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 	// If we read the JSON from a table, pass through the bytes to avoid a deserialization and reserialization round-trip.
 	// This is kind of a hack, and it means that reading JSON from tables no longer matches MySQL byte-for-byte.
 	// But its worth it to avoid the round-trip, which can be very slow.
-	if j, ok := v.(*LazyJSONDocument); ok {
+	if j, ok := v.(JSONBytes); ok {
 		str, err := MarshallJson(j)
 		if err != nil {
 			return sqltypes.NULL, err


### PR DESCRIPTION
This moves the test cases for JSON_INSERT into a non-test file, and also allows the caller to provide a function that converts the test's json values into a different representation. This allows us to test the behavior of each implementation of sql.JSONWrapper.