### PR TITLE
handle user variables in load data

### DIFF
--- a/enginetest/queries/load_queries.go
+++ b/enginetest/queries/load_queries.go
@@ -261,6 +261,8 @@ var LoadDataScripts = []ScriptTest{
 			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt3 set i = '123', j = '456', k = '789'",
 			"create table lt4(i text, j text, k text);",
 			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt4 set i = '123', i = '321'",
+			"create table lt5(i text, j text, k text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt5 set j = concat(j, j)",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -289,6 +291,14 @@ var LoadDataScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{"321", "def", "ghi"},
 					{"321", "mno", "pqr"},
+				},
+			},
+			{
+				Skip: true, // self references are problematic
+				Query: "select * from lt5 order by i, j, k",
+				Expected: []sql.Row{
+					{"321", "defdef", "ghi"},
+					{"321", "mnomno", "pqr"},
 				},
 			},
 		},
@@ -332,6 +342,156 @@ var LoadDataScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{"123", nil, "abc"},
 					{"123", nil, "jkl"},
+				},
+			},
+		},
+	},
+	{
+		Name: "LOAD DATA assign to static User Variables",
+		SetUpScript: []string{
+			"set @i = '123';",
+			"set @j = '456';",
+			"set @k = '789';",
+			"create table lt(i text, j text, k text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt set i = @i",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt set i = @i, j = @j",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt set i = @i, j = @j, k = @k",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from lt order by i, j, k",
+				Expected: []sql.Row{
+					{"123", "456", "789"},
+					{"123", "456", "789"},
+					{"123", "456", "ghi"},
+					{"123", "456", "pqr"},
+					{"123", "def", "ghi"},
+					{"123", "mno", "pqr"},
+				},
+			},
+		},
+	},
+	{
+		Name: "LOAD DATA assign to User Variables",
+		SetUpScript: []string{
+			"create table lt1(i text, j text, k text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt1 (@i, j, k)",
+			"create table lt2(i text, j text, k text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt2 (i, @j, k)",
+			"create table lt3(i text, j text, k text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt3 (i, j, @k)",
+			"create table lt4(i text, j text, k text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt4 (@ii, @jj, @kk)",
+			"create table lt5(i text, j text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt5 (i, j, @trash1)",
+			"create table lt6(j text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt6 (@trash2, j, @trash2)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from lt1 order by i, j, k",
+				Expected: []sql.Row{
+					{nil, "def", "ghi"},
+					{nil, "mno", "pqr"},
+				},
+			},
+			{
+				Query:    "select * from lt2 order by i, j, k",
+				Expected: []sql.Row{
+					{"abc", nil, "ghi"},
+					{"jkl", nil, "pqr"},
+				},
+			},
+			{
+				Query:    "select * from lt3 order by i, j, k",
+				Expected: []sql.Row{
+					{"abc", "def", nil},
+					{"jkl", "mno", nil},
+				},
+			},
+			{
+				Query:    "select @i, @j, @k",
+				Expected: []sql.Row{
+					{"jkl", "mno", "pqr"},
+				},
+			},
+			{
+				Query:    "select * from lt4 order by i, j, k",
+				Expected: []sql.Row{
+					{nil, nil, nil},
+					{nil, nil, nil},
+				},
+			},
+			{
+				Query:    "select @ii, @jj, @kk",
+				Expected: []sql.Row{
+					{"jkl", "mno", "pqr"},
+				},
+			},
+			{
+				Query:    "select * from lt5 order by i, j",
+				Expected: []sql.Row{
+					{"abc", "def"},
+					{"jkl", "mno"},
+				},
+			},
+			{
+				Query:    "select @trash1",
+				Expected: []sql.Row{
+					{"pqr"},
+				},
+			},
+			{
+				Query:    "select * from lt6 order by j",
+				Expected: []sql.Row{
+					{"def"},
+					{"mno"},
+				},
+			},
+			{
+				Query:    "select @trash2",
+				Expected: []sql.Row{
+					{"pqr"},
+				},
+			},
+		},
+	},
+	{
+		Name: "LOAD DATA with user vars and set expressions",
+		SetUpScript: []string{
+			"create table lt1(i text, j text, k text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt1 (k, @j, i) set j = @j",
+			"create table lt2(i text, j text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt2 (i, j, @k) set j = concat(@k, @k)",
+			"create table lt3(i text, j text);",
+			"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt3 (i, @j, @k) set j = concat(@j, @k)",
+
+			// TODO: fix these
+			//"create table lt3(i text, j text);",
+			//"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt3 (i, j, @k) set j = concat(j, @k)",
+			//"create table lt4(i text, j text);",
+			//"LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt4 (@i, @j) set i = @j, j = @i",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from lt1 order by i, j, k",
+				Expected: []sql.Row{
+					{"ghi", "def", "abc"},
+					{"pqr", "mno", "jkl"},
+				},
+			},
+			{
+				Query:    "select * from lt2 order by i, j",
+				Expected: []sql.Row{
+					{"abc", "ghighi"},
+					{"jkl", "pqrpqr"},
+				},
+			},
+			{
+				Query:    "select * from lt3 order by i, j",
+				Expected: []sql.Row{
+					{"abc", "defghi"},
+					{"jkl", "mnopqr"},
 				},
 			},
 		},

