### PR TITLE
update `LAST_INSERT_ID` when auto incrementing from `empty`, `NULL`, and `DEFAULT`

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1994,6 +1994,127 @@ CREATE TABLE tab3 (
 		},
 	},
 	{
+		Name: "last_insert_id(default) behavior",
+		SetUpScript: []string{
+			"create table t (pk int primary key auto_increment, i int default 0)",
+		},
+		Assertions:  []ScriptTestAssertion{
+			{
+				Query: "insert into t(pk) values (default);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 1}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(1)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+				},
+			},
+
+			{
+				Query: "insert into t(pk) values (default), (default), (default), (default), (default);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 5, InsertID: 2}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(2)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 0},
+					{3, 0},
+					{4, 0},
+					{5, 0},
+					{6, 0},
+				},
+			},
+
+			{
+				Query: "insert into t(pk) values (10), (default);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 3}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(11)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 0},
+					{3, 0},
+					{4, 0},
+					{5, 0},
+					{6, 0},
+					{10, 0},
+					{11, 0},
+				},
+			},
+
+			{
+				Query: "insert into t(i) values (100);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 4}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(11)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 0},
+					{3, 0},
+					{4, 0},
+					{5, 0},
+					{6, 0},
+					{10, 0},
+					{11, 0},
+					{12, 100},
+				},
+			},
+
+			{
+				Query: "insert into t(i, pk) values (200, default);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 5}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(13)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 0},
+					{3, 0},
+					{4, 0},
+					{5, 0},
+					{6, 0},
+					{10, 0},
+					{11, 0},
+					{12, 100},
+					{13, 200},
+				},
+			},
+		},
+	},
+	{
 		Name: "row_count() behavior",
 		SetUpScript: []string{
 			"create table b (x int primary key)",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2040,7 +2040,7 @@ CREATE TABLE tab3 (
 
 			{
 				Query: "insert into t(pk) values (10), (default);",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 3}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 10}}},
 			},
 			{
 				Query: "select last_insert_id()",
@@ -2059,17 +2059,44 @@ CREATE TABLE tab3 (
 					{6, 0},
 					{10, 0},
 					{11, 0},
+				},
+			},
+
+			{
+				Query: "insert into t(pk) values (20), (default), (default);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, InsertID: 20}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(21)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 0},
+					{3, 0},
+					{4, 0},
+					{5, 0},
+					{6, 0},
+					{10, 0},
+					{11, 0},
+					{20, 0},
+					{21, 0},
+					{22, 0},
 				},
 			},
 
 			{
 				Query: "insert into t(i) values (100);",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 4}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 23}}},
 			},
 			{
 				Query: "select last_insert_id()",
 				Expected: []sql.Row{
-					{uint64(11)},
+					{uint64(23)},
 				},
 			},
 			{
@@ -2083,18 +2110,21 @@ CREATE TABLE tab3 (
 					{6, 0},
 					{10, 0},
 					{11, 0},
-					{12, 100},
+					{20, 0},
+					{21, 0},
+					{22, 0},
+					{23, 100},
 				},
 			},
 
 			{
 				Query: "insert into t(i, pk) values (200, default);",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 5}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 24}}},
 			},
 			{
 				Query: "select last_insert_id()",
 				Expected: []sql.Row{
-					{uint64(13)},
+					{uint64(24)},
 				},
 			},
 			{
@@ -2108,8 +2138,11 @@ CREATE TABLE tab3 (
 					{6, 0},
 					{10, 0},
 					{11, 0},
-					{12, 100},
-					{13, 200},
+					{20, 0},
+					{21, 0},
+					{22, 0},
+					{23, 100},
+					{24, 200},
 				},
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2177,7 +2177,7 @@ CREATE TABLE tab3 (
 			},
 
 			{
-				Query:    "insert into t(pk) values ();",
+				Query:    "insert into t values ();",
 				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 26}}},
 			},
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2145,6 +2145,68 @@ CREATE TABLE tab3 (
 					{24, 200},
 				},
 			},
