### PR TITLE
calling JSON_EXTRACT and JSON_VALUE with a path that has an out-of-bounds array access should return SQL NULL, not an error.

### DIFF
--- a/sql/expression/function/json/jsontests/json_contains_path_tests.go
+++ b/sql/expression/function/json/jsontests/json_contains_path_tests.go
@@ -59,6 +59,8 @@ func JsonContainsPathTestCases(t *testing.T, prepare prepareJsonValue) []testCas
 		{f: onePath, row: sql.Row{prepare(t, `{"a": 1, "b": 2, "c": {"d": 4}}`), `all`, `$.e`}, expected: false},
 		{f: onePath, row: sql.Row{prepare(t, `{"a": 1, "b": 2, "c": {"d": 4}}`), `All`, `$.c.d`}, expected: true},
 
+		{f: onePath, row: sql.Row{prepare(t, `[]`), `one`, `$[1]`}, expected: false},
+
 		{f: twoPath, row: sql.Row{prepare(t, `{"a": 1, "b": 2, "c": {"d": 4}}`), `one`, `$.a`, `$.e`}, expected: true},
 		{f: twoPath, row: sql.Row{prepare(t, `{"a": 1, "b": 2, "c": {"d": 4}}`), `ALL`, `$.a`, `$.e`}, expected: false},
 

--- a/sql/expression/function/json/jsontests/json_extract_tests.go
+++ b/sql/expression/function/json/jsontests/json_extract_tests.go
@@ -78,6 +78,7 @@ func JsonExtractTestCases(t *testing.T, prepare prepareJsonValue) []testCase {
 		{f: f2, row: sql.Row{"null", "$"}, expected: types.JSONDocument{Val: nil}},
 		{f: f2, row: sql.Row{"null", "$.b.c"}},
 		{f: f2, row: sql.Row{jsonInput, "$.foo"}},
+		{f: f2, row: sql.Row{jsonInput, "$.a[4]"}},
 		{f: f2, row: sql.Row{jsonInput, "$.b.c"}, expected: types.JSONDocument{Val: "foo"}},
 		{f: f3, row: sql.Row{jsonInput, "$.b.c", "$.b.d"}, expected: types.JSONDocument{Val: []interface{}{"foo", true}}},
 		{f: f4, row: sql.Row{jsonInput, "$.b.c", "$.b.d", "$.e[0][*]"}, expected: types.JSONDocument{Val: []interface{}{

--- a/sql/expression/function/json/jsontests/json_value_tests.go
+++ b/sql/expression/function/json/jsontests/json_value_tests.go
@@ -44,6 +44,7 @@ func RunJsonValueTests(t *testing.T, prepare prepareJsonValue) {
 		{row: sql.Row{prepare(t, `[1, false]`)}, path: "$[0]", typ: types.Int64, expected: int64(1)},
 		{row: sql.Row{prepare(t, `[1, false]`)}, path: "$[0]", typ: types.Uint64, expected: uint64(1)},
 		{row: sql.Row{prepare(t, `[1, false]`)}, path: "$[0]", expected: "1"},
+		{row: sql.Row{`[1, false]`}, path: "$[3]", expected: nil},
 		{row: sql.Row{prepare(t, `[1, {"a": 1}]`)}, path: "$[1].a", typ: types.Int64, expected: int64(1)},
 		{row: sql.Row{prepare(t, `[1, {"a": 1}]`)}, path: "$[1]", typ: types.JSON, expected: types.MustJSON(`{"a": 1}`)},
 		{row: sql.Row{1}, path: `$.f`, err: sql.ErrInvalidJSONArgument.New(1, "json_value")},

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -264,6 +264,10 @@ func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 			// A missing key results in a SQL null
 			return nil, nil
 		}
+		if strings.Contains(err.Error(), "index out of range") {
+			// A array index out of bounds results in a SQL null
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
The jsonpath module returns an error when performing a lookup with an out-of-bounds array index. We need to capture that error and return nil for the lookup operation instead.