### PR TITLE
return ok result for `select into` statements

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1025,8 +1025,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		skip    bool
 	}{
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1\tfirst row\n" +
@@ -1034,14 +1034,14 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"3\tthird row\n",
 		},
 		{
-			file:  "dumpfile.txt",
-			query: "select * from mytable limit 1 into dumpfile 'dumpfile.txt';",
+			file:    "dumpfile.txt",
+			query:   "select * from mytable limit 1 into dumpfile 'dumpfile.txt';",
 			expRows: []sql.Row{{types.NewOkResult(1)}},
-			exp:   "1first row",
+			exp:     "1first row",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by ',';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,first row\n" +
@@ -1049,8 +1049,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"3,third row\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by '$$';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by '$$';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1$$first row\n" +
@@ -1058,8 +1058,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"3$$third row\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' optionally enclosed by '\"';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by ',' optionally enclosed by '\"';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,\"first row\"\n" +
@@ -1077,8 +1077,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 			err:   sql.ErrUnexpectedSeparator,
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' enclosed by '\"';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by ',' enclosed by '\"';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"\"1\",\"first row\"\n" +
@@ -1086,8 +1086,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"\"3\",\"third row\"\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by ';';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by ';';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,first row;" +
@@ -1095,8 +1095,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"3,third row;",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by 'r';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by 'r';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,fi\\rst \\rowr" +
@@ -1104,8 +1104,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"3,thi\\rd \\rowr",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines starting by 'r';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines starting by 'r';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"r1,first row\n" +
@@ -1113,8 +1113,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"r3,third row\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by '';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by '';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1\tfirst row\n" +
@@ -1122,8 +1122,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"3\tthird row\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by '';",
+			file:    "outfile.txt",
+			query:   "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by '';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,first row" +
@@ -1131,8 +1131,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"3,third row",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from niltable into outfile 'outfile.txt';",
+			file:    "outfile.txt",
+			query:   "select * from niltable into outfile 'outfile.txt';",
 			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "1\t\\N\t\\N\t\\N\n" +
 				"2\t2\t1\t\\N\n" +
@@ -1142,8 +1142,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"6\t6\t0\t6\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from niltable into outfile 'outfile.txt' fields terminated by ',' enclosed by '\"';",
+			file:    "outfile.txt",
+			query:   "select * from niltable into outfile 'outfile.txt' fields terminated by ',' enclosed by '\"';",
 			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "\"1\",\\N,\\N,\\N\n" +
 				"\"2\",\"2\",\"1\",\\N\n" +
@@ -1153,8 +1153,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"\"6\",\"6\",\"0\",\"6\"\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from niltable into outfile 'outfile.txt' fields terminated by ',' escaped by '$';",
+			file:    "outfile.txt",
+			query:   "select * from niltable into outfile 'outfile.txt' fields terminated by ',' escaped by '$';",
 			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "1,$N,$N,$N\n" +
 				"2,2,1,$N\n" +
@@ -1164,8 +1164,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"6,6,0,6\n",
 		},
 		{
-			file:  "outfile.txt",
-			query: "select * from niltable into outfile 'outfile.txt' fields terminated by ',' escaped by '';",
+			file:    "outfile.txt",
+			query:   "select * from niltable into outfile 'outfile.txt' fields terminated by ',' escaped by '';",
 			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "1,NULL,NULL,NULL\n" +
 				"2,2,1,NULL\n" +
@@ -1175,8 +1175,8 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 				"6,6,0,6\n",
 		},
 		{
-			file:  "./subdir/outfile.txt",
-			query: "select * from mytable into outfile './subdir/outfile.txt';",
+			file:    "./subdir/outfile.txt",
+			query:   "select * from mytable into outfile './subdir/outfile.txt';",
 			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1\tfirst row\n" +

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1215,7 +1215,11 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 			}
 			// in case there are any residual files from previous runs
 			os.Remove(tt.file)
