### PR TITLE
Fix UPDATE JOIN matchedRows

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -156,6 +156,25 @@ var ScriptTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Dolt issue 7957, update join matched rows",
+		SetUpScript: []string{
+			`CREATE TABLE entity_test(
+    id INT PRIMARY KEY,
+    value INT
+);`,
+			"INSERT INTO entity_test (id, value) values (1,10), (2,20), (3,30);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `UPDATE entity_test
+    JOIN (VALUES ROW(1, 10), ROW(2,20)) joined (id, value)
+    ON joined.id = entity_test.id
+SET entity_test.value = joined.value;`,
+				Expected: []sql.Row{{types.OkResult{Info: plan.UpdateInfo{Matched: 2}}}},
+			},
+		},
+	},
+	{
 		Name: "GMS issue 2349",
 		SetUpScript: []string{
 			"CREATE TABLE table1 (id int NOT NULL AUTO_INCREMENT primary key, name text)",
@@ -2553,7 +2572,7 @@ CREATE TABLE tab3 (
 			{
 				Query: `update test inner join test2 on test.pk = test2.pk SET test.pk=test.pk*10, test2.pk = test2.pk * 4 where test.pk < 10;`,
 				Expected: []sql.Row{{types.OkResult{RowsAffected: 6, Info: plan.UpdateInfo{
-					Matched:  6, // TODO: The answer should be 8
+					Matched:  8,
 					Updated:  6,
 					Warnings: 0,
 				}}}},
@@ -5652,14 +5671,14 @@ CREATE TABLE tab3 (
 		},
 		Assertions: []ScriptTestAssertion{
 			{
+				// TODO: this query isn't valid SQL, why
 				Query: `update joinparent as jp 
 							left join joinchild as jc on jc.parent_id = jp.id
 								set jp.archived = jp.id, jp.archived_at = now(), 
 									jc.archived = jc.id, jc.archived_at = now()
 						where jp.id > 0 and jp.name != "never"
-						order by jp.name
 						limit 100`,
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 8, Info: plan.UpdateInfo{Matched: 10, Updated: 8}}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 8, Info: plan.UpdateInfo{Matched: 8, Updated: 8}}}},
 			},
 			// do without limit to use `plan.Sort` instead of `plan.TopN`
 			{
@@ -5667,9 +5686,8 @@ CREATE TABLE tab3 (
 							left join joinchild as jc on jc.parent_id = jp.id
 								set jp.archived = 0, jp.archived_at = null, 
 									jc.archived = 0, jc.archived_at = null
-						where jp.id > 0 and jp.name != "never"
-						order by jp.name`,
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 8, Info: plan.UpdateInfo{Matched: 10, Updated: 8}}}},
+						where jp.id > 0 and jp.name != "never"`,
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 8, Info: plan.UpdateInfo{Matched: 8, Updated: 8}}}},
 			},
 		},
 	},

--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -257,7 +257,7 @@ var UpdateTests = []WriteQueryTest{
 	},
 	{
 		WriteQuery:          `UPDATE one_pk INNER JOIN two_pk on one_pk.pk = two_pk.pk1 SET one_pk.c1 = one_pk.c1 + 1, two_pk.c1 = two_pk.c2 + 1`,
-		ExpectedWriteResult: []sql.Row{{newUpdateResult(8, 6)}}, // TODO: Should be matched = 6
+		ExpectedWriteResult: []sql.Row{{newUpdateResult(6, 6)}},
 		SelectQuery:         "SELECT * FROM two_pk;",
 		ExpectedSelect: []sql.Row{
 			sql.NewRow(0, 0, 2, 1, 2, 3, 4),

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -428,7 +428,8 @@ type updateJoinRowHandler struct {
 	updaterMap   map[string]sql.RowUpdater
 }
 
-func (u *updateJoinRowHandler) handleRowsMatched(_ sql.Row) {
+// handleRowMatched is called when an update join's source returns a row
+func (u *updateJoinRowHandler) handleRowMatched() {
 	u.rowsMatched += 1
 }
 
@@ -440,7 +441,6 @@ func (u *updateJoinRowHandler) handleRowUpdate(row sql.Row) error {
 	tableToNewRow := plan.SplitRowIntoTableRowMap(newJoinRow, u.joinSchema)
 
 	for tableName, _ := range u.updaterMap {
-		//u.rowsMatched++ // TODO: This currently returns the incorrect answer
 		tableOldRow := tableToOldRow[tableName]
 		tableNewRow := tableToNewRow[tableName]
 		if equals, err := tableOldRow.Equals(tableNewRow, u.tableMap[tableName]); err == nil {

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -428,6 +428,10 @@ type updateJoinRowHandler struct {
 	updaterMap   map[string]sql.RowUpdater
 }
 
+func (u *updateJoinRowHandler) handleRowsMatched(_ sql.Row) {
+	u.rowsMatched += 1
+}
+
 func (u *updateJoinRowHandler) handleRowUpdate(row sql.Row) error {
 	oldJoinRow := row[:len(row)/2]
 	newJoinRow := row[len(row)/2:]
@@ -436,7 +440,7 @@ func (u *updateJoinRowHandler) handleRowUpdate(row sql.Row) error {
 	tableToNewRow := plan.SplitRowIntoTableRowMap(newJoinRow, u.joinSchema)
 
 	for tableName, _ := range u.updaterMap {
-		u.rowsMatched++ // TODO: This currently returns the incorrect answer
+		//u.rowsMatched++ // TODO: This currently returns the incorrect answer
 		tableOldRow := tableToOldRow[tableName]
 		tableNewRow := tableToNewRow[tableName]
 		if equals, err := tableOldRow.Equals(tableNewRow, u.tableMap[tableName]); err == nil {

--- a/sql/rowexec/update.go
+++ b/sql/rowexec/update.go
@@ -238,7 +238,7 @@ func (u *updateJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 				cache.Put(hash, struct{}{})
 
 				// updateJoin counts matched rows from join output
-				u.accumulator.handleRowsMatched(oldTableRow)
+				u.accumulator.handleRowMatched()
 
 				continue
 			} else if err != nil {

--- a/sql/rowexec/update.go
+++ b/sql/rowexec/update.go
@@ -192,6 +192,7 @@ type updateJoinIter struct {
 	caches           map[string]sql.KeyValueCache
 	disposals        map[string]sql.DisposeFunc
 	joinNode         sql.Node
+	accumulator      *updateJoinRowHandler
 }
 
 var _ sql.RowIter = (*updateJoinIter)(nil)
@@ -235,6 +236,10 @@ func (u *updateJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			_, err = cache.Get(hash)
 			if errors.Is(err, sql.ErrKeyNotFound) {
 				cache.Put(hash, struct{}{})
+
+				// updateJoin counts matched rows from join output
+				u.accumulator.handleRowsMatched(oldTableRow)
+
 				continue
 			} else if err != nil {
 				return nil, err


### PR DESCRIPTION
fixes: https://github.com/dolthub/dolt/issues/7957

Main question is how thorough we want to make the child iter check. Should all iterators implement a `ChildIter` interface?