### PR TITLE
Assume text index comparisons are exact

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4770,7 +4770,6 @@ func TestTracing(t *testing.T, harness Harness) {
 		"plan.Distinct",
 		"plan.Project",
 		"plan.Sort",
-		"plan.Filter",
 		"plan.IndexedTableAccess",
 	}
 

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -19,112 +19,160 @@ package queries
 var IndexPlanTests = []QueryPlanTest{
 	{
 		Query: `select * from pref_index_t4 where v1 = 'a'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t4\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t4.v1:1\n" +
+			" │   └─ a (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t4\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t4.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t4.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 = 'abc'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t4\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t4.v1:1\n" +
+			" │   └─ abc (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t4\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t4.v1 = 'abc')\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t4.v1 = 'abc')\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 = 'abcd'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t4\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t4.v1:1\n" +
+			" │   └─ abcd (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t4\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t4.v1 = 'abcd')\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t4.v1 = 'abcd')\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 > 'a' and v1 < 'abcde'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t4\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t4.v1:1\n" +
+			" │   │   └─ a (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t4.v1:1\n" +
+			" │       └─ abcde (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t4\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v1 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v1 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 > 'a' and v2 < 'abcde'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t4\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t4.v1:1\n" +
+			" │   │   └─ a (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t4.v2:2\n" +
+			" │       └─ abcde (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t4\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v2 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
-			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v2 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t4)\n" +
+			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -132,6 +180,28 @@ var IndexPlanTests = []QueryPlanTest{
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET pref_index_t4.v1:1 = concat(pref_index_t4.v1:1,z (longtext)))\n" +
+			"         └─ Filter\n" +
+			"             ├─ GreaterThanOrEqual\n" +
+			"             │   ├─ pref_index_t4.v1:1\n" +
+			"             │   └─ a (longtext)\n" +
+			"             └─ IndexedTableAccess(pref_index_t4)\n" +
+			"                 ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ colSet: (1-3)\n" +
+			"                 ├─ tableId: 1\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: pref_index_t4\n" +
+			"                     └─ columns: [i v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `delete from pref_index_t4 where v1 >= 'a'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Delete\n" +
+			"     └─ Filter\n" +
+			"         ├─ GreaterThanOrEqual\n" +
+			"         │   ├─ pref_index_t4.v1:1\n" +
+			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t4)\n" +
 			"             ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
@@ -143,127 +213,161 @@ var IndexPlanTests = []QueryPlanTest{
 			"",
 	},
 	{
-		Query: `delete from pref_index_t4 where v1 >= 'a'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Delete\n" +
-			"     └─ IndexedTableAccess(pref_index_t4)\n" +
-			"         ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"         ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"         ├─ colSet: (1-3)\n" +
-			"         ├─ tableId: 1\n" +
-			"         └─ Table\n" +
-			"             ├─ name: pref_index_t4\n" +
-			"             └─ columns: [i v1 v2]\n" +
-			"",
-	},
-	{
 		Query: `select * from pref_index_t3 where v1 = 'a'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1,2)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t3\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t3.v1:0\n" +
+			" │   └─ a (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1,2)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t3\n" +
+			"         └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t3.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t3.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 = 'abc'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1,2)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t3\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t3.v1:0\n" +
+			" │   └─ abc (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1,2)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t3\n" +
+			"         └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t3.v1 = 'abc')\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t3.v1 = 'abc')\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 = 'abcd'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1,2)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t3\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t3.v1:0\n" +
+			" │   └─ abcd (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1,2)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t3\n" +
+			"         └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t3.v1 = 'abcd')\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t3.v1 = 'abcd')\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 > 'a' and v1 < 'abcde'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1,2)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t3\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t3.v1:0\n" +
+			" │   │   └─ a (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t3.v1:0\n" +
+			" │       └─ abcde (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1,2)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t3\n" +
+			"         └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v1 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			" └─ columns: [v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v1 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 > 'a' and v2 < 'abcde'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			" ├─ colSet: (1,2)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t3\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t3.v1:0\n" +
+			" │   │   └─ a (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t3.v2:1\n" +
+			" │       └─ abcde (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
+			"     ├─ colSet: (1,2)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t3\n" +
+			"         └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v2 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			" └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
-			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			" └─ columns: [v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v2 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t3)\n" +
+			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			"     └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -271,6 +375,28 @@ var IndexPlanTests = []QueryPlanTest{
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET pref_index_t3.v1:0 = concat(pref_index_t3.v1:0,z (longtext)))\n" +
+			"         └─ Filter\n" +
+			"             ├─ GreaterThanOrEqual\n" +
+			"             │   ├─ pref_index_t3.v1:0\n" +
+			"             │   └─ a (longtext)\n" +
+			"             └─ IndexedTableAccess(pref_index_t3)\n" +
+			"                 ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ colSet: (1,2)\n" +
+			"                 ├─ tableId: 1\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: pref_index_t3\n" +
+			"                     └─ columns: [v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `delete from pref_index_t3 where v1 >= 'a'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Delete\n" +
+			"     └─ Filter\n" +
+			"         ├─ GreaterThanOrEqual\n" +
+			"         │   ├─ pref_index_t3.v1:0\n" +
+			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t3)\n" +
 			"             ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
