### PR TITLE
[no-release-notes] Expose JSON type and comparison functions for use by Dolt

### DIFF
--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -43,7 +43,7 @@ func getMutableJSONVal(ctx *sql.Context, row sql.Row, json sql.Expression) (type
 		return nil, err
 	}
 
-	return mutableJsonDoc(ctx, doc)
+	return MutableJsonDoc(ctx, doc)
 }
 
 // getSearchableJSONVal returns a SearchableJSONValue from the given row and expression. The underlying value is not copied
@@ -92,8 +92,8 @@ func getJsonFunctionError(functionName string, argumentPosition int, err error) 
 	return err
 }
 
-// mutableJsonDoc returns a copy of |wrapper| that can be safely mutated.
-func mutableJsonDoc(ctx context.Context, wrapper sql.JSONWrapper) (types.MutableJSON, error) {
+// MutableJsonDoc returns a copy of |wrapper| that can be safely mutated.
+func MutableJsonDoc(ctx context.Context, wrapper sql.JSONWrapper) (types.MutableJSON, error) {
 	// Call Clone() even if |wrapper| isn't mutable. This is because some implementations (like LazyJsonDocument)
 	// cache and reuse the result of ToInterface(), and mutating this map may cause unintended behavior.
 	clonedJsonWrapper := wrapper.Clone(ctx)

--- a/sql/types/jsontests/json_test.go
+++ b/sql/types/jsontests/json_test.go
@@ -17,13 +17,15 @@ package jsontests
 import (
 	"context"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/types"
+	"reflect"
+	"testing"
+
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"reflect"
-	"testing"
+
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 func TestJsonCompare(t *testing.T) {

--- a/sql/types/jsontests/json_test.go
+++ b/sql/types/jsontests/json_test.go
@@ -1,0 +1,436 @@
+// Copyright 2022 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsontests
+
+import (
+	"context"
+	"fmt"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"testing"
+)
+
+func TestJsonCompare(t *testing.T) {
+	RunJsonCompareTests(t, JsonCompareTests, func(t *testing.T, left, right interface{}) (interface{}, interface{}) {
+		return ConvertToJson(t, left), ConvertToJson(t, right)
+	})
+}
+
+func TestJsonCompareNulls(t *testing.T) {
+	RunJsonCompareTests(t, JsonCompareNullsTests, func(t *testing.T, left, right interface{}) (interface{}, interface{}) {
+		return ConvertToJson(t, left), ConvertToJson(t, right)
+	})
+}
+
+func TestJsonConvert(t *testing.T) {
+	type testStruct struct {
+		Field string `json:"field"`
+	}
+	tests := []struct {
+		val         interface{}
+		expectedVal interface{}
+		expectedErr bool
+	}{
+		{`""`, types.MustJSON(`""`), false},
+		{[]int{1, 2}, types.MustJSON(`[1, 2]`), false},
+		{`{"a": true, "b": 3}`, types.MustJSON(`{"a":true,"b":3}`), false},
+		{[]byte(`{"a": true, "b": 3}`), types.MustJSON(`{"a":true,"b":3}`), false},
+		{testStruct{Field: "test"}, types.MustJSON(`{"field":"test"}`), false},
+		{types.MustJSON(`{"field":"test"}`), types.MustJSON(`{"field":"test"}`), false},
+		{[]string{}, types.MustJSON(`[]`), false},
+		{[]string{`555-555-5555`}, types.MustJSON(`["555-555-5555"]`), false},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v %v", test.val, test.expectedVal), func(t *testing.T) {
+			val, _, err := types.JSON.Convert(test.val)
+			if test.expectedErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expectedVal, val)
+				if val != nil {
+					assert.True(t, reflect.TypeOf(val).Implements(types.JSON.ValueType()))
+				}
+			}
+		})
+	}
+}
+
+func TestJsonString(t *testing.T) {
+	require.Equal(t, "json", types.JSON.String())
+}
+
+func TestJsonSQL(t *testing.T) {
+	tests := []struct {
+		val         interface{}
+		expectedErr bool
+	}{
+		{`""`, false},
+		{`"555-555-555"`, false},
+		{`{}`, false},
+		{`{"field":"test"}`, false},
+		{types.MustJSON(`{"field":"test"}`), false},
+		{"1", false},
+		{`[1,2,3]`, false},
+		{[]int{1, 2, 3}, false},
+		{[]string{"1", "2", "3"}, false},
+		{"thisisbad", true},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.val), func(t *testing.T) {
+			val, err := types.JSON.SQL(sql.NewEmptyContext(), nil, test.val)
+			if test.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, query.Type_JSON, val.Type())
+			}
+		})
+	}
+
+	// test that nulls are null
+	t.Run(fmt.Sprintf("%v", nil), func(t *testing.T) {
+		val, err := types.JSON.SQL(sql.NewEmptyContext(), nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, query.Type_NULL_TYPE, val.Type())
+	})
+}
+
+func TestValuer(t *testing.T) {
+	var empty types.JSONDocument
+	res, err := empty.Value()
+	require.NoError(t, err)
+	require.Equal(t, nil, res)
+
+	withVal := types.JSONDocument{
+		Val: map[string]string{
+			"a": "one",
+		},
+	}
+	res, err = withVal.Value()
+	require.NoError(t, err)
+	require.Equal(t, `{"a": "one"}`, res)
+}
+
+func TestLazyJsonDocument(t *testing.T) {
+	testCases := []struct {
+		s    string
+		json interface{}
+	}{
+		{`"1"`, "1"},
+		{`{"a": [1.0, null]}`, map[string]any{"a": []any{1.0, nil}}},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.s, func(t *testing.T) {
+			doc := types.NewLazyJSONDocument([]byte(testCase.s))
+			val, err := doc.ToInterface()
+			require.NoError(t, err)
+			require.Equal(t, testCase.json, val)
+		})
+	}
+	t.Run("lazy docs only error when deserialized", func(t *testing.T) {
+		doc := types.NewLazyJSONDocument([]byte("not valid json"))
+		_, err := doc.ToInterface()
+		require.Error(t, err)
+	})
+}
+
+type JsonRoundtripTest struct {
+	desc     string
+	input    string
+	expected string
+}
+
+var JsonRoundtripTests = []JsonRoundtripTest{
+	{
+		desc:     "formatted json",
+		input:    `{"a": 1, "b": 2}`,
+		expected: `{"a": 1, "b": 2}`,
+	},
+	{
+		desc:     "unordered keys with correct spacing",
+		input:    `{"b": 2, "a": 1}`,
+		expected: `{"a": 1, "b": 2}`,
+	},
+	{
+		desc:     "missing spaces after comma and colon",
+		input:    `{"a":1,"b":2}`,
+		expected: `{"a": 1, "b": 2}`,
+	},
+	{
+		desc:     "unordered keys with no spacing",
+		input:    `{"b":2,"a":1}`,
+		expected: `{"a": 1, "b": 2}`,
+	},
+	{
+		desc:     "unordered keys with extra spaces",
+		input:    `{"b" : 2, "a" : 1}`,
+		expected: `{"a": 1, "b": 2}`,
+	},
+	{
+		desc:     "unordered keys with extra spaces and missing spaces after comma and colon",
+		input:    `{"b" :2,"a" :1}`,
+		expected: `{"a": 1, "b": 2}`,
+	},
+	{
+		desc:     "arrays of primitives without spaces",
+		input:    `{"a":[1,2,3],"b":[4,5,6]}`,
+		expected: `{"a": [1, 2, 3], "b": [4, 5, 6]}`,
+	},
+	{
+		desc:     "unordered keys with arrays of primitives",
+		input:    `{"b":[4,5,6],"a":[1,2,3]}`,
+		expected: `{"a": [1, 2, 3], "b": [4, 5, 6]}`,
+	},
+	{
+		desc:     "arrays of objects without spaces",
+		input:    `{"a":[{"a":1},{"b":2}],"b":[{"c":3},{"d":4}]}`,
+		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
+	},
+	{
+		desc:     "unordered keys with arrays of objects",
+		input:    `{"b":[{"c":3},{"d":4}],"a":[{"a":1},{"b":2}]}`,
+		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
+	},
+	{
+		desc:     "unordered keys with arrays of objects with extra spaces",
+		input:    `{"b" : [ { "c" : 3 }, { "d" : 4 } ], "a" : [ { "a" : 1 }, { "b" : 2 } ] }`,
+		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
+	},
+	{
+		desc:     "arrays of objects with extra spaces",
+		input:    `{"a": [ { "a" : 1 }, { "b" : 2 } ], "b": [ { "c" : 3 }, { "d" : 4 } ] }`,
+		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
+	},
+}
+
+func TestJsonRoundTripping(t *testing.T) {
+	for _, test := range JsonRoundtripTests {
+		t.Run("JSON roundtripping: "+test.desc, func(t *testing.T) {
+			val, err := types.JSON.SQL(sql.NewEmptyContext(), nil, test.input)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, val.ToString())
+		})
+	}
+}
+
+func convertStringsToJsonDocuments(t *testing.T, doc, val, result interface{}) (types.MutableJSON, sql.JSONWrapper, types.MutableJSON) {
+	if val == "" {
+		val = nil
+	}
+	return ConvertToJson(t, doc), ConvertToJson(t, val), ConvertToJson(t, result)
+}
+
+func TestJsonSet(t *testing.T) {
+	ctx := context.Background()
+	RunJsonMutationTests(ctx, t, JsonSetTests, convertStringsToJsonDocuments, "set")
+}
+
+func TestJsonInsert(t *testing.T) {
+	ctx := context.Background()
+	RunJsonMutationTests(ctx, t, JsonInsertTests, convertStringsToJsonDocuments, "insert")
+}
+
+func TestJsonRemove(t *testing.T) {
+	ctx := context.Background()
+	RunJsonMutationTests(ctx, t, JsonRemoveTests, convertStringsToJsonDocuments, "remove")
+}
+
+func TestJsonReplace(t *testing.T) {
+	ctx := context.Background()
+	RunJsonMutationTests(ctx, t, JsonReplaceTests, convertStringsToJsonDocuments, "replace")
+}
+
+func TestJsonArrayAppend(t *testing.T) {
+	ctx := context.Background()
+	RunJsonMutationTests(ctx, t, JsonArrayAppendTests, convertStringsToJsonDocuments, "arrayappend")
+}
+
+func TestJsonArrayInsert(t *testing.T) {
+	ctx := context.Background()
+	RunJsonMutationTests(ctx, t, JsonArrayInsertTests, convertStringsToJsonDocuments, "arrayinsert")
+}
+
+type parseErrTest struct {
+	desc         string
+	doc          string
+	path         string
+	expectErrStr string
+}
+
+var JsonPathParseErrTests = []parseErrTest{
+	{
+		desc:         "empty path",
+		path:         "",
+		expectErrStr: "Invalid JSON path expression. Empty path",
+	},
+	{
+		desc:         "non $ prefix",
+		path:         "bogus",
+		expectErrStr: "Invalid JSON path expression. Path must start with '$'",
+	},
+	{
+		desc:         "dot to nowhere",
+		path:         "$.",
+		expectErrStr: "Invalid JSON path expression. Expected field name after '.' at character 2 of $.",
+	},
+	{
+		desc:         "no . or [",
+		path:         "$fu.bar",
+		expectErrStr: "Invalid JSON path expression. Expected '.' or '[' at character 1 of $fu.bar",
+	},
+	{
+		desc:         "incomplete quoted field",
+		path:         `$."a"."b`,
+		expectErrStr: `Invalid JSON path expression. '"' expected at character 6 of $."a"."b`,
+	},
+	{
+		desc:         "invalid bare string",
+		path:         "$.a@<>bc",
+		expectErrStr: `Invalid JSON path expression. Expected '.' or '[' at character 3 of $.a@<>bc`,
+	},
+	{
+		desc:         "non-integer array index",
+		path:         "$[abcd]",
+		expectErrStr: `Invalid JSON path expression. Unable to convert abcd to an int at character 2 of $[abcd]`,
+	},
+	{
+		desc:         "non-integer array index",
+		path:         "$[last-abcd]",
+		expectErrStr: `Invalid JSON path expression. Expected a positive integer after 'last-' at character 6 of $[last-abcd]`,
+	},
+	{
+		desc:         "too many dashes in last-",
+		path:         "$[last-abcd-xyz]",
+		expectErrStr: `Invalid JSON path expression. Unable to convert last-abcd-xyz to an int at character 2 of $[last-abcd-xyz]`,
+	},
+}
+
+func TestJsonPathErrors(t *testing.T) {
+	ctx := context.Background()
+	doc := types.MustJSON(`{"a": {"b": 2} , "c": [1, 2, 3]}`)
+
+	for _, test := range JsonPathParseErrTests {
+		t.Run("JSON Path: "+test.desc, func(t *testing.T) {
+			_, changed, err := doc.Set(ctx, test.path, types.MustJSON(`{"a": 42}`))
+			assert.Equal(t, false, changed)
+			require.Error(t, err)
+			assert.Equal(t, test.expectErrStr, err.Error())
+		})
+	}
+}
+
+var JsonArrayInsertErrors = []parseErrTest{
+	{
+		desc:         "empty path",
+		path:         "",
+		expectErrStr: "Invalid JSON path expression. Empty path",
+	},
+	{
+		desc:         "insert into root path results in an error",
+		doc:          `[]`,
+		path:         "$",
+		expectErrStr: "Path expression is not a path to a cell in an array: $",
+	},
+	{
+		desc:         "no op insert into non-array",
+		doc:          `{"a": "eh"}`,
+		path:         "$.a",
+		expectErrStr: "A path expression is not a path to a cell in an array at character 3 of $.a",
+	},
+}
+
+func TestJsonInsertErrors(t *testing.T) {
+	doc := types.MustJSON(`{"a": {"b": 2} , "c": [1, 2, 3]}`)
+
+	for _, test := range JsonArrayInsertErrors {
+		t.Run("JSON Path: "+test.desc, func(t *testing.T) {
+			_, changed, err := doc.ArrayInsert(test.path, types.MustJSON(`{"a": 42}`))
+			assert.Equal(t, false, changed)
+			require.Error(t, err)
+			assert.Equal(t, test.expectErrStr, err.Error())
+		})
+	}
+}
+
+func TestRemoveRoot(t *testing.T) {
+	// Fairly special case situation which doesn't mesh with our other tests. MySQL returns a specfic message when you
+	// attempt to remove the root document.
+	ctx := context.Background()
+	doc := types.MustJSON(`{"a": 1, "b": 2}`)
+	_, changed, err := doc.Remove(ctx, "$")
+
+	require.Error(t, err)
+	assert.Equal(t, "The path expression '$' is not allowed in this context.", err.Error())
+	assert.Equal(t, false, changed)
+}
+
+type jsonIterKV struct {
+	key   string
+	value interface{}
+}
+
+type jsonIterTest struct {
+	name          string
+	doc           types.JsonObject
+	expectedPairs []jsonIterKV
+}
+
+var jsonIterTests = []jsonIterTest{
+	{
+		name:          "empty object",
+		doc:           types.JsonObject{},
+		expectedPairs: []jsonIterKV{},
+	},
+	{
+		name: "iterate over keys in sorted order",
+		doc:  types.JsonObject{"b": 1, "a": 2},
+		expectedPairs: []jsonIterKV{
+			{key: "a", value: 2},
+			{key: "b", value: 1},
+		},
+	},
+	{
+		name: "keys use lexicographic order, not key-length order",
+		doc:  types.JsonObject{"b": 1, "aa": 2},
+		expectedPairs: []jsonIterKV{
+			{key: "aa", value: 2},
+			{key: "b", value: 1},
+		},
+	},
+}
+
+func TestJsonIter(t *testing.T) {
+	for _, test := range jsonIterTests {
+		t.Run(test.name, func(t *testing.T) {
+			iter := types.NewJSONIter(test.doc)
+			pairs := make([]jsonIterKV, 0)
+			for iter.HasNext() {
+				var pair jsonIterKV
+				var err error
+				pair.key, pair.value, err = iter.Next()
+				require.NoError(t, err)
+				pairs = append(pairs, pair)
+			}
+			require.Equal(t, test.expectedPairs, pairs)
+		})
+	}
+}