-			TestQueryWithContext(t, ctx, e, harness, tt.query, tt.expRows, types.OkResultSchema, nil, nil)
+			var expected = tt.expRows
+			if IsServerEngine(e) {
+				expected = nil
+			}
+			TestQueryWithContext(t, ctx, e, harness, tt.query, expected, types.OkResultSchema, nil, nil)
 			res, err := os.ReadFile(tt.file)
 			require.NoError(t, err)
 			require.Equal(t, tt.exp, string(res))

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1017,15 +1017,17 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 	})
 
 	tests := []struct {
-		file  string
-		query string
-		exp   string
-		err   *errors.Kind
-		skip  bool
+		file    string
+		query   string
+		exp     string
+		expRows []sql.Row
+		err     *errors.Kind
+		skip    bool
 	}{
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1\tfirst row\n" +
 				"2\tsecond row\n" +
@@ -1034,11 +1036,13 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "dumpfile.txt",
 			query: "select * from mytable limit 1 into dumpfile 'dumpfile.txt';",
+			expRows: []sql.Row{{types.NewOkResult(1)}},
 			exp:   "1first row",
 		},
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,first row\n" +
 				"2,second row\n" +
@@ -1047,6 +1051,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by '$$';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1$$first row\n" +
 				"2$$second row\n" +
@@ -1055,6 +1060,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' optionally enclosed by '\"';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,\"first row\"\n" +
 				"2,\"second row\"\n" +
@@ -1073,6 +1079,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' enclosed by '\"';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"\"1\",\"first row\"\n" +
 				"\"2\",\"second row\"\n" +
@@ -1081,6 +1088,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by ';';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,first row;" +
 				"2,second row;" +
@@ -1089,6 +1097,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by 'r';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,fi\\rst \\rowr" +
 				"2,second \\rowr" +
@@ -1097,6 +1106,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines starting by 'r';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"r1,first row\n" +
 				"r2,second row\n" +
@@ -1105,6 +1115,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by '';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1\tfirst row\n" +
 				"2\tsecond row\n" +
@@ -1113,6 +1124,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from mytable into outfile 'outfile.txt' fields terminated by ',' lines terminated by '';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1,first row" +
 				"2,second row" +
@@ -1121,6 +1133,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from niltable into outfile 'outfile.txt';",
+			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "1\t\\N\t\\N\t\\N\n" +
 				"2\t2\t1\t\\N\n" +
 				"3\t\\N\t0\t\\N\n" +
@@ -1131,6 +1144,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from niltable into outfile 'outfile.txt' fields terminated by ',' enclosed by '\"';",
+			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "\"1\",\\N,\\N,\\N\n" +
 				"\"2\",\"2\",\"1\",\\N\n" +
 				"\"3\",\\N,\"0\",\\N\n" +
@@ -1141,6 +1155,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from niltable into outfile 'outfile.txt' fields terminated by ',' escaped by '$';",
+			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "1,$N,$N,$N\n" +
 				"2,2,1,$N\n" +
 				"3,$N,0,$N\n" +
@@ -1151,6 +1166,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "outfile.txt",
 			query: "select * from niltable into outfile 'outfile.txt' fields terminated by ',' escaped by '';",
+			expRows: []sql.Row{{types.NewOkResult(6)}},
 			exp: "1,NULL,NULL,NULL\n" +
 				"2,2,1,NULL\n" +
 				"3,NULL,0,NULL\n" +
