### PR TITLE
Fix FunctionalDependencies for NonUnique, NonNull indexes on Server

### DIFF
--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -17717,8 +17717,8 @@ WHERE LUEVY IN ('1', '2', '3')`,
 		ExpectedPlan: "RowUpdateAccumulator\n" +
 			" └─ Delete\n" +
 			"     └─ IndexedTableAccess(AMYXQ)\n" +
-			"         ├─ index: [AMYXQ.LUEVY]\n" +
-			"         ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
+			"         ├─ index: [AMYXQ.GXLUB,AMYXQ.LUEVY]\n" +
+			"         ├─ static: [{[NULL, ∞), [1, 1]}, {[NULL, ∞), [2, 2]}, {[NULL, ∞), [3, 3]}]\n" +
 			"         ├─ colSet: (1-8)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15,8 +15,7 @@
 package queries
 
 import (
-	"github.com/dolthub/go-mysql-server/enginetest/queries"
-"time"
+	"time"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
@@ -7283,12 +7282,12 @@ where
 		},
 	},
 	{
-		Name:        "not null not unique index works on server engine",
+		Name: "not null not unique index works on server engine",
 		SetUpScript: []string{
 			"create table t (i int not null, index (i));",
 			"insert into t values (1), (1), (1);",
 		},
-		Assertions:  []ScriptTestAssertion{
+		Assertions: []ScriptTestAssertion{
 			{
 				Query: "select * from t where i = 1;",
 				Expected: []sql.Row{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15,7 +15,8 @@
 package queries
 
 import (
-	"time"
+	"github.com/dolthub/go-mysql-server/enginetest/queries"
+"time"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	querypb "github.com/dolthub/vitess/go/vt/proto/query"
@@ -7278,6 +7279,23 @@ where
 			{
 				Query:    "select * from t where (t1, t2) in (('abc', 'DEF'));",
 				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name:        "not null not unique index works on server engine",
+		SetUpScript: []string{
+			"create table t (i int not null, index (i));",
+			"insert into t values (1), (1), (1);",
+		},
+		Assertions:  []ScriptTestAssertion{
+			{
+				Query: "select * from t where i = 1;",
+				Expected: []sql.Row{
+					{1},
+					{1},
+					{1},
+				},
 			},
 		},
 	},

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -1323,12 +1323,14 @@ func (c *indexCoster) costIndexScanLeaf(filter *iScanLeaf, s sql.Statistic, buck
 		stat, ok, err := c.costFulltext(filter, s, ord)
 		return buckets, stat.FuncDeps(), ok, 0, err
 	default:
-		if !idx.IsUnique() {
-			return nil, nil, false, 0, nil
-		}
 		conj := newConjCollector(s, buckets, ordinals)
 		conj.add(filter)
-		return conj.hist, conj.getFds(), true, conj.missingPrefix, nil
+		var conjFDs *sql.FuncDepSet
+		if idx.IsUnique() {
+			conjFDs = conj.getFds()
+		}
+		conjFDs = conj.getFds()
+		return conj.hist, conjFDs, true, conj.missingPrefix, nil
 	}
 }
 

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -1323,6 +1323,9 @@ func (c *indexCoster) costIndexScanLeaf(filter *iScanLeaf, s sql.Statistic, buck
 		stat, ok, err := c.costFulltext(filter, s, ord)
 		return buckets, stat.FuncDeps(), ok, 0, err
 	default:
+		if !idx.IsUnique() {
+			return nil, nil, false, 0, nil
+		}
 		conj := newConjCollector(s, buckets, ordinals)
 		conj.add(filter)
 		return conj.hist, conj.getFds(), true, conj.missingPrefix, nil

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -1329,7 +1329,6 @@ func (c *indexCoster) costIndexScanLeaf(filter *iScanLeaf, s sql.Statistic, buck
 		if idx.IsUnique() {
 			conjFDs = conj.getFds()
 		}
-		conjFDs = conj.getFds()
 		return conj.hist, conjFDs, true, conj.missingPrefix, nil
 	}
 }

--- a/sql/func_deps.go
+++ b/sql/func_deps.go
@@ -59,7 +59,7 @@ func (e *EquivSets) String() string {
 
 // Key maintains a strict or lax dependency
 type Key struct {
-	strict  bool
+	strict  bool // strict keys are unique and non-nullable
 	cols    ColSet
 	allCols ColSet
 }
@@ -313,8 +313,8 @@ func (f *FuncDepSet) AddStrictKey(cols ColSet) {
 
 func (f *FuncDepSet) AddLaxKey(cols ColSet) {
 	nullableCols := cols.Difference(f.notNull)
-	if nullableCols.Empty() {
-		f.AddStrictKey(cols)
+	if nullableCols.Empty() { // TODO: just because they are not null does not mean they are strict
+		//f.AddStrictKey(cols)
 	}
 
 	cols = f.simplifyCols(cols, nil)

--- a/sql/func_deps.go
+++ b/sql/func_deps.go
@@ -313,8 +313,8 @@ func (f *FuncDepSet) AddStrictKey(cols ColSet) {
 
 func (f *FuncDepSet) AddLaxKey(cols ColSet) {
 	nullableCols := cols.Difference(f.notNull)
-	if nullableCols.Empty() { // TODO: just because they are not null does not mean they are strict
-		//f.AddStrictKey(cols)
+	if nullableCols.Empty() {
+		f.AddStrictKey(cols)
 	}
 
 	cols = f.simplifyCols(cols, nil)

--- a/sql/func_deps.go
+++ b/sql/func_deps.go
@@ -59,7 +59,7 @@ func (e *EquivSets) String() string {
 
 // Key maintains a strict or lax dependency
 type Key struct {
-	strict  bool // strict keys are unique and non-nullable
+	strict  bool
 	cols    ColSet
 	allCols ColSet
 }


### PR DESCRIPTION
When using the server engine, we return an error for indexes defined over non-unique not null columns.
This meant that filters over these columns would incorrectly return error when there were duplicate entries.
Oddly, this only happens on server engine and not using dolt sql-shell directly.

The bug stems from a missing check when gathering functional dependencies for equalities.

Related: https://github.com/dolthub/dolt/issues/8365