### PR TITLE
Fix multi-statements in nested triggers

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -206,50 +206,12 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
 			Name:        "test script",
-			SetUpScript: []string{
-				"create table t (i int);",
-                "create table t1 (id int primary key, t2_id int);",
-                "create table t2 (id int primary key, t3_id int);",
-                "create table t3 (id int primary key);",
-
-				"insert into t1 values (1, 2);",
-                "insert into t2 values (2, 3);",
-                "insert into t3 values (3);",
-
-				"create trigger trig1 after delete on t1\nfor each row\n  begin\n    insert into t values (old.t2_id);\n    delete from t2 where id = old.t2_id;\n  end;",
-				"create trigger trig2 after delete on t2\nfor each row\n  begin\n    insert into t values (old.t3_id);\n    delete from t3 where id = old.t3_id;\n  end;",
-			},
-			Assertions:  []queries.ScriptTestAssertion{
-				{
-					Query: "delete from t1 where id = 1;",
-					Expected: []sql.Row{
-						{types.NewOkResult(1)},
-					},
-				},
-				{
-					Query: "select * from t1;",
-					Expected: []sql.Row{},
-				},
-				{
-					Query: "select * from t2;",
-					Expected: []sql.Row{},
-				},
-				{
-					Query: "select * from t3;",
-					Expected: []sql.Row{},
-				},
-				{
-					Query: "select * from t;",
-					Expected: []sql.Row{
-						{2},
-						{3},
-					},
-				},
-			},
+			SetUpScript: []string{},
+			Assertions:  []queries.ScriptTestAssertion{},
 		},
 	}
 
@@ -259,9 +221,6 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-
-		engine.EngineAnalyzer().Debug = true
-		engine.EngineAnalyzer().Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -277,15 +277,15 @@ for each row
 					},
 				},
 				{
-					Query: "select * from t1;",
+					Query:    "select * from t1;",
 					Expected: []sql.Row{},
 				},
 				{
-					Query: "select * from t2;",
+					Query:    "select * from t2;",
 					Expected: []sql.Row{},
 				},
 				{
-					Query: "select * from t3;",
+					Query:    "select * from t3;",
 					Expected: []sql.Row{},
 				},
 			},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -206,12 +206,50 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
 			Name:        "test script",
-			SetUpScript: []string{},
-			Assertions:  []queries.ScriptTestAssertion{},
+			SetUpScript: []string{
+				"create table t (i int);",
+                "create table t1 (id int primary key, t2_id int);",
+                "create table t2 (id int primary key, t3_id int);",
+                "create table t3 (id int primary key);",
+
+				"insert into t1 values (1, 2);",
+                "insert into t2 values (2, 3);",
+                "insert into t3 values (3);",
+
+				"create trigger trig1 after delete on t1\nfor each row\n  begin\n    insert into t values (old.t2_id);\n    delete from t2 where id = old.t2_id;\n  end;",
+				"create trigger trig2 after delete on t2\nfor each row\n  begin\n    insert into t values (old.t3_id);\n    delete from t3 where id = old.t3_id;\n  end;",
+			},
+			Assertions:  []queries.ScriptTestAssertion{
+				{
+					Query: "delete from t1 where id = 1;",
+					Expected: []sql.Row{
+						{types.NewOkResult(1)},
+					},
+				},
+				{
+					Query: "select * from t1;",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "select * from t2;",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "select * from t3;",
+					Expected: []sql.Row{},
+				},
+				{
+					Query: "select * from t;",
+					Expected: []sql.Row{
+						{2},
+						{3},
+					},
+				},
+			},
 		},
 	}
 
