### PR TITLE
Catch panics in listener

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -522,7 +522,7 @@ func (h *Handler) resultForDefaultIter(
 			err = fmt.Errorf("handler caught panic: %v", recoveredPanic)
 		}
 	}
-	
+
 	wg := sync.WaitGroup{}
 	wg.Add(2)
 	// Read rows off the row iterator and send them to the row channel.


### PR DESCRIPTION
We had several goroutines in which panics would crash the server process. These were being triggered by panics due to errors in doltgres.  Added a recover block to each goroutine.