### PR TITLE
Aggregation/range scan perf edits

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -173,7 +173,7 @@ func New(a *analyzer.Analyzer, cfg *Config) *Engine {
 
 	emptyCtx := sql.NewEmptyContext()
 
-	if fn, err := a.Catalog.Function(emptyCtx, "version"); fn == nil || err != nil {
+	if _, ok := a.Catalog.Function(emptyCtx, "version"); !ok {
 		a.Catalog.RegisterFunction(emptyCtx, sql.FunctionN{
 			Name: "version",
 			Fn:   function.NewVersion(cfg.VersionPostfix),

--- a/enginetest/join_stats_tests.go
+++ b/enginetest/join_stats_tests.go
@@ -355,8 +355,8 @@ type TestProvider struct {
 	tableFunctions map[string]sql.TableFunction
 }
 
-func (t TestProvider) Function(_ *sql.Context, name string) (sql.Function, error) {
-	return nil, sql.ErrFunctionNotFound.New(name)
+func (t TestProvider) Function(ctx *sql.Context, name string) (sql.Function, bool) {
+	return nil, false
 }
 
 func (t TestProvider) TableFunction(_ *sql.Context, name string) (sql.TableFunction, error) {

--- a/sql/analyzer/catalog.go
+++ b/sql/analyzer/catalog.go
@@ -311,13 +311,11 @@ func (c *Catalog) RegisterFunction(ctx *sql.Context, fns ...sql.Function) {
 }
 
 // Function returns the function with the name given, or sql.ErrFunctionNotFound if it doesn't exist
-func (c *Catalog) Function(ctx *sql.Context, name string) (sql.Function, error) {
+func (c *Catalog) Function(ctx *sql.Context, name string) (sql.Function, bool) {
 	if fp, ok := c.DbProvider.(sql.FunctionProvider); ok {
-		f, err := fp.Function(ctx, name)
-		if err != nil && !sql.ErrFunctionNotFound.Is(err) {
-			return nil, err
-		} else if f != nil {
-			return f, nil
+		f, ok := fp.Function(ctx, name)
+		if ok {
+			return f, true
 		}
 	}
 

--- a/sql/analyzer/catalog.go
+++ b/sql/analyzer/catalog.go
@@ -310,7 +310,7 @@ func (c *Catalog) RegisterFunction(ctx *sql.Context, fns ...sql.Function) {
 	}
 }
 
-// Function returns the function with the name given, or sql.ErrFunctionNotFound if it doesn't exist
+// Function returns the function with the name given, or false if it doesn't exist.
 func (c *Catalog) Function(ctx *sql.Context, name string) (sql.Function, bool) {
 	if fp, ok := c.DbProvider.(sql.FunctionProvider); ok {
 		f, ok := fp.Function(ctx, name)

--- a/sql/analyzer/replace_count_star.go
+++ b/sql/analyzer/replace_count_star.go
@@ -36,8 +36,8 @@ func replaceCountStar(ctx *sql.Context, a *Analyzer, n sql.Node, _ *plan.Scope, 
 	return transform.Node(n, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		if agg, ok := n.(*plan.GroupBy); ok {
 
-			if len(agg.GroupByExprs) == 0 && !qFlags.JoinIsSet() && !qFlags.SubqueryIsSet() {
-				// top-level aggregation with a single group can only return one row
+			if len(agg.GroupByExprs) == 0 && !qFlags.JoinIsSet() && !qFlags.SubqueryIsSet() && !qFlags.IsSet(sql.QFlagAnyAgg) {
+				// top-level aggregation with a single group and no "any_value" functions can only return one row
 				qFlags.Set(sql.QFlagMax1Row)
 			}
 

--- a/sql/analyzer/replace_count_star.go
+++ b/sql/analyzer/replace_count_star.go
@@ -35,6 +35,12 @@ func replaceCountStar(ctx *sql.Context, a *Analyzer, n sql.Node, _ *plan.Scope, 
 
 	return transform.Node(n, func(n sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		if agg, ok := n.(*plan.GroupBy); ok {
+
+			if len(agg.GroupByExprs) == 0 && !qFlags.JoinIsSet() && !qFlags.SubqueryIsSet() {
+				// top-level aggregation with a single group can only return one row
+				qFlags.Set(sql.QFlagMax1Row)
+			}
+
 			if len(agg.SelectedExprs) == 1 && len(agg.GroupByExprs) == 0 {
 				child := agg.SelectedExprs[0]
 				var cnt *aggregation.Count

--- a/sql/catalog_map.go
+++ b/sql/catalog_map.go
@@ -18,11 +18,11 @@ func (t MapCatalog) WithTableFunctions(fns ...TableFunction) (TableFunctionProvi
 	panic("implement me")
 }
 
-func (t MapCatalog) Function(ctx *Context, name string) (Function, error) {
+func (t MapCatalog) Function(ctx *Context, name string) (Function, bool) {
 	if f, ok := t.Funcs[name]; ok {
-		return f, nil
+		return f, true
 	}
-	return nil, fmt.Errorf("func not found")
+	return nil, false
 }
 
 func (t MapCatalog) TableFunction(ctx *Context, name string) (TableFunction, error) {

--- a/sql/expression/function/functionregistry_test.go
+++ b/sql/expression/function/functionregistry_test.go
@@ -35,8 +35,8 @@ func TestFunctionRegistry(t *testing.T) {
 		Fn:   func(arg sql.Expression) sql.Expression { return expected },
 	})
 
-	f, err := reg.Function(sql.NewEmptyContext(), name)
-	require.NoError(err)
+	f, ok := reg.Function(sql.NewEmptyContext(), name)
+	require.True(ok)
 
 	e, err := f.NewInstance(nil)
 	require.Error(err)
@@ -55,7 +55,7 @@ func TestFunctionRegistryMissingFunction(t *testing.T) {
 	require := require.New(t)
 
 	reg := function.NewRegistry()
-	f, err := reg.Function(sql.NewEmptyContext(), "func")
-	require.Error(err)
+	f, ok := reg.Function(sql.NewEmptyContext(), "func")
+	require.False(ok)
 	require.Nil(f)
 }

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -19,7 +19,6 @@ import (
 
 	"gopkg.in/src-d/go-errors.v1"
 
-	"github.com/dolthub/go-mysql-server/internal/similartext"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation/window"
@@ -344,12 +343,11 @@ func (r Registry) Register(fn ...sql.Function) error {
 }
 
 // Function implements sql.FunctionProvider
-func (r Registry) Function(ctx *sql.Context, name string) (sql.Function, error) {
+func (r Registry) Function(ctx *sql.Context, name string) (sql.Function, bool) {
 	if fn, ok := r[name]; ok {
-		return fn, nil
+		return fn, true
 	}
-	similar := similartext.FindFromMap(r, name)
-	return nil, sql.ErrFunctionNotFound.New(name + similar)
+	return nil, false
 }
 
 func (r Registry) mustRegister(fn ...sql.Function) {

--- a/sql/functions.go
+++ b/sql/functions.go
@@ -28,7 +28,7 @@ type Function interface {
 // implemented by a DatabaseProvider.
 type FunctionProvider interface {
 	// Function returns the function with the name provided, case-insensitive
-	Function(ctx *Context, name string) (Function, error)
+	Function(ctx *Context, name string) (Function, bool)
 }
 
 type CreateFunc0Args func() Expression

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -284,7 +284,7 @@ func (b *Builder) buildAggregateFunc(inScope *scope, name string, e *ast.FuncExp
 	}
 	gb := inScope.groupBy
 
-	if name == "count" {
+	if strings.EqualFold(name, "count") {
 		if _, ok := e.Exprs[0].(*ast.StarExpr); ok {
 			var agg sql.Aggregation
 			if e.Distinct {
@@ -313,7 +313,7 @@ func (b *Builder) buildAggregateFunc(inScope *scope, name string, e *ast.FuncExp
 		}
 	}
 
-	if name == "jsonarray" {
+	if strings.EqualFold(name, "jsonarray") {
 		// TODO we don't have any tests for this
 		if _, ok := e.Exprs[0].(*ast.StarExpr); ok {
 			var agg sql.Aggregation
@@ -343,7 +343,7 @@ func (b *Builder) buildAggregateFunc(inScope *scope, name string, e *ast.FuncExp
 		}
 	}
 
-	if name == "any_value" {
+	if strings.EqualFold(name, "any_value") {
 		b.qFlags.Set(sql.QFlagAnyAgg)
 	}
 

--- a/sql/planbuilder/builder.go
+++ b/sql/planbuilder/builder.go
@@ -49,7 +49,7 @@ type Builder struct {
 	insertActive    bool
 	nesting         int
 	parser          sql.Parser
-	qProps          *sql.QueryFlags
+	qFlags          *sql.QueryFlags
 }
 
 // BindvarContext holds bind variable replacement literals.
@@ -114,7 +114,7 @@ func New(ctx *sql.Context, cat sql.Catalog, p sql.Parser) *Builder {
 		parserOpts: sqlMode.ParserOptions(),
 		f:          &factory{},
 		parser:     p,
-		qProps:     &sql.QueryFlags{},
+		qFlags:     &sql.QueryFlags{},
 	}
 }
 
@@ -173,7 +173,7 @@ func (b *Builder) Reset() {
 	b.triggerCtx = nil
 	b.viewCtx = nil
 	b.nesting = 0
-	b.qProps = &sql.QueryFlags{}
+	b.qFlags = &sql.QueryFlags{}
 }
 
 type parseErr struct {
@@ -210,7 +210,7 @@ func (b *Builder) buildSubquery(inScope *scope, stmt ast.Statement, subQuery str
 	case *ast.DDL:
 		return b.buildDDL(inScope, subQuery, fullQuery, n)
 	case *ast.AlterTable:
-		b.qProps.Set(sql.QFlagAlterTable)
+		b.qFlags.Set(sql.QFlagAlterTable)
 		return b.buildAlterTable(inScope, subQuery, n)
 	case *ast.DBDDL:
 		return b.buildDBDDL(inScope, n)

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -450,7 +450,7 @@ func (b *Builder) buildCreateView(inScope *scope, subQuery string, fullQuery str
 	queryScope := b.buildSelectStmt(inScope, selectStatement)
 
 	queryAlias := plan.NewSubqueryAlias(c.ViewSpec.ViewName.Name.String(), selectStr, queryScope.node)
-	b.qProps.Set(sql.QFlagRelSubquery)
+	b.qFlags.Set(sql.QFlagRelSubquery)
 
 	definer := getCurrentUserForDefiner(b.ctx, c.ViewSpec.Definer)
 

--- a/sql/planbuilder/cte.go
+++ b/sql/planbuilder/cte.go
@@ -98,7 +98,7 @@ func (b *Builder) buildRecursiveCte(inScope *scope, union *ast.SetOp, name strin
 		switch n := cteScope.node.(type) {
 		case *plan.SetOp:
 			sq := plan.NewSubqueryAlias(name, "", n)
-			b.qProps.Set(sql.QFlagRelSubquery)
+			b.qFlags.Set(sql.QFlagRelSubquery)
 			sq = sq.WithColumnNames(columns)
 			sq = sq.WithCorrelated(sqScope.correlated())
 			sq = sq.WithVolatile(sqScope.volatile())
@@ -201,7 +201,7 @@ func (b *Builder) buildRecursiveCte(inScope *scope, union *ast.SetOp, name strin
 	rcteId := rcte.WithId(tableId).WithColumns(cols)
 
 	sq := plan.NewSubqueryAlias(name, "", rcteId)
-	b.qProps.Set(sql.QFlagRelSubquery)
+	b.qFlags.Set(sql.QFlagRelSubquery)
 	sq = sq.WithColumnNames(columns)
 	sq = sq.WithCorrelated(corr)
 	sq = sq.WithVolatile(vol)

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -289,7 +289,7 @@ func (b *Builder) buildCreateTable(inScope *scope, c *ast.DDL) (outScope *scope)
 		TableOpts: tblOpts,
 	}
 
-	b.qProps.Set(sql.QFlagSetDatabase)
+	b.qFlags.Set(sql.QFlagSetDatabase)
 	if c.OptSelect != nil {
 		selectScope := b.buildSelectStmt(inScope, c.OptSelect.Select)
 		outScope.node = plan.NewCreateTableSelect(database, c.Table.Name.String(), c.IfNotExists, c.Temporary, selectScope.node, tableSpec)
@@ -419,7 +419,7 @@ func (b *Builder) buildCreateTableLike(inScope *scope, ct *ast.DDL) *scope {
 
 	database := b.resolveDbForTable(ct.Table)
 
-	b.qProps.Set(sql.QFlagSetDatabase)
+	b.qFlags.Set(sql.QFlagSetDatabase)
 	outScope.node = plan.NewCreateTable(database, newTableName, ct.IfNotExists, ct.Temporary, tableSpec)
 	return outScope
 }

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -32,7 +32,7 @@ func (b *Builder) buildInsert(inScope *scope, i *ast.Insert) (outScope *scope) {
 	// TODO: this shouldn't be called during ComPrepare or `PREPARE ... FROM ...` statements, but currently it is.
 	//   The end result is that the ComDelete counter is incremented during prepare statements, which is incorrect.
 	sql.IncrementStatusVariable(b.ctx, "Com_insert", 1)
-	b.qProps.Set(sql.QFlagInsert)
+	b.qFlags.Set(sql.QFlagInsert)
 
 	if i.With != nil {
 		inScope = b.buildWith(inScope, i.With)
@@ -427,7 +427,7 @@ func (b *Builder) buildDelete(inScope *scope, d *ast.Delete) (outScope *scope) {
 	// TODO: this shouldn't be called during ComPrepare or `PREPARE ... FROM ...` statements, but currently it is.
 	//   The end result is that the ComDelete counter is incremented during prepare statements, which is incorrect.
 	sql.IncrementStatusVariable(b.ctx, "Com_delete", 1)
-	b.qProps.Set(sql.QFlagDelete)
+	b.qFlags.Set(sql.QFlagDelete)
 
 	outScope = b.buildFrom(inScope, d.TableExprs)
 	b.buildWhere(outScope, d.Where)
@@ -482,7 +482,7 @@ func (b *Builder) buildUpdate(inScope *scope, u *ast.Update) (outScope *scope) {
 	// TODO: this shouldn't be called during ComPrepare or `PREPARE ... FROM ...` statements, but currently it is.
 	//   The end result is that the ComDelete counter is incremented during prepare statements, which is incorrect.
 	sql.IncrementStatusVariable(b.ctx, "Com_update", 1)
-	b.qProps.Set(sql.QFlagUpdate)
+	b.qFlags.Set(sql.QFlagUpdate)
 
 	outScope = b.buildFrom(inScope, u.TableExprs)
 

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -78,7 +78,7 @@ func (b *Builder) isUsingJoin(te *ast.JoinTableExpr) bool {
 }
 
 func (b *Builder) buildJoin(inScope *scope, te *ast.JoinTableExpr) (outScope *scope) {
-	b.qProps.Set(sql.QFlagInnerJoin)
+	b.qFlags.Set(sql.QFlagInnerJoin)
 
 	//TODO build individual table expressions
 	// collect column  definitions
@@ -110,7 +110,7 @@ func (b *Builder) buildJoin(inScope *scope, te *ast.JoinTableExpr) (outScope *sc
 		} else if b.isLateral(te.RightExpr) {
 			outScope.node = plan.NewJoin(leftScope.node, rightScope.node, plan.JoinTypeLateralCross, nil)
 		} else {
-			b.qProps.Set(sql.QFlagCrossJoin)
+			b.qFlags.Set(sql.QFlagCrossJoin)
 			outScope.node = plan.NewCrossJoin(leftScope.node, rightScope.node)
 		}
 		return
@@ -304,7 +304,7 @@ func (b *Builder) buildDataSource(inScope *scope, te ast.TableExpr) (outScope *s
 			fromScope := b.buildSelectStmt(sqScope, e.Select)
 			alias := strings.ToLower(t.As.String())
 			sq := plan.NewSubqueryAlias(alias, ast.String(e.Select), fromScope.node)
-			b.qProps.Set(sql.QFlagRelSubquery)
+			b.qFlags.Set(sql.QFlagRelSubquery)
 			sq = sq.WithCorrelated(sqScope.correlated())
 			sq = sq.WithVolatile(sqScope.volatile())
 			sq.IsLateral = t.Lateral
@@ -844,7 +844,7 @@ func (b *Builder) resolveView(name string, database sql.Database, asOf interface
 				view = n.AsView(viewDef.CreateViewStatement)
 			default:
 				view = plan.NewSubqueryAlias(name, create.Definition.TextDefinition, n).AsView(viewDef.CreateViewStatement)
-				b.qProps.Set(sql.QFlagRelSubquery)
+				b.qFlags.Set(sql.QFlagRelSubquery)
 			}
 		}
 	}

--- a/sql/planbuilder/parse.go
+++ b/sql/planbuilder/parse.go
@@ -76,7 +76,7 @@ func (b *Builder) Parse(query string, multi bool) (ret sql.Node, parsed, remaind
 
 	outScope := b.build(nil, stmt, parsed)
 
-	return outScope.node, parsed, remainder, b.qProps, err
+	return outScope.node, parsed, remainder, b.qFlags, err
 }
 
 func (b *Builder) BindOnly(stmt ast.Statement, s string) (_ sql.Node, _ *sql.QueryFlags, err error) {
@@ -93,5 +93,5 @@ func (b *Builder) BindOnly(stmt ast.Statement, s string) (_ sql.Node, _ *sql.Que
 	}()
 
 	outScope := b.build(nil, stmt, s)
-	return outScope.node, b.qProps, err
+	return outScope.node, b.qFlags, err
 }

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -169,7 +169,7 @@ func (b *Builder) analyzeSelectList(inScope, outScope *scope, selectExprs ast.Se
 func (b *Builder) selectExprToExpression(inScope *scope, se ast.SelectExpr) sql.Expression {
 	switch e := se.(type) {
 	case *ast.StarExpr:
-		b.qProps.Set(sql.QFlagStar)
+		b.qFlags.Set(sql.QFlagStar)
 		if e.TableName.IsEmpty() {
 			return expression.NewStar()
 		}

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -146,8 +146,10 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 			return b.buildWindowFunc(inScope, name, v, (*ast.WindowDef)(v.Over))
 		}
 
-		f, err := b.cat.Function(b.ctx, name)
-		if err != nil {
+		f, ok := b.cat.Function(b.ctx, name)
+		if !ok {
+			// todo(max): similar names in registry?
+			err := sql.ErrFunctionNotFound.New(name)
 			b.handleErr(err)
 		}
 
@@ -341,8 +343,9 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 			return col.scalarGf()
 		} else {
 			col := b.buildScalar(inScope, v.Name)
-			fn, err := b.cat.Function(b.ctx, "values")
-			if err != nil {
+			fn, ok := b.cat.Function(b.ctx, "values")
+			if !ok {
+				err := sql.ErrFunctionNotFound.New("values")
 				b.handleErr(err)
 			}
 			values, err := fn.NewInstance([]sql.Expression{col})

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -95,7 +95,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 		return b.buildIsExprToExpression(inScope, v)
 	case *ast.NotExpr:
 		c := b.buildScalar(inScope, v.Expr)
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 
 		return expression.NewNot(c)
 	case *ast.SQLVal:
@@ -275,7 +275,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 		case ast.BetweenStr:
 			return expression.NewBetween(val, lower, upper)
 		case ast.NotBetweenStr:
-			b.qProps.Set(sql.QFlgNotExpr)
+			b.qFlags.Set(sql.QFlgNotExpr)
 			return expression.NewNot(expression.NewBetween(val, lower, upper))
 		default:
 			return nil
@@ -298,7 +298,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 		selScope := b.buildSelectStmt(sqScope, v.Select)
 		// TODO: get the original select statement, not the reconstruction
 		sq := plan.NewSubquery(selScope.node, selectString)
-		b.qProps.Set(sql.QFlagScalarSubquery)
+		b.qFlags.Set(sql.QFlagScalarSubquery)
 		sq = sq.WithCorrelated(sqScope.correlated())
 		if b.TriggerCtx().Active {
 			sq = sq.WithVolatile()
@@ -308,7 +308,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 		return b.buildCaseExpr(inScope, v)
 	case *ast.IntervalExpr:
 		e := b.buildScalar(inScope, v.Expr)
-		b.qProps.Set(sql.QFlagInterval)
+		b.qFlags.Set(sql.QFlagInterval)
 		return expression.NewInterval(e, v.Unit)
 	case *ast.CollateExpr:
 		// handleCollateExpr is meant to handle generic text-returning expressions that should be reinterpreted as a different collation.
@@ -361,7 +361,7 @@ func (b *Builder) buildScalar(inScope *scope, e ast.Expr) (ex sql.Expression) {
 		selectString := ast.String(v.Subquery.Select)
 		sq := plan.NewSubquery(selScope.node, selectString)
 		sq = sq.WithCorrelated(sqScope.correlated())
-		b.qProps.Set(sql.QFlagScalarSubquery)
+		b.qFlags.Set(sql.QFlagScalarSubquery)
 		return plan.NewExistsSubquery(sq)
 	case *ast.TimestampFuncExpr:
 		var (
@@ -444,7 +444,7 @@ func (b *Builder) buildUnaryScalar(inScope *scope, e *ast.UnaryExpr) sql.Express
 		return b.buildScalar(inScope, e.Expr)
 	case ast.BangStr:
 		c := b.buildScalar(inScope, e.Expr)
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		return expression.NewNot(c)
 	case ast.BinaryStr:
 		c := b.buildScalar(inScope, e.Expr)
@@ -596,7 +596,7 @@ func (b *Builder) buildComparison(inScope *scope, c *ast.ComparisonExpr) sql.Exp
 		if err != nil {
 			b.handleErr(err)
 		}
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		return expression.NewNot(regexpLike)
 	case ast.EqualStr:
 		return expression.NewEquals(left, right)
@@ -611,7 +611,7 @@ func (b *Builder) buildComparison(inScope *scope, c *ast.ComparisonExpr) sql.Exp
 	case ast.NullSafeEqualStr:
 		return expression.NewNullSafeEquals(left, right)
 	case ast.NotEqualStr:
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		return expression.NewNot(
 			expression.NewEquals(left, right),
 		)
@@ -620,20 +620,20 @@ func (b *Builder) buildComparison(inScope *scope, c *ast.ComparisonExpr) sql.Exp
 		case expression.Tuple:
 			return expression.NewInTuple(left, right)
 		case *plan.Subquery:
-			b.qProps.Set(sql.QFlagScalarSubquery)
+			b.qFlags.Set(sql.QFlagScalarSubquery)
 			return plan.NewInSubquery(left, right)
 		default:
 			err := sql.ErrUnsupportedFeature.New(fmt.Sprintf("IN %T", right))
 			b.handleErr(err)
 		}
 	case ast.NotInStr:
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		switch right.(type) {
 		case expression.Tuple:
-			b.qProps.Set(sql.QFlgNotExpr)
+			b.qFlags.Set(sql.QFlgNotExpr)
 			return expression.NewNotInTuple(left, right)
 		case *plan.Subquery:
-			b.qProps.Set(sql.QFlagScalarSubquery)
+			b.qFlags.Set(sql.QFlagScalarSubquery)
 			return plan.NewNotInSubquery(left, right)
 		default:
 			err := sql.ErrUnsupportedFeature.New(fmt.Sprintf("NOT IN %T", right))
@@ -642,7 +642,7 @@ func (b *Builder) buildComparison(inScope *scope, c *ast.ComparisonExpr) sql.Exp
 	case ast.LikeStr:
 		return expression.NewLike(left, right, escape)
 	case ast.NotLikeStr:
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		return expression.NewNot(expression.NewLike(left, right, escape))
 	default:
 		err := sql.ErrUnsupportedFeature.New(c.Operator)
@@ -677,17 +677,17 @@ func (b *Builder) buildIsExprToExpression(inScope *scope, c *ast.IsExpr) sql.Exp
 	case ast.IsNullStr:
 		return expression.NewIsNull(e)
 	case ast.IsNotNullStr:
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		return expression.NewNot(expression.NewIsNull(e))
 	case ast.IsTrueStr:
 		return expression.NewIsTrue(e)
 	case ast.IsFalseStr:
 		return expression.NewIsFalse(e)
 	case ast.IsNotTrueStr:
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		return expression.NewNot(expression.NewIsTrue(e))
 	case ast.IsNotFalseStr:
-		b.qProps.Set(sql.QFlgNotExpr)
+		b.qFlags.Set(sql.QFlgNotExpr)
 		return expression.NewNot(expression.NewIsFalse(e))
 	default:
 		err := sql.ErrUnsupportedSyntax.New(ast.String(c))
@@ -791,7 +791,7 @@ func (b *Builder) caseExprToExpression(inScope *scope, e *ast.CaseExpr) (sql.Exp
 
 func (b *Builder) intervalExprToExpression(inScope *scope, e *ast.IntervalExpr) *expression.Interval {
 	expr := b.buildScalar(inScope, e.Expr)
-	b.qProps.Set(sql.QFlagInterval)
+	b.qFlags.Set(sql.QFlagInterval)
 	return expression.NewInterval(expr, e.Unit)
 }
 

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -206,7 +206,7 @@ func (b *Builder) buildShowAllTriggers(inScope *scope, s *ast.Show) (outScope *s
 	}
 	db := b.resolveDb(dbName)
 
-	b.qProps.Set(sql.QFlagSetDatabase)
+	b.qFlags.Set(sql.QFlagSetDatabase)
 	var node sql.Node = plan.NewShowTriggers(db)
 
 	outScope = inScope.push()
@@ -626,7 +626,7 @@ func (b *Builder) buildShowAllTables(inScope *scope, s *ast.Show) (outScope *sco
 	}
 	db := b.resolveDb(dbName)
 
-	b.qProps.Set(sql.QFlagSetDatabase)
+	b.qFlags.Set(sql.QFlagSetDatabase)
 	showTabs := plan.NewShowTables(db, s.Full, asOf)
 	for _, c := range showTabs.Schema() {
 		outScope.newColumn(scopeColumn{
@@ -761,7 +761,7 @@ func (b *Builder) buildShowWarnings(inScope *scope, s *ast.Show) (outScope *scop
 		unsupportedShow := "SHOW COUNT(*) WARNINGS"
 		b.handleErr(sql.ErrUnsupportedFeature.New(unsupportedShow))
 	}
-	b.qProps.Set(sql.QFlagShowWarnings)
+	b.qFlags.Set(sql.QFlagShowWarnings)
 	var node sql.Node
 	node = plan.ShowWarnings(b.ctx.Session.Warnings())
 	if s.Limit != nil {

--- a/sql/query_flags.go
+++ b/sql/query_flags.go
@@ -38,6 +38,7 @@ const (
 	QFlagInnerJoin
 	QFlagLimit
 	QFlagInterval
+	QFlagAnyAgg
 
 	// QFlagMax1Row indicates that a query can only return at most one row
 	QFlagMax1Row

--- a/test/test_catalog.go
+++ b/test/test_catalog.go
@@ -149,8 +149,8 @@ func (c *Catalog) DatabaseTableAsOf(ctx *sql.Context, db sql.Database, tableName
 
 func (c *Catalog) RegisterFunction(ctx *sql.Context, fns ...sql.Function) {}
 
-func (c *Catalog) Function(ctx *sql.Context, name string) (sql.Function, error) {
-	return nil, sql.ErrFunctionNotFound.New(name)
+func (c *Catalog) Function(ctx *sql.Context, name string) (sql.Function, bool) {
+	return nil, false
 }
 
 func (c *Catalog) LockTable(ctx *sql.Context, table string) {}


### PR DESCRIPTION
- Resolving aggregation functions checks the integrator function provider first. The interface required us to create an expensive error object to resolve any standard functions. Now we only create the error object if a function name is not found in integrator and standard list.
- Skip duplicate unused functional dependency tracking in coster.
- Aggregations with no group by and single scopes can only return one row, so use the `sql.QFlagMax1Row` shortcut.

benchmarks here: https://github.com/dolthub/dolt/pull/8241