### PR TITLE
Bug fix: the `timestamp` function should convert to a `datetime` type

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -482,11 +482,11 @@ var analyzerTestCases = []analyzerTestCase{
 		planGenerator: func(t *testing.T, ctx *sql.Context, engine enginetest.QueryEngine) sql.Node {
 			db, err := engine.EngineAnalyzer().Catalog.Database(ctx, "foo")
 			require.NoError(t, err)
-			timestamp, err := function.NewTimestamp(
+			datetime, err := function.NewDatetime(
 				expression.NewLiteral("20200101:120000Z", types.LongText),
 			)
 			require.NoError(t, err)
-			return plan.NewShowTables(db, false, timestamp)
+			return plan.NewShowTables(db, false, datetime)
 		},
 	},
 	{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3681,6 +3681,13 @@ Select * from (
 		Expected: []sql.Row{{1}},
 	},
 	{
+		// The timestamp function actually converts to a datetime type, so check that we can convert values
+		// outside of the timestamp range, but inside the datetime range.
+		// https://github.com/dolthub/dolt/issues/8236
+		Query:    "SELECT timestamp('1001-01-01 00:00:00');",
+		Expected: []sql.Row{{time.Date(1001, time.January, 1, 0, 0, 0, 0, time.UTC)}},
+	},
+	{
 		Query:    "select i from datetime_table where timestamp_col = '2020-01-02T12:00:01'",
 		Expected: []sql.Row{},
 	},

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -290,7 +290,7 @@ var BuiltIns = []sql.Function{
 	sql.Function2{Name: "time_format", Fn: NewTimeFormat},
 	sql.Function1{Name: "time_to_sec", Fn: NewTimeToSec},
 	sql.Function2{Name: "timediff", Fn: NewTimeDiff},
-	sql.FunctionN{Name: "timestamp", Fn: NewTimestamp},
+	sql.FunctionN{Name: "timestamp", Fn: NewDatetime},
 	sql.Function3{Name: "timestampdiff", Fn: NewTimestampDiff},
 	sql.Function1{Name: "to_base64", Fn: NewToBase64},
 	sql.Function1{Name: "to_days", Fn: NewToDays},


### PR DESCRIPTION
[MySQL's `timestamp` function](https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_timestamp), despite its name, actually returns a `datetime` type and not a `timestamp` type. 

MySQL example: 
```bash
mysql -uroot --protocol TCP -e "select timestamp('1000-01-01 00:00:00');" --column-type-info
Field   1:  `timestamp('1000-01-01 00:00:00')`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       DATETIME
Collation:  binary (63)
Length:     19
Max_length: 19
Decimals:   0
Flags:      BINARY 

+----------------------------------+
| timestamp('1000-01-01 00:00:00') |
+----------------------------------+
| 1000-01-01 00:00:00              |
+----------------------------------+
```

Note: We still need to add support for the second, optional parameter to `timestamp()`. 

Customer issue: https://github.com/dolthub/dolt/issues/8236