@@ -221,6 +259,9 @@ func TestSingleScript(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+
+		engine.EngineAnalyzer().Debug = true
+		engine.EngineAnalyzer().Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -209,9 +209,9 @@ func TestSingleScript(t *testing.T) {
 	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "test script",
+			Name:        "test script",
 			SetUpScript: []string{},
-			Assertions: []queries.ScriptTestAssertion{},
+			Assertions:  []queries.ScriptTestAssertion{},
 		},
 	}
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -238,7 +238,6 @@ for each row
     delete from t3 where id = old.t3_id;
   end;
 `,
-
 			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
@@ -247,35 +246,29 @@ for each row
 						{types.NewOkResult(1)},
 					},
 				},
-				//{
-				//	Query: "select * from t order by i;",
-				//	Expected: []sql.Row{
-				//		{3},
-				//	},
-				//},
-				//{
-				//	Query: "select * from tt order by i;",
-				//	Expected: []sql.Row{
-				//		{1},
-				//		{10},
-				//		{20},
-				//	},
-				//},
-				//{
-				//	Query: "select * from t1;",
-				//	Expected: []sql.Row{
-				//	},
-				//},
-				//{
-				//	Query: "select * from t2;",
-				//	Expected: []sql.Row{
-				//	},
-				//},
-				//{
-				//	Query: "select * from t3;",
-				//	Expected: []sql.Row{
-				//	},
-				//},
+				{
+					Query: "select * from tt order by i;",
+					Expected: []sql.Row{
+						{1},
+						{10},
+						{20},
+					},
+				},
+				{
+					Query: "select * from t1;",
+					Expected: []sql.Row{
+					},
+				},
+				{
+					Query: "select * from t2;",
+					Expected: []sql.Row{
+					},
+				},
+				{
+					Query: "select * from t3;",
+					Expected: []sql.Row{
+					},
+				},
 			},
 		},
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -206,89 +206,12 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "triple nested triggers referencing multiple tables",
-			SetUpScript: []string{
-				"create table t (i int);",
-				"create table tt (i int);",
-				"create table t1 (id int primary key, t2_id int);",
-				"create table t2 (id int primary key, t3_id int);",
-				"create table t3 (id int primary key);",
-
-				"insert into tt values (1), (2), (3);",
-				"insert into t1 values (1, 2);",
-				"insert into t2 values (2, 3);",
-				"insert into t3 values (3);",
-
-				`
-create trigger trig1 after delete on t1
-for each row
-  begin
-	insert into t values (old.id);
-    insert into t values (old.t2_id);
-    update tt set i = 10 * old.t2_id where i = old.id;
-    delete from t2 where id = old.t2_id;
-  end;
-`,
-				`
-create trigger trig2 after delete on t2
-for each row
-  begin
-	insert into t values (old.id);
-    insert into t values (old.t3_id);
-    update tt set i = 10 * old.t3_id where i = old.id;
-    delete from t3 where id = old.t3_id;
-  end;
-`,
-				`
-create trigger trig3 after delete on t3
-for each row
-  begin
-	insert into t values (old.id);
-    update tt set i = 9999 where i = old.id;
-  end;
-`,
-			},
-			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query: "delete from t1 where id = 1;",
-					Expected: []sql.Row{
-						{types.NewOkResult(1)},
-					},
-				},
-				{
-					Query: "select * from t order by i;",
-					Expected: []sql.Row{
-						{1},
-						{2},
-						{2},
-						{3},
-						{3},
-					},
-				},
-				{
-					Query: "select * from tt order by i;",
-					Expected: []sql.Row{
-						{20},
-						{30},
-						{9999},
-					},
-				},
-				{
-					Query:    "select * from t1;",
-					Expected: []sql.Row{},
-				},
-				{
-					Query:    "select * from t2;",
-					Expected: []sql.Row{},
-				},
-				{
-					Query:    "select * from t3;",
-					Expected: []sql.Row{},
-				},
-			},
+			Name: "test script",
+			SetUpScript: []string{},
+			Assertions: []queries.ScriptTestAssertion{},
 		},
 	}
 
@@ -298,9 +221,6 @@ for each row
 		if err != nil {
 			panic(err)
 		}
-
-		engine.EngineAnalyzer().Debug = true
-		engine.EngineAnalyzer().Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -206,101 +206,13 @@ func newUpdateResult(matched, updated int) types.OkResult {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name:        "triple nested update triggers referencing multiple tables",
-		SetUpScript: []string{
-			"create table t (i int);",
-			"create table tt (i int primary key, j int);",
-			"insert into tt values (1, 0), (2, 0), (3, 0);",
-			"create table ttt (i int primary key);",
-			"insert into ttt values (1), (2), (3);",
-			"create table t1 (i int primary key);",
-			"create table t2 (i int primary key, j int);",
-			"create table t3 (i int primary key, j int, k int);",
-			"insert into t1 values (1);",
-			"insert into t2 values (1, 0);",
-			"insert into t3 values (1, 0, 0);",
-			`
-create trigger trig1 after update on t1
-for each row
-  begin
-    update t2 set j = 10 * new.i where i = old.i;
-  end;
-`,
-			`
-create trigger trig2 after update on t2
-for each row
-  begin
-	insert into t values (old.i), (old.j), (new.i), (new.j);
-  end;
-`,
+			Name: "test script",
+			SetUpScript: []string{},
+			Assertions: []queries.ScriptTestAssertion{},
 		},
-		Assertions: []queries.ScriptTestAssertion{
-			{
-				Query: "update t1 set i = 2 where i = 1;",
-				Expected: []sql.Row{
-					{types.NewOkResult(1)},
-				},
-			},
-			//{
-			//	Query: "select * from t order by i;",
-			//	Expected: []sql.Row{
-			//		{0},
-			//		{0},
-			//		{0},
-			//		{0},
-			//		{0},
-			//		{1},
-			//		{1},
-			//		{1},
-			//		{1},
-			//		{1},
-			//		{1},
-			//		{1},
-			//		{2},
-			//		{10},
-			//		{10},
-			//		{10},
-			//		{20},
-			//		{100},
-			//	},
-			//},
-			//{
-			//	Query: "select * from tt order by i;",
-			//	Expected: []sql.Row{
-			//		{1, 100},
-			//		{1, 200},
-			//		{3, 0},
-			//	},
-			//},
-			//{
-			//	Query: "select * from ttt order by i;",
-			//	Expected: []sql.Row{
-			//		{3},
-			//	},
-			//},
-			//{
-			//	Query:    "select * from t1;",
-			//	Expected: []sql.Row{
-			//		{2},
-			//	},
-			//},
-			//{
-			//	Query:    "select * from t2;",
-			//	Expected: []sql.Row{
-			//		{1, 20},
-			//	},
-			//},
-			//{
-			//	Query:    "select * from t3;",
-			//	Expected: []sql.Row{
-			//		{1, 10, 100},
-			//	},
-			//},
-		},
-	},
 	}
 
 	for _, test := range scripts {
@@ -309,9 +221,6 @@ for each row
 		if err != nil {
 			panic(err)
 		}
-
-		engine.EngineAnalyzer().Debug = true
-		engine.EngineAnalyzer().Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3208,19 +3208,19 @@ for each row
 				},
 			},
 			{
-				Query:    "select * from t1;",
+				Query: "select * from t1;",
 				Expected: []sql.Row{
 					{2},
 				},
 			},
 			{
-				Query:    "select * from t2;",
+				Query: "select * from t2;",
 				Expected: []sql.Row{
 					{1, 20},
 				},
 			},
 			{
-				Query:    "select * from t3;",
+				Query: "select * from t3;",
 				Expected: []sql.Row{
 					{1, 10, 100},
 				},

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3094,23 +3094,23 @@ for each row
 				},
 			},
 			{
-				Query: "select * from ttt order by i;",
+				Query:    "select * from ttt order by i;",
 				Expected: []sql.Row{},
 			},
 			{
-				Query:    "select * from t1;",
+				Query: "select * from t1;",
 				Expected: []sql.Row{
 					{1},
 				},
 			},
 			{
-				Query:    "select * from t2;",
+				Query: "select * from t2;",
 				Expected: []sql.Row{
 					{2, 10},
 				},
 			},
 			{
-				Query:    "select * from t3;",
+				Query: "select * from t3;",
 				Expected: []sql.Row{
 					{3, 100, 12},
 				},

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2947,13 +2947,15 @@ for each row
 	},
 
 	{
-		Name: "nested triggers referencing multiple tables",
+		Name: "triple nested triggers referencing multiple tables",
 		SetUpScript: []string{
 			"create table t (i int);",
+			"create table tt (i int);",
 			"create table t1 (id int primary key, t2_id int);",
 			"create table t2 (id int primary key, t3_id int);",
 			"create table t3 (id int primary key);",
 
+			"insert into tt values (1), (2), (3);",
 			"insert into t1 values (1, 2);",
 			"insert into t2 values (2, 3);",
 			"insert into t3 values (3);",
@@ -2964,6 +2966,7 @@ for each row
   begin
 	insert into t values (old.id);
     insert into t values (old.t2_id);
+    update tt set i = 10 * old.t2_id where i = old.id;
     delete from t2 where id = old.t2_id;
   end;
 `,
