### PR TITLE
Implement row alias expressions (`INSERT ... VALUES (...) AS new_tbl ON DUPLICATE x = new_tbl.x`)

### DIFF
--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -16,8 +16,9 @@ package analyzer
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -16,9 +16,8 @@ package analyzer
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/dolthub/go-mysql-server/sql/planbuilder"
+	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -425,7 +424,20 @@ func (s *idxScope) visitSelf(n sql.Node) error {
 		for oldRowIdx, c := range n.Destination.Schema() {
 			rightSchema[oldRowIdx] = c
 			newRowIdx := len(n.Destination.Schema()) + oldRowIdx
-			if _, ok := n.Source.(*plan.Values); !ok && len(n.Destination.Schema()) == len(n.Source.Schema()) {
+			if values, ok := n.Source.(*plan.Values); ok {
+				// The source table is either named via VALUES(...) AS ... or has
+				// the default value planbuilder.OnDupValuesPrefix
+				newC := c.Copy()
+				newC.Source = values.AliasName
+				if values.ColumnNames != nil {
+					newC.Name = values.ColumnNames[newC.Name]
+				}
+				rightSchema[newRowIdx] = newC
+			} else if len(n.Destination.Schema()) != len(n.Source.Schema()) {
+				newC := c.Copy()
+				newC.Source = planbuilder.OnDupValuesPrefix
+				rightSchema[newRowIdx] = newC
+			} else {
 				// find source index that aligns with dest column
 				var matched bool
 				for j, sourceCol := range n.ColumnNames {
@@ -441,10 +453,6 @@ func (s *idxScope) visitSelf(n sql.Node) error {
 					//  define the columns upfront.
 					rightSchema[newRowIdx] = n.Source.Schema()[oldRowIdx]
 				}
-			} else {
-				newC := c.Copy()
-				newC.Source = planbuilder.OnDupValuesPrefix
-				rightSchema[newRowIdx] = newC
 			}
 		}
 		rightScope := &idxScope{}

--- a/sql/plan/values.go
+++ b/sql/plan/values.go
@@ -23,6 +23,8 @@ import (
 
 // Values represents a set of tuples of expressions.
 type Values struct {
+	AliasName        string
+	ColumnNames      map[string]string
 	ExpressionTuples [][]sql.Expression
 }
 
@@ -31,7 +33,12 @@ var _ sql.CollationCoercible = (*Values)(nil)
 
 // NewValues creates a Values node with the given tuples.
 func NewValues(tuples [][]sql.Expression) *Values {
-	return &Values{tuples}
+	return &Values{ExpressionTuples: tuples}
+}
+
+// NewValuesWithAliasName creates a Values node with the given row and column aliases.
+func NewValuesWithAlias(tableName string, columnNames map[string]string, tuples [][]sql.Expression) *Values {
+	return &Values{ExpressionTuples: tuples, AliasName: tableName, ColumnNames: columnNames}
 }
 
 // Schema implements the Node interface.
@@ -186,5 +193,5 @@ func (p *Values) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
 		}
 	}
 
-	return NewValues(tuples), nil
+	return NewValuesWithAlias(p.AliasName, p.ColumnNames, tuples), nil
 }

--- a/sql/planbuilder/builder.go
+++ b/sql/planbuilder/builder.go
@@ -34,23 +34,21 @@ var BinderFactory = &sync.Pool{New: func() interface{} {
 }}
 
 type Builder struct {
-	ctx                 *sql.Context
-	cat                 sql.Catalog
-	parserOpts          ast.ParserOptions
-	f                   *factory
-	currentDatabase     sql.Database
-	colId               columnId
-	tabId               sql.TableId
-	multiDDL            bool
-	viewCtx             *ViewContext
-	procCtx             *ProcContext
-	triggerCtx          *TriggerContext
-	bindCtx             *BindvarContext
-	insertActive        bool
-	insertTableAlias    string
-	insertColumnAliases map[string]string
-	nesting             int
-	parser              sql.Parser
+	ctx             *sql.Context
+	cat             sql.Catalog
+	parserOpts      ast.ParserOptions
+	f               *factory
+	currentDatabase sql.Database
+	colId           columnId
+	tabId           sql.TableId
+	multiDDL        bool
+	viewCtx         *ViewContext
+	procCtx         *ProcContext
+	triggerCtx      *TriggerContext
+	bindCtx         *BindvarContext
+	insertActive    bool
+	nesting         int
+	parser          sql.Parser
 }
 
 // BindvarContext holds bind variable replacement literals.

--- a/sql/planbuilder/builder.go
+++ b/sql/planbuilder/builder.go
@@ -34,21 +34,23 @@ var BinderFactory = &sync.Pool{New: func() interface{} {
 }}
 
 type Builder struct {
-	ctx             *sql.Context
-	cat             sql.Catalog
-	parserOpts      ast.ParserOptions
-	f               *factory
-	currentDatabase sql.Database
-	colId           columnId
-	tabId           sql.TableId
-	multiDDL        bool
-	viewCtx         *ViewContext
-	procCtx         *ProcContext
-	triggerCtx      *TriggerContext
-	bindCtx         *BindvarContext
-	insertActive    bool
-	nesting         int
-	parser          sql.Parser
+	ctx                 *sql.Context
+	cat                 sql.Catalog
+	parserOpts          ast.ParserOptions
+	f                   *factory
+	currentDatabase     sql.Database
+	colId               columnId
+	tabId               sql.TableId
+	multiDDL            bool
+	viewCtx             *ViewContext
+	procCtx             *ProcContext
+	triggerCtx          *TriggerContext
+	bindCtx             *BindvarContext
+	insertActive        bool
+	insertTableAlias    string
+	insertColumnAliases map[string]string
+	nesting             int
+	parser              sql.Parser
 }
 
 // BindvarContext holds bind variable replacement literals.

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -99,7 +99,7 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 		if len(aliasedValues.Columns) > 0 {
 			inScope.insertColumnAliases = make(map[string]string)
 			for i, destColumn := range columns {
-				sourceColumn := aliasedValues.Columns[i].String()
+				sourceColumn := aliasedValues.Columns[i].Lowered()
 				inScope.insertColumnAliases[destColumn] = sourceColumn
 			}
 		}

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -316,7 +316,10 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 	case *ast.ValuesFuncExpr:
 		if b.insertActive {
 			if v.Name.Qualifier.Name.String() == "" {
-				v.Name.Qualifier.Name = ast.NewTableIdent(OnDupValuesPrefix)
+				v.Name.Qualifier.Name = ast.NewTableIdent(b.insertTableAlias)
+				if len(b.insertColumnAliases) > 0 {
+					v.Name.Name = ast.NewColIdent(b.insertColumnAliases[v.Name.Name.String()])
+				}
 			}
 			dbName := strings.ToLower(v.Name.Qualifier.DbQualifier.String())
 			tblName := strings.ToLower(v.Name.Qualifier.Name.String())

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -316,9 +316,9 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 	case *ast.ValuesFuncExpr:
 		if b.insertActive {
 			if v.Name.Qualifier.Name.String() == "" {
-				v.Name.Qualifier.Name = ast.NewTableIdent(b.insertTableAlias)
-				if len(b.insertColumnAliases) > 0 {
-					v.Name.Name = ast.NewColIdent(b.insertColumnAliases[v.Name.Name.String()])
+				v.Name.Qualifier.Name = ast.NewTableIdent(inScope.insertTableAlias)
+				if len(inScope.insertColumnAliases) > 0 {
+					v.Name.Name = ast.NewColIdent(inScope.insertColumnAliases[v.Name.Name.String()])
 				}
 			}
 			dbName := strings.ToLower(v.Name.Qualifier.DbQualifier.String())

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -318,7 +318,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 			if v.Name.Qualifier.Name.String() == "" {
 				v.Name.Qualifier.Name = ast.NewTableIdent(inScope.insertTableAlias)
 				if len(inScope.insertColumnAliases) > 0 {
-					v.Name.Name = ast.NewColIdent(inScope.insertColumnAliases[v.Name.Name.String()])
+					v.Name.Name = ast.NewColIdent(inScope.insertColumnAliases[v.Name.Name.Lowered()])
 				}
 			}
 			dbName := strings.ToLower(v.Name.Qualifier.DbQualifier.String())

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -59,6 +59,9 @@ type scope struct {
 	// exprs collects unique expression ids for reference
 	exprs map[string]columnId
 	proc  *procCtx
+
+	insertTableAlias    string
+	insertColumnAliases map[string]string
 }
 
 // resolveColumn matches a variable use to a column definition with a unique


### PR DESCRIPTION
When inserting values, the user can specify names for both the source table and columns which are used in `ON DUPLICATE` expressions. It looks like either of the below options:

```sql
INSERT INTO tbl VALUES (1, 2) AS tbl_new ON DUPLICATE KEY b = tbl_new.b;

INSERT INTO tbl VALUES (1, 2) AS tbl_new(a_new, b_new) ON DUPLICATE KEY b = b_new;
```

This replaces the previous (now-deprecated) syntax:

```sql
INSERT INTO tbl VALUES (1, 2) ON DUPLICATE KEY b = VALUES(b);
```

Supporting both syntaxes together was non-trivial because it means there's now two different ways to refer to the same column. While he had an existing way to "redirect" one column name to another, this only worked for unqualified names (no table name), and it overrode the normal name resolution rules, which meant we would fail to detect cases that should be seen as ambiguous.

Previously, we would implement references to the inserted values by using a special table named "__new_ins". I implemented this by keeping that as the default, but using the row alias instead of one was provided. We then create a map from the destination table names to column aliases, and use that map to rewrite expressions that appear inside the VALUES() function.