### PR TITLE
[no-release-notes] Update GMS interfaces for Dolt IndexedJsonDocument PR

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -933,4 +933,19 @@ var JsonScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "json mutations don't modify objects that could be seen by other expressions",
+		SetUpScript: []string{
+			"create table t (pk int primary key, col1 json);",
+			"insert into t values (1, '{}');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select pk, json_insert(col1, '$.x', 1), json_insert(col1, '$.y', 2) from t order by pk;",
+				Expected: []sql.Row{
+					{1, types.MustJSON("{\"x\":1}"), types.MustJSON("{\"y\":2}")},
+				},
+			},
+		},
+	},
 }

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -15,6 +15,7 @@
 package json
 
 import (
+	"context"
 	goJson "encoding/json"
 	"fmt"
 
@@ -42,7 +43,7 @@ func getMutableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (type
 		return nil, err
 	}
 
-	return mutableJsonDoc(doc)
+	return mutableJsonDoc(ctx, doc)
 }
 
 // getSearchableJSONVal returns a SearchableJSONValue from the given row and expression. The underlying value is not copied
@@ -92,10 +93,10 @@ func getJsonFunctionError(functionName string, argumentPosition int, err error) 
 }
 
 // mutableJsonDoc returns a copy of |wrapper| that can be safely mutated.