@@ -2973,10 +2976,18 @@ for each row
   begin
 	insert into t values (old.id);
     insert into t values (old.t3_id);
+    update tt set i = 10 * old.t3_id where i = old.id;
     delete from t3 where id = old.t3_id;
   end;
 `,
-
+			`
+create trigger trig3 after delete on t3
+for each row
+  begin
+	insert into t values (old.id);
+    update tt set i = 9999 where i = old.id;
+  end;
+`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2834,16 +2834,16 @@ end;
 			"create table t1 (i int);",
 			"create table t2 (j int);",
 			`
-create trigger trig before insert on t1 
-for each row 
-begin
-	insert into t2 values (10 * new.i);
-	insert into t2 values (20 * new.i);
-	insert into t2 values (30 * new.i);
-	update t2 set j = 100 * j;
-	delete from t2 where j = 2000 * new.i;
-end;
-`,
+    create trigger trig before insert on t1 
+    for each row 
+    begin
+    	insert into t2 values (10 * new.i);
+    	insert into t2 values (20 * new.i);
+    	insert into t2 values (30 * new.i);
+    	update t2 set j = 100 * j;
+    	delete from t2 where j = 2000 * new.i;
+    end;
+    `,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -2868,7 +2868,149 @@ end;
 		},
 	},
 
