### PR TITLE
When a subroutine (like `CREATE PROCEDURE` contains a subqeury, correctly index into it.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -2033,6 +2033,9 @@ func TestTriggers(t *testing.T, harness Harness) {
 	for _, script := range queries.TriggerTests {
 		TestScript(t, harness, script)
 	}
+	for _, script := range queries.TriggerCreateInSubroutineTests {
+		TestScript(t, harness, script)
+	}
 
 	harness.Setup(setup.MydbData)
 	e := mustNewEngine(t, harness)
@@ -2321,6 +2324,11 @@ func TestStoredProcedures(t *testing.T, harness Harness) {
 			TestScript(t, harness, script)
 		}
 	})
+	t.Run("create tests", func(t *testing.T) {
+		for _, script := range queries.ProcedureCreateInSubroutineTests {
+			TestScript(t, harness, script)
+		}
+	})
 	t.Run("drop tests", func(t *testing.T) {
 		for _, script := range queries.ProcedureDropTests {
 			TestScript(t, harness, script)
@@ -2384,6 +2392,9 @@ func TestEvents(t *testing.T, h Harness) {
 	for _, script := range queries.EventTests {
 		TestScript(t, h, script)
 	}
+	for _, script := range queries.EventCreateInSubroutineTests {
+		TestScript(t, h, script)
+	}
 }
 
 func TestTriggerErrors(t *testing.T, harness Harness) {
@@ -2445,6 +2456,10 @@ func TestViews(t *testing.T, harness Harness) {
 	// Newer Tests should be put in view_queries.go
 	harness.Setup(setup.MydbData)
 	for _, script := range queries.ViewScripts {
+		TestScript(t, harness, script)
+	}
+	harness.Setup(setup.MydbData)
+	for _, script := range queries.ViewCreateInSubroutineTests {
 		TestScript(t, harness, script)
 	}
 }
@@ -2548,6 +2563,10 @@ func TestCreateTable(t *testing.T, harness Harness) {
 	}
 
 	for _, script := range queries.CreateTableScriptTests {
+		TestScript(t, harness, script)
+	}
+
+	for _, script := range queries.CreateTableInSubroutineTests {
 		TestScript(t, harness, script)
 	}
 

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -939,6 +939,50 @@ var CreateTableScriptTests = []ScriptTest{
 	},
 }
 
+var CreateTableInSubroutineTests = []ScriptTest{
+	//TODO: Match MySQL behavior (https://github.com/dolthub/dolt/issues/8053)
+	{
+		// Skipped because Dolt doesn't support this, although MySQL does.
+		Name: "procedure contains CREATE TABLE AS",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CREATE PROCEDURE foo() CREATE TABLE bar AS SELECT 1;",
+				Skip:  true,
+			},
+			{
+				Query: "CALL foo();",
+				Skip:  true,
+			},
+			{
+				Query:    "SELECT * from bar;",
+				Expected: []sql.Row{{1}},
+				Skip:     true,
+			},
+		},
+	},
+	{
+		Name: "event contains CREATE TABLE AS",
+		//TODO: Verify that event executes correctly. (https://github.com/dolthub/dolt/issues/8053)
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CREATE EVENT foo ON SCHEDULE EVERY 1 YEAR DO CREATE TABLE bar AS SELECT 1;",
+			},
+		},
+	},
+	{
+		Name: "trigger contains CREATE TABLE AS",
+		//TODO: Verify that trigger executes correctly. (https://github.com/dolthub/dolt/issues/8053)
+		SetUpScript: []string{
+			"CREATE TABLE t (pk INT PRIMARY KEY);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CREATE TRIGGER foo AFTER UPDATE ON t FOR EACH ROW BEGIN CREATE TABLE bar AS SELECT 1; END;",
+			},
+		},
+	},
+}
+
 var CreateTableAutoIncrementTests = []ScriptTest{
 	{
 		Name:        "create table with non primary auto_increment column",

--- a/enginetest/queries/event_queries.go
+++ b/enginetest/queries/event_queries.go
@@ -307,3 +307,43 @@ var EventTests = []ScriptTest{
 		},
 	},
 }
