### PR TITLE
fix cascade for foreign keys with multiple references

### DIFF
--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -707,9 +707,9 @@ var UpdateIgnoreScripts = []ScriptTest{
 		Name: "UPDATE IGNORE with foreign keys",
 		SetUpScript: []string{
 			"CREATE TABLE colors ( id INT NOT NULL, color VARCHAR(32) NOT NULL, PRIMARY KEY (id), INDEX color_index(color));",
-			"CREATE TABLE objects (id INT NOT NULL, name VARCHAR(64) NOT NULL,color VARCHAR(32), PRIMARY KEY(id),FOREIGN KEY (color) REFERENCES colors(color))",
-			"INSERT INTO colors (id,color) VALUES (1,'red'),(2,'green'),(3,'blue'),(4,'purple')",
-			"INSERT INTO objects (id,name,color) VALUES (1,'truck','red'),(2,'ball','green'),(3,'shoe','blue')",
+			"CREATE TABLE objects (id INT NOT NULL, name VARCHAR(64) NOT NULL,color VARCHAR(32), PRIMARY KEY(id),FOREIGN KEY (color) REFERENCES colors(color));",
+			"INSERT INTO colors (id,color) VALUES (1,'red'),(2,'green'),(3,'blue'),(4,'purple');",
+			"INSERT INTO objects (id,name,color) VALUES (1,'truck','red'),(2,'ball','green'),(3,'shoe','blue');",
 		},
 		Assertions: []ScriptTestAssertion{
 			{

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -385,8 +385,7 @@ func getForeignKeyRefActions(ctx *sql.Context, a *Analyzer, tbl sql.ForeignKeyTa
 			return nil, err
 		}
 
-		fkChain = fkChain.AddForeignKey(fk.Name)
-		childEditor, err := getForeignKeyEditor(ctx, a, childTbl, cache, fkChain, checkRows)
+		childEditor, err := getForeignKeyEditor(ctx, a, childTbl, cache, fkChain.AddForeignKey(fk.Name), checkRows)
 		if err != nil {
 			return nil, err
 		}
@@ -568,6 +567,9 @@ func (chain foreignKeyChain) AddTable(dbName string, tblName string) foreignKeyC
 	newFkTables := make(map[foreignKeyTableName]struct{})
 	for fkName := range chain.fkNames {
 		newFkNames[fkName] = struct{}{}
+	}
+	for fkTable := range chain.fkTables {
+		newFkTables[fkTable] = struct{}{}
 	}
 	newFkTables[newForeignKeyTableName(dbName, tblName)] = struct{}{}
 	return foreignKeyChain{

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -597,8 +597,8 @@ func (chain foreignKeyChain) AddForeignKey(fkName string) foreignKeyChain {
 	}
 	newFkNames[strings.ToLower(fkName)] = struct{}{}
 	return foreignKeyChain{
-		fkNames:  newFkNames,
-		fkTables: newFkTables,
+		fkNames:    newFkNames,
+		fkTables:   newFkTables,
 		fkUpdaters: chain.fkUpdaters,
 	}
 }

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -354,7 +354,6 @@ func getForeignKeyRefActions(ctx *sql.Context, a *Analyzer, tbl sql.ForeignKeyTa
 		// If either referential action is not equivalent to RESTRICT, then the updater has the possibility of having
 		// its contents modified, therefore we add it to the chain.
 		if !fk.OnUpdate.IsEquivalentToRestrict() || !fk.OnDelete.IsEquivalentToRestrict() {
-			// TODO: why would I add the updater without the table here?
 			fkChain = fkChain.AddTableUpdater(fk.Database, fk.Table, childUpdater)
 		}
 
@@ -386,7 +385,6 @@ func getForeignKeyRefActions(ctx *sql.Context, a *Analyzer, tbl sql.ForeignKeyTa
 			return nil, err
 		}
 
-		// TODO: does this need to be a deep copy or no???
 		fkChain = fkChain.AddForeignKey(fk.Name)
 		childEditor, err := getForeignKeyEditor(ctx, a, childTbl, cache, fkChain, checkRows)
 		if err != nil {


### PR DESCRIPTION
This PR fixes an issue where foreign keys referencing the same column would fail to update the parent table (only on GMS).
Turns out we were adding the updater in the chain under the parent table's name instead of the child's name.

Additionally, has some small refactoring to tidy up the foreign key chain code.

fixes: https://github.com/dolthub/go-mysql-server/issues/2671