### PR TITLE
[no-release-notes] Add context parameter to MutableJSON::Insert.

### DIFF
--- a/sql/expression/function/json/json_insert.go
+++ b/sql/expression/function/json/json_insert.go
@@ -94,7 +94,7 @@ func (j JSONInsert) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	// Apply the path-value pairs to the document.
 	for _, pair := range pairs {
-		doc, _, err = doc.Insert(pair.path, pair.val)
+		doc, _, err = doc.Insert(ctx, pair.path, pair.val)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/types/json_test.go
+++ b/sql/types/json_test.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -803,11 +804,12 @@ var JsonInsertTests = []JsonMutationTest{
 }
 
 func TestJsonInsert(t *testing.T) {
+	ctx := context.Background()
 	for _, test := range JsonInsertTests {
 		t.Run("JSON insert: "+test.desc, func(t *testing.T) {
 			doc := MustJSON(test.doc)
 			val := MustJSON(test.value)
-			res, changed, err := doc.Insert(test.path, val)
+			res, changed, err := doc.Insert(ctx, test.path, val)
 			require.NoError(t, err)
 			assert.Equal(t, MustJSON(test.resultVal), res)
 			assert.Equal(t, test.changed, changed)

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -99,7 +99,7 @@ type MutableJSON interface {
 	sql.JSONWrapper
 	// Insert Adds the value at the given path, only if it is not present. Updated value returned, and bool indicating if
 	// a change was made.
-	Insert(path string, val sql.JSONWrapper) (MutableJSON, bool, error)
+	Insert(ctx context.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error)
 	// Remove the value at the given path. Updated value returned, and bool indicating if a change was made.
 	Remove(path string) (MutableJSON, bool, error)
 	// Set the value at the given path. Updated value returned, and bool indicating if a change was made.
@@ -748,7 +748,7 @@ func jsonObjectDeterministicOrder(a, b JsonObject, inter []string) (int, error) 
 	return strings.Compare(aa, bb), nil
 }
 
-func (doc JSONDocument) Insert(path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
+func (doc JSONDocument) Insert(_ context.Context, path string, val sql.JSONWrapper) (MutableJSON, bool, error) {
 	path = strings.TrimSpace(path)
 	return doc.unwrapAndExecute(path, val, INSERT)
 }


### PR DESCRIPTION
Just a refactor so that implementations of MutableJSON have access to the context.