@@ -282,127 +408,161 @@ var IndexPlanTests = []QueryPlanTest{
 			"",
 	},
 	{
-		Query: `delete from pref_index_t3 where v1 >= 'a'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Delete\n" +
-			"     └─ IndexedTableAccess(pref_index_t3)\n" +
-			"         ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"         ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"         ├─ colSet: (1,2)\n" +
-			"         ├─ tableId: 1\n" +
-			"         └─ Table\n" +
-			"             ├─ name: pref_index_t3\n" +
-			"             └─ columns: [v1 v2]\n" +
-			"",
-	},
-	{
 		Query: `select * from pref_index_t2 where v1 = 'A'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ static: [{[A, A], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t2\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t2.v1:1\n" +
+			" │   └─ A (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ static: [{[A, A], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t2\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t2.v1 = 'A')\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t2.v1 = 'A')\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 = 'ABC'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ static: [{[ABC, ABC], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t2\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t2.v1:1\n" +
+			" │   └─ ABC (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ static: [{[ABC, ABC], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t2\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t2.v1 = 'ABC')\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t2.v1 = 'ABC')\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 = 'ABCD'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ static: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t2\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t2.v1:1\n" +
+			" │   └─ ABCD (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ static: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t2\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t2.v1 = 'ABCD')\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t2.v1 = 'ABCD')\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 > 'A' and v1 < 'ABCDE'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ static: [{(A, ABCDE), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t2\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t2.v1:1\n" +
+			" │   │   └─ A (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t2.v1:1\n" +
+			" │       └─ ABCDE (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ static: [{(A, ABCDE), [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t2\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v1 < 'ABCDE'))\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v1 < 'ABCDE'))\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 > 'A' and v2 < 'ABCDE'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ static: [{(A, ∞), (NULL, ABCDE)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t2\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t2.v1:1\n" +
+			" │   │   └─ A (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t2.v2:2\n" +
+			" │       └─ ABCDE (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ static: [{(A, ∞), (NULL, ABCDE)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t2\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v2 < 'ABCDE'))\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
-			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			" ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v2 < 'ABCDE'))\n" +
+			" └─ IndexedTableAccess(pref_index_t2)\n" +
+			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"     ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -410,6 +570,28 @@ var IndexPlanTests = []QueryPlanTest{
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET pref_index_t2.v1:1 = concat(pref_index_t2.v1:1,Z (longtext)))\n" +
+			"         └─ Filter\n" +
+			"             ├─ GreaterThanOrEqual\n" +
+			"             │   ├─ pref_index_t2.v1:1\n" +
+			"             │   └─ A (longtext)\n" +
+			"             └─ IndexedTableAccess(pref_index_t2)\n" +
+			"                 ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"                 ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ colSet: (1-3)\n" +
+			"                 ├─ tableId: 1\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: pref_index_t2\n" +
+			"                     └─ columns: [i v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `delete from pref_index_t2 where v1 >= 'A'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Delete\n" +
+			"     └─ Filter\n" +
+			"         ├─ GreaterThanOrEqual\n" +
+			"         │   ├─ pref_index_t2.v1:1\n" +
+			"         │   └─ A (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t2)\n" +
 			"             ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"             ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
@@ -421,148 +603,171 @@ var IndexPlanTests = []QueryPlanTest{
 			"",
 	},
 	{
-		Query: `delete from pref_index_t2 where v1 >= 'A'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Delete\n" +
-			"     └─ IndexedTableAccess(pref_index_t2)\n" +
-			"         ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"         ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
-			"         ├─ colSet: (1-3)\n" +
-			"         ├─ tableId: 1\n" +
-			"         └─ Table\n" +
-			"             ├─ name: pref_index_t2\n" +
-			"             └─ columns: [i v1 v2]\n" +
-			"",
-	},
-	{
 		Query: `select * from pref_index_t1 where v1 = 'a'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t1.v1:1\n" +
+			" │   └─ a (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t1\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t1.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t1.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 = 'abc'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t1.v1:1\n" +
+			" │   └─ abc (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t1\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t1.v1 = 'abc')\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t1.v1 = 'abc')\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 = 'abcd'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ pref_index_t1.v1:1\n" +
+			" │   └─ abcd (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t1\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (pref_index_t1.v1 = 'abcd')\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (pref_index_t1.v1 = 'abcd')\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 > 'a' and v1 < 'abcde'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t1.v1:1\n" +
+			" │   │   └─ a (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t1.v1:1\n" +
+			" │       └─ abcde (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t1\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v1 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v1 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 > 'a' and v2 < 'abcde'`,
-		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: pref_index_t1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ AND\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ pref_index_t1.v1:1\n" +
+			" │   │   └─ a (longtext)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ pref_index_t1.v2:2\n" +
+			" │       └─ abcde (longtext)\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: pref_index_t1\n" +
+			"         └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v2 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
-			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			" └─ columns: [i v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v2 < 'abcde'))\n" +
+			" └─ IndexedTableAccess(pref_index_t1)\n" +
+			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			"     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `delete from pref_index_t1 where v1 >= 'a'`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ IndexedTableAccess(pref_index_t1)\n" +
-			"         ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"         ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"         ├─ colSet: (1-3)\n" +
-			"         ├─ tableId: 1\n" +
-			"         └─ Table\n" +
-			"             ├─ name: pref_index_t1\n" +
-			"             └─ columns: [i v1 v2]\n" +
-			"",
-	},
-	{
-		Query: `update pref_index_t1 set v1 = concat(v1, 'z') where v1 >= 'a'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Update\n" +
-			"     └─ UpdateSource(SET pref_index_t1.v1:1 = concat(pref_index_t1.v1:1,z (longtext)))\n" +
+			"     └─ Filter\n" +
+			"         ├─ GreaterThanOrEqual\n" +
+			"         │   ├─ pref_index_t1.v1:1\n" +
+			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t1)\n" +
 			"             ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
@@ -571,6 +776,25 @@ var IndexPlanTests = []QueryPlanTest{
 			"             └─ Table\n" +
 			"                 ├─ name: pref_index_t1\n" +
 			"                 └─ columns: [i v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `update pref_index_t1 set v1 = concat(v1, 'z') where v1 >= 'a'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Update\n" +
+			"     └─ UpdateSource(SET pref_index_t1.v1:1 = concat(pref_index_t1.v1:1,z (longtext)))\n" +
+			"         └─ Filter\n" +
+			"             ├─ GreaterThanOrEqual\n" +
+			"             │   ├─ pref_index_t1.v1:1\n" +
+			"             │   └─ a (longtext)\n" +
+			"             └─ IndexedTableAccess(pref_index_t1)\n" +
+			"                 ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ colSet: (1-3)\n" +
+			"                 ├─ tableId: 1\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: pref_index_t1\n" +
+			"                     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -15975,24 +16199,32 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `select * from comp_index_t3 where v1 = 'a'`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t3)\n" +
-			" ├─ index: [comp_index_t3.v1]\n" +
-			" ├─ static: [{[[97], [97]]}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t3\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ comp_index_t3.v1:1\n" +
+			" │   └─ a (longtext)\n" +
+			" └─ IndexedTableAccess(comp_index_t3)\n" +
+			"     ├─ index: [comp_index_t3.v1]\n" +
+			"     ├─ static: [{[[97], [97]]}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t3\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (comp_index_t3.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(comp_index_t3)\n" +
+			"     ├─ index: [comp_index_t3.v1]\n" +
+			"     ├─ filters: [{[[97], [97]]}]\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t3)\n" +
-			" ├─ index: [comp_index_t3.v1]\n" +
-			" ├─ filters: [{[[97], [97]]}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t3)\n" +
-			" ├─ index: [comp_index_t3.v1]\n" +
-			" ├─ filters: [{[[97], [97]]}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (comp_index_t3.v1 = 'a')\n" +
+			" └─ IndexedTableAccess(comp_index_t3)\n" +
+			"     ├─ index: [comp_index_t3.v1]\n" +
+			"     ├─ filters: [{[[97], [97]]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -19,160 +19,112 @@ package queries
 var IndexPlanTests = []QueryPlanTest{
 	{
 		Query: `select * from pref_index_t4 where v1 = 'a'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t4.v1:1\n" +
-			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t4.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ static: [{[a, a], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t4\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t4.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 = 'abc'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t4.v1:1\n" +
-			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t4.v1 = 'abc')\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t4\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t4.v1 = 'abc')\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 = 'abcd'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t4.v1:1\n" +
-			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t4.v1 = 'abcd')\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t4\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t4.v1 = 'abcd')\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 > 'a' and v1 < 'abcde'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t4.v1:1\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t4.v1:1\n" +
-			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v1 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t4\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v1 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t4 where v1 > 'a' and v2 < 'abcde'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t4.v1:1\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t4.v2:2\n" +
-			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t4\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v2 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t4\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t4.v1 > 'a') AND (pref_index_t4.v2 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t4)\n" +
-			"     ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t4)\n" +
+			" ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -180,28 +132,6 @@ var IndexPlanTests = []QueryPlanTest{
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET pref_index_t4.v1:1 = concat(pref_index_t4.v1:1,z (longtext)))\n" +
-			"         └─ Filter\n" +
-			"             ├─ GreaterThanOrEqual\n" +
-			"             │   ├─ pref_index_t4.v1:1\n" +
-			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess(pref_index_t4)\n" +
-			"                 ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
-			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 ├─ colSet: (1-3)\n" +
-			"                 ├─ tableId: 1\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: pref_index_t4\n" +
-			"                     └─ columns: [i v1 v2]\n" +
-			"",
-	},
-	{
-		Query: `delete from pref_index_t4 where v1 >= 'a'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ GreaterThanOrEqual\n" +
-			"         │   ├─ pref_index_t4.v1:1\n" +
-			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t4)\n" +
 			"             ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
@@ -213,161 +143,127 @@ var IndexPlanTests = []QueryPlanTest{
 			"",
 	},
 	{
+		Query: `delete from pref_index_t4 where v1 >= 'a'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Delete\n" +
+			"     └─ IndexedTableAccess(pref_index_t4)\n" +
+			"         ├─ index: [pref_index_t4.v1,pref_index_t4.v2]\n" +
+			"         ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1-3)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: pref_index_t4\n" +
+			"             └─ columns: [i v1 v2]\n" +
+			"",
+	},
+	{
 		Query: `select * from pref_index_t3 where v1 = 'a'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t3.v1:0\n" +
-			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t3.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ static: [{[a, a], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1,2)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t3\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t3.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			"     └─ columns: [v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 = 'abc'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t3.v1:0\n" +
-			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t3.v1 = 'abc')\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1,2)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t3\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t3.v1 = 'abc')\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     └─ columns: [v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 = 'abcd'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t3.v1:0\n" +
-			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t3.v1 = 'abcd')\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1,2)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t3\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t3.v1 = 'abcd')\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     └─ columns: [v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 > 'a' and v1 < 'abcde'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t3.v1:0\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t3.v1:0\n" +
-			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v1 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1,2)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t3\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v1 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     └─ columns: [v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			" └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t3 where v1 > 'a' and v2 < 'abcde'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t3.v1:0\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t3.v2:1\n" +
-			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t3\n" +
-			"         └─ columns: [v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v2 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
+			" ├─ colSet: (1,2)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t3\n" +
 			"     └─ columns: [v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t3.v1 > 'a') AND (pref_index_t3.v2 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t3)\n" +
-			"     ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     └─ columns: [v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			" └─ columns: [v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t3)\n" +
+			" ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			" └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -375,28 +271,6 @@ var IndexPlanTests = []QueryPlanTest{
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET pref_index_t3.v1:0 = concat(pref_index_t3.v1:0,z (longtext)))\n" +
-			"         └─ Filter\n" +
-			"             ├─ GreaterThanOrEqual\n" +
-			"             │   ├─ pref_index_t3.v1:0\n" +
-			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess(pref_index_t3)\n" +
-			"                 ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
-			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 ├─ colSet: (1,2)\n" +
-			"                 ├─ tableId: 1\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: pref_index_t3\n" +
-			"                     └─ columns: [v1 v2]\n" +
-			"",
-	},
-	{
-		Query: `delete from pref_index_t3 where v1 >= 'a'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ GreaterThanOrEqual\n" +
-			"         │   ├─ pref_index_t3.v1:0\n" +
-			"         │   └─ a (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t3)\n" +
 			"             ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
@@ -408,161 +282,127 @@ var IndexPlanTests = []QueryPlanTest{
 			"",
 	},
 	{
+		Query: `delete from pref_index_t3 where v1 >= 'a'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Delete\n" +
+			"     └─ IndexedTableAccess(pref_index_t3)\n" +
+			"         ├─ index: [pref_index_t3.v1,pref_index_t3.v2]\n" +
+			"         ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1,2)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: pref_index_t3\n" +
+			"             └─ columns: [v1 v2]\n" +
+			"",
+	},
+	{
 		Query: `select * from pref_index_t2 where v1 = 'A'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t2.v1:1\n" +
-			" │   └─ A (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ static: [{[A, A], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t2.v1 = 'A')\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ static: [{[A, A], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t2\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t2.v1 = 'A')\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{[A, A], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 = 'ABC'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t2.v1:1\n" +
-			" │   └─ ABC (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ static: [{[ABC, ABC], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t2.v1 = 'ABC')\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ static: [{[ABC, ABC], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t2\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t2.v1 = 'ABC')\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{[ABC, ABC], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 = 'ABCD'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t2.v1:1\n" +
-			" │   └─ ABCD (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ static: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t2.v1 = 'ABCD')\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ static: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t2\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t2.v1 = 'ABCD')\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{[ABCD, ABCD], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 > 'A' and v1 < 'ABCDE'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t2.v1:1\n" +
-			" │   │   └─ A (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t2.v1:1\n" +
-			" │       └─ ABCDE (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ static: [{(A, ABCDE), [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v1 < 'ABCDE'))\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ static: [{(A, ABCDE), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t2\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v1 < 'ABCDE'))\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{(A, ABCDE), [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t2 where v1 > 'A' and v2 < 'ABCDE'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t2.v1:1\n" +
-			" │   │   └─ A (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t2.v2:2\n" +
-			" │       └─ ABCDE (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ static: [{(A, ∞), (NULL, ABCDE)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t2\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v2 < 'ABCDE'))\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ static: [{(A, ∞), (NULL, ABCDE)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t2\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t2.v1 > 'A') AND (pref_index_t2.v2 < 'ABCDE'))\n" +
-			" └─ IndexedTableAccess(pref_index_t2)\n" +
-			"     ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"     ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t2)\n" +
+			" ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			" ├─ filters: [{(A, ∞), (NULL, ABCDE)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -570,28 +410,6 @@ var IndexPlanTests = []QueryPlanTest{
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Update\n" +
 			"     └─ UpdateSource(SET pref_index_t2.v1:1 = concat(pref_index_t2.v1:1,Z (longtext)))\n" +
-			"         └─ Filter\n" +
-			"             ├─ GreaterThanOrEqual\n" +
-			"             │   ├─ pref_index_t2.v1:1\n" +
-			"             │   └─ A (longtext)\n" +
-			"             └─ IndexedTableAccess(pref_index_t2)\n" +
-			"                 ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
-			"                 ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
-			"                 ├─ colSet: (1-3)\n" +
-			"                 ├─ tableId: 1\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: pref_index_t2\n" +
-			"                     └─ columns: [i v1 v2]\n" +
-			"",
-	},
-	{
-		Query: `delete from pref_index_t2 where v1 >= 'A'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ GreaterThanOrEqual\n" +
-			"         │   ├─ pref_index_t2.v1:1\n" +
-			"         │   └─ A (longtext)\n" +
 			"         └─ IndexedTableAccess(pref_index_t2)\n" +
 			"             ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
 			"             ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
@@ -603,171 +421,148 @@ var IndexPlanTests = []QueryPlanTest{
 			"",
 	},
 	{
+		Query: `delete from pref_index_t2 where v1 >= 'A'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Delete\n" +
+			"     └─ IndexedTableAccess(pref_index_t2)\n" +
+			"         ├─ index: [pref_index_t2.v1,pref_index_t2.v2]\n" +
+			"         ├─ static: [{[A, ∞), [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1-3)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: pref_index_t2\n" +
+			"             └─ columns: [i v1 v2]\n" +
+			"",
+	},
+	{
 		Query: `select * from pref_index_t1 where v1 = 'a'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t1.v1:1\n" +
-			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ static: [{[a, a], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t1.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ static: [{[a, a], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t1\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t1.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{[a, a], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 = 'abc'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t1.v1:1\n" +
-			" │   └─ abc (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t1.v1 = 'abc')\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ static: [{[abc, abc], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t1\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t1.v1 = 'abc')\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{[abc, abc], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 = 'abcd'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ pref_index_t1.v1:1\n" +
-			" │   └─ abcd (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (pref_index_t1.v1 = 'abcd')\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ static: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t1\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (pref_index_t1.v1 = 'abcd')\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{[abcd, abcd], [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 > 'a' and v1 < 'abcde'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t1.v1:1\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t1.v1:1\n" +
-			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v1 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ static: [{(a, abcde), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t1\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v1 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{(a, abcde), [NULL, ∞)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from pref_index_t1 where v1 > 'a' and v2 < 'abcde'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ AND\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ pref_index_t1.v1:1\n" +
-			" │   │   └─ a (longtext)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ pref_index_t1.v2:2\n" +
-			" │       └─ abcde (longtext)\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: pref_index_t1\n" +
-			"         └─ columns: [i v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v2 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+		ExpectedPlan: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ static: [{(a, ∞), (NULL, abcde)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: pref_index_t1\n" +
 			"     └─ columns: [i v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((pref_index_t1.v1 > 'a') AND (pref_index_t1.v2 < 'abcde'))\n" +
-			" └─ IndexedTableAccess(pref_index_t1)\n" +
-			"     ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"     ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
-			"     └─ columns: [i v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(pref_index_t1)\n" +
+			" ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			" ├─ filters: [{(a, ∞), (NULL, abcde)}]\n" +
+			" └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `delete from pref_index_t1 where v1 >= 'a'`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ GreaterThanOrEqual\n" +
-			"         │   ├─ pref_index_t1.v1:1\n" +
-			"         │   └─ a (longtext)\n" +
+			"     └─ IndexedTableAccess(pref_index_t1)\n" +
+			"         ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
+			"         ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1-3)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: pref_index_t1\n" +
+			"             └─ columns: [i v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `update pref_index_t1 set v1 = concat(v1, 'z') where v1 >= 'a'`,
+		ExpectedPlan: "RowUpdateAccumulator\n" +
+			" └─ Update\n" +
+			"     └─ UpdateSource(SET pref_index_t1.v1:1 = concat(pref_index_t1.v1:1,z (longtext)))\n" +
 			"         └─ IndexedTableAccess(pref_index_t1)\n" +
 			"             ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
 			"             ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
@@ -776,25 +571,6 @@ var IndexPlanTests = []QueryPlanTest{
 			"             └─ Table\n" +
 			"                 ├─ name: pref_index_t1\n" +
 			"                 └─ columns: [i v1 v2]\n" +
-			"",
-	},
-	{
-		Query: `update pref_index_t1 set v1 = concat(v1, 'z') where v1 >= 'a'`,
-		ExpectedPlan: "RowUpdateAccumulator\n" +
-			" └─ Update\n" +
-			"     └─ UpdateSource(SET pref_index_t1.v1:1 = concat(pref_index_t1.v1:1,z (longtext)))\n" +
-			"         └─ Filter\n" +
-			"             ├─ GreaterThanOrEqual\n" +
-			"             │   ├─ pref_index_t1.v1:1\n" +
-			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess(pref_index_t1)\n" +
-			"                 ├─ index: [pref_index_t1.v1,pref_index_t1.v2]\n" +
-			"                 ├─ static: [{[a, ∞), [NULL, ∞)}]\n" +
-			"                 ├─ colSet: (1-3)\n" +
-			"                 ├─ tableId: 1\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: pref_index_t1\n" +
-			"                     └─ columns: [i v1 v2]\n" +
 			"",
 	},
 	{
@@ -16199,32 +15975,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `select * from comp_index_t3 where v1 = 'a'`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Eq\n" +
-			" │   ├─ comp_index_t3.v1:1\n" +
-			" │   └─ a (longtext)\n" +
-			" └─ IndexedTableAccess(comp_index_t3)\n" +
-			"     ├─ index: [comp_index_t3.v1]\n" +
-			"     ├─ static: [{[[97], [97]]}]\n" +
-			"     ├─ colSet: (1-3)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t3\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (comp_index_t3.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(comp_index_t3)\n" +
-			"     ├─ index: [comp_index_t3.v1]\n" +
-			"     ├─ filters: [{[[97], [97]]}]\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t3)\n" +
+			" ├─ index: [comp_index_t3.v1]\n" +
+			" ├─ static: [{[[97], [97]]}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t3\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (comp_index_t3.v1 = 'a')\n" +
-			" └─ IndexedTableAccess(comp_index_t3)\n" +
-			"     ├─ index: [comp_index_t3.v1]\n" +
-			"     ├─ filters: [{[[97], [97]]}]\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t3)\n" +
+			" ├─ index: [comp_index_t3.v1]\n" +
+			" ├─ filters: [{[[97], [97]]}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t3)\n" +
+			" ├─ index: [comp_index_t3.v1]\n" +
+			" ├─ filters: [{[[97], [97]]}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -4572,19 +4572,15 @@ WHERE
 			" │               │   │   │   │           ├─ Eq\n" +
 			" │               │   │   │   │           │   ├─ ci.id:0!null\n" +
 			" │               │   │   │   │           │   └─ ct.FZ2R5:2!null\n" +
-			" │               │   │   │   │           ├─ Filter\n" +
-			" │               │   │   │   │           │   ├─ HashIn\n" +
-			" │               │   │   │   │           │   │   ├─ ci.FTQLQ:1!null\n" +
-			" │               │   │   │   │           │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			" │               │   │   │   │           │   └─ TableAlias(ci)\n" +
-			" │               │   │   │   │           │       └─ IndexedTableAccess(JDLNA)\n" +
-			" │               │   │   │   │           │           ├─ index: [JDLNA.FTQLQ]\n" +
-			" │               │   │   │   │           │           ├─ static: [{[SQ1, SQ1]}]\n" +
-			" │               │   │   │   │           │           ├─ colSet: (107-111)\n" +
-			" │               │   │   │   │           │           ├─ tableId: 9\n" +
-			" │               │   │   │   │           │           └─ Table\n" +
-			" │               │   │   │   │           │               ├─ name: JDLNA\n" +
-			" │               │   │   │   │           │               └─ columns: [id ftqlq]\n" +
+			" │               │   │   │   │           ├─ TableAlias(ci)\n" +
+			" │               │   │   │   │           │   └─ IndexedTableAccess(JDLNA)\n" +
+			" │               │   │   │   │           │       ├─ index: [JDLNA.FTQLQ]\n" +
+			" │               │   │   │   │           │       ├─ static: [{[SQ1, SQ1]}]\n" +
+			" │               │   │   │   │           │       ├─ colSet: (107-111)\n" +
+			" │               │   │   │   │           │       ├─ tableId: 9\n" +
+			" │               │   │   │   │           │       └─ Table\n" +
+			" │               │   │   │   │           │           ├─ name: JDLNA\n" +
+			" │               │   │   │   │           │           └─ columns: [id ftqlq]\n" +
 			" │               │   │   │   │           └─ HashLookup\n" +
 			" │               │   │   │   │               ├─ left-key: TUPLE(ci.id:0!null)\n" +
 			" │               │   │   │   │               ├─ right-key: TUPLE(ct.FZ2R5:0!null)\n" +
@@ -4772,19 +4768,15 @@ WHERE
 			"             │               │           │   │   │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
 			"             │               │           │   │   │       └─ Project\n" +
 			"             │               │           │   │   │           ├─ columns: [aac.id:22!null]\n" +
-			"             │               │           │   │   │           └─ Filter\n" +
-			"             │               │           │   │   │               ├─ Eq\n" +
-			"             │               │           │   │   │               │   ├─ aac.BTXC5:23\n" +
-			"             │               │           │   │   │               │   └─ WT (longtext)\n" +
-			"             │               │           │   │   │               └─ TableAlias(aac)\n" +
-			"             │               │           │   │   │                   └─ IndexedTableAccess(TPXBU)\n" +
-			"             │               │           │   │   │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"             │               │           │   │   │                       ├─ static: [{[WT, WT]}]\n" +
-			"             │               │           │   │   │                       ├─ colSet: (172-174)\n" +
-			"             │               │           │   │   │                       ├─ tableId: 16\n" +
-			"             │               │           │   │   │                       └─ Table\n" +
-			"             │               │           │   │   │                           ├─ name: TPXBU\n" +
-			"             │               │           │   │   │                           └─ columns: [id btxc5]\n" +
+			"             │               │           │   │   │           └─ TableAlias(aac)\n" +
+			"             │               │           │   │   │               └─ IndexedTableAccess(TPXBU)\n" +
+			"             │               │           │   │   │                   ├─ index: [TPXBU.BTXC5]\n" +
+			"             │               │           │   │   │                   ├─ static: [{[WT, WT]}]\n" +
+			"             │               │           │   │   │                   ├─ colSet: (172-174)\n" +
+			"             │               │           │   │   │                   ├─ tableId: 16\n" +
+			"             │               │           │   │   │                   └─ Table\n" +
+			"             │               │           │   │   │                       ├─ name: TPXBU\n" +
+			"             │               │           │   │   │                       └─ columns: [id btxc5]\n" +
 			"             │               │           │   │   ├─ TableAlias(sn)\n" +
 			"             │               │           │   │   │   └─ IndexedTableAccess(NOXN3)\n" +
 			"             │               │           │   │   │       ├─ index: [NOXN3.BRQP2]\n" +
@@ -4810,19 +4802,15 @@ WHERE
 			"             │               │           │   └─ HashLookup\n" +
 			"             │               │           │       ├─ left-key: TUPLE(ct.FZ2R5:11!null)\n" +
 			"             │               │           │       ├─ right-key: TUPLE(ci.id:0!null)\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ HashIn\n" +
-			"             │               │           │           │   ├─ ci.FTQLQ:1!null\n" +
-			"             │               │           │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"             │               │           │           └─ TableAlias(ci)\n" +
-			"             │               │           │               └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │           │                   ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │           │                   ├─ static: [{[SQ1, SQ1]}]\n" +
-			"             │               │           │                   ├─ colSet: (175-179)\n" +
-			"             │               │           │                   ├─ tableId: 17\n" +
-			"             │               │           │                   └─ Table\n" +
-			"             │               │           │                       ├─ name: JDLNA\n" +
-			"             │               │           │                       └─ columns: [id ftqlq]\n" +
+			"             │               │           │       └─ TableAlias(ci)\n" +
+			"             │               │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │               │           │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │               │           │               ├─ static: [{[SQ1, SQ1]}]\n" +
+			"             │               │           │               ├─ colSet: (175-179)\n" +
+			"             │               │           │               ├─ tableId: 17\n" +
+			"             │               │           │               └─ Table\n" +
+			"             │               │           │                   ├─ name: JDLNA\n" +
+			"             │               │           │                   └─ columns: [id ftqlq]\n" +
 			"             │               │           └─ HashLookup\n" +
 			"             │               │               ├─ left-key: TUPLE(ct.OVE3E:14!null)\n" +
 			"             │               │               ├─ right-key: TUPLE(cec.id:0!null)\n" +
@@ -4908,13 +4896,11 @@ WHERE
 			" │               │   │   │   │       ├─ columns: [khjjo.BDNYB as BDNYB, ci.FTQLQ as TOFPN, ct.M22QN as M22QN, cec.ADURZ as ADURZ, cec.NO52D as NO52D, ct.S3Q3Y as IDPK7]\n" +
 			" │               │   │   │   │       └─ HashJoin\n" +
 			" │               │   │   │   │           ├─ (ci.id = ct.FZ2R5)\n" +
-			" │               │   │   │   │           ├─ Filter\n" +
-			" │               │   │   │   │           │   ├─ (ci.FTQLQ HASH IN ('SQ1'))\n" +
-			" │               │   │   │   │           │   └─ TableAlias(ci)\n" +
-			" │               │   │   │   │           │       └─ IndexedTableAccess(JDLNA)\n" +
-			" │               │   │   │   │           │           ├─ index: [JDLNA.FTQLQ]\n" +
-			" │               │   │   │   │           │           ├─ filters: [{[SQ1, SQ1]}]\n" +
-			" │               │   │   │   │           │           └─ columns: [id ftqlq]\n" +
+			" │               │   │   │   │           ├─ TableAlias(ci)\n" +
+			" │               │   │   │   │           │   └─ IndexedTableAccess(JDLNA)\n" +
+			" │               │   │   │   │           │       ├─ index: [JDLNA.FTQLQ]\n" +
+			" │               │   │   │   │           │       ├─ filters: [{[SQ1, SQ1]}]\n" +
+			" │               │   │   │   │           │       └─ columns: [id ftqlq]\n" +
 			" │               │   │   │   │           └─ HashLookup\n" +
 			" │               │   │   │   │               ├─ left-key: (ci.id)\n" +
 			" │               │   │   │   │               ├─ right-key: (ct.FZ2R5)\n" +
@@ -5025,13 +5011,11 @@ WHERE
 			"             │               │           │   │   │   ├─ cacheable: true\n" +
 			"             │               │           │   │   │   └─ Project\n" +
 			"             │               │           │   │   │       ├─ columns: [aac.id]\n" +
-			"             │               │           │   │   │       └─ Filter\n" +
-			"             │               │           │   │   │           ├─ (aac.BTXC5 = 'WT')\n" +
-			"             │               │           │   │   │           └─ TableAlias(aac)\n" +
-			"             │               │           │   │   │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │               │           │   │   │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │               │           │   │   │                   ├─ filters: [{[WT, WT]}]\n" +
-			"             │               │           │   │   │                   └─ columns: [id btxc5]\n" +
+			"             │               │           │   │   │       └─ TableAlias(aac)\n" +
+			"             │               │           │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
+			"             │               │           │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
+			"             │               │           │   │   │               ├─ filters: [{[WT, WT]}]\n" +
+			"             │               │           │   │   │               └─ columns: [id btxc5]\n" +
 			"             │               │           │   │   │  )\n" +
 			"             │               │           │   │   ├─ TableAlias(sn)\n" +
 			"             │               │           │   │   │   └─ IndexedTableAccess(NOXN3)\n" +
@@ -5046,13 +5030,11 @@ WHERE
 			"             │               │           │   └─ HashLookup\n" +
 			"             │               │           │       ├─ left-key: (ct.FZ2R5)\n" +
 			"             │               │           │       ├─ right-key: (ci.id)\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ (ci.FTQLQ HASH IN ('SQ1'))\n" +
-			"             │               │           │           └─ TableAlias(ci)\n" +
-			"             │               │           │               └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │           │                   ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │           │                   ├─ filters: [{[SQ1, SQ1]}]\n" +
-			"             │               │           │                   └─ columns: [id ftqlq]\n" +
+			"             │               │           │       └─ TableAlias(ci)\n" +
+			"             │               │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │               │           │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │               │           │               ├─ filters: [{[SQ1, SQ1]}]\n" +
+			"             │               │           │               └─ columns: [id ftqlq]\n" +
 			"             │               │           └─ HashLookup\n" +
 			"             │               │               ├─ left-key: (ct.OVE3E)\n" +
 			"             │               │               ├─ right-key: (cec.id)\n" +
@@ -5129,13 +5111,11 @@ WHERE
 			" │               │   │   │   │       ├─ columns: [khjjo.BDNYB as BDNYB, ci.FTQLQ as TOFPN, ct.M22QN as M22QN, cec.ADURZ as ADURZ, cec.NO52D as NO52D, ct.S3Q3Y as IDPK7]\n" +
 			" │               │   │   │   │       └─ HashJoin\n" +
 			" │               │   │   │   │           ├─ (ci.id = ct.FZ2R5)\n" +
-			" │               │   │   │   │           ├─ Filter\n" +
-			" │               │   │   │   │           │   ├─ (ci.FTQLQ HASH IN ('SQ1'))\n" +
-			" │               │   │   │   │           │   └─ TableAlias(ci)\n" +
-			" │               │   │   │   │           │       └─ IndexedTableAccess(JDLNA)\n" +
-			" │               │   │   │   │           │           ├─ index: [JDLNA.FTQLQ]\n" +
-			" │               │   │   │   │           │           ├─ filters: [{[SQ1, SQ1]}]\n" +
-			" │               │   │   │   │           │           └─ columns: [id ftqlq]\n" +
+			" │               │   │   │   │           ├─ TableAlias(ci)\n" +
+			" │               │   │   │   │           │   └─ IndexedTableAccess(JDLNA)\n" +
+			" │               │   │   │   │           │       ├─ index: [JDLNA.FTQLQ]\n" +
+			" │               │   │   │   │           │       ├─ filters: [{[SQ1, SQ1]}]\n" +
+			" │               │   │   │   │           │       └─ columns: [id ftqlq]\n" +
 			" │               │   │   │   │           └─ HashLookup\n" +
 			" │               │   │   │   │               ├─ left-key: (ci.id)\n" +
 			" │               │   │   │   │               ├─ right-key: (ct.FZ2R5)\n" +
@@ -5246,13 +5226,11 @@ WHERE
 			"             │               │           │   │   │   ├─ cacheable: true\n" +
 			"             │               │           │   │   │   └─ Project\n" +
 			"             │               │           │   │   │       ├─ columns: [aac.id]\n" +
-			"             │               │           │   │   │       └─ Filter\n" +
-			"             │               │           │   │   │           ├─ (aac.BTXC5 = 'WT')\n" +
-			"             │               │           │   │   │           └─ TableAlias(aac)\n" +
-			"             │               │           │   │   │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │               │           │   │   │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │               │           │   │   │                   ├─ filters: [{[WT, WT]}]\n" +
-			"             │               │           │   │   │                   └─ columns: [id btxc5]\n" +
+			"             │               │           │   │   │       └─ TableAlias(aac)\n" +
+			"             │               │           │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
+			"             │               │           │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
+			"             │               │           │   │   │               ├─ filters: [{[WT, WT]}]\n" +
+			"             │               │           │   │   │               └─ columns: [id btxc5]\n" +
 			"             │               │           │   │   │  )\n" +
 			"             │               │           │   │   ├─ TableAlias(sn)\n" +
 			"             │               │           │   │   │   └─ IndexedTableAccess(NOXN3)\n" +
@@ -5267,13 +5245,11 @@ WHERE
 			"             │               │           │   └─ HashLookup\n" +
 			"             │               │           │       ├─ left-key: (ct.FZ2R5)\n" +
 			"             │               │           │       ├─ right-key: (ci.id)\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ (ci.FTQLQ HASH IN ('SQ1'))\n" +
-			"             │               │           │           └─ TableAlias(ci)\n" +
-			"             │               │           │               └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │           │                   ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │           │                   ├─ filters: [{[SQ1, SQ1]}]\n" +
-			"             │               │           │                   └─ columns: [id ftqlq]\n" +
+			"             │               │           │       └─ TableAlias(ci)\n" +
+			"             │               │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │               │           │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │               │           │               ├─ filters: [{[SQ1, SQ1]}]\n" +
+			"             │               │           │               └─ columns: [id ftqlq]\n" +
 			"             │               │           └─ HashLookup\n" +
 			"             │               │               ├─ left-key: (ct.OVE3E)\n" +
 			"             │               │               ├─ right-key: (cec.id)\n" +
@@ -5658,19 +5634,15 @@ WHERE
 			"             │               │           │   │   │       ├─ alias-string: select aac.id from TPXBU as aac where BTXC5 = 'WT'\n" +
 			"             │               │           │   │   │       └─ Project\n" +
 			"             │               │           │   │   │           ├─ columns: [aac.id:22!null]\n" +
-			"             │               │           │   │   │           └─ Filter\n" +
-			"             │               │           │   │   │               ├─ Eq\n" +
-			"             │               │           │   │   │               │   ├─ aac.BTXC5:23\n" +
-			"             │               │           │   │   │               │   └─ WT (longtext)\n" +
-			"             │               │           │   │   │               └─ TableAlias(aac)\n" +
-			"             │               │           │   │   │                   └─ IndexedTableAccess(TPXBU)\n" +
-			"             │               │           │   │   │                       ├─ index: [TPXBU.BTXC5]\n" +
-			"             │               │           │   │   │                       ├─ static: [{[WT, WT]}]\n" +
-			"             │               │           │   │   │                       ├─ colSet: (172-174)\n" +
-			"             │               │           │   │   │                       ├─ tableId: 16\n" +
-			"             │               │           │   │   │                       └─ Table\n" +
-			"             │               │           │   │   │                           ├─ name: TPXBU\n" +
-			"             │               │           │   │   │                           └─ columns: [id btxc5]\n" +
+			"             │               │           │   │   │           └─ TableAlias(aac)\n" +
+			"             │               │           │   │   │               └─ IndexedTableAccess(TPXBU)\n" +
+			"             │               │           │   │   │                   ├─ index: [TPXBU.BTXC5]\n" +
+			"             │               │           │   │   │                   ├─ static: [{[WT, WT]}]\n" +
+			"             │               │           │   │   │                   ├─ colSet: (172-174)\n" +
+			"             │               │           │   │   │                   ├─ tableId: 16\n" +
+			"             │               │           │   │   │                   └─ Table\n" +
+			"             │               │           │   │   │                       ├─ name: TPXBU\n" +
+			"             │               │           │   │   │                       └─ columns: [id btxc5]\n" +
 			"             │               │           │   │   ├─ TableAlias(sn)\n" +
 			"             │               │           │   │   │   └─ IndexedTableAccess(NOXN3)\n" +
 			"             │               │           │   │   │       ├─ index: [NOXN3.BRQP2]\n" +
@@ -5696,19 +5668,15 @@ WHERE
 			"             │               │           │   └─ HashLookup\n" +
 			"             │               │           │       ├─ left-key: TUPLE(ct.FZ2R5:11!null)\n" +
 			"             │               │           │       ├─ right-key: TUPLE(ci.id:0!null)\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ HashIn\n" +
-			"             │               │           │           │   ├─ ci.FTQLQ:1!null\n" +
-			"             │               │           │           │   └─ TUPLE(SQ1 (longtext))\n" +
-			"             │               │           │           └─ TableAlias(ci)\n" +
-			"             │               │           │               └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │           │                   ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │           │                   ├─ static: [{[SQ1, SQ1]}]\n" +
-			"             │               │           │                   ├─ colSet: (175-179)\n" +
-			"             │               │           │                   ├─ tableId: 17\n" +
-			"             │               │           │                   └─ Table\n" +
-			"             │               │           │                       ├─ name: JDLNA\n" +
-			"             │               │           │                       └─ columns: [id ftqlq]\n" +
+			"             │               │           │       └─ TableAlias(ci)\n" +
+			"             │               │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │               │           │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │               │           │               ├─ static: [{[SQ1, SQ1]}]\n" +
+			"             │               │           │               ├─ colSet: (175-179)\n" +
+			"             │               │           │               ├─ tableId: 17\n" +
+			"             │               │           │               └─ Table\n" +
+			"             │               │           │                   ├─ name: JDLNA\n" +
+			"             │               │           │                   └─ columns: [id ftqlq]\n" +
 			"             │               │           └─ HashLookup\n" +
 			"             │               │               ├─ left-key: TUPLE(ct.OVE3E:14!null)\n" +
 			"             │               │               ├─ right-key: TUPLE(cec.id:0!null)\n" +
@@ -5903,13 +5871,11 @@ WHERE
 			"             │               │           │   │   │   ├─ cacheable: true\n" +
 			"             │               │           │   │   │   └─ Project\n" +
 			"             │               │           │   │   │       ├─ columns: [aac.id]\n" +
-			"             │               │           │   │   │       └─ Filter\n" +
-			"             │               │           │   │   │           ├─ (aac.BTXC5 = 'WT')\n" +
-			"             │               │           │   │   │           └─ TableAlias(aac)\n" +
-			"             │               │           │   │   │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │               │           │   │   │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │               │           │   │   │                   ├─ filters: [{[WT, WT]}]\n" +
-			"             │               │           │   │   │                   └─ columns: [id btxc5]\n" +
+			"             │               │           │   │   │       └─ TableAlias(aac)\n" +
+			"             │               │           │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
+			"             │               │           │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
+			"             │               │           │   │   │               ├─ filters: [{[WT, WT]}]\n" +
+			"             │               │           │   │   │               └─ columns: [id btxc5]\n" +
 			"             │               │           │   │   │  )\n" +
 			"             │               │           │   │   ├─ TableAlias(sn)\n" +
 			"             │               │           │   │   │   └─ IndexedTableAccess(NOXN3)\n" +
@@ -5924,13 +5890,11 @@ WHERE
 			"             │               │           │   └─ HashLookup\n" +
 			"             │               │           │       ├─ left-key: (ct.FZ2R5)\n" +
 			"             │               │           │       ├─ right-key: (ci.id)\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ (ci.FTQLQ HASH IN ('SQ1'))\n" +
-			"             │               │           │           └─ TableAlias(ci)\n" +
-			"             │               │           │               └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │           │                   ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │           │                   ├─ filters: [{[SQ1, SQ1]}]\n" +
-			"             │               │           │                   └─ columns: [id ftqlq]\n" +
+			"             │               │           │       └─ TableAlias(ci)\n" +
+			"             │               │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │               │           │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │               │           │               ├─ filters: [{[SQ1, SQ1]}]\n" +
+			"             │               │           │               └─ columns: [id ftqlq]\n" +
 			"             │               │           └─ HashLookup\n" +
 			"             │               │               ├─ left-key: (ct.OVE3E)\n" +
 			"             │               │               ├─ right-key: (cec.id)\n" +
@@ -6116,13 +6080,11 @@ WHERE
 			"             │               │           │   │   │   ├─ cacheable: true\n" +
 			"             │               │           │   │   │   └─ Project\n" +
 			"             │               │           │   │   │       ├─ columns: [aac.id]\n" +
-			"             │               │           │   │   │       └─ Filter\n" +
-			"             │               │           │   │   │           ├─ (aac.BTXC5 = 'WT')\n" +
-			"             │               │           │   │   │           └─ TableAlias(aac)\n" +
-			"             │               │           │   │   │               └─ IndexedTableAccess(TPXBU)\n" +
-			"             │               │           │   │   │                   ├─ index: [TPXBU.BTXC5]\n" +
-			"             │               │           │   │   │                   ├─ filters: [{[WT, WT]}]\n" +
-			"             │               │           │   │   │                   └─ columns: [id btxc5]\n" +
+			"             │               │           │   │   │       └─ TableAlias(aac)\n" +
+			"             │               │           │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
+			"             │               │           │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
+			"             │               │           │   │   │               ├─ filters: [{[WT, WT]}]\n" +
+			"             │               │           │   │   │               └─ columns: [id btxc5]\n" +
 			"             │               │           │   │   │  )\n" +
 			"             │               │           │   │   ├─ TableAlias(sn)\n" +
 			"             │               │           │   │   │   └─ IndexedTableAccess(NOXN3)\n" +
@@ -6137,13 +6099,11 @@ WHERE
 			"             │               │           │   └─ HashLookup\n" +
 			"             │               │           │       ├─ left-key: (ct.FZ2R5)\n" +
 			"             │               │           │       ├─ right-key: (ci.id)\n" +
-			"             │               │           │       └─ Filter\n" +
-			"             │               │           │           ├─ (ci.FTQLQ HASH IN ('SQ1'))\n" +
-			"             │               │           │           └─ TableAlias(ci)\n" +
-			"             │               │           │               └─ IndexedTableAccess(JDLNA)\n" +
-			"             │               │           │                   ├─ index: [JDLNA.FTQLQ]\n" +
-			"             │               │           │                   ├─ filters: [{[SQ1, SQ1]}]\n" +
-			"             │               │           │                   └─ columns: [id ftqlq]\n" +
+			"             │               │           │       └─ TableAlias(ci)\n" +
+			"             │               │           │           └─ IndexedTableAccess(JDLNA)\n" +
+			"             │               │           │               ├─ index: [JDLNA.FTQLQ]\n" +
+			"             │               │           │               ├─ filters: [{[SQ1, SQ1]}]\n" +
+			"             │               │           │               └─ columns: [id ftqlq]\n" +
 			"             │               │           └─ HashLookup\n" +
 			"             │               │               ├─ left-key: (ct.OVE3E)\n" +
 			"             │               │               ├─ right-key: (cec.id)\n" +
@@ -6625,87 +6585,87 @@ WHERE
 
 	ORDER BY nd.TW55N`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [nd.TW55N:9!null, il.LIILR:3, il.KSFXH:4, il.KLMAU:5, il.ecm:6]\n" +
-			" └─ Sort(nd.TW55N:9!null ASC nullsFirst)\n" +
-			"     └─ InnerJoin\n" +
+			" ├─ columns: [nd.TW55N:7!null, il.LIILR:1, il.KSFXH:2, il.KLMAU:3, il.ecm:4]\n" +
+			" └─ Sort(nd.TW55N:7!null ASC nullsFirst)\n" +
+			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ nd.DKCAJ:8!null\n" +
-			"         │   └─ nt.id:0!null\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ NOT\n" +
-			"         │   │   └─ Eq\n" +
-			"         │   │       ├─ nt.DZLIM:1!null\n" +
-			"         │   │       └─ SUZTA (longtext)\n" +
-			"         │   └─ TableAlias(nt)\n" +
-			"         │       └─ IndexedTableAccess(F35MI)\n" +
-			"         │           ├─ index: [F35MI.DZLIM]\n" +
-			"         │           ├─ static: [{(NULL, SUZTA)}, {(SUZTA, ∞)}]\n" +
-			"         │           ├─ colSet: (26-28)\n" +
-			"         │           ├─ tableId: 3\n" +
+			"         │   ├─ nd.DKCAJ:6!null\n" +
+			"         │   └─ nt.id:8!null\n" +
+			"         ├─ LookupJoin\n" +
+			"         │   ├─ TableAlias(il)\n" +
+			"         │   │   └─ ProcessTable\n" +
+			"         │   │       └─ Table\n" +
+			"         │   │           ├─ name: RLOHD\n" +
+			"         │   │           └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
+			"         │   └─ TableAlias(nd)\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           ├─ keys: [il.LUEVY:0!null]\n" +
+			"         │           ├─ colSet: (9-25)\n" +
+			"         │           ├─ tableId: 2\n" +
 			"         │           └─ Table\n" +
-			"         │               ├─ name: F35MI\n" +
-			"         │               └─ columns: [id dzlim]\n" +
-			"         └─ LookupJoin\n" +
-			"             ├─ TableAlias(il)\n" +
-			"             │   └─ ProcessTable\n" +
-			"             │       └─ Table\n" +
-			"             │           ├─ name: RLOHD\n" +
-			"             │           └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.id]\n" +
-			"                     ├─ keys: [il.LUEVY:2!null]\n" +
-			"                     ├─ colSet: (9-25)\n" +
-			"                     ├─ tableId: 2\n" +
+			"         │               ├─ name: E2I7U\n" +
+			"         │               └─ columns: [id dkcaj tw55n]\n" +
+			"         └─ HashLookup\n" +
+			"             ├─ left-key: TUPLE(nd.DKCAJ:6!null)\n" +
+			"             ├─ right-key: TUPLE(nt.id:0!null)\n" +
+			"             └─ TableAlias(nt)\n" +
+			"                 └─ IndexedTableAccess(F35MI)\n" +
+			"                     ├─ index: [F35MI.DZLIM]\n" +
+			"                     ├─ static: [{(NULL, SUZTA)}, {(SUZTA, ∞)}]\n" +
+			"                     ├─ colSet: (26-28)\n" +
+			"                     ├─ tableId: 3\n" +
 			"                     └─ Table\n" +
-			"                         ├─ name: E2I7U\n" +
-			"                         └─ columns: [id dkcaj tw55n]\n" +
+			"                         ├─ name: F35MI\n" +
+			"                         └─ columns: [id dzlim]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [nd.TW55N, il.LIILR, il.KSFXH, il.KLMAU, il.ecm]\n" +
 			" └─ Sort(nd.TW55N ASC)\n" +
-			"     └─ InnerJoin\n" +
+			"     └─ HashJoin\n" +
 			"         ├─ (nd.DKCAJ = nt.id)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (NOT((nt.DZLIM = 'SUZTA')))\n" +
-			"         │   └─ TableAlias(nt)\n" +
-			"         │       └─ IndexedTableAccess(F35MI)\n" +
-			"         │           ├─ index: [F35MI.DZLIM]\n" +
-			"         │           ├─ filters: [{(NULL, SUZTA)}, {(SUZTA, ∞)}]\n" +
-			"         │           └─ columns: [id dzlim]\n" +
-			"         └─ LookupJoin\n" +
-			"             ├─ TableAlias(il)\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: RLOHD\n" +
-			"             │       └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.id]\n" +
-			"                     ├─ columns: [id dkcaj tw55n]\n" +
-			"                     └─ keys: il.LUEVY\n" +
+			"         ├─ LookupJoin\n" +
+			"         │   ├─ TableAlias(il)\n" +
+			"         │   │   └─ Table\n" +
+			"         │   │       ├─ name: RLOHD\n" +
+			"         │   │       └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
+			"         │   └─ TableAlias(nd)\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           ├─ columns: [id dkcaj tw55n]\n" +
+			"         │           └─ keys: il.LUEVY\n" +
+			"         └─ HashLookup\n" +
+			"             ├─ left-key: (nd.DKCAJ)\n" +
+			"             ├─ right-key: (nt.id)\n" +
+			"             └─ TableAlias(nt)\n" +
+			"                 └─ IndexedTableAccess(F35MI)\n" +
+			"                     ├─ index: [F35MI.DZLIM]\n" +
+			"                     ├─ filters: [{(NULL, SUZTA)}, {(SUZTA, ∞)}]\n" +
+			"                     └─ columns: [id dzlim]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [nd.TW55N, il.LIILR, il.KSFXH, il.KLMAU, il.ecm]\n" +
 			" └─ Sort(nd.TW55N ASC)\n" +
-			"     └─ InnerJoin\n" +
+			"     └─ HashJoin\n" +
 			"         ├─ (nd.DKCAJ = nt.id)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (NOT((nt.DZLIM = 'SUZTA')))\n" +
-			"         │   └─ TableAlias(nt)\n" +
-			"         │       └─ IndexedTableAccess(F35MI)\n" +
-			"         │           ├─ index: [F35MI.DZLIM]\n" +
-			"         │           ├─ filters: [{(NULL, SUZTA)}, {(SUZTA, ∞)}]\n" +
-			"         │           └─ columns: [id dzlim]\n" +
-			"         └─ LookupJoin\n" +
-			"             ├─ TableAlias(il)\n" +
-			"             │   └─ Table\n" +
-			"             │       ├─ name: RLOHD\n" +
-			"             │       └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.id]\n" +
-			"                     ├─ columns: [id dkcaj tw55n]\n" +
-			"                     └─ keys: il.LUEVY\n" +
+			"         ├─ LookupJoin\n" +
+			"         │   ├─ TableAlias(il)\n" +
+			"         │   │   └─ Table\n" +
+			"         │   │       ├─ name: RLOHD\n" +
+			"         │   │       └─ columns: [luevy liilr ksfxh klmau ecm]\n" +
+			"         │   └─ TableAlias(nd)\n" +
+			"         │       └─ IndexedTableAccess(E2I7U)\n" +
+			"         │           ├─ index: [E2I7U.id]\n" +
+			"         │           ├─ columns: [id dkcaj tw55n]\n" +
+			"         │           └─ keys: il.LUEVY\n" +
+			"         └─ HashLookup\n" +
+			"             ├─ left-key: (nd.DKCAJ)\n" +
+			"             ├─ right-key: (nt.id)\n" +
+			"             └─ TableAlias(nt)\n" +
+			"                 └─ IndexedTableAccess(F35MI)\n" +
+			"                     ├─ index: [F35MI.DZLIM]\n" +
+			"                     ├─ filters: [{(NULL, SUZTA)}, {(SUZTA, ∞)}]\n" +
+			"                     └─ columns: [id dzlim]\n" +
 			"",
 	},
 	{
@@ -6714,32 +6674,24 @@ WHERE
 	   FTQLQ, TPNJ6
 	FROM YK2GW
 	WHERE FTQLQ IN ('SQ1')`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ HashIn\n" +
-			" │   ├─ yk2gw.FTQLQ:0!null\n" +
-			" │   └─ TUPLE(SQ1 (longtext))\n" +
-			" └─ IndexedTableAccess(YK2GW)\n" +
-			"     ├─ index: [YK2GW.FTQLQ]\n" +
-			"     ├─ static: [{[SQ1, SQ1]}]\n" +
-			"     ├─ colSet: (1-30)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: YK2GW\n" +
-			"         └─ columns: [ftqlq tpnj6]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (yk2gw.FTQLQ HASH IN ('SQ1'))\n" +
-			" └─ IndexedTableAccess(YK2GW)\n" +
-			"     ├─ index: [YK2GW.FTQLQ]\n" +
-			"     ├─ filters: [{[SQ1, SQ1]}]\n" +
+		ExpectedPlan: "IndexedTableAccess(YK2GW)\n" +
+			" ├─ index: [YK2GW.FTQLQ]\n" +
+			" ├─ static: [{[SQ1, SQ1]}]\n" +
+			" ├─ colSet: (1-30)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: YK2GW\n" +
 			"     └─ columns: [ftqlq tpnj6]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (yk2gw.FTQLQ HASH IN ('SQ1'))\n" +
-			" └─ IndexedTableAccess(YK2GW)\n" +
-			"     ├─ index: [YK2GW.FTQLQ]\n" +
-			"     ├─ filters: [{[SQ1, SQ1]}]\n" +
-			"     └─ columns: [ftqlq tpnj6]\n" +
+		ExpectedEstimates: "IndexedTableAccess(YK2GW)\n" +
+			" ├─ index: [YK2GW.FTQLQ]\n" +
+			" ├─ filters: [{[SQ1, SQ1]}]\n" +
+			" └─ columns: [ftqlq tpnj6]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(YK2GW)\n" +
+			" ├─ index: [YK2GW.FTQLQ]\n" +
+			" ├─ filters: [{[SQ1, SQ1]}]\n" +
+			" └─ columns: [ftqlq tpnj6]\n" +
 			"",
 	},
 	{
@@ -9907,24 +9859,24 @@ WHERE
 			"                 │   │   ├─ colSet: (126-132)\n" +
 			"                 │   │   ├─ tableId: 15\n" +
 			"                 │   │   └─ Project\n" +
-			"                 │   │       ├─ columns: [cla.FTQLQ:11!null as T4IBQ, sn.id:0!null as BDNYB, aac.BTXC5:19 as BTXC5, mf.id:2!null as Z7CP5, CASE  WHEN NOT\n" +
+			"                 │   │       ├─ columns: [cla.FTQLQ:15!null as T4IBQ, sn.id:0!null as BDNYB, aac.BTXC5:13 as BTXC5, mf.id:2!null as Z7CP5, CASE  WHEN NOT\n" +
 			"                 │   │       │   └─ mf.LT7K6:7 IS NULL\n" +
 			"                 │   │       │   THEN mf.LT7K6:7 ELSE mf.SPPYD:8 END as vaf, CASE  WHEN NOT\n" +
 			"                 │   │       │   └─ mf.QCGTS:9 IS NULL\n" +
 			"                 │   │       │   THEN mf.QCGTS:9 ELSE 0.5 (decimal(2,1)) END as QCGTS, CASE  WHEN Eq\n" +
-			"                 │   │       │   ├─ vc.ZNP4P:17!null\n" +
+			"                 │   │       │   ├─ vc.ZNP4P:19!null\n" +
 			"                 │   │       │   └─ L5Q44 (longtext)\n" +
 			"                 │   │       │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
-			"                 │   │       └─ LookupJoin\n" +
+			"                 │   │       └─ HashJoin\n" +
+			"                 │   │           ├─ Eq\n" +
+			"                 │   │           │   ├─ vc.id:18!null\n" +
+			"                 │   │           │   └─ w2mao.YH4XB:11!null\n" +
 			"                 │   │           ├─ HashJoin\n" +
 			"                 │   │           │   ├─ Eq\n" +
-			"                 │   │           │   │   ├─ vc.id:16!null\n" +
-			"                 │   │           │   │   └─ w2mao.YH4XB:15!null\n" +
+			"                 │   │           │   │   ├─ mf.GXLUB:3!null\n" +
+			"                 │   │           │   │   └─ bs.id:16!null\n" +
 			"                 │   │           │   ├─ LookupJoin\n" +
-			"                 │   │           │   │   ├─ HashJoin\n" +
-			"                 │   │           │   │   │   ├─ Eq\n" +
-			"                 │   │           │   │   │   │   ├─ mf.GXLUB:3!null\n" +
-			"                 │   │           │   │   │   │   └─ bs.id:12!null\n" +
+			"                 │   │           │   │   ├─ LookupJoin\n" +
 			"                 │   │           │   │   │   ├─ LookupJoin\n" +
 			"                 │   │           │   │   │   │   ├─ TableAlias(sn)\n" +
 			"                 │   │           │   │   │   │   │   └─ Table\n" +
@@ -9945,62 +9897,62 @@ WHERE
 			"                 │   │           │   │   │   │               └─ Table\n" +
 			"                 │   │           │   │   │   │                   ├─ name: HGMQ6\n" +
 			"                 │   │           │   │   │   │                   └─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
-			"                 │   │           │   │   │   └─ HashLookup\n" +
-			"                 │   │           │   │   │       ├─ left-key: TUPLE(mf.GXLUB:3!null)\n" +
-			"                 │   │           │   │   │       ├─ right-key: TUPLE(bs.id:2!null)\n" +
-			"                 │   │           │   │   │       └─ MergeJoin\n" +
-			"                 │   │           │   │   │           ├─ cmp: Eq\n" +
-			"                 │   │           │   │   │           │   ├─ cla.id:10!null\n" +
-			"                 │   │           │   │   │           │   └─ bs.IXUXU:13\n" +
-			"                 │   │           │   │   │           ├─ Filter\n" +
-			"                 │   │           │   │   │           │   ├─ HashIn\n" +
-			"                 │   │           │   │   │           │   │   ├─ cla.FTQLQ:1!null\n" +
-			"                 │   │           │   │   │           │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                 │   │           │   │   │           │   └─ TableAlias(cla)\n" +
-			"                 │   │           │   │   │           │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                 │   │           │   │   │           │           ├─ index: [YK2GW.id]\n" +
-			"                 │   │           │   │   │           │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │   │           │   │   │           │           ├─ colSet: (1-30)\n" +
-			"                 │   │           │   │   │           │           ├─ tableId: 1\n" +
-			"                 │   │           │   │   │           │           └─ Table\n" +
-			"                 │   │           │   │   │           │               ├─ name: YK2GW\n" +
-			"                 │   │           │   │   │           │               └─ columns: [id ftqlq]\n" +
-			"                 │   │           │   │   │           └─ TableAlias(bs)\n" +
-			"                 │   │           │   │   │               └─ IndexedTableAccess(THNTS)\n" +
-			"                 │   │           │   │   │                   ├─ index: [THNTS.IXUXU]\n" +
-			"                 │   │           │   │   │                   ├─ static: [{[NULL, ∞)}]\n" +
-			"                 │   │           │   │   │                   ├─ colSet: (31-34)\n" +
-			"                 │   │           │   │   │                   ├─ tableId: 2\n" +
-			"                 │   │           │   │   │                   └─ Table\n" +
-			"                 │   │           │   │   │                       ├─ name: THNTS\n" +
-			"                 │   │           │   │   │                       └─ columns: [id ixuxu]\n" +
-			"                 │   │           │   │   └─ TableAlias(w2mao)\n" +
-			"                 │   │           │   │       └─ IndexedTableAccess(SEQS3)\n" +
-			"                 │   │           │   │           ├─ index: [SEQS3.Z7CP5]\n" +
-			"                 │   │           │   │           ├─ keys: [mf.id:2!null]\n" +
-			"                 │   │           │   │           ├─ colSet: (65-67)\n" +
-			"                 │   │           │   │           ├─ tableId: 6\n" +
+			"                 │   │           │   │   │   └─ TableAlias(w2mao)\n" +
+			"                 │   │           │   │   │       └─ IndexedTableAccess(SEQS3)\n" +
+			"                 │   │           │   │   │           ├─ index: [SEQS3.Z7CP5]\n" +
+			"                 │   │           │   │   │           ├─ keys: [mf.id:2!null]\n" +
+			"                 │   │           │   │   │           ├─ colSet: (65-67)\n" +
+			"                 │   │           │   │   │           ├─ tableId: 6\n" +
+			"                 │   │           │   │   │           └─ Table\n" +
+			"                 │   │           │   │   │               ├─ name: SEQS3\n" +
+			"                 │   │           │   │   │               └─ columns: [z7cp5 yh4xb]\n" +
+			"                 │   │           │   │   └─ TableAlias(aac)\n" +
+			"                 │   │           │   │       └─ IndexedTableAccess(TPXBU)\n" +
+			"                 │   │           │   │           ├─ index: [TPXBU.id]\n" +
+			"                 │   │           │   │           ├─ keys: [mf.M22QN:5!null]\n" +
+			"                 │   │           │   │           ├─ colSet: (62-64)\n" +
+			"                 │   │           │   │           ├─ tableId: 5\n" +
 			"                 │   │           │   │           └─ Table\n" +
-			"                 │   │           │   │               ├─ name: SEQS3\n" +
-			"                 │   │           │   │               └─ columns: [z7cp5 yh4xb]\n" +
+			"                 │   │           │   │               ├─ name: TPXBU\n" +
+			"                 │   │           │   │               └─ columns: [id btxc5]\n" +
 			"                 │   │           │   └─ HashLookup\n" +
-			"                 │   │           │       ├─ left-key: TUPLE(w2mao.YH4XB:15!null)\n" +
-			"                 │   │           │       ├─ right-key: TUPLE(vc.id:0!null)\n" +
-			"                 │   │           │       └─ TableAlias(vc)\n" +
-			"                 │   │           │           └─ Table\n" +
-			"                 │   │           │               ├─ name: D34QP\n" +
-			"                 │   │           │               ├─ columns: [id znp4p]\n" +
-			"                 │   │           │               ├─ colSet: (68-73)\n" +
-			"                 │   │           │               └─ tableId: 7\n" +
-			"                 │   │           └─ TableAlias(aac)\n" +
-			"                 │   │               └─ IndexedTableAccess(TPXBU)\n" +
-			"                 │   │                   ├─ index: [TPXBU.id]\n" +
-			"                 │   │                   ├─ keys: [mf.M22QN:5!null]\n" +
-			"                 │   │                   ├─ colSet: (62-64)\n" +
-			"                 │   │                   ├─ tableId: 5\n" +
+			"                 │   │           │       ├─ left-key: TUPLE(mf.GXLUB:3!null)\n" +
+			"                 │   │           │       ├─ right-key: TUPLE(bs.id:2!null)\n" +
+			"                 │   │           │       └─ MergeJoin\n" +
+			"                 │   │           │           ├─ cmp: Eq\n" +
+			"                 │   │           │           │   ├─ cla.id:14!null\n" +
+			"                 │   │           │           │   └─ bs.IXUXU:17\n" +
+			"                 │   │           │           ├─ Filter\n" +
+			"                 │   │           │           │   ├─ HashIn\n" +
+			"                 │   │           │           │   │   ├─ cla.FTQLQ:1!null\n" +
+			"                 │   │           │           │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                 │   │           │           │   └─ TableAlias(cla)\n" +
+			"                 │   │           │           │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                 │   │           │           │           ├─ index: [YK2GW.id]\n" +
+			"                 │   │           │           │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │           │           │           ├─ colSet: (1-30)\n" +
+			"                 │   │           │           │           ├─ tableId: 1\n" +
+			"                 │   │           │           │           └─ Table\n" +
+			"                 │   │           │           │               ├─ name: YK2GW\n" +
+			"                 │   │           │           │               └─ columns: [id ftqlq]\n" +
+			"                 │   │           │           └─ TableAlias(bs)\n" +
+			"                 │   │           │               └─ IndexedTableAccess(THNTS)\n" +
+			"                 │   │           │                   ├─ index: [THNTS.IXUXU]\n" +
+			"                 │   │           │                   ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                   ├─ colSet: (31-34)\n" +
+			"                 │   │           │                   ├─ tableId: 2\n" +
+			"                 │   │           │                   └─ Table\n" +
+			"                 │   │           │                       ├─ name: THNTS\n" +
+			"                 │   │           │                       └─ columns: [id ixuxu]\n" +
+			"                 │   │           └─ HashLookup\n" +
+			"                 │   │               ├─ left-key: TUPLE(w2mao.YH4XB:11!null)\n" +
+			"                 │   │               ├─ right-key: TUPLE(vc.id:0!null)\n" +
+			"                 │   │               └─ TableAlias(vc)\n" +
 			"                 │   │                   └─ Table\n" +
-			"                 │   │                       ├─ name: TPXBU\n" +
-			"                 │   │                       └─ columns: [id btxc5]\n" +
+			"                 │   │                       ├─ name: D34QP\n" +
+			"                 │   │                       ├─ columns: [id znp4p]\n" +
+			"                 │   │                       ├─ colSet: (68-73)\n" +
+			"                 │   │                       └─ tableId: 7\n" +
 			"                 │   └─ HashLookup\n" +
 			"                 │       ├─ left-key: TUPLE(oxxei.BDNYB:1!null)\n" +
 			"                 │       ├─ right-key: TUPLE(e52ap.BDNYB:1!null)\n" +
@@ -10097,12 +10049,12 @@ WHERE
 			"                 │   │   ├─ cacheable: true\n" +
 			"                 │   │   └─ Project\n" +
 			"                 │   │       ├─ columns: [cla.FTQLQ as T4IBQ, sn.id as BDNYB, aac.BTXC5 as BTXC5, mf.id as Z7CP5, CASE  WHEN (NOT(mf.LT7K6 IS NULL)) THEN mf.LT7K6 ELSE mf.SPPYD END as vaf, CASE  WHEN (NOT(mf.QCGTS IS NULL)) THEN mf.QCGTS ELSE 0.5 END as QCGTS, CASE  WHEN (vc.ZNP4P = 'L5Q44') THEN 1 ELSE 0 END as SNY4H]\n" +
-			"                 │   │       └─ LookupJoin\n" +
+			"                 │   │       └─ HashJoin\n" +
+			"                 │   │           ├─ (vc.id = w2mao.YH4XB)\n" +
 			"                 │   │           ├─ HashJoin\n" +
-			"                 │   │           │   ├─ (vc.id = w2mao.YH4XB)\n" +
+			"                 │   │           │   ├─ (mf.GXLUB = bs.id)\n" +
 			"                 │   │           │   ├─ LookupJoin\n" +
-			"                 │   │           │   │   ├─ HashJoin\n" +
-			"                 │   │           │   │   │   ├─ (mf.GXLUB = bs.id)\n" +
+			"                 │   │           │   │   ├─ LookupJoin\n" +
 			"                 │   │           │   │   │   ├─ LookupJoin\n" +
 			"                 │   │           │   │   │   │   ├─ TableAlias(sn)\n" +
 			"                 │   │           │   │   │   │   │   └─ Table\n" +
@@ -10115,40 +10067,40 @@ WHERE
 			"                 │   │           │   │   │   │               ├─ index: [HGMQ6.LUEVY]\n" +
 			"                 │   │           │   │   │   │               ├─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
 			"                 │   │           │   │   │   │               └─ keys: sn.BRQP2\n" +
-			"                 │   │           │   │   │   └─ HashLookup\n" +
-			"                 │   │           │   │   │       ├─ left-key: (mf.GXLUB)\n" +
-			"                 │   │           │   │   │       ├─ right-key: (bs.id)\n" +
-			"                 │   │           │   │   │       └─ MergeJoin\n" +
-			"                 │   │           │   │   │           ├─ cmp: (cla.id = bs.IXUXU)\n" +
-			"                 │   │           │   │   │           ├─ Filter\n" +
-			"                 │   │           │   │   │           │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
-			"                 │   │           │   │   │           │   └─ TableAlias(cla)\n" +
-			"                 │   │           │   │   │           │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                 │   │           │   │   │           │           ├─ index: [YK2GW.id]\n" +
-			"                 │   │           │   │   │           │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"                 │   │           │   │   │           │           └─ columns: [id ftqlq]\n" +
-			"                 │   │           │   │   │           └─ TableAlias(bs)\n" +
-			"                 │   │           │   │   │               └─ IndexedTableAccess(THNTS)\n" +
-			"                 │   │           │   │   │                   ├─ index: [THNTS.IXUXU]\n" +
-			"                 │   │           │   │   │                   ├─ filters: [{[NULL, ∞)}]\n" +
-			"                 │   │           │   │   │                   └─ columns: [id ixuxu]\n" +
-			"                 │   │           │   │   └─ TableAlias(w2mao)\n" +
-			"                 │   │           │   │       └─ IndexedTableAccess(SEQS3)\n" +
-			"                 │   │           │   │           ├─ index: [SEQS3.Z7CP5]\n" +
-			"                 │   │           │   │           ├─ columns: [z7cp5 yh4xb]\n" +
-			"                 │   │           │   │           └─ keys: mf.id\n" +
+			"                 │   │           │   │   │   └─ TableAlias(w2mao)\n" +
+			"                 │   │           │   │   │       └─ IndexedTableAccess(SEQS3)\n" +
+			"                 │   │           │   │   │           ├─ index: [SEQS3.Z7CP5]\n" +
+			"                 │   │           │   │   │           ├─ columns: [z7cp5 yh4xb]\n" +
+			"                 │   │           │   │   │           └─ keys: mf.id\n" +
+			"                 │   │           │   │   └─ TableAlias(aac)\n" +
+			"                 │   │           │   │       └─ IndexedTableAccess(TPXBU)\n" +
+			"                 │   │           │   │           ├─ index: [TPXBU.id]\n" +
+			"                 │   │           │   │           ├─ columns: [id btxc5]\n" +
+			"                 │   │           │   │           └─ keys: mf.M22QN\n" +
 			"                 │   │           │   └─ HashLookup\n" +
-			"                 │   │           │       ├─ left-key: (w2mao.YH4XB)\n" +
-			"                 │   │           │       ├─ right-key: (vc.id)\n" +
-			"                 │   │           │       └─ TableAlias(vc)\n" +
-			"                 │   │           │           └─ Table\n" +
-			"                 │   │           │               ├─ name: D34QP\n" +
-			"                 │   │           │               └─ columns: [id znp4p]\n" +
-			"                 │   │           └─ TableAlias(aac)\n" +
-			"                 │   │               └─ IndexedTableAccess(TPXBU)\n" +
-			"                 │   │                   ├─ index: [TPXBU.id]\n" +
-			"                 │   │                   ├─ columns: [id btxc5]\n" +
-			"                 │   │                   └─ keys: mf.M22QN\n" +
+			"                 │   │           │       ├─ left-key: (mf.GXLUB)\n" +
+			"                 │   │           │       ├─ right-key: (bs.id)\n" +
+			"                 │   │           │       └─ MergeJoin\n" +
+			"                 │   │           │           ├─ cmp: (cla.id = bs.IXUXU)\n" +
+			"                 │   │           │           ├─ Filter\n" +
+			"                 │   │           │           │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
+			"                 │   │           │           │   └─ TableAlias(cla)\n" +
+			"                 │   │           │           │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                 │   │           │           │           ├─ index: [YK2GW.id]\n" +
+			"                 │   │           │           │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │           │           └─ columns: [id ftqlq]\n" +
+			"                 │   │           │           └─ TableAlias(bs)\n" +
+			"                 │   │           │               └─ IndexedTableAccess(THNTS)\n" +
+			"                 │   │           │                   ├─ index: [THNTS.IXUXU]\n" +
+			"                 │   │           │                   ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                   └─ columns: [id ixuxu]\n" +
+			"                 │   │           └─ HashLookup\n" +
+			"                 │   │               ├─ left-key: (w2mao.YH4XB)\n" +
+			"                 │   │               ├─ right-key: (vc.id)\n" +
+			"                 │   │               └─ TableAlias(vc)\n" +
+			"                 │   │                   └─ Table\n" +
+			"                 │   │                       ├─ name: D34QP\n" +
+			"                 │   │                       └─ columns: [id znp4p]\n" +
 			"                 │   └─ HashLookup\n" +
 			"                 │       ├─ left-key: (oxxei.BDNYB)\n" +
 			"                 │       ├─ right-key: (e52ap.BDNYB)\n" +
@@ -10214,12 +10166,12 @@ WHERE
 			"                 │   │   ├─ cacheable: true\n" +
 			"                 │   │   └─ Project\n" +
 			"                 │   │       ├─ columns: [cla.FTQLQ as T4IBQ, sn.id as BDNYB, aac.BTXC5 as BTXC5, mf.id as Z7CP5, CASE  WHEN (NOT(mf.LT7K6 IS NULL)) THEN mf.LT7K6 ELSE mf.SPPYD END as vaf, CASE  WHEN (NOT(mf.QCGTS IS NULL)) THEN mf.QCGTS ELSE 0.5 END as QCGTS, CASE  WHEN (vc.ZNP4P = 'L5Q44') THEN 1 ELSE 0 END as SNY4H]\n" +
-			"                 │   │       └─ LookupJoin\n" +
+			"                 │   │       └─ HashJoin\n" +
+			"                 │   │           ├─ (vc.id = w2mao.YH4XB)\n" +
 			"                 │   │           ├─ HashJoin\n" +
-			"                 │   │           │   ├─ (vc.id = w2mao.YH4XB)\n" +
+			"                 │   │           │   ├─ (mf.GXLUB = bs.id)\n" +
 			"                 │   │           │   ├─ LookupJoin\n" +
-			"                 │   │           │   │   ├─ HashJoin\n" +
-			"                 │   │           │   │   │   ├─ (mf.GXLUB = bs.id)\n" +
+			"                 │   │           │   │   ├─ LookupJoin\n" +
 			"                 │   │           │   │   │   ├─ LookupJoin\n" +
 			"                 │   │           │   │   │   │   ├─ TableAlias(sn)\n" +
 			"                 │   │           │   │   │   │   │   └─ Table\n" +
@@ -10232,40 +10184,40 @@ WHERE
 			"                 │   │           │   │   │   │               ├─ index: [HGMQ6.LUEVY]\n" +
 			"                 │   │           │   │   │   │               ├─ columns: [id gxlub luevy m22qn fsdy2 lt7k6 sppyd qcgts]\n" +
 			"                 │   │           │   │   │   │               └─ keys: sn.BRQP2\n" +
-			"                 │   │           │   │   │   └─ HashLookup\n" +
-			"                 │   │           │   │   │       ├─ left-key: (mf.GXLUB)\n" +
-			"                 │   │           │   │   │       ├─ right-key: (bs.id)\n" +
-			"                 │   │           │   │   │       └─ MergeJoin\n" +
-			"                 │   │           │   │   │           ├─ cmp: (cla.id = bs.IXUXU)\n" +
-			"                 │   │           │   │   │           ├─ Filter\n" +
-			"                 │   │           │   │   │           │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
-			"                 │   │           │   │   │           │   └─ TableAlias(cla)\n" +
-			"                 │   │           │   │   │           │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                 │   │           │   │   │           │           ├─ index: [YK2GW.id]\n" +
-			"                 │   │           │   │   │           │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"                 │   │           │   │   │           │           └─ columns: [id ftqlq]\n" +
-			"                 │   │           │   │   │           └─ TableAlias(bs)\n" +
-			"                 │   │           │   │   │               └─ IndexedTableAccess(THNTS)\n" +
-			"                 │   │           │   │   │                   ├─ index: [THNTS.IXUXU]\n" +
-			"                 │   │           │   │   │                   ├─ filters: [{[NULL, ∞)}]\n" +
-			"                 │   │           │   │   │                   └─ columns: [id ixuxu]\n" +
-			"                 │   │           │   │   └─ TableAlias(w2mao)\n" +
-			"                 │   │           │   │       └─ IndexedTableAccess(SEQS3)\n" +
-			"                 │   │           │   │           ├─ index: [SEQS3.Z7CP5]\n" +
-			"                 │   │           │   │           ├─ columns: [z7cp5 yh4xb]\n" +
-			"                 │   │           │   │           └─ keys: mf.id\n" +
+			"                 │   │           │   │   │   └─ TableAlias(w2mao)\n" +
+			"                 │   │           │   │   │       └─ IndexedTableAccess(SEQS3)\n" +
+			"                 │   │           │   │   │           ├─ index: [SEQS3.Z7CP5]\n" +
+			"                 │   │           │   │   │           ├─ columns: [z7cp5 yh4xb]\n" +
+			"                 │   │           │   │   │           └─ keys: mf.id\n" +
+			"                 │   │           │   │   └─ TableAlias(aac)\n" +
+			"                 │   │           │   │       └─ IndexedTableAccess(TPXBU)\n" +
+			"                 │   │           │   │           ├─ index: [TPXBU.id]\n" +
+			"                 │   │           │   │           ├─ columns: [id btxc5]\n" +
+			"                 │   │           │   │           └─ keys: mf.M22QN\n" +
 			"                 │   │           │   └─ HashLookup\n" +
-			"                 │   │           │       ├─ left-key: (w2mao.YH4XB)\n" +
-			"                 │   │           │       ├─ right-key: (vc.id)\n" +
-			"                 │   │           │       └─ TableAlias(vc)\n" +
-			"                 │   │           │           └─ Table\n" +
-			"                 │   │           │               ├─ name: D34QP\n" +
-			"                 │   │           │               └─ columns: [id znp4p]\n" +
-			"                 │   │           └─ TableAlias(aac)\n" +
-			"                 │   │               └─ IndexedTableAccess(TPXBU)\n" +
-			"                 │   │                   ├─ index: [TPXBU.id]\n" +
-			"                 │   │                   ├─ columns: [id btxc5]\n" +
-			"                 │   │                   └─ keys: mf.M22QN\n" +
+			"                 │   │           │       ├─ left-key: (mf.GXLUB)\n" +
+			"                 │   │           │       ├─ right-key: (bs.id)\n" +
+			"                 │   │           │       └─ MergeJoin\n" +
+			"                 │   │           │           ├─ cmp: (cla.id = bs.IXUXU)\n" +
+			"                 │   │           │           ├─ Filter\n" +
+			"                 │   │           │           │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
+			"                 │   │           │           │   └─ TableAlias(cla)\n" +
+			"                 │   │           │           │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                 │   │           │           │           ├─ index: [YK2GW.id]\n" +
+			"                 │   │           │           │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │           │           └─ columns: [id ftqlq]\n" +
+			"                 │   │           │           └─ TableAlias(bs)\n" +
+			"                 │   │           │               └─ IndexedTableAccess(THNTS)\n" +
+			"                 │   │           │                   ├─ index: [THNTS.IXUXU]\n" +
+			"                 │   │           │                   ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                   └─ columns: [id ixuxu]\n" +
+			"                 │   │           └─ HashLookup\n" +
+			"                 │   │               ├─ left-key: (w2mao.YH4XB)\n" +
+			"                 │   │               ├─ right-key: (vc.id)\n" +
+			"                 │   │               └─ TableAlias(vc)\n" +
+			"                 │   │                   └─ Table\n" +
+			"                 │   │                       ├─ name: D34QP\n" +
+			"                 │   │                       └─ columns: [id znp4p]\n" +
 			"                 │   └─ HashLookup\n" +
 			"                 │       ├─ left-key: (oxxei.BDNYB)\n" +
 			"                 │       ├─ right-key: (e52ap.BDNYB)\n" +
@@ -17710,18 +17662,14 @@ DELETE FROM QYWQD
 WHERE id IN ('1','2','3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ qywqd.id:0!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(QYWQD)\n" +
-			"             ├─ index: [QYWQD.id]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-6)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: QYWQD\n" +
-			"                 └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
+			"     └─ IndexedTableAccess(QYWQD)\n" +
+			"         ├─ index: [QYWQD.id]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-6)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: QYWQD\n" +
+			"             └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -17752,18 +17700,14 @@ DELETE FROM QYWQD
 WHERE id IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ qywqd.id:0!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(QYWQD)\n" +
-			"             ├─ index: [QYWQD.id]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-6)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: QYWQD\n" +
-			"                 └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
+			"     └─ IndexedTableAccess(QYWQD)\n" +
+			"         ├─ index: [QYWQD.id]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-6)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: QYWQD\n" +
+			"             └─ columns: [id wnunu hhvlx hvhrz ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -17772,18 +17716,14 @@ DELETE FROM AMYXQ
 WHERE LUEVY IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ amyxq.LUEVY:2!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(AMYXQ)\n" +
-			"             ├─ index: [AMYXQ.LUEVY]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-8)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: AMYXQ\n" +
-			"                 └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
+			"     └─ IndexedTableAccess(AMYXQ)\n" +
+			"         ├─ index: [AMYXQ.LUEVY]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-8)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: AMYXQ\n" +
+			"             └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
 			"",
 	},
 	{
@@ -17792,18 +17732,14 @@ DELETE FROM HGMQ6
 WHERE id IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ hgmq6.id:0!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(HGMQ6)\n" +
-			"             ├─ index: [HGMQ6.id]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-17)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: HGMQ6\n" +
-			"                 └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
+			"     └─ IndexedTableAccess(HGMQ6)\n" +
+			"         ├─ index: [HGMQ6.id]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-17)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: HGMQ6\n" +
+			"             └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
 			"",
 	},
 	{
@@ -17812,18 +17748,14 @@ DELETE FROM HDDVB
 WHERE id IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ hddvb.id:0!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(HDDVB)\n" +
-			"             ├─ index: [HDDVB.id]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-9)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: HDDVB\n" +
-			"                 └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
+			"     └─ IndexedTableAccess(HDDVB)\n" +
+			"         ├─ index: [HDDVB.id]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-9)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: HDDVB\n" +
+			"             └─ columns: [id fv24e uj6xy m22qn nz4mq etpqv pruv2 ykssu fhcyt]\n" +
 			"",
 	},
 	{
@@ -17832,18 +17764,14 @@ DELETE FROM FLQLP
 WHERE LUEVY IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ flqlp.LUEVY:2!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(FLQLP)\n" +
-			"             ├─ index: [FLQLP.LUEVY]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-12)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: FLQLP\n" +
-			"                 └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
+			"     └─ IndexedTableAccess(FLQLP)\n" +
+			"         ├─ index: [FLQLP.LUEVY]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-12)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: FLQLP\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -17852,18 +17780,14 @@ DELETE FROM FLQLP
 WHERE id IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ flqlp.id:0!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(FLQLP)\n" +
-			"             ├─ index: [FLQLP.id]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-12)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: FLQLP\n" +
-			"                 └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
+			"     └─ IndexedTableAccess(FLQLP)\n" +
+			"         ├─ index: [FLQLP.id]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-12)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: FLQLP\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -17872,18 +17796,14 @@ DELETE FROM FLQLP
 WHERE id IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
-			"     └─ Filter\n" +
-			"         ├─ HashIn\n" +
-			"         │   ├─ flqlp.id:0!null\n" +
-			"         │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"         └─ IndexedTableAccess(FLQLP)\n" +
-			"             ├─ index: [FLQLP.id]\n" +
-			"             ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             ├─ colSet: (1-12)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: FLQLP\n" +
-			"                 └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
+			"     └─ IndexedTableAccess(FLQLP)\n" +
+			"         ├─ index: [FLQLP.id]\n" +
+			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ colSet: (1-12)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: FLQLP\n" +
+			"             └─ columns: [id fz2r5 luevy m22qn ove3e nrurt oca7e xmm6q v5dpx s3q3y zrv3b fhcyt]\n" +
 			"",
 	},
 	{
@@ -18026,18 +17946,14 @@ WHERE
 			"             │       │   ├─ alias-string: select id from JMRQL where DZLIM = 'T4IBQ'\n" +
 			"             │       │   └─ Project\n" +
 			"             │       │       ├─ columns: [jmrql.id:34!null]\n" +
-			"             │       │       └─ Filter\n" +
-			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ jmrql.DZLIM:35!null\n" +
-			"             │       │           │   └─ T4IBQ (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess(JMRQL)\n" +
-			"             │       │               ├─ index: [JMRQL.DZLIM]\n" +
-			"             │       │               ├─ static: [{[T4IBQ, T4IBQ]}]\n" +
-			"             │       │               ├─ colSet: (36-38)\n" +
-			"             │       │               ├─ tableId: 3\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: JMRQL\n" +
-			"             │       │                   └─ columns: [id dzlim]\n" +
+			"             │       │       └─ IndexedTableAccess(JMRQL)\n" +
+			"             │       │           ├─ index: [JMRQL.DZLIM]\n" +
+			"             │       │           ├─ static: [{[T4IBQ, T4IBQ]}]\n" +
+			"             │       │           ├─ colSet: (36-38)\n" +
+			"             │       │           ├─ tableId: 3\n" +
+			"             │       │           └─ Table\n" +
+			"             │       │               ├─ name: JMRQL\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as NFRYN, yk2gw.id:0!null as IXUXU, NULL (null) as FHCYT]\n" +
 			"             │       └─ Project\n" +
 			"             │           ├─ columns: [yk2gw.id:0!null, yk2gw.FTQLQ:1!null, yk2gw.TUXML:2, yk2gw.PAEF5:3, yk2gw.RUCY4:4, yk2gw.TPNJ6:5!null, yk2gw.LBL53:6, yk2gw.NB3QS:7, yk2gw.EO7IV:8, yk2gw.MUHJF:9, yk2gw.FM34L:10, yk2gw.TY5RF:11, yk2gw.ZHTLH:12, yk2gw.NPB7W:13, yk2gw.SX3HH:14, yk2gw.ISBNF:15, yk2gw.YA7YB:16, yk2gw.C5YKB:17, yk2gw.QK7KT:18, yk2gw.FFGE6:19, yk2gw.FIIGJ:20, yk2gw.SH3NC:21, yk2gw.NTENA:22, yk2gw.M4AUB:23, yk2gw.X5AIR:24, yk2gw.SAB6M:25, yk2gw.G5QI5:26, yk2gw.ZVQVD:27, yk2gw.YKSSU:28, yk2gw.FHCYT:29, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
@@ -18045,31 +17961,23 @@ WHERE
 			"             │           │   ├─ alias-string: select id from JMRQL where DZLIM = 'T4IBQ'\n" +
 			"             │           │   └─ Project\n" +
 			"             │           │       ├─ columns: [jmrql.id:30!null]\n" +
-			"             │           │       └─ Filter\n" +
-			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ jmrql.DZLIM:31!null\n" +
-			"             │           │           │   └─ T4IBQ (longtext)\n" +
-			"             │           │           └─ IndexedTableAccess(JMRQL)\n" +
-			"             │           │               ├─ index: [JMRQL.DZLIM]\n" +
-			"             │           │               ├─ static: [{[T4IBQ, T4IBQ]}]\n" +
-			"             │           │               ├─ colSet: (36-38)\n" +
-			"             │           │               ├─ tableId: 3\n" +
-			"             │           │               └─ Table\n" +
-			"             │           │                   ├─ name: JMRQL\n" +
-			"             │           │                   └─ columns: [id dzlim]\n" +
+			"             │           │       └─ IndexedTableAccess(JMRQL)\n" +
+			"             │           │           ├─ index: [JMRQL.DZLIM]\n" +
+			"             │           │           ├─ static: [{[T4IBQ, T4IBQ]}]\n" +
+			"             │           │           ├─ colSet: (36-38)\n" +
+			"             │           │           ├─ tableId: 3\n" +
+			"             │           │           └─ Table\n" +
+			"             │           │               ├─ name: JMRQL\n" +
+			"             │           │               └─ columns: [id dzlim]\n" +
 			"             │           │   as NFRYN, yk2gw.id:0!null as IXUXU, NULL (null) as FHCYT]\n" +
-			"             │           └─ Filter\n" +
-			"             │               ├─ HashIn\n" +
-			"             │               │   ├─ yk2gw.id:0!null\n" +
-			"             │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               └─ IndexedTableAccess(YK2GW)\n" +
-			"             │                   ├─ index: [YK2GW.id]\n" +
-			"             │                   ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                   ├─ colSet: (5-34)\n" +
-			"             │                   ├─ tableId: 2\n" +
-			"             │                   └─ Table\n" +
-			"             │                       ├─ name: YK2GW\n" +
-			"             │                       └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"             │           └─ IndexedTableAccess(YK2GW)\n" +
+			"             │               ├─ index: [YK2GW.id]\n" +
+			"             │               ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │               ├─ colSet: (5-34)\n" +
+			"             │               ├─ tableId: 2\n" +
+			"             │               └─ Table\n" +
+			"             │                   ├─ name: YK2GW\n" +
+			"             │                   └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(new.IXUXU:2 IS NULL)\n" +
@@ -18267,18 +18175,14 @@ WHERE
 			"             │   ├─ columns: [id:0!null, QZ7E7:1!null, SSHPJ:2!null, FHCYT:3]\n" +
 			"             │   └─ Project\n" +
 			"             │       ├─ columns: [tdrvg.id:0!null, tdrvg.SFJ6L:2!null, tdrvg.SSHPJ:1!null, NULL (null) as FHCYT]\n" +
-			"             │       └─ Filter\n" +
-			"             │           ├─ HashIn\n" +
-			"             │           │   ├─ tdrvg.id:0!null\n" +
-			"             │           │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │           └─ IndexedTableAccess(TDRVG)\n" +
-			"             │               ├─ index: [TDRVG.id]\n" +
-			"             │               ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │               ├─ colSet: (5-9)\n" +
-			"             │               ├─ tableId: 2\n" +
-			"             │               └─ Table\n" +
-			"             │                   ├─ name: TDRVG\n" +
-			"             │                   └─ columns: [id sshpj sfj6l]\n" +
+			"             │       └─ IndexedTableAccess(TDRVG)\n" +
+			"             │           ├─ index: [TDRVG.id]\n" +
+			"             │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │           ├─ colSet: (5-9)\n" +
+			"             │           ├─ tableId: 2\n" +
+			"             │           └─ Table\n" +
+			"             │               ├─ name: TDRVG\n" +
+			"             │               └─ columns: [id sshpj sfj6l]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 └─ IF BLOCK\n" +
 			"                     └─ IF(Or\n" +
@@ -18473,39 +18377,41 @@ WHERE
 			"             │           │   ├─ ybbg5.DZLIM:29!null\n" +
 			"             │           │   └─ DN3OQ (longtext)\n" +
 			"             │           │   THEN (ufc.DN3OQ:6 + 0 (decimal(2,1))) ELSE NULL (null) END as OZTQF, (ufc.SRZZO:9 + 0 (decimal(2,1))) as Z35GY, ufc.id:0!null as KKGN5]\n" +
-			"             │           └─ LookupJoin\n" +
-			"             │               ├─ LookupJoin\n" +
-			"             │               │   ├─ Filter\n" +
-			"             │               │   │   ├─ HashIn\n" +
-			"             │               │   │   │   ├─ ufc.id:0!null\n" +
-			"             │               │   │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               │   │   └─ TableAlias(ufc)\n" +
-			"             │               │   │       └─ IndexedTableAccess(SISUT)\n" +
-			"             │               │   │           ├─ index: [SISUT.id]\n" +
-			"             │               │   │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │               │   │           ├─ colSet: (9-19)\n" +
-			"             │               │   │           ├─ tableId: 2\n" +
-			"             │               │   │           └─ Table\n" +
-			"             │               │   │               ├─ name: SISUT\n" +
-			"             │               │   │               └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
-			"             │               │   └─ TableAlias(nd)\n" +
-			"             │               │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │               │           ├─ index: [E2I7U.ZH72S]\n" +
-			"             │               │           ├─ keys: [ufc.ZH72S:2]\n" +
-			"             │               │           ├─ colSet: (20-36)\n" +
-			"             │               │           ├─ tableId: 3\n" +
-			"             │               │           └─ Table\n" +
-			"             │               │               ├─ name: E2I7U\n" +
-			"             │               │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │               └─ TableAlias(ybbg5)\n" +
-			"             │                   └─ IndexedTableAccess(XGSJM)\n" +
-			"             │                       ├─ index: [XGSJM.id]\n" +
-			"             │                       ├─ keys: [nd.XQDYT:20!null]\n" +
-			"             │                       ├─ colSet: (37-39)\n" +
-			"             │                       ├─ tableId: 4\n" +
-			"             │                       └─ Table\n" +
-			"             │                           ├─ name: XGSJM\n" +
-			"             │                           └─ columns: [id dzlim f3yue]\n" +
+			"             │           └─ InnerJoin\n" +
+			"             │               ├─ Eq\n" +
+			"             │               │   ├─ nd.ZH72S:18\n" +
+			"             │               │   └─ ufc.ZH72S:2\n" +
+			"             │               ├─ TableAlias(ufc)\n" +
+			"             │               │   └─ IndexedTableAccess(SISUT)\n" +
+			"             │               │       ├─ index: [SISUT.id]\n" +
+			"             │               │       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │               │       ├─ colSet: (9-19)\n" +
+			"             │               │       ├─ tableId: 2\n" +
+			"             │               │       └─ Table\n" +
+			"             │               │           ├─ name: SISUT\n" +
+			"             │               │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
+			"             │               └─ MergeJoin\n" +
+			"             │                   ├─ cmp: Eq\n" +
+			"             │                   │   ├─ nd.XQDYT:20!null\n" +
+			"             │                   │   └─ ybbg5.id:28!null\n" +
+			"             │                   ├─ TableAlias(nd)\n" +
+			"             │                   │   └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                   │       ├─ index: [E2I7U.XQDYT]\n" +
+			"             │                   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                   │       ├─ colSet: (20-36)\n" +
+			"             │                   │       ├─ tableId: 3\n" +
+			"             │                   │       └─ Table\n" +
+			"             │                   │           ├─ name: E2I7U\n" +
+			"             │                   │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"             │                   └─ TableAlias(ybbg5)\n" +
+			"             │                       └─ IndexedTableAccess(XGSJM)\n" +
+			"             │                           ├─ index: [XGSJM.id]\n" +
+			"             │                           ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                           ├─ colSet: (37-39)\n" +
+			"             │                           ├─ tableId: 4\n" +
+			"             │                           └─ Table\n" +
+			"             │                               ├─ name: XGSJM\n" +
+			"             │                               └─ columns: [id dzlim f3yue]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(Subquery\n" +
@@ -18628,18 +18534,14 @@ WHERE
 			"             │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'NER'\n" +
 			"             │       │   └─ Project\n" +
 			"             │       │       ├─ columns: [xoaop.id:12!null]\n" +
-			"             │       │       └─ Filter\n" +
-			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ xoaop.DZLIM:13!null\n" +
-			"             │       │           │   └─ NER (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │       │               ├─ static: [{[NER, NER]}]\n" +
-			"             │       │               ├─ colSet: (49-51)\n" +
-			"             │       │               ├─ tableId: 5\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ columns: [id dzlim]\n" +
+			"             │       │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │       │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │       │           ├─ static: [{[NER, NER]}]\n" +
+			"             │       │           ├─ colSet: (49-51)\n" +
+			"             │       │           ├─ tableId: 5\n" +
+			"             │       │           └─ Table\n" +
+			"             │       │               ├─ name: XOAOP\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.ner:2\n" +
 			"             │       │   └─ 0.5 (decimal(2,1))\n" +
@@ -18684,18 +18586,14 @@ WHERE
 			"             │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'NER'\n" +
 			"             │           │   └─ Project\n" +
 			"             │           │       ├─ columns: [xoaop.id:7!null]\n" +
-			"             │           │       └─ Filter\n" +
-			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ xoaop.DZLIM:8!null\n" +
-			"             │           │           │   └─ NER (longtext)\n" +
-			"             │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │           │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │           │               ├─ static: [{[NER, NER]}]\n" +
-			"             │           │               ├─ colSet: (49-51)\n" +
-			"             │           │               ├─ tableId: 5\n" +
-			"             │           │               └─ Table\n" +
-			"             │           │                   ├─ name: XOAOP\n" +
-			"             │           │                   └─ columns: [id dzlim]\n" +
+			"             │           │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │           │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │           │           ├─ static: [{[NER, NER]}]\n" +
+			"             │           │           ├─ colSet: (49-51)\n" +
+			"             │           │           ├─ tableId: 5\n" +
+			"             │           │           └─ Table\n" +
+			"             │           │               ├─ name: XOAOP\n" +
+			"             │           │               └─ columns: [id dzlim]\n" +
 			"             │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │           │   ├─ ums.ner:2\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
@@ -18703,19 +18601,15 @@ WHERE
 			"             │           │   ├─ ums.ner:2\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
 			"             │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
-			"             │           └─ Filter\n" +
-			"             │               ├─ HashIn\n" +
-			"             │               │   ├─ ums.id:0!null\n" +
-			"             │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               └─ TableAlias(ums)\n" +
-			"             │                   └─ IndexedTableAccess(FG26Y)\n" +
-			"             │                       ├─ index: [FG26Y.id]\n" +
-			"             │                       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                       ├─ colSet: (6-12)\n" +
-			"             │                       ├─ tableId: 2\n" +
-			"             │                       └─ Table\n" +
-			"             │                           ├─ name: FG26Y\n" +
-			"             │                           └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
+			"             │           └─ TableAlias(ums)\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
+			"             │                   ├─ index: [FG26Y.id]\n" +
+			"             │                   ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                   ├─ colSet: (6-12)\n" +
+			"             │                   ├─ tableId: 2\n" +
+			"             │                   └─ Table\n" +
+			"             │                       ├─ name: FG26Y\n" +
+			"             │                       └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(NOT\n" +
@@ -18834,18 +18728,14 @@ WHERE
 			"             │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'BER'\n" +
 			"             │       │   └─ Project\n" +
 			"             │       │       ├─ columns: [xoaop.id:12!null]\n" +
-			"             │       │       └─ Filter\n" +
-			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ xoaop.DZLIM:13!null\n" +
-			"             │       │           │   └─ BER (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │       │               ├─ static: [{[BER, BER]}]\n" +
-			"             │       │               ├─ colSet: (49-51)\n" +
-			"             │       │               ├─ tableId: 5\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ columns: [id dzlim]\n" +
+			"             │       │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │       │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │       │           ├─ static: [{[BER, BER]}]\n" +
+			"             │       │           ├─ colSet: (49-51)\n" +
+			"             │       │           ├─ tableId: 5\n" +
+			"             │       │           └─ Table\n" +
+			"             │       │               ├─ name: XOAOP\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.ber:3\n" +
 			"             │       │   └─ 0.5 (decimal(2,1))\n" +
@@ -18890,18 +18780,14 @@ WHERE
 			"             │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'BER'\n" +
 			"             │           │   └─ Project\n" +
 			"             │           │       ├─ columns: [xoaop.id:7!null]\n" +
-			"             │           │       └─ Filter\n" +
-			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ xoaop.DZLIM:8!null\n" +
-			"             │           │           │   └─ BER (longtext)\n" +
-			"             │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │           │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │           │               ├─ static: [{[BER, BER]}]\n" +
-			"             │           │               ├─ colSet: (49-51)\n" +
-			"             │           │               ├─ tableId: 5\n" +
-			"             │           │               └─ Table\n" +
-			"             │           │                   ├─ name: XOAOP\n" +
-			"             │           │                   └─ columns: [id dzlim]\n" +
+			"             │           │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │           │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │           │           ├─ static: [{[BER, BER]}]\n" +
+			"             │           │           ├─ colSet: (49-51)\n" +
+			"             │           │           ├─ tableId: 5\n" +
+			"             │           │           └─ Table\n" +
+			"             │           │               ├─ name: XOAOP\n" +
+			"             │           │               └─ columns: [id dzlim]\n" +
 			"             │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │           │   ├─ ums.ber:3\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
@@ -18909,19 +18795,15 @@ WHERE
 			"             │           │   ├─ ums.ber:3\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
 			"             │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
-			"             │           └─ Filter\n" +
-			"             │               ├─ HashIn\n" +
-			"             │               │   ├─ ums.id:0!null\n" +
-			"             │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               └─ TableAlias(ums)\n" +
-			"             │                   └─ IndexedTableAccess(FG26Y)\n" +
-			"             │                       ├─ index: [FG26Y.id]\n" +
-			"             │                       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                       ├─ colSet: (6-12)\n" +
-			"             │                       ├─ tableId: 2\n" +
-			"             │                       └─ Table\n" +
-			"             │                           ├─ name: FG26Y\n" +
-			"             │                           └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
+			"             │           └─ TableAlias(ums)\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
+			"             │                   ├─ index: [FG26Y.id]\n" +
+			"             │                   ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                   ├─ colSet: (6-12)\n" +
+			"             │                   ├─ tableId: 2\n" +
+			"             │                   └─ Table\n" +
+			"             │                       ├─ name: FG26Y\n" +
+			"             │                       └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(NOT\n" +
@@ -19040,18 +18922,14 @@ WHERE
 			"             │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'HR'\n" +
 			"             │       │   └─ Project\n" +
 			"             │       │       ├─ columns: [xoaop.id:12!null]\n" +
-			"             │       │       └─ Filter\n" +
-			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ xoaop.DZLIM:13!null\n" +
-			"             │       │           │   └─ HR (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │       │               ├─ static: [{[HR, HR]}]\n" +
-			"             │       │               ├─ colSet: (49-51)\n" +
-			"             │       │               ├─ tableId: 5\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ columns: [id dzlim]\n" +
+			"             │       │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │       │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │       │           ├─ static: [{[HR, HR]}]\n" +
+			"             │       │           ├─ colSet: (49-51)\n" +
+			"             │       │           ├─ tableId: 5\n" +
+			"             │       │           └─ Table\n" +
+			"             │       │               ├─ name: XOAOP\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.hr:4\n" +
 			"             │       │   └─ 0.5 (decimal(2,1))\n" +
@@ -19096,18 +18974,14 @@ WHERE
 			"             │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'HR'\n" +
 			"             │           │   └─ Project\n" +
 			"             │           │       ├─ columns: [xoaop.id:7!null]\n" +
-			"             │           │       └─ Filter\n" +
-			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ xoaop.DZLIM:8!null\n" +
-			"             │           │           │   └─ HR (longtext)\n" +
-			"             │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │           │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │           │               ├─ static: [{[HR, HR]}]\n" +
-			"             │           │               ├─ colSet: (49-51)\n" +
-			"             │           │               ├─ tableId: 5\n" +
-			"             │           │               └─ Table\n" +
-			"             │           │                   ├─ name: XOAOP\n" +
-			"             │           │                   └─ columns: [id dzlim]\n" +
+			"             │           │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │           │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │           │           ├─ static: [{[HR, HR]}]\n" +
+			"             │           │           ├─ colSet: (49-51)\n" +
+			"             │           │           ├─ tableId: 5\n" +
+			"             │           │           └─ Table\n" +
+			"             │           │               ├─ name: XOAOP\n" +
+			"             │           │               └─ columns: [id dzlim]\n" +
 			"             │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │           │   ├─ ums.hr:4\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
@@ -19115,19 +18989,15 @@ WHERE
 			"             │           │   ├─ ums.hr:4\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
 			"             │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
-			"             │           └─ Filter\n" +
-			"             │               ├─ HashIn\n" +
-			"             │               │   ├─ ums.id:0!null\n" +
-			"             │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               └─ TableAlias(ums)\n" +
-			"             │                   └─ IndexedTableAccess(FG26Y)\n" +
-			"             │                       ├─ index: [FG26Y.id]\n" +
-			"             │                       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                       ├─ colSet: (6-12)\n" +
-			"             │                       ├─ tableId: 2\n" +
-			"             │                       └─ Table\n" +
-			"             │                           ├─ name: FG26Y\n" +
-			"             │                           └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
+			"             │           └─ TableAlias(ums)\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
+			"             │                   ├─ index: [FG26Y.id]\n" +
+			"             │                   ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                   ├─ colSet: (6-12)\n" +
+			"             │                   ├─ tableId: 2\n" +
+			"             │                   └─ Table\n" +
+			"             │                       ├─ name: FG26Y\n" +
+			"             │                       └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(NOT\n" +
@@ -19246,18 +19116,14 @@ WHERE
 			"             │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'MMR'\n" +
 			"             │       │   └─ Project\n" +
 			"             │       │       ├─ columns: [xoaop.id:12!null]\n" +
-			"             │       │       └─ Filter\n" +
-			"             │       │           ├─ Eq\n" +
-			"             │       │           │   ├─ xoaop.DZLIM:13!null\n" +
-			"             │       │           │   └─ MMR (longtext)\n" +
-			"             │       │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │       │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │       │               ├─ static: [{[MMR, MMR]}]\n" +
-			"             │       │               ├─ colSet: (49-51)\n" +
-			"             │       │               ├─ tableId: 5\n" +
-			"             │       │               └─ Table\n" +
-			"             │       │                   ├─ name: XOAOP\n" +
-			"             │       │                   └─ columns: [id dzlim]\n" +
+			"             │       │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │       │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │       │           ├─ static: [{[MMR, MMR]}]\n" +
+			"             │       │           ├─ colSet: (49-51)\n" +
+			"             │       │           ├─ tableId: 5\n" +
+			"             │       │           └─ Table\n" +
+			"             │       │               ├─ name: XOAOP\n" +
+			"             │       │               └─ columns: [id dzlim]\n" +
 			"             │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │       │   ├─ ums.mmr:5\n" +
 			"             │       │   └─ 0.5 (decimal(2,1))\n" +
@@ -19302,18 +19168,14 @@ WHERE
 			"             │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'MMR'\n" +
 			"             │           │   └─ Project\n" +
 			"             │           │       ├─ columns: [xoaop.id:7!null]\n" +
-			"             │           │       └─ Filter\n" +
-			"             │           │           ├─ Eq\n" +
-			"             │           │           │   ├─ xoaop.DZLIM:8!null\n" +
-			"             │           │           │   └─ MMR (longtext)\n" +
-			"             │           │           └─ IndexedTableAccess(XOAOP)\n" +
-			"             │           │               ├─ index: [XOAOP.DZLIM]\n" +
-			"             │           │               ├─ static: [{[MMR, MMR]}]\n" +
-			"             │           │               ├─ colSet: (49-51)\n" +
-			"             │           │               ├─ tableId: 5\n" +
-			"             │           │               └─ Table\n" +
-			"             │           │                   ├─ name: XOAOP\n" +
-			"             │           │                   └─ columns: [id dzlim]\n" +
+			"             │           │       └─ IndexedTableAccess(XOAOP)\n" +
+			"             │           │           ├─ index: [XOAOP.DZLIM]\n" +
+			"             │           │           ├─ static: [{[MMR, MMR]}]\n" +
+			"             │           │           ├─ colSet: (49-51)\n" +
+			"             │           │           ├─ tableId: 5\n" +
+			"             │           │           └─ Table\n" +
+			"             │           │               ├─ name: XOAOP\n" +
+			"             │           │               └─ columns: [id dzlim]\n" +
 			"             │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
 			"             │           │   ├─ ums.mmr:5\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
@@ -19321,19 +19183,15 @@ WHERE
 			"             │           │   ├─ ums.mmr:5\n" +
 			"             │           │   └─ 0.5 (decimal(2,1))\n" +
 			"             │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
-			"             │           └─ Filter\n" +
-			"             │               ├─ HashIn\n" +
-			"             │               │   ├─ ums.id:0!null\n" +
-			"             │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               └─ TableAlias(ums)\n" +
-			"             │                   └─ IndexedTableAccess(FG26Y)\n" +
-			"             │                       ├─ index: [FG26Y.id]\n" +
-			"             │                       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                       ├─ colSet: (6-12)\n" +
-			"             │                       ├─ tableId: 2\n" +
-			"             │                       └─ Table\n" +
-			"             │                           ├─ name: FG26Y\n" +
-			"             │                           └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
+			"             │           └─ TableAlias(ums)\n" +
+			"             │               └─ IndexedTableAccess(FG26Y)\n" +
+			"             │                   ├─ index: [FG26Y.id]\n" +
+			"             │                   ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                   ├─ colSet: (6-12)\n" +
+			"             │                   ├─ tableId: 2\n" +
+			"             │                   └─ Table\n" +
+			"             │                       ├─ name: FG26Y\n" +
+			"             │                       └─ columns: [id t4ibq ner ber hr mmr qz6vt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(NOT\n" +
@@ -19428,30 +19286,26 @@ WHERE
 			"             │                   └─ Filter\n" +
 			"             │                       ├─ AND\n" +
 			"             │                       │   ├─ AND\n" +
-			"             │                       │   │   ├─ AND\n" +
-			"             │                       │   │   │   ├─ NOT\n" +
-			"             │                       │   │   │   │   └─ InSubquery\n" +
-			"             │                       │   │   │   │       ├─ left: umf.SYPKF:8\n" +
-			"             │                       │   │   │   │       └─ right: Subquery\n" +
-			"             │                       │   │   │   │           ├─ cacheable: true\n" +
-			"             │                       │   │   │   │           ├─ alias-string: select BTXC5 from TPXBU where BTXC5 is not null\n" +
-			"             │                       │   │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
-			"             │                       │   │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
-			"             │                       │   │   │   │               ├─ static: [{(NULL, ∞)}]\n" +
-			"             │                       │   │   │   │               ├─ colSet: (29-31)\n" +
-			"             │                       │   │   │   │               ├─ tableId: 3\n" +
-			"             │                       │   │   │   │               └─ Table\n" +
-			"             │                       │   │   │   │                   ├─ name: TPXBU\n" +
-			"             │                       │   │   │   │                   └─ columns: [btxc5]\n" +
-			"             │                       │   │   │   └─ NOT\n" +
-			"             │                       │   │   │       └─ umf.SYPKF:8 IS NULL\n" +
+			"             │                       │   │   ├─ NOT\n" +
+			"             │                       │   │   │   └─ InSubquery\n" +
+			"             │                       │   │   │       ├─ left: umf.SYPKF:8\n" +
+			"             │                       │   │   │       └─ right: Subquery\n" +
+			"             │                       │   │   │           ├─ cacheable: true\n" +
+			"             │                       │   │   │           ├─ alias-string: select BTXC5 from TPXBU where BTXC5 is not null\n" +
+			"             │                       │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
+			"             │                       │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
+			"             │                       │   │   │               ├─ static: [{(NULL, ∞)}]\n" +
+			"             │                       │   │   │               ├─ colSet: (29-31)\n" +
+			"             │                       │   │   │               ├─ tableId: 3\n" +
+			"             │                       │   │   │               └─ Table\n" +
+			"             │                       │   │   │                   ├─ name: TPXBU\n" +
+			"             │                       │   │   │                   └─ columns: [btxc5]\n" +
 			"             │                       │   │   └─ NOT\n" +
-			"             │                       │   │       └─ Eq\n" +
-			"             │                       │   │           ├─ umf.SYPKF:8\n" +
-			"             │                       │   │           └─ N/A (longtext)\n" +
-			"             │                       │   └─ HashIn\n" +
-			"             │                       │       ├─ umf.id:0!null\n" +
-			"             │                       │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
+			"             │                       │   │       └─ umf.SYPKF:8 IS NULL\n" +
+			"             │                       │   └─ NOT\n" +
+			"             │                       │       └─ Eq\n" +
+			"             │                       │           ├─ umf.SYPKF:8\n" +
+			"             │                       │           └─ N/A (longtext)\n" +
 			"             │                       └─ TableAlias(umf)\n" +
 			"             │                           └─ IndexedTableAccess(NZKPM)\n" +
 			"             │                               ├─ index: [NZKPM.id]\n" +
@@ -19819,33 +19673,29 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"             │               │   │   │   └─ Filter\n" +
 			"             │               │   │   │       ├─ AND\n" +
 			"             │               │   │   │       │   ├─ AND\n" +
-			"             │               │   │   │       │   │   ├─ AND\n" +
-			"             │               │   │   │       │   │   │   ├─ InSubquery\n" +
-			"             │               │   │   │       │   │   │   │   ├─ left: nzkpm.T4IBQ:1\n" +
-			"             │               │   │   │       │   │   │   │   └─ right: Subquery\n" +
-			"             │               │   │   │       │   │   │   │       ├─ cacheable: true\n" +
-			"             │               │   │   │       │   │   │   │       ├─ alias-string: select FTQLQ from YK2GW\n" +
-			"             │               │   │   │       │   │   │   │       └─ Table\n" +
-			"             │               │   │   │       │   │   │   │           ├─ name: YK2GW\n" +
-			"             │               │   │   │       │   │   │   │           ├─ columns: [ftqlq]\n" +
-			"             │               │   │   │       │   │   │   │           ├─ colSet: (43-72)\n" +
-			"             │               │   │   │       │   │   │   │           └─ tableId: 3\n" +
-			"             │               │   │   │       │   │   │   └─ InSubquery\n" +
-			"             │               │   │   │       │   │   │       ├─ left: nzkpm.FGG57:2\n" +
-			"             │               │   │   │       │   │   │       └─ right: Subquery\n" +
-			"             │               │   │   │       │   │   │           ├─ cacheable: true\n" +
-			"             │               │   │   │       │   │   │           ├─ alias-string: select FGG57 from E2I7U where FGG57 is not null\n" +
-			"             │               │   │   │       │   │   │           └─ IndexedTableAccess(E2I7U)\n" +
-			"             │               │   │   │       │   │   │               ├─ index: [E2I7U.FGG57]\n" +
-			"             │               │   │   │       │   │   │               ├─ static: [{(NULL, ∞)}]\n" +
-			"             │               │   │   │       │   │   │               ├─ colSet: (73-89)\n" +
-			"             │               │   │   │       │   │   │               ├─ tableId: 4\n" +
-			"             │               │   │   │       │   │   │               └─ Table\n" +
-			"             │               │   │   │       │   │   │                   ├─ name: E2I7U\n" +
-			"             │               │   │   │       │   │   │                   └─ columns: [fgg57]\n" +
-			"             │               │   │   │       │   │   └─ HashIn\n" +
-			"             │               │   │   │       │   │       ├─ nzkpm.id:0!null\n" +
-			"             │               │   │   │       │   │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
+			"             │               │   │   │       │   │   ├─ InSubquery\n" +
+			"             │               │   │   │       │   │   │   ├─ left: nzkpm.T4IBQ:1\n" +
+			"             │               │   │   │       │   │   │   └─ right: Subquery\n" +
+			"             │               │   │   │       │   │   │       ├─ cacheable: true\n" +
+			"             │               │   │   │       │   │   │       ├─ alias-string: select FTQLQ from YK2GW\n" +
+			"             │               │   │   │       │   │   │       └─ Table\n" +
+			"             │               │   │   │       │   │   │           ├─ name: YK2GW\n" +
+			"             │               │   │   │       │   │   │           ├─ columns: [ftqlq]\n" +
+			"             │               │   │   │       │   │   │           ├─ colSet: (43-72)\n" +
+			"             │               │   │   │       │   │   │           └─ tableId: 3\n" +
+			"             │               │   │   │       │   │   └─ InSubquery\n" +
+			"             │               │   │   │       │   │       ├─ left: nzkpm.FGG57:2\n" +
+			"             │               │   │   │       │   │       └─ right: Subquery\n" +
+			"             │               │   │   │       │   │           ├─ cacheable: true\n" +
+			"             │               │   │   │       │   │           ├─ alias-string: select FGG57 from E2I7U where FGG57 is not null\n" +
+			"             │               │   │   │       │   │           └─ IndexedTableAccess(E2I7U)\n" +
+			"             │               │   │   │       │   │               ├─ index: [E2I7U.FGG57]\n" +
+			"             │               │   │   │       │   │               ├─ static: [{(NULL, ∞)}]\n" +
+			"             │               │   │   │       │   │               ├─ colSet: (73-89)\n" +
+			"             │               │   │   │       │   │               ├─ tableId: 4\n" +
+			"             │               │   │   │       │   │               └─ Table\n" +
+			"             │               │   │   │       │   │                   ├─ name: E2I7U\n" +
+			"             │               │   │   │       │   │                   └─ columns: [fgg57]\n" +
 			"             │               │   │   │       │   └─ NOT\n" +
 			"             │               │   │   │       │       └─ Eq\n" +
 			"             │               │   │   │       │           ├─ nzkpm.ARN5P:7\n" +
@@ -20021,19 +19871,15 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			"                             ├─ Eq\n" +
 			"                             │   ├─ umf.id:0!null\n" +
 			"                             │   └─ mf.TEUJA:3\n" +
-			"                             ├─ Filter\n" +
-			"                             │   ├─ HashIn\n" +
-			"                             │   │   ├─ umf.id:0!null\n" +
-			"                             │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"                             │   └─ TableAlias(umf)\n" +
-			"                             │       └─ IndexedTableAccess(NZKPM)\n" +
-			"                             │           ├─ index: [NZKPM.id]\n" +
-			"                             │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"                             │           ├─ colSet: (21-45)\n" +
-			"                             │           ├─ tableId: 3\n" +
-			"                             │           └─ Table\n" +
-			"                             │               ├─ name: NZKPM\n" +
-			"                             │               └─ columns: [id az6sp]\n" +
+			"                             ├─ TableAlias(umf)\n" +
+			"                             │   └─ IndexedTableAccess(NZKPM)\n" +
+			"                             │       ├─ index: [NZKPM.id]\n" +
+			"                             │       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"                             │       ├─ colSet: (21-45)\n" +
+			"                             │       ├─ tableId: 3\n" +
+			"                             │       └─ Table\n" +
+			"                             │           ├─ name: NZKPM\n" +
+			"                             │           └─ columns: [id az6sp]\n" +
 			"                             └─ TableAlias(mf)\n" +
 			"                                 └─ Table\n" +
 			"                                     ├─ name: HGMQ6\n" +
@@ -20198,7 +20044,7 @@ FROM
 			"             │                   │                   └─ tableId: 8\n" +
 			"             │                   │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU]\n" +
 			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [tizhk.id:0!null, tizhk.TVNW2:1, tizhk.ZHITY:2, tizhk.SYPKF:3, tizhk.IDUT2:4, tizhk.O6QJ3:5, tizhk.NO2JA:6, tizhk.YKSSU:7, tizhk.FHCYT:8, tizhk.QZ6VT:9, nhmxw.id:10!null, nhmxw.NOHHR:11!null, nhmxw.AVPYF:12!null, nhmxw.SYPKF:13!null, nhmxw.IDUT2:14!null, nhmxw.FZXV5:15, nhmxw.DQYGV:16, nhmxw.SWCQV:17!null, nhmxw.YKSSU:18, nhmxw.FHCYT:19, j4jyp.id:20!null, j4jyp.DKCAJ:21!null, j4jyp.KNG7T:22, j4jyp.TW55N:23!null, j4jyp.QRQXW:24!null, j4jyp.ECXAJ:25!null, j4jyp.FGG57:26, j4jyp.ZH72S:27, j4jyp.FSK67:28!null, j4jyp.XQDYT:29!null, j4jyp.TCE7A:30, j4jyp.IWV2H:31, j4jyp.HPCMS:32!null, j4jyp.N5CC2:33, j4jyp.FHCYT:34, j4jyp.ETAQ7:35, j4jyp.A75X7:36, rhuzn.id:37!null, rhuzn.DKCAJ:38!null, rhuzn.KNG7T:39, rhuzn.TW55N:40!null, rhuzn.QRQXW:41!null, rhuzn.ECXAJ:42!null, rhuzn.FGG57:43, rhuzn.ZH72S:44, rhuzn.FSK67:45!null, rhuzn.XQDYT:46!null, rhuzn.TCE7A:47, rhuzn.IWV2H:48, rhuzn.HPCMS:49!null, rhuzn.N5CC2:50, rhuzn.FHCYT:51, rhuzn.ETAQ7:52, rhuzn.A75X7:53, mf.id:54!null, mf.GXLUB:55!null, mf.LUEVY:56!null, mf.M22QN:57!null, mf.TJPT7:58!null, mf.ARN5P:59!null, mf.XOSD4:60!null, mf.IDE43:61, mf.HMW4H:62, mf.ZBT6R:63, mf.FSDY2:64!null, mf.LT7K6:65, mf.SPPYD:66, mf.QCGTS:67, mf.TEUJA:68, mf.QQV4M:69, mf.FHCYT:70, aac.id:71!null, aac.BTXC5:72, aac.FHCYT:73, tizhk.id:0!null as MU3KG, j4jyp.id:20!null as FV24E, rhuzn.id:37!null as UJ6XY, aac.id:71!null as M22QN, Subquery\n" +
+			"             │                       ├─ columns: [tizhk.id:0!null, tizhk.TVNW2:1, tizhk.ZHITY:2, tizhk.SYPKF:3, tizhk.IDUT2:4, tizhk.O6QJ3:5, tizhk.NO2JA:6, tizhk.YKSSU:7, tizhk.FHCYT:8, tizhk.QZ6VT:9, nhmxw.id:10!null, nhmxw.NOHHR:11!null, nhmxw.AVPYF:12!null, nhmxw.SYPKF:13!null, nhmxw.IDUT2:14!null, nhmxw.FZXV5:15, nhmxw.DQYGV:16, nhmxw.SWCQV:17!null, nhmxw.YKSSU:18, nhmxw.FHCYT:19, j4jyp.id:20!null, j4jyp.DKCAJ:21!null, j4jyp.KNG7T:22, j4jyp.TW55N:23!null, j4jyp.QRQXW:24!null, j4jyp.ECXAJ:25!null, j4jyp.FGG57:26, j4jyp.ZH72S:27, j4jyp.FSK67:28!null, j4jyp.XQDYT:29!null, j4jyp.TCE7A:30, j4jyp.IWV2H:31, j4jyp.HPCMS:32!null, j4jyp.N5CC2:33, j4jyp.FHCYT:34, j4jyp.ETAQ7:35, j4jyp.A75X7:36, rhuzn.id:57!null, rhuzn.DKCAJ:58!null, rhuzn.KNG7T:59, rhuzn.TW55N:60!null, rhuzn.QRQXW:61!null, rhuzn.ECXAJ:62!null, rhuzn.FGG57:63, rhuzn.ZH72S:64, rhuzn.FSK67:65!null, rhuzn.XQDYT:66!null, rhuzn.TCE7A:67, rhuzn.IWV2H:68, rhuzn.HPCMS:69!null, rhuzn.N5CC2:70, rhuzn.FHCYT:71, rhuzn.ETAQ7:72, rhuzn.A75X7:73, mf.id:37!null, mf.GXLUB:38!null, mf.LUEVY:39!null, mf.M22QN:40!null, mf.TJPT7:41!null, mf.ARN5P:42!null, mf.XOSD4:43!null, mf.IDE43:44, mf.HMW4H:45, mf.ZBT6R:46, mf.FSDY2:47!null, mf.LT7K6:48, mf.SPPYD:49, mf.QCGTS:50, mf.TEUJA:51, mf.QQV4M:52, mf.FHCYT:53, aac.id:54!null, aac.BTXC5:55, aac.FHCYT:56, tizhk.id:0!null as MU3KG, j4jyp.id:20!null as FV24E, rhuzn.id:57!null as UJ6XY, aac.id:54!null as M22QN, Subquery\n" +
 			"             │                       │   ├─ cacheable: false\n" +
 			"             │                       │   ├─ alias-string: select G3YXS.id from YYBCX as G3YXS where CONCAT(G3YXS.ESFVY, '(MI:', G3YXS.SL76B, ')') = TIZHK.IDUT2\n" +
 			"             │                       │   └─ Project\n" +
@@ -20217,20 +20063,24 @@ FROM
 			"             │                       └─ Filter\n" +
 			"             │                           ├─ AND\n" +
 			"             │                           │   ├─ Eq\n" +
-			"             │                           │   │   ├─ aac.BTXC5:72\n" +
+			"             │                           │   │   ├─ aac.BTXC5:55\n" +
 			"             │                           │   │   └─ tizhk.SYPKF:3\n" +
 			"             │                           │   └─ nhmxw.id:10!null IS NULL\n" +
 			"             │                           └─ LookupJoin\n" +
 			"             │                               ├─ LookupJoin\n" +
 			"             │                               │   ├─ LookupJoin\n" +
 			"             │                               │   │   ├─ LookupJoin\n" +
-			"             │                               │   │   │   ├─ LeftOuterLookupJoin\n" +
+			"             │                               │   │   │   ├─ LeftOuterJoin\n" +
 			"             │                               │   │   │   │   ├─ AND\n" +
 			"             │                               │   │   │   │   │   ├─ AND\n" +
 			"             │                               │   │   │   │   │   │   ├─ AND\n" +
-			"             │                               │   │   │   │   │   │   │   ├─ Eq\n" +
-			"             │                               │   │   │   │   │   │   │   │   ├─ nhmxw.SWCQV:17!null\n" +
-			"             │                               │   │   │   │   │   │   │   │   └─ 0 (int)\n" +
+			"             │                               │   │   │   │   │   │   │   ├─ AND\n" +
+			"             │                               │   │   │   │   │   │   │   │   ├─ Eq\n" +
+			"             │                               │   │   │   │   │   │   │   │   │   ├─ nhmxw.SWCQV:17!null\n" +
+			"             │                               │   │   │   │   │   │   │   │   │   └─ 0 (int)\n" +
+			"             │                               │   │   │   │   │   │   │   │   └─ Eq\n" +
+			"             │                               │   │   │   │   │   │   │   │       ├─ nhmxw.NOHHR:11!null\n" +
+			"             │                               │   │   │   │   │   │   │   │       └─ tizhk.TVNW2:1\n" +
 			"             │                               │   │   │   │   │   │   │   └─ Eq\n" +
 			"             │                               │   │   │   │   │   │   │       ├─ nhmxw.AVPYF:12!null\n" +
 			"             │                               │   │   │   │   │   │   │       └─ tizhk.ZHITY:2\n" +
@@ -20240,28 +20090,21 @@ FROM
 			"             │                               │   │   │   │   │   └─ Eq\n" +
 			"             │                               │   │   │   │   │       ├─ nhmxw.IDUT2:14!null\n" +
 			"             │                               │   │   │   │   │       └─ tizhk.IDUT2:4\n" +
-			"             │                               │   │   │   │   ├─ Filter\n" +
-			"             │                               │   │   │   │   │   ├─ HashIn\n" +
-			"             │                               │   │   │   │   │   │   ├─ tizhk.id:0!null\n" +
-			"             │                               │   │   │   │   │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │                               │   │   │   │   │   └─ TableAlias(tizhk)\n" +
-			"             │                               │   │   │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
-			"             │                               │   │   │   │   │           ├─ index: [WRZVO.id]\n" +
-			"             │                               │   │   │   │   │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                               │   │   │   │   │           ├─ colSet: (10-19)\n" +
-			"             │                               │   │   │   │   │           ├─ tableId: 2\n" +
-			"             │                               │   │   │   │   │           └─ Table\n" +
-			"             │                               │   │   │   │   │               ├─ name: WRZVO\n" +
-			"             │                               │   │   │   │   │               └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
+			"             │                               │   │   │   │   ├─ TableAlias(tizhk)\n" +
+			"             │                               │   │   │   │   │   └─ IndexedTableAccess(WRZVO)\n" +
+			"             │                               │   │   │   │   │       ├─ index: [WRZVO.id]\n" +
+			"             │                               │   │   │   │   │       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                               │   │   │   │   │       ├─ colSet: (10-19)\n" +
+			"             │                               │   │   │   │   │       ├─ tableId: 2\n" +
+			"             │                               │   │   │   │   │       └─ Table\n" +
+			"             │                               │   │   │   │   │           ├─ name: WRZVO\n" +
+			"             │                               │   │   │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			"             │                               │   │   │   │   └─ TableAlias(nhmxw)\n" +
-			"             │                               │   │   │   │       └─ IndexedTableAccess(WGSDC)\n" +
-			"             │                               │   │   │   │           ├─ index: [WGSDC.NOHHR]\n" +
-			"             │                               │   │   │   │           ├─ keys: [tizhk.TVNW2:1]\n" +
+			"             │                               │   │   │   │       └─ Table\n" +
+			"             │                               │   │   │   │           ├─ name: WGSDC\n" +
+			"             │                               │   │   │   │           ├─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"             │                               │   │   │   │           ├─ colSet: (20-29)\n" +
-			"             │                               │   │   │   │           ├─ tableId: 3\n" +
-			"             │                               │   │   │   │           └─ Table\n" +
-			"             │                               │   │   │   │               ├─ name: WGSDC\n" +
-			"             │                               │   │   │   │               └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
+			"             │                               │   │   │   │           └─ tableId: 3\n" +
 			"             │                               │   │   │   └─ TableAlias(j4jyp)\n" +
 			"             │                               │   │   │       └─ IndexedTableAccess(E2I7U)\n" +
 			"             │                               │   │   │           ├─ index: [E2I7U.ZH72S]\n" +
@@ -20271,33 +20114,33 @@ FROM
 			"             │                               │   │   │           └─ Table\n" +
 			"             │                               │   │   │               ├─ name: E2I7U\n" +
 			"             │                               │   │   │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               │   │   └─ TableAlias(rhuzn)\n" +
-			"             │                               │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                               │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"             │                               │   │           ├─ keys: [tizhk.ZHITY:2]\n" +
-			"             │                               │   │           ├─ colSet: (47-63)\n" +
-			"             │                               │   │           ├─ tableId: 5\n" +
+			"             │                               │   │   └─ TableAlias(mf)\n" +
+			"             │                               │   │       └─ IndexedTableAccess(HGMQ6)\n" +
+			"             │                               │   │           ├─ index: [HGMQ6.LUEVY]\n" +
+			"             │                               │   │           ├─ keys: [j4jyp.id:20!null]\n" +
+			"             │                               │   │           ├─ colSet: (64-80)\n" +
+			"             │                               │   │           ├─ tableId: 6\n" +
 			"             │                               │   │           └─ Table\n" +
-			"             │                               │   │               ├─ name: E2I7U\n" +
-			"             │                               │   │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               │   └─ TableAlias(mf)\n" +
-			"             │                               │       └─ IndexedTableAccess(HGMQ6)\n" +
-			"             │                               │           ├─ index: [HGMQ6.LUEVY]\n" +
-			"             │                               │           ├─ keys: [j4jyp.id:20!null]\n" +
-			"             │                               │           ├─ colSet: (64-80)\n" +
-			"             │                               │           ├─ tableId: 6\n" +
+			"             │                               │   │               ├─ name: HGMQ6\n" +
+			"             │                               │   │               └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
+			"             │                               │   └─ TableAlias(aac)\n" +
+			"             │                               │       └─ IndexedTableAccess(TPXBU)\n" +
+			"             │                               │           ├─ index: [TPXBU.id]\n" +
+			"             │                               │           ├─ keys: [mf.M22QN:40!null]\n" +
+			"             │                               │           ├─ colSet: (81-83)\n" +
+			"             │                               │           ├─ tableId: 7\n" +
 			"             │                               │           └─ Table\n" +
-			"             │                               │               ├─ name: HGMQ6\n" +
-			"             │                               │               └─ columns: [id gxlub luevy m22qn tjpt7 arn5p xosd4 ide43 hmw4h zbt6r fsdy2 lt7k6 sppyd qcgts teuja qqv4m fhcyt]\n" +
-			"             │                               └─ TableAlias(aac)\n" +
-			"             │                                   └─ IndexedTableAccess(TPXBU)\n" +
-			"             │                                       ├─ index: [TPXBU.id]\n" +
-			"             │                                       ├─ keys: [mf.M22QN:57!null]\n" +
-			"             │                                       ├─ colSet: (81-83)\n" +
-			"             │                                       ├─ tableId: 7\n" +
+			"             │                               │               ├─ name: TPXBU\n" +
+			"             │                               │               └─ columns: [id btxc5 fhcyt]\n" +
+			"             │                               └─ TableAlias(rhuzn)\n" +
+			"             │                                   └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                                       ├─ index: [E2I7U.ZH72S]\n" +
+			"             │                                       ├─ keys: [tizhk.ZHITY:2]\n" +
+			"             │                                       ├─ colSet: (47-63)\n" +
+			"             │                                       ├─ tableId: 5\n" +
 			"             │                                       └─ Table\n" +
-			"             │                                           ├─ name: TPXBU\n" +
-			"             │                                           └─ columns: [id btxc5 fhcyt]\n" +
+			"             │                                           ├─ name: E2I7U\n" +
+			"             │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [id:0!null, FV24E:1 as FV24E, UJ6XY:2 as UJ6XY, M22QN:3, NZ4MQ:4, ETPQV:5!null, convert\n" +
 			"                 │   ├─ type: char\n" +
@@ -20470,13 +20313,17 @@ FROM
 			"                                             │   └─ nhmxw.id:10!null IS NULL\n" +
 			"                                             └─ LeftOuterLookupJoin\n" +
 			"                                                 ├─ LeftOuterLookupJoin\n" +
-			"                                                 │   ├─ LeftOuterLookupJoin\n" +
+			"                                                 │   ├─ LeftOuterJoin\n" +
 			"                                                 │   │   ├─ AND\n" +
 			"                                                 │   │   │   ├─ AND\n" +
 			"                                                 │   │   │   │   ├─ AND\n" +
-			"                                                 │   │   │   │   │   ├─ Eq\n" +
-			"                                                 │   │   │   │   │   │   ├─ nhmxw.SWCQV:17!null\n" +
-			"                                                 │   │   │   │   │   │   └─ 0 (int)\n" +
+			"                                                 │   │   │   │   │   ├─ AND\n" +
+			"                                                 │   │   │   │   │   │   ├─ Eq\n" +
+			"                                                 │   │   │   │   │   │   │   ├─ nhmxw.SWCQV:17!null\n" +
+			"                                                 │   │   │   │   │   │   │   └─ 0 (int)\n" +
+			"                                                 │   │   │   │   │   │   └─ Eq\n" +
+			"                                                 │   │   │   │   │   │       ├─ nhmxw.NOHHR:11!null\n" +
+			"                                                 │   │   │   │   │   │       └─ tizhk.TVNW2:1\n" +
 			"                                                 │   │   │   │   │   └─ Eq\n" +
 			"                                                 │   │   │   │   │       ├─ nhmxw.AVPYF:12!null\n" +
 			"                                                 │   │   │   │   │       └─ tizhk.ZHITY:2\n" +
@@ -20486,28 +20333,21 @@ FROM
 			"                                                 │   │   │   └─ Eq\n" +
 			"                                                 │   │   │       ├─ nhmxw.IDUT2:14!null\n" +
 			"                                                 │   │   │       └─ tizhk.IDUT2:4\n" +
-			"                                                 │   │   ├─ Filter\n" +
-			"                                                 │   │   │   ├─ HashIn\n" +
-			"                                                 │   │   │   │   ├─ tizhk.id:0!null\n" +
-			"                                                 │   │   │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"                                                 │   │   │   └─ TableAlias(tizhk)\n" +
-			"                                                 │   │   │       └─ IndexedTableAccess(WRZVO)\n" +
-			"                                                 │   │   │           ├─ index: [WRZVO.id]\n" +
-			"                                                 │   │   │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"                                                 │   │   │           ├─ colSet: (115-124)\n" +
-			"                                                 │   │   │           ├─ tableId: 10\n" +
-			"                                                 │   │   │           └─ Table\n" +
-			"                                                 │   │   │               ├─ name: WRZVO\n" +
-			"                                                 │   │   │               └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
+			"                                                 │   │   ├─ TableAlias(tizhk)\n" +
+			"                                                 │   │   │   └─ IndexedTableAccess(WRZVO)\n" +
+			"                                                 │   │   │       ├─ index: [WRZVO.id]\n" +
+			"                                                 │   │   │       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"                                                 │   │   │       ├─ colSet: (115-124)\n" +
+			"                                                 │   │   │       ├─ tableId: 10\n" +
+			"                                                 │   │   │       └─ Table\n" +
+			"                                                 │   │   │           ├─ name: WRZVO\n" +
+			"                                                 │   │   │           └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			"                                                 │   │   └─ TableAlias(nhmxw)\n" +
-			"                                                 │   │       └─ IndexedTableAccess(WGSDC)\n" +
-			"                                                 │   │           ├─ index: [WGSDC.NOHHR]\n" +
-			"                                                 │   │           ├─ keys: [tizhk.TVNW2:1]\n" +
+			"                                                 │   │       └─ Table\n" +
+			"                                                 │   │           ├─ name: WGSDC\n" +
+			"                                                 │   │           ├─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
 			"                                                 │   │           ├─ colSet: (125-134)\n" +
-			"                                                 │   │           ├─ tableId: 11\n" +
-			"                                                 │   │           └─ Table\n" +
-			"                                                 │   │               ├─ name: WGSDC\n" +
-			"                                                 │   │               └─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
+			"                                                 │   │           └─ tableId: 11\n" +
 			"                                                 │   └─ TableAlias(j4jyp)\n" +
 			"                                                 │       └─ IndexedTableAccess(E2I7U)\n" +
 			"                                                 │           ├─ index: [E2I7U.ZH72S]\n" +
@@ -20762,40 +20602,37 @@ WHERE
 			"             │                           │   │   └─ Distinct\n" +
 			"             │                           │   │       └─ Project\n" +
 			"             │                           │   │           ├─ columns: [uct.NO52D:7, uct.VYO5E:9, uct.ZH72S:2, i7hcr.FVUCX:17!null]\n" +
-			"             │                           │   │           └─ LeftOuterLookupJoin\n" +
+			"             │                           │   │           └─ LeftOuterJoin\n" +
 			"             │                           │   │               ├─ AND\n" +
 			"             │                           │   │               │   ├─ AND\n" +
-			"             │                           │   │               │   │   ├─ Eq\n" +
-			"             │                           │   │               │   │   │   ├─ i7hcr.SWCQV:18!null\n" +
-			"             │                           │   │               │   │   │   └─ 0 (int)\n" +
+			"             │                           │   │               │   │   ├─ AND\n" +
+			"             │                           │   │               │   │   │   ├─ Eq\n" +
+			"             │                           │   │               │   │   │   │   ├─ i7hcr.SWCQV:18!null\n" +
+			"             │                           │   │               │   │   │   │   └─ 0 (int)\n" +
+			"             │                           │   │               │   │   │   └─ Eq\n" +
+			"             │                           │   │               │   │   │       ├─ i7hcr.TOFPN:14!null\n" +
+			"             │                           │   │               │   │   │       └─ uct.FTQLQ:1\n" +
 			"             │                           │   │               │   │   └─ Eq\n" +
 			"             │                           │   │               │   │       ├─ i7hcr.SJYN2:15!null\n" +
 			"             │                           │   │               │   │       └─ uct.ZH72S:2\n" +
 			"             │                           │   │               │   └─ Eq\n" +
 			"             │                           │   │               │       ├─ i7hcr.BTXC5:16!null\n" +
 			"             │                           │   │               │       └─ uct.LJLUM:5\n" +
-			"             │                           │   │               ├─ Filter\n" +
-			"             │                           │   │               │   ├─ HashIn\n" +
-			"             │                           │   │               │   │   ├─ uct.id:0!null\n" +
-			"             │                           │   │               │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │                           │   │               │   └─ TableAlias(uct)\n" +
-			"             │                           │   │               │       └─ IndexedTableAccess(OUBDL)\n" +
-			"             │                           │   │               │           ├─ index: [OUBDL.id]\n" +
-			"             │                           │   │               │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                           │   │               │           ├─ colSet: (7-19)\n" +
-			"             │                           │   │               │           ├─ tableId: 2\n" +
-			"             │                           │   │               │           └─ Table\n" +
-			"             │                           │   │               │               ├─ name: OUBDL\n" +
-			"             │                           │   │               │               └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
+			"             │                           │   │               ├─ TableAlias(uct)\n" +
+			"             │                           │   │               │   └─ IndexedTableAccess(OUBDL)\n" +
+			"             │                           │   │               │       ├─ index: [OUBDL.id]\n" +
+			"             │                           │   │               │       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                           │   │               │       ├─ colSet: (7-19)\n" +
+			"             │                           │   │               │       ├─ tableId: 2\n" +
+			"             │                           │   │               │       └─ Table\n" +
+			"             │                           │   │               │           ├─ name: OUBDL\n" +
+			"             │                           │   │               │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"             │                           │   │               └─ TableAlias(i7hcr)\n" +
-			"             │                           │   │                   └─ IndexedTableAccess(EPZU6)\n" +
-			"             │                           │   │                       ├─ index: [EPZU6.TOFPN]\n" +
-			"             │                           │   │                       ├─ keys: [uct.FTQLQ:1]\n" +
+			"             │                           │   │                   └─ Table\n" +
+			"             │                           │   │                       ├─ name: EPZU6\n" +
+			"             │                           │   │                       ├─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"             │                           │   │                       ├─ colSet: (20-27)\n" +
-			"             │                           │   │                       ├─ tableId: 3\n" +
-			"             │                           │   │                       └─ Table\n" +
-			"             │                           │   │                           ├─ name: EPZU6\n" +
-			"             │                           │   │                           └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
+			"             │                           │   │                       └─ tableId: 3\n" +
 			"             │                           │   └─ TableAlias(nd)\n" +
 			"             │                           │       └─ Concat\n" +
 			"             │                           │           ├─ TableAlias(nd)\n" +
@@ -21261,40 +21098,37 @@ WHERE
 			"             │                   │           │       ├─ uct.FHCYT:11\n" +
 			"             │                   │           │       └─ N/A (longtext)\n" +
 			"             │                   │           │   THEN uct.FHCYT:11 ELSE NULL (null) END as FHCYT, uct.ZH72S:2 as K3B6V, uct.LJLUM:5 as BTXC5, i7hcr.FVUCX:17!null as H4DMT]\n" +
-			"             │                   │           └─ LeftOuterLookupJoin\n" +
+			"             │                   │           └─ LeftOuterJoin\n" +
 			"             │                   │               ├─ AND\n" +
 			"             │                   │               │   ├─ AND\n" +
-			"             │                   │               │   │   ├─ Eq\n" +
-			"             │                   │               │   │   │   ├─ i7hcr.SWCQV:18!null\n" +
-			"             │                   │               │   │   │   └─ 0 (int)\n" +
+			"             │                   │               │   │   ├─ AND\n" +
+			"             │                   │               │   │   │   ├─ Eq\n" +
+			"             │                   │               │   │   │   │   ├─ i7hcr.SWCQV:18!null\n" +
+			"             │                   │               │   │   │   │   └─ 0 (int)\n" +
+			"             │                   │               │   │   │   └─ Eq\n" +
+			"             │                   │               │   │   │       ├─ i7hcr.TOFPN:14!null\n" +
+			"             │                   │               │   │   │       └─ uct.FTQLQ:1\n" +
 			"             │                   │               │   │   └─ Eq\n" +
 			"             │                   │               │   │       ├─ i7hcr.SJYN2:15!null\n" +
 			"             │                   │               │   │       └─ uct.ZH72S:2\n" +
 			"             │                   │               │   └─ Eq\n" +
 			"             │                   │               │       ├─ i7hcr.BTXC5:16!null\n" +
 			"             │                   │               │       └─ uct.LJLUM:5\n" +
-			"             │                   │               ├─ Filter\n" +
-			"             │                   │               │   ├─ HashIn\n" +
-			"             │                   │               │   │   ├─ uct.id:0!null\n" +
-			"             │                   │               │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │                   │               │   └─ TableAlias(uct)\n" +
-			"             │                   │               │       └─ IndexedTableAccess(OUBDL)\n" +
-			"             │                   │               │           ├─ index: [OUBDL.id]\n" +
-			"             │                   │               │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                   │               │           ├─ colSet: (13-25)\n" +
-			"             │                   │               │           ├─ tableId: 2\n" +
-			"             │                   │               │           └─ Table\n" +
-			"             │                   │               │               ├─ name: OUBDL\n" +
-			"             │                   │               │               └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
+			"             │                   │               ├─ TableAlias(uct)\n" +
+			"             │                   │               │   └─ IndexedTableAccess(OUBDL)\n" +
+			"             │                   │               │       ├─ index: [OUBDL.id]\n" +
+			"             │                   │               │       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                   │               │       ├─ colSet: (13-25)\n" +
+			"             │                   │               │       ├─ tableId: 2\n" +
+			"             │                   │               │       └─ Table\n" +
+			"             │                   │               │           ├─ name: OUBDL\n" +
+			"             │                   │               │           └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"             │                   │               └─ TableAlias(i7hcr)\n" +
-			"             │                   │                   └─ IndexedTableAccess(EPZU6)\n" +
-			"             │                   │                       ├─ index: [EPZU6.TOFPN]\n" +
-			"             │                   │                       ├─ keys: [uct.FTQLQ:1]\n" +
+			"             │                   │                   └─ Table\n" +
+			"             │                   │                       ├─ name: EPZU6\n" +
+			"             │                   │                       ├─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
 			"             │                   │                       ├─ colSet: (26-33)\n" +
-			"             │                   │                       ├─ tableId: 3\n" +
-			"             │                   │                       └─ Table\n" +
-			"             │                   │                           ├─ name: EPZU6\n" +
-			"             │                   │                           └─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
+			"             │                   │                       └─ tableId: 3\n" +
 			"             │                   └─ TableAlias(nd)\n" +
 			"             │                       └─ Concat\n" +
 			"             │                           ├─ TableAlias(nd)\n" +
@@ -21513,19 +21347,15 @@ WHERE
 			"             │                       ├─ columns: [tvtjs.NO52D:7!null as NO52D, tvtjs.VYO5E:9 as VYO5E, nt.id:30!null as DKCAJ, nt.DZLIM:31!null as F35MI]\n" +
 			"             │                       └─ LookupJoin\n" +
 			"             │                           ├─ LookupJoin\n" +
-			"             │                           │   ├─ Filter\n" +
-			"             │                           │   │   ├─ HashIn\n" +
-			"             │                           │   │   │   ├─ tvtjs.id:0!null\n" +
-			"             │                           │   │   │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │                           │   │   └─ TableAlias(tvtjs)\n" +
-			"             │                           │   │       └─ IndexedTableAccess(HU5A5)\n" +
-			"             │                           │   │           ├─ index: [HU5A5.id]\n" +
-			"             │                           │   │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                           │   │           ├─ colSet: (7-19)\n" +
-			"             │                           │   │           ├─ tableId: 2\n" +
-			"             │                           │   │           └─ Table\n" +
-			"             │                           │   │               ├─ name: HU5A5\n" +
-			"             │                           │   │               └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
+			"             │                           │   ├─ TableAlias(tvtjs)\n" +
+			"             │                           │   │   └─ IndexedTableAccess(HU5A5)\n" +
+			"             │                           │   │       ├─ index: [HU5A5.id]\n" +
+			"             │                           │   │       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                           │   │       ├─ colSet: (7-19)\n" +
+			"             │                           │   │       ├─ tableId: 2\n" +
+			"             │                           │   │       └─ Table\n" +
+			"             │                           │   │           ├─ name: HU5A5\n" +
+			"             │                           │   │           └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			"             │                           │   └─ TableAlias(nd)\n" +
 			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
 			"             │                           │           ├─ index: [E2I7U.TW55N]\n" +
@@ -21851,19 +21681,15 @@ WHERE
 			"             │           │                   ├─ name: SFEGG\n" +
 			"             │           │                   └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
 			"             │           │   as OVE3E, NULL (null) as NRURT, NULL (null) as OCA7E, tvtjs.id:0!null as XMM6Q, tvtjs.V5DPX:4!null as V5DPX, (tvtjs.IDPK7:6!null + 0 (decimal(2,1))) as S3Q3Y, tvtjs.ZRV3B:8!null as ZRV3B, tvtjs.FHCYT:12 as FHCYT]\n" +
-			"             │           └─ Filter\n" +
-			"             │               ├─ HashIn\n" +
-			"             │               │   ├─ tvtjs.id:0!null\n" +
-			"             │               │   └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext))\n" +
-			"             │               └─ TableAlias(tvtjs)\n" +
-			"             │                   └─ IndexedTableAccess(HU5A5)\n" +
-			"             │                       ├─ index: [HU5A5.id]\n" +
-			"             │                       ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
-			"             │                       ├─ colSet: (13-25)\n" +
-			"             │                       ├─ tableId: 2\n" +
-			"             │                       └─ Table\n" +
-			"             │                           ├─ name: HU5A5\n" +
-			"             │                           └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
+			"             │           └─ TableAlias(tvtjs)\n" +
+			"             │               └─ IndexedTableAccess(HU5A5)\n" +
+			"             │                   ├─ index: [HU5A5.id]\n" +
+			"             │                   ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"             │                   ├─ colSet: (13-25)\n" +
+			"             │                   ├─ tableId: 2\n" +
+			"             │                   └─ Table\n" +
+			"             │                       ├─ name: HU5A5\n" +
+			"             │                       └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
 			"             └─ BEGIN .. END\n" +
 			"                 ├─ IF BLOCK\n" +
 			"                 │   └─ IF(InSubquery\n" +

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -1078,6 +1078,22 @@ Select * from (
 		Expected: []sql.Row{{1}},
 	},
 	{
+		Query:    "select count(*) from mytable where s in ('', 'first row');",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "select count(*) from mytable where s in (1, 'first row');",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "select count(*) from mytable where s in (NULL, 'first row');",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "select count(*) from niltable where i2 in (NULL, 1);",
+		Expected: []sql.Row{{0}},
+	},
+	{
 		Query: "SELECT * FROM mytable;",
 		Expected: []sql.Row{
 			{int64(1), "first row"},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -1260,27 +1260,15 @@ where
 			" ├─ columns: [style.assetId:1]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ LookupJoin\n" +
-			"     │   ├─ Filter\n" +
-			"     │   │   ├─ AND\n" +
-			"     │   │   │   ├─ AND\n" +
-			"     │   │   │   │   ├─ Eq\n" +
-			"     │   │   │   │   │   ├─ style.val:3\n" +
-			"     │   │   │   │   │   └─ curve (longtext)\n" +
-			"     │   │   │   │   └─ Eq\n" +
-			"     │   │   │   │       ├─ style.name:2\n" +
-			"     │   │   │   │       └─ style (longtext)\n" +
-			"     │   │   │   └─ Eq\n" +
-			"     │   │   │       ├─ style.orgId:0\n" +
-			"     │   │   │       └─ org1 (longtext)\n" +
-			"     │   │   └─ TableAlias(style)\n" +
-			"     │   │       └─ IndexedTableAccess(asset)\n" +
-			"     │   │           ├─ index: [asset.orgId,asset.name,asset.val]\n" +
-			"     │   │           ├─ static: [{[org1, org1], [style, style], [curve, curve]}]\n" +
-			"     │   │           ├─ colSet: (1-5)\n" +
-			"     │   │           ├─ tableId: 1\n" +
-			"     │   │           └─ Table\n" +
-			"     │   │               ├─ name: asset\n" +
-			"     │   │               └─ columns: [orgid assetid name val]\n" +
+			"     │   ├─ TableAlias(style)\n" +
+			"     │   │   └─ IndexedTableAccess(asset)\n" +
+			"     │   │       ├─ index: [asset.orgId,asset.name,asset.val]\n" +
+			"     │   │       ├─ static: [{[org1, org1], [style, style], [curve, curve]}]\n" +
+			"     │   │       ├─ colSet: (1-5)\n" +
+			"     │   │       ├─ tableId: 1\n" +
+			"     │   │       └─ Table\n" +
+			"     │   │           ├─ name: asset\n" +
+			"     │   │           └─ columns: [orgid assetid name val]\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ AND\n" +
 			"     │       │   ├─ AND\n" +
@@ -1326,15 +1314,13 @@ where
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [style.assetId]\n" +
-			" └─ LookupJoin (estimated cost=16.500 rows=5)\n" +
-			"     ├─ LookupJoin (estimated cost=16.500 rows=5)\n" +
-			"     │   ├─ Filter\n" +
-			"     │   │   ├─ (((style.val = 'curve') AND (style.name = 'style')) AND (style.orgId = 'org1'))\n" +
-			"     │   │   └─ TableAlias(style)\n" +
-			"     │   │       └─ IndexedTableAccess(asset)\n" +
-			"     │   │           ├─ index: [asset.orgId,asset.name,asset.val]\n" +
-			"     │   │           ├─ filters: [{[org1, org1], [style, style], [curve, curve]}]\n" +
-			"     │   │           └─ columns: [orgid assetid name val]\n" +
+			" └─ LookupJoin (estimated cost=19.800 rows=6)\n" +
+			"     ├─ LookupJoin (estimated cost=19.800 rows=6)\n" +
+			"     │   ├─ TableAlias(style)\n" +
+			"     │   │   └─ IndexedTableAccess(asset)\n" +
+			"     │   │       ├─ index: [asset.orgId,asset.name,asset.val]\n" +
+			"     │   │       ├─ filters: [{[org1, org1], [style, style], [curve, curve]}]\n" +
+			"     │   │       └─ columns: [orgid assetid name val]\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ (((dimension.val = 'wide') AND (dimension.name = 'dimension')) AND (dimension.orgId = 'org1'))\n" +
 			"     │       └─ TableAlias(dimension)\n" +
@@ -1352,15 +1338,13 @@ where
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [style.assetId]\n" +
-			" └─ LookupJoin (estimated cost=16.500 rows=5) (actual rows=1 loops=1)\n" +
-			"     ├─ LookupJoin (estimated cost=16.500 rows=5) (actual rows=1 loops=1)\n" +
-			"     │   ├─ Filter\n" +
-			"     │   │   ├─ (((style.val = 'curve') AND (style.name = 'style')) AND (style.orgId = 'org1'))\n" +
-			"     │   │   └─ TableAlias(style)\n" +
-			"     │   │       └─ IndexedTableAccess(asset)\n" +
-			"     │   │           ├─ index: [asset.orgId,asset.name,asset.val]\n" +
-			"     │   │           ├─ filters: [{[org1, org1], [style, style], [curve, curve]}]\n" +
-			"     │   │           └─ columns: [orgid assetid name val]\n" +
+			" └─ LookupJoin (estimated cost=19.800 rows=6) (actual rows=1 loops=1)\n" +
+			"     ├─ LookupJoin (estimated cost=19.800 rows=6) (actual rows=1 loops=1)\n" +
+			"     │   ├─ TableAlias(style)\n" +
+			"     │   │   └─ IndexedTableAccess(asset)\n" +
+			"     │   │       ├─ index: [asset.orgId,asset.name,asset.val]\n" +
+			"     │   │       ├─ filters: [{[org1, org1], [style, style], [curve, curve]}]\n" +
+			"     │   │       └─ columns: [orgid assetid name val]\n" +
 			"     │   └─ Filter\n" +
 			"     │       ├─ (((dimension.val = 'wide') AND (dimension.name = 'dimension')) AND (dimension.orgId = 'org1'))\n" +
 			"     │       └─ TableAlias(dimension)\n" +
@@ -1535,23 +1519,15 @@ where
 			"                 │           ├─ Distinct\n" +
 			"                 │           │   └─ Project\n" +
 			"                 │           │       ├─ columns: [parts_1.part:0!null]\n" +
-			"                 │           │       └─ Filter\n" +
-			"                 │           │           ├─ AND\n" +
-			"                 │           │           │   ├─ Eq\n" +
-			"                 │           │           │   │   ├─ parts_1.part:0!null\n" +
-			"                 │           │           │   │   └─ pie (longtext)\n" +
-			"                 │           │           │   └─ Eq\n" +
-			"                 │           │           │       ├─ parts_1.sub_part:1!null\n" +
-			"                 │           │           │       └─ crust (longtext)\n" +
-			"                 │           │           └─ TableAlias(parts_1)\n" +
-			"                 │           │               └─ IndexedTableAccess(parts)\n" +
-			"                 │           │                   ├─ index: [parts.part,parts.sub_part]\n" +
-			"                 │           │                   ├─ static: [{[pie, pie], [crust, crust]}]\n" +
-			"                 │           │                   ├─ colSet: (4-6)\n" +
-			"                 │           │                   ├─ tableId: 2\n" +
-			"                 │           │                   └─ Table\n" +
-			"                 │           │                       ├─ name: parts\n" +
-			"                 │           │                       └─ columns: [part sub_part quantity]\n" +
+			"                 │           │       └─ TableAlias(parts_1)\n" +
+			"                 │           │           └─ IndexedTableAccess(parts)\n" +
+			"                 │           │               ├─ index: [parts.part,parts.sub_part]\n" +
+			"                 │           │               ├─ static: [{[pie, pie], [crust, crust]}]\n" +
+			"                 │           │               ├─ colSet: (4-6)\n" +
+			"                 │           │               ├─ tableId: 2\n" +
+			"                 │           │               └─ Table\n" +
+			"                 │           │                   ├─ name: parts\n" +
+			"                 │           │                   └─ columns: [part sub_part quantity]\n" +
 			"                 │           └─ Table\n" +
 			"                 │               ├─ name: parts\n" +
 			"                 │               ├─ columns: [part sub_part quantity]\n" +
@@ -1593,12 +1569,10 @@ where
 			"                 │           ├─ Distinct\n" +
 			"                 │           │   └─ Project\n" +
 			"                 │           │       ├─ columns: [parts_1.part]\n" +
-			"                 │           │       └─ Filter\n" +
-			"                 │           │           ├─ ((parts_1.part = 'pie') AND (parts_1.sub_part = 'crust'))\n" +
-			"                 │           │           └─ TableAlias(parts_1)\n" +
-			"                 │           │               └─ IndexedTableAccess(parts)\n" +
-			"                 │           │                   ├─ index: [parts.part,parts.sub_part]\n" +
-			"                 │           │                   └─ filters: [{[pie, pie], [crust, crust]}]\n" +
+			"                 │           │       └─ TableAlias(parts_1)\n" +
+			"                 │           │           └─ IndexedTableAccess(parts)\n" +
+			"                 │           │               ├─ index: [parts.part,parts.sub_part]\n" +
+			"                 │           │               └─ filters: [{[pie, pie], [crust, crust]}]\n" +
 			"                 │           └─ Table\n" +
 			"                 │               └─ name: parts\n" +
 			"                 └─ Project\n" +
@@ -1633,12 +1607,10 @@ where
 			"                 │           ├─ Distinct\n" +
 			"                 │           │   └─ Project\n" +
 			"                 │           │       ├─ columns: [parts_1.part]\n" +
-			"                 │           │       └─ Filter\n" +
-			"                 │           │           ├─ ((parts_1.part = 'pie') AND (parts_1.sub_part = 'crust'))\n" +
-			"                 │           │           └─ TableAlias(parts_1)\n" +
-			"                 │           │               └─ IndexedTableAccess(parts)\n" +
-			"                 │           │                   ├─ index: [parts.part,parts.sub_part]\n" +
-			"                 │           │                   └─ filters: [{[pie, pie], [crust, crust]}]\n" +
+			"                 │           │       └─ TableAlias(parts_1)\n" +
+			"                 │           │           └─ IndexedTableAccess(parts)\n" +
+			"                 │           │               ├─ index: [parts.part,parts.sub_part]\n" +
+			"                 │           │               └─ filters: [{[pie, pie], [crust, crust]}]\n" +
 			"                 │           └─ Table\n" +
 			"                 │               └─ name: parts\n" +
 			"                 └─ Project\n" +
@@ -2473,18 +2445,14 @@ Select * from (
 			"     ├─ Distinct\n" +
 			"     │   └─ Project\n" +
 			"     │       ├─ columns: [othertable.i2:1!null]\n" +
-			"     │       └─ Filter\n" +
-			"     │           ├─ Eq\n" +
-			"     │           │   ├─ othertable.s2:0!null\n" +
-			"     │           │   └─ second (longtext)\n" +
-			"     │           └─ IndexedTableAccess(othertable)\n" +
-			"     │               ├─ index: [othertable.s2]\n" +
-			"     │               ├─ static: [{[second, second]}]\n" +
-			"     │               ├─ colSet: (3,4)\n" +
-			"     │               ├─ tableId: 2\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: othertable\n" +
-			"     │                   └─ columns: [s2 i2]\n" +
+			"     │       └─ IndexedTableAccess(othertable)\n" +
+			"     │           ├─ index: [othertable.s2]\n" +
+			"     │           ├─ static: [{[second, second]}]\n" +
+			"     │           ├─ colSet: (3,4)\n" +
+			"     │           ├─ tableId: 2\n" +
+			"     │           └─ Table\n" +
+			"     │               ├─ name: othertable\n" +
+			"     │               └─ columns: [s2 i2]\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
 			"         ├─ keys: [othertable.i2:0!null]\n" +
@@ -2496,32 +2464,28 @@ Select * from (
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [mytable.s]\n" +
-			" └─ LookupJoin (estimated cost=3.300 rows=0)\n" +
+			" └─ LookupJoin (estimated cost=3.300 rows=1)\n" +
 			"     ├─ (mytable.i = othertable.i2)\n" +
 			"     ├─ Distinct\n" +
 			"     │   └─ Project\n" +
 			"     │       ├─ columns: [othertable.i2]\n" +
-			"     │       └─ Filter\n" +
-			"     │           ├─ (othertable.s2 = 'second')\n" +
-			"     │           └─ IndexedTableAccess(othertable)\n" +
-			"     │               ├─ index: [othertable.s2]\n" +
-			"     │               └─ filters: [{[second, second]}]\n" +
+			"     │       └─ IndexedTableAccess(othertable)\n" +
+			"     │           ├─ index: [othertable.s2]\n" +
+			"     │           └─ filters: [{[second, second]}]\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
 			"         └─ keys: othertable.i2\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [mytable.s]\n" +
-			" └─ LookupJoin (estimated cost=3.300 rows=0) (actual rows=1 loops=1)\n" +
+			" └─ LookupJoin (estimated cost=3.300 rows=1) (actual rows=1 loops=1)\n" +
 			"     ├─ (mytable.i = othertable.i2)\n" +
 			"     ├─ Distinct\n" +
 			"     │   └─ Project\n" +
 			"     │       ├─ columns: [othertable.i2]\n" +
-			"     │       └─ Filter\n" +
-			"     │           ├─ (othertable.s2 = 'second')\n" +
-			"     │           └─ IndexedTableAccess(othertable)\n" +
-			"     │               ├─ index: [othertable.s2]\n" +
-			"     │               └─ filters: [{[second, second]}]\n" +
+			"     │       └─ IndexedTableAccess(othertable)\n" +
+			"     │           ├─ index: [othertable.s2]\n" +
+			"     │           └─ filters: [{[second, second]}]\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
 			"         └─ keys: othertable.i2\n" +
@@ -3712,18 +3676,14 @@ Select * from (
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [bus_routes.origin:0!null as dst]\n" +
-			"             │   └─ Filter\n" +
-			"             │       ├─ Eq\n" +
-			"             │       │   ├─ bus_routes.origin:0!null\n" +
-			"             │       │   └─ New York (longtext)\n" +
-			"             │       └─ IndexedTableAccess(bus_routes)\n" +
-			"             │           ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │           ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
-			"             │           ├─ colSet: (1,2)\n" +
-			"             │           ├─ tableId: 1\n" +
-			"             │           └─ Table\n" +
-			"             │               ├─ name: bus_routes\n" +
-			"             │               └─ columns: [origin]\n" +
+			"             │   └─ IndexedTableAccess(bus_routes)\n" +
+			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
+			"             │       ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       ├─ colSet: (1,2)\n" +
+			"             │       ├─ tableId: 1\n" +
+			"             │       └─ Table\n" +
+			"             │           ├─ name: bus_routes\n" +
+			"             │           └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst:2!null]\n" +
 			"                 └─ HashJoin\n" +
@@ -3750,12 +3710,10 @@ Select * from (
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
-			"             │   └─ Filter\n" +
-			"             │       ├─ (bus_routes.origin = 'New York')\n" +
-			"             │       └─ IndexedTableAccess(bus_routes)\n" +
-			"             │           ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │           ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
-			"             │           └─ columns: [origin]\n" +
+			"             │   └─ IndexedTableAccess(bus_routes)\n" +
+			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
+			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
 			"                 └─ HashJoin\n" +
@@ -3778,12 +3736,10 @@ Select * from (
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
-			"             │   └─ Filter\n" +
-			"             │       ├─ (bus_routes.origin = 'New York')\n" +
-			"             │       └─ IndexedTableAccess(bus_routes)\n" +
-			"             │           ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │           ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
-			"             │           └─ columns: [origin]\n" +
+			"             │   └─ IndexedTableAccess(bus_routes)\n" +
+			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
+			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
 			"                 └─ HashJoin\n" +
@@ -9054,20 +9010,15 @@ inner join pq on true
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [a.i:0!null, a.s:1!null]\n" +
 			" └─ LookupJoin\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ NOT\n" +
-			"     │   │   └─ HashIn\n" +
-			"     │   │       ├─ a.s:1!null\n" +
-			"     │   │       └─ TUPLE(1 (longtext), 2 (longtext), 3 (longtext), 4 (longtext))\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess(mytable)\n" +
-			"     │           ├─ index: [mytable.s,mytable.i]\n" +
-			"     │           ├─ static: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
-			"     │           ├─ colSet: (1,2)\n" +
-			"     │           ├─ tableId: 1\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: mytable\n" +
-			"     │               └─ columns: [i s]\n" +
+			"     ├─ TableAlias(a)\n" +
+			"     │   └─ IndexedTableAccess(mytable)\n" +
+			"     │       ├─ index: [mytable.s,mytable.i]\n" +
+			"     │       ├─ static: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"     │       ├─ colSet: (1,2)\n" +
+			"     │       ├─ tableId: 1\n" +
+			"     │       └─ Table\n" +
+			"     │           ├─ name: mytable\n" +
+			"     │           └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s]\n" +
@@ -9080,14 +9031,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ LookupJoin (estimated cost=3.300 rows=0)\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ (NOT((a.s HASH IN ('1', '2', '3', '4'))))\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess(mytable)\n" +
-			"     │           ├─ index: [mytable.s,mytable.i]\n" +
-			"     │           ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
-			"     │           └─ columns: [i s]\n" +
+			" └─ LookupJoin (estimated cost=3.300 rows=1)\n" +
+			"     ├─ TableAlias(a)\n" +
+			"     │   └─ IndexedTableAccess(mytable)\n" +
+			"     │       ├─ index: [mytable.s,mytable.i]\n" +
+			"     │       ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s]\n" +
@@ -9096,14 +9045,12 @@ inner join pq on true
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ LookupJoin (estimated cost=3.300 rows=0) (actual rows=0 loops=1)\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ (NOT((a.s HASH IN ('1', '2', '3', '4'))))\n" +
-			"     │   └─ TableAlias(a)\n" +
-			"     │       └─ IndexedTableAccess(mytable)\n" +
-			"     │           ├─ index: [mytable.s,mytable.i]\n" +
-			"     │           ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
-			"     │           └─ columns: [i s]\n" +
+			" └─ LookupJoin (estimated cost=3.300 rows=1) (actual rows=0 loops=1)\n" +
+			"     ├─ TableAlias(a)\n" +
+			"     │   └─ IndexedTableAccess(mytable)\n" +
+			"     │       ├─ index: [mytable.s,mytable.i]\n" +
+			"     │       ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"     │       └─ columns: [i s]\n" +
 			"     └─ TableAlias(b)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s]\n" +
@@ -9528,62 +9475,46 @@ inner join pq on true
 	},
 	{
 		Query: `SELECT * from mytable WHERE s IN (cast('first row' AS CHAR))`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ HashIn\n" +
-			" │   ├─ mytable.s:1!null\n" +
-			" │   └─ TUPLE(first row (longtext))\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ static: [{[first row, first row]}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ columns: [i s]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (mytable.s HASH IN ('first row'))\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ filters: [{[first row, first row]}]\n" +
+		ExpectedPlan: "IndexedTableAccess(mytable)\n" +
+			" ├─ index: [mytable.s]\n" +
+			" ├─ static: [{[first row, first row]}]\n" +
+			" ├─ colSet: (1,2)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: mytable\n" +
 			"     └─ columns: [i s]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (mytable.s HASH IN ('first row'))\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ filters: [{[first row, first row]}]\n" +
-			"     └─ columns: [i s]\n" +
+		ExpectedEstimates: "IndexedTableAccess(mytable)\n" +
+			" ├─ index: [mytable.s]\n" +
+			" ├─ filters: [{[first row, first row]}]\n" +
+			" └─ columns: [i s]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(mytable)\n" +
+			" ├─ index: [mytable.s]\n" +
+			" ├─ filters: [{[first row, first row]}]\n" +
+			" └─ columns: [i s]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * from mytable WHERE s IN (lower('SECOND ROW'), 'FIRST ROW')`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ HashIn\n" +
-			" │   ├─ mytable.s:1!null\n" +
-			" │   └─ TUPLE(second row (longtext), FIRST ROW (longtext))\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ static: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ columns: [i s]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (mytable.s HASH IN ('second row', 'FIRST ROW'))\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ filters: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
+		ExpectedPlan: "IndexedTableAccess(mytable)\n" +
+			" ├─ index: [mytable.s]\n" +
+			" ├─ static: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
+			" ├─ colSet: (1,2)\n" +
+			" ├─ tableId: 1\n" +
+			" └─ Table\n" +
+			"     ├─ name: mytable\n" +
 			"     └─ columns: [i s]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (mytable.s HASH IN ('second row', 'FIRST ROW'))\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s]\n" +
-			"     ├─ filters: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
-			"     └─ columns: [i s]\n" +
+		ExpectedEstimates: "IndexedTableAccess(mytable)\n" +
+			" ├─ index: [mytable.s]\n" +
+			" ├─ filters: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
+			" └─ columns: [i s]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(mytable)\n" +
+			" ├─ index: [mytable.s]\n" +
+			" ├─ filters: [{[FIRST ROW, FIRST ROW]}, {[second row, second row]}]\n" +
+			" └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -11278,42 +11209,34 @@ inner join pq on true
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (3,4)\n" +
 			" ├─ tableId: 2\n" +
-			" └─ Filter\n" +
-			"     ├─ Eq\n" +
-			"     │   ├─ othertable.s2:0!null\n" +
-			"     │   └─ a (longtext)\n" +
-			"     └─ IndexedTableAccess(othertable)\n" +
-			"         ├─ index: [othertable.s2]\n" +
-			"         ├─ static: [{[a, a]}]\n" +
-			"         ├─ colSet: (1,2)\n" +
-			"         ├─ tableId: 1\n" +
-			"         └─ Table\n" +
-			"             ├─ name: othertable\n" +
-			"             └─ columns: [s2 i2]\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
+			"     ├─ index: [othertable.s2]\n" +
+			"     ├─ static: [{[a, a]}]\n" +
+			"     ├─ colSet: (1,2)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: othertable\n" +
+			"         └─ columns: [s2 i2]\n" +
 			"",
 		ExpectedEstimates: "SubqueryAlias\n" +
 			" ├─ name: othertable_alias\n" +
 			" ├─ outerVisibility: false\n" +
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
-			" └─ Filter\n" +
-			"     ├─ (othertable.s2 = 'a')\n" +
-			"     └─ IndexedTableAccess(othertable)\n" +
-			"         ├─ index: [othertable.s2]\n" +
-			"         ├─ filters: [{[a, a]}]\n" +
-			"         └─ columns: [s2 i2]\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
+			"     ├─ index: [othertable.s2]\n" +
+			"     ├─ filters: [{[a, a]}]\n" +
+			"     └─ columns: [s2 i2]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
 			" ├─ name: othertable_alias\n" +
 			" ├─ outerVisibility: false\n" +
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
-			" └─ Filter\n" +
-			"     ├─ (othertable.s2 = 'a')\n" +
-			"     └─ IndexedTableAccess(othertable)\n" +
-			"         ├─ index: [othertable.s2]\n" +
-			"         ├─ filters: [{[a, a]}]\n" +
-			"         └─ columns: [s2 i2]\n" +
+			" └─ IndexedTableAccess(othertable)\n" +
+			"     ├─ index: [othertable.s2]\n" +
+			"     ├─ filters: [{[a, a]}]\n" +
+			"     └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -11339,18 +11262,14 @@ inner join pq on true
 			"         ├─ cacheable: true\n" +
 			"         ├─ colSet: (3,4)\n" +
 			"         ├─ tableId: 2\n" +
-			"         └─ Filter\n" +
-			"             ├─ Eq\n" +
-			"             │   ├─ othertable.s2:0!null\n" +
-			"             │   └─ a (longtext)\n" +
-			"             └─ IndexedTableAccess(othertable)\n" +
-			"                 ├─ index: [othertable.s2]\n" +
-			"                 ├─ static: [{[a, a]}]\n" +
-			"                 ├─ colSet: (1,2)\n" +
-			"                 ├─ tableId: 1\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: othertable\n" +
-			"                     └─ columns: [s2 i2]\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
+			"             ├─ index: [othertable.s2]\n" +
+			"             ├─ static: [{[a, a]}]\n" +
+			"             ├─ colSet: (1,2)\n" +
+			"             ├─ tableId: 1\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: othertable\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 		ExpectedEstimates: "SubqueryAlias\n" +
 			" ├─ name: othertable_three\n" +
@@ -11367,12 +11286,10 @@ inner join pq on true
 			"         ├─ outerVisibility: false\n" +
 			"         ├─ isLateral: false\n" +
 			"         ├─ cacheable: true\n" +
-			"         └─ Filter\n" +
-			"             ├─ (othertable.s2 = 'a')\n" +
-			"             └─ IndexedTableAccess(othertable)\n" +
-			"                 ├─ index: [othertable.s2]\n" +
-			"                 ├─ filters: [{[a, a]}]\n" +
-			"                 └─ columns: [s2 i2]\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
+			"             ├─ index: [othertable.s2]\n" +
+			"             ├─ filters: [{[a, a]}]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
 			" ├─ name: othertable_three\n" +
@@ -11389,12 +11306,10 @@ inner join pq on true
 			"         ├─ outerVisibility: false\n" +
 			"         ├─ isLateral: false\n" +
 			"         ├─ cacheable: true\n" +
-			"         └─ Filter\n" +
-			"             ├─ (othertable.s2 = 'a')\n" +
-			"             └─ IndexedTableAccess(othertable)\n" +
-			"                 ├─ index: [othertable.s2]\n" +
-			"                 ├─ filters: [{[a, a]}]\n" +
-			"                 └─ columns: [s2 i2]\n" +
+			"         └─ IndexedTableAccess(othertable)\n" +
+			"             ├─ index: [othertable.s2]\n" +
+			"             ├─ filters: [{[a, a]}]\n" +
+			"             └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{
@@ -11410,18 +11325,14 @@ inner join pq on true
 			" │   ├─ cacheable: true\n" +
 			" │   ├─ colSet: (5,6)\n" +
 			" │   ├─ tableId: 3\n" +
-			" │   └─ Filter\n" +
-			" │       ├─ GreaterThan\n" +
-			" │       │   ├─ othertable.s2:0!null\n" +
-			" │       │   └─ a (longtext)\n" +
-			" │       └─ IndexedTableAccess(othertable)\n" +
-			" │           ├─ index: [othertable.s2]\n" +
-			" │           ├─ static: [{(a, ∞)}]\n" +
-			" │           ├─ colSet: (3,4)\n" +
-			" │           ├─ tableId: 2\n" +
-			" │           └─ Table\n" +
-			" │               ├─ name: othertable\n" +
-			" │               └─ columns: [s2 i2]\n" +
+			" │   └─ IndexedTableAccess(othertable)\n" +
+			" │       ├─ index: [othertable.s2]\n" +
+			" │       ├─ static: [{(a, ∞)}]\n" +
+			" │       ├─ colSet: (3,4)\n" +
+			" │       ├─ tableId: 2\n" +
+			" │       └─ Table\n" +
+			" │           ├─ name: othertable\n" +
+			" │           └─ columns: [s2 i2]\n" +
 			" └─ HashLookup\n" +
 			"     ├─ left-key: TUPLE(othertable.i2:1!null)\n" +
 			"     ├─ right-key: TUPLE(mytable.i:0!null)\n" +
@@ -11437,12 +11348,10 @@ inner join pq on true
 			" │   ├─ outerVisibility: false\n" +
 			" │   ├─ isLateral: false\n" +
 			" │   ├─ cacheable: true\n" +
-			" │   └─ Filter\n" +
-			" │       ├─ (othertable.s2 > 'a')\n" +
-			" │       └─ IndexedTableAccess(othertable)\n" +
-			" │           ├─ index: [othertable.s2]\n" +
-			" │           ├─ filters: [{(a, ∞)}]\n" +
-			" │           └─ columns: [s2 i2]\n" +
+			" │   └─ IndexedTableAccess(othertable)\n" +
+			" │       ├─ index: [othertable.s2]\n" +
+			" │       ├─ filters: [{(a, ∞)}]\n" +
+			" │       └─ columns: [s2 i2]\n" +
 			" └─ HashLookup\n" +
 			"     ├─ left-key: (othertable.i2)\n" +
 			"     ├─ right-key: (mytable.i)\n" +
@@ -11457,12 +11366,10 @@ inner join pq on true
 			" │   ├─ outerVisibility: false\n" +
 			" │   ├─ isLateral: false\n" +
 			" │   ├─ cacheable: true\n" +
-			" │   └─ Filter\n" +
-			" │       ├─ (othertable.s2 > 'a')\n" +
-			" │       └─ IndexedTableAccess(othertable)\n" +
-			" │           ├─ index: [othertable.s2]\n" +
-			" │           ├─ filters: [{(a, ∞)}]\n" +
-			" │           └─ columns: [s2 i2]\n" +
+			" │   └─ IndexedTableAccess(othertable)\n" +
+			" │       ├─ index: [othertable.s2]\n" +
+			" │       ├─ filters: [{(a, ∞)}]\n" +
+			" │       └─ columns: [s2 i2]\n" +
 			" └─ HashLookup\n" +
 			"     ├─ left-key: (othertable.i2)\n" +
 			"     ├─ right-key: (mytable.i)\n" +
@@ -16733,19 +16640,14 @@ inner join pq on true
 			"             ├─ row_number() over ( order by othertable.s2 ASC)\n" +
 			"             ├─ othertable.i2:1!null\n" +
 			"             ├─ othertable.s2:0!null\n" +
-			"             └─ Filter\n" +
-			"                 ├─ NOT\n" +
-			"                 │   └─ Eq\n" +
-			"                 │       ├─ othertable.s2:0!null\n" +
-			"                 │       └─ second (longtext)\n" +
-			"                 └─ IndexedTableAccess(othertable)\n" +
-			"                     ├─ index: [othertable.s2]\n" +
-			"                     ├─ static: [{(NULL, second)}, {(second, ∞)}]\n" +
-			"                     ├─ colSet: (1,2)\n" +
-			"                     ├─ tableId: 1\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: othertable\n" +
-			"                         └─ columns: [s2 i2]\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
+			"                 ├─ index: [othertable.s2]\n" +
+			"                 ├─ static: [{(NULL, second)}, {(second, ∞)}]\n" +
+			"                 ├─ colSet: (1,2)\n" +
+			"                 ├─ tableId: 1\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: othertable\n" +
+			"                     └─ columns: [s2 i2]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [row_number() over ( order by othertable.s2 asc) as idx, othertable.i2, othertable.s2]\n" +
@@ -16753,12 +16655,10 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [row_number() over ( order by othertable.s2 asc), othertable.i2, othertable.s2, row_number() over ( order by othertable.s2 asc) as idx]\n" +
 			"         └─ Window(row_number() over ( order by othertable.s2 ASC), othertable.i2, othertable.s2)\n" +
-			"             └─ Filter\n" +
-			"                 ├─ (NOT((othertable.s2 = 'second')))\n" +
-			"                 └─ IndexedTableAccess(othertable)\n" +
-			"                     ├─ index: [othertable.s2]\n" +
-			"                     ├─ filters: [{(NULL, second)}, {(second, ∞)}]\n" +
-			"                     └─ columns: [s2 i2]\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
+			"                 ├─ index: [othertable.s2]\n" +
+			"                 ├─ filters: [{(NULL, second)}, {(second, ∞)}]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [row_number() over ( order by othertable.s2 asc) as idx, othertable.i2, othertable.s2]\n" +
@@ -16766,12 +16666,10 @@ inner join pq on true
 			"     └─ Project\n" +
 			"         ├─ columns: [row_number() over ( order by othertable.s2 asc), othertable.i2, othertable.s2, row_number() over ( order by othertable.s2 asc) as idx]\n" +
 			"         └─ Window(row_number() over ( order by othertable.s2 ASC), othertable.i2, othertable.s2)\n" +
-			"             └─ Filter\n" +
-			"                 ├─ (NOT((othertable.s2 = 'second')))\n" +
-			"                 └─ IndexedTableAccess(othertable)\n" +
-			"                     ├─ index: [othertable.s2]\n" +
-			"                     ├─ filters: [{(NULL, second)}, {(second, ∞)}]\n" +
-			"                     └─ columns: [s2 i2]\n" +
+			"             └─ IndexedTableAccess(othertable)\n" +
+			"                 ├─ index: [othertable.s2]\n" +
+			"                 ├─ filters: [{(NULL, second)}, {(second, ∞)}]\n" +
+			"                 └─ columns: [s2 i2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/tpcc_plans.go
+++ b/enginetest/queries/tpcc_plans.go
@@ -418,42 +418,34 @@ UPDATE warehouse2 SET w_ytd = w_ytd + 1767 WHERE w_id = 1`,
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(customer2.c_id:0!null)\n" +
 			"     ├─ group: \n" +
-			"     └─ Filter\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ customer2.c_last:3\n" +
-			"         │   └─ ESEEINGABLE (longtext)\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ static: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
-			"             ├─ colSet: (1-21)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: customer2\n" +
-			"                 └─ columns: [c_id c_d_id c_w_id c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ static: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1-21)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: customer2\n" +
+			"             └─ columns: [c_id c_d_id c_w_id c_last]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [count(customer2.c_id) as namecnt]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ SelectedExprs(COUNT(customer2.c_id))\n" +
 			"     ├─ Grouping()\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'ESEEINGABLE')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_last]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [count(customer2.c_id) as namecnt]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ SelectedExprs(COUNT(customer2.c_id))\n" +
 			"     ├─ Grouping()\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'ESEEINGABLE')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_last]\n" +
 			"",
 	},
 	{
@@ -461,38 +453,30 @@ UPDATE warehouse2 SET w_ytd = w_ytd + 1767 WHERE w_id = 1`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [customer2.c_id:0!null]\n" +
 			" └─ Sort(customer2.c_first:3 ASC nullsFirst)\n" +
-			"     └─ Filter\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ customer2.c_last:4\n" +
-			"         │   └─ ESEEINGABLE (longtext)\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ static: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
-			"             ├─ colSet: (1-21)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: customer2\n" +
-			"                 └─ columns: [c_id c_d_id c_w_id c_first c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ static: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1-21)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: customer2\n" +
+			"             └─ columns: [c_id c_d_id c_w_id c_first c_last]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [customer2.c_id]\n" +
 			" └─ Sort(customer2.c_first ASC)\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'ESEEINGABLE')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_first c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_first c_last]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [customer2.c_id]\n" +
 			" └─ Sort(customer2.c_first ASC)\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'ESEEINGABLE')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_first c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [5, 5], [ESEEINGABLE, ESEEINGABLE], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_first c_last]\n" +
 			"",
 	},
 	{
@@ -561,42 +545,34 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(customer2.c_id:0!null)\n" +
 			"     ├─ group: \n" +
-			"     └─ Filter\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ customer2.c_last:3\n" +
-			"         │   └─ PRIESEPRES (longtext)\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ static: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
-			"             ├─ colSet: (1-21)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: customer2\n" +
-			"                 └─ columns: [c_id c_d_id c_w_id c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ static: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1-21)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: customer2\n" +
+			"             └─ columns: [c_id c_d_id c_w_id c_last]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [count(customer2.c_id) as namecnt]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ SelectedExprs(COUNT(customer2.c_id))\n" +
 			"     ├─ Grouping()\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'PRIESEPRES')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_last]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [count(customer2.c_id) as namecnt]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ SelectedExprs(COUNT(customer2.c_id))\n" +
 			"     ├─ Grouping()\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'PRIESEPRES')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_last]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_last]\n" +
 			"",
 	},
 	{
@@ -604,38 +580,30 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [customer2.c_balance:6, customer2.c_first:3, customer2.c_middle:4, customer2.c_id:0!null]\n" +
 			" └─ Sort(customer2.c_first:3 ASC nullsFirst)\n" +
-			"     └─ Filter\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ customer2.c_last:5\n" +
-			"         │   └─ PRIESEPRES (longtext)\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ static: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
-			"             ├─ colSet: (1-21)\n" +
-			"             ├─ tableId: 1\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: customer2\n" +
-			"                 └─ columns: [c_id c_d_id c_w_id c_first c_middle c_last c_balance]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ static: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
+			"         ├─ colSet: (1-21)\n" +
+			"         ├─ tableId: 1\n" +
+			"         └─ Table\n" +
+			"             ├─ name: customer2\n" +
+			"             └─ columns: [c_id c_d_id c_w_id c_first c_middle c_last c_balance]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [customer2.c_balance, customer2.c_first, customer2.c_middle, customer2.c_id]\n" +
 			" └─ Sort(customer2.c_first ASC)\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'PRIESEPRES')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_first c_middle c_last c_balance]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_first c_middle c_last c_balance]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [customer2.c_balance, customer2.c_first, customer2.c_middle, customer2.c_id]\n" +
 			" └─ Sort(customer2.c_first ASC)\n" +
-			"     └─ Filter\n" +
-			"         ├─ (customer2.c_last = 'PRIESEPRES')\n" +
-			"         └─ IndexedTableAccess(customer2)\n" +
-			"             ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
-			"             ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
-			"             └─ columns: [c_id c_d_id c_w_id c_first c_middle c_last c_balance]\n" +
+			"     └─ IndexedTableAccess(customer2)\n" +
+			"         ├─ index: [customer2.c_w_id,customer2.c_d_id,customer2.c_last,customer2.c_first]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [PRIESEPRES, PRIESEPRES], [NULL, ∞)}]\n" +
+			"         └─ columns: [c_id c_d_id c_w_id c_first c_middle c_last c_balance]\n" +
 			"",
 	},
 	{

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -104,7 +104,7 @@ func indexSearchableLookup(n sql.Node, rt sql.TableNode, lookup sql.IndexLookup,
 		return n, transform.SameTree, nil
 	}
 
-	if preciseIndexAccess(iat, lookup.Index) {
+	if !preciseIndexAccess(iat, lookup.Index) {
 		// cannot drop any filters
 		newFilter = oldFilter
 	}
@@ -284,7 +284,7 @@ func getCostedIndexScan(ctx *sql.Context, statsProv sql.StatsProvider, rt sql.Ta
 	}
 
 	var retFilters []sql.Expression
-	if preciseIndexAccess(iat, lookup.Index) {
+	if !preciseIndexAccess(iat, lookup.Index) {
 		// cannot drop filters
 		retFilters = filters
 	} else if len(b.leftover) > 0 {

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -56,19 +56,8 @@ func PreciseComparison(e sql.Expression) bool {
 			}
 
 			if tupType, ok := right.(types.TupleType); ok {
-				for _, typCb := range []func(t sql.Type) bool{types.IsText, types.IsInteger} {
-					if typCb(left) {
-						rightAllSameType := true
-						for _, typ := range tupType {
-							if !typCb(typ) {
-								rightAllSameType = false
-								break
-							}
-						}
-						if rightAllSameType {
-							return true
-						}
-					}
+				if tupleTypesMatch(left, tupType, types.IsInteger) || tupleTypesMatch(left, tupType, types.IsText) {
+					return true
 				}
 				for _, right := range tupType {
 					if !left.Equals(right) {
@@ -88,6 +77,18 @@ func PreciseComparison(e sql.Expression) bool {
 		return true
 	})
 	return !imprecise
+}
+
+func tupleTypesMatch(left sql.Type, tup types.TupleType, typeCb func(t sql.Type) bool) bool {
+	if !typeCb(left) {
+		return false
+	}
+	for _, right := range tup {
+		if !typeCb(right) {
+			return false
+		}
+	}
+	return true
 }
 
 type comparison struct {


### PR DESCRIPTION
We currently do not eliminate filters of the form `column(VARCHAR) = text literal (longtext)` when pushing filters into index lookups. The safety check is necessary at least for datetimes, spatial/fulltext and partial TEXT indexes. It's not clear whether it is necessary for full varchar indexes.

dolt side seems OK: https://github.com/dolthub/dolt/pull/8218