### PR TITLE
Compute GetField indexes in procedure if-conditions.

### DIFF
--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1606,6 +1606,7 @@ END;`,
 				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 1,
 				}}},
+				SkipResultCheckOnServerEngine: true,
 			},
 			{
 				Query: "SELECT * FROM test;",
@@ -1636,6 +1637,7 @@ END;`,
 				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 1,
 				}}},
+				SkipResultCheckOnServerEngine: true,
 			},
 			{
 				Query: "SELECT * FROM test;",
@@ -1668,6 +1670,7 @@ END;`,
 				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 1,
 				}}},
+				SkipResultCheckOnServerEngine: true,
 			},
 			{
 				Query: "SELECT * FROM test;",

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1586,6 +1586,35 @@ END`,
 		},
 	},
 	{
+		Name: "Conditional expression doesn't have body columns in its scope. (issues/7994)",
+		SetUpScript: []string{
+			"CREATE TABLE test (id INT);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `
+CREATE PROCEDURE populate(IN val INT)
+BEGIN
+	IF (SELECT COUNT(*) FROM test where id = val) = 0 THEN
+        INSERT INTO test (id) VALUES (val);
+    END IF;
+END;`,
+				Expected: []sql.Row{{types.OkResult{}}},
+			},
+			{
+				Query:    "CALL populate(1);",
+				Expected: []sql.Row{{types.OkResult{}}},
+			},
+			{
+				Query: "SELECT * FROM test;",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+		},
+	},
+
+	{
 		Name: "HANDLERs ignore variables declared after them",
 		SetUpScript: []string{
 			`CREATE TABLE t1 (pk BIGINT PRIMARY KEY);`,

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -1586,7 +1586,7 @@ END`,
 		},
 	},
 	{
-		Name: "Conditional expression doesn't have body columns in its scope. (issues/7994)",
+		Name: "Conditional expression doesn't have body columns in its scope",
 		SetUpScript: []string{
 			"CREATE TABLE test (id INT);",
 		},
@@ -1602,8 +1602,10 @@ END;`,
 				Expected: []sql.Row{{types.OkResult{}}},
 			},
 			{
-				Query:    "CALL populate(1);",
-				Expected: []sql.Row{{types.OkResult{}}},
+				Query: "CALL populate(1);",
+				Expected: []sql.Row{{types.OkResult{
+					RowsAffected: 1,
+				}}},
 			},
 			{
 				Query: "SELECT * FROM test;",

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -349,6 +349,16 @@ func (s *idxScope) visitChildren(n sql.Node) error {
 		s.childScopes = append(s.childScopes, dScope)
 	case *plan.Procedure, *plan.CreateTable:
 		// do nothing
+
+	case *plan.IfConditional:
+		for _, c := range n.Children() {
+			// Don't append the child scope because it's not visible from the conditional expression.
+			newC, _, err := assignIndexesHelper(c, s)
+			if err != nil {
+				return err
+			}
+			s.children = append(s.children, newC)
+		}
 	default:
 		for _, c := range n.Children() {
 			newC, cScope, err := assignIndexesHelper(c, s)

--- a/sql/analyzer/stored_procedures.go
+++ b/sql/analyzer/stored_procedures.go
@@ -138,7 +138,7 @@ func analyzeProcedureBodies(ctx *sql.Context, a *Analyzer, node sql.Node, skipCa
 			// If a block node also has expressions (e.g. IfConditional), then we need to run the
 			// finalizeSubqueries analyzer rule in case the expressions contain any subqueries.
 			if _, ok := child.(sql.Expressioner); ok {
-				rulesToRun = append(rulesToRun, finalizeSubqueriesId)
+				rulesToRun = append(rulesToRun, finalizeSubqueriesId, assignExecIndexesId)
 			}
 			newChild, _, err = a.analyzeWithSelector(ctx, newChild, scope, SelectAllBatches, func(id RuleId) bool {
 				return slices.Contains(rulesToRun, id)


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/7994

It seems like we aren't running the `assignExecIndexes` analysis pass on if-conditions when invoking stored procedures, which can cause execution failures if the condition has a sub-expression that has a `GetField` node.

Fixing this revealed a related issue: when constructing the scope of the if-condition to determine the correct indexes, we were incorrectly including any columns from the condition's body in the scope. This was also causing incorrect index calculations for `GetFields` in the if-condition, and is also fixed here.

(This only affected conditionals in stored procedures, not conditionals in triggers, because the analysis has a separate execution path for each; `analyzeProcedureBodies` is not called for triggers.)