### PR TITLE
Bug Fix: Index name case-insensitivity

### DIFF
--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -916,27 +916,36 @@ var AlterTableScripts = []ScriptTest{
 		},
 	},
 	{
-		Name: "Rename index",
+		Name: "Index case-insensitivity",
 		SetUpScript: []string{
-			"create table t (i int, KEY myIndex (`i`))",
+			"create table t1 (i int, KEY myIndex1 (`i`))",
+			"create table t2 (i int, KEY myIndex2 (`i`))",
+			"create table t3 (i int, KEY myIndex3 (`i`))",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "alter table t rename index myIndex to mySecondIndex;",
+				Query:    "alter table t1 drop index MYINDEX1;",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:    "show indexes from t;",
-				Expected: []sql.Row{{"t", 1, "mySecondIndex", 1, "i", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil}},
+				Query:    "show indexes from t1;",
+				Expected: []sql.Row{},
 			},
 			{
-				// Index names are case-insensitive
-				Query:    "alter table t rename index MYsecondindEX to anotherIndex;",
+				Query:    "alter table t2 rename index myIndex2 to mySecondIndex;",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:    "show indexes from t;",
-				Expected: []sql.Row{{"t", 1, "anotherIndex", 1, "i", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil}},
+				Query:    "show indexes from t2;",
+				Expected: []sql.Row{{"t2", 1, "mySecondIndex", 1, "i", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil}},
+			},
+			{
+				Query:    "alter table t3 rename index MYiNDEX3 to anotherIndex;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "show indexes from t3;",
+				Expected: []sql.Row{{"t3", 1, "anotherIndex", 1, "i", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil}},
 			},
 		},
 	},

--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -916,6 +916,31 @@ var AlterTableScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "Rename index",
+		SetUpScript: []string{
+			"create table t (i int, KEY myIndex (`i`))",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "alter table t rename index myIndex to mySecondIndex;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "show indexes from t;",
+				Expected: []sql.Row{{"t", 1, "mySecondIndex", 1, "i", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil}},
+			},
+			{
+				// Index names are case-insensitive
+				Query:    "alter table t rename index MYsecondindEX to anotherIndex;",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "show indexes from t;",
+				Expected: []sql.Row{{"t", 1, "anotherIndex", 1, "i", nil, 0, nil, nil, "YES", "BTREE", "", "", "YES", nil}},
+			},
+		},
+	},
+	{
 		Name: "alter column and rename table work within same transaction",
 		SetUpScript: []string{
 			"create table t (i int)",

--- a/go.sum
+++ b/go.sum
@@ -58,16 +58,6 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20240514182535-00461f67afae h1:q3Fy11eAibKoO6t2c+GADn1qafVLPSwGE349DVSTngI=
-github.com/dolthub/vitess v0.0.0-20240514182535-00461f67afae/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
-github.com/dolthub/vitess v0.0.0-20240515231645-966f8cb81cfe h1:40//2vXX3xDDud5bgrw6pcNHSZBexqvdlHvIoSA2dyA=
-github.com/dolthub/vitess v0.0.0-20240515231645-966f8cb81cfe/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
-github.com/dolthub/vitess v0.0.0-20240520192903-ff7bd6353f3e h1:idIiEhWOfi6vuBD7wZxn75TGPMcnZ6r9Zr/DHGAOCrQ=
-github.com/dolthub/vitess v0.0.0-20240520192903-ff7bd6353f3e/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
-github.com/dolthub/vitess v0.0.0-20240521104846-e778edc6deb3 h1:2Q6j9yI1XjDH5UOY0EAhaXoGIdN11jItAzpRGLl6O8o=
-github.com/dolthub/vitess v0.0.0-20240521104846-e778edc6deb3/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
-github.com/dolthub/vitess v0.0.0-20240524204318-4c419c3de9c4 h1:nk+hnh7bpDs3vvOaaE+YtQPXnLenvEtd6Q8SptcbJRc=
-github.com/dolthub/vitess v0.0.0-20240524204318-4c419c3de9c4/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
 github.com/dolthub/vitess v0.0.0-20240603172811-467efd832e48 h1:KfVnDVNytmTHeYZaQfUWZF/uE/fbLdLvXVdebQTPaMk=
 github.com/dolthub/vitess v0.0.0-20240603172811-467efd832e48/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/memory/table_data.go
+++ b/memory/table_data.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/cespare/xxhash/v2"
 
@@ -386,7 +387,7 @@ func (td *TableData) sortRows() {
 
 func (td *TableData) sortSecondaryIndexes() {
 	for idxName, idxStorage := range td.secondaryIndexStorage {
-		idx := td.indexes[string(idxName)].(*Index)
+		idx := td.indexes[strings.ToLower(string(idxName))].(*Index)
 		fieldIndexes := idx.columnIndexes(td.schema.Schema)
 		types := make([]sql.Type, len(fieldIndexes))
 		for i, idx := range fieldIndexes {


### PR DESCRIPTION
MySQL index names are case-insensitive, but GMS' memory implementation wasn't handling them that way. This makes index names case-insensitive.

Related to https://github.com/dolthub/dolt/issues/7945