-func mutableJsonDoc(wrapper sql.JSONWrapper) (types.MutableJSON, error) {
+func mutableJsonDoc(ctx context.Context, wrapper sql.JSONWrapper) (types.MutableJSON, error) {
 	// Call Clone() even if |wrapper| isn't mutable. This is because some implementations (like LazyJsonDocument)
 	// cache and reuse the result of ToInterface(), and mutating this map may cause unintended behavior.
-	clonedJsonWrapper := wrapper.Clone()
+	clonedJsonWrapper := wrapper.Clone(ctx)
 
 	if mutable, ok := clonedJsonWrapper.(types.MutableJSON); ok {
 		return mutable, nil

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -42,15 +42,10 @@ func getMutableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (type
 		return nil, err
 	}
 
-	val, err := doc.ToInterface()
-	if err != nil {
-		return nil, err
-	}
-	mutable := types.DeepCopyJson(val)
-	return types.JSONDocument{Val: mutable}, nil
+	return mutableJsonDoc(doc)
 }
 
-// getSearchableJSONVal returns a SearchableJSONValue from the given row and expression. The underling value is not copied
+// getSearchableJSONVal returns a SearchableJSONValue from the given row and expression. The underlying value is not copied
 // so it is intended to be used for read-only operations.
 // nil will be returned only if the inputs are nil. This will not return an error, so callers must check.
 func getSearchableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (sql.JSONWrapper, error) {
@@ -94,6 +89,23 @@ func getJsonFunctionError(functionName string, argumentPosition int, err error) 
 		return sql.ErrInvalidJSONText.New(argumentPosition, functionName, string(ij))
 	}
 	return err
+}
+
+// mutableJsonDoc returns a copy of |wrapper| that can be safely mutated.
+func mutableJsonDoc(wrapper sql.JSONWrapper) (types.MutableJSON, error) {
+	// Call Clone() even if |wrapper| isn't mutable. This is because some implementations (like LazyJsonDocument)
+	// cache and reuse the result of ToInterface(), and mutating this map may cause unintended behavior.
+	clonedJsonWrapper := wrapper.Clone()
+
+	if mutable, ok := clonedJsonWrapper.(types.MutableJSON); ok {
+		return mutable, nil
+	}
+
+	val, err := clonedJsonWrapper.ToInterface()
+	if err != nil {
+		return nil, err
+	}
+	return &types.JSONDocument{Val: val}, nil
 }
 
 // pathValPair is a helper struct for use by functions which take json paths paired with a json value. eg. JSON_SET, JSON_INSERT, etc.

--- a/sql/statistics.go
+++ b/sql/statistics.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -142,7 +143,7 @@ func (h Histogram) IsEmpty() bool {
 	return len(h) == 0
 }
 
-func (h Histogram) Clone() JSONWrapper {
+func (h Histogram) Clone(context.Context) JSONWrapper {
 	return h
 }
 
@@ -220,7 +221,7 @@ type HistogramBucket interface {
 // by minimizing the need to unmarshall a JSONWrapper into a JSONDocument.
 type JSONWrapper interface {
 	// Clone creates a new value that can be mutated without affecting the original.
-	Clone() JSONWrapper
+	Clone(ctx context.Context) JSONWrapper
 	// ToInterface converts a JSONWrapper to an interface{} of simple types
 	ToInterface() (interface{}, error)
 }

--- a/sql/statistics.go
+++ b/sql/statistics.go
@@ -142,6 +142,10 @@ func (h Histogram) IsEmpty() bool {
 	return len(h) == 0
 }
 
+func (h Histogram) Clone() JSONWrapper {
+	return h
+}
+
 func (h Histogram) ToInterface() (interface{}, error) {
 	ret := make([]interface{}, len(h))
 	for i, b := range h {
@@ -215,6 +219,8 @@ type HistogramBucket interface {
 // The query engine can utilize these optimized access methods improve performance
 // by minimizing the need to unmarshall a JSONWrapper into a JSONDocument.
 type JSONWrapper interface {
+	// Clone creates a new value that can be mutated without affecting the original.
+	Clone() JSONWrapper
 	// ToInterface converts a JSONWrapper to an interface{} of simple types
 	ToInterface() (interface{}, error)
 }

--- a/sql/stats/statistic.go
+++ b/sql/stats/statistic.go
@@ -19,6 +19,7 @@ package stats
 // interfaces defined in |sql|, but the separation is necessary for import conflicts.
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"time"
@@ -209,7 +210,7 @@ func (s *Statistic) IndexClass() sql.IndexClass {
 	return sql.IndexClass(s.IdxClass)
 }
 
-func (s *Statistic) Clone() sql.JSONWrapper {
+func (s *Statistic) Clone(context.Context) sql.JSONWrapper {
 	return s
 }
 

--- a/sql/stats/statistic.go
+++ b/sql/stats/statistic.go
@@ -209,6 +209,10 @@ func (s *Statistic) IndexClass() sql.IndexClass {
 	return sql.IndexClass(s.IdxClass)
 }
 
+func (s *Statistic) Clone() sql.JSONWrapper {
+	return s
+}
+
 func (s *Statistic) ToInterface() (interface{}, error) {
 	typs := make([]string, len(s.Typs))
 	for i, t := range s.Typs {

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -135,7 +135,7 @@ func (t JsonType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 	// If we read the JSON from a table, pass through the bytes to avoid a deserialization and reserialization round-trip.
 	// This is kind of a hack, and it means that reading JSON from tables no longer matches MySQL byte-for-byte.
 	// But its worth it to avoid the round-trip, which can be very slow.
-	if j, ok := v.(*LazyJSONDocument); ok {
+	if j, ok := v.(JSONBytes); ok {
 		str, err := MarshallJson(j)
 		if err != nil {
 			return sqltypes.NULL, err

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -151,7 +151,7 @@ func (doc JSONDocument) Lookup(ctx context.Context, path string) (sql.JSONWrappe
 	return lookupJson(doc.Val, path)
 }
 
-func (doc JSONDocument) Clone() sql.JSONWrapper {
+func (doc JSONDocument) Clone(context.Context) sql.JSONWrapper {
 	return &JSONDocument{Val: DeepCopyJson(doc.Val)}
 }
 
@@ -182,7 +182,7 @@ func NewLazyJSONDocument(bytes []byte) sql.JSONWrapper {
 }
 
 // Clone implements sql.JSONWrapper.
-func (j *LazyJSONDocument) Clone() sql.JSONWrapper {
+func (j *LazyJSONDocument) Clone(context.Context) sql.JSONWrapper {
 	return NewLazyJSONDocument(j.Bytes)
 }
 


### PR DESCRIPTION
These are the GMS changes necessary for implementing IndexedJsonDocument in Dolt.

The main changes are the addition of a `SearchableJSON` interface, and adding a `Clone` method to `MutableJson`, tweaking how JSON operations create a copy of the document, such that mutations can't affect the state of the original document.