--- a/enginetest/queries/load_queries.go
+++ b/enginetest/queries/load_queries.go
@@ -492,14 +492,14 @@ var LoadDataScripts = []ScriptTest{
 				},
 			},
 			{
-				Query:    "select * from lt4 order by i, j",
+				Query: "select * from lt4 order by i, j",
 				Expected: []sql.Row{
 					{"abc", "defghi"},
 					{"jkl", "mnopqr"},
 				},
 			},
 			{
-				Query:    "select * from lt5 order by i, j",
+				Query: "select * from lt5 order by i, j",
 				Expected: []sql.Row{
 					{"def", "abc"},
 					{"mno", "jkl"},
@@ -530,8 +530,8 @@ var LoadDataScripts = []ScriptTest{
 				ExpectedErrStr: "syntax error near '@@k'",
 			},
 			{
-				Skip:     true, // escaped column names are ok
-				Query:    "LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt(i, @j, `@@k`)",
+				Skip:  true, // escaped column names are ok
+				Query: "LOAD DATA INFILE './testdata/test9.txt' INTO TABLE lt(i, @j, `@@k`)",
 				Expected: []sql.Row{
 					{"abc", "def", "ghi"},
 					{"jkl", "mno", "pqr"},

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -486,6 +486,14 @@ func (s *idxScope) visitSelf(n sql.Node) error {
 			newCheck.Expr = newE
 			s.checks = append(s.checks, &newCheck)
 		}
+		if ld, isLoadData := n.Source.(*plan.LoadData); isLoadData {
+			for i, e := range ld.SetExprs {
+				if e == nil {
+					continue
+				}
+				ld.SetExprs[i] = fixExprToScope(e, dstScope)
+			}
+		}
 	case *plan.Update:
 		newScope := s.copy()
 		srcScope := s.childScopes[0]

--- a/sql/plan/load_data.go
+++ b/sql/plan/load_data.go
@@ -23,18 +23,16 @@ import (
 )
 
 type LoadData struct {
-	Local              bool
-	File               string
-	DestSch            sql.Schema
-	ColumnNames        []string
-	SetExprs           []sql.Expression
-	UserSetFields      []sql.Expression
-	ResponsePacketSent bool
-	IgnoreNum          int64
-	IsIgnore           bool
-	IsReplace          bool
-
-	Charset string
+	Local     bool
+	File      string
+	DestSch   sql.Schema
+	ColNames  []string
+	SetExprs  []sql.Expression
+	UserVars  []sql.Expression
+	IgnoreNum int64
+	IsIgnore  bool
+	IsReplace bool
+	Charset   string
 
 	FieldsTerminatedBy  string
 	FieldsEnclosedBy    string
@@ -108,18 +106,18 @@ func (*LoadData) CollationCoercibility(ctx *sql.Context) (collation sql.Collatio
 	return sql.Collation_binary, 7
 }
 
-func NewLoadData(local bool, file string, destSch sql.Schema, cols []string, userSetFields []sql.Expression, ignoreNum int64, ignoreOrReplace string) *LoadData {
+func NewLoadData(local bool, file string, destSch sql.Schema, cols []string, userVars []sql.Expression, ignoreNum int64, ignoreOrReplace string) *LoadData {
 	isReplace := ignoreOrReplace == sqlparser.ReplaceStr
 	isIgnore := ignoreOrReplace == sqlparser.IgnoreStr || (local && !isReplace)
 	return &LoadData{
-		Local:         local,
-		File:          file,
-		DestSch:       destSch,
-		ColumnNames:   cols,
-		UserSetFields: userSetFields,
-		IgnoreNum:     ignoreNum,
-		IsIgnore:      isIgnore,
-		IsReplace:     isReplace,
+		Local:     local,
+		File:      file,
+		DestSch:   destSch,
+		ColNames:  cols,
+		UserVars:  userVars,
+		IgnoreNum: ignoreNum,
+		IsIgnore:  isIgnore,
+		IsReplace: isReplace,
 
 		FieldsTerminatedBy:  defaultFieldsTerminatedBy,
 		FieldsEnclosedBy:    defaultFieldsEnclosedBy,

--- a/sql/plan/load_data.go
+++ b/sql/plan/load_data.go
@@ -28,6 +28,7 @@ type LoadData struct {
 	DestSch            sql.Schema
 	ColumnNames        []string
 	SetExprs           []sql.Expression
+	UserSetFields      []sql.Expression
 	ResponsePacketSent bool
 	IgnoreNum          int64
 	IsIgnore           bool
@@ -107,17 +108,18 @@ func (*LoadData) CollationCoercibility(ctx *sql.Context) (collation sql.Collatio
 	return sql.Collation_binary, 7
 }
 
-func NewLoadData(local bool, file string, destSch sql.Schema, cols []string, ignoreNum int64, ignoreOrReplace string) *LoadData {
+func NewLoadData(local bool, file string, destSch sql.Schema, cols []string, userSetFields []sql.Expression, ignoreNum int64, ignoreOrReplace string) *LoadData {
 	isReplace := ignoreOrReplace == sqlparser.ReplaceStr
 	isIgnore := ignoreOrReplace == sqlparser.IgnoreStr || (local && !isReplace)
 	return &LoadData{
-		Local:       local,
-		File:        file,
-		DestSch:     destSch,
-		ColumnNames: cols,
-		IgnoreNum:   ignoreNum,
-		IsIgnore:    isIgnore,
-		IsReplace:   isReplace,
+		Local:         local,
+		File:          file,
+		DestSch:       destSch,
+		ColumnNames:   cols,
+		UserSetFields: userSetFields,
+		IgnoreNum:     ignoreNum,
+		IsIgnore:      isIgnore,
+		IsReplace:     isReplace,
 
 		FieldsTerminatedBy:  defaultFieldsTerminatedBy,
 		FieldsEnclosedBy:    defaultFieldsEnclosedBy,

--- a/sql/planbuilder/dml_validate.go
+++ b/sql/planbuilder/dml_validate.go
@@ -189,7 +189,7 @@ func validateValueCount(columnNames []string, values sql.Node) error {
 			}
 		}
 	case *plan.LoadData:
-		dataColLen := len(node.ColumnNames)
+		dataColLen := len(node.ColNames)
 		if dataColLen == 0 {
 			dataColLen = len(node.Schema())
 		}

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -117,7 +117,6 @@ func (b *BaseBuilder) buildLoadData(ctx *sql.Context, n *plan.LoadData, row sql.
 		}
 	}
 
-	// TODO: account for offsets from user variables?
 	fieldToColMap := make([]int, len(n.UserSetFields))
 	for fieldIdx, colIdx := 0, 0; fieldIdx < len(n.UserSetFields) && colIdx < len(colNames); fieldIdx++ {
 		if n.UserSetFields[fieldIdx] != nil {

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -109,7 +109,7 @@ func (b *BaseBuilder) buildLoadData(ctx *sql.Context, n *plan.LoadData, row sql.
 
 	sch := n.Schema()
 	source := sch[0].Source // Schema will always have at least one column
-	colNames := n.ColumnNames
+	colNames := n.ColNames
 	if len(colNames) == 0 {
 		colNames = make([]string, len(sch))
 		for i, col := range sch {
@@ -117,9 +117,9 @@ func (b *BaseBuilder) buildLoadData(ctx *sql.Context, n *plan.LoadData, row sql.
 		}
 	}
 
-	fieldToColMap := make([]int, len(n.UserSetFields))
-	for fieldIdx, colIdx := 0, 0; fieldIdx < len(n.UserSetFields) && colIdx < len(colNames); fieldIdx++ {
-		if n.UserSetFields[fieldIdx] != nil {
+	fieldToColMap := make([]int, len(n.UserVars))
+	for fieldIdx, colIdx := 0, 0; fieldIdx < len(n.UserVars) && colIdx < len(colNames); fieldIdx++ {
+		if n.UserVars[fieldIdx] != nil {
 			fieldToColMap[fieldIdx] = -1
 			continue
 		}
@@ -128,13 +128,13 @@ func (b *BaseBuilder) buildLoadData(ctx *sql.Context, n *plan.LoadData, row sql.
 	}
 
 	return &loadDataIter{
-		destSch:          n.DestSch,
-		reader:           reader,
-		scanner:          scanner,
-		columnCount:      len(n.ColumnNames), // Needs to be the original column count
-		fieldToColumnMap: fieldToColMap,
-		setExprs:         n.SetExprs,
-		userSetFields:    n.UserSetFields,
+		destSch:       n.DestSch,
+		reader:        reader,
+		scanner:       scanner,
+		colCount:      len(n.ColNames), // Needs to be the original column count
+		fieldToColMap: fieldToColMap,
+		setExprs:      n.SetExprs,
+		userVars:      n.UserVars,
 
 		fieldsTerminatedBy:  n.FieldsTerminatedBy,
 		fieldsEnclosedBy:    n.FieldsEnclosedBy,

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -224,7 +224,7 @@ func (l loadDataIter) parseFields(ctx *sql.Context, line string) ([]sql.Expressi
 	// projection will not insert default values, so we must do it here.
 	if l.colCount == 0 {
 		for exprIdx, expr := range exprs {
-			if expr != nil || l.destSch[exprIdx].Default == nil {
+			if expr != nil {
 				continue
 			}
 			col := l.destSch[exprIdx]


### PR DESCRIPTION
This PR adds support for assigning user variables within a `LOAD DATA` query, and referencing user variables withing an expression for `SET` clauses within the same `LOAD DATA` query.

Additionally, this PR refactors much of the `LOAD DATA` code.
We also moved `GetField` indexing out of iterator and into analyzer

fixes: https://github.com/dolthub/dolt/issues/8307