### PR TITLE
Bug fix: Fix `@@binlog_row_metadata`, add `@@binlog_row_image`

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3915,6 +3915,14 @@ func TestVariables(t *testing.T, harness Harness) {
 	require.NoError(t, err)
 	for _, assertion := range []queries.ScriptTestAssertion{
 		{
+			Query:    "SELECT @@binlog_row_metadata",
+			Expected: []sql.Row{{"MINIMAL"}},
+		},
+		{
+			Query:    "SELECT @@binlog_row_image",
+			Expected: []sql.Row{{"FULL"}},
+		},
+		{
 			Query:    "SELECT @@select_into_buffer_size",
 			Expected: []sql.Row{{131072}},
 		},

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -407,12 +407,20 @@ var systemVars = map[string]sql.SystemVariable{
 		Type:              types.NewSystemBoolType("binlog_gtid_simple_recovery"),
 		Default:           int8(1),
 	},
+	"binlog_row_image": &sql.MysqlSystemVariable{
+		Name:              "binlog_row_image",
+		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Both),
+		Dynamic:           true,
+		SetVarHintApplies: false,
+		Type:              types.NewSystemEnumType("binlog_row_image", "MINIMAL", "FULL", "NOBLOB"),
+		Default:           "FULL",
+	},
 	"binlog_row_metadata": &sql.MysqlSystemVariable{
 		Name:              "binlog_row_metadata",
 		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Global),
 		Dynamic:           true,
 		SetVarHintApplies: false,
-		Type:              types.NewSystemEnumType("MINIMAL", "FULL"),
+		Type:              types.NewSystemEnumType("binlog_row_metadata", "MINIMAL", "FULL"),
 		Default:           "MINIMAL",
 	},
 	"block_encryption_mode": &sql.MysqlSystemVariable{


### PR DESCRIPTION
Fixes an error in the definition for the [`@@binlog_row_metadata` system variable](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_row_metadata) that prevented it from being queried. Adds the [`@@binlog_row_image` system variable](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_row_image) that was missing. 