### PR TITLE
fix output type for `DateAdd()` and `DateSub()` functions

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5302,14 +5302,28 @@ func TestPrepared(t *testing.T, harness Harness) {
 		},
 		{
 			Query:    "SELECT DATE_ADD(TIMESTAMP(?), INTERVAL 1 DAY);",
-			Expected: []sql.Row{{time.Date(2022, time.October, 27, 13, 14, 15, 0, time.UTC)}},
+			Expected: []sql.Row{{"2022-10-27 13:14:15"}},
+			Bindings: map[string]*query.BindVariable{
+				"v1": mustBuildBindVariable(time.Date(2022, time.October, 26, 13, 14, 15, 0, time.UTC)),
+			},
+		},
+		{
+			Query:    "SELECT DATE_ADD(TIMESTAMP(?), INTERVAL 1 DAY);",
+			Expected: []sql.Row{{"2022-10-27 13:14:15"}},
 			Bindings: map[string]*query.BindVariable{
 				"v1": mustBuildBindVariable("2022-10-26 13:14:15"),
 			},
 		},
 		{
 			Query:    "SELECT DATE_ADD(?, INTERVAL 1 DAY);",
-			Expected: []sql.Row{{time.Date(2022, time.October, 27, 13, 14, 15, 0, time.UTC)}},
+			Expected: []sql.Row{{"2022-10-27 13:14:15"}},
+			Bindings: map[string]*query.BindVariable{
+				"v1": mustBuildBindVariable(time.Date(2022, time.October, 26, 13, 14, 15, 0, time.UTC)),
+			},
+		},
+		{
+			Query:    "SELECT DATE_ADD(?, INTERVAL 1 DAY);",
+			Expected: []sql.Row{{"2022-10-27 13:14:15"}},
 			Bindings: map[string]*query.BindVariable{
 				"v1": mustBuildBindVariable("2022-10-26 13:14:15"),
 			},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6309,7 +6309,7 @@ Select * from (
 	},
 	{
 		Query:    "SELECT DATE_ADD('2018-05-02', INTERVAL 1 day)",
-		Expected: []sql.Row{{time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)}},
+		Expected: []sql.Row{{"2018-05-03"}},
 	},
 	{
 		Query:    "SELECT DATE_ADD(DATE('2018-05-02'), INTERVAL 1 day)",
@@ -6321,7 +6321,7 @@ Select * from (
 	},
 	{
 		Query:    "SELECT DATE_SUB('2018-05-02', INTERVAL 1 DAY)",
-		Expected: []sql.Row{{time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)}},
+		Expected: []sql.Row{{"2018-05-01"}},
 	},
 	{
 		Query:    "SELECT DATE_SUB(DATE('2018-05-02'), INTERVAL 1 DAY)",

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -26,7 +26,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
-	)
+)
 
 // NewAddDate returns a new function expression, or an error if one couldn't be created. The ADDDATE
 // function is a synonym for DATE_ADD, with the one exception that if the second argument is NOT an

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -41,13 +41,43 @@ func TestAddDate(t *testing.T) {
 	_, err = NewAddDate(expression.NewLiteral("2018-05-02", types.LongText))
 	require.Error(err)
 
+	var expected, result interface{}
+	var f sql.Expression
+
+	f, err = NewAddDate(
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 123456000, time.UTC), types.Date),
+		expression.NewLiteral(int64(1), types.Int64))
+	require.NoError(err)
+	expected = time.Date(2018, 5, 3, 0, 0,0, 0, time.UTC)
+	result, err = f.Eval(ctx, sql.Row{})
+	require.NoError(err)
+	require.Equal(expected, result)
+
+	f, err = NewAddDate(
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 0, time.UTC), types.Datetime),
+		expression.NewLiteral(int64(1), types.Int64))
+	require.NoError(err)
+	expected = time.Date(2018, 5, 3, 12, 34,56, 0, time.UTC)
+	result, err = f.Eval(ctx, sql.Row{})
+	require.NoError(err)
+	require.Equal(expected, result)
+
+	f, err = NewAddDate(
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 123456000, time.UTC), types.DatetimeMaxPrecision),
+		expression.NewLiteral(int64(1), types.Int64))
+	require.NoError(err)
+	expected = time.Date(2018, 5, 3, 12, 34,56, 123456000, time.UTC)
+	result, err = f.Eval(ctx, sql.Row{})
+	require.NoError(err)
+	require.Equal(expected, result)
+
 	// If the second argument is NOT an interval, then it's assumed to be a day interval