+
+			{
+				Query: "insert into t(pk) values (null);",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 25}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(25)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 0},
+					{3, 0},
+					{4, 0},
+					{5, 0},
+					{6, 0},
+					{10, 0},
+					{11, 0},
+					{20, 0},
+					{21, 0},
+					{22, 0},
+					{23, 100},
+					{24, 200},
+					{25, 0},
+				},
+			},
+
+
+			{
+				Query: "insert into t(pk) values ();",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 26}}},
+			},
+			{
+				Query: "select last_insert_id()",
+				Expected: []sql.Row{
+					{uint64(26)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 0},
+					{2, 0},
+					{3, 0},
+					{4, 0},
+					{5, 0},
+					{6, 0},
+					{10, 0},
+					{11, 0},
+					{20, 0},
+					{21, 0},
+					{22, 0},
+					{23, 100},
+					{24, 200},
+					{25, 0},
+					{26, 0},
+				},
+			},
 		},
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -2063,7 +2063,7 @@ CREATE TABLE tab3 (
 			},
 
 			{
-				Query: "insert into t(pk) values (20), (default), (default);",
+				Query:    "insert into t(pk) values (20), (default), (default);",
 				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, InsertID: 20}}},
 			},
 			{
@@ -2147,7 +2147,7 @@ CREATE TABLE tab3 (
 			},
 
 			{
-				Query: "insert into t(pk) values (null);",
+				Query:    "insert into t(pk) values (null);",
 				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 25}}},
 			},
 			{
@@ -2176,9 +2176,8 @@ CREATE TABLE tab3 (
 				},
 			},
 
