### PR TITLE
[no-release-notes] Updated Integration Workflow

### DIFF
--- a/.github/workflows/dependency-test.yml
+++ b/.github/workflows/dependency-test.yml
@@ -1,11 +1,40 @@
 name: Test Integration with Dolt and DoltgreSQL
-on: [pull_request]
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created, edited]
 
 jobs:
   test-integration:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check for a Dolt PR link
+        id: check_dolt_pr
+        run: |
+          COMMENTS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments)
+          COMMENT_EXISTS=$(echo "$COMMENTS" | jq -r '.[] | select(.body | contains("github.com/dolthub/dolt/pull/"))')
+          if [ -n "$COMMENT_EXISTS" ]; then
+            echo "comment_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "comment_exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for a DoltgreSQL PR link
+        id: check_doltgresql_pr
+        run: |
+          COMMENTS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments)
+          COMMENT_EXISTS=$(echo "$COMMENTS" | jq -r '.[] | select(.body | contains("github.com/dolthub/doltgresql/pull/"))')
+          if [ -n "$COMMENT_EXISTS" ]; then
+            echo "comment_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "comment_exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout go-mysql-server
         uses: actions/checkout@v4
         with:
@@ -17,47 +46,57 @@ jobs:
           go-version-file: go.mod
 
       - name: Clone Dolt
+        if: steps.check_dolt_pr.outputs.comment_exists == 'false'
         run: git clone https://github.com/dolthub/dolt.git
 
       - name: Clone DoltgreSQL repository
+        if: steps.check_doltgresql_pr.outputs.comment_exists == 'false'
         run: git clone https://github.com/dolthub/doltgresql.git
 
-      - name: Update Dolt's dependency
-        run: |
-          cd dolt/go
-          go get github.com/dolthub/go-mysql-server@${{ github.event.pull_request.head.sha }}
-          go mod tidy
-
-      - name: Update DoltgreSQL's dependency
+      - name: Build DoltgreSQL's parser
+        if: steps.check_doltgresql_pr.outputs.comment_exists == 'false'
         run: |
           cd doltgresql
           ./postgres/parser/build.sh
-          go get github.com/dolthub/go-mysql-server@${{ github.event.pull_request.head.sha }}
+
+      - name: Test Dolt against main
+        id: test_dolt_main
+        if: steps.check_dolt_pr.outputs.comment_exists == 'false'
+        continue-on-error: true
+        run: |
+          cd dolt/go
+          go get github.com/dolthub/go-mysql-server@main
           go mod tidy
+          cd libraries/doltcore/sqle/enginetest
+          go test ./... --count=1
 
-      - name: Test Dolt
+      - name: Test DoltgreSQL against main
+        id: test_doltgresql_main
+        if: steps.check_doltgresql_pr.outputs.comment_exists == 'false'
+        continue-on-error: true
         run: |
-          cd dolt/go/libraries/doltcore/sqle/enginetest
-          go test ./... --count=1 || echo "dolt-tests-failed" > $GITHUB_WORKSPACE/dolt-test-result.txt
+          cd doltgresql
+          go get github.com/dolthub/go-mysql-server@main
+          go mod tidy
+          cd testing/go
+          go test ./... --count=1 -skip Replication
 
-      - name: Test DoltgreSQL
+      - name: Test Dolt against PR
+        if: steps.check_dolt_pr.outputs.comment_exists == 'false' && steps.test_dolt_main.outcome == 'success'
         run: |
-          cd doltgresql/testing/go
-          go test ./... --count=1 -skip Replication || echo "doltgresql-tests-failed" > $GITHUB_WORKSPACE/doltgresql-test-result.txt
+          cd dolt/go
+          git reset --hard
+          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
+          go mod tidy
+          cd libraries/doltcore/sqle/enginetest
+          go test ./... --count=1
 
-      - name: Comment on failures
-        if: always()
+      - name: Test DoltgreSQL against PR
+        if: steps.check_doltgresql_pr.outputs.comment_exists == 'false' && steps.test_doltgresql_main.outcome == 'success'
         run: |
-          TEST_COMMENT=""
-          if [ -f $GITHUB_WORKSPACE/dolt-test-result.txt ]; then
-            TEST_COMMENT="Additional work is required for integration with [Dolt](https://github.com/dolthub/dolt).\n"
-          fi
-          if [ -f $GITHUB_WORKSPACE/doltgresql-test-result.txt ]; then
-            TEST_COMMENT="${TEST_COMMENT}Additional work is required for integration with [DoltgreSQL](https://github.com/dolthub/doltgresql).\n"
-          fi
-          if [ -n "$TEST_COMMENT" ]; then
-            curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-              -X POST \
-              -d "{\"body\": \"$TEST_COMMENT\"}" \
-              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
-          fi
+          cd doltgresql
+          git reset --hard
+          go get github.com/${{ github.event.pull_request.head.repo.full_name }}@${{ github.event.pull_request.head.sha }}
+          go mod tidy
+          cd testing/go
+          go test ./... --count=1 -skip Replication

--- a/.github/workflows/dependency-test.yml
+++ b/.github/workflows/dependency-test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test-integration:
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This changes the integration workflow with Dolt and DoltgreSQL quite a bit.
* We now check that the `main` branch isn't broken before running tests. If `main` is broken, then the relevant tests are skipped. This is performed for both Dolt and DoltgreSQL, since `main` may only be broken for one of them. This ensures that a failing test is due to the PR specifically.
* We no longer post a message stating that the tests failed, which is easily ignored. The test will now fail like all other tests, and a link to a Dolt and/or DoltgreSQL PR is required to pass the test. Technically any PR link will do, as we're not checking that the linked PR passes, but this will force our hand to either fix the integration issues, or purposely merge the PR with a failing test.
* Fixed the issue with the test failing for non-team members. `go get` assumed that all PRs were made on the `dolthub/go-mysql-server` repository, but non-team members would merge changes from their forks. This now references the name of the repository that is being merged.