### PR TITLE
[memo] assume self-join stats cardinality continuity

### DIFF
--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -491,6 +491,10 @@ func getJoinStats(leftIdx, rightIdx, leftChild, rightChild sql.Statistic, prefix
 	if stats.Empty(rightIdx) || stats.Empty(leftIdx) {
 		return nil, nil
 	}
+	if leftIdx.Qualifier() == rightIdx.Qualifier() {
+		// simplifying assumption, index is unique and will not expand cardinality
+		return leftChild, nil
+	}
 	// if either child is not nil, try to interpolate join index stats from child
 	if !stats.Empty(leftChild) {
 		leftIdx = stats.InterpolateNewCounts(leftIdx, leftChild)

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -492,8 +492,14 @@ func getJoinStats(leftIdx, rightIdx, leftChild, rightChild sql.Statistic, prefix
 		return nil, nil
 	}
 	if leftIdx.Qualifier() == rightIdx.Qualifier() {
-		// simplifying assumption, index is unique and will not expand cardinality
-		return leftChild, nil
+		expandRatio := leftIdx.RowCount() / leftIdx.DistinctCount()
+		if expandRatio == 1 {
+			return leftIdx, nil
+		} else {
+			// ths undershoots the estimate, but is directionally correct and faster
+			// than squaring every bucket
+			return leftIdx.WithRowCount(leftIdx.RowCount() * expandRatio), nil
+		}
 	}
 	// if either child is not nil, try to interpolate join index stats from child
 	if !stats.Empty(leftChild) {


### PR DESCRIPTION
Self-join stats estimation is particularly expensive because all of the buckets exactly overlap. If the index is unique, the cardinality distribution will not change. If the index is non-unique, the cardinality will expand proportional to `rowCount/distinctCount`.

```
before
BenchmarkOltpJoinScan-12    	    1766	    694524 ns/op	  462834 B/op	    8240 allocs/op
after
BenchmarkOltpJoinScan-12    	    2460	    481166 ns/op	  193569 B/op	    7129 allocs/op
```

sysbench perf here: https://github.com/dolthub/dolt/pull/8159