### PR TITLE
resolve default values for views

### DIFF
--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -198,4 +198,57 @@ CREATE TABLE tab1 (
 			},
 		},
 	},
+	{
+		Name: "views with defaults",
+		SetUpScript: []string{
+			"create table t (i int primary key, j int default 100);",
+			"insert into t(i) values (1);",
+			"create view v as select * from t;",
+			"create view v1 as select i, j + 10 as jj from t;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show full columns from v;",
+				Expected: []sql.Row{
+					{"i", "int", nil, "NO", "", nil, "", "", ""},
+					{"j", "int", nil, "YES", "", "100", "", "", ""},
+				},
+			},
+			{
+				Query: "show columns from v;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "", nil, ""},
+					{"j", "int", "YES", "", "100", ""},
+				},
+			},
+			{
+				Query: "describe v;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "", nil, ""},
+					{"j", "int", "YES", "", "100", ""},
+				},
+			},
+			{
+				Query: "show full columns from v1;",
+				Expected: []sql.Row{
+					{"i", "int", nil, "NO", "", nil, "", "", ""},
+					{"jj", "bigint", nil, "YES", "", nil, "", "", ""},
+				},
+			},
+			{
+				Query: "show columns from v1;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "", nil, ""},
+					{"jj", "bigint", "YES", "", nil, ""},
+				},
+			},
+			{
+				Query: "describe v1;",
+				Expected: []sql.Row{
+					{"i", "int", "NO", "", nil, ""},
+					{"jj", "bigint", "YES", "", nil, ""},
+				},
+			},
+		},
+	},
 }

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -155,7 +155,7 @@ func (b *Builder) buildShowTable(inScope *scope, s *ast.Show, showType string) (
 		if pks != nil {
 			showCreate.PrimaryKeySchema = pks.PrimaryKeySchema()
 		}
-		outScope.node = b.modifySchemaTarget(outScope, showCreate, rt)
+		outScope.node = b.modifySchemaTarget(outScope, showCreate, rt.Schema())
 
 	}
 	return
@@ -716,13 +716,9 @@ func (b *Builder) buildShowAllColumns(inScope *scope, s *ast.Show) (outScope *sc
 	switch t := table.(type) {
 	case *plan.ResolvedTable:
 		show.Indexes = b.getInfoSchemaIndexes(t)
-		node = b.modifySchemaTarget(tableScope, show, t)
+		node = b.modifySchemaTarget(tableScope, show, t.Schema())
 	case *plan.SubqueryAlias:
-		var err error
-		node, err = show.WithTargetSchema(t.Schema())
-		if err != nil {
-			b.handleErr(err)
-		}
+		node = b.modifySchemaTarget(tableScope, show, t.Schema())
 	default:
 	}
 


### PR DESCRIPTION
This was somewhat of a regression caused by https://github.com/dolthub/go-mysql-server/pull/2465.
However, before that PR views always had `NULL` as their default values, which did not match MySQL.
Now, we just resolve the default values in the schema, similar to `ResolvedTables`.

fixes https://github.com/dolthub/dolt/issues/7997