### PR TITLE
bump mysql version

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5346,7 +5346,7 @@ Select * from (
 	{
 		Query: "SELECT version()",
 		Expected: []sql.Row{
-			{string("8.0.11")},
+			{"8.0.23"},
 		},
 	},
 	{
@@ -5742,7 +5742,7 @@ Select * from (
 	{
 		Query: `SHOW VARIABLES WHERE Variable_name = 'version' || variable_name = 'autocommit'`,
 		Expected: []sql.Row{
-			{"autocommit", 1}, {"version", "8.0.11"},
+			{"autocommit", 1}, {"version", "8.0.23"},
 		},
 	},
 	{
@@ -5782,7 +5782,7 @@ Select * from (
 	{
 		Query: "SHOW VARIABLES LIKE 'VERSION'",
 		Expected: []sql.Row{
-			{"version", "8.0.11"},
+			{"version", "8.0.23"},
 		},
 	},
 	{

--- a/sql/expression/function/version.go
+++ b/sql/expression/function/version.go
@@ -21,8 +21,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
-const mysqlVersion = "8.0.11"
-
 // Version is a function that returns server version.
 type Version string
 
@@ -86,9 +84,12 @@ func (f Version) Children() []sql.Expression { return nil }
 
 // Eval implements the Expression interface.
 func (f Version) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
-	if f == "" {
-		return mysqlVersion, nil
+	v, err := ctx.Session.GetSessionVariable(ctx, "version")
+	if err != nil {
+		return nil, err
 	}
-
-	return fmt.Sprintf("%s-%s", mysqlVersion, string(f)), nil
+	if f == "" {
+		return v, nil
+	}
+	return fmt.Sprintf("%s-%s", v, string(f)), nil
 }

--- a/sql/expression/function/version_test.go
+++ b/sql/expression/function/version_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 Dolthub, Inc.
+// Copyright 2020-2024 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,12 +32,12 @@ func TestNewVersion(t *testing.T) {
 
 	val, err := f.Eval(ctx, nil)
 	require.NoError(err)
-	require.Equal("8.0.11-"+versionPostfix, val)
+	require.Equal("8.0.23-"+versionPostfix, val)
 
 	f, err = NewVersion("")()
 	require.NoError(err)
 
 	val, err = f.Eval(ctx, nil)
 	require.NoError(err)
-	require.Equal("8.0.11", val)
+	require.Equal("8.0.23", val)
 }

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -2941,7 +2941,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("version"),
-		Default:           "8.0.11",
+		Default:           "8.0.23",
 	},
 	"version_comment": &sql.MysqlSystemVariable{
 		Name:              "version_comment",


### PR DESCRIPTION
Certain tools expect a higher version of MySQL.
Currently, the latest stable version of MySQL is 8.4.4, but `8.0.23` is the minimum needed to satisfy mydumper.

Additionally, this alters the `version()` method to select directly from the `@@version` system variable.

related: https://github.com/dolthub/dolt/issues/8592