+
+var EventCreateInSubroutineTests = []ScriptTest{
+	//TODO: Match MySQL behavior (https://github.com/dolthub/dolt/issues/8053)
+	{
+		Name: "procedure must not contain CREATE EVENT",
+		Assertions: []ScriptTestAssertion{
+			{
+				// Skipped because MySQL errors here but we don't.
+				Query:          "CREATE PROCEDURE foo() CREATE EVENT bar ON SCHEDULE EVERY 1 YEAR DO SELECT 1;",
+				ExpectedErrStr: "Recursion of EVENT DDL statements is forbidden when body is present",
+				Skip:           true,
+			},
+		},
+	},
+	{
+		Name: "event must not contain CREATE EVENT",
+		Assertions: []ScriptTestAssertion{
+			{
+				// Skipped because MySQL errors here but we don't.
+				Query:          "CREATE EVENT foo ON SCHEDULE EVERY 1 YEAR DO CREATE EVENT bar ON SCHEDULE EVERY 1 YEAR DO SELECT 1;",
+				ExpectedErrStr: "Recursion of EVENT DDL statements is forbidden when body is present",
+				Skip:           true,
+			},
+		},
+	},
+	{
+		Name: "trigger must not contain CREATE EVENT",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk INT PRIMARY KEY);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// Skipped because MySQL errors here but we don't.
+				Query:          "CREATE TRIGGER foo AFTER UPDATE ON t FOR EACH ROW BEGIN CREATE EVENT bar ON SCHEDULE EVERY 1 YEAR DO SELECT 1; END",
+				ExpectedErrStr: "Recursion of EVENT DDL statements is forbidden when body is present",
+				Skip:           true,
+			},
+		},
+	},
+}

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -2786,6 +2786,45 @@ var ProcedureShowCreate = []ScriptTest{
 	},
 }
 
+var ProcedureCreateInSubroutineTests = []ScriptTest{
+	//TODO: Match MySQL behavior (https://github.com/dolthub/dolt/issues/8053)
+	{
+		Name: "procedure must not contain CREATE PROCEDURE",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CREATE PROCEDURE foo() CREATE PROCEDURE bar() SELECT 0;",
+				// MySQL output: "Can't create a PROCEDURE from within another stored routine",
+				ExpectedErrStr: "creating procedures in stored procedures is currently unsupported and will be added in a future release",
+			},
+		},
+	},
+	{
+		Name: "event must not contain CREATE PROCEDURE",
+		Assertions: []ScriptTestAssertion{
+			{
+				// Skipped because MySQL errors here but we don't.
+				Query:          "CREATE EVENT foo ON SCHEDULE EVERY 1 YEAR DO CREATE PROCEDURE bar() SELECT 1;",
+				ExpectedErrStr: "Can't create a PROCEDURE from within another stored routine",
+				Skip:           true,
+			},
+		},
+	},
+	{
+		Name: "trigger must not contain CREATE PROCEDURE",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk INT PRIMARY KEY);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// Skipped because MySQL errors here but we don't.
+				Query:          "CREATE TRIGGER foo AFTER UPDATE ON t FOR EACH ROW BEGIN CREATE PROCEDURE bar() SELECT 1; END",
+				ExpectedErrStr: "Can't create a PROCEDURE from within another stored routine",
+				Skip:           true,
+			},
+		},
+	},
+}
+
 var NoDbProcedureTests = []ScriptTestAssertion{
 	{
 		Query:    "SHOW databases;",

--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -252,3 +252,47 @@ CREATE TABLE tab1 (
 		},
 	},
 }
+
+var ViewCreateInSubroutineTests = []ScriptTest{
+	//TODO: Match MySQL behavior (https://github.com/dolthub/dolt/issues/8053)
+	{
+		// Skipped because we return an error even though MySQL supports this.
+		Name: "procedure contains CREATE VIEW AS",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "CREATE PROCEDURE foo() CREATE VIEW bar AS SELECT 1;",
+				Skip:  true,
+			},
+			{
+				Query: "CALL foo();",
+				Skip:  true,
+			},
+			{
+				Query:    "SELECT * from bar;",
+				Expected: []sql.Row{{1}},
+				Skip:     true,
+			},
+		},
+	},
+	{
+		Name: "event contains CREATE VIEW AS",
+		Assertions: []ScriptTestAssertion{
+			{
+				// Tests that the query doesn't panic.
+				Query: "CREATE EVENT foo ON SCHEDULE EVERY 1 YEAR DO CREATE VIEW bar AS SELECT 1;",
+			},
+		},
+	},
+	{
+		Name: "trigger contains CREATE VIEW AS",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk INT PRIMARY KEY);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// Tests that the query doesn't panic.
+				Query: "CREATE TRIGGER foo AFTER UPDATE ON t FOR EACH ROW BEGIN CREATE TABLE bar AS SELECT 1; END;",
+			},
+		},
+	},
+}

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -113,21 +113,21 @@ func (b *Builder) buildAlterTable(inScope *scope, query string, c *ast.AlterTabl
 	return
 }
 
