### PR TITLE
Update generated index names to match MySQL

### DIFF
--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -132,13 +132,13 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `CREATE TABLE t1 (i int primary key, j int auto_increment, k int, unique(j,k))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `jk` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `j` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 (i int primary key, j int auto_increment, k int, index (j,k))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE t1",
-		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  KEY `jk` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `j` int NOT NULL AUTO_INCREMENT,\n  `k` int,\n  PRIMARY KEY (`i`),\n  KEY `j` (`j`,`k`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery: `CREATE TABLE t1 (
@@ -171,19 +171,19 @@ var CreateTableQueries = []WriteQueryTest{
 		WriteQuery:          `create table t1 (i int primary key, b1 blob, b2 blob, index(b1(123), b2(456)))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `show create table t1`,
-		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `b1` blob,\n  `b2` blob,\n  PRIMARY KEY (`i`),\n  KEY `b1b2` (`b1`(123),`b2`(456))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `b1` blob,\n  `b2` blob,\n  PRIMARY KEY (`i`),\n  KEY `b1` (`b1`(123),`b2`(456))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `create table t1 (i int primary key, b1 blob, b2 blob, unique index(b1(123), b2(456)))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `show create table t1`,
-		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `b1` blob,\n  `b2` blob,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `b1b2` (`b1`(123),`b2`(456))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `b1` blob,\n  `b2` blob,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `b1` (`b1`(123),`b2`(456))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `create table t1 (i int primary key, b1 blob, b2 blob, index(b1(10)), index(b2(20)), index(b1(123), b2(456)))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         `show create table t1`,
-		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `b1` blob,\n  `b2` blob,\n  PRIMARY KEY (`i`),\n  KEY `b1` (`b1`(10)),\n  KEY `b1b2` (`b1`(123),`b2`(456)),\n  KEY `b2` (`b2`(20))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `i` int NOT NULL,\n  `b1` blob,\n  `b2` blob,\n  PRIMARY KEY (`i`),\n  KEY `b1` (`b1`(10)),\n  KEY `b1_2` (`b1`(123),`b2`(456)),\n  KEY `b2` (`b2`(20))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `CREATE TABLE t1 as select * from mytable`,

--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -32,7 +32,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW CREATE TABLE child;",
-				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `v1` (`v1`),\n  CONSTRAINT `fk_named` FOREIGN KEY (`v1`) REFERENCES `parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `fk_named` (`v1`),\n  CONSTRAINT `fk_named` FOREIGN KEY (`v1`) REFERENCES `parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},
@@ -44,7 +44,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW CREATE TABLE sibling;",
-				Expected: []sql.Row{{"sibling", "CREATE TABLE `sibling` (\n  `id` int NOT NULL,\n  `v1` int,\n  PRIMARY KEY (`id`),\n  KEY `v1` (`v1`),\n  CONSTRAINT `fk_named` FOREIGN KEY (`v1`) REFERENCES `parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"sibling", "CREATE TABLE `sibling` (\n  `id` int NOT NULL,\n  `v1` int,\n  PRIMARY KEY (`id`),\n  KEY `fk_named` (`v1`),\n  CONSTRAINT `fk_named` FOREIGN KEY (`v1`) REFERENCES `parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},
@@ -233,7 +233,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW CREATE TABLE child;",
-				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `v1` (`v1`),\n  CONSTRAINT `fk_name` FOREIGN KEY (`v1`) REFERENCES `parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `fk_name` (`v1`),\n  CONSTRAINT `fk_name` FOREIGN KEY (`v1`) REFERENCES `parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "ALTER TABLE child DROP FOREIGN KEY fk_name;",
@@ -241,7 +241,7 @@ var ForeignKeyTests = []ScriptTest{
 			},
 			{
 				Query:    "SHOW CREATE TABLE child;",
-				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `v1` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `fk_name` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:       "ALTER TABLE child DROP FOREIGN KEY fk_name;",
@@ -291,7 +291,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW CREATE TABLE child;",
-				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `v1` (`v1`),\n  CONSTRAINT `fk_name` FOREIGN KEY (`v1`) REFERENCES `new_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `fk_name` (`v1`),\n  CONSTRAINT `fk_name` FOREIGN KEY (`v1`) REFERENCES `new_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "RENAME TABLE child TO new_child;",
@@ -299,7 +299,7 @@ var ForeignKeyTests = []ScriptTest{
 			},
 			{
 				Query:    "SHOW CREATE TABLE new_child;",
-				Expected: []sql.Row{{"new_child", "CREATE TABLE `new_child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `v1` (`v1`),\n  CONSTRAINT `fk_name` FOREIGN KEY (`v1`) REFERENCES `new_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"new_child", "CREATE TABLE `new_child` (\n  `id` int NOT NULL,\n  `v1` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `fk_name` (`v1`),\n  CONSTRAINT `fk_name` FOREIGN KEY (`v1`) REFERENCES `new_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},
@@ -419,7 +419,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW CREATE TABLE child;",
-				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1_new` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `v1` (`v1_new`),\n  CONSTRAINT `fk1` FOREIGN KEY (`v1_new`) REFERENCES `parent` (`v1_new`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"child", "CREATE TABLE `child` (\n  `id` int NOT NULL,\n  `v1_new` int,\n  `v2` int,\n  PRIMARY KEY (`id`),\n  KEY `fk1` (`v1_new`),\n  CONSTRAINT `fk1` FOREIGN KEY (`v1_new`) REFERENCES `parent` (`v1_new`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},
@@ -1356,7 +1356,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW CREATE TABLE delayed_child;",
-				Expected: []sql.Row{{"delayed_child", "CREATE TABLE `delayed_child` (\n  `pk` int NOT NULL,\n  `v1` int,\n  PRIMARY KEY (`pk`),\n  KEY `v1` (`v1`),\n  CONSTRAINT `fk_delayed` FOREIGN KEY (`v1`) REFERENCES `delayed_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"delayed_child", "CREATE TABLE `delayed_child` (\n  `pk` int NOT NULL,\n  `v1` int,\n  PRIMARY KEY (`pk`),\n  KEY `fk_delayed` (`v1`),\n  CONSTRAINT `fk_delayed` FOREIGN KEY (`v1`) REFERENCES `delayed_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "SELECT * FROM delayed_parent;",
@@ -1408,7 +1408,7 @@ var ForeignKeyTests = []ScriptTest{
 				ExpectedErr: sql.ErrAddForeignKeyDuplicateColumn,
 			},
 			{
-				Query:       "ALTER TABLE valid_delayed_child drop index i",
+				Query:       "ALTER TABLE valid_delayed_child drop index valid_fk",
 				ExpectedErr: sql.ErrForeignKeyDropIndex,
 			},
 		},
@@ -1424,7 +1424,7 @@ var ForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SHOW CREATE TABLE delayed_child;",
-				Expected: []sql.Row{{"delayed_child", "CREATE TABLE `delayed_child` (\n  `pk` int NOT NULL,\n  `v1` int,\n  PRIMARY KEY (`pk`),\n  KEY `v1` (`v1`),\n  CONSTRAINT `fk_delayed` FOREIGN KEY (`v1`) REFERENCES `delayed_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"delayed_child", "CREATE TABLE `delayed_child` (\n  `pk` int NOT NULL,\n  `v1` int,\n  PRIMARY KEY (`pk`),\n  KEY `fk_delayed` (`v1`),\n  CONSTRAINT `fk_delayed` FOREIGN KEY (`v1`) REFERENCES `delayed_parent` (`v1`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "SELECT * FROM delayed_child;",
@@ -1590,7 +1590,7 @@ var ForeignKeyTests = []ScriptTest{
 						"  `fk1` int NOT NULL,\n" +
 						"  `fk2` int NOT NULL,\n" +
 						"  PRIMARY KEY (`fk2`,`fk1`,`id`),\n" +
-						"  KEY `fk1fk2` (`fk1`,`fk2`),\n" +
+						"  KEY `fk` (`fk1`,`fk2`),\n" +
 						"  UNIQUE KEY `id` (`id`),\n" +
 						"  CONSTRAINT `fk` FOREIGN KEY (`fk1`,`fk2`) REFERENCES `parent` (`fk1`,`fk2`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
@@ -1678,7 +1678,7 @@ var ForeignKeyTests = []ScriptTest{
 					{"t1", "CREATE TABLE `t1` (\n" +
 						"  `i` int NOT NULL,\n  `J` int,\n" +
 						"  PRIMARY KEY (`i`),\n" +
-						"  KEY `J` (`J`),\n" +
+						"  KEY `fk1` (`J`),\n" +
 						"  CONSTRAINT `fk1` FOREIGN KEY (`J`) REFERENCES `t1` (`i`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -1701,7 +1701,7 @@ var ForeignKeyTests = []ScriptTest{
 						"  `I` int NOT NULL,\n" +
 						"  `j` int,\n" +
 						"  PRIMARY KEY (`I`),\n" +
-						"  KEY `j` (`j`),\n" +
+						"  KEY `fk2` (`j`),\n" +
 						"  CONSTRAINT `fk2` FOREIGN KEY (`j`) REFERENCES `t2` (`I`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -1722,7 +1722,7 @@ var ForeignKeyTests = []ScriptTest{
 					{"t3", "CREATE TABLE `t3` (\n" +
 						"  `i` int NOT NULL,\n  `j` int,\n" +
 						"  PRIMARY KEY (`i`),\n" +
-						"  KEY `j` (`j`),\n" +
+						"  KEY `fk3` (`j`),\n" +
 						"  CONSTRAINT `fk3` FOREIGN KEY (`j`) REFERENCES `t3` (`i`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -2119,7 +2119,7 @@ var ForeignKeyTests = []ScriptTest{
 						"  `pk2` int NOT NULL,\n" +
 						"  `pk3` int NOT NULL,\n" +
 						"  PRIMARY KEY (`pk1`,`pk2`,`pk3`),\n" +
-						"  KEY `fk1pk2` (`fk1`,`pk2`),\n" +
+						"  KEY `fk1` (`fk1`,`pk2`),\n" +
 						"  CONSTRAINT `fk1` FOREIGN KEY (`fk1`,`pk2`) REFERENCES `parent1` (`fk1`,`pk2`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -2155,7 +2155,7 @@ var ForeignKeyTests = []ScriptTest{
 						"  `pk2` int NOT NULL,\n" +
 						"  `pk3` int NOT NULL,\n" +
 						"  PRIMARY KEY (`pk1`,`pk2`,`pk3`),\n" +
-						"  KEY `fk1pk2pk1` (`fk1`,`pk2`,`pk1`),\n" +
+						"  KEY `fk2` (`fk1`,`pk2`,`pk1`),\n" +
 						"  CONSTRAINT `fk2` FOREIGN KEY (`fk1`,`pk2`,`pk1`) REFERENCES `parent1` (`fk1`,`pk2`,`pk1`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -2197,7 +2197,7 @@ var ForeignKeyTests = []ScriptTest{
 						"  `pk2` int NOT NULL,\n" +
 						"  `pk3` int NOT NULL,\n" +
 						"  PRIMARY KEY (`pk1`,`pk2`,`pk3`),\n" +
-						"  KEY `fk1pk2pk1pk3` (`fk1`,`pk2`,`pk1`,`pk3`),\n" +
+						"  KEY `fk3` (`fk1`,`pk2`,`pk1`,`pk3`),\n" +
 						"  CONSTRAINT `fk3` FOREIGN KEY (`fk1`,`pk2`,`pk1`,`pk3`) REFERENCES `parent1` (`fk1`,`pk2`,`pk1`,`pk3`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
@@ -2221,7 +2221,7 @@ var ForeignKeyTests = []ScriptTest{
 						"  `pk2` int NOT NULL,\n" +
 						"  `pk3` int NOT NULL,\n" +
 						"  PRIMARY KEY (`pk1`,`pk2`,`pk3`),\n" +
-						"  KEY `fk1pk2pk1pk3` (`fk1`,`pk2`,`pk1`,`pk3`),\n" +
+						"  KEY `fk4` (`fk1`,`pk2`,`pk1`,`pk3`),\n" +
 						"  KEY `idx4` (`fk1`,`pk2`),\n" +
 						"  CONSTRAINT `fk4` FOREIGN KEY (`fk1`,`pk2`,`pk1`,`pk3`) REFERENCES `parent1` (`fk1`,`pk2`,`pk1`,`pk3`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
@@ -2242,7 +2242,7 @@ var ForeignKeyTests = []ScriptTest{
 						"  `pk2` int NOT NULL,\n" +
 						"  `pk3` int NOT NULL,\n" +
 						"  PRIMARY KEY (`pk1`,`pk2`,`pk3`),\n" +
-						"  KEY `fk1pk2pk1pk3` (`fk1`,`pk2`,`pk1`,`pk3`),\n" +
+						"  KEY `fk4` (`fk1`,`pk2`,`pk1`,`pk3`),\n" +
 						"  KEY `idx4` (`fk1`,`pk2`),\n" +
 						"  CONSTRAINT `fk4` FOREIGN KEY (`fk1`,`pk2`,`pk1`,`pk3`) REFERENCES `parent1` (`fk1`,`pk2`,`pk1`,`pk3`),\n" +
 						"  CONSTRAINT `fk5` FOREIGN KEY (`fk1`) REFERENCES `parent1` (`fk1`)\n" +

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4065,43 +4065,6 @@ var IndexPrefixQueries = []ScriptTest{
 
 var IndexQueries = []ScriptTest{
 	{
-		// https://github.com/dolthub/dolt/issues/7960
-		Name: "Generated index names",
-		SetUpScript: []string{
-			`CREATE TABLE a_test (id1 INT, id2 INT, id3 INT, PRIMARY KEY (id1, id2), KEY (id2, id3));`,
-			`CREATE TABLE b_test(
-					a_id1 INT,
-					a_id2 INT,
-					a_id3 INT,
-					FOREIGN KEY (a_id1, a_id2) REFERENCES a_test (id1, id2),
-					CONSTRAINT fk_b_a FOREIGN KEY (a_id2, a_id3) REFERENCES a_test (id2, id3)
-				);`,
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				// Composite keys are named after the first column in the key
-				Query: "SELECT TABLE_NAME, INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX FROM information_schema.STATISTICS WHERE TABLE_NAME='a_test' ORDER BY INDEX_NAME, SEQ_IN_INDEX;",
-				Expected: []sql.Row{
-					{"a_test", "id2", "id2", 1},
-					{"a_test", "id2", "id3", 2},
-					{"a_test", "PRIMARY", "id1", 1},
-					{"a_test", "PRIMARY", "id2", 2},
-				},
-			},
-			{
-				// When an explicit name is provided for a foreign key, the same name is used for the generated index
-				// TODO: This should probably live with the foreign key tests
-				Query: "SELECT TABLE_NAME, INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX FROM information_schema.STATISTICS WHERE TABLE_NAME='b_test' ORDER BY INDEX_NAME, SEQ_IN_INDEX;",
-				Expected: []sql.Row{
-					{"b_test", "a_id1", "a_id1", 1},
-					{"b_test", "a_id1", "a_id2", 2},
-					{"b_test", "fk_b_a", "a_id2", 1},
-					{"b_test", "fk_b_a", "a_id3", 2},
-				},
-			},
-		},
-	},
-	{
 		Name: "unique key violation prevents insert",
 		SetUpScript: []string{
 			"create table users (id varchar(26) primary key, namespace varchar(50), name varchar(50));",

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -3447,7 +3447,7 @@ var IndexPrefixQueries = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "show create table t",
-				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` varchar(10),\n  `v2` varchar(10),\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1v2` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` varchar(10),\n  `v2` varchar(10),\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "insert into t values (0, 'a', 'a'), (1, 'ab','ab'), (2, 'abc', 'abc'), (3, 'abcde', 'abcde')",
@@ -3526,7 +3526,7 @@ var IndexPrefixQueries = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "show create table t",
-				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `v1` varchar(10),\n  `v2` varchar(10),\n  UNIQUE KEY `v1v2` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `v1` varchar(10),\n  `v2` varchar(10),\n  UNIQUE KEY `v1` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "insert into t values ('a', 'a'), ('ab','ab'), ('abc', 'abc'), ('abcde', 'abcde')",
@@ -3606,7 +3606,7 @@ var IndexPrefixQueries = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "show create table t",
-				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` varchar(10),\n  `v2` varchar(10),\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1v2` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"}},
+				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` varchar(10),\n  `v2` varchar(10),\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"}},
 			},
 			{
 				Query:    "insert into t values (0, 'a', 'a'), (1, 'ab','ab'), (2, 'abc', 'abc'), (3, 'abcde', 'abcde')",
@@ -3693,7 +3693,7 @@ var IndexPrefixQueries = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "show create table t",
-				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` text,\n  `v2` text,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1v2` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Expected: []sql.Row{{"t", "CREATE TABLE `t` (\n  `i` int NOT NULL,\n  `v1` text,\n  `v2` text,\n  PRIMARY KEY (`i`),\n  UNIQUE KEY `v1` (`v1`(3),`v2`(5))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
 				Query:    "insert into t values (0, 'a', 'a'), (1, 'ab','ab'), (2, 'abc', 'abc'), (3, 'abcde', 'abcde')",
@@ -4064,6 +4064,43 @@ var IndexPrefixQueries = []ScriptTest{
 }
 
 var IndexQueries = []ScriptTest{
+	{
+		// https://github.com/dolthub/dolt/issues/7960
+		Name: "Generated index names",
+		SetUpScript: []string{
+			`CREATE TABLE a_test (id1 INT, id2 INT, id3 INT, PRIMARY KEY (id1, id2), KEY (id2, id3));`,
+			`CREATE TABLE b_test(
+					a_id1 INT,
+					a_id2 INT,
+					a_id3 INT,
+					FOREIGN KEY (a_id1, a_id2) REFERENCES a_test (id1, id2),
+					CONSTRAINT fk_b_a FOREIGN KEY (a_id2, a_id3) REFERENCES a_test (id2, id3)
+				);`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// Composite keys are named after the first column in the key
+				Query: "SELECT TABLE_NAME, INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX FROM information_schema.STATISTICS WHERE TABLE_NAME='a_test' ORDER BY INDEX_NAME, SEQ_IN_INDEX;",
+				Expected: []sql.Row{
+					{"a_test", "id2", "id2", 1},
+					{"a_test", "id2", "id3", 2},
+					{"a_test", "PRIMARY", "id1", 1},
+					{"a_test", "PRIMARY", "id2", 2},
+				},
+			},
+			{
+				// When an explicit name is provided for a foreign key, the same name is used for the generated index
+				// TODO: This should probably live with the foreign key tests
+				Query: "SELECT TABLE_NAME, INDEX_NAME, COLUMN_NAME, SEQ_IN_INDEX FROM information_schema.STATISTICS WHERE TABLE_NAME='b_test' ORDER BY INDEX_NAME, SEQ_IN_INDEX;",
+				Expected: []sql.Row{
+					{"b_test", "a_id1", "a_id1", 1},
+					{"b_test", "a_id1", "a_id2", 2},
+					{"b_test", "fk_b_a", "a_id2", 1},
+					{"b_test", "fk_b_a", "a_id3", 2},
+				},
+			},
+		},
+	},
 	{
 		Name: "unique key violation prevents insert",
 		SetUpScript: []string{

--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -405,7 +405,7 @@ var InfoSchemaQueries = []QueryTest{
 				"  `a` bigint,\n" +
 				"  `b` varchar(20),\n" +
 				"  PRIMARY KEY (`pk`),\n" +
-				"  KEY `ab` (`a`,`b`),\n" +
+				"  KEY `fk1` (`a`,`b`),\n" +
 				"  CONSTRAINT `fk1` FOREIGN KEY (`a`,`b`) REFERENCES `mytable` (`i`,`s`) ON DELETE CASCADE\n" +
 				") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 		},
@@ -790,7 +790,7 @@ FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = 'mydb' AND INDEX_NAME='P
 	},
 	{
 		Query:    `SELECT * FROM information_schema.table_constraints_extensions where table_name = 'fk_tbl'`,
-		Expected: []sql.Row{{"def", "mydb", "PRIMARY", "fk_tbl", nil, nil}, {"def", "mydb", "ab", "fk_tbl", nil, nil}},
+		Expected: []sql.Row{{"def", "mydb", "PRIMARY", "fk_tbl", nil, nil}, {"def", "mydb", "fk1", "fk_tbl", nil, nil}},
 	},
 	{
 		Query:    `SELECT * FROM information_schema.tables_extensions where table_name = 'mytable'`,

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -248,12 +248,12 @@ create table t (
 			{
 				Query:           "select * from t where to_ = 'L1' and from_ = 'L2'",
 				Expected:        []sql.Row{},
-				ExpectedIndexes: []string{"to_from_"},
+				ExpectedIndexes: []string{"to_"},
 			},
 			{
 				Query:           "select * from t where BIN_TO_UUID(id) = '0' and  to_ = 'L1' and from_ = 'L2'",
 				Expected:        []sql.Row{},
-				ExpectedIndexes: []string{"to_from_"},
+				ExpectedIndexes: []string{"to_"},
 			},
 		},
 	},

--- a/enginetest/queries/stats_queries.go
+++ b/enginetest/queries/stats_queries.go
@@ -238,7 +238,7 @@ analyze table xy update histogram on (x,y) using data
 			{
 				Query:           "select * from xy where x > 4 and y = 1 and w = 'a'",
 				Expected:        []sql.Row{},
-				ExpectedIndexes: []string{"yw"},
+				ExpectedIndexes: []string{"y"},
 			},
 		},
 	},

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -233,6 +233,9 @@ func ResolveForeignKey(ctx *sql.Context, tbl sql.ForeignKeyTable, refTbl sql.For
 		}
 	}
 
+	// If no name was explicitly provided, we'll generate one
+	generateConstraintName := len(fkDef.Name) == 0
+
 	// Check if the current foreign key name has already been used. Rather than checking the table first (which is the
 	// highest cost part of creating a foreign key), we'll check the name if it needs to be checked. If the foreign key
 	// was previously added, we don't need to check the name.
@@ -242,7 +245,7 @@ func ResolveForeignKey(ctx *sql.Context, tbl sql.ForeignKeyTable, refTbl sql.For
 			return err
 		}
 
-		if len(fkDef.Name) == 0 {
+		if generateConstraintName {
 			// find the next available name
 			// negative numbers behave weirdly
 			fkNamePrefix := fmt.Sprintf("%s_ibfk_", strings.ToLower(tbl.Name()))
@@ -290,15 +293,24 @@ func ResolveForeignKey(ctx *sql.Context, tbl sql.ForeignKeyTable, refTbl sql.For
 		for _, index := range indexes {
 			indexMap[strings.ToLower(index.ID())] = struct{}{}
 		}
-		indexName := strings.Join(fkDef.Columns, "")
-		if _, ok = indexMap[strings.ToLower(indexName)]; ok {
-			for i := 0; true; i++ {
-				newIndexName := fmt.Sprintf("%s_%d", indexName, i)
-				if _, ok = indexMap[strings.ToLower(newIndexName)]; !ok {
-					indexName = newIndexName
-					break
+
+		var indexName string
+		if generateConstraintName {
+			// MySQL names the index after the first column in the foreign key
+			indexName = fkDef.Columns[0]
+			if _, ok = indexMap[strings.ToLower(indexName)]; ok {
+				for i := 0; true; i++ {
+					newIndexName := fmt.Sprintf("%s_%d", indexName, i)
+					if _, ok = indexMap[strings.ToLower(newIndexName)]; !ok {
+						indexName = newIndexName
+						break
+					}
 				}
 			}
+		} else {
+			// If the FK constraint name was explicitly provided, use that as the index name to match MySQL's behavior
+			// TODO: Handle conflicts (and test)
+			indexName = fkDef.Name
 		}
 		err = tbl.CreateIndexForForeignKey(ctx, sql.IndexDef{
 			Name:       indexName,

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -1818,7 +1818,8 @@ func generateIndexName(ctx *sql.Context, idxAltable sql.IndexAlterableTable, idx
 			indexMap[strings.ToLower(index.ID())] = struct{}{}
 		}
 	}
-	indexName := strings.Join(idxColNames, "")
+	// MySQL names the index by the first column in the definition
+	indexName := idxColNames[0]
 	if _, ok := indexMap[strings.ToLower(indexName)]; !ok {
 		return indexName, nil
 	}


### PR DESCRIPTION
A customer pointed out that when we add indexes with generated names, we don't generate the same names as MySQL. Specifically:
* When a FK is added with an explicit constraint name, that name should be used to name the automatically created index, if one is created. 
* Secondary indexes are named after the first column in the index in MySQL, not by joining all the columns together.

</br>

Customer issue: https://github.com/dolthub/dolt/issues/7960

Dolt PR with test fixes: https://github.com/dolthub/dolt/pull/7974