### PR TITLE
faster status updates

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/variables"
 	"os"
 	"strconv"
 	"strings"
@@ -167,6 +168,8 @@ func New(a *analyzer.Analyzer, cfg *Config) *Engine {
 	}
 
 	ls := sql.NewLockSubsystem()
+
+	variables.InitStatusVariables()
 
 	emptyCtx := sql.NewEmptyContext()
 

--- a/processlist.go
+++ b/processlist.go
@@ -116,7 +116,7 @@ func (pl *ProcessList) BeginQuery(
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
 
-	sql.IncrementStatusVariable(ctx, "Threads_running", 1)
+	sql.StatusVariables.IncrementGlobal("Threads_running", 1)
 
 	id := ctx.Session.ID()
 	pid := ctx.Pid()
@@ -158,7 +158,7 @@ func (pl *ProcessList) EndQuery(ctx *sql.Context) {
 			sql.IncrementStatusVariable(ctx, "Slow_queries", 1)
 		}
 
-		sql.IncrementStatusVariable(ctx, "Threads_running", -1)
+		sql.StatusVariables.IncrementGlobal("Threads_running", -1)
 		p.Command = sql.ProcessCommandSleep
 		p.Query = ""
 		p.StartedAt = time.Now()

--- a/processlist.go
+++ b/processlist.go
@@ -70,9 +70,9 @@ func (pl *ProcessList) Processes() []sql.Process {
 }
 
 func (pl *ProcessList) AddConnection(id uint32, addr string) {
+	sql.StatusVariables.IncrementGlobal("Threads_connected", 1)
 	pl.mu.Lock()
 	defer pl.mu.Unlock()
-	sql.StatusVariables.IncrementGlobal("Threads_connected", 1)
 	pl.procs[id] = &sql.Process{
 		Connection: id,
 		Command:    sql.ProcessCommandConnect,

--- a/processlist_test.go
+++ b/processlist_test.go
@@ -16,6 +16,7 @@ package sqle
 
 import (
 	"context"
+	"github.com/dolthub/go-mysql-server/sql/variables"
 	"sort"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 
 func TestProcessList(t *testing.T) {
 	require := require.New(t)
+	variables.InitStatusVariables()
 
 	clientHostOne := "127.0.0.1:34567"
 	clientHostTwo := "127.0.0.1:34568"

--- a/server/handler.go
+++ b/server/handler.go
@@ -94,7 +94,8 @@ func (h *Handler) NewConnection(c *mysql.Conn) {
 }
 
 func (h *Handler) ConnectionAborted(_ *mysql.Conn, _ string) error {
-	return sql.StatusVariables.IncrementGlobal("Aborted_connects", 1)
+	sql.StatusVariables.IncrementGlobal("Aborted_connects", 1)
+	return nil
 }
 
 func (h *Handler) ComInitDB(c *mysql.Conn, schemaName string) error {

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -235,17 +235,19 @@ func (s *BaseSession) GetAllStatusVariables(_ *Context) map[string]StatusVarValu
 	return m
 }
 
+var done bool
+
 // IncrementStatusVariable implements the Session interface.
-func (s *BaseSession) IncrementStatusVariable(_ *Context, statVarName string, val int) error {
+func (s *BaseSession) IncrementStatusVariable(ctx *Context, statVarName string, val int) {
 	if _, ok := s.statusVars[statVarName]; !ok {
-		return ErrUnknownSystemVariable.New(statVarName)
+		return
 	}
 	if val < 0 {
 		s.statusVars[statVarName].Increment(-(uint64(-val)))
 	} else {
 		s.statusVars[statVarName].Increment((uint64(val)))
 	}
-	return nil
+	return
 }
 
 // GetCharacterSet returns the character set for this session (defined by the system variable `character_set_connection`).

--- a/sql/base_session.go
+++ b/sql/base_session.go
@@ -235,8 +235,6 @@ func (s *BaseSession) GetAllStatusVariables(_ *Context) map[string]StatusVarValu
 	return m
 }
 
-var done bool
-
 // IncrementStatusVariable implements the Session interface.
 func (s *BaseSession) IncrementStatusVariable(ctx *Context, statVarName string, val int) {
 	if _, ok := s.statusVars[statVarName]; !ok {

--- a/sql/core.go
+++ b/sql/core.go
@@ -833,8 +833,7 @@ func (s *ImmutableStatusVarValue) Copy() StatusVarValue {
 }
 
 // IncrementStatusVariable increments the value of the status variable by integer val.
-// name is case-insensitive. Errors are ignored.
-// This runs in a goroutine to avoid blocking the caller, but we do not wait for it to complete.
+// |name| is case-sensitive.
 func IncrementStatusVariable(ctx *Context, name string, val int) {
 	StatusVariables.IncrementGlobal(name, val)
 	ctx.Session.IncrementStatusVariable(ctx, name, val)

--- a/sql/core.go
+++ b/sql/core.go
@@ -704,15 +704,18 @@ var StatusVariables StatusVariableRegistry
 
 // StatusVariableRegistry is a registry of status variables.
 type StatusVariableRegistry interface {
-	// NewSessionMap returns a deep copy of the status variables that are not GlobalOnly scope (i.e. SessionOnly or Both)
+	// NewSessionMap returns a deep copy of the status variables that are
+	// not GlobalOnly scope (i.e. SessionOnly or Both)
 	NewSessionMap() map[string]StatusVarValue
 	// NewGlobalMap returns a deep copy of the status variables of every scope
 	NewGlobalMap() map[string]StatusVarValue
 	// GetGlobal returns the current global value of the status variable with the given name
 	GetGlobal(name string) (StatusVariable, interface{}, bool)
-	// SetGlobal sets the global value of the status variable with the given name, returns an error if the variable is SessionOnly scope
+	// SetGlobal sets the global value of the status variable with the given
+	// name, returns an error if the variable is SessionOnly scope
 	SetGlobal(name string, val interface{}) error
-	// IncrementGlobal increments the value of the status variable by the given integer value
+	// IncrementGlobal increments the value of the status variable by the
+	// given integer value. Noop if the variable is session-only scoped.
 	IncrementGlobal(name string, val int)
 }
 

--- a/sql/core.go
+++ b/sql/core.go
@@ -713,7 +713,7 @@ type StatusVariableRegistry interface {
 	// SetGlobal sets the global value of the status variable with the given name, returns an error if the variable is SessionOnly scope
 	SetGlobal(name string, val interface{}) error
 	// IncrementGlobal increments the value of the status variable by the given integer value
-	IncrementGlobal(name string, val int) error
+	IncrementGlobal(name string, val int)
 }
 
 // StatusVariableScope represents the scope of a status variable.

--- a/sql/core.go
+++ b/sql/core.go
@@ -836,8 +836,6 @@ func (s *ImmutableStatusVarValue) Copy() StatusVarValue {
 // name is case-insensitive. Errors are ignored.
 // This runs in a goroutine to avoid blocking the caller, but we do not wait for it to complete.
 func IncrementStatusVariable(ctx *Context, name string, val int) {
-	go func() {
-		StatusVariables.IncrementGlobal(name, val)
-		ctx.Session.IncrementStatusVariable(ctx, name, val)
-	}()
+	StatusVariables.IncrementGlobal(name, val)
+	ctx.Session.IncrementStatusVariable(ctx, name, val)
 }

--- a/sql/rowexec/show_status_test.go
+++ b/sql/rowexec/show_status_test.go
@@ -15,6 +15,7 @@
 package rowexec
 
 import (
+	"github.com/dolthub/go-mysql-server/sql/variables"
 	"io"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 func TestShowStatus(t *testing.T) {
 	require := require.New(t)
 	ctx := sql.NewEmptyContext()
+	variables.InitStatusVariables()
 
 	var res sql.Row
 	var err error

--- a/sql/session.go
+++ b/sql/session.go
@@ -91,7 +91,7 @@ type Session interface {
 	// To access global scope, use sql.StatusVariables instead.
 	GetAllStatusVariables(ctx *Context) map[string]StatusVarValue
 	// IncrementStatusVariable increments the value of the status variable by the integer value
-	IncrementStatusVariable(ctx *Context, statVarName string, val int) error
+	IncrementStatusVariable(ctx *Context, statVarName string, val int)
 	// GetCurrentDatabase gets the current database for this session
 	GetCurrentDatabase() string
 	// SetCurrentDatabase sets the current database for this session

--- a/sql/variables/status_variables.go
+++ b/sql/variables/status_variables.go
@@ -102,12 +102,6 @@ func (g *globalStatusVariables) IncrementGlobal(name string, val int) error {
 	return nil
 }
 
-// init initializes SystemVariables as it functions as a global variable.
-// TODO: get rid of me, make this construction the responsibility of the engine
-func init() {
-	InitStatusVariables()
-}
-
 // InitStatusVariables initializes the global status variables in sql.StatusVariables. If they have already
 // been initialized, this function will reset their values back to their defaults, which is useful for testing.
 func InitStatusVariables() {

--- a/sql/variables/status_variables.go
+++ b/sql/variables/status_variables.go
@@ -93,13 +93,13 @@ func (g *globalStatusVariables) SetGlobal(name string, val interface{}) error {
 }
 
 // IncrementGlobal implements sql.StatusVariableRegistry
-func (g *globalStatusVariables) IncrementGlobal(name string, val int) error {
+func (g *globalStatusVariables) IncrementGlobal(name string, val int) {
 	v, ok := g.varVals[name]
 	if !ok || v.Variable().GetScope() == sql.StatusVariableScope_Session {
-		return sql.ErrUnknownSystemVariable.New(name)
+		return
 	}
 	g.varVals[name].Increment(uint64(val))
-	return nil
+	return
 }
 
 // InitStatusVariables initializes the global status variables in sql.StatusVariables. If they have already

--- a/sql/variables/status_variables_test.go
+++ b/sql/variables/status_variables_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestStatusVariables(t *testing.T) {
+	InitStatusVariables()
 	defer InitStatusVariables()
 
 	require := require.New(t)


### PR DESCRIPTION
System variables can be session, global, or both. `sql.IncrementStatusVariable` is a helper method that primarily helps the "both" category increment the global and session counters for certain variables. `Threads_running` is a global only variable that is incremented/decremented every begin/end query, and gets a lot of traffic. The old code used `sql.IncrementStatusVariable` to increment `Threads_running`, which was a particularly expensive way to increment a global var because (1) we'd make a new error for every call to the session updater, and (2) the extra map lookup is unnecessary. We don't do the extra map lookup now, and we weren't using the error return so I removed the return variable.

Note: this also refactors status variables to be explicitly initializated in the engine

bump/perf here: https://github.com/dolthub/dolt/pull/8189