### PR TITLE
Adding tests for supporting duplicate secondary indexes

### DIFF
--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4126,8 +4126,11 @@ var IndexQueries = []ScriptTest{
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:    "ALTER TABLE t0 ADD CONSTRAINT unique_2 UNIQUE(col1, col2);",
-				Expected: []sql.Row{{types.NewOkResult(0)}},
+				Query:                           "ALTER TABLE t0 ADD CONSTRAINT unique_2 UNIQUE(col1, col2);",
+				Expected:                        []sql.Row{{types.NewOkResult(0)}},
+				ExpectedWarningsCount:           1,
+				ExpectedWarning:                 1831,
+				ExpectedWarningMessageSubstring: "Duplicate index 'unique_2' defined on the table 'mydb.t0'",
 			},
 			{
 				Query: "SELECT kc.`constraint_name`, kc.`column_name`, kc.`referenced_table_name`, kc.`referenced_column_name` FROM information_schema.key_column_usage AS kc WHERE kc.table_schema = DATABASE() AND kc.table_name = 't0' ORDER BY kc.`ordinal_position`;",
@@ -4145,8 +4148,11 @@ var IndexQueries = []ScriptTest{
 			},
 			// Create a new table with two indexes over the same column set
 			{
-				Query:    "CREATE TABLE `t2` (`id` char(32) NOT NULL PRIMARY KEY, `col1` varchar(255) NOT NULL, `col2` varchar(255) NOT NULL, UNIQUE KEY unique_1(col1, col2), UNIQUE KEY unique_2(col1, col2));",
-				Expected: []sql.Row{{types.NewOkResult(0)}},
+				Query:                           "CREATE TABLE `t2` (`id` char(32) NOT NULL PRIMARY KEY, `col1` varchar(255) NOT NULL, `col2` varchar(255) NOT NULL, UNIQUE KEY unique_1(col1, col2), UNIQUE KEY unique_2(col1, col2));",
+				Expected:                        []sql.Row{{types.NewOkResult(0)}},
+				ExpectedWarningsCount:           1,
+				ExpectedWarning:                 1831,
+				ExpectedWarningMessageSubstring: "Duplicate index 'unique_2' defined on the table 'mydb.t2'",
 			},
 			{
 				Query: "SELECT kc.`constraint_name`, kc.`column_name`, kc.`referenced_table_name`, kc.`referenced_column_name` FROM information_schema.key_column_usage AS kc WHERE kc.table_schema = DATABASE() AND kc.table_name = 't2' ORDER BY kc.`ordinal_position`;",
@@ -4168,8 +4174,11 @@ var IndexQueries = []ScriptTest{
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:    "ALTER TABLE t3 ADD CONSTRAINT UNIQUE(col1, col2);",
-				Expected: []sql.Row{{types.NewOkResult(0)}},
+				Query:                           "ALTER TABLE t3 ADD CONSTRAINT UNIQUE(col1, col2);",
+				Expected:                        []sql.Row{{types.NewOkResult(0)}},
+				ExpectedWarningsCount:           1,
+				ExpectedWarning:                 1831,
+				ExpectedWarningMessageSubstring: "Duplicate index 'col1_2' defined on the table 'mydb.t3'",
 			},
 			{
 				Query: "SELECT kc.`constraint_name`, kc.`column_name`, kc.`referenced_table_name`, kc.`referenced_column_name` FROM information_schema.key_column_usage AS kc WHERE kc.table_schema = DATABASE() AND kc.table_name = 't3' ORDER BY kc.`ordinal_position`;",

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4111,6 +4111,51 @@ var IndexQueries = []ScriptTest{
 		},
 	},
 	{
+		// MySQL allows creating multiple indexes over the same set of columns. This isn't generally
+		// useful, but some customers need this support. For example, generated migration code from
+		// Django can create cases that require this: https://github.com/dolthub/dolt/issues/8254
+		Name: "multiple indexes over same set of columns",
+		SetUpScript: []string{
+			"CREATE TABLE `t0` (`id` char(32) NOT NULL PRIMARY KEY, `col1` varchar(255) NOT NULL, `col2` varchar(255) NOT NULL);",
+		},
+		Assertions: []ScriptTestAssertion{
+			// Add two indexes over the same column set to t0
+			{
+				Query:    "ALTER TABLE t0 ADD CONSTRAINT unique_1 UNIQUE(col1, col2);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "ALTER TABLE t0 ADD CONSTRAINT unique_2 UNIQUE(col1, col2);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "SELECT kc.`constraint_name`, kc.`column_name`, kc.`referenced_table_name`, kc.`referenced_column_name` FROM information_schema.key_column_usage AS kc WHERE kc.table_schema = DATABASE() AND kc.table_name = 't0' ORDER BY kc.`ordinal_position`;",
+				Expected: []sql.Row{
+					{"PRIMARY", "id", nil, nil},
+					{"unique_1", "col1", nil, nil},
+					{"unique_2", "col1", nil, nil},
+					{"unique_1", "col2", nil, nil},
+					{"unique_2", "col2", nil, nil},
+				},
+			},
+			// Create a new table with two indexes over the same column set
+			{
+				Query:    "CREATE TABLE `t2` (`id` char(32) NOT NULL PRIMARY KEY, `col1` varchar(255) NOT NULL, `col2` varchar(255) NOT NULL, UNIQUE KEY unique_1(col1, col2), UNIQUE KEY unique_2(col1, col2));",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "SELECT kc.`constraint_name`, kc.`column_name`, kc.`referenced_table_name`, kc.`referenced_column_name` FROM information_schema.key_column_usage AS kc WHERE kc.table_schema = DATABASE() AND kc.table_name = 't2' ORDER BY kc.`ordinal_position`;",
+				Expected: []sql.Row{
+					{"PRIMARY", "id", nil, nil},
+					{"unique_1", "col1", nil, nil},
+					{"unique_2", "col1", nil, nil},
+					{"unique_1", "col2", nil, nil},
+					{"unique_2", "col2", nil, nil},
+				},
+			},
+		},
+	},
+	{
 		Name: "non-unique indexes on keyless tables",
 		SetUpScript: []string{
 			"create table t (i int, j int, index(i))",

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4117,6 +4117,7 @@ var IndexQueries = []ScriptTest{
 		Name: "multiple indexes over same set of columns",
 		SetUpScript: []string{
 			"CREATE TABLE `t0` (`id` char(32) NOT NULL PRIMARY KEY, `col1` varchar(255) NOT NULL, `col2` varchar(255) NOT NULL);",
+			"CREATE TABLE `t3` (`id` char(32) NOT NULL PRIMARY KEY, `col1` varchar(255) NOT NULL, `col2` varchar(255) NOT NULL);",
 		},
 		Assertions: []ScriptTestAssertion{
 			// Add two indexes over the same column set to t0
@@ -4160,6 +4161,29 @@ var IndexQueries = []ScriptTest{
 			{
 				Query:    "SHOW CREATE TABLE t2;",
 				Expected: []sql.Row{{"t2", "CREATE TABLE `t2` (\n  `id` char(32) NOT NULL,\n  `col1` varchar(255) NOT NULL,\n  `col2` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `unique_1` (`col1`,`col2`),\n  UNIQUE KEY `unique_2` (`col1`,`col2`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			// Add unnamed duplicate indexes
+			{
+				Query:    "ALTER TABLE t3 ADD CONSTRAINT UNIQUE(col1, col2);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "ALTER TABLE t3 ADD CONSTRAINT UNIQUE(col1, col2);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "SELECT kc.`constraint_name`, kc.`column_name`, kc.`referenced_table_name`, kc.`referenced_column_name` FROM information_schema.key_column_usage AS kc WHERE kc.table_schema = DATABASE() AND kc.table_name = 't3' ORDER BY kc.`ordinal_position`;",
+				Expected: []sql.Row{
+					{"PRIMARY", "id", nil, nil},
+					{"col1", "col1", nil, nil},
+					{"col1_2", "col1", nil, nil},
+					{"col1", "col2", nil, nil},
+					{"col1_2", "col2", nil, nil},
+				},
+			},
+			{
+				Query:    "SHOW CREATE TABLE t3;",
+				Expected: []sql.Row{{"t3", "CREATE TABLE `t3` (\n  `id` char(32) NOT NULL,\n  `col1` varchar(255) NOT NULL,\n  `col2` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `col1` (`col1`,`col2`),\n  UNIQUE KEY `col1_2` (`col1`,`col2`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4138,6 +4138,10 @@ var IndexQueries = []ScriptTest{
 					{"unique_2", "col2", nil, nil},
 				},
 			},
+			{
+				Query:    "SHOW CREATE TABLE t0;",
+				Expected: []sql.Row{{"t0", "CREATE TABLE `t0` (\n  `id` char(32) NOT NULL,\n  `col1` varchar(255) NOT NULL,\n  `col2` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `unique_1` (`col1`,`col2`),\n  UNIQUE KEY `unique_2` (`col1`,`col2`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
 			// Create a new table with two indexes over the same column set
 			{
 				Query:    "CREATE TABLE `t2` (`id` char(32) NOT NULL PRIMARY KEY, `col1` varchar(255) NOT NULL, `col2` varchar(255) NOT NULL, UNIQUE KEY unique_1(col1, col2), UNIQUE KEY unique_2(col1, col2));",
@@ -4152,6 +4156,10 @@ var IndexQueries = []ScriptTest{
 					{"unique_1", "col2", nil, nil},
 					{"unique_2", "col2", nil, nil},
 				},
+			},
+			{
+				Query:    "SHOW CREATE TABLE t2;",
+				Expected: []sql.Row{{"t2", "CREATE TABLE `t2` (\n  `id` char(32) NOT NULL,\n  `col1` varchar(255) NOT NULL,\n  `col2` varchar(255) NOT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `unique_1` (`col1`,`col2`),\n  UNIQUE KEY `unique_2` (`col1`,`col2`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -1096,6 +1096,11 @@ func createIndexesForCreateTable(ctx *sql.Context, db sql.Database, tableNode sq
 		if err != nil {
 			return err
 		}
+
+		err = warnOnDuplicateSecondaryIndex(ctx, idxDef.Name, idxAltTbl)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Evaluate our Full-Text indexes now


### PR DESCRIPTION
New tests asserting that multiple indexes over the same set of columns can be created on tables. 

https://github.com/dolthub/dolt/pull/8274 fixes Dolt for these tests to pass. 