+	{
+		Name: "double nested triggers referencing multiple tables",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"create table tt (i int);",
+			"create table t1 (id int primary key, t2_id int);",
+			"create table t2 (id int primary key, t3_id int);",
+			"create table t3 (id int primary key);",
 
+			"insert into tt values (1), (2), (3);",
+			"insert into t1 values (1, 2);",
+			"insert into t2 values (2, 3);",
+			"insert into t3 values (3);",
+
+			`
+create trigger trig1 after delete on t1
+for each row
+  begin
+	insert into t values (old.id);
+    insert into t values (old.t2_id);
+    update tt set i = 10 * old.id where i = old.t2_id;
+    delete from t2 where id = old.t2_id;
+  end;
+`,
+			`
+create trigger trig2 after delete on t2
+for each row
+  begin
+	insert into t values (old.id);
+    insert into t values (old.t3_id);
+    update tt set i = 10 * old.id where i = old.t3_id;
+    delete from t3 where id = old.t3_id;
+  end;
+`,
+
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "delete from t1 where id = 1;",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "select * from t order by i;",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{2},
+					{3},
+				},
+			},
+			{
+				Query: "select * from tt order by i;",
+				Expected: []sql.Row{
+					{1},
+					{10},
+					{20},
+				},
+			},
+			{
+				Query: "select * from t1;",
+				Expected: []sql.Row{
+				},
+			},
+			{
+				Query: "select * from t2;",
+				Expected: []sql.Row{
+				},
+			},
+			{
+				Query: "select * from t3;",
+				Expected: []sql.Row{
+				},
+			},
+		},
+	},
+
+	{
+		Name: "nested triggers referencing multiple tables",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"create table t1 (id int primary key, t2_id int);",
+			"create table t2 (id int primary key, t3_id int);",
+			"create table t3 (id int primary key);",
+
+			"insert into t1 values (1, 2);",
+			"insert into t2 values (2, 3);",
+			"insert into t3 values (3);",
+
+			`
+create trigger trig1 after delete on t1
+for each row
+  begin
+	insert into t values (old.id);
+    insert into t values (old.t2_id);
+    delete from t2 where id = old.t2_id;
+  end;
+`,
+			`
+create trigger trig2 after delete on t2
+for each row
+  begin
+	insert into t values (old.id);
+    insert into t values (old.t3_id);
+    delete from t3 where id = old.t3_id;
+  end;
+`,
+
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "delete from t1 where id = 1;",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "select * from t1;",
+				Expected: []sql.Row{
+				},
+			},
+			{
+				Query: "select * from t2;",
+				Expected: []sql.Row{
+				},
+			},
+			{
+				Query: "select * from t3;",
+				Expected: []sql.Row{
+				},
+			},
+			{
+				Query: "select * from t order by i;",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{2},
+					{3},
+				},
+			},
+		},
+	},
 }
 
 var TriggerCreateInSubroutineTests = []ScriptTest{

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3117,6 +3117,116 @@ for each row
 			},
 		},
 	},
