### PR TITLE
Correctly handle indexes on virtual columns

### DIFF
--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -275,8 +275,8 @@ var GeneratedColumnTests = []ScriptTest{
 	{
 		Name: "creating unique index on stored generated column",
 		SetUpScript: []string{
-			"create table t1 (a int primary key, b int as (a + 1) stored)",
-			"insert into t1(a) values (1), (2)",
+			"create table t1 (a int primary key, b int as (a * a) stored)",
+			"insert into t1(a) values (-1), (-2)",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -288,22 +288,26 @@ var GeneratedColumnTests = []ScriptTest{
 				Expected: []sql.Row{{"t1",
 					"CREATE TABLE `t1` (\n" +
 						"  `a` int NOT NULL,\n" +
-						"  `b` int GENERATED ALWAYS AS ((`a` + 1)) STORED,\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` * `a`)) STORED,\n" +
 						"  PRIMARY KEY (`a`),\n" +
 						"  UNIQUE KEY `i1` (`b`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
-				Query:    "select * from t1 where b = 2 order by a",
-				Expected: []sql.Row{{1, 2}},
+				Query:    "select * from t1 where b = 4 order by a",
+				Expected: []sql.Row{{-2, 4}},
 			},
 			{
 				Query:    "select * from t1 order by a",
-				Expected: []sql.Row{{1, 2}, {2, 3}},
+				Expected: []sql.Row{{-2, 4}, {-1, 1}},
 			},
 			{
 				Query:    "select * from t1 order by b",
-				Expected: []sql.Row{{1, 2}, {2, 3}},
+				Expected: []sql.Row{{-1, 1}, {-2, 4}},
+			},
+			{
+				Query:       "insert into t1(a) values (2)",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
 			},
 		},
 	},
@@ -332,7 +336,6 @@ var GeneratedColumnTests = []ScriptTest{
 			{
 				Query:    "select * from t1 where b = 2 order by a",
 				Expected: []sql.Row{{1, 2}},
-				Skip:     true, // https://github.com/dolthub/dolt/issues/8276
 			},
 			{
 				Query:    "select * from t1 order by a",
@@ -404,7 +407,6 @@ var GeneratedColumnTests = []ScriptTest{
 			{
 				Query:    "select * from t1 where b = 2 order by a",
 				Expected: []sql.Row{{1, float64(2)}},
-				Skip:     true, // https://github.com/dolthub/dolt/issues/8276
 			},
 			{
 				Query:    "select * from t1 order by a",
@@ -1086,7 +1088,6 @@ var GeneratedColumnTests = []ScriptTest{
 			{
 				Query:    "select * from t1 where b = 2 order by a",
 				Expected: []sql.Row{{1, float64(2)}},
-				Skip:     true, // https://github.com/dolthub/dolt/issues/8276
 			},
 			{
 				Query:    "select * from t1 order by a",
@@ -1139,8 +1140,8 @@ var GeneratedColumnTests = []ScriptTest{
 	{
 		Name: "creating unique index on virtual generated column",
 		SetUpScript: []string{
-			"create table t1 (a int primary key, b int as (a + 1) virtual)",
-			"insert into t1(a) values (1), (2)",
+			"create table t1 (a int primary key, b int as (a * a) virtual)",
+			"insert into t1(a) values (-1), (-2)",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1152,23 +1153,28 @@ var GeneratedColumnTests = []ScriptTest{
 				Expected: []sql.Row{{"t1",
 					"CREATE TABLE `t1` (\n" +
 						"  `a` int NOT NULL,\n" +
-						"  `b` int GENERATED ALWAYS AS ((`a` + 1)),\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` * `a`)),\n" +
 						"  PRIMARY KEY (`a`),\n" +
 						"  KEY `i1` (`b`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 				Skip: true, // https://github.com/dolthub/dolt/issues/8275
 			},
 			{
-				Query:    "select * from t1 where b = 2 order by a",
-				Expected: []sql.Row{{1, 2}},
+				Query:    "select * from t1 where b = 4 order by a",
+				Expected: []sql.Row{{-2, 4}},
 			},
 			{
 				Query:    "select * from t1 order by a",
-				Expected: []sql.Row{{1, 2}, {2, 3}},
+				Expected: []sql.Row{{-2, 4}, {-1, 1}},
 			},
 			{
 				Query:    "select * from t1 order by b",
-				Expected: []sql.Row{{1, 2}, {2, 3}},
+				Expected: []sql.Row{{-1, 1}, {-2, 4}},
+			},
+			{
+				Query:       "insert into t1(a) values (2)",
+				ExpectedErr: sql.ErrUniqueKeyViolation,
+				Skip:        true,
 			},
 		},
 	},

--- a/enginetest/queries/generated_columns.go
+++ b/enginetest/queries/generated_columns.go
@@ -88,6 +88,30 @@ var GeneratedColumnTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "Add stored column first with literal",
+		SetUpScript: []string{
+			"CREATE TABLE t16(pk BIGINT PRIMARY KEY, v1 BIGINT DEFAULT '4')",
+			"INSERT INTO t16 (pk) VALUES (1), (2)",
+			"ALTER TABLE t16 ADD COLUMN v2 BIGINT AS (5) STORED FIRST",
+		},
+		Assertions: []ScriptTestAssertion{{
+			Query:    "SELECT * FROM t16",
+			Expected: []sql.Row{{5, 1, 4}, {5, 2, 4}}},
+		},
+	},
+	{
+		Name: "Add stored column first with expression",
+		SetUpScript: []string{
+			"CREATE TABLE t17(pk BIGINT PRIMARY KEY, v1 BIGINT)",
+			"INSERT INTO t17 VALUES (1, 3), (2, 4)",
+			"ALTER TABLE t17 ADD COLUMN v2 BIGINT AS (v1 + 2) STORED FIRST",
+		},
+		Assertions: []ScriptTestAssertion{{
+			Query:    "SELECT * FROM t17",
+			Expected: []sql.Row{{5, 1, 3}, {6, 2, 4}}},
+		},
+	},
+	{
 		Name: "index on stored generated column",
 		SetUpScript: []string{
 			"create table t1 (a int primary key, b int as (a + 1) stored)",
@@ -160,6 +184,113 @@ var GeneratedColumnTests = []ScriptTest{
 						"  `b` int GENERATED ALWAYS AS ((`a` + 1)) STORED,\n" +
 						"  PRIMARY KEY (`a`),\n" +
 						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, 2}},
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
+			},
+		},
+	},
+	{
+		Name: "creating index on stored generated column with type conversion",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b float generated always as (a + 1) stored)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` float GENERATED ALWAYS AS ((`a` + 1)) STORED,\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, float64(2)}},
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+		},
+	},
+	{
+		Name: "creating index on stored generated column within multi-alter statement",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int as (a + 1) stored)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "alter table t1 add column c int as (b+1) stored, add index b1(b), add column d int as (b+2) stored",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` + 1)) STORED,\n" +
+						"  `c` int GENERATED ALWAYS AS ((`b` + 1)) STORED,\n" +
+						"  `d` int GENERATED ALWAYS AS ((`b` + 2)) STORED,\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `b1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, 2, 3, 4}},
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, 2, 3, 4}, {2, 3, 4, 5}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, 2, 3, 4}, {2, 3, 4, 5}},
+			},
+		},
+	},
+	{
+		Name: "creating unique index on stored generated column",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int as (a + 1) stored)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create unique index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` + 1)) STORED,\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  UNIQUE KEY `i1` (`b`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 			{
@@ -429,6 +560,94 @@ var GeneratedColumnTests = []ScriptTest{
 					{1, 2, 4},
 				},
 			},
+		},
+	},
+	{
+		Name: "virtual generated column with spaces",
+		SetUpScript: []string{
+			"create table tt (`col 1` int, `col 2` int);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "create table t (`col 1` int, `col 2` int, `col 3` int generated always as (`col 1` + `col 2` + pow(`col 1`, `col 2`)) virtual);",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "show create table t",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `col 1` int,\n" +
+						"  `col 2` int,\n" +
+						"  `col 3` int GENERATED ALWAYS AS (((`col 1` + `col 2`) + power(`col 1`, `col 2`)))\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "insert into t (`col 1`, `col 2`) values (1, 2);",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "select * from t",
+				Expected: []sql.Row{
+					{1, 2, 4},
+				},
+			},
+			{
+				Query: "alter table tt add column `col 3` int generated always as (`col 1` + `col 2` + pow(`col 1`, `col 2`)) virtual;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "show create table tt",
+				Expected: []sql.Row{
+					{"tt", "CREATE TABLE `tt` (\n" +
+						"  `col 1` int,\n" +
+						"  `col 2` int,\n" +
+						"  `col 3` int GENERATED ALWAYS AS (((`col 1` + `col 2`) + power(`col 1`, `col 2`)))\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "insert into tt (`col 1`, `col 2`) values (1, 2);",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "select * from tt",
+				Expected: []sql.Row{
+					{1, 2, 4},
+				},
+			},
+		},
+	},
+	{
+		Name: "Add virtual column first with literal",
+		SetUpScript: []string{
+			"CREATE TABLE t16(pk BIGINT PRIMARY KEY, v1 BIGINT DEFAULT '4')",
+			"INSERT INTO t16 (pk) VALUES (1), (2)",
+			"ALTER TABLE t16 ADD COLUMN v2 BIGINT AS (5) VIRTUAL FIRST",
+		},
+		Assertions: []ScriptTestAssertion{{
+			Query:    "SELECT * FROM t16",
+			Expected: []sql.Row{{5, 1, 4}, {5, 2, 4}}},
+		},
+	},
+	{
+		Name: "Add virtual column first with expression",
+		SetUpScript: []string{
+			"CREATE TABLE t17(pk BIGINT PRIMARY KEY, v1 BIGINT)",
+			"INSERT INTO t17 VALUES (1, 3), (2, 4)",
+			"ALTER TABLE t17 ADD COLUMN v2 BIGINT AS (v1 + 2) VIRTUAL FIRST",
+		},
+		Assertions: []ScriptTestAssertion{{
+			Query:    "SELECT * FROM t17",
+			Expected: []sql.Row{{5, 1, 3}, {6, 2, 4}}},
 		},
 	},
 	{
@@ -728,6 +947,42 @@ var GeneratedColumnTests = []ScriptTest{
 		},
 	},
 	{
+		Name: "creating index on virtual generated column",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int as (a + 1) virtual)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` + 1)),\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Skip: true, // https://github.com/dolthub/dolt/issues/8275
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, 2}},
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
+			},
+		},
+	},
+	{
 		Name: "virtual column index",
 		SetUpScript: []string{
 			"create table t1 (a int primary key, b int, c int generated always as (a + b) virtual, index idx_c (c))",
@@ -803,6 +1058,117 @@ var GeneratedColumnTests = []ScriptTest{
 					{"{\"b\": 3}", nil},
 					{"{\"a\": 1}", 1},
 				},
+			},
+		},
+	},
+	{
+		Name: "creating index on virtual generated column with type conversion",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b float generated always as (a + 1))",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` float GENERATED ALWAYS AS ((`a` + 1)),\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Skip: true, // https://github.com/dolthub/dolt/issues/8275
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, float64(2)}},
+				Skip:     true, // https://github.com/dolthub/dolt/issues/8276
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, float64(2)}, {2, float64(3)}},
+			},
+		},
+	},
+	{
+		Name: "creating index on virtual generated column within multi-alter statement",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int as (a + 1) virtual)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "alter table t1 add column c int as (b+1) stored, add index b1(b), add column d int as (b+2) stored",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` + 1)),\n" +
+						"  `c` int GENERATED ALWAYS AS ((`b` + 1)),\n" +
+						"  `d` int GENERATED ALWAYS AS ((`b` + 2)),\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Skip: true, // https://github.com/dolthub/dolt/issues/8275
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, 2, 3, 4}},
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, 2, 3, 4}, {2, 3, 4, 5}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, 2, 3, 4}, {2, 3, 4, 5}},
+			},
+		},
+	},
+	{
+		Name: "creating unique index on virtual generated column",
+		SetUpScript: []string{
+			"create table t1 (a int primary key, b int as (a + 1) virtual)",
+			"insert into t1(a) values (1), (2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "create unique index i1 on t1(b)",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query: "show create table t1",
+				Expected: []sql.Row{{"t1",
+					"CREATE TABLE `t1` (\n" +
+						"  `a` int NOT NULL,\n" +
+						"  `b` int GENERATED ALWAYS AS ((`a` + 1)),\n" +
+						"  PRIMARY KEY (`a`),\n" +
+						"  KEY `i1` (`b`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Skip: true, // https://github.com/dolthub/dolt/issues/8275
+			},
+			{
+				Query:    "select * from t1 where b = 2 order by a",
+				Expected: []sql.Row{{1, 2}},
+			},
+			{
+				Query:    "select * from t1 order by a",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
+			},
+			{
+				Query:    "select * from t1 order by b",
+				Expected: []sql.Row{{1, 2}, {2, 3}},
 			},
 		},
 	},

--- a/memory/table_data.go
+++ b/memory/table_data.go
@@ -278,6 +278,8 @@ func (td *TableData) errIfDuplicateEntryExist(cols []string, idxName string) err
 	columnMapping, err := td.columnIndexes(cols)
 
 	// We currently skip validating duplicates on unique virtual columns.
+	// Right now trying to validate them would just trigger a panic.
+	// See https://github.com/dolthub/go-mysql-server/issues/2643
 	for _, i := range columnMapping {
 		if td.schema.Schema[i].Virtual {
 			return nil

--- a/memory/table_data.go
+++ b/memory/table_data.go
@@ -276,6 +276,14 @@ func (td *TableData) numRows(ctx *sql.Context) (uint64, error) {
 // throws an error if any two or more rows share the same |cols| values.
 func (td *TableData) errIfDuplicateEntryExist(cols []string, idxName string) error {
 	columnMapping, err := td.columnIndexes(cols)
+
+	// We currently skip validating duplicates on unique virtual columns.
+	for _, i := range columnMapping {
+		if td.schema.Schema[i].Virtual {
+			return nil
+		}
+	}
+
 	if err != nil {
 		return err
 	}

--- a/sql/rowexec/alter_table_test.go
+++ b/sql/rowexec/alter_table_test.go
@@ -102,7 +102,7 @@ func TestAddColumnToSchema(t *testing.T) {
 			},
 			order: &sql.ColumnOrder{First: true},
 			newSchema: sql.Schema{
-				{Name: "i2", Type: types.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(0, types.Int64, "i", false), types.Int64, false, true, true)},
+				{Name: "i2", Type: types.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(1, types.Int64, "i", false), types.Int64, false, true, true)},
 				{Name: "i", Type: types.Int64, Source: "mytable", PrimaryKey: true},
 				{Name: "s", Type: varchar20, Source: "mytable", Comment: "column s"},
 			},
@@ -111,7 +111,7 @@ func TestAddColumnToSchema(t *testing.T) {
 					Name:    "i2",
 					Type:    types.Int64,
 					Source:  "mytable",
-					Default: mustDefault(expression.NewGetField(0, types.Int64, "i", false), types.Int64, false, true, true),
+					Default: mustDefault(expression.NewGetField(1, types.Int64, "i", false), types.Int64, false, true, true),
 				}},
 				expression.NewGetField(0, types.Int64, "i", false),
 				expression.NewGetField(1, varchar20, "s", false),
@@ -145,7 +145,7 @@ func TestAddColumnToSchema(t *testing.T) {
 			order: &sql.ColumnOrder{AfterColumn: "i"},
 			newSchema: sql.Schema{
 				{Name: "i", Type: types.Int64, Source: "mytable", PrimaryKey: true},
-				{Name: "i2", Type: types.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(1, types.Int64, "s", false), types.Int64, false, true, true)},
+				{Name: "i2", Type: types.Int64, Source: "mytable", Default: mustDefault(expression.NewGetField(2, types.Int64, "s", false), types.Int64, false, true, true)},
 				{Name: "s", Type: varchar20, Source: "mytable", Comment: "column s"},
 			},
 			projections: []sql.Expression{
@@ -154,7 +154,7 @@ func TestAddColumnToSchema(t *testing.T) {
 					Name:    "i2",
 					Type:    types.Int64,
 					Source:  "mytable",
-					Default: mustDefault(expression.NewGetField(1, types.Int64, "s", false), types.Int64, false, true, true),
+					Default: mustDefault(expression.NewGetField(2, types.Int64, "s", false), types.Int64, false, true, true),
 				}},
 				expression.NewGetField(1, varchar20, "s", false),
 			},

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2256,7 +2256,7 @@ func rewriteTableForIndexCreate(ctx *sql.Context, n *plan.AlterIndex, table sql.
 
 // indexRequiresBuild returns whether the given index requires a build operation to be performed as part of its creation
 func indexCreateRequiresBuild(n *plan.AlterIndex) bool {
-	return n.Constraint == sql.IndexConstraint_Unique || indexOnVirtualColumn(n.Columns, n.TargetSchema())
+	return n.Constraint == sql.IndexConstraint_Unique
 }
 
 func indexOnVirtualColumn(columns []sql.IndexColumn, schema sql.Schema) bool {

--- a/sql/rowexec/rel_iters.go
+++ b/sql/rowexec/rel_iters.go
@@ -565,6 +565,13 @@ func defaultValFromProjectExpr(e sql.Expression) (*sql.ColumnDefaultValue, bool)
 	if defaultVal, ok := e.(*sql.ColumnDefaultValue); ok {
 		return defaultVal, true
 	}
+	if defaultExpr, ok := e.(plan.ColDefaultExpression); ok {
+		if defaultExpr.Column.Default != nil {
+			return defaultExpr.Column.Default, true
+		} else if defaultExpr.Column.Generated != nil {
+			return defaultExpr.Column.Generated, true
+		}
+	}
 
 	return nil, false
 }


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/8276

Lots of small behaviors around virtual columns were not working correctly:

- Adding an index on a virtual column triggered a table rebuild even when this wasn't necessary
- Rebuilding a table that contained virtual columns could lead to incorrect results
- Inserting into a table with a virtual column could update indexes incorrectly
- Adding a generated column to the start of a table could lead to incorrect results

This PR adds tests for these cases and fixes them by tweaking the logic for projections on tables with generated columns.

