### PR TITLE
Add support for creating users with the `caching_sha2_password` auth plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20240916130659-0118adc6b662
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20241126223332-cd8f828f26ac
+	github.com/dolthub/vitess v0.0.0-20241204224532-0cfa560c28f6
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2
@@ -43,4 +43,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )
 
-go 1.22.2
+go 1.23.3
+
+toolchain go1.23.4

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/dolthub/vitess v0.0.0-20241126205153-88972ec5fe52 h1:RH0eygj4DLPQ6fvJ
 github.com/dolthub/vitess v0.0.0-20241126205153-88972ec5fe52/go.mod h1:alcJgfdyIhFaAiYyEmuDCFSLCzedz3KCaIclLoCUtJg=
 github.com/dolthub/vitess v0.0.0-20241126223332-cd8f828f26ac h1:A0U/OdIqdCkAV0by7MVBbnSyZBsa94ZjIZxx7PhjBW4=
 github.com/dolthub/vitess v0.0.0-20241126223332-cd8f828f26ac/go.mod h1:alcJgfdyIhFaAiYyEmuDCFSLCzedz3KCaIclLoCUtJg=
+github.com/dolthub/vitess v0.0.0-20241204224532-0cfa560c28f6 h1:awcaDlXFRSFrcm/f3EzbpMYiIEi/FzcgNJyONerf7zc=
+github.com/dolthub/vitess v0.0.0-20241204224532-0cfa560c28f6/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/mysql_db/mysql_db.go
+++ b/sql/mysql_db/mysql_db.go
@@ -780,8 +780,8 @@ func (db *MySQLDb) ValidateHash(salt []byte, user string, authResponse []byte, a
 	if userEntry == nil || userEntry.Locked {
 		return nil, mysql.NewSQLError(mysql.ERAccessDeniedError, mysql.SSAccessDeniedError, "Access denied for user '%v'", user)
 	}
-	if len(userEntry.Password) > 0 {
-		if !validateMysqlNativePassword(authResponse, salt, userEntry.Password) {
+	if len(userEntry.AuthString) > 0 {
+		if !validateMysqlNativePassword(authResponse, salt, userEntry.AuthString) {
 			return nil, mysql.NewSQLError(mysql.ERAccessDeniedError, mysql.SSAccessDeniedError, "Access denied for user '%v'", user)
 		}
 	} else if len(authResponse) > 0 { // password is nil or empty, therefore no password is set

--- a/sql/mysql_db/mysql_db_load.go
+++ b/sql/mysql_db/mysql_db_load.go
@@ -132,7 +132,7 @@ func LoadUser(serialUser *serial.User) *User {
 		Host:                string(serialUser.Host()),
 		PrivilegeSet:        *privilegeSet,
 		Plugin:              string(serialUser.Plugin()),
-		Password:            string(serialUser.Password()),
+		AuthString:          string(serialUser.Password()),
 		PasswordLastChanged: time.Unix(serialUser.PasswordLastChanged(), 0),
 		Locked:              serialUser.Locked(),
 		Attributes:          attributes,

--- a/sql/mysql_db/mysql_db_serialize.go
+++ b/sql/mysql_db/mysql_db_serialize.go
@@ -169,7 +169,7 @@ func serializeUser(b *flatbuffers.Builder, users []*User) flatbuffers.UOffsetT {
 		host := b.CreateString(user.Host)
 		privilegeSet := serializePrivilegeSet(b, &user.PrivilegeSet)
 		plugin := b.CreateString(user.Plugin)
-		password := b.CreateString(user.Password)
+		authString := b.CreateString(user.AuthString)
 		attributes := serializeAttributes(b, user.Attributes)
 		identity := b.CreateString(user.Identity)
 
@@ -178,7 +178,7 @@ func serializeUser(b *flatbuffers.Builder, users []*User) flatbuffers.UOffsetT {
 		serial.UserAddHost(b, host)
 		serial.UserAddPrivilegeSet(b, privilegeSet)
 		serial.UserAddPlugin(b, plugin)
-		serial.UserAddPassword(b, password)
+		serial.UserAddPassword(b, authString)
 		serial.UserAddPasswordLastChanged(b, user.PasswordLastChanged.Unix())
 		serial.UserAddLocked(b, user.Locked)
 		serial.UserAddAttributes(b, attributes)

--- a/sql/mysql_db/user.go
+++ b/sql/mysql_db/user.go
@@ -30,7 +30,7 @@ type User struct {
 	Host                string
 	PrivilegeSet        PrivilegeSet
 	Plugin              string
-	Password            string
+	AuthString          string
 	PasswordLastChanged time.Time
 	Locked              bool
 	Attributes          *string
@@ -56,7 +56,7 @@ func UserToRow(ctx *sql.Context, u *User) (sql.Row, error) {
 	row[userTblColIndex_User] = u.User
 	row[userTblColIndex_Host] = u.Host
 	row[userTblColIndex_plugin] = u.Plugin
-	row[userTblColIndex_authentication_string] = u.Password
+	row[userTblColIndex_authentication_string] = u.AuthString
 	row[userTblColIndex_password_last_changed] = u.PasswordLastChanged
 	row[userTblColIndex_identity] = u.Identity
 	if u.Locked {
@@ -87,7 +87,7 @@ func UserFromRow(ctx *sql.Context, row sql.Row) (*User, error) {
 		Host:                row[userTblColIndex_Host].(string),
 		PrivilegeSet:        UserRowToPrivSet(ctx, row),
 		Plugin:              row[userTblColIndex_plugin].(string),
-		Password:            row[userTblColIndex_authentication_string].(string),
+		AuthString:          row[userTblColIndex_authentication_string].(string),
 		PasswordLastChanged: passwordLastChanged,
 		Locked:              row[userTblColIndex_account_locked].(uint16) == 2,
 		Attributes:          attributes,
@@ -117,7 +117,7 @@ func UserEquals(left, right *User) bool {
 	if left.User != right.User ||
 		left.Host != right.Host ||
 		left.Plugin != right.Plugin ||
-		left.Password != right.Password ||
+		left.AuthString != right.AuthString ||
 		left.Identity != right.Identity ||
 		!left.PasswordLastChanged.Equal(right.PasswordLastChanged) ||
 		left.Locked != right.Locked ||

--- a/sql/mysql_db/user_table.go
+++ b/sql/mysql_db/user_table.go
@@ -215,13 +215,13 @@ func init() {
 	}
 }
 
-func addSuperUser(ed *Editor, username string, host string, password string) {
+func addSuperUser(ed *Editor, username string, host string, authString string) {
 	ed.PutUser(&User{
 		User:                username,
 		Host:                host,
 		PrivilegeSet:        NewPrivilegeSetWithAllPrivileges(),
 		Plugin:              "mysql_native_password",
-		Password:            password,
+		AuthString:          authString,
 		PasswordLastChanged: time.Unix(1, 0).UTC(),
 		Locked:              false,
 		Attributes:          nil,

--- a/sql/mysql_db/user_test.go
+++ b/sql/mysql_db/user_test.go
@@ -34,7 +34,7 @@ func TestUserJson(t *testing.T) {
 		Host:                "localhost",
 		PrivilegeSet:        NewPrivilegeSet(),
 		Plugin:              "mysql_native_password",
-		Password:            "*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19",
+		AuthString:          "*2470C0C06DEE42FD1618BB99005ADCA2EC9D1E19",
 		PasswordLastChanged: time.Unix(184301, 0),
 		Locked:              false,
 		Attributes:          nil,

--- a/sql/rowexec/priv.go
+++ b/sql/rowexec/priv.go
@@ -415,7 +415,7 @@ func (b *BaseBuilder) buildCreateRole(ctx *sql.Context, n *plan.CreateRole, row 
 			Host:                userPk.Host,
 			PrivilegeSet:        mysql_db.NewPrivilegeSet(),
 			Plugin:              "mysql_native_password",
-			Password:            "",
+			AuthString:          "",
 			PasswordLastChanged: time.Now().UTC(),
 			Locked:              true,
 			Attributes:          nil,


### PR DESCRIPTION
This change enables customers to create users configured to authenticate with the `caching_sha2_password` auth plugin. The generated authentication string uses the same logic as MySQL's `caching_sha2_password` auth plugin. Users created with `caching_sha2_password` can not yet authenticate with a GMS server – the next change in this series will enable that.

Example usage:
```sql
CREATE USER fred@localhost identified with caching_sha2_password by 'pa$$w0rd';
```

Depends on: https://github.com/dolthub/vitess/pull/387

Related to: https://github.com/dolthub/dolt/issues/8496