### PR TITLE
[no-release-notes] Support hashing all implementations of sql.JSONWrapper when writing hashes for fulltext indexes.

### DIFF
--- a/sql/fulltext/fulltext.go
+++ b/sql/fulltext/fulltext.go
@@ -167,15 +167,7 @@ func writeHashedValue(h hash.Hash, val interface{}) (valIsNull bool, err error) 
 		if _, err := h.Write(val.Serialize()); err != nil {
 			return false, err
 		}
-	case types.JSONDocument:
-		str, err := val.JSONString()
-		if err != nil {
-			return false, err
-		}
-		if _, err := h.Write([]byte(str)); err != nil {
-			return false, err
-		}
-	case *types.LazyJSONDocument:
+	case sql.JSONWrapper:
 		str, err := types.StringifyJSON(val)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This fix will allow full text indexes to work properly for Dolt tables that contain IndexedJsonDocuments.