### PR TITLE
conflict in `EqualityRangeBuilder`

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3433,6 +3433,22 @@ Select * from (
 		Expected: []sql.Row{},
 	},
 	{
+		Query:    "SELECT i FROM mytable WHERE i = 1 and s = 'first row' and i = 2",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT i FROM mytable WHERE s = 'first row' and s = 'second row'",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT i FROM mytable WHERE i = 1 and i between 2 and 2",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT i FROM mytable WHERE i between 1 and 1 and i between 2 and 2",
+		Expected: []sql.Row{},
+	},
+	{
 		Query:    "SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC LIMIT 1;",
 		Expected: []sql.Row{{int64(1)}},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3433,6 +3433,18 @@ Select * from (
 		Expected: []sql.Row{},
 	},
 	{
+		Query:    "SELECT i FROM mytable WHERE I = 1 and i = 2",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT i FROM mytable WHERE i = 1 and i = '1'",
+		Expected: []sql.Row{},
+	},
+	{
+		Query:    "SELECT i FROM mytable WHERE i = 1 and i = '2'",
+		Expected: []sql.Row{},
+	},
+	{
 		Query:    "SELECT i FROM mytable WHERE i = 1 and s = 'first row' and i = 2",
 		Expected: []sql.Row{},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3429,6 +3429,10 @@ Select * from (
 		Expected: nil,
 	},
 	{
+		Query:    "SELECT i FROM mytable WHERE i = 1 and i = 2",
+		Expected: []sql.Row{},
+	},
+	{
 		Query:    "SELECT i FROM mytable WHERE s = 'first row' ORDER BY i DESC LIMIT 1;",
 		Expected: []sql.Row{{int64(1)}},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -3438,7 +3438,7 @@ Select * from (
 	},
 	{
 		Query:    "SELECT i FROM mytable WHERE i = 1 and i = '1'",
-		Expected: []sql.Row{},
+		Expected: []sql.Row{{1}},
 	},
 	{
 		Query:    "SELECT i FROM mytable WHERE i = 1 and i = '2'",

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -545,6 +545,10 @@ func (b *EqualityIndexBuilder) AddEquality(_ *Context, colIdx int, k interface{}
 	if colIdx >= len(b.rng) {
 		return fmt.Errorf("invalid index for building index lookup")
 	}
+	if b.rng[colIdx].UpperBound != nil {
+		return fmt.Errorf("redundant restriction on index column")
+	}
+
 	typ := b.idx.ColumnExpressionTypes()[colIdx].Type
 	// if converting from float to int results in rounding, then it's empty range
 	if t, ok := typ.(NumberType); ok && !t.IsFloat() {


### PR DESCRIPTION
Fix bug in equality range builder where duplicate equality filters to one value would stomp each other.

fixes: https://github.com/dolthub/dolt/issues/8317

dolt-side: https://github.com/dolthub/dolt/pull/8322