### PR TITLE
increase column size for `information_schema.processlist.state`

### DIFF
--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -459,7 +459,7 @@ var processListSchema = Schema{
 	{Name: "DB", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: ProcessListTableName},
 	{Name: "COMMAND", Type: types.MustCreateString(sqltypes.VarChar, 16, Collation_Information_Schema_Default), Default: nil, Nullable: false, Source: ProcessListTableName},
 	{Name: "TIME", Type: types.Int32, Default: nil, Nullable: false, Source: ProcessListTableName},
-	{Name: "STATE", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: ProcessListTableName},
+	{Name: "STATE", Type: types.MustCreateString(sqltypes.VarChar, 65535, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: ProcessListTableName},
 	{Name: "INFO", Type: types.MustCreateString(sqltypes.VarChar, 65535, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: ProcessListTableName},
 }
 


### PR DESCRIPTION
The `State` column in our `information_schema.processlist` table is different than the MySQL implementation because we include progress information. As a result, it is possible to exceed the 64 character limit that the column is defined as.

However, thius means deviating from MySQL's definition of the table.