### PR TITLE
Add support for `SHOW BINARY LOGS`

### DIFF
--- a/enginetest/queries/priv_auth_queries.go
+++ b/enginetest/queries/priv_auth_queries.go
@@ -251,6 +251,38 @@ var UserPrivTests = []UserPrivilegeTest{
 				Expected: []sql.Row{},
 			},
 
+			// SHOW BINARY LOGS
+			{
+				User:        "user",
+				Host:        "localhost",
+				Query:       "SHOW BINARY LOGS;",
+				ExpectedErr: sql.ErrPrivilegeCheckFailed,
+			},
+			{
+				User:        "replica-admin",
+				Host:        "localhost",
+				Query:       "SHOW BINARY LOGS;",
+				ExpectedErr: sql.ErrPrivilegeCheckFailed,
+			},
+			{
+				User:     "replica-client",
+				Host:     "localhost",
+				Query:    "SHOW BINARY LOGS;",
+				Expected: []sql.Row{},
+			},
+			{
+				User:        "replica-reload",
+				Host:        "localhost",
+				Query:       "SHOW BINARY LOGS;",
+				ExpectedErr: sql.ErrPrivilegeCheckFailed,
+			},
+			{
+				User:     "root",
+				Host:     "localhost",
+				Query:    "SHOW BINARY LOGS;",
+				Expected: []sql.Row{},
+			},
+
 			// SHOW BINARY LOG STATUS
 			{
 				User:        "user",

--- a/sql/binlogreplication/binlog_replication.go
+++ b/sql/binlogreplication/binlog_replication.go
@@ -91,11 +91,18 @@ type BinlogPrimaryController interface {
 	// ListBinaryLogs is called when the SHOW BINARY LOGS statement is executed. The integrator should return a list
 	// of the binary logs currently being managed. Note that this function will be expanded
 	// with an additional response parameter once it is wired up to the SQL engine.
-	ListBinaryLogs(ctx *sql.Context) error
+	ListBinaryLogs(ctx *sql.Context) ([]BinaryLogFileMetadata, error)
 
 	// GetBinaryLogStatus is called when the SHOW BINARY LOG STATUS statement is executed. The integrator should return
 	// the current status of all available (i.e. non-purged) binary logs.
 	GetBinaryLogStatus(ctx *sql.Context) ([]BinaryLogStatus, error)
+}
+
+// BinaryLogFileMetadata holds high level metadata about a binary log file, used for the `SHOW BINARY LOGS` statement.
+type BinaryLogFileMetadata struct {
+	Name      string
+	Size      uint64
+	Encrypted bool
 }
 
 // BinaryLogStatus holds the data for one row of results from the `SHOW BINARY LOG STATUS` statement (or the deprecated

--- a/sql/plan/show_binlogs.go
+++ b/sql/plan/show_binlogs.go
@@ -1,0 +1,86 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plan
+
+import (
+	"github.com/dolthub/vitess/go/sqltypes"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/binlogreplication"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+// ShowBinlogs is the plan node for the "SHOW BINARY LOGS" statement.
+// https://dev.mysql.com/doc/refman/8.4/en/show-binary-logs.html
+type ShowBinlogs struct {
+	PrimaryController binlogreplication.BinlogPrimaryController
+}
+
+var _ sql.Node = (*ShowBinlogs)(nil)
+var _ sql.CollationCoercible = (*ShowBinlogs)(nil)
+var _ BinlogPrimaryControllerCommand = (*ShowBinlogs)(nil)
+
+func NewShowBinlogs() *ShowBinlogs {
+	return &ShowBinlogs{}
+}
+
+// WithBinlogPrimaryController implements the BinlogPrimaryControllerCommand interface.
+func (s *ShowBinlogs) WithBinlogPrimaryController(controller binlogreplication.BinlogPrimaryController) sql.Node {
+	nc := *s
+	nc.PrimaryController = controller
+	return &nc
+}
+
+func (s *ShowBinlogs) Resolved() bool {
+	return true
+}
+
+func (s *ShowBinlogs) String() string {
+	return "SHOW BINARY LOGS"
+}
+
+func (s *ShowBinlogs) Schema() sql.Schema {
+	return sql.Schema{
+		{Name: "Log_name", Type: types.MustCreateString(sqltypes.VarChar, 1020, sql.Collation_utf8mb4_0900_ai_ci), Default: nil, Nullable: false},
+		{Name: "File_size", Type: types.Uint64, Default: nil, Nullable: false},
+		{Name: "Encrypted", Type: types.MustCreateString(sqltypes.VarChar, 12, sql.Collation_utf8mb4_0900_ai_ci), Default: nil, Nullable: false},
+	}
+}
+
+func (s *ShowBinlogs) Children() []sql.Node {
+	return nil
+}
+
+func (s *ShowBinlogs) IsReadOnly() bool {
+	return true
+}
+
+func (s *ShowBinlogs) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(s, len(children), 0)
+	}
+
+	newNode := *s
+	return &newNode, nil
+}
+
+func (s *ShowBinlogs) CheckPrivileges(ctx *sql.Context, opChecker sql.PrivilegedOperationChecker) bool {
+	return opChecker.UserHasPrivileges(ctx, sql.NewPrivilegedOperation(sql.PrivilegeCheckSubject{}, sql.PrivilegeType_ReplicationClient))
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*ShowBinlogs) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -85,6 +85,13 @@ func (b *Builder) buildShow(inScope *scope, s *ast.Show) (outScope *scope) {
 			showRep.PrimaryController = binCat.GetBinlogPrimaryController()
 		}
 		outScope.node = showRep
+	case "binary logs":
+		outScope = inScope.push()
+		showRep := plan.NewShowBinlogs()
+		if binCat, ok := b.cat.(binlogreplication.BinlogPrimaryCatalog); ok && binCat.HasBinlogPrimaryController() {
+			showRep.PrimaryController = binCat.GetBinlogPrimaryController()
+		}
+		outScope.node = showRep
 	case "replica status":
 		outScope = inScope.push()
 		showRep := plan.NewShowReplicaStatus()

--- a/sql/rowexec/node_builder.gen.go
+++ b/sql/rowexec/node_builder.gen.go
@@ -56,6 +56,8 @@ func (b *BaseBuilder) buildNodeExecNoAnalyze(ctx *sql.Context, n sql.Node, row s
 		return b.buildDropHistogram(ctx, n, row)
 	case *plan.QueryProcess:
 		return b.buildQueryProcess(ctx, n, row)
+	case *plan.ShowBinlogs:
+		return b.buildShowBinlogs(ctx, n, row)
 	case *plan.ShowBinlogStatus:
 		return b.buildShowBinlogStatus(ctx, n, row)
 	case *plan.ShowReplicaStatus:


### PR DESCRIPTION
When the `SHOW BINARY LOGS` statement is executed, GMS will invoke the registered `BinlogPrimaryController` to ask it for the list of binary logs and send them back to the client. 