+
+	{
+		Name: "triple nested update triggers referencing multiple tables",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"create table tt (i int primary key, j int);",
+			"insert into tt values (1, 0), (2, 0), (3, 0);",
+			"create table ttt (i int primary key);",
+			"insert into ttt values (1), (2), (3);",
+			"create table t1 (i int primary key);",
+			"create table t2 (i int primary key, j int);",
+			"create table t3 (i int primary key, j int, k int);",
+			"insert into t1 values (1);",
+			"insert into t2 values (1, 0);",
+			"insert into t3 values (1, 0, 0);",
+			`
+create trigger trig1 after update on t1
+for each row
+  begin
+	insert into t values (old.i), (new.i);
+    update tt set j = 100 * new.i where i = new.i;
+    delete from ttt where i = new.i;
+    update t2 set j = 10 * new.i where i = old.i;
+  end;
+`,
+			`
+create trigger trig2 after update on t2
+for each row
+  begin
+	insert into t values (old.i), (old.j), (new.i), (new.j);
+    update tt set j = 100 * new.i where i = new.i;
+    delete from ttt where i = new.i;
+    update t3 set j = 10 * new.i where i = old.i;
+    update t3 set k = 100 * new.i where i = old.i;
+  end;
+`,
+			`
+create trigger trig3 after update on t3
+for each row
+  begin
+	insert into t values (old.i), (new.i), (old.j), (new.j), (old.k), (new.k);
+    update tt set j = 100 * new.i where i = new.i;
+    delete from ttt where i = new.i;
+  end;
+`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "update t1 set i = 2 where i = 1;",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "select * from t order by i;",
+				Expected: []sql.Row{
+					{0},
+					{0},
+					{0},
+					{0},
+					{0},
+					{1},
+					{1},
+					{1},
+					{1},
+					{1},
+					{1},
+					{1},
+					{2},
+					{10},
+					{10},
+					{10},
+					{20},
+					{100},
+				},
+			},
+			{
+				Query: "select * from tt order by i;",
+				Expected: []sql.Row{
+					{1, 100},
+					{1, 200},
+					{3, 0},
+				},
+			},
+			{
+				Query: "select * from ttt order by i;",
+				Expected: []sql.Row{
+					{3},
+				},
+			},
+			{
+				Query:    "select * from t1;",
+				Expected: []sql.Row{
+					{2},
+				},
+			},
+			{
+				Query:    "select * from t2;",
+				Expected: []sql.Row{
+					{1, 20},
+				},
+			},
+			{
+				Query:    "select * from t3;",
+				Expected: []sql.Row{
+					{1, 10, 100},
+				},
+			},
+		},
+	},
 }
 
 var TriggerCreateInSubroutineTests = []ScriptTest{

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2840,8 +2840,8 @@ begin
 	insert into t2 values (10 * new.i);
 	insert into t2 values (20 * new.i);
 	insert into t2 values (30 * new.i);
-    update t2 set j = 100 * j;
-    delete from t2 where j = 2000 * new.i;
+	update t2 set j = 100 * j;
+	delete from t2 where j = 2000 * new.i;
 end;
 `,
 		},
@@ -2867,6 +2867,8 @@ end;
 			},
 		},
 	},
+
+
 }
 
 var TriggerCreateInSubroutineTests = []ScriptTest{

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3167,7 +3167,7 @@ for each row
 			{
 				Query: "update t1 set i = 2 where i = 1;",
 				Expected: []sql.Row{
-					{types.NewOkResult(1)},
+					{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
 				},
 			},
 			{
@@ -3197,7 +3197,7 @@ for each row
 				Query: "select * from tt order by i;",
 				Expected: []sql.Row{
 					{1, 100},
-					{1, 200},
+					{2, 200},
 					{3, 0},
 				},
 			},

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2997,6 +2997,24 @@ for each row
 				},
 			},
 			{
+				Query: "select * from t order by i;",
+				Expected: []sql.Row{
+					{1},
+					{2},
+					{2},
+					{3},
+					{3},
+				},
+			},
+			{
+				Query: "select * from tt order by i;",
+				Expected: []sql.Row{
+					{20},
+					{30},
+					{9999},
+				},
+			},
+			{
 				Query: "select * from t1;",
 				Expected: []sql.Row{
 				},
@@ -3009,15 +3027,6 @@ for each row
 			{
 				Query: "select * from t3;",
 				Expected: []sql.Row{
-				},
-			},
-			{
-				Query: "select * from t order by i;",
-				Expected: []sql.Row{
-					{1},
-					{2},
-					{2},
-					{3},
 				},
 			},
 		},

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3011,19 +3011,16 @@ for each row
 				},
 			},
 			{
-				Query: "select * from t1;",
-				Expected: []sql.Row{
-				},
+				Query:    "select * from t1;",
+				Expected: []sql.Row{},
 			},
 			{
-				Query: "select * from t2;",
-				Expected: []sql.Row{
-				},
+				Query:    "select * from t2;",
+				Expected: []sql.Row{},
 			},
 			{
-				Query: "select * from t3;",
-				Expected: []sql.Row{
-				},
+				Query:    "select * from t3;",
+				Expected: []sql.Row{},
 			},
 		},
 	},

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -490,7 +490,7 @@ func (s *idxScope) visitSelf(n sql.Node) error {
 	case *plan.Update:
 		newScope := s.copy()
 		srcScope := s.childScopes[0]
-		// schema is |old_row|-|new_row|; checks only recieve half
+		// schema is |old_row|-|new_row|; checks only receive half
 		newScope.columns = append(newScope.columns, srcScope.columns[:len(srcScope.columns)/2]...)
 		for _, c := range n.Checks() {
 			newE := fixExprToScope(c.Expr, newScope)
@@ -651,6 +651,7 @@ func fixExprToScope(e sql.Expression, scopes ...*idxScope) sql.Expression {
 			//  queries where the columns being selected are only found in subqueries. Conversely, we actually want to ignore
 			//  this error for the case of DEFAULT in a `plan.Values`, since we analyze the insert source in isolation (we
 			//  don't have the destination schema, and column references in default values are determined in the build phase)
+
 			idx, _ := newScope.getIdxId(e.Id(), e.String())
 			if idx >= 0 {
 				return e.WithIndex(idx), transform.NewTree, nil

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -651,13 +651,6 @@ func fixExprToScope(e sql.Expression, scopes ...*idxScope) sql.Expression {
 			//  this error for the case of DEFAULT in a `plan.Values`, since we analyze the insert source in isolation (we
 			//  don't have the destination schema, and column references in default values are determined in the build phase)
 
-			if e.String() == "old.id" {
-				print()
-			}
-			if e.String() == "old.t3_id" {
-				print()
-			}
-
 			idx, _ := newScope.getIdxId(e.Id(), e.String())
 			if idx >= 0 {
 				return e.WithIndex(idx), transform.NewTree, nil

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -651,6 +651,9 @@ func fixExprToScope(e sql.Expression, scopes ...*idxScope) sql.Expression {
 			//  this error for the case of DEFAULT in a `plan.Values`, since we analyze the insert source in isolation (we
 			//  don't have the destination schema, and column references in default values are determined in the build phase)
 
+			if e.String() == "old.id" {
+				print()
+			}
 			if e.String() == "old.t3_id" {
 				print()
 			}

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -57,7 +57,6 @@ func assignExecIndexes(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 			// joins, subqueries, triggers, and procedures preclude fast indexing
 			return offsetAssignIndexes(n), transform.NewTree, nil
 		}
-
 	default:
 	}
 	ret, _, err := assignIndexesHelper(n, s)
@@ -651,6 +650,10 @@ func fixExprToScope(e sql.Expression, scopes ...*idxScope) sql.Expression {
 			//  queries where the columns being selected are only found in subqueries. Conversely, we actually want to ignore
 			//  this error for the case of DEFAULT in a `plan.Values`, since we analyze the insert source in isolation (we
 			//  don't have the destination schema, and column references in default values are determined in the build phase)
+
+			if e.String() == "old.t3_id" {
+				print()
+			}
 
 			idx, _ := newScope.getIdxId(e.Id(), e.String())
 			if idx >= 0 {

--- a/sql/analyzer/triggers.go
+++ b/sql/analyzer/triggers.go
@@ -431,12 +431,11 @@ func getTriggerLogic(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 	case sqlparser.UpdateStr:
 		var scopeNode *plan.Project
 		if updateSrc := getUpdateJoinSource(n); updateSrc == nil {
-			resTbl := getResolvedTable(n) // TODO: maybe not this?
 			scopeNode = plan.NewProject(
 				[]sql.Expression{expression.NewStar()},
 				plan.NewCrossJoin(
-					plan.NewTableAlias("old", resTbl),
-					plan.NewTableAlias("new", resTbl),
+					plan.NewTableAlias("old", trigger.Table),
+					plan.NewTableAlias("new", trigger.Table),
 				),
 			)
 		} else {

--- a/sql/analyzer/triggers.go
+++ b/sql/analyzer/triggers.go
@@ -463,7 +463,7 @@ func getTriggerLogic(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 			)
 		}
 		// Triggers are wrapped in prepend nodes, which means that the parent scope is included
-		s := scope.NewScope(scopeNode)
+		s := (*plan.Scope)(nil).NewScope(scopeNode).WithMemos(scope.Memo(n).MemoNodes()).WithProcedureCache(scope.ProcedureCache())
 		triggerLogic, _, err = a.analyzeWithSelector(ctx, trigger.Body, s, SelectAllBatches, noRowUpdateAccumulators, qFlags)
 	case sqlparser.DeleteStr:
 		scopeNode := plan.NewProject(

--- a/sql/analyzer/triggers.go
+++ b/sql/analyzer/triggers.go
@@ -456,7 +456,6 @@ func getTriggerLogic(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 		scopeNode := plan.NewProject(
 			[]sql.Expression{expression.NewStar()},
 			plan.NewTableAlias("old", trigger.Table),
-			//plan.NewTableAlias("old", getResolvedTable(n)),
 		)
 		// Triggers are wrapped in prepend nodes, which means that the parent scope is included
 		s := scope.NewScope(scopeNode)

--- a/sql/analyzer/triggers.go
+++ b/sql/analyzer/triggers.go
@@ -443,8 +443,8 @@ func getTriggerLogic(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 			scopeNode = plan.NewProject(
 				[]sql.Expression{expression.NewStar()},
 				plan.NewCrossJoin(
-					plan.NewSubqueryAlias("old", "", updateSrc.Child), // TODO: maybe not this?
-					plan.NewSubqueryAlias("new", "", updateSrc.Child), // TODO: maybe not this?
+					plan.NewSubqueryAlias("old", "", updateSrc.Child),
+					plan.NewSubqueryAlias("new", "", updateSrc.Child),
 				),
 			)
 		}

--- a/sql/analyzer/triggers.go
+++ b/sql/analyzer/triggers.go
@@ -440,14 +440,16 @@ func getTriggerLogic(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scop
 				),
 			)
 		}
-		s := (*plan.Scope)(nil).NewScope(scopeNode).WithMemos(scope.Memo(n).MemoNodes()).WithProcedureCache(scope.ProcedureCache())
+		// Triggers are wrapped in prepend nodes, which means that the parent scope is included
+		s := scope.NewScope(scopeNode)
 		triggerLogic, _, err = a.analyzeWithSelector(ctx, trigger.Body, s, SelectAllBatches, noRowUpdateAccumulators, qFlags)
 	case sqlparser.DeleteStr:
 		scopeNode := plan.NewProject(
 			[]sql.Expression{expression.NewStar()},
 			plan.NewTableAlias("old", getResolvedTable(n)),
 		)
-		s := (*plan.Scope)(nil).NewScope(scopeNode).WithMemos(scope.Memo(n).MemoNodes()).WithProcedureCache(scope.ProcedureCache())
+		// Triggers are wrapped in prepend nodes, which means that the parent scope is included
+		s := scope.NewScope(scopeNode)
 		triggerLogic, _, err = a.analyzeWithSelector(ctx, trigger.Body, s, SelectAllBatches, noRowUpdateAccumulators, qFlags)
 	}
 

--- a/sql/rowexec/builder.go
+++ b/sql/rowexec/builder.go
@@ -32,6 +32,7 @@ type ExecBuilderFunc func(ctx *sql.Context, n sql.Node, r sql.Row) (sql.RowIter,
 type BaseBuilder struct {
 	// if override is provided, we try to build executor with this first
 	override sql.NodeExecBuilder
+	triggerSavePointCounter int // tracks the number of save points that have been created by triggers
 }
 
 func (b *BaseBuilder) Build(ctx *sql.Context, n sql.Node, r sql.Row) (sql.RowIter, error) {

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -175,7 +175,7 @@ func prependRowInPlanForTriggerExecution(row sql.Row) func(c transform.Context) 
 			default:
 				return plan.NewPrependNode(n, row), transform.NewTree, nil
 			}
-		case *plan.ResolvedTable, *plan.IndexedTableAccess:
+		case *plan.ResolvedTable, *plan.IndexedTableAccess, *plan.Values:
 			return plan.NewPrependNode(n, row), transform.NewTree, nil
 		default:
 			return n, transform.SameTree, nil

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -175,7 +175,11 @@ func prependRowInPlanForTriggerExecution(row sql.Row) func(c transform.Context) 
 			default:
 				return plan.NewPrependNode(n, row), transform.NewTree, nil
 			}
-		case *plan.ResolvedTable, *plan.IndexedTableAccess, *plan.Values:
+		case *plan.InsertInto:
+			return n.WithSource(plan.NewPrependNode(n.Source, row)), transform.NewTree, nil
+		case *plan.ResolvedTable, *plan.IndexedTableAccess:
+			return plan.NewPrependNode(n, row), transform.NewTree, nil
+		case *plan.Values:
 			return plan.NewPrependNode(n, row), transform.NewTree, nil
 		default:
 			return n, transform.SameTree, nil

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -185,7 +185,7 @@ func prependRowInPlanForTriggerExecution(row sql.Row) func(c transform.Context) 
 
 func prependRowForTriggerExecutionSelector(ctx transform.Context) bool {
 	switch ctx.Node.(type) {
-	case *plan.TriggerBeginEndBlock:
+	case *plan.TriggerBeginEndBlock, *plan.TriggerRollback:
 		// we don't want to double prepend the row for nested trigger blocks
 		_, isTrig := ctx.Parent.(*plan.TriggerExecutor)
 		return !isTrig


### PR DESCRIPTION
changes: 
- have different savepoint names
  - this fixes nested triggers overwriting save points and clearing the same savepoint
- handle aliases independently for each statement in trigger blocks
- sync up prepend and scope nesting for triggers
- wrap `applyTrigger` rule wraps `triggerExecutor`s over individual statements in `BeginEndBlock`s
  - this prevents wrapping `triggerExecutor`s over the wrong statements (not matching event or table)

related: https://github.com/dolthub/dolt/issues/8213