@@ -1161,6 +1177,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 		{
 			file:  "./subdir/outfile.txt",
 			query: "select * from mytable into outfile './subdir/outfile.txt';",
+			expRows: []sql.Row{{types.NewOkResult(3)}},
 			exp: "" +
 				"1\tfirst row\n" +
 				"2\tsecond row\n" +
@@ -1198,7 +1215,7 @@ func TestSelectIntoFile(t *testing.T, harness Harness) {
 			}
 			// in case there are any residual files from previous runs
 			os.Remove(tt.file)
-			TestQueryWithContext(t, ctx, e, harness, tt.query, nil, nil, nil, nil)
+			TestQueryWithContext(t, ctx, e, harness, tt.query, tt.expRows, types.OkResultSchema, nil, nil)
 			res, err := os.ReadFile(tt.file)
 			require.NoError(t, err)
 			require.Equal(t, tt.exp, string(res))

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1623,8 +1623,6 @@ CREATE TABLE tab3 (
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				// SELECT INTO has an empty result schema
-				// https://github.com/dolthub/dolt/issues/6105
 				Query:           `SELECT 1 INTO @abc`,
 				SkipResultCheckOnServerEngine: true,
 				Expected:        []sql.Row{{types.NewOkResult(1)}},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1626,6 +1626,7 @@ CREATE TABLE tab3 (
 				// SELECT INTO has an empty result schema
 				// https://github.com/dolthub/dolt/issues/6105
 				Query:           `SELECT 1 INTO @abc`,
+				SkipResultCheckOnServerEngine: true,
 				Expected:        []sql.Row{{types.NewOkResult(1)}},
 				ExpectedColumns: nil,
 			},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1626,7 +1626,7 @@ CREATE TABLE tab3 (
 				// SELECT INTO has an empty result schema
 				// https://github.com/dolthub/dolt/issues/6105
 				Query:           `SELECT 1 INTO @abc`,
-				Expected:        []sql.Row{{}},
+				Expected:        []sql.Row{{types.NewOkResult(1)}},
 				ExpectedColumns: nil,
 			},
 			{

--- a/sql/plan/into.go
+++ b/sql/plan/into.go
@@ -16,10 +16,10 @@ package plan
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/types"
-"strings"
+	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // Into is a node to wrap the top-level node in a query plan so that any result will set user-defined or others

--- a/sql/plan/into.go
+++ b/sql/plan/into.go
@@ -16,7 +16,8 @@ package plan
 
 import (
 	"fmt"
-	"strings"
+	"github.com/dolthub/go-mysql-server/sql/types"
+"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )
@@ -79,7 +80,7 @@ var emptySch = make(sql.Schema, 0)
 func (i *Into) Schema() sql.Schema {
 	// SELECT INTO does not return results directly (only through SQL vars or files),
 	// so it's result schema is always empty.
-	return emptySch
+	return types.OkResultSchema
 }
 
 func (i *Into) IsReadOnly() bool {

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -630,7 +630,7 @@ func (b *BaseBuilder) buildInto(ctx *sql.Context, n *plan.Into, row sql.Row) (sq
 			}
 			file.WriteString(n.LinesTerminatedBy)
 		}
-		return sql.RowsToRowIter(sql.Row{}), nil
+		return sql.RowsToRowIter(sql.Row{types.NewOkResult(len(rows))}), nil
 	}
 
 	rowNum := len(rows)
@@ -652,12 +652,12 @@ func (b *BaseBuilder) buildInto(ctx *sql.Context, n *plan.Into, row sql.Row) (sq
 				file.WriteString(fmt.Sprintf("%v", val))
 			}
 		}
-		return sql.RowsToRowIter(sql.Row{}), nil
+		return sql.RowsToRowIter(sql.Row{types.NewOkResult(rowNum)}), nil
 	}
 
 	if rowNum == 0 {
 		// a warning with error code 1329 occurs (No data), and make no change to variables
-		return sql.RowsToRowIter(sql.Row{}), nil
+		return sql.RowsToRowIter(sql.Row{types.NewOkResult(0)}), nil
 	}
 	if len(rows[0]) != len(n.IntoVars) {
 		return nil, sql.ErrColumnNumberDoesNotMatch.New()
@@ -684,7 +684,7 @@ func (b *BaseBuilder) buildInto(ctx *sql.Context, n *plan.Into, row sql.Row) (sq
 		}
 	}
 
-	return sql.RowsToRowIter(sql.Row{}), nil
+	return sql.RowsToRowIter(sql.Row{types.NewOkResult(1)}), nil
 }
 
 func (b *BaseBuilder) buildExternalProcedure(ctx *sql.Context, n *plan.ExternalProcedure, row sql.Row) (sql.RowIter, error) {


### PR DESCRIPTION
Our `SELECT ... INTO ...` statements return empty result set, which produces strange output in the `dolt sql` shell.
MySQL just returns ok results, so we should too.

discovered in: https://github.com/dolthub/go-mysql-server/pull/2779