### PR TITLE
Implicitly set prefix lengths for Doltgres

### DIFF
--- a/memory/index.go
+++ b/memory/index.go
@@ -137,6 +137,10 @@ func (idx *Index) PrefixLengths() []uint16 {
 	return idx.PrefixLens
 }
 
+func (idx *Index) SetPrefixLengths(prefixLengths []uint16) {
+	idx.PrefixLens = prefixLengths
+}
+
 func (idx *Index) IndexType() string {
 	if len(idx.DriverName) > 0 {
 		return idx.DriverName

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -274,6 +274,7 @@ func (ab *Builder) Build() *Analyzer {
 		Parallelism:  ab.parallelism,
 		Coster:       memo.NewDefaultCoster(),
 		ExecBuilder:  rowexec.DefaultBuilder,
+		DatabaseType: sql.EngineType_MySql,
 	}
 }
 
@@ -298,6 +299,9 @@ type Analyzer struct {
 	// EventScheduler is used to communiate with the event scheduler
 	// for any EVENT related statements. It can be nil if EventScheduler is not defined.
 	EventScheduler sql.EventScheduler
+	// DatabaseType indicates whether the analyzer's behavior is compatible with a MySQL
+	// database or a PostgreSQL database.
+	DatabaseType sql.EngineType
 }
 
 // NewDefault creates a default Analyzer instance with all default Rules and configuration.

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -274,7 +274,7 @@ func (ab *Builder) Build() *Analyzer {
 		Parallelism:  ab.parallelism,
 		Coster:       memo.NewDefaultCoster(),
 		ExecBuilder:  rowexec.DefaultBuilder,
-		DatabaseType: sql.EngineType_MySql,
+		EngineType:   sql.EngineType_MySql,
 	}
 }
 
@@ -299,9 +299,9 @@ type Analyzer struct {
 	// EventScheduler is used to communiate with the event scheduler
 	// for any EVENT related statements. It can be nil if EventScheduler is not defined.
 	EventScheduler sql.EventScheduler
-	// DatabaseType indicates whether the analyzer's behavior is compatible with a MySQL
+	// EngineType indicates whether the analyzer's behavior is compatible with a MySQL
 	// database or a PostgreSQL database.
-	DatabaseType sql.EngineType
+	EngineType sql.EngineType
 }
 
 // NewDefault creates a default Analyzer instance with all default Rules and configuration.

--- a/sql/analyzer/index_analyzer_test.go
+++ b/sql/analyzer/index_analyzer_test.go
@@ -152,8 +152,9 @@ func (i *dummyIdx) Comment() string                       { return "" }
 func (i *dummyIdx) IsGenerated() bool                     { return false }
 func (i *dummyIdx) CanSupportOrderBy(sql.Expression) bool { return false }
 
