### PR TITLE
use Equals method for sql.Types

### DIFF
--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -551,6 +551,6 @@ func TypesEqual(a, b sql.Type) bool {
 		}
 		return false
 	default:
-		return a == b
+		return a.Equals(b)
 	}
 }


### PR DESCRIPTION
The new `DoltgresType` struct cannot be compared with `==`, so should use `sql.Type.Equals()` function.