### PR TITLE
fix `AS OF` clause panic for certain expressions

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -197,20 +197,12 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "test script",
-			SetUpScript: []string{
-				"create table t (i tinytext unique);",
-				"insert into t values ('hello');",
-			},
-			Assertions: []queries.ScriptTestAssertion{
-				{
-					Query:          "insert into t values ('hello');",
-					ExpectedErrStr: "asdf",
-				},
-			},
+			Name:        "test script",
+			SetUpScript: []string{},
+			Assertions:  []queries.ScriptTestAssertion{},
 		},
 	}
 

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -197,12 +197,20 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
 			Name:        "test script",
-			SetUpScript: []string{},
-			Assertions:  []queries.ScriptTestAssertion{},
+			SetUpScript: []string{
+				"create table t (i tinytext unique);",
+				"insert into t values ('hello');",
+			},
+			Assertions:  []queries.ScriptTestAssertion{
+				{
+					Query:    "insert into t values ('hello');",
+					ExpectedErrStr: "asdf",
+				},
+			},
 		},
 	}
 

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10752,6 +10752,10 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: sql.ErrInvalidAsOfExpression,
 	},
 	{
+		Query:          "SELECT i FROM myhistorytable AS OF (SELECT 1)",
+		ExpectedErrStr: "invalid AS OF expression type",
+	},
+	{
 		Query:       "SELECT pk FROM one_pk WHERE pk > ?",
 		ExpectedErr: sql.ErrUnboundPreparedStatementVariable,
 	},

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -349,6 +349,10 @@ func (s *Subquery) evalMultiple(ctx *sql.Context, row sql.Row) ([]interface{}, e
 		return nil, err
 	}
 
+	if s.b == nil {
+		return nil, fmt.Errorf("attempted to evaluate uninitialized subquery")
+	}
+
 	iter, err := s.b.Build(ctx, q, row)
 	if err != nil {
 		return nil, err
@@ -432,6 +436,10 @@ func (s *Subquery) HasResultRow(ctx *sql.Context, row sql.Row) (bool, error) {
 	q, _, err := transform.Node(s.Query, PrependRowInPlan(row, false))
 	if err != nil {
 		return false, err
+	}
+
+	if s.b == nil {
+		return false, fmt.Errorf("attempted to evaluate uninitialized subquery")
 	}
 
 	iter, err := s.b.Build(ctx, q, row)

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -615,9 +615,9 @@ func (b *Builder) buildAsOfExpr(inScope *scope, time ast.Expr) sql.Expression {
 			err := sql.ErrInvalidAsOfExpression.New(v)
 			b.handleErr(err)
 		}
-	case *ast.Subquery:
-		b.handleErr(fmt.Errorf("invalid AS OF expression type"))
+	case *ast.ConvertExpr:
 	default:
+		b.handleErr(fmt.Errorf("invalid AS OF expression type"))
 	}
 	return b.buildScalar(b.newScope(), time)
 }

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -616,6 +616,7 @@ func (b *Builder) buildAsOfExpr(inScope *scope, time ast.Expr) sql.Expression {
 			b.handleErr(err)
 		}
 	case *ast.ConvertExpr:
+	case ast.InjectedExpr:
 	default:
 		b.handleErr(fmt.Errorf("invalid AS OF expression type"))
 	}

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -616,6 +616,7 @@ func (b *Builder) buildAsOfExpr(inScope *scope, time ast.Expr) sql.Expression {
 			b.handleErr(err)
 		}
 	default:
+		b.handleErr(fmt.Errorf("invalid AS OF expression type"))
 	}
 	return b.buildScalar(b.newScope(), time)
 }

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -615,8 +615,9 @@ func (b *Builder) buildAsOfExpr(inScope *scope, time ast.Expr) sql.Expression {
 			err := sql.ErrInvalidAsOfExpression.New(v)
 			b.handleErr(err)
 		}
-	default:
+	case *ast.Subquery:
 		b.handleErr(fmt.Errorf("invalid AS OF expression type"))
+	default:
 	}
 	return b.buildScalar(b.newScope(), time)
 }


### PR DESCRIPTION
We attempt to parse eval `AS OF` expressions in the builder (because we assume it is going to be a literal), but Subqueries cannot be evaluated until after they have gone through the analyzer.

partially addresses: https://github.com/dolthub/dolt/issues/8635