### PR TITLE
sql/rowexec: merge_join.go: Fix dropped error in incLeft and incRight.

### DIFF
--- a/sql/rowexec/merge_join.go
+++ b/sql/rowexec/merge_join.go
@@ -244,9 +244,15 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			}
 		case msIncLeft:
 			err = i.incLeft(ctx)
+			if err != nil {
+				return nil, err
+			}
 			nextState = msExhaustCheck
 		case msIncRight:
 			err = i.incRight(ctx)
+			if err != nil {
+				return nil, err
+			}
 			nextState = msExhaustCheck
 		case msSelect:
 			ret = i.copyReturnRow()


### PR DESCRIPTION
This fixes a bug where certain joins were not able to be canceled in a timely manner by canceling their Context.