### PR TITLE
Add additional engine tests for indexes on generated columns.

### DIFF
--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -177,6 +177,115 @@ var GeneratedColumnTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "creating index on virtual generated column",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int as (a + 1) virtual)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` + 1)),\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Skip: true, // https://github.com/dolthub/dolt/issues/8275
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, 2}},
+				Skip:     true, // https://github.com/dolthub/dolt/issues/8276
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
+			},
+		},
+	},
+	{
+		Name: "creating index on stored generated column with type conversion",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b float generated always as (a + 1) stored)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` float GENERATED ALWAYS AS ((`a` + 1)) STORED,\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, float64(2)}},
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+		},
+	},
+	{
+		Name: "creating index on virtual generated column with type conversion",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b float generated always as (a + 1))",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` float GENERATED ALWAYS AS ((`a` + 1)),\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Skip: true, // https://github.com/dolthub/dolt/issues/8275
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, float64(2)}},
+				Skip:     true, // https://github.com/dolthub/dolt/issues/8276
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+		},
+	},
+	{
 		Name: "index on stored generated column and one non-generated column",
 		SetUpScript: []string{
 			"create table t1 (a int primary key, b int as (a + 1) stored, c int)",


### PR DESCRIPTION
These tests verify the correctness of https://github.com/dolthub/dolt/pull/8273.

Some of the checks in these tests are skipped because they run afoul of https://github.com/dolthub/dolt/issues/8275 and https://github.com/dolthub/dolt/issues/8276