### PR TITLE
Add `sql.ContextProvider` interface

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -78,6 +78,7 @@ type Handler struct {
 var _ mysql.Handler = (*Handler)(nil)
 var _ mysql.ExtendedHandler = (*Handler)(nil)
 var _ mysql.BinlogReplicaHandler = (*Handler)(nil)
+var _ sql.ContextProvider = (*Handler)(nil)
 
 // NewConnection reports that a new connection has been established.
 func (h *Handler) NewConnection(c *mysql.Conn) {
@@ -175,6 +176,10 @@ func (h *Handler) ComPrepareParsed(ctx context.Context, c *mysql.Conn, query str
 	}
 
 	return analyzed, fields, nil
+}
+
+func (h *Handler) NewContext(ctx context.Context, c *mysql.Conn, query string) (*sql.Context, error) {
+	return h.sm.NewContext(ctx, c, query)
 }
 
 func (h *Handler) ComBind(ctx context.Context, c *mysql.Conn, query string, parsedQuery mysql.ParsedQuery, prepare *mysql.PrepareData) (mysql.BoundQuery, []*querypb.Field, error) {

--- a/sql/core.go
+++ b/sql/core.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"context"
 	"fmt"
 	trace2 "runtime/trace"
 	"strconv"
@@ -22,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dolthub/vitess/go/mysql"
 	"github.com/shopspring/decimal"
 )
 
@@ -205,6 +207,13 @@ type PartitionCounter interface {
 // Closer is a node that can be closed.
 type Closer interface {
 	Close(*Context) error
+}
+
+// ContextProvider creates sql.Context instances from a database connection.
+type ContextProvider interface {
+	// NewContext creates a new sql.Context instance for the connection |c|. The
+	// optional |query| can be specified to populate the sql.Context's query field.
+	NewContext(ctx context.Context, c *mysql.Conn, query string) (*Context, error)
 }
 
 // ExternalStoredProcedureProvider provides access to built-in stored procedures. These procedures are implemented


### PR DESCRIPTION
Doltgres needs a way to get a `sql.Context` in order to call some functions. This change adds a new `sql.ContextProvider` interface and has `Handler` implement it. 

See https://github.com/dolthub/doltgresql/pull/685 for the code that needs to call this new interface.