### PR TITLE
add lock to prevent warnings from being cleared

### DIFF
--- a/sql/session.go
+++ b/sql/session.go
@@ -108,6 +108,10 @@ type Session interface {
 	ClearWarnings()
 	// WarningCount returns a number of session warnings
 	WarningCount() uint16
+	// LockWarnings prevents the session warnings from being cleared.
+	LockWarnings()
+	// UnlockWarnings allows the session warnings to be cleared.
+	UnlockWarnings()
 	// AddLock adds a lock to the set of locks owned by this user which will need to be released if this session terminates
 	AddLock(lockName string) error
 	// DelLock removes a lock from the set of locks owned by this user


### PR DESCRIPTION
This PR adds two functions to BaseSession that toggle a boolean, so integrators can prevent warnings from being cleared.
This is mostly useful for `dolt sql shell`.

addresses https://github.com/dolthub/dolt/issues/8016