-func (b *Builder) buildDDL(inScope *scope, query string, c *ast.DDL) (outScope *scope) {
+func (b *Builder) buildDDL(inScope *scope, subQuery string, fullQuery string, c *ast.DDL) (outScope *scope) {
 	outScope = inScope.push()
 	switch strings.ToLower(c.Action) {
 	case ast.CreateStr:
 		if c.TriggerSpec != nil {
-			return b.buildCreateTrigger(inScope, query, c)
+			return b.buildCreateTrigger(inScope, subQuery, fullQuery, c)
 		}
 		if c.ProcedureSpec != nil {
-			return b.buildCreateProcedure(inScope, query, c)
+			return b.buildCreateProcedure(inScope, subQuery, fullQuery, c)
 		}
 		if c.EventSpec != nil {
-			return b.buildCreateEvent(inScope, query, c)
+			return b.buildCreateEvent(inScope, subQuery, fullQuery, c)
 		}
 		if c.ViewSpec != nil {
-			return b.buildCreateView(inScope, query, c)
+			return b.buildCreateView(inScope, subQuery, fullQuery, c)
 		}
 		return b.buildCreateTable(inScope, c)
 	case ast.DropStr:
@@ -170,9 +170,9 @@ func (b *Builder) buildDDL(inScope *scope, query string, c *ast.DDL) (outScope *
 		return b.buildDropTable(inScope, c)
 	case ast.AlterStr:
 		if c.EventSpec != nil {
-			return b.buildAlterEvent(inScope, query, c)
+			return b.buildAlterEvent(inScope, subQuery, fullQuery, c)
 		} else if !c.User.IsEmpty() {
-			return b.buildAlterUser(inScope, query, c)
+			return b.buildAlterUser(inScope, subQuery, c)
 		}
 		b.handleErr(sql.ErrUnsupportedFeature.New(ast.String(c)))
 	case ast.RenameStr:

--- a/sql/planbuilder/proc.go
+++ b/sql/planbuilder/proc.go
@@ -171,40 +171,40 @@ func (p *procCtx) GetCondition(name string) *plan.DeclareCondition {
 	return cond
 }
 
-func (b *Builder) buildBeginEndBlock(inScope *scope, n *ast.BeginEndBlock) (outScope *scope) {
+func (b *Builder) buildBeginEndBlock(inScope *scope, n *ast.BeginEndBlock, fullQuery string) (outScope *scope) {
 	outScope = inScope.push()
 	outScope.initProc()
 	outScope.proc.AddLabel(n.Label, false)
-	block := b.buildBlock(outScope, n.Statements)
+	block := b.buildBlock(outScope, n.Statements, fullQuery)
 	outScope.node = plan.NewBeginEndBlock(n.Label, block)
 	return outScope
 }
 
-func (b *Builder) buildIfBlock(inScope *scope, n *ast.IfStatement) (outScope *scope) {
+func (b *Builder) buildIfBlock(inScope *scope, n *ast.IfStatement, fullQuery string) (outScope *scope) {
 	outScope = inScope.push()
 	ifConditionals := make([]*plan.IfConditional, len(n.Conditions))
 	for i, ic := range n.Conditions {
-		ifConditionalScope := b.buildIfConditional(inScope, ic)
+		ifConditionalScope := b.buildIfConditional(inScope, ic, fullQuery)
 		ifConditionals[i] = ifConditionalScope.node.(*plan.IfConditional)
 	}
-	elseBlock := b.buildBlock(inScope, n.Else)
+	elseBlock := b.buildBlock(inScope, n.Else, fullQuery)
 	outScope.node = plan.NewIfElse(ifConditionals, elseBlock)
 	return outScope
 }
 
-func (b *Builder) buildCaseStatement(inScope *scope, n *ast.CaseStatement) (outScope *scope) {
+func (b *Builder) buildCaseStatement(inScope *scope, n *ast.CaseStatement, fullQuery string) (outScope *scope) {
 	outScope = inScope.push()
 	ifConditionals := make([]*plan.IfConditional, len(n.Cases))
 	for i, c := range n.Cases {
 		ifConditionalScope := b.buildIfConditional(inScope, ast.IfStatementCondition{
 			Expr:       c.Case,
 			Statements: c.Statements,
-		})
+		}, fullQuery)
 		ifConditionals[i] = ifConditionalScope.node.(*plan.IfConditional)
 	}
 	var elseBlock sql.Node
 	if n.Else != nil {
-		elseBlock = b.buildBlock(inScope, n.Else)
+		elseBlock = b.buildBlock(inScope, n.Else, fullQuery)
 	}
 	if n.Expr == nil {
 		outScope.node = plan.NewCaseStatement(nil, ifConditionals, elseBlock)
@@ -216,9 +216,9 @@ func (b *Builder) buildCaseStatement(inScope *scope, n *ast.CaseStatement) (outS
 	}
 }
 
-func (b *Builder) buildIfConditional(inScope *scope, n ast.IfStatementCondition) (outScope *scope) {
+func (b *Builder) buildIfConditional(inScope *scope, n ast.IfStatementCondition, fullQuery string) (outScope *scope) {
 	outScope = inScope.push()
-	block := b.buildBlock(inScope, n.Statements)
+	block := b.buildBlock(inScope, n.Statements, fullQuery)
 	condition := b.buildScalar(inScope, n.Expr)
 	outScope.node = plan.NewIfConditional(condition, block)
 	return outScope
@@ -390,7 +390,7 @@ func (b *Builder) buildDeclareHandler(inScope *scope, d *ast.Declare, query stri
 	return outScope
 }
 
-func (b *Builder) buildBlock(inScope *scope, parserStatements ast.Statements) *plan.Block {
+func (b *Builder) buildBlock(inScope *scope, parserStatements ast.Statements, fullQuery string) *plan.Block {
 	var statements []sql.Node
 	for _, s := range parserStatements {
 		switch s.(type) {
@@ -400,7 +400,7 @@ func (b *Builder) buildBlock(inScope *scope, parserStatements ast.Statements) *p
 				inScope.proc.NewState(dsBody)
 			}
 		}
-		stmtScope := b.build(inScope, s, ast.String(s))
+		stmtScope := b.buildSubquery(inScope, s, ast.String(s), fullQuery)
 		statements = append(statements, stmtScope.node)
 	}
 	return plan.NewBlock(statements)
@@ -448,30 +448,30 @@ func (b *Builder) buildCloseCursor(inScope *scope, closeCursor *ast.CloseCursor)
 	return outScope
 }
 
-func (b *Builder) buildLoop(inScope *scope, loop *ast.Loop) (outScope *scope) {
+func (b *Builder) buildLoop(inScope *scope, loop *ast.Loop, fullQuery string) (outScope *scope) {
 	outScope = inScope.push()
 	outScope.initProc()
 	outScope.proc.AddLabel(loop.Label, true)
-	block := b.buildBlock(outScope, loop.Statements)
+	block := b.buildBlock(outScope, loop.Statements, fullQuery)
 	outScope.node = plan.NewLoop(loop.Label, block)
 	return outScope
 }
 
-func (b *Builder) buildRepeat(inScope *scope, repeat *ast.Repeat) (outScope *scope) {
+func (b *Builder) buildRepeat(inScope *scope, repeat *ast.Repeat, fullQuery string) (outScope *scope) {
 	outScope = inScope.push()
 	outScope.initProc()
 	outScope.proc.AddLabel(repeat.Label, true)
-	block := b.buildBlock(outScope, repeat.Statements)
+	block := b.buildBlock(outScope, repeat.Statements, fullQuery)
 	expr := b.buildScalar(inScope, repeat.Condition)
 	outScope.node = plan.NewRepeat(repeat.Label, expr, block)
 	return outScope
 }
 
-func (b *Builder) buildWhile(inScope *scope, while *ast.While) (outScope *scope) {
+func (b *Builder) buildWhile(inScope *scope, while *ast.While, fullQuery string) (outScope *scope) {
 	outScope = inScope.push()
 	outScope.initProc()
 	outScope.proc.AddLabel(while.Label, true)
-	block := b.buildBlock(outScope, while.Statements)
+	block := b.buildBlock(outScope, while.Statements, fullQuery)
 	expr := b.buildScalar(inScope, while.Condition)
 	outScope.node = plan.NewWhile(while.Label, expr, block)
 	return outScope


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/8028

We didn't have tests for constructs containing nested subroutines (like `CREATE PROCEDURE foo() CREATE PROCEDURE bar() SELECT 1;`

This PR adds tests for those, but tests where we don't currently match MySQL are disabled. There's enough enabled tests to show that statements like this no longer cause a panic.

Making sure that we match MySQL for these statements should be done in a follow-up.