### PR TITLE
fix: add checking precision to decide sql types & handling limit unix timestamp date

### DIFF
--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -470,7 +470,7 @@ func (ut *UnixTimestamp) WithChildren(children ...sql.Expression) (sql.Expressio
 
 func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if ut.Date == nil {
-		return toUnixTimestamp(ctx.QueryTime())
+		return toUnixTimestamp(ctx.QueryTime().Round(time.Second))
 	}
 
 	date, err := ut.Date.Eval(ctx, row)
@@ -519,6 +519,10 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 }
 
 func toUnixTimestamp(t time.Time) (interface{}, error) {
+	if !t.Before(time.Date(3001, 01, 19, 0, 0, 0, 0, time.UTC)) {
+		return float64(0), nil
+	}
+
 	ret, _, err := types.Float64.Convert(float64(t.Unix()) + float64(t.Nanosecond())/float64(1000000000))
 	return ret, err
 }

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -558,7 +558,7 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 
 func toUnixTimestamp(t time.Time) (interface{}, error) {
 	if !t.Before(time.Date(3001, 01, 19, 0, 0, 0, 0, time.UTC)) {
-		return 0, nil
+		return int64(0), nil
 	}
 
 	ret, _, err := types.Float64.Convert(float64(t.Unix()) + float64(t.Nanosecond())/float64(1000000000))

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -456,7 +456,7 @@ func (ut *UnixTimestamp) IsNullable() bool {
 }
 
 func (ut *UnixTimestamp) Type() sql.Type {
-	return types.Float64
+	return types.Int64
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.
@@ -519,8 +519,7 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 }
 
 func toUnixTimestamp(t time.Time) (interface{}, error) {
-	ret, _, err := types.Float64.Convert(float64(t.Unix()) + float64(t.Nanosecond())/float64(1000000000))
-	return ret, err
+	return t.Unix(), nil
 }
 
 func (ut *UnixTimestamp) String() string {

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -558,7 +558,7 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 
 func toUnixTimestamp(t time.Time) (interface{}, error) {
 	if !t.Before(time.Date(3001, 01, 19, 0, 0, 0, 0, time.UTC)) {
-		return int64(0), nil
+		return float64(0), nil
 	}
 
 	ret, _, err := types.Float64.Convert(float64(t.Unix()) + float64(t.Nanosecond())/float64(1000000000))

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -558,7 +558,7 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 
 func toUnixTimestamp(t time.Time) (interface{}, error) {
 	if !t.Before(time.Date(3001, 01, 19, 0, 0, 0, 0, time.UTC)) {
-		return float64(0), nil
+		return 0, nil
 	}
 
 	ret, _, err := types.Float64.Convert(float64(t.Unix()) + float64(t.Nanosecond())/float64(1000000000))

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -456,7 +456,7 @@ func (ut *UnixTimestamp) IsNullable() bool {
 }
 
 func (ut *UnixTimestamp) Type() sql.Type {
-	return types.Int64
+	return types.Float64
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.
@@ -519,7 +519,8 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 }
 
 func toUnixTimestamp(t time.Time) (interface{}, error) {
-	return t.Unix(), nil
+	ret, _, err := types.Float64.Convert(float64(t.Unix()) + float64(t.Nanosecond())/float64(1000000000))
+	return ret, err
 }
 
 func (ut *UnixTimestamp) String() string {

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -282,6 +282,23 @@ func TestUnixTimestamp(t *testing.T) {
 	require.Equal(expected, result)
 	require.Equal(uint16(0), ctx.WarningCount())
 
+	ut, err = NewUnixTimestamp(expression.NewLiteral("2024-01-15 20:52:59.99", types.LongText))
+	require.NoError(err)
+	testTime := time.Date(2024, 1, 15, 20, 52, 59, 990000000, time.UTC)
+	expected = float64(testTime.Unix()) + (float64(testTime.Nanosecond()) / float64(1000000000))
+	result, err = ut.Eval(ctx, nil)
+	require.NoError(err)
+	require.Equal(expected, result)
+	require.Equal(uint16(0), ctx.WarningCount())
+
+	ut, err = NewUnixTimestamp(expression.NewLiteral("3001-01-19", types.LongText))
+	require.NoError(err)
+	expected = float64(0)
+	result, err = ut.Eval(ctx, nil)
+	require.NoError(err)
+	require.Equal(expected, result)
+	require.Equal(uint16(0), ctx.WarningCount())
+
 	ut, err = NewUnixTimestamp(expression.NewLiteral(nil, types.Null))
 	require.NoError(err)
 	expected = nil

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -268,7 +268,7 @@ func TestUnixTimestamp(t *testing.T) {
 	var ut sql.Expression
 	var expected interface{}
 	ut = &UnixTimestamp{nil}
-	expected = float64(date.Unix())
+	expected = date.Unix()
 	result, err := ut.Eval(ctx2, nil)
 	require.NoError(err)
 	require.Equal(expected, result)
@@ -276,7 +276,7 @@ func TestUnixTimestamp(t *testing.T) {
 
 	ut, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", types.LongText))
 	require.NoError(err)
-	expected = float64(time.Date(2018, 5, 2, 0, 0, 0, 0, time.UTC).Unix())
+	expected = time.Date(2018, 5, 2, 0, 0, 0, 0, time.UTC).Unix()
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(expected, result)

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -304,7 +304,7 @@ func TestUnixTimestamp(t *testing.T) {
 
 	ut, err = NewUnixTimestamp(expression.NewLiteral("3001-01-19", types.LongText))
 	require.NoError(err)
-	expected = float64(0)
+	expected = int64(0)
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(expected, result)

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -304,7 +304,7 @@ func TestUnixTimestamp(t *testing.T) {
 
 	ut, err = NewUnixTimestamp(expression.NewLiteral("3001-01-19", types.LongText))
 	require.NoError(err)
-	expected = int64(0)
+	expected = float64(0)
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(expected, result)

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -268,7 +268,7 @@ func TestUnixTimestamp(t *testing.T) {
 	var ut sql.Expression
 	var expected interface{}
 	ut = &UnixTimestamp{nil}
-	expected = date.Unix()
+	expected = float64(date.Unix())
 	result, err := ut.Eval(ctx2, nil)
 	require.NoError(err)
 	require.Equal(expected, result)
@@ -276,7 +276,7 @@ func TestUnixTimestamp(t *testing.T) {
 
 	ut, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", types.LongText))
 	require.NoError(err)
-	expected = time.Date(2018, 5, 2, 0, 0, 0, 0, time.UTC).Unix()
+	expected = float64(time.Date(2018, 5, 2, 0, 0, 0, 0, time.UTC).Unix())
 	result, err = ut.Eval(ctx, nil)
 	require.NoError(err)
 	require.Equal(expected, result)

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -241,14 +241,25 @@ func TestUnixTimestamp(t *testing.T) {
 	require := require.New(t)
 
 	ctx := sql.NewEmptyContext()
-	_, err := NewUnixTimestamp()
+	utimestamp, err := NewUnixTimestamp()
 	require.NoError(err)
+	require.Equal(types.Int64, utimestamp.Type())
 
-	_, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", types.LongText))
+	utimestamp, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", types.LongText))
 	require.NoError(err)
+	require.Equal(types.Int64, utimestamp.Type())
 
-	_, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", types.LongText))
+	utimestamp, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", types.LongText))
 	require.NoError(err)
+	require.Equal(types.Int64, utimestamp.Type())
+
+	utimestamp, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02 20:00:00", types.LongText))
+	require.NoError(err)
+	require.Equal(types.Int64, utimestamp.Type())
+
+	utimestamp, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02 20:00:00.99999", types.LongText))
+	require.NoError(err)
+	require.Equal(types.MustCreateDecimalType(19, 6), utimestamp.Type())
 
 	_, err = NewUnixTimestamp(expression.NewLiteral("2018-05-02", types.LongText), expression.NewLiteral("2018-05-02", types.LongText))
 	require.Error(err)
@@ -267,7 +278,7 @@ func TestUnixTimestamp(t *testing.T) {
 
 	var ut sql.Expression
 	var expected interface{}
-	ut = &UnixTimestamp{nil}
+	ut = &UnixTimestamp{Date: nil}
 	expected = float64(date.Unix())
 	result, err := ut.Eval(ctx2, nil)
 	require.NoError(err)

--- a/sql/types/number.go
+++ b/sql/types/number.go
@@ -420,9 +420,9 @@ func (t NumberTypeImpl_) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqlt
 		case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Uint64:
 			dest = strconv.AppendUint(dest, mustUint64(vt), 10)
 		case sqltypes.Float32:
-			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'g', -1, 32)
+			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'f', -1, 32)
 		case sqltypes.Float64:
-			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'g', -1, 64)
+			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'f', -1, 64)
 		default:
 			panic(sql.ErrInvalidBaseType.New(t.baseType.String(), "number"))
 		}

--- a/sql/types/number.go
+++ b/sql/types/number.go
@@ -420,9 +420,9 @@ func (t NumberTypeImpl_) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqlt
 		case sqltypes.Uint8, sqltypes.Uint16, sqltypes.Uint24, sqltypes.Uint32, sqltypes.Uint64:
 			dest = strconv.AppendUint(dest, mustUint64(vt), 10)
 		case sqltypes.Float32:
-			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'f', -1, 32)
+			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'g', -1, 32)
 		case sqltypes.Float64:
-			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'f', -1, 64)
+			dest = strconv.AppendFloat(dest, mustFloat64(vt), 'g', -1, 64)
 		default:
 			panic(sql.ErrInvalidBaseType.New(t.baseType.String(), "number"))
 		}


### PR DESCRIPTION
This PR will 
- checking precision to decide sql types (int64 or decimal)
- handling limit unix timestamp date like mysql

Fixes: 
- https://github.com/dolthub/dolt/issues/7698

![image](https://github.com/dolthub/go-mysql-server/assets/65933490/65be46f7-ad0e-4165-b574-5acc901e5650)

