### PR TITLE
add view column information to `information_schema.columns`

### DIFF
--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -1158,15 +1158,18 @@ FROM INFORMATION_SCHEMA.TRIGGERS WHERE trigger_schema = 'mydb'`,
 		SetUpScript: []string{
 			"USE foo",
 			"drop table othertable",
-			"CREATE TABLE t (i int)",
-			"CREATE VIEW v as select * from t",
+			"CREATE TABLE t (i int primary key, j int)",
+			"CREATE VIEW v as select i + 1, j * 2, mod(i, j) from t",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
 				Query: "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = 'foo'",
 				Expected: []sql.Row{
-					{"def", "foo", "t", "i", uint32(1), nil, "YES", "int", nil, nil, int64(10), int64(0), nil, nil, nil, "int", "", "", "insert,references,select,update", "", "", nil},
-					{"def", "foo", "v", "", uint32(0), nil, "", nil, nil, nil, nil, nil, nil, "", "", "", "", "", "select", "", "", nil},
+					{"def", "foo", "t", "i", uint32(1), nil, "NO", "int", nil, nil, 10, 0, nil, nil, nil, "int", "PRI", "", "insert,references,select,update", "", "", nil},
+					{"def", "foo", "t", "j", uint32(2), nil, "YES", "int", nil, nil, 10, 0, nil, nil, nil, "int", "", "", "insert,references,select,update", "", "", nil},
+					{"def", "foo", "v", "i + 1", uint32(1), nil, "NO", "bigint", nil, nil, 19, 0, nil, nil, nil, "bigint", "", "", "insert,references,select,update", "", "", nil},
+					{"def", "foo", "v", "j * 2", uint32(2), nil, "YES", "bigint", nil, nil, 19, 0, nil, nil, nil, "bigint", "", "", "insert,references,select,update", "", "", nil},
+					{"def", "foo", "v", "mod(i, j)", uint32(3), nil, "YES", "decimal", nil, nil, 10, 0, nil, nil, nil, "decimal(10,0)", "", "", "insert,references,select,update", "", "", nil},
 				},
 			},
 		},

--- a/sql/information_schema/columns_table.go
+++ b/sql/information_schema/columns_table.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -235,7 +236,7 @@ func columnsRowIter(ctx *sql.Context, catalog sql.Catalog, allColsWithDefaultVal
 		}
 		rows = append(rows, rs...)
 
-		rs, err = getRowsFromViews(ctx, db)
+		rs, err = getRowsFromViews(ctx, catalog, db, privSet, globalPrivSetMap)
 		if err != nil {
 			return nil, err
 		}
@@ -364,41 +365,28 @@ func getRowsFromTable(ctx *sql.Context, db DbWithNames, t sql.Table, privSetDb s
 }
 
 // getRowsFromViews returns array or rows for columns for all views for given database.
-func getRowsFromViews(ctx *sql.Context, db DbWithNames) ([]sql.Row, error) {
+func getRowsFromViews(ctx *sql.Context, catalog sql.Catalog, db DbWithNames, privSet sql.PrivilegeSet, privSetMap map[string]struct{}) ([]sql.Row, error) {
 	var rows []sql.Row
-	// TODO: View Definition is lacking information to properly fill out these table
-	// TODO: Should somehow get reference to table(s) view is referencing
-	// TODO: Each column that view references should also show up as unique entries as well
 	views, err := ViewsInDatabase(ctx, db.Database)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, view := range views {
-		rows = append(rows, sql.Row{
-			db.CatalogName, // table_catalog
-			db.SchemaName,  // table_schema
-			view.Name,      // table_name
-			"",             // column_name
-			uint32(0),      // ordinal_position
-			nil,            // column_default
-			"",             // is_nullable
-			nil,            // data_type
-			nil,            // character_maximum_length
-			nil,            // character_octet_length
-			nil,            // numeric_precision
-			nil,            // numeric_scale
-			nil,            // datetime_precision
-			"",             // character_set_name
-			"",             // collation_name
-			"",             // column_type
-			"",             // column_key
-			"",             // extra
-			"select",       // privileges
-			"",             // column_comment
-			"",             // generation_expression
-			nil,            // srs_id
-		})
+	for i, view := range views {
+		node, _, err := planbuilder.Parse(ctx, catalog, view.TextDefinition)
+		if err != nil {
+			// TODO: should we error?
+			continue
+		}
+		privSetDb := privSet.Database(db.Database.Name())
+		privSetTbl := privSetDb.Table(view.Name)
+		curPrivSetMap := getCurrentPrivSetMapForColumn(privSetDb.ToSlice(), privSetMap)
+		for _, col := range node.Schema() {
+			r := getRowFromColumn(ctx, i, col, db.CatalogName, db.SchemaName, view.Name, "", privSetTbl, curPrivSetMap)
+			if r != nil {
+				rows = append(rows, r)
+			}
+		}
 	}
 
 	return rows, nil


### PR DESCRIPTION
This PR has information_schema reparse create view statements to fill in missing information for the `information_schema.columns` table. There maybe small differences in column type for more complex views, but should be fine.

Implementing using `view.TextDefinition` would be slightly easier/cleaner, but for some reason its sometimes empty? Seems like something to do with fragments on dolt side.

fixes: https://github.com/dolthub/dolt/issues/3168