### PR TITLE
fix insert id

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -610,9 +610,9 @@ var InsertQueries = []WriteQueryTest{
 		},
 	},
 	{
-		WriteQuery: `INSERT INTO auto_increment_tbl VALUES ('4', 44)`,
+		WriteQuery:          `INSERT INTO auto_increment_tbl VALUES ('4', 44)`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(1)}},
-		SelectQuery: `SELECT * from auto_increment_tbl where pk=4`,
+		SelectQuery:         `SELECT * from auto_increment_tbl where pk=4`,
 		ExpectedSelect: []sql.Row{
 			{4, 44},
 		},

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -544,7 +544,7 @@ var InsertQueries = []WriteQueryTest{
 	},
 	{
 		WriteQuery:          "INSERT INTO auto_increment_tbl values (0, 44)",
-		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 4}}},
+		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 0}}},
 		SelectQuery:         "SELECT * FROM auto_increment_tbl ORDER BY pk",
 		ExpectedSelect: []sql.Row{
 			{1, 11},
@@ -555,7 +555,7 @@ var InsertQueries = []WriteQueryTest{
 	},
 	{
 		WriteQuery:          "INSERT INTO auto_increment_tbl values (5, 44)",
-		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 5}}},
+		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 0}}},
 		SelectQuery:         "SELECT * FROM auto_increment_tbl ORDER BY pk",
 		ExpectedSelect: []sql.Row{
 			{1, 11},
@@ -611,9 +611,7 @@ var InsertQueries = []WriteQueryTest{
 	},
 	{
 		WriteQuery: `INSERT INTO auto_increment_tbl VALUES ('4', 44)`,
-		ExpectedWriteResult: []sql.Row{
-			{types.OkResult{InsertID: 4, RowsAffected: 1}},
-		},
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(1)}},
 		SelectQuery: `SELECT * from auto_increment_tbl where pk=4`,
 		ExpectedSelect: []sql.Row{
 			{4, 44},
@@ -1282,10 +1280,10 @@ var InsertScripts = []ScriptTest{
 	{
 		Name: "sql_mode=NO_AUTO_VALUE_ON_ZERO",
 		SetUpScript: []string{
-			"set @old_sql_mode=@@sql_mode",
-			"set @@sql_mode='NO_AUTO_VALUE_ON_ZERO'",
-			"create table auto (i int auto_increment, index (i))",
-			"create table auto_pk (i int auto_increment primary key)",
+			"set @old_sql_mode=@@sql_mode;",
+			"set @@sql_mode='NO_AUTO_VALUE_ON_ZERO';",
+			"create table auto (i int auto_increment, index (i));",
+			"create table auto_pk (i int auto_increment primary key);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1317,7 +1315,7 @@ var InsertScripts = []ScriptTest{
 			{
 				Query: "insert into auto values (1)",
 				Expected: []sql.Row{
-					{types.OkResult{RowsAffected: 1, InsertID: 1}},
+					{types.OkResult{RowsAffected: 1, InsertID: 0}},
 				},
 			},
 			{
@@ -1336,7 +1334,7 @@ var InsertScripts = []ScriptTest{
 			{
 				Query: "insert into auto_pk values (0), (1), (NULL), ()",
 				Expected: []sql.Row{
-					{types.NewOkResult(4)},
+					{types.OkResult{RowsAffected: 4, InsertID: 2}},
 				},
 			},
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15,7 +15,7 @@
 package queries
 
 import (
-		"time"
+	"time"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15,8 +15,7 @@
 package queries
 
 import (
-	"math"
-	"time"
+		"time"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
@@ -1899,7 +1898,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    "insert into a (x,y) values (1,1)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 1}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 0}}},
 			},
 			{
 				Query:    "select last_insert_id()",
@@ -1924,7 +1923,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    "insert into b (x) values (1), (2)",
-				Expected: []sql.Row{{types.NewOkResult(2)}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 3}}},
 			},
 			{
 				// The above query doesn't have an auto increment column, so last_insert_id is unchanged
@@ -1935,7 +1934,7 @@ CREATE TABLE tab3 (
 				Query: "insert into a (x, y) values (-100, 10)",
 				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 1,
-					InsertID:     uint64(math.MaxUint64 - uint(100-1)),
+					InsertID:     3,
 				}}},
 			},
 			{
@@ -1947,7 +1946,7 @@ CREATE TABLE tab3 (
 				Query: "insert into a (x, y) values (100, 10)",
 				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 1,
-					InsertID:     100,
+					InsertID:     3,
 				}}},
 			},
 			{
@@ -2040,7 +2039,7 @@ CREATE TABLE tab3 (
 
 			{
 				Query:    "insert into t(pk) values (10), (default);",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 10}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 11}}},
 			},
 			{
 				Query: "select last_insert_id()",
@@ -2064,7 +2063,7 @@ CREATE TABLE tab3 (
 
 			{
 				Query:    "insert into t(pk) values (20), (default), (default);",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, InsertID: 20}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, InsertID: 21}}},
 			},
 			{
 				Query: "select last_insert_id()",

--- a/enginetest/queries/transaction_queries.go
+++ b/enginetest/queries/transaction_queries.go
@@ -837,7 +837,7 @@ var TransactionTests = []TransactionTest{
 			// Client a does a skip ahead
 			{
 				Query:    "/* client a */ insert into t values (10, 10)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 10}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 12}}},
 			},
 			{
 				Query:    "/* client b */ insert into t (y) values (11)",
@@ -846,7 +846,7 @@ var TransactionTests = []TransactionTest{
 			// Client c skips ahead
 			{
 				Query:    "/* client c */ insert into t values (50, 50)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 50}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 11}}},
 			},
 			{
 				Query:    "/* client b */ insert into t (y) values (51)",

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2127,7 +2127,7 @@ end;`,
 			},
 			{
 				Query:    "INSERT INTO `film` VALUES (3,'ADAPTATION HOLES','An Astounding Reflection in A Baloon Factory'),(4,'AFFAIR PREJUDICE','A Fanciful Documentary in A Shark Tank')",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 3}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 0}}},
 			},
 			{
 				Query:    "SELECT COUNT(*) FROM film",
@@ -2188,7 +2188,7 @@ INSERT INTO t0 (v1, v2) VALUES (i, s); END;`,
 			{
 				SkipResultCheckOnServerEngine: true, // call depends on stored procedure stmt for whether to use 'query' or 'exec' from go sql driver.
 				Query:                         "CALL add_entry(4, 'aaa');",
-				Expected:                      []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 3}}},
+				Expected:                      []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 1}}},
 			},
 			{
 				Query:    "SELECT * FROM t0;",

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -328,15 +328,7 @@ func (b *BaseBuilder) buildRowUpdateAccumulator(ctx *sql.Context, n *plan.RowUpd
 	var rowHandler accumulatorRowHandler
 	switch n.RowUpdateType {
 	case plan.UpdateTypeInsert:
-		insertItr, err := findInsertIter(rowIter)
-		if err != nil {
-			return nil, err
-		}
-
-		rowHandler = &insertRowHandler{
-			lastInsertIdGetter: insertItr.getAutoIncVal,
-		}
-		// TODO: some of these other row handlers also need to keep track of the last insert id
+		rowHandler = &insertRowHandler{}
 	case plan.UpdateTypeReplace:
 		rowHandler = &replaceRowHandler{}
 	case plan.UpdateTypeDuplicateKeyUpdate:


### PR DESCRIPTION
The logic setting the InsertID in OkResult, did not match results returned from `last_insert_id()`.
This was made apparent due to changes from https://github.com/dolthub/go-mysql-server/pull/2614.
For a single insert statement, MySQL sets InsertID exactly once when the AutoIncrement on the column is first triggered.
While the linked PR fixes that issue and properly sets the session variable, our `insertRowHandler` (which is responsible for returning OkResult structs) was setting InsertID incorrectly.

The fix is to just read the LastInsertID from the session, since it is already set to the right value.
