### PR TITLE
When casting json to a string, always call StringifyJSON. 

### DIFF
--- a/sql/types/strings_test.go
+++ b/sql/types/strings_test.go
@@ -343,6 +343,8 @@ func TestStringConvert(t *testing.T) {
 		{MustCreateBinary(sqltypes.VarBinary, 3), []byte{01, 02, 03, 04}, nil, true},
 		{MustCreateStringWithDefaults(sqltypes.VarChar, 3), []byte("abcd"), nil, true},
 		{MustCreateStringWithDefaults(sqltypes.Char, 20), JSONDocument{Val: nil}, "null", false},
+		{MustCreateStringWithDefaults(sqltypes.Char, 20), JSONDocument{Val: map[string]interface{}{"a": 1}}, `{"a": 1}`, false},
+		{MustCreateStringWithDefaults(sqltypes.Char, 20), NewLazyJSONDocument([]byte(`{"a":1}`)), `{"a": 1}`, false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This ensures we match MySQL.

We previously weren't calling StringifyJSON  in `ConvertToString` because that same method was being used when printing JSON to the screen or a MySQL client, which favored speed over matching MySQL exactly. But for casts we must be precise.

By adding an extra case to `StringType.SQL` we can distinguish between these cases and handle them properly.