### PR TITLE
Fix error when comparing incompatible types in `IndexLookup`s

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -25073,4 +25073,28 @@ order by x, y;
 			"     └─ keys: xy.x\n" +
 			"",
 	},
+	{
+		Query: "select * from xy where x = json_object();",
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ xy.x:0!null\n" +
+			" │   └─ {} (json)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: xy\n" +
+			"         └─ columns: [x y]\n" +
+			"",
+	},
+	{
+		Query: "select * from xy where x = json_array();",
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ xy.x:0!null\n" +
+			" │   └─ [] (json)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: xy\n" +
+			"         └─ columns: [x y]\n" +
+			"",
+	},
 }

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -221,6 +221,9 @@ func getCostedIndexScan(ctx *sql.Context, statsProv sql.StatsProvider, rt sql.Ta
 		b.leftover = append(b.leftover, leftover)
 	}
 	ranges, err := b.buildRangeCollection(root)
+	if sql.ErrInvalidValueType.Is(err) {
+		return nil, nil, nil, nil
+	}
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -563,8 +563,6 @@ func (b *EqualityIndexBuilder) AddEquality(_ *Context, colIdx int, k interface{}
 		}
 	}
 
-	// TODO: take into account key type?
-
 	var err error
 	k, _, err = typ.Convert(k)
 	if err != nil {

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -563,6 +563,8 @@ func (b *EqualityIndexBuilder) AddEquality(_ *Context, colIdx int, k interface{}
 		}
 	}
 
+	// TODO: take into account key type?
+
 	var err error
 	k, _, err = typ.Convert(k)
 	if err != nil {

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -2472,38 +2472,6 @@ Project
      └─ tableId: 0
 `,
 		},
-		{
-			Query: "select * from xy where x = json_object();",
-			ExpectedPlan: `
-Project
- ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null]
- └─ Filter
-     ├─ Eq
-     │   ├─ xy.x:1!null
-     │   └─ json_object()
-     └─ Table
-         ├─ name: xy
-         ├─ columns: [x y z]
-         ├─ colSet: (1-3)
-         └─ tableId: 1
-`,
-		},
-		{
-			Query: "select * from xy where x = json_array();",
-			ExpectedPlan: `
-Project
- ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null]
- └─ Filter
-     ├─ Eq
-     │   ├─ xy.x:1!null
-     │   └─ json_array()
-     └─ Table
-         ├─ name: xy
-         ├─ columns: [x y z]
-         ├─ colSet: (1-3)
-         └─ tableId: 1
-`,
-		},
 	}
 
 	var w *bufio.Writer

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -2448,7 +2448,6 @@ Project
 			Skip:  true,
 			Query: "select x + 1 as xx from xy join uv on (x = u) group by xx having avg(xx) = 123;",
 		},
-
 		{
 			Query: "select name_const('abc', 123);",
 			ExpectedPlan: `
@@ -2461,7 +2460,6 @@ Project
      └─ tableId: 0
 `,
 		},
-
 		{
 			Query: "select icu_version();",
 			ExpectedPlan: `
@@ -2472,6 +2470,38 @@ Project
      ├─ columns: []
      ├─ colSet: ()
      └─ tableId: 0
+`,
+		},
+		{
+			Query: "select * from xy where x = json_object();",
+			ExpectedPlan: `
+Project
+ ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null]
+ └─ Filter
+     ├─ Eq
+     │   ├─ xy.x:1!null
+     │   └─ json_object()
+     └─ Table
+         ├─ name: xy
+         ├─ columns: [x y z]
+         ├─ colSet: (1-3)
+         └─ tableId: 1
+`,
+		},
+		{
+			Query: "select * from xy where x = json_array();",
+			ExpectedPlan: `
+Project
+ ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null]
+ └─ Filter
+     ├─ Eq
+     │   ├─ xy.x:1!null
+     │   └─ json_array()
+     └─ Table
+         ├─ name: xy
+         ├─ columns: [x y z]
+         ├─ colSet: (1-3)
+         └─ tableId: 1
 `,
 		},
 	}


### PR DESCRIPTION
When building lookups for `IndexedTableAccess`, we always convert the key type to the columns type.
This is problematic when the key can't be converted to the column type without error.

The expressions used in `Filters` properly handle this conversion, so we should default to that.

Example:
```sql
tmp/main*> create table t (i int primary key);
tmp/main*> select * from t where i = json_array();
error: '[]interface {}' is not a valid value type for 'int'
```
This doesn't errror in MySQL. Also without a primary key or secondary index, the query succeeds in dolt.