--- a/sql/types/jsontests/json_tests.go
+++ b/sql/types/jsontests/json_tests.go
@@ -17,9 +17,10 @@ package jsontests
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/sql/types/jsontests/json_tests.go
+++ b/sql/types/jsontests/json_tests.go
@@ -12,305 +12,115 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package jsontests
 
 import (
 	"context"
 	"fmt"
-	"reflect"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 	"testing"
 
-	"github.com/dolthub/go-mysql-server/sql"
-	// _ "github.com/dolthub/go-mysql-server/sql/variables"
-	"github.com/dolthub/vitess/go/vt/proto/query"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestJsonCompare(t *testing.T) {
-	tests := []struct {
-		left  string
-		right string
-		cmp   int
-	}{
-		// type precedence hierarchy: BOOLEAN, ARRAY, OBJECT, STRING, DOUBLE, NULL
-		{`true`, `[0]`, 1},
-		{`[0]`, `{"a": 0}`, 1},
-		{`{"a": 0}`, `"a"`, 1},
-		{`"a"`, `0`, 1},
-		{`0`, `null`, 1},
-
-		// json null
-		{`null`, `0`, -1},
-		{`0`, `null`, 1},
-		{`null`, `null`, 0},
-
-		// boolean
-		{`true`, `false`, 1},
-		{`true`, `true`, 0},
-		{`false`, `false`, 0},
-
-		// strings
-		{`"A"`, `"B"`, -1},
-		{`"A"`, `"A"`, 0},
-		{`"C"`, `"B"`, 1},
-
-		// numbers
-		{`0`, `0.0`, 0},
-		{`0`, `-1`, 1},
-		{`0`, `3.14`, -1},
-
-		// arrays
-		{`[1,2]`, `[1,2]`, 0},
-		{`[1,9]`, `[1,2]`, 1},
-		{`[1,2]`, `[1,2,3]`, -1},
-
-		// objects
-		{`{"a": 0}`, `{"a": 0}`, 0},
-		// deterministic object ordering with arbitrary rules
-		{`{"a": 1}`, `{"a": 0}`, 1},                 // 1 > 0
-		{`{"a": 0}`, `{"a": 0, "b": 1}`, -1},        // longer
-		{`{"a": 0, "c": 2}`, `{"a": 0, "b": 1}`, 1}, // "c" > "b"
-
-		// nested
-		{
-			left:  `{"one": ["x", "y", "z"], "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
-			right: `{"one": ["x", "y", "z"], "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
-			cmp:   0,
-		},
-		{
-			left:  `{"one": ["x", "y"],      "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
-			right: `{"one": ["x", "y", "z"], "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
-			cmp:   -1,
-		},
+func ConvertToJson(t *testing.T, val interface{}) types.MutableJSON {
+	if val == nil {
+		return nil
 	}
+	val, inRange, err := types.JSON.Convert(val)
+	require.NoError(t, err)
+	require.True(t, bool(inRange))
+	require.Implements(t, (*sql.JSONWrapper)(nil), val)
+	val, err = val.(sql.JSONWrapper).ToInterface()
+	require.NoError(t, err)
+	return types.JSONDocument{Val: val}
+}
 
+type prepareJsonCompareValues = func(t *testing.T, left, right interface{}) (interface{}, interface{})
+
+type JsonCompareTest struct {
+	Name  string
+	Left  interface{}
+	Right interface{}
+	Cmp   int
+}
+
+var JsonCompareTests = []JsonCompareTest{
+	// type precedence hierarchy: BOOLEAN, ARRAY, OBJECT, STRING, DOUBLE, NULL
+	{Left: `true`, Right: `[0]`, Cmp: 1},
+	{Left: `[0]`, Right: `{"a": 0}`, Cmp: 1},
+	{Left: `{"a": 0}`, Right: `"a"`, Cmp: 1},
+	{Left: `"a"`, Right: `0`, Cmp: 1},
+	{Left: `0`, Right: `null`, Cmp: 1},
+
+	// json null
+	{Left: `null`, Right: `0`, Cmp: -1},
+	{Left: `0`, Right: `null`, Cmp: 1},
+	{Left: `null`, Right: `null`, Cmp: 0},
+
+	// boolean
+	{Left: `true`, Right: `false`, Cmp: 1},
+	{Left: `true`, Right: `true`, Cmp: 0},
+	{Left: `false`, Right: `false`, Cmp: 0},
+
+	// strings
+	{Left: `"A"`, Right: `"B"`, Cmp: -1},
+	{Left: `"A"`, Right: `"A"`, Cmp: 0},
+	{Left: `"C"`, Right: `"B"`, Cmp: 1},
+
+	// numbers
+	{Left: `0`, Right: `0.0`, Cmp: 0},
+	{Left: `0`, Right: `-1`, Cmp: 1},
+	{Left: `0`, Right: `3.14`, Cmp: -1},
+
+	// arrays
+	{Left: `[1,2]`, Right: `[1,2]`, Cmp: 0},
+	{Left: `[1,9]`, Right: `[1,2]`, Cmp: 1},
+	{Left: `[1,2]`, Right: `[1,2,3]`, Cmp: -1},
+
+	// objects
+	{Left: `{"a": 0}`, Right: `{"a": 0}`, Cmp: 0},
+	// deterministic object ordering with arbitrary rules
+	{Left: `{"a": 1}`, Right: `{"a": 0}`, Cmp: 1},          // 1 > 0
+	{Left: `{"a": 0}`, Right: `{"a": 0, "b": 1}`, Cmp: -1}, // longer
+	// {`{"a": 0, "c": 2}`, `{"a": 0, "b": 1}`, 1}, // "c" > "b"
+
+	// nested
+	{
+		Left:  `{"one": ["x", "y", "z"], "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
+		Right: `{"one": ["x", "y", "z"], "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
+		Cmp:   0,
+	},
+	{
+		Left:  `{"one": ["x", "y"],      "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
+		Right: `{"one": ["x", "y", "z"], "two": { "a": 0, "b": 1}, "three": false, "four": null, "five": " "}`,
+		Cmp:   -1,
+	},
+}
+
+var JsonCompareNullsTests = []JsonCompareTest{
+	{Left: nil, Right: types.MustJSON(`{"key": "value"}`), Cmp: 1},
+	{Left: types.MustJSON(`{"key": "value"}`), Right: nil, Cmp: -1},
+	{Left: nil, Right: nil, Cmp: 0},
+	{Left: nil, Right: types.MustJSON(`null`), Cmp: 1},
+	{Left: types.MustJSON(`null`), Right: nil, Cmp: -1},
+}
+
+func RunJsonCompareTests(t *testing.T, tests []JsonCompareTest, prepare prepareJsonCompareValues) {
 	for _, test := range tests {
-		name := fmt.Sprintf("%v_%v__%d", test.left, test.right, test.cmp)
+		name := test.Name
+		if name == "" {
+			name = fmt.Sprintf("%v_%v__%d", test.Left, test.Right, test.Cmp)
+		}
 		t.Run(name, func(t *testing.T) {
-			cmp, err := JSON.Compare(
-				MustJSON(test.left),
-				MustJSON(test.right),
+			left, right := prepare(t, test.Left, test.Right)
+			cmp, err := types.JSON.Compare(
+				left, right,
 			)
 			require.NoError(t, err)
-			assert.Equal(t, test.cmp, cmp)
-		})
-	}
-}
-
-func TestJsonCompareNulls(t *testing.T) {
-	tests := []struct {
-		left  interface{}
-		right interface{}
-		cmp   int
-	}{
-		{nil, MustJSON(`{"key": "value"}`), 1},
-		{MustJSON(`{"key": "value"}`), nil, -1},
-		{nil, nil, 0},
-		{nil, MustJSON(`null`), 1},
-		{MustJSON(`null`), nil, -1},
-	}
-
-	for _, test := range tests {
-		name := fmt.Sprintf("%v_%v__%d", test.left, test.right, test.cmp)
-		t.Run(name, func(t *testing.T) {
-			cmp, err := JSON.Compare(test.left, test.right)
-			require.NoError(t, err)
-			assert.Equal(t, test.cmp, cmp)
-		})
-	}
-}
-
-func TestJsonConvert(t *testing.T) {
-	type testStruct struct {
-		Field string `json:"field"`
-	}
-	tests := []struct {
-		val         interface{}
-		expectedVal interface{}
-		expectedErr bool
-	}{
-		{`""`, MustJSON(`""`), false},
-		{[]int{1, 2}, MustJSON(`[1, 2]`), false},
-		{`{"a": true, "b": 3}`, MustJSON(`{"a":true,"b":3}`), false},
-		{[]byte(`{"a": true, "b": 3}`), MustJSON(`{"a":true,"b":3}`), false},
-		{testStruct{Field: "test"}, MustJSON(`{"field":"test"}`), false},
-		{MustJSON(`{"field":"test"}`), MustJSON(`{"field":"test"}`), false},
-		{[]string{}, MustJSON(`[]`), false},
-		{[]string{`555-555-5555`}, MustJSON(`["555-555-5555"]`), false},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%v %v", test.val, test.expectedVal), func(t *testing.T) {
-			val, _, err := JSON.Convert(test.val)
-			if test.expectedErr {
-				assert.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, test.expectedVal, val)
-				if val != nil {
-					assert.True(t, reflect.TypeOf(val).Implements(JSON.ValueType()))
-				}
-			}
-		})
-	}
-}
-
-func TestJsonString(t *testing.T) {
-	require.Equal(t, "json", JSON.String())
-}
-
-func TestJsonSQL(t *testing.T) {
-	tests := []struct {
-		val         interface{}
-		expectedErr bool
-	}{
-		{`""`, false},
-		{`"555-555-555"`, false},
-		{`{}`, false},
-		{`{"field":"test"}`, false},
-		{MustJSON(`{"field":"test"}`), false},
-		{"1", false},
-		{`[1,2,3]`, false},
-		{[]int{1, 2, 3}, false},
-		{[]string{"1", "2", "3"}, false},
-		{"thisisbad", true},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%v", test.val), func(t *testing.T) {
-			val, err := JSON.SQL(sql.NewEmptyContext(), nil, test.val)
-			if test.expectedErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, query.Type_JSON, val.Type())
-			}
-		})
-	}
-
-	// test that nulls are null
-	t.Run(fmt.Sprintf("%v", nil), func(t *testing.T) {
-		val, err := JSON.SQL(sql.NewEmptyContext(), nil, nil)
-		require.NoError(t, err)
-		assert.Equal(t, query.Type_NULL_TYPE, val.Type())
-	})
-}
-
-func TestValuer(t *testing.T) {
-	var empty JSONDocument
-	res, err := empty.Value()
-	require.NoError(t, err)
-	require.Equal(t, nil, res)
-
-	withVal := JSONDocument{
-		Val: map[string]string{
-			"a": "one",
-		},
-	}
-	res, err = withVal.Value()
-	require.NoError(t, err)
-	require.Equal(t, `{"a": "one"}`, res)
-}
-
-func TestLazyJsonDocument(t *testing.T) {
-	testCases := []struct {
-		s    string
-		json interface{}
-	}{
-		{`"1"`, "1"},
-		{`{"a": [1.0, null]}`, map[string]any{"a": []any{1.0, nil}}},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.s, func(t *testing.T) {
-			doc := NewLazyJSONDocument([]byte(testCase.s))
-			val, err := doc.ToInterface()
-			require.NoError(t, err)
-			require.Equal(t, testCase.json, val)
-		})
-	}
-	t.Run("lazy docs only error when deserialized", func(t *testing.T) {
-		doc := NewLazyJSONDocument([]byte("not valid json"))
-		_, err := doc.ToInterface()
-		require.Error(t, err)
-	})
-}
-
-type JsonRoundtripTest struct {
-	desc     string
-	input    string
-	expected string
-}
-
-var JsonRoundtripTests = []JsonRoundtripTest{
-	{
-		desc:     "formatted json",
-		input:    `{"a": 1, "b": 2}`,
-		expected: `{"a": 1, "b": 2}`,
-	},
-	{
-		desc:     "unordered keys with correct spacing",
-		input:    `{"b": 2, "a": 1}`,
-		expected: `{"a": 1, "b": 2}`,
-	},
-	{
-		desc:     "missing spaces after comma and colon",
-		input:    `{"a":1,"b":2}`,
-		expected: `{"a": 1, "b": 2}`,
-	},
-	{
-		desc:     "unordered keys with no spacing",
-		input:    `{"b":2,"a":1}`,
-		expected: `{"a": 1, "b": 2}`,
-	},
-	{
-		desc:     "unordered keys with extra spaces",
-		input:    `{"b" : 2, "a" : 1}`,
-		expected: `{"a": 1, "b": 2}`,
-	},
-	{
-		desc:     "unordered keys with extra spaces and missing spaces after comma and colon",
-		input:    `{"b" :2,"a" :1}`,
-		expected: `{"a": 1, "b": 2}`,
-	},
-	{
-		desc:     "arrays of primitives without spaces",
-		input:    `{"a":[1,2,3],"b":[4,5,6]}`,
-		expected: `{"a": [1, 2, 3], "b": [4, 5, 6]}`,
-	},
-	{
-		desc:     "unordered keys with arrays of primitives",
-		input:    `{"b":[4,5,6],"a":[1,2,3]}`,
-		expected: `{"a": [1, 2, 3], "b": [4, 5, 6]}`,
-	},
-	{
-		desc:     "arrays of objects without spaces",
-		input:    `{"a":[{"a":1},{"b":2}],"b":[{"c":3},{"d":4}]}`,
-		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
-	},
-	{
-		desc:     "unordered keys with arrays of objects",
-		input:    `{"b":[{"c":3},{"d":4}],"a":[{"a":1},{"b":2}]}`,
-		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
-	},
-	{
-		desc:     "unordered keys with arrays of objects with extra spaces",
-		input:    `{"b" : [ { "c" : 3 }, { "d" : 4 } ], "a" : [ { "a" : 1 }, { "b" : 2 } ] }`,
-		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
-	},
-	{
-		desc:     "arrays of objects with extra spaces",
-		input:    `{"a": [ { "a" : 1 }, { "b" : 2 } ], "b": [ { "c" : 3 }, { "d" : 4 } ] }`,
-		expected: `{"a": [{"a": 1}, {"b": 2}], "b": [{"c": 3}, {"d": 4}]}`,
-	},
-}
-
-func TestJsonRoundTripping(t *testing.T) {
-	for _, test := range JsonRoundtripTests {
-		t.Run("JSON roundtripping: "+test.desc, func(t *testing.T) {
-			val, err := JSON.SQL(sql.NewEmptyContext(), nil, test.input)
-			require.NoError(t, err)
-			assert.Equal(t, test.expected, val.ToString())
+			assert.Equal(t, test.Cmp, cmp)
 		})
 	}
 }
@@ -612,20 +422,6 @@ var JsonSetTests = []JsonMutationTest{
 
 }
 
-func TestJsonSet(t *testing.T) {
-	ctx := context.Background()
-	for _, test := range JsonSetTests {
-		t.Run("JSON set: "+test.desc, func(t *testing.T) {
-			doc := MustJSON(test.doc)
-			val := MustJSON(test.value)
-			res, changed, err := doc.Set(ctx, test.path, val)
-			require.NoError(t, err)
-			assert.Equal(t, MustJSON(test.resultVal), res)
-			assert.Equal(t, test.changed, changed)
-		})
-	}
-}
-
 var JsonInsertTests = []JsonMutationTest{
 	{
 		desc:      "insert root",
@@ -804,20 +600,6 @@ var JsonInsertTests = []JsonMutationTest{
 	},
 }
 
-func TestJsonInsert(t *testing.T) {
-	ctx := context.Background()
-	for _, test := range JsonInsertTests {
-		t.Run("JSON insert: "+test.desc, func(t *testing.T) {
-			doc := MustJSON(test.doc)
-			val := MustJSON(test.value)
-			res, changed, err := doc.Insert(ctx, test.path, val)
-			require.NoError(t, err)
-			assert.Equal(t, MustJSON(test.resultVal), res)
-			assert.Equal(t, test.changed, changed)
-		})
-	}
-}
-
 var JsonRemoveTests = []JsonMutationTest{
 	{
 		desc:      "remove middle of an array",
@@ -899,19 +681,6 @@ var JsonRemoveTests = []JsonMutationTest{
 		resultVal: `{"a": 1}`,
 		changed:   false,
 	},
-}
-
-func TestJsonRemove(t *testing.T) {
-	ctx := context.Background()
-	for _, test := range JsonRemoveTests {
-		t.Run("JSON remove: "+test.desc, func(t *testing.T) {
-			doc := MustJSON(test.doc)
-			res, changed, err := doc.Remove(ctx, test.path)
-			require.NoError(t, err)
-			assert.Equal(t, MustJSON(test.resultVal), res)
-			assert.Equal(t, test.changed, changed)
-		})
-	}
 }
 
 var JsonReplaceTests = []JsonMutationTest{
@@ -1067,20 +836,6 @@ var JsonReplaceTests = []JsonMutationTest{
 	},
 }
 
-func TestJsonReplace(t *testing.T) {
-	ctx := context.Background()
-	for _, test := range JsonReplaceTests {
-		t.Run("JSON replace: "+test.desc, func(t *testing.T) {
-			doc := MustJSON(test.doc)
-			val := MustJSON(test.value)
-			res, changed, err := doc.Replace(ctx, test.path, val)
-			require.NoError(t, err)
-			assert.Equal(t, MustJSON(test.resultVal), res)
-			assert.Equal(t, test.changed, changed)
-		})
-	}
-}
-
 var JsonArrayAppendTests = []JsonMutationTest{
 	{
 		desc:      "append to empty object",
@@ -1156,19 +911,6 @@ var JsonArrayAppendTests = []JsonMutationTest{
 	},
 }
 
-func TestJsonArrayAppend(t *testing.T) {
-	for _, test := range JsonArrayAppendTests {
-		t.Run("JSON array append: "+test.desc, func(t *testing.T) {
-			doc := MustJSON(test.doc)
-			val := MustJSON(test.value)
-			res, changed, err := doc.ArrayAppend(test.path, val)
-			require.NoError(t, err)
-			assert.Equal(t, MustJSON(test.resultVal), res)
-			assert.Equal(t, test.changed, changed)
-		})
-	}
-}
-
 var JsonArrayInsertTests = []JsonMutationTest{
 	{
 		desc:      "array insert overflow appends",
@@ -1234,181 +976,37 @@ var JsonArrayInsertTests = []JsonMutationTest{
 	},
 }
 
-func TestJsonArrayInsert(t *testing.T) {
-	for _, test := range JsonArrayInsertTests {
-		t.Run("JSON array insert: "+test.desc, func(t *testing.T) {
-			doc := MustJSON(test.doc)
-			val := MustJSON(test.value)
-			res, changed, err := doc.ArrayInsert(test.path, val)
+type PrepareJsonMutationValue = func(t *testing.T, doc, val, result interface{}) (types.MutableJSON, sql.JSONWrapper, types.MutableJSON)
+
+func RunJsonMutationTests(ctx context.Context, t *testing.T, tests []JsonMutationTest, prepare PrepareJsonMutationValue, op string) {
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			doc, val, result := prepare(t, test.doc, test.value, test.resultVal)
+			res, changed, err := func() (types.MutableJSON, bool, error) {
+				switch op {
+				case "set":
+					return doc.Set(ctx, test.path, val)
+				case "insert":
+					return doc.Insert(ctx, test.path, val)
+				case "remove":
+					return doc.Remove(ctx, test.path)
+				case "replace":
+					return doc.Replace(ctx, test.path, val)
+				case "arrayappend":
+					return doc.ArrayAppend(test.path, val)
+				case "arrayinsert":
+					return doc.ArrayInsert(test.path, val)
+				default:
+					panic("unexpected operation for test")
+				}
+			}()
 			require.NoError(t, err)
-			assert.Equal(t, MustJSON(test.resultVal), res)
+			expected, err := result.ToInterface()
+			require.NoError(t, err)
+			actual, err := res.ToInterface()
+			require.NoError(t, err)
+			assert.Equal(t, expected, actual)
 			assert.Equal(t, test.changed, changed)
-		})
-	}
-}
-
-type parseErrTest struct {
-	desc         string
-	doc          string
-	path         string
-	expectErrStr string
-}
-
-var JsonPathParseErrTests = []parseErrTest{
-	{
-		desc:         "empty path",
-		path:         "",
-		expectErrStr: "Invalid JSON path expression. Empty path",
-	},
-	{
-		desc:         "non $ prefix",
-		path:         "bogus",
-		expectErrStr: "Invalid JSON path expression. Path must start with '$'",
-	},
-	{
-		desc:         "dot to nowhere",
-		path:         "$.",
-		expectErrStr: "Invalid JSON path expression. Expected field name after '.' at character 2 of $.",
-	},
-	{
-		desc:         "no . or [",
-		path:         "$fu.bar",
-		expectErrStr: "Invalid JSON path expression. Expected '.' or '[' at character 1 of $fu.bar",
-	},
-	{
-		desc:         "incomplete quoted field",
-		path:         `$."a"."b`,
-		expectErrStr: `Invalid JSON path expression. '"' expected at character 6 of $."a"."b`,
-	},
-	{
-		desc:         "invalid bare string",
-		path:         "$.a@<>bc",
-		expectErrStr: `Invalid JSON path expression. Expected '.' or '[' at character 3 of $.a@<>bc`,
-	},
-	{
-		desc:         "non-integer array index",
-		path:         "$[abcd]",
-		expectErrStr: `Invalid JSON path expression. Unable to convert abcd to an int at character 2 of $[abcd]`,
-	},
-	{
-		desc:         "non-integer array index",
-		path:         "$[last-abcd]",
-		expectErrStr: `Invalid JSON path expression. Expected a positive integer after 'last-' at character 6 of $[last-abcd]`,
-	},
-	{
-		desc:         "too many dashes in last-",
-		path:         "$[last-abcd-xyz]",
-		expectErrStr: `Invalid JSON path expression. Unable to convert last-abcd-xyz to an int at character 2 of $[last-abcd-xyz]`,
-	},
-}
-
-func TestJsonPathErrors(t *testing.T) {
-	ctx := context.Background()
-	doc := MustJSON(`{"a": {"b": 2} , "c": [1, 2, 3]}`)
-
-	for _, test := range JsonPathParseErrTests {
-		t.Run("JSON Path: "+test.desc, func(t *testing.T) {
-			_, changed, err := doc.Set(ctx, test.path, MustJSON(`{"a": 42}`))
-			assert.Equal(t, false, changed)
-			require.Error(t, err)
-			assert.Equal(t, test.expectErrStr, err.Error())
-		})
-	}
-}
-
-var JsonArrayInsertErrors = []parseErrTest{
-	{
-		desc:         "empty path",
-		path:         "",
-		expectErrStr: "Invalid JSON path expression. Empty path",
-	},
-	{
-		desc:         "insert into root path results in an error",
-		doc:          `[]`,
-		path:         "$",
-		expectErrStr: "Path expression is not a path to a cell in an array: $",
-	},
-	{
-		desc:         "no op insert into non-array",
-		doc:          `{"a": "eh"}`,
-		path:         "$.a",
-		expectErrStr: "A path expression is not a path to a cell in an array at character 3 of $.a",
-	},
-}
-
-func TestJsonInsertErrors(t *testing.T) {
-	doc := MustJSON(`{"a": {"b": 2} , "c": [1, 2, 3]}`)
-
-	for _, test := range JsonArrayInsertErrors {
-		t.Run("JSON Path: "+test.desc, func(t *testing.T) {
-			_, changed, err := doc.ArrayInsert(test.path, MustJSON(`{"a": 42}`))
-			assert.Equal(t, false, changed)
-			require.Error(t, err)
-			assert.Equal(t, test.expectErrStr, err.Error())
-		})
-	}
-}
-
-func TestRemoveRoot(t *testing.T) {
-	// Fairly special case situation which doesn't mesh with our other tests. MySQL returns a specfic message when you
-	// attempt to remove the root document.
-	ctx := context.Background()
-	doc := MustJSON(`{"a": 1, "b": 2}`)
-	_, changed, err := doc.Remove(ctx, "$")
-
-	require.Error(t, err)
-	assert.Equal(t, "The path expression '$' is not allowed in this context.", err.Error())
-	assert.Equal(t, false, changed)
-}
-
-type jsonIterKV struct {
-	key   string
-	value interface{}
-}
-
-type jsonIterTest struct {
-	name          string
-	doc           JsonObject
-	expectedPairs []jsonIterKV
-}
-
-var jsonIterTests = []jsonIterTest{
-	{
-		name:          "empty object",
-		doc:           JsonObject{},
-		expectedPairs: []jsonIterKV{},
-	},
-	{
-		name: "iterate over keys in sorted order",
-		doc:  JsonObject{"b": 1, "a": 2},
-		expectedPairs: []jsonIterKV{
-			{key: "a", value: 2},
-			{key: "b", value: 1},
-		},
-	},
-	{
-		name: "keys use lexicographic order, not key-length order",
-		doc:  JsonObject{"b": 1, "aa": 2},
-		expectedPairs: []jsonIterKV{
-			{key: "aa", value: 2},
-			{key: "b", value: 1},
-		},
-	},
-}
-
-func TestJsonIter(t *testing.T) {
-	for _, test := range jsonIterTests {
-		t.Run(test.name, func(t *testing.T) {
-			iter := NewJSONIter(test.doc)
-			pairs := make([]jsonIterKV, 0)
-			for iter.HasNext() {
-				var pair jsonIterKV
-				var err error
-				pair.key, pair.value, err = iter.Next()
-				require.NoError(t, err)
-				pairs = append(pairs, pair)
-			}
-			require.Equal(t, test.expectedPairs, pairs)
 		})
 	}
 }


### PR DESCRIPTION
This is the GMS side of optimized three-way JSON merge. It has the following changes:

- Makes some test code and functions accessible from Dolt
- Adds an interface for JSON values that can be compared to each other.
- Outlines a method for returning the type of a JSON document as would be returned by the `JSON_TYPE()` function.