### PR TITLE
Additional support for vector indexes.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5871,6 +5871,18 @@ func TestIndexes(t *testing.T, h Harness) {
 	}
 }
 
+func TestVectorIndexes(t *testing.T, h Harness) {
+	for _, tt := range queries.VectorIndexQueries {
+		TestScript(t, h, tt)
+	}
+}
+
+func TestVectorFunctions(t *testing.T, h Harness) {
+	for _, tt := range queries.VectorFunctionQueries {
+		TestScript(t, h, tt)
+	}
+}
+
 func TestIndexPrefix(t *testing.T, h Harness) {
 	for _, tt := range queries.IndexPrefixQueries {
 		TestScript(t, h, tt)

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -890,6 +890,14 @@ func TestIndexes(t *testing.T) {
 	enginetest.TestIndexes(t, enginetest.NewDefaultMemoryHarness())
 }
 
+func TestVectorIndexes(t *testing.T) {
+	enginetest.TestVectorIndexes(t, enginetest.NewDefaultMemoryHarness())
+}
+
+func TestVectorFunctions(t *testing.T) {
+	enginetest.TestVectorFunctions(t, enginetest.NewDefaultMemoryHarness())
+}
+
 func TestIndexPrefix(t *testing.T) {
 	enginetest.TestIndexPrefix(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/enginetest/queries/vector_function_queries.go
+++ b/enginetest/queries/vector_function_queries.go
@@ -1,0 +1,58 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queries
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+var VectorFunctionQueries = []ScriptTest{
+	{
+		Name: "basic usage of VEC_DISTANCE without index",
+		SetUpScript: []string{
+			"create table vectors (id int primary key, v json);",
+			`insert into vectors values (1, '[3.0,4.0]'), (2, '[0.0,0.0]'), (3, '[1.0,-1.0]'), (4, '[-2.0,0.0]');`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select VEC_DISTANCE('[10.0]', '[20.0]');",
+				Expected: []sql.Row{{100.0}},
+			},
+			{
+				Query:    "select VEC_DISTANCE_L2_SQUARED('[1.0, 2.0]', '[5.0, 5.0]');",
+				Expected: []sql.Row{{25.0}},
+			},
+			{
+				Query: "select * from vectors order by VEC_DISTANCE('[0.0,0.0]', v)",
+				Expected: []sql.Row{
+					{2, types.MustJSON(`[0.0, 0.0]`)},
+					{3, types.MustJSON(`[1.0, -1.0]`)},
+					{4, types.MustJSON(`[-2.0, 0.0]`)},
+					{1, types.MustJSON(`[3.0, 4.0]`)},
+				},
+			},
+			{
+				Query: "select * from vectors order by VEC_DISTANCE_L2_SQUARED('[-2.0,0.0]', v)",
+				Expected: []sql.Row{
+					{4, types.MustJSON(`[-2.0, 0.0]`)},
+					{2, types.MustJSON(`[0.0, 0.0]`)},
+					{3, types.MustJSON(`[1.0, -1.0]`)},
+					{1, types.MustJSON(`[3.0, 4.0]`)},
+				},
+			},
+		},
+	},
+}

--- a/enginetest/queries/vector_index_queries.go
+++ b/enginetest/queries/vector_index_queries.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queries
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+var VectorIndexQueries = []ScriptTest{
+	{
+		Name: "basic vector index",
+		SetUpScript: []string{
+			"create table vectors (id int primary key, v json);",
+			`insert into vectors values (1, '[3.0,4.0]'), (2, '[0.0,0.0]'), (3, '[1.0,-1.0]'), (4, '[-2.0,0.0]');`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `create vector index v_idx on vectors(v);`,
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 0}},
+				},
+			},
+			{
+				Query: "show create table vectors",
+				Expected: []sql.Row{
+					{"vectors", "CREATE TABLE `vectors` (\n  `id` int NOT NULL,\n  `v` json,\n  PRIMARY KEY (`id`),\n  VECTOR KEY `v_idx` (`v`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query: "select * from vectors order by VEC_DISTANCE('[0.0,0.0]', v)",
+				Expected: []sql.Row{
+					{2, types.MustJSON(`[0.0, 0.0]`)},
+					{3, types.MustJSON(`[1.0, -1.0]`)},
+					{4, types.MustJSON(`[-2.0, 0.0]`)},
+					{1, types.MustJSON(`[3.0, 4.0]`)},
+				},
+				ExpectedIndexes: []string{"v_idx"},
+			},
+			{
+				Query: "select * from vectors order by VEC_DISTANCE_L2_SQUARED('[-2.0,0.0]', v)",
+				Expected: []sql.Row{
+					{4, types.MustJSON(`[-2.0, 0.0]`)},
+					{2, types.MustJSON(`[0.0, 0.0]`)},
+					{3, types.MustJSON(`[1.0, -1.0]`)},
+					{1, types.MustJSON(`[3.0, 4.0]`)},
+				},
+				ExpectedIndexes: []string{"v_idx"},
+			},
+		},
+	},
+}

--- a/enginetest/queries/vector_index_queries.go
+++ b/enginetest/queries/vector_index_queries.go
@@ -53,7 +53,7 @@ var VectorIndexQueries = []ScriptTest{
 					{4, types.MustJSON(`[-2.0, 0.0]`)},
 					{1, types.MustJSON(`[3.0, 4.0]`)},
 				},
-				ExpectedIndexes: []string{""},
+				ExpectedIndexes: nil,
 			},
 			{
 				Query: "select * from vectors order by VEC_DISTANCE_L2_SQUARED('[-2.0,0.0]', v) limit 4",

--- a/memory/index.go
+++ b/memory/index.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -38,7 +39,7 @@ type Index struct {
 	Fulltext   bool
 	// If SupportedVectorFunction is non-nil, this index can be used to optimize ORDER BY
 	// expressions on this type of distance function.
-	SupportedVectorFunction expression.DistanceType
+	SupportedVectorFunction vector.DistanceType
 	CommentStr              string
 	PrefixLens              []uint16
 	fulltextInfo
@@ -125,7 +126,7 @@ func (idx *Index) CanSupportOrderBy(expr sql.Expression) bool {
 	if idx.SupportedVectorFunction == nil {
 		return false
 	}
-	dist, isDist := expr.(*expression.Distance)
+	dist, isDist := expr.(*vector.Distance)
 	return isDist && idx.SupportedVectorFunction.CanEval(dist.DistanceType)
 }
 

--- a/memory/index.go
+++ b/memory/index.go
@@ -122,6 +122,10 @@ func (idx *Index) IsFullText() bool {
 	return idx.Fulltext
 }
 
+func (idx *Index) IsVector() bool {
+	return idx.SupportedVectorFunction != nil
+}
+
 func (idx *Index) CanSupportOrderBy(expr sql.Expression) bool {
 	if idx.SupportedVectorFunction == nil {
 		return false

--- a/memory/table.go
+++ b/memory/table.go
@@ -1598,7 +1598,6 @@ func (t *IndexedTable) LookupPartitions(ctx *sql.Context, lookup sql.IndexLookup
 
 	if lookup.VectorOrderAndLimit.OrderBy != nil {
 		return &vectorPartitionIter{
-			Column:        lookup.Index.(*Index).Exprs[0],
 			OrderAndLimit: lookup.VectorOrderAndLimit,
 		}, nil
 	}

--- a/memory/table.go
+++ b/memory/table.go
@@ -2012,6 +2012,11 @@ func (t *Table) createIndex(data *TableData, name string, columns []sql.IndexCol
 		}
 	}
 
+	var vectorFunction vector.DistanceType
+	if constraint == sql.IndexConstraint_Vector {
+		vectorFunction = vector.DistanceL2Squared{}
+	}
+
 	return &Index{
 		DB:                      t.dbName(),
 		DriverName:              "",
@@ -2022,7 +2027,7 @@ func (t *Table) createIndex(data *TableData, name string, columns []sql.IndexCol
 		Unique:                  constraint == sql.IndexConstraint_Unique,
 		Spatial:                 constraint == sql.IndexConstraint_Spatial,
 		Fulltext:                constraint == sql.IndexConstraint_Fulltext,
-		SupportedVectorFunction: nil,
+		SupportedVectorFunction: vectorFunction,
 		CommentStr:              comment,
 		PrefixLens:              prefixLengths,
 	}, nil

--- a/memory/table.go
+++ b/memory/table.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer/analyzererrors"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/iters"
 	"github.com/dolthub/go-mysql-server/sql/transform"
@@ -2121,7 +2122,7 @@ func (t *Table) CreateFulltextIndex(ctx *sql.Context, indexDef sql.IndexDef, key
 	return nil
 }
 
-func (t *Table) CreateVectorIndex(ctx *sql.Context, idx sql.IndexDef, distanceType expression.DistanceType) error {
+func (t *Table) CreateVectorIndex(ctx *sql.Context, idx sql.IndexDef, distanceType vector.DistanceType) error {
 	if len(idx.Columns) > 1 {
 		return fmt.Errorf("vector indexes must have exactly one column")
 	}

--- a/sql/analyzer/index_analyzer_test.go
+++ b/sql/analyzer/index_analyzer_test.go
@@ -148,6 +148,7 @@ func (i *dummyIdx) Table() string                         { return i.table }
 func (i *dummyIdx) IsUnique() bool                        { return false }
 func (i *dummyIdx) IsSpatial() bool                       { return false }
 func (i *dummyIdx) IsFullText() bool                      { return false }
+func (i *dummyIdx) IsVector() bool                        { return false }
 func (i *dummyIdx) Comment() string                       { return "" }
 func (i *dummyIdx) IsGenerated() bool                     { return false }
 func (i *dummyIdx) CanSupportOrderBy(sql.Expression) bool { return false }

--- a/sql/analyzer/replace_order_by_distance.go
+++ b/sql/analyzer/replace_order_by_distance.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 )
@@ -49,7 +50,7 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 		if len(sfExprs) != 1 {
 			return n, transform.SameTree, nil
 		}
-		distance, isDistance := sfExprs[0].(*expression.Distance)
+		distance, isDistance := sfExprs[0].(*vector.Distance)
 		if !isDistance {
 			return n, transform.SameTree, nil
 		}

--- a/sql/analyzer/replace_order_by_distance.go
+++ b/sql/analyzer/replace_order_by_distance.go
@@ -118,7 +118,7 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 		var err error
 		same := transform.SameTree
 		switch c := child.(type) {
-		case *plan.Project, *plan.TableAlias, *plan.ResolvedTable, *plan.Filter, *plan.Limit, *plan.Offset, *plan.Sort, *plan.IndexedTableAccess:
+		case *plan.Project, *plan.TableAlias, *plan.ResolvedTable, *plan.Filter, *plan.Limit, *plan.TopN, *plan.Offset, *plan.Sort, *plan.IndexedTableAccess:
 			newChildren[i], same, err = replaceIdxOrderByDistanceHelper(ctx, scope, child, sortNode)
 		default:
 			newChildren[i] = c

--- a/sql/analyzer/replace_order_by_distance.go
+++ b/sql/analyzer/replace_order_by_distance.go
@@ -60,13 +60,16 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 			return n, transform.SameTree, nil
 		}
 		var column sql.Expression
+		var literal sql.Expression
 		_, leftIsLiteral := distance.LeftChild.(*expression.Literal)
 		if leftIsLiteral {
 			column = distance.RightChild
+			literal = distance.LeftChild
 		} else {
 			_, rightIsLiteral := distance.RightChild.(*expression.Literal)
 			if rightIsLiteral {
 				column = distance.LeftChild
+				literal = distance.RightChild
 			} else {
 				return n, transform.SameTree, nil
 			}
@@ -99,6 +102,7 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 			VectorOrderAndLimit: sql.OrderAndLimit{
 				OrderBy: distance,
 				Limit:   limit,
+				Literal: literal,
 			},
 		}
 		nn, err := plan.NewStaticIndexedAccessForTableNode(n, lookup)

--- a/sql/analyzer/replace_order_by_distance.go
+++ b/sql/analyzer/replace_order_by_distance.go
@@ -41,6 +41,11 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
+
+		// Column references have not been assigned their final indexes yet, so do that for the ORDER BY expression now.
+		// We can safely do this because an expression that references other tables won't pass `isSortFieldsValidPrefix` below.
+		sortNode = offsetAssignIndexes(sortNode).(plan.Sortable)
+
 		sfExprs := normalizeExpressions(tableAliases, sortNode.GetSortFields().ToExpressions()...)
 		sfAliases := aliasedExpressionsInNode(sortNode)
 

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -107,6 +107,10 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 			if idxCandidate.IsSpatial() {
 				continue
 			}
+			if idxCandidate.IsVector() {
+				// TODO: It's possible that we may be able to use vector indexes for point lookups, but not range lookups
+				continue
+			}
 			if isSortFieldsValidPrefix(sfExprs, sfAliases, idxCandidate.Expressions()) {
 				idx = idxCandidate
 				break

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -505,7 +505,7 @@ func validateModifyColumn(ctx *sql.Context, initialSch sql.Schema, schema sql.Sc
 			if !strings.EqualFold(col.Name, oldColName) {
 				continue
 			}
-			if types.IsJSON(newCol.Type) {
+			if types.IsJSON(newCol.Type) && !index.IsVector() {
 				return nil, sql.ErrJSONIndex.New(col.Name)
 			}
 			var prefixLen int64
@@ -883,7 +883,7 @@ func validateIndex(ctx *sql.Context, colMap map[string]*sql.Column, idxDef *sql.
 			return sql.ErrDuplicateColumn.New(schCol.Name)
 		}
 		seenCols[schCol.Name] = struct{}{}
-		if types.IsJSON(schCol.Type) {
+		if types.IsJSON(schCol.Type) && !idxDef.IsVector() {
 			return sql.ErrJSONIndex.New(schCol.Name)
 		}
 

--- a/sql/analyzer/vector_index_test.go
+++ b/sql/analyzer/vector_index_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/rowexec"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -49,7 +50,7 @@ func vectorIndexTestCases(t *testing.T, db *memory.Database, table sql.IndexedTa
 			name: "without limit",
 			inputPlan: plan.NewSort(
 				sql.SortFields{
-					{Column: expression.NewDistance(expression.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetField(1, types.JSON, "v", false)), Order: sql.Ascending},
+					{Column: vector.NewDistance(vector.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetField(1, types.JSON, "v", false)), Order: sql.Ascending},
 				}, plan.NewResolvedTable(table, db, nil)),
 			expectedPlan: `
 IndexedTableAccess(test)
@@ -66,7 +67,7 @@ IndexedTableAccess(test)
 			name: "with limit",
 			inputPlan: plan.NewTopN(
 				sql.SortFields{
-					{Column: expression.NewDistance(expression.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetField(1, types.JSON, "v", false)), Order: sql.Ascending},
+					{Column: vector.NewDistance(vector.DistanceL2Squared{}, jsonExpression(t, "[0.0, 0.0]"), expression.NewGetField(1, types.JSON, "v", false)), Order: sql.Ascending},
 				}, expression.NewLiteral(1, types.Int64), plan.NewResolvedTable(table, db, nil)),
 			expectedPlan: `
 IndexedTableAccess(test)
@@ -197,7 +198,7 @@ var vectorIndex = memory.Index{
 	Unique:                  true,
 	Spatial:                 false,
 	Fulltext:                false,
-	SupportedVectorFunction: expression.DistanceL2Squared{},
+	SupportedVectorFunction: vector.DistanceL2Squared{},
 	CommentStr:              "",
 	PrefixLens:              nil,
 }

--- a/sql/core.go
+++ b/sql/core.go
@@ -16,6 +16,7 @@ package sql
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	trace2 "runtime/trace"
 	"strconv"
@@ -317,27 +318,38 @@ func ConvertToVector(v interface{}) ([]float64, error) {
 	switch b := v.(type) {
 	case []float64:
 		return b, nil
+	case string:
+		var val interface{}
+		err := json.Unmarshal([]byte(b), &val)
+		if err != nil {
+			return nil, err
+		}
+		return convertJsonInterfaceToVector(val)
 	case JSONWrapper:
 		val, err := b.ToInterface()
 		if err != nil {
 			return nil, err
 		}
-		array, ok := val.([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("can't convert JSON to vector; expected array, got %v", val)
-		}
-		res := make([]float64, len(array))
-		for i, elem := range array {
-			floatElem, ok := elem.(float64)
-			if !ok {
-				return nil, fmt.Errorf("can't convert JSON to vector; expected array of floats, got %v", elem)
-			}
-			res[i] = floatElem
-		}
-		return res, nil
+		return convertJsonInterfaceToVector(val)
 	default:
 		return nil, fmt.Errorf("unable to cast %#v of type %T to vector", v, v)
 	}
+}
+
+func convertJsonInterfaceToVector(val interface{}) ([]float64, error) {
+	array, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("can't convert JSON to vector; expected array, got %v", val)
+	}
+	res := make([]float64, len(array))
+	for i, elem := range array {
+		floatElem, ok := elem.(float64)
+		if !ok {
+			return nil, fmt.Errorf("can't convert JSON to vector; expected array of floats, got %v", elem)
+		}
+		res[i] = floatElem
+	}
+	return res, nil
 }
 
 // EvaluateCondition evaluates a condition, which is an expression whose value

--- a/sql/core.go
+++ b/sql/core.go
@@ -894,6 +894,7 @@ func IncrementStatusVariable(ctx *Context, name string, val int) {
 type OrderAndLimit struct {
 	OrderBy       Expression
 	Limit         Expression
+	Literal       Expression
 	CalcFoundRows bool
 }
 

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation/window"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/spatial"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 )
 
 // ErrFunctionAlreadyRegistered is thrown when a function is already registered
@@ -309,6 +310,8 @@ var BuiltIns = []sql.Function{
 	sql.FunctionN{Name: "week", Fn: NewWeek},
 	sql.Function1{Name: "values", Fn: NewValues},
 	sql.Function1{Name: "validate_password_strength", Fn: NewValidatePasswordStrength},
+	sql.Function2{Name: "vec_distance", Fn: vector.NewL2SquaredDistance},
+	sql.Function2{Name: "vec_distance_l2_squared", Fn: vector.NewL2SquaredDistance},
 	sql.Function1{Name: "weekday", Fn: NewWeekday},
 	sql.Function1{Name: "weekofyear", Fn: NewWeekOfYear},
 	sql.Function1{Name: "year", Fn: NewYear},

--- a/sql/expression/function/vector/distance.go
+++ b/sql/expression/function/vector/distance.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package expression
+package vector
 
 import (
 	"fmt"
-
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -25,6 +25,8 @@ type DistanceType interface {
 	String() string
 	Eval(left []float64, right []float64) (float64, error)
 	CanEval(distanceType DistanceType) bool
+	FunctionName() string
+	Description() string
 }
 
 type DistanceL2Squared struct{}
@@ -52,17 +54,40 @@ func (d DistanceL2Squared) CanEval(other DistanceType) bool {
 	return other == DistanceL2Squared{}
 }
 
+func (d DistanceL2Squared) FunctionName() string {
+	return "vec_distance_l2_squared"
+}
+
+func (d DistanceL2Squared) Description() string {
+	return "returns the squared l2 norm (euclidian distance) between two vectors"
+}
+
 type Distance struct {
 	DistanceType DistanceType
-	BinaryExpressionStub
+	expression.BinaryExpressionStub
+}
+
+func (d Distance) FunctionName() string {
+	return d.DistanceType.FunctionName()
+}
+
+func (d Distance) Description() string {
+	return d.DistanceType.Description()
 }
 
 var _ sql.Expression = (*Distance)(nil)
+var _ sql.FunctionExpression = (*Distance)(nil)
 var _ sql.CollationCoercible = (*Distance)(nil)
 
 // NewDistance creates a new Distance expression.
 func NewDistance(distanceType DistanceType, left sql.Expression, right sql.Expression) sql.Expression {
-	return &Distance{DistanceType: distanceType, BinaryExpressionStub: BinaryExpressionStub{LeftChild: left, RightChild: right}}
+	return &Distance{DistanceType: distanceType, BinaryExpressionStub: expression.BinaryExpressionStub{LeftChild: left, RightChild: right}}
+}
+
+var _ sql.CreateFunc2Args = NewL2SquaredDistance
+
+func NewL2SquaredDistance(left, right sql.Expression) sql.Expression {
+	return NewDistance(DistanceL2Squared{}, left, right)
 }
 
 func (d Distance) CollationCoercibility(_ *sql.Context) (collation sql.CollationID, coercibility byte) {

--- a/sql/expression/function/vector/distance.go
+++ b/sql/expression/function/vector/distance.go
@@ -16,6 +16,7 @@ package vector
 
 import (
 	"fmt"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"

--- a/sql/expression/function/vector/distance_test.go
+++ b/sql/expression/function/vector/distance_test.go
@@ -15,12 +15,12 @@
 package vector
 
 import (
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 	"github.com/dolthub/go-mysql-server/sql/types/jsontests"
 )

--- a/sql/expression/function/vector/distance_test.go
+++ b/sql/expression/function/vector/distance_test.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package expression
+package vector
 
 import (
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"testing"
 
 	assert "github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ import (
 )
 
 func jsonExpression(t *testing.T, val interface{}) sql.Expression {
-	return NewLiteral(jsontests.ConvertToJson(t, val), types.JSON)
+	return expression.NewLiteral(jsontests.ConvertToJson(t, val), types.JSON)
 }
 
 func TestDistance(t *testing.T) {

--- a/sql/index.go
+++ b/sql/index.go
@@ -108,6 +108,8 @@ type Index interface {
 	IsSpatial() bool
 	// IsFullText returns whether this index is a Full-Text index
 	IsFullText() bool
+	// IsVector returns whether this index is a Full-Text index
+	IsVector() bool
 	// Comment returns the comment for this index
 	Comment() string
 	// IndexType returns the type of this index, e.g. BTREE

--- a/sql/index_builder_test.go
+++ b/sql/index_builder_test.go
@@ -200,6 +200,10 @@ func (testIndex) IsFullText() bool {
 	return false
 }
 
+func (testIndex) IsVector() bool {
+	return false
+}
+
 func (testIndex) Comment() string {
 	return ""
 }

--- a/sql/index_registry_test.go
+++ b/sql/index_registry_test.go
@@ -450,6 +450,7 @@ func (i dummyIdx) Driver() string          { return "dummy" }
 func (i dummyIdx) IsUnique() bool          { return false }
 func (i dummyIdx) IsSpatial() bool         { return false }
 func (i dummyIdx) IsFullText() bool        { return false }
+func (i dummyIdx) IsVector() bool          { return false }
 func (i dummyIdx) Comment() string         { return "" }
 func (i dummyIdx) IsGenerated() bool       { return false }
 func (i dummyIdx) IndexType() string       { return "BTREE" }

--- a/sql/memo/rel_props_test.go
+++ b/sql/memo/rel_props_test.go
@@ -229,6 +229,10 @@ func (dummyIndex) IsFullText() bool {
 	return false
 }
 
+func (dummyIndex) IsVector() bool {
+	return false
+}
+
 func (dummyIndex) CanSupportOrderBy(sql.Expression) bool {
 	return false
 }

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -701,7 +701,6 @@ func (b *Builder) buildIndexDefs(_ *scope, spec *ast.TableSpec) (idxDefs sql.Ind
 		} else if idxDef.Info.Vector {
 			// TODO: different kinds of vector HNSW, IVFFLAT, etc...
 			constraint = sql.IndexConstraint_Vector
-			b.handleErr(sql.ErrUnsupportedFeature.New("vector index"))
 		}
 
 		columns := b.gatherIndexColumns(idxDef.Columns)
@@ -839,7 +838,6 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 			constraint = sql.IndexConstraint_Spatial
 		case ast.VectorStr:
 			constraint = sql.IndexConstraint_Vector
-			b.handleErr(sql.ErrUnsupportedFeature.New("vector index"))
 		case ast.PrimaryStr:
 			constraint = sql.IndexConstraint_Primary
 		default:

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -453,7 +453,7 @@ func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, tab
 		}
 
 		colStmts = append(colStmts, sql.GenerateCreateTableIndexDefinition(index.IsUnique(), index.IsSpatial(),
-			index.IsFullText(), index.ID(), indexCols, index.Comment()))
+			index.IsFullText(), index.IsVector(), index.ID(), indexCols, index.Comment()))
 	}
 
 	fkt, err := getForeignKeyTable(table)

--- a/sql/sqlfmt.go
+++ b/sql/sqlfmt.go
@@ -102,7 +102,7 @@ func GenerateCreateTablePrimaryKeyDefinition(pkCols []string) string {
 
 // GenerateCreateTableIndexDefinition returns index definition string for 'CREATE TABLE' statement
 // for given index. This part comes after primary key definition if there is any.
-func GenerateCreateTableIndexDefinition(isUnique, isSpatial, isFullText bool, isVector bool, indexID string, indexCols []string, comment string) string {
+func GenerateCreateTableIndexDefinition(isUnique, isSpatial, isFullText, isVector bool, indexID string, indexCols []string, comment string) string {
 	unique := ""
 	if isUnique {
 		unique = "UNIQUE "

--- a/sql/sqlfmt.go
+++ b/sql/sqlfmt.go
@@ -102,7 +102,7 @@ func GenerateCreateTablePrimaryKeyDefinition(pkCols []string) string {
 
 // GenerateCreateTableIndexDefinition returns index definition string for 'CREATE TABLE' statement
 // for given index. This part comes after primary key definition if there is any.
-func GenerateCreateTableIndexDefinition(isUnique, isSpatial, isFullText bool, indexID string, indexCols []string, comment string) string {
+func GenerateCreateTableIndexDefinition(isUnique, isSpatial, isFullText bool, isVector bool, indexID string, indexCols []string, comment string) string {
 	unique := ""
 	if isUnique {
 		unique = "UNIQUE "
@@ -117,7 +117,13 @@ func GenerateCreateTableIndexDefinition(isUnique, isSpatial, isFullText bool, in
 	if isFullText {
 		fulltext = "FULLTEXT "
 	}
-	key := fmt.Sprintf("  %s%s%sKEY %s (%s)", unique, spatial, fulltext, QuoteIdentifier(indexID), strings.Join(indexCols, ","))
+
+	vector := ""
+	if isVector {
+		vector = "VECTOR "
+	}
+
+	key := fmt.Sprintf("  %s%s%s%sKEY %s (%s)", unique, spatial, fulltext, vector, QuoteIdentifier(indexID), strings.Join(indexCols, ","))
 	if comment != "" {
 		key = fmt.Sprintf("%s COMMENT '%s'", key, comment)
 	}


### PR DESCRIPTION
This PR adds the vector function VEC_DISTANCE to GMS, as well as support for adding and altering vector indexes, and support for `SHOW CREATE` on tables with vector indexes.

Vector indexes are not yet supported in Dolt. The corresponding version bump in Dolt will have checks preventing vector indexes from being added to Dolt tables.