### PR TITLE
Adding user name and host length validation to CREATE USER

### DIFF
--- a/enginetest/queries/priv_auth_queries.go
+++ b/enginetest/queries/priv_auth_queries.go
@@ -106,6 +106,26 @@ type ServerAuthenticationTestAssertion struct {
 // account is used with any queries in the SetUpScript.
 var UserPrivTests = []UserPrivilegeTest{
 	{
+		Name: "Create user limits",
+		Assertions: []UserPrivilegeTestAssertion{
+			{
+				User:        "root",
+				Host:        "localhost",
+				Query:       "create user abcdefghijklmnopqrstuvwxyz0123456789@'localhost' identified by 'abc123';",
+				ExpectedErr: sql.ErrUserNameTooLong,
+			},
+			{
+				User: "root",
+				Host: "localhost",
+				Query: "create user j@'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" +
+					"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" +
+					"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'" +
+					" identified by 'abc123';",
+				ExpectedErr: sql.ErrUserHostTooLong,
+			},
+		},
+	},
+	{
 		Name: "Binlog replication privileges",
 		SetUpScript: []string{
 			"CREATE USER user@localhost;",

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -668,6 +668,12 @@ var (
 	// ErrUserCreationFailure is returned when attempting to create a user and it fails for any reason.
 	ErrUserCreationFailure = errors.NewKind("Operation CREATE USER failed for %s")
 
+	// ErrUserNameTooLong is returned when a CREATE USER statement uses a name that is longer than 32 chars.
+	ErrUserNameTooLong = errors.NewKind("String '%s' is too long for user name (should be no longer than 32)")
+
+	// ErrUserHostTooLong is returned when a CREATE USER statement uses a host that is longer than 255 chars.
+	ErrUserHostTooLong = errors.NewKind("String '%s' is too long for host name (should be no longer than 255)")
+
 	// ErrUserAlterFailure is returned when attempting to alter a user and it fails for any reason.
 	ErrUserAlterFailure = errors.NewKind("Operation ALTER USER failed for %s")
 

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -576,6 +576,14 @@ func (b *BaseBuilder) buildCreateUser(ctx *sql.Context, n *plan.CreateUser, _ sq
 			return nil, sql.ErrUserCreationFailure.New(user.UserName.String("'"))
 		}
 
+		if len(user.UserName.Name) > 32 {
+			return nil, sql.ErrUserNameTooLong.New(user.UserName.Name)
+		}
+
+		if len(user.UserName.Host) > 255 {
+			return nil, sql.ErrUserHostTooLong.New(user.UserName.Host)
+		}
+
 		plugin := "mysql_native_password"
 		password := ""
 		if user.Auth1 != nil {


### PR DESCRIPTION
This change matches MySQL's behavior of limiting user names to 32 chars and host names to 255 chars. Attempting to create a user with a name or host longer than that limit now returns a validation error. 

Customer issue: https://github.com/dolthub/dolt/issues/8120