### PR TITLE
fix collations with recursive hash for `HashInTuple` expressions

### DIFF
--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -1775,6 +1775,26 @@ from information_schema.routines where routine_schema = 'mydb' and routine_type 
 			},
 		},
 	},
+	{
+		Name: "information_schema.columns in expression uses info schema collation",
+		SetUpScript: []string{
+			"create table TEST (COL int);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select table_schema, table_name, column_name table_comment from information_schema.columns where (table_name, column_name) in (('TEST', 'COL'));",
+				Expected: []sql.Row{
+					{"mydb", "TEST", "COL"},
+				},
+			},
+			{
+				Query: "select table_schema, table_name, column_name table_comment from information_schema.columns where (table_name, column_name) in (('test', 'col'));",
+				Expected: []sql.Row{
+					{"mydb", "TEST", "COL"},
+				},
+			},
+		},
+	},
 }
 
 var SkippedInfoSchemaScripts = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7262,7 +7262,7 @@ where
 			"create table t (t1 text collate utf8mb4_0900_bin, t2 text collate utf8mb4_0900_ai_ci)",
 			"insert into t values ('ABC', 'DEF')",
 		},
-		Assertions:  []ScriptTestAssertion{
+		Assertions: []ScriptTestAssertion{
 			{
 				Query: "select * from t where (t1, t2) in (('ABC', 'DEF'));",
 				Expected: []sql.Row{
@@ -7276,10 +7276,10 @@ where
 				},
 			},
 			{
-				Query: "select * from t where (t1, t2) in (('abc', 'DEF'));",
+				Query:    "select * from t where (t1, t2) in (('abc', 'DEF'));",
 				Expected: []sql.Row{},
 			},
-			},
+		},
 	},
 }
 

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7143,7 +7143,6 @@ where
 			},
 		},
 	},
-
 	{
 		Name: "unix_timestamp script tests",
 		SetUpScript: []string{
@@ -7174,7 +7173,6 @@ where
 			},
 		},
 	},
-
 	{
 		Name: "name_const queries",
 		SetUpScript: []string{
@@ -7257,6 +7255,31 @@ where
 				ExpectedErrStr: "incorrect parameter count in the call to native function NAME_CONST",
 			},
 		},
+	},
+	{
+		Name: "mismatched collation using hash in tuples",
+		SetUpScript: []string{
+			"create table t (t1 text collate utf8mb4_0900_bin, t2 text collate utf8mb4_0900_ai_ci)",
+			"insert into t values ('ABC', 'DEF')",
+		},
+		Assertions:  []ScriptTestAssertion{
+			{
+				Query: "select * from t where (t1, t2) in (('ABC', 'DEF'));",
+				Expected: []sql.Row{
+					{"ABC", "DEF"},
+				},
+			},
+			{
+				Query: "select * from t where (t1, t2) in (('ABC', 'def'));",
+				Expected: []sql.Row{
+					{"ABC", "DEF"},
+				},
+			},
+			{
+				Query: "select * from t where (t1, t2) in (('abc', 'DEF'));",
+				Expected: []sql.Row{},
+			},
+			},
 	},
 }
 

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -246,29 +246,6 @@ func newInMap(ctx *sql.Context, right Tuple, lType sql.Type) (map[uint64]sql.Exp
 	return elements, hasNull, nil
 }
 
-// getTupleCollation returns the collation to use for a tuple.
-// If the tuple consists entirely of string types with the same collation, that collation is returned.
-// Otherwise, Default collation is returned.
-func getTupleCollation(tup types.TupleType) sql.CollationID {
-	coll := sql.Collation_Unspecified
-	for _, typ := range tup {
-		// if any element is not text, return default
-		if !types.IsTextOnly(typ) {
-			return sql.Collation_Default
-		}
-		// all text elements must have the same collation
-		c := typ.(sql.StringType).Collation()
-		if coll == sql.Collation_Unspecified {
-			coll = c
-			continue
-		}
-		if coll != c {
-			return sql.Collation_Default
-		}
-	}
-	return coll
-}
-
 func hashOfSimple(ctx *sql.Context, i interface{}, t sql.Type) (uint64, error) {
 	if i == nil {
 		return 0, nil

--- a/sql/expression/in.go
+++ b/sql/expression/in.go
@@ -246,6 +246,29 @@ func newInMap(ctx *sql.Context, right Tuple, lType sql.Type) (map[uint64]sql.Exp
 	return elements, hasNull, nil
 }
 
+// getTupleCollation returns the collation to use for a tuple.
+// If the tuple consists entirely of string types with the same collation, that collation is returned.
+// Otherwise, Default collation is returned.
+func getTupleCollation(tup types.TupleType) sql.CollationID {
+	coll := sql.Collation_Unspecified
+	for _, typ := range tup {
+		// if any element is not text, return default
+		if !types.IsTextOnly(typ) {
+			return sql.Collation_Default
+		}
+		// all text elements must have the same collation
+		c := typ.(sql.StringType).Collation()
+		if coll == sql.Collation_Unspecified {
+			coll = c
+			continue
+		}
+		if coll != c {
+			return sql.Collation_Default
+		}
+	}
+	return coll
+}
+
 func hashOfSimple(ctx *sql.Context, i interface{}, t sql.Type) (uint64, error) {
 	if i == nil {
 		return 0, nil
@@ -265,6 +288,10 @@ func hashOfSimple(ctx *sql.Context, i interface{}, t sql.Type) (uint64, error) {
 			str = converted.(string)
 		}
 	} else {
+		if types.IsTuple(t) {
+			coll = getTupleCollation(t.(types.TupleType))
+		}
+
 		x, err := convertOrTruncate(ctx, i, t.Promote())
 		if err != nil {
 			return 0, err

--- a/sql/expression/in_test.go
+++ b/sql/expression/in_test.go
@@ -415,6 +415,23 @@ func TestHashInTuple(t *testing.T) {
 			nil,
 		},
 		{
+			"heterogeneous collations with nested",
+			expression.NewTuple(
+					expression.NewLiteral("ABC", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Default)),
+					expression.NewLiteral("def", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_utf8mb4_0900_ai_ci)),
+			),
+			expression.NewTuple(
+				expression.NewTuple(
+					expression.NewLiteral("ABC", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Default)),
+					expression.NewLiteral("DEF", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Default)),
+				),
+			),
+			nil,
+			true,
+			nil,
+			nil,
+		},
+		{
 			"left get field tuple is in right",
 			expression.NewTuple(
 				expression.NewGetField(0, types.Int64, "foo", false),

--- a/sql/expression/in_test.go
+++ b/sql/expression/in_test.go
@@ -417,8 +417,8 @@ func TestHashInTuple(t *testing.T) {
 		{
 			"heterogeneous collations with nested",
 			expression.NewTuple(
-					expression.NewLiteral("ABC", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Default)),
-					expression.NewLiteral("def", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_utf8mb4_0900_ai_ci)),
+				expression.NewLiteral("ABC", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_Default)),
+				expression.NewLiteral("def", types.MustCreateString(sqltypes.VarChar, 20, sql.Collation_utf8mb4_0900_ai_ci)),
 			),
 			expression.NewTuple(
 				expression.NewTuple(


### PR DESCRIPTION
When hashing tuples, we don't take into account the collation of the individual elements, which results in incorrect comparisons for case insensitive collations.

The fix here was to recursively hash each individual element in a tuple, and hash the slice of hashes.

fixes https://github.com/dolthub/dolt/issues/8316