-
 			{
-				Query: "insert into t(pk) values ();",
+				Query:    "insert into t(pk) values ();",
 				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 26}}},
 			},
 			{

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -178,7 +178,7 @@ func wrapRowSource(ctx *sql.Context, insertSource sql.Node, destTbl sql.Table, s
 				return nil, -1, err
 			}
 			projExprs[i] = ai
-			if autoAutoIncrement == -1 {
+			if autoAutoIncrement == -1 && !columnExplicitlySpecified {
 				autoAutoIncrement = 0
 			}
 		}

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -431,7 +431,6 @@ func (s *BaseSession) SetLastQueryInfoInt(key string, value int64) {
 }
 
 func (s *BaseSession) GetLastQueryInfoInt(key string) int64 {
-
 	value, ok := s.lastQueryInfo[key].Load().(int64)
 	if !ok {
 		panic(fmt.Sprintf("last query info value stored for %s is not an int64 value, but a %T", key, s.lastQueryInfo[key]))

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -93,16 +93,19 @@ func NewInsertInto(db sql.Database, dst, src sql.Node, isReplace bool, cols []st
 
 var _ sql.CheckConstraintNode = (*RenameColumn)(nil)
 
+// Checks implements the sql.CheckConstraintNode interface.
 func (ii *InsertInto) Checks() sql.CheckConstraints {
 	return ii.checks
 }
 
+// WithChecks implements the sql.CheckConstraintNode interface.
 func (ii *InsertInto) WithChecks(checks sql.CheckConstraints) sql.Node {
 	ret := *ii
 	ret.checks = checks
 	return &ret
 }
 
+// Dispose implements the sql.Disposable interface.
 func (ii *InsertInto) Dispose() {
 	disposeNode(ii.Source)
 }
@@ -117,19 +120,23 @@ func (ii *InsertInto) Schema() sql.Schema {
 	return ii.Destination.Schema()
 }
 
+// Children implements the sql.Node interface.
 func (ii *InsertInto) Children() []sql.Node {
 	// The source node is analyzed completely independently, so we don't include it in children
 	return []sql.Node{ii.Destination}
 }
 
+// Database implements the sql.Databaser interface.
 func (ii *InsertInto) Database() sql.Database {
 	return ii.db
 }
 
+// IsReadOnly implements the sql.Node interface.
 func (ii *InsertInto) IsReadOnly() bool {
 	return false
 }
 
+// WithDatabase implements the sql.Databaser interface.
 func (ii *InsertInto) WithDatabase(database sql.Database) (sql.Node, error) {
 	nc := *ii
 	nc.db = database
@@ -209,6 +216,7 @@ func (ii *InsertInto) WithUnspecifiedAutoIncrementIdx(unspecifiedAutoIncrementId
 	return &np
 }
 
+// String implements the fmt.Stringer interface.
 func (ii *InsertInto) String() string {
 	pr := sql.NewTreePrinter()
 	if ii.IsReplace {
@@ -220,6 +228,7 @@ func (ii *InsertInto) String() string {
 	return pr.String()
 }
 
+// DebugString implements the sql.Node interface.
 func (ii *InsertInto) DebugString() string {
 	pr := sql.NewTreePrinter()
 	if ii.IsReplace {
@@ -231,10 +240,12 @@ func (ii *InsertInto) DebugString() string {
 	return pr.String()
 }
 
+// Expressions implements the sql.Expressioner interface.
 func (ii *InsertInto) Expressions() []sql.Expression {
 	return append(ii.OnDupExprs, ii.checks.ToExpressions()...)
 }
 
+// WithExpressions implements the sql.Expressioner interface.
 func (ii *InsertInto) WithExpressions(newExprs ...sql.Expression) (sql.Node, error) {
 	if len(newExprs) != len(ii.OnDupExprs)+len(ii.checks) {
 		return nil, sql.ErrInvalidChildrenNumber.New(ii, len(newExprs), len(ii.OnDupExprs)+len(ii.checks))

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -79,18 +79,18 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		}
 	}
 	insertIter := &insertIter{
-		schema:      dstSchema,
-		tableNode:   ii.Destination,
-		inserter:    inserter,
-		replacer:    replacer,
-		updater:     updater,
-		rowSource:   rowIter,
-		unlocker:    unlocker,
-		updateExprs: ii.OnDupExprs,
-		insertExprs: insertExpressions,
-		checks:      ii.Checks(),
-		ctx:         ctx,
-		ignore:      ii.Ignore,
+		schema:                      dstSchema,
+		tableNode:                   ii.Destination,
+		inserter:                    inserter,
+		replacer:                    replacer,
+		updater:                     updater,
+		rowSource:                   rowIter,
+		unlocker:                    unlocker,
+		updateExprs:                 ii.OnDupExprs,
+		insertExprs:                 insertExpressions,
+		checks:                      ii.Checks(),
+		ctx:                         ctx,
+		ignore:                      ii.Ignore,
 		firstGeneratedAutoIncRowIdx: ii.FirstGeneratedAutoIncRowIdx,
 	}
 

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -58,7 +58,7 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 
 	var unlocker func()
 	insertExpressions := getInsertExpressions(ii.Source)
-	if ii.HasUnspecifiedAutoInc {
+	if ii.UnspecifiedAutoIncIdx >= 0 {
 		_, i, _ := sql.SystemVariables.GetGlobal("innodb_autoinc_lock_mode")
 		lockMode, ok := i.(int64)
 		if !ok {
@@ -85,7 +85,7 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		replacer:            replacer,
 		updater:             updater,
 		rowSource:           rowIter,
-		hasAutoAutoIncValue: ii.HasUnspecifiedAutoInc,
+		autoAutoIncIdx:      ii.UnspecifiedAutoIncIdx,
 		unlocker:            unlocker,
 		updateExprs:         ii.OnDupExprs,
 		insertExprs:         insertExpressions,

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -58,7 +58,7 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 
 	var unlocker func()
 	insertExpressions := getInsertExpressions(ii.Source)
-	if ii.UnspecifiedAutoIncIdx >= 0 {
+	if ii.FirstGeneratedAutoIncRowIdx >= 0 {
 		_, i, _ := sql.SystemVariables.GetGlobal("innodb_autoinc_lock_mode")
 		lockMode, ok := i.(int64)
 		if !ok {
@@ -79,19 +79,19 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		}
 	}
 	insertIter := &insertIter{
-		schema:         dstSchema,
-		tableNode:      ii.Destination,
-		inserter:       inserter,
-		replacer:       replacer,
-		updater:        updater,
-		rowSource:      rowIter,
-		autoAutoIncIdx: ii.UnspecifiedAutoIncIdx,
-		unlocker:       unlocker,
-		updateExprs:    ii.OnDupExprs,
-		insertExprs:    insertExpressions,
-		checks:         ii.Checks(),
-		ctx:            ctx,
-		ignore:         ii.Ignore,
+		schema:      dstSchema,
+		tableNode:   ii.Destination,
+		inserter:    inserter,
+		replacer:    replacer,
+		updater:     updater,
+		rowSource:   rowIter,
+		unlocker:    unlocker,
+		updateExprs: ii.OnDupExprs,
+		insertExprs: insertExpressions,
+		checks:      ii.Checks(),
+		ctx:         ctx,
+		ignore:      ii.Ignore,
+		firstGeneratedAutoIncRowIdx: ii.FirstGeneratedAutoIncRowIdx,
 	}
 
 	var ed sql.EditOpenerCloser

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -44,7 +44,7 @@ type insertIter struct {
 	closed      bool
 	ignore      bool
 
-	firstGeneratedAutoIncRowIdx      int
+	firstGeneratedAutoIncRowIdx int
 }
 
 func getInsertExpressions(values sql.Node) []sql.Expression {

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -171,7 +171,6 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 		}
 	}
 
-	// TODO: only do this when auto increment is triggered
 	i.updateLastInsertId(ctx, row)
 
 	return row, nil

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -30,21 +30,21 @@ import (
 )
 
 type insertIter struct {
-	schema              sql.Schema
-	inserter            sql.RowInserter
-	replacer            sql.RowReplacer
-	updater             sql.RowUpdater
-	rowSource           sql.RowIter
-	lastInsertIdUpdated bool
-	autoAutoIncIdx      int
-	unlocker            func()
-	ctx                 *sql.Context
-	insertExprs         []sql.Expression
-	updateExprs         []sql.Expression
-	checks              sql.CheckConstraints
-	tableNode           sql.Node
-	closed              bool
-	ignore              bool
+	schema      sql.Schema
+	inserter    sql.RowInserter
+	replacer    sql.RowReplacer
+	updater     sql.RowUpdater
+	rowSource   sql.RowIter
+	unlocker    func()
+	ctx         *sql.Context
+	insertExprs []sql.Expression
+	updateExprs []sql.Expression
+	checks      sql.CheckConstraints
+	tableNode   sql.Node
+	closed      bool
+	ignore      bool
+
+	firstGeneratedAutoIncRowIdx      int
 }
 
 func getInsertExpressions(values sql.Node) []sql.Expression {
@@ -291,14 +291,14 @@ func (i *insertIter) Close(ctx *sql.Context) error {
 }
 
 func (i *insertIter) updateLastInsertId(ctx *sql.Context, row sql.Row) {
-	if i.autoAutoIncIdx < 0 {
+	if i.firstGeneratedAutoIncRowIdx < 0 {
 		return
 	}
-	if i.autoAutoIncIdx == 0 {
+	if i.firstGeneratedAutoIncRowIdx == 0 {
 		autoIncVal := i.getAutoIncVal(row)
 		ctx.SetLastQueryInfoInt(sql.LastInsertId, autoIncVal)
 	}
-	i.autoAutoIncIdx--
+	i.firstGeneratedAutoIncRowIdx--
 }
 
 func (i *insertIter) getAutoIncVal(row sql.Row) int64 {


### PR DESCRIPTION
Our logic for determining whether or not we needed to update last insert id only looked at the insertSource schema.
This does not take into consideration `empty`, `NULL` or `DEFAULT` values.
Additionally, the value that last insert id is set to depends on what the auto increment value will be.

This PR addresses those issues.
Also, has some refactoring for readability.

fixes: https://github.com/dolthub/dolt/issues/7565