-	f, err := NewAddDate(
+	f, err = NewAddDate(
 		expression.NewLiteral("2018-05-02", types.LongText),
 		expression.NewLiteral(int64(1), types.Int64))
 	require.NoError(err)
-	expected := time.Date(2018, time.May, 3, 0, 0, 0, 0, time.UTC)
-	result, err := f.Eval(ctx, sql.Row{})
+	expected = "2018-05-03"
+	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
 
@@ -89,7 +119,7 @@ func TestAddDate(t *testing.T) {
 		expression.NewLiteral("2018-05-02", types.Text),
 		expression.NewLiteral(int64(1_000_000), types.Int64))
 	require.NoError(err)
-	expected = time.Date(4756, time.March, 29, 0, 0, 0, 0, time.UTC)
+	expected = "4756-03-29"
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -218,7 +218,6 @@ func TestDateAdd(t *testing.T) {
 	require.NoError(err)
 
 	expected := "2018-05-03"
-
 	result, err := f.Eval(ctx, sql.Row{"2018-05-02"})
 	require.NoError(err)
 	require.Equal(expected, result)
@@ -414,8 +413,7 @@ func TestDateSub(t *testing.T) {
 	)
 	require.NoError(err)
 
-	expected := time.Date(2018, time.May, 1, 0, 0, 0, 0, time.UTC)
-
+	expected := "2018-05-01"
 	result, err := f.Eval(ctx, sql.Row{"2018-05-02"})
 	require.NoError(err)
 	require.Equal(expected, result)

--- a/sql/expression/function/date_test.go
+++ b/sql/expression/function/date_test.go
@@ -45,28 +45,28 @@ func TestAddDate(t *testing.T) {
 	var f sql.Expression
 
 	f, err = NewAddDate(
-		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 123456000, time.UTC), types.Date),
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34, 56, 123456000, time.UTC), types.Date),
 		expression.NewLiteral(int64(1), types.Int64))
 	require.NoError(err)
-	expected = time.Date(2018, 5, 3, 0, 0,0, 0, time.UTC)
+	expected = time.Date(2018, 5, 3, 0, 0, 0, 0, time.UTC)
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
 
 	f, err = NewAddDate(
-		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 0, time.UTC), types.Datetime),
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34, 56, 0, time.UTC), types.Datetime),
 		expression.NewLiteral(int64(1), types.Int64))
 	require.NoError(err)
-	expected = time.Date(2018, 5, 3, 12, 34,56, 0, time.UTC)
+	expected = time.Date(2018, 5, 3, 12, 34, 56, 0, time.UTC)
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
 
 	f, err = NewAddDate(
-		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 123456000, time.UTC), types.DatetimeMaxPrecision),
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34, 56, 123456000, time.UTC), types.DatetimeMaxPrecision),
 		expression.NewLiteral(int64(1), types.Int64))
 	require.NoError(err)
-	expected = time.Date(2018, 5, 3, 12, 34,56, 123456000, time.UTC)
+	expected = time.Date(2018, 5, 3, 12, 34, 56, 123456000, time.UTC)
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
@@ -152,7 +152,6 @@ func TestAddDate(t *testing.T) {
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
-
 
 	// If the interval param is NULL, then NULL is returned
 	f2, err := NewAddDate(
@@ -256,28 +255,28 @@ func TestSubDate(t *testing.T) {
 	var f sql.Expression
 
 	f, err = NewSubDate(
-		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 123456000, time.UTC), types.Date),
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34, 56, 123456000, time.UTC), types.Date),
 		expression.NewLiteral(int64(1), types.Int64))
 	require.NoError(err)
-	expected = time.Date(2018, 5, 1, 0, 0,0, 0, time.UTC)
+	expected = time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC)
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
 
 	f, err = NewSubDate(
-		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 0, time.UTC), types.Datetime),
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34, 56, 0, time.UTC), types.Datetime),
 		expression.NewLiteral(int64(1), types.Int64))
 	require.NoError(err)
-	expected = time.Date(2018, 5, 1, 12, 34,56, 0, time.UTC)
+	expected = time.Date(2018, 5, 1, 12, 34, 56, 0, time.UTC)
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
 
 	f, err = NewSubDate(
-		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34,56, 123456000, time.UTC), types.DatetimeMaxPrecision),
+		expression.NewLiteral(time.Date(2018, 5, 2, 12, 34, 56, 123456000, time.UTC), types.DatetimeMaxPrecision),
 		expression.NewLiteral(int64(1), types.Int64))
 	require.NoError(err)
-	expected = time.Date(2018, 5, 1, 12, 34,56, 123456000, time.UTC)
+	expected = time.Date(2018, 5, 1, 12, 34, 56, 123456000, time.UTC)
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
@@ -363,7 +362,6 @@ func TestSubDate(t *testing.T) {
 	result, err = f.Eval(ctx, sql.Row{})
 	require.NoError(err)
 	require.Equal(expected, result)
-
 
 	// If the interval param is NULL, then NULL is returned
 	f2, err := NewSubDate(

--- a/sql/type.go
+++ b/sql/type.go
@@ -48,6 +48,10 @@ const (
 	// TimestampDatetimeLayout is the formatting string with the layout of the timestamp
 	// using the format of Go "time" package.
 	TimestampDatetimeLayout = "2006-01-02 15:04:05.999999"
+
+	// DatetimeLayoutNoTrim is the formatting string with the layout of the datetime that
+	// doesn't trim trailing zeros
+	DatetimeLayoutNoTrim = "2006-01-02 15:04:05.000000"
 )
 
 const (

--- a/sql/types/datetime.go
+++ b/sql/types/datetime.go
@@ -50,29 +50,32 @@ var (
 	// datetimeTypeMinTimestamp is the minimum representable Timestamp value, which is one second past the epoch.
 	datetimeTypeMinTimestamp = time.Unix(1, 0)
 
+	DateOnlyLayouts = []string{
+		"20060102",
+		"2006-1-2",
+		"2006-01-02",
+		"2006/01/02",
+	}
+
 	// TimestampDatetimeLayouts hold extra timestamps allowed for parsing. It does
 	// not have all the layouts supported by mysql. Missing are two digit year
 	// versions of common cases and dates that use non common separators.
 	//
 	// https://github.com/MariaDB/server/blob/mysql-5.5.36/sql-common/my_time.c#L124
-	TimestampDatetimeLayouts = []string{
+	TimestampDatetimeLayouts = append(DateOnlyLayouts, []string{
 		"2006-01-02 15:4",
 		"2006-01-02 15:04",
 		"2006-01-02 15:04:",
 		"2006-01-02 15:04:.",
 		"2006-01-02 15:04:05.",
 		"2006-01-02 15:04:05.999999",
-		"2006-01-02",
-		"2006-1-2",
 		"2006-1-2 15:4:5.999999",
 		time.RFC3339,
 		time.RFC3339Nano,
 		"2006-01-02T15:04:05",
 		"20060102150405",
-		"20060102",
-		"2006/01/02",
 		"2006-01-02 15:04:05.999999999 -0700 MST", // represents standard Time.time.UTC()
-	}
+	}...)
 
 	// zeroTime is 0000-01-01 00:00:00 UTC which is the closest Go can get to 0000-00-00 00:00:00
 	zeroTime = time.Unix(-62167219200, 0).UTC()


### PR DESCRIPTION
The output of `DateAdd()`, `AddDate()`, `DateSub()`, and `SubDate()`, changes if the input is a properly formatted string vs a date/datetime/time/timestamp.

fixes: https://github.com/dolthub/dolt/issues/7304