### PR TITLE
Fix global decimal.MarshalJSONWithoutQuotes overwrite

### DIFF
--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -31,8 +31,6 @@ func init() {
 	escapeSeq[uint8('\t')] = []byte("\\t")
 	escapeSeq[uint8('"')] = []byte("\\\"")
 	escapeSeq[uint8('\\')] = []byte("\\\\")
-
-	decimal.MarshalJSONWithoutQuotes = true
 }
 
 type NoCopyBuilder struct {
@@ -317,8 +315,10 @@ func writeMarshalledValue(writer io.Writer, val interface{}) error {
 		writer.Write([]byte(val.Format(time.RFC3339)))
 		writer.Write([]byte{'"'})
 		return nil
+	case decimal.Decimal:
+		writer.Write([]byte(val.String()))
+		return nil
 	case json.Marshaler:
-		decimal.MarshalJSONWithoutQuotes = true
 		bytes, err := val.MarshalJSON()
 		if err != nil {
 			return err

--- a/sql/types/json_encode_test.go
+++ b/sql/types/json_encode_test.go
@@ -3,6 +3,8 @@ package types
 import (
 	"testing"
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 func TestMarshalToMySqlString(t *testing.T) {
@@ -98,6 +100,11 @@ newlines
 	"nested_escapedQuotes": "here \"you\" go"
 }`},
 			expected: `["{\n\t\"nested\": \"json\",\n\t\"nested_escapedQuotes\": \"here \\\"you\\\" go\"\n}"]`,
+		},
+		{
+			name:     "decimal",
+			val:      decimal.New(123, -2),
+			expected: "1.23",
 		},
 	}
 


### PR DESCRIPTION
The `decimal.MarshalJSONWithoutQuotes` is a global variable.

By setting this value then this can cause problems with any other code that does not expect this value to be changed.

Instead using a custom encoder to ensure that the marshalling behaviour is as expected without changing the global value ensure that this will not cause compatibility issues with other projects.

This code is covered both by existing tests, and an additional one in this PR.
(if the custom encode switch case is not added, but the global variables are, then the tests fail).