### PR TITLE
Add support for `show slave status`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20240916130659-0118adc6b662
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20241121221517-3e7b5ffc22b0
+	github.com/dolthub/vitess v0.0.0-20241125223808-07f6e12611ec
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/dolthub/vitess v0.0.0-20241120000209-5ff664bddfc4 h1:C3RSQjvv2T5TdQzR
 github.com/dolthub/vitess v0.0.0-20241120000209-5ff664bddfc4/go.mod h1:uBvlRluuL+SbEWTCZ68o0xvsdYZER3CEG/35INdzfJM=
 github.com/dolthub/vitess v0.0.0-20241121221517-3e7b5ffc22b0 h1:C8X4RkkWKcrJG6rG+MsdFINX2PhB7ObpbBvFcWsI8K8=
 github.com/dolthub/vitess v0.0.0-20241121221517-3e7b5ffc22b0/go.mod h1:alcJgfdyIhFaAiYyEmuDCFSLCzedz3KCaIclLoCUtJg=
+github.com/dolthub/vitess v0.0.0-20241125223808-07f6e12611ec h1:4EpyVnCleDMSuIqg8oCHf5IpwW7DPhjSQEgYCWkKpTo=
+github.com/dolthub/vitess v0.0.0-20241125223808-07f6e12611ec/go.mod h1:alcJgfdyIhFaAiYyEmuDCFSLCzedz3KCaIclLoCUtJg=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -102,6 +102,15 @@ func (b *Builder) buildShow(inScope *scope, s *ast.Show) (outScope *scope) {
 			showRep.ReplicaController = binCat.GetBinlogReplicaController()
 		}
 		outScope.node = showRep
+	case "slave status":
+		// The deprecated "show slave status" command returns the same information as "show replica status",
+		// but uses a schema with different column names so we create the node differently here.
+		outScope = inScope.push()
+		showRep := plan.NewShowSlaveStatus()
+		if binCat, ok := b.cat.(binlogreplication.BinlogReplicaCatalog); ok && binCat.HasBinlogReplicaController() {
+			showRep.ReplicaController = binCat.GetBinlogReplicaController()
+		}
+		outScope.node = showRep
 	default:
 		unsupportedShow := fmt.Sprintf("SHOW %s", s.Type)
 		b.handleErr(sql.ErrUnsupportedFeature.New(unsupportedShow))


### PR DESCRIPTION
This syntax is deprecated and will be removed in future MySQL versions (`SHOW REPLICA STATUS` should be preferred instead). However, some tools (e.g. Dolphie, MyDumper) still rely on this deprecated syntax, so we're adding support for it to keep compatibility with those tools.

Depends on: https://github.com/dolthub/vitess/pull/381