### PR TITLE
[stats] Disable histogram bucket merging for now because it mutated shared memory

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -173,6 +173,28 @@ CREATE TABLE sourceTable_test (
 		},
 	},
 	{
+		Name: "histogram bucket merging error for implementor buckets",
+		SetUpScript: []string{
+			"CREATE TABLE xy (x int primary key, y varchar(10), key(y));",
+			"insert into xy select x, 'x' from (with recursive inputs(x) as (select 1 union select x+1 from inputs where x < 5000) select * from inputs) dt",
+			"analyze table xy",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select (select count(*) from dolt_statistics) > 0",
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    "select a.y from xy a join xy b on a.y = b.y limit 1",
+				Expected: []sql.Row{{"x"}},
+			},
+			{
+				Query:    "select y from xy where y = 'x' limit 1",
+				Expected: []sql.Row{{"x"}},
+			},
+		},
+	},
+	{
 		Name: "GMS issue 2369",
 		SetUpScript: []string{
 			`CREATE TABLE table1 (

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -181,7 +181,7 @@ CREATE TABLE sourceTable_test (
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "select (select count(*) from dolt_statistics) > 0",
+				Query:    "select (select count(*) from information_schema.statistics) > 0",
 				Expected: []sql.Row{{true}},
 			},
 			{

--- a/sql/stats/join.go
+++ b/sql/stats/join.go
@@ -518,17 +518,18 @@ func MergeOverlappingBuckets(h []sql.HistogramBucket, types []sql.Type, newB Buc
 	}
 	// |k| is the write position, |i| is the compare position
 	// |k| <= |i|
+	var ret []sql.HistogramBucket
 	i := 0
 	k := 0
 	for i < len(h) {
-		h[k] = h[i]
+		ret = append(ret, h[i])
 		i++
 		if i >= len(h) {
 			k++
 			break
 		}
 		for ; i < len(h) && h[i].DistinctCount() == 1; i++ {
-			eq, err := cmp(h[k].UpperBound(), h[i].UpperBound())
+			eq, err := cmp(ret[k].UpperBound(), h[i].UpperBound())
 			if err != nil {
 				return nil, err
 			}
@@ -536,18 +537,18 @@ func MergeOverlappingBuckets(h []sql.HistogramBucket, types []sql.Type, newB Buc
 				break
 			}
 
-			h[k] = newB(
-				h[k].RowCount()+h[i].RowCount(),
-				h[k].DistinctCount(),
-				h[k].NullCount()+h[i].NullCount(),
-				h[k].BoundCount()+h[i].BoundCount(),
-				h[k].UpperBound(),
-				h[k].McvCounts(),
-				h[k].Mcvs())
+			ret[k] = newB(
+				ret[k].RowCount()+h[i].RowCount(),
+				ret[k].DistinctCount(),
+				ret[k].NullCount()+h[i].NullCount(),
+				ret[k].BoundCount()+h[i].BoundCount(),
+				ret[k].UpperBound(),
+				ret[k].McvCounts(),
+				ret[k].Mcvs())
 		}
 		k++
 	}
-	return h[:k], nil
+	return ret, nil
 }
 
 type sjState int8

--- a/sql/stats/join_test.go
+++ b/sql/stats/join_test.go
@@ -70,7 +70,7 @@ func TestBinMerge(t *testing.T) {
 	}
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("bin merge %d", i), func(t *testing.T) {
-			cmp, err := mergeOverlappingBuckets(tt.inp, []sql.Type{types.Int64})
+			cmp, err := MergeOverlappingBuckets(tt.inp, []sql.Type{types.Int64}, NewHistogramBucket)
 			require.NoError(t, err)
 			compareHist(t, tt.exp, cmp)
 		})

--- a/sql/stats/statistic.go
+++ b/sql/stats/statistic.go
@@ -266,7 +266,7 @@ func ParseTypeStrings(typs []string) ([]sql.Type, error) {
 	return ret, nil
 }
 
-func NewHistogramBucket(rowCount, distinctCount, nullCount, boundCount uint64, boundValue sql.Row, mcvCounts []uint64, mcvs []sql.Row) *Bucket {
+func NewHistogramBucket(rowCount, distinctCount, nullCount, boundCount uint64, boundValue sql.Row, mcvCounts []uint64, mcvs []sql.Row) sql.HistogramBucket {
 	return &Bucket{
 		RowCnt:      rowCount,
 		DistinctCnt: distinctCount,


### PR DESCRIPTION
Merging buckets in the current format is unsafe:
- we collect statistics for an index where two buckets have overlapping values
- we execute a join using the index with overlapping values, and use a merge algorithm to combine those buckets. The merged bucket is synthetic, but the statistics used for the join is also synthetic, so this all works as expected.
- a future indexscan selects the compressed range from before, accessing one of the synthetic buckets created by the join
- we error `invalid bucket type: *stats.Bucket` at the end of the indexscan when adding the filtered histogram with a synthetic back to the implementor-type statistic

Edited `mergeOverlappingBuckets` to not share memory, but also I'm not sure if merging buckets is a common performance win in most cases, so disabling for now