### PR TITLE
Implement support for `DECLARE CONTINUE HANDLER`

### DIFF
--- a/sql/plan/begin_end_block.go
+++ b/sql/plan/begin_end_block.go
@@ -23,7 +23,6 @@ import (
 type BeginEndBlock struct {
 	*Block
 	Label string
-	Pref  *expression.ProcedureReference
 }
 
 // NewBeginEndBlock creates a new *BeginEndBlock node.
@@ -95,7 +94,9 @@ func (b *BeginEndBlock) CollationCoercibility(ctx *sql.Context) (collation sql.C
 // WithParamReference implements the interface expression.ProcedureReferencable.
 func (b *BeginEndBlock) WithParamReference(pRef *expression.ProcedureReference) sql.Node {
 	nb := *b
-	nb.Pref = pRef
+	newBlock := *nb.Block
+	newBlock.Pref = pRef
+	nb.Block = &newBlock
 	return &nb
 }
 

--- a/sql/plan/block.go
+++ b/sql/plan/block.go
@@ -16,12 +16,14 @@ package plan
 
 import (
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 )
 
 // Block represents a collection of statements that should be executed in sequence.
 type Block struct {
 	statements []sql.Node
 	rowIterSch sql.Schema // This is set during RowIter, as the schema is unknown until iterating over the statements.
+	Pref       *expression.ProcedureReference
 }
 
 // RepresentsBlock is an interface that defines whether a node contains a Block node, or contains multiple child
@@ -121,6 +123,13 @@ func (b *Block) WithChildren(children ...sql.Node) (sql.Node, error) {
 	nb := *b
 	nb.statements = children
 	return &nb, nil
+}
+
+// WithParamReference implements the expression.ProcedureReferencable interface
+func (b *Block) WithParamReference(pRef *expression.ProcedureReference) sql.Node {
+	nb := *b
+	nb.Pref = pRef
+	return &nb
 }
 
 // CheckPrivileges implements the interface sql.Node.

--- a/sql/plan/loop.go
+++ b/sql/plan/loop.go
@@ -83,11 +83,15 @@ func (l *Loop) Resolved() bool {
 
 // WithChildren implements the interface sql.Node.
 func (l *Loop) WithChildren(children ...sql.Node) (sql.Node, error) {
+	newBlock, err := l.Block.WithChildren(children...)
+	if err != nil {
+		return nil, err
+	}
 	return &Loop{
 		Label:          l.Label,
 		Condition:      l.Condition,
 		OnceBeforeEval: l.OnceBeforeEval,
-		Block:          NewBlock(children),
+		Block:          newBlock.(*Block),
 	}, nil
 }
 
@@ -108,6 +112,15 @@ func (l *Loop) WithExpressions(exprs ...sql.Expression) (sql.Node, error) {
 		OnceBeforeEval: l.OnceBeforeEval,
 		Block:          l.Block,
 	}, nil
+}
+
+// WithParamReference implements the expression.ProcedureReferencable interface
+func (l *Loop) WithParamReference(pRef *expression.ProcedureReference) sql.Node {
+	nl := *l
+	newBlock := *nl.Block
+	newBlock.Pref = pRef
+	nl.Block = &newBlock
+	return &nl
 }
 
 // CheckPrivileges implements the interface sql.Node.


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/7971

Previously, we would always terminate a block when encountering an error, even if there's a matching handler. Additionally, there was no mechanism to resume an error that happened inside a `LOOP` construct.

This correctly implements `DECLARE CONTINUE HANDLER` by making the following changes:

- Checks for handlers while executing the `Block` node instead of the `BeginEnd` node.
- For `DECLARE EXIT HANDLER`, the `Block` returns a special error value that propagates to the containing `BeginEnd` node in order to terminate just that node.