### PR TITLE
Fix str_to_date function

### DIFF
--- a/sql/expression/function/str_to_date_test.go
+++ b/sql/expression/function/str_to_date_test.go
@@ -25,6 +25,10 @@ func TestStrToDate(t *testing.T) {
 		{"ymd", "2024121", "%Y%m%d", "2024-12-01"},
 		{"ymd", "20241301", "%Y%m%d", nil},
 		{"ymd", "20240001", "%Y%m%d", nil},
+		{"ymd-with-time", "2024010203:04:05", "%Y%m%d%T", "2024-01-02 03:04:05"},
+		{"ymd-with-time", "202408122:03:04", "%Y%m%d%T", "2024-08-12 02:03:04"},
+		// TODO: It shoud be nil, but returns "2024-02-31"
+		// {"ymd", "20240231", "%Y%m%d", nil},
 	}
 
 	for _, tt := range testCases {

--- a/sql/expression/function/str_to_date_test.go
+++ b/sql/expression/function/str_to_date_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
-func ptrStr(s string) *string {
-	return &s
-}
-
 func TestStrToDate(t *testing.T) {
 	setupTimezone(t)
 
@@ -22,11 +18,11 @@ func TestStrToDate(t *testing.T) {
 		name     string
 		dateStr  string
 		fmtStr   string
-		expected *string
+		expected interface{}
 	}{
-		{"standard", "Dec 26, 2000 2:13:15", "%b %e, %Y %T", ptrStr("2000-12-26 02:13:15")},
-		{"ymd", "20240101", "%Y%m%d", ptrStr("2024-01-01")},
-		{"ymd", "2024121", "%Y%m%d", ptrStr("2024-12-01")},
+		{"standard", "Dec 26, 2000 2:13:15", "%b %e, %Y %T", "2000-12-26 02:13:15"},
+		{"ymd", "20240101", "%Y%m%d", "2024-01-01"},
+		{"ymd", "2024121", "%Y%m%d", "2024-12-01"},
 		{"ymd", "20241301", "%Y%m%d", nil},
 		{"ymd", "20240001", "%Y%m%d", nil},
 	}
@@ -41,11 +37,7 @@ func TestStrToDate(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			dtime := eval(t, f, sql.NewRow(tt.dateStr, tt.fmtStr))
-			if tt.expected != nil {
-				require.Equal(t, *tt.expected, dtime)
-			} else {
-				require.Equal(t, nil, dtime)
-			}
+			require.Equal(t, tt.expected, dtime)
 		})
 		req := require.New(t)
 		req.True(f.IsNullable())

--- a/sql/planbuilder/dateparse/date.go
+++ b/sql/planbuilder/dateparse/date.go
@@ -220,7 +220,7 @@ var formatSpecifiers = map[byte]parser{
 	// %D	Day of the month with English suffix (0th, 1st, 2nd, 3rd, …)
 	'D': parseDayNumericWithEnglishSuffix,
 	// %d	Day of the month, numeric (00..31)
-	'd': parseDayOfMonthNumeric,
+	'd': parseDayOfMonth2DigitNumeric,
 	// %e	Day of the month, numeric (0..31)
 	'e': parseDayOfMonthNumeric,
 	// %f	Microseconds (000000..999999)

--- a/sql/planbuilder/dateparse/date.go
+++ b/sql/planbuilder/dateparse/date.go
@@ -242,7 +242,7 @@ var formatSpecifiers = map[byte]parser{
 	// %M	Month name (January..December)
 	'M': parseMonthName,
 	// %m	Month, numeric (00..12)
-	'm': parseMonthNumeric,
+	'm': parseMonth2DigitNumeric,
 	// %p	AM or PM
 	'p': parseAmPm,
 	// %r	Time, 12-hour (hh:mm:ss followed by AM or PM)

--- a/sql/planbuilder/dateparse/parsers.go
+++ b/sql/planbuilder/dateparse/parsers.go
@@ -75,7 +75,7 @@ func parseMonthAbbreviation(result *datetime, chars string) (rest string, _ erro
 }
 
 func parseMonthNumeric(result *datetime, chars string) (rest string, _ error) {
-	num, rest, err := takeNumberAtMostNChars(2, chars)
+	num, rest, err := takeNumber(chars)
 	if err != nil {
 		return "", err
 	}

--- a/sql/planbuilder/dateparse/parsers.go
+++ b/sql/planbuilder/dateparse/parsers.go
@@ -75,9 +75,22 @@ func parseMonthAbbreviation(result *datetime, chars string) (rest string, _ erro
 }
 
 func parseMonthNumeric(result *datetime, chars string) (rest string, _ error) {
-	num, rest, err := takeNumber(chars)
+	num, rest, err := takeNumberAtMostNChars(2, chars)
 	if err != nil {
 		return "", err
+	}
+	month := time.Month(num)
+	result.month = &month
+	return rest, nil
+}
+
+func parseMonth2DigitNumeric(result *datetime, chars string) (rest string, _ error) {
+	num, rest, err := takeNumberAtMostNChars(2, chars)
+	if err != nil {
+		return "", err
+	}
+	if num < 1 || num > 12 {
+		return "", fmt.Errorf("expected 01-12, got %m", len(chars))
 	}
 	month := time.Month(num)
 	result.month = &month
@@ -224,7 +237,7 @@ func parseYear4DigitNumeric(result *datetime, chars string) (rest string, _ erro
 	if len(chars) < 4 {
 		return "", fmt.Errorf("expected at least 4 chars, got %d", len(chars))
 	}
-	year, rest, err := takeNumber(chars)
+	year, rest, err := takeNumberAtMostNChars(4, chars)
 	if err != nil {
 		return "", err
 	}

--- a/sql/planbuilder/dateparse/parsers.go
+++ b/sql/planbuilder/dateparse/parsers.go
@@ -90,7 +90,7 @@ func parseMonth2DigitNumeric(result *datetime, chars string) (rest string, _ err
 		return "", err
 	}
 	if num < 1 || num > 12 {
-		return "", fmt.Errorf("expected 01-12, got %m", len(chars))
+		return "", fmt.Errorf("expected 01-12, got %s", string(chars))
 	}
 	month := time.Month(num)
 	result.month = &month

--- a/sql/planbuilder/dateparse/parsers.go
+++ b/sql/planbuilder/dateparse/parsers.go
@@ -106,6 +106,18 @@ func parseDayOfMonthNumeric(result *datetime, chars string) (rest string, _ erro
 	return rest, nil
 }
 
+func parseDayOfMonth2DigitNumeric(result *datetime, chars string) (rest string, _ error) {
+	num, rest, err := takeNumberAtMostNChars(2, chars)
+	if err != nil {
+		return "", err
+	}
+	if num < 1 || num > 31 {
+		return "", fmt.Errorf("expected 01-31, got %s", string(chars))
+	}
+	result.day = &num
+	return rest, nil
+}
+
 func parseMicrosecondsNumeric(result *datetime, chars string) (rest string, _ error) {
 	num, rest, err := takeNumber(chars)
 	if err != nil {


### PR DESCRIPTION
`STR_TO_DATE` function cannot parse "%Y%m%d".
I mentioned it in the issue #2666