-func (i *dummyIdx) IndexType() string       { return "BTREE" }
-func (i *dummyIdx) PrefixLengths() []uint16 { return nil }
+func (i *dummyIdx) IndexType() string                { return "BTREE" }
+func (i *dummyIdx) PrefixLengths() []uint16          { return nil }
+func (i dummyIdx) SetPrefixLengths(uint16s []uint16) {}
 
 func (i *dummyIdx) NewLookup(*sql.Context, ...sql.Range) (sql.IndexLookup, error) {
 	panic("not implemented")

--- a/sql/engines.go
+++ b/sql/engines.go
@@ -16,6 +16,15 @@ package sql
 
 import "fmt"
 
+// EngineType indicates which type of database is being emulated. This is used to switch
+// between MySQL behavior and PostgreSQL behavior.
+type EngineType byte
+
+const (
+	EngineType_MySql EngineType = iota
+	EngineType_Postgres
+)
+
 // Engine represents a sql engine.
 type Engine struct {
 	Name        string

--- a/sql/index.go
+++ b/sql/index.go
@@ -126,8 +126,10 @@ type Index interface {
 	// Verifying that the expression's children match the index columns are done separately.
 	CanSupportOrderBy(expr Expression) bool
 
-	// PrefixLengths returns the prefix lengths for each column in this index
+	// PrefixLengths returns the prefix lengths for each column in this index.
 	PrefixLengths() []uint16
+	// SetPrefixLengths sets the prefix lengths for each column in this index.
+	SetPrefixLengths([]uint16)
 }
 
 // ExtendedIndex is an extension of Index, that allows access to appended primary keys. MySQL internally represents an

--- a/sql/index_builder_test.go
+++ b/sql/index_builder_test.go
@@ -225,4 +225,6 @@ func (testIndex) PrefixLengths() []uint16 {
 	return nil
 }
 
+func (i testIndex) SetPrefixLengths(uint16s []uint16) {}
+
 var _ sql.Index = testIndex{}

--- a/sql/index_registry_test.go
+++ b/sql/index_registry_test.go
@@ -443,17 +443,18 @@ func (i dummyIdx) Expressions() []string {
 	}
 	return exprs
 }
-func (i dummyIdx) ID() string              { return i.id }
-func (i dummyIdx) Database() string        { return i.database }
-func (i dummyIdx) Table() string           { return i.table }
-func (i dummyIdx) Driver() string          { return "dummy" }
-func (i dummyIdx) IsUnique() bool          { return false }
-func (i dummyIdx) IsSpatial() bool         { return false }
-func (i dummyIdx) IsFullText() bool        { return false }
-func (i dummyIdx) Comment() string         { return "" }
-func (i dummyIdx) IsGenerated() bool       { return false }
-func (i dummyIdx) IndexType() string       { return "BTREE" }
-func (i dummyIdx) PrefixLengths() []uint16 { return nil }
+func (i dummyIdx) ID() string                        { return i.id }
+func (i dummyIdx) Database() string                  { return i.database }
+func (i dummyIdx) Table() string                     { return i.table }
+func (i dummyIdx) Driver() string                    { return "dummy" }
+func (i dummyIdx) IsUnique() bool                    { return false }
+func (i dummyIdx) IsSpatial() bool                   { return false }
+func (i dummyIdx) IsFullText() bool                  { return false }
+func (i dummyIdx) Comment() string                   { return "" }
+func (i dummyIdx) IsGenerated() bool                 { return false }
+func (i dummyIdx) IndexType() string                 { return "BTREE" }
+func (i dummyIdx) PrefixLengths() []uint16           { return nil }
+func (i dummyIdx) SetPrefixLengths(uint16s []uint16) {}
 
 func (i dummyIdx) NewLookup(ctx *Context, ranges ...Range) (IndexLookup, error) {
 	panic("not implemented")

--- a/sql/memo/rel_props_test.go
+++ b/sql/memo/rel_props_test.go
@@ -257,5 +257,6 @@ func (i dummyIndex) ColumnExpressionTypes() []sql.ColumnExpressionType {
 func (dummyIndex) PrefixLengths() []uint16 {
 	return nil
 }
+func (i dummyIndex) SetPrefixLengths(uint16s []uint16) {}
 
 var _ sql.Index = dummyIndex{}


### PR DESCRIPTION
This change allows Doltgres customers to use `TEXT` columns in secondary indexes and `UNIQUE` constraints.

MySQL requires that users specify a prefix length when using a `TEXT` or `BLOB` column in a secondary index (also in the primary key, but Dolt/GMS doesn't support that currently). PostgreSQL does not have a concept of prefix lengths. Including the full `TEXT` content in an index introduces problems with our 65kb row size limit and allowing a secondary index to include an address and de-ref it in `TupleComparator` is a larger/messier change. Implicitly setting a prefix length is a pragmatic way to get the right behavior, without doing the large refactoring to allow secondary indexes to support address-encoded values correctly. That work seems to be required before we can support `TEXT` columns being used in primary keys, too. 

I played with a few ways to structure this behavior difference. My first choice way to refactor out a separate analyzer rule that Doltgres could insert, but that turned into a lot of copy and paste that didn't seem easier to maintain, so I tried adding a `EngineType` property to `Analyzer` so that code can be aware of what type of engine it is emulating and switch on that for different behaviors. I may still take another pass at a separate analyzer rule, just to try that approach again – putting that analyzer rule in GMS, instead of in Doltgres, could prevent some of the copy/paste, without having to export additional, small helper functions.