### PR TITLE
`information_schema` uppercase rule doesn't apply to `processlist` table

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -313,6 +313,51 @@ func TestInfoSchema(t *testing.T, h Harness) {
 		}, nil, nil, nil)
 	})
 
+	t.Run("information_schema.processlist projection case", func(t *testing.T) {
+		e := mustNewEngine(t, h)
+		defer e.Close()
+
+		if IsServerEngine(e) {
+			t.Skip("skipping for server engine as the processlist returned from server differs")
+		}
+		p := sqle.NewProcessList()
+		p.AddConnection(1, "localhost")
+
+		ctx := NewContext(h)
+		ctx.Session.SetClient(sql.Client{Address: "localhost", User: "root"})
+		ctx.Session.SetConnectionId(1)
+		ctx.ProcessList = p
+		ctx.SetCurrentDatabase("")
+
+		p.ConnectionReady(ctx.Session)
+
+		ctx, err := p.BeginQuery(ctx, "SELECT foo")
+		require.NoError(t, err)
+
+		p.AddConnection(2, "otherhost")
+		sess2 := sql.NewBaseSessionWithClientServer("localhost", sql.Client{Address: "otherhost", User: "root"}, 2)
+		sess2.SetCurrentDatabase("otherdb")
+		p.ConnectionReady(sess2)
+		ctx2 := sql.NewContext(context.Background(), sql.WithPid(2), sql.WithSession(sess2))
+		ctx2, err = p.BeginQuery(ctx2, "SELECT bar")
+		require.NoError(t, err)
+		p.EndQuery(ctx2)
+
+		TestQueryWithContext(t, ctx, e, h,
+			"SELECT id, uSeR, hOST FROM information_schema.processlist ORDER BY id",
+			[]sql.Row{
+				{uint64(1), "root", "localhost"},
+				{uint64(2), "root", "otherhost"},
+			},
+			sql.Schema{
+				{Name: "id", Type: types.Uint64},
+				{Name: "uSeR", Type: types.MustCreateString(sqltypes.VarChar, 96, sql.Collation_Information_Schema_Default)},
+				{Name: "hOST", Type: types.MustCreateString(sqltypes.VarChar, 783, sql.Collation_Information_Schema_Default)},
+			},
+			nil, nil,
+		)
+	})
+
 	for _, tt := range queries.SkippedInfoSchemaQueries {
 		t.Run(tt.Query, func(t *testing.T) {
 			t.Skip()

--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -38,19 +38,19 @@ var InfoSchemaQueries = []QueryTest{
    GROUP BY index_name;`,
 		ExpectedColumns: sql.Schema{
 			{
-				Name: "TABLE_NAME",
+				Name: "table_name",
 				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
 			},
 			{
-				Name: "INDEX_NAME",
+				Name: "index_name",
 				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
 			},
 			{
-				Name: "COMMENT",
+				Name: "comment",
 				Type: types.MustCreateString(sqltypes.VarChar, 8, sql.Collation_Information_Schema_Default),
 			},
 			{
-				Name: "NON_UNIQUE",
+				Name: "non_unique",
 				Type: types.Int32,
 			},
 			{
@@ -68,7 +68,7 @@ var InfoSchemaQueries = []QueryTest{
 		Query: `select table_name from information_schema.tables where table_name = 'mytable' limit 1;`,
 		ExpectedColumns: sql.Schema{
 			{
-				Name: "TABLE_NAME",
+				Name: "table_name",
 				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
 			},
 		},
@@ -77,9 +77,9 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		Query: `select table_catalog, table_schema, table_name from information_schema.tables where table_name = 'mytable' limit 1;`,
 		ExpectedColumns: sql.Schema{
-			{Name: "TABLE_CATALOG", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
-			{Name: "TABLE_SCHEMA", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
-			{Name: "TABLE_NAME", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
+			{Name: "table_catalog", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
+			{Name: "table_schema", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
+			{Name: "table_name", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
 		},
 		Expected: []sql.Row{{"def", "mydb", "mytable"}},
 	},

--- a/enginetest/queries/information_schema_queries.go
+++ b/enginetest/queries/information_schema_queries.go
@@ -38,19 +38,19 @@ var InfoSchemaQueries = []QueryTest{
    GROUP BY index_name;`,
 		ExpectedColumns: sql.Schema{
 			{
-				Name: "table_name",
+				Name: "TABLE_NAME",
 				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
 			},
 			{
-				Name: "index_name",
+				Name: "INDEX_NAME",
 				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
 			},
 			{
-				Name: "comment",
+				Name: "COMMENT",
 				Type: types.MustCreateString(sqltypes.VarChar, 8, sql.Collation_Information_Schema_Default),
 			},
 			{
-				Name: "non_unique",
+				Name: "NON_UNIQUE",
 				Type: types.Int32,
 			},
 			{
@@ -68,7 +68,7 @@ var InfoSchemaQueries = []QueryTest{
 		Query: `select table_name from information_schema.tables where table_name = 'mytable' limit 1;`,
 		ExpectedColumns: sql.Schema{
 			{
-				Name: "table_name",
+				Name: "TABLE_NAME",
 				Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default),
 			},
 		},
@@ -77,9 +77,9 @@ var InfoSchemaQueries = []QueryTest{
 	{
 		Query: `select table_catalog, table_schema, table_name from information_schema.tables where table_name = 'mytable' limit 1;`,
 		ExpectedColumns: sql.Schema{
-			{Name: "table_catalog", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
-			{Name: "table_schema", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
-			{Name: "table_name", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
+			{Name: "TABLE_CATALOG", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
+			{Name: "TABLE_SCHEMA", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
+			{Name: "TABLE_NAME", Type: types.MustCreateString(sqltypes.VarChar, 64, sql.Collation_Information_Schema_Default)},
 		},
 		Expected: []sql.Row{{"def", "mydb", "mytable"}},
 	},

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -613,10 +613,6 @@ func (c scopeColumn) unwrapGetFieldAliasId() columnId {
 }
 
 func (c scopeColumn) withOriginal(col string) scopeColumn {
-	if !strings.EqualFold(c.db, sql.InformationSchemaDatabaseName) {
-		// info schema columns always presented as uppercase
-		c.originalCol = col
-	}
 	return c
 }
 

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -613,7 +613,11 @@ func (c scopeColumn) unwrapGetFieldAliasId() columnId {
 }
 
 func (c scopeColumn) withOriginal(col string) scopeColumn {
-	c.originalCol = col
+	// info schema columns always presented as uppercase, except for processlist
+	// can't reference information_schema.ProcessListTableName because of import cycles
+	if !strings.EqualFold(c.db, sql.InformationSchemaDatabaseName) || (strings.EqualFold(c.db, sql.InformationSchemaDatabaseName) && strings.EqualFold(c.table, "processlist")) {
+		c.originalCol = col
+	}
 	return c
 }
 

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -613,6 +613,7 @@ func (c scopeColumn) unwrapGetFieldAliasId() columnId {
 }
 
 func (c scopeColumn) withOriginal(col string) scopeColumn {
+	c.originalCol = col
 	return c
 }
 


### PR DESCRIPTION
Selecting from information schema typically results in all uppercase column names, except for the `information_schema.processlist` table, which follows the non info schema casing (matches the projection).

Relevant MySQL Bug: https://bugs.mysql.com/bug.php?id=84456