### PR TITLE
Fix the warning checks in enginetest to be more strict

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -1042,15 +1042,25 @@ func AssertWarningAndTestQuery(
 		// check warnings depend on context, which ServerEngine does not depend on
 		if expectedWarningsCount > 0 {
 			assert.Equal(t, expectedWarningsCount, len(ctx.Warnings()))
+			// Verify that if warnings are expected, we also configured a specific value check.
+			if expectedCode == 0 && len(expectedWarningMessageSubstring) == 0 {
+				require.Fail("Invalid test setup. Warning expected, but no value validation was configured.")
+			}
+		} else {
+			if expectedCode != 0 || len(expectedWarningMessageSubstring) != 0 {
+				require.Fail("Invalid test setup. No warnings expected, but value validation was configured")
+			}
+			assert.Zero(t, len(ctx.Warnings()), "Unexpected warnings")
 		}
 
 		if expectedCode > 0 {
+			// Not ideal. We are only supporting all warning codes being identical in a given test.
 			for _, warning := range ctx.Warnings() {
 				assert.Equal(t, expectedCode, warning.Code, "Unexpected warning code")
 			}
 		}
-
 		if len(expectedWarningMessageSubstring) > 0 {
+			// Not ideal. All messages must have the same substring for a given test.
 			for _, warning := range ctx.Warnings() {
 				assert.Contains(t, warning.Message, expectedWarningMessageSubstring, "Unexpected warning message")
 			}

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1529,7 +1529,8 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
-		Name: "Try INSERT IGNORE with primary key, non null, and single row violations",
+		Name:    "Try INSERT IGNORE with primary key, non null, and single row violations",
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE y (pk int primary key, c1 int NOT NULL);",
 			"INSERT IGNORE INTO y VALUES (1, 1), (1,2), (2, 2), (3, 3)",
@@ -2171,7 +2172,8 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
-		Name: "INSERT IGNORE works with FK Violations",
+		Name:    "INSERT IGNORE works with FK Violations",
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE t1 (id INT PRIMARY KEY, v int);",
 			"CREATE TABLE t2 (id INT PRIMARY KEY, v2 int, CONSTRAINT mfk FOREIGN KEY (v2) REFERENCES t1(id));",
@@ -2909,7 +2911,8 @@ var IgnoreWithDuplicateUniqueKeyKeylessScripts = []ScriptTest{
 var InsertBrokenScripts = []ScriptTest{
 	// TODO: Condense all of our casting logic into a single error.
 	{
-		Name: "Test that INSERT IGNORE assigns the closest dataype correctly",
+		Name:    "Test that INSERT IGNORE assigns the closest dataype correctly",
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE x (pk int primary key, c1 varchar(20) NOT NULL);",
 			`INSERT IGNORE INTO x VALUES (1, "one"), (2, TRUE), (3, "three")`,

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1546,49 +1546,56 @@ var InsertScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERDupEntry,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query: "INSERT IGNORE INTO y VALUES (5, NULL)",
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERBadNullError,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERBadNullError,
 			},
 			{
 				Query: "INSERT IGNORE INTO y SELECT * FROM y WHERE pk=(SELECT pk+10 FROM y WHERE pk > 1);",
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 0}},
 				},
-				ExpectedWarning: mysql.ERSubqueryNo1Row,
+				ExpectedWarningsCount: 5,
+				ExpectedWarning:       mysql.ERSubqueryNo1Row,
 			},
 			{
 				Query: "INSERT IGNORE INTO y SELECT 10, 0 FROM dual WHERE 1=(SELECT 1 FROM dual UNION SELECT 2 FROM dual);",
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 0}},
 				},
-				ExpectedWarning: mysql.ERSubqueryNo1Row,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERSubqueryNo1Row,
 			},
 			{
 				Query: "INSERT IGNORE INTO y SELECT 11, 0 FROM dual WHERE 1=(SELECT 1 FROM dual UNION SELECT 2 FROM dual) UNION SELECT 12, 0 FROM dual;",
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERSubqueryNo1Row,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERSubqueryNo1Row,
 			},
 			{
 				Query: "INSERT IGNORE INTO y SELECT 13, 0 FROM dual UNION SELECT 14, 0 FROM dual WHERE 1=(SELECT 1 FROM dual UNION SELECT 2 FROM dual);",
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERSubqueryNo1Row,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERSubqueryNo1Row,
 			},
 			{
 				Query: "INSERT IGNORE INTO y VALUES (3, 8)",
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 0}},
 				},
-				ExpectedWarning: mysql.ERDupEntry,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 		},
 	},
@@ -2176,7 +2183,8 @@ var InsertScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 0}},
 				},
-				ExpectedWarning: mysql.ErNoReferencedRow2,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ErNoReferencedRow2,
 			},
 		},
 	},
@@ -2622,7 +2630,8 @@ var InsertIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERBadNullError,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERBadNullError,
 			},
 		},
 	},
@@ -2638,7 +2647,8 @@ var InsertIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERTruncatedWrongValueForField,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
 			},
 			{
 				Query: "SELECT * FROM t1",
@@ -2651,7 +2661,8 @@ var InsertIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERUnknownError,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERUnknownError,
 			},
 			{
 				Query: "SELECT * FROM t2",
@@ -2675,7 +2686,8 @@ var InsertIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 2}},
 				},
-				ExpectedWarning: mysql.ERTruncatedWrongValueForField,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
 			},
 			{
 				Query: "SELECT * FROM t1",
@@ -2688,7 +2700,8 @@ var InsertIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERUnknownError,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERUnknownError,
 			},
 			{
 				Query: "SELECT * FROM t2",
@@ -2722,7 +2735,8 @@ var InsertIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 3}},
 				},
-				ExpectedWarning: mysql.ERDupEntry,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query: "SELECT * from one_uniq;",
@@ -2735,7 +2749,8 @@ var InsertIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 8}},
 				},
-				ExpectedWarning: mysql.ERDupEntry,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query: "SELECT * from two_uniq;",
@@ -2784,7 +2799,8 @@ var IgnoreWithDuplicateUniqueKeyKeylessScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 3}},
 				},
-				ExpectedWarning: mysql.ERDupEntry,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query: "SELECT * from one_uniq;",
@@ -2797,7 +2813,8 @@ var IgnoreWithDuplicateUniqueKeyKeylessScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 8}},
 				},
-				ExpectedWarning: mysql.ERDupEntry,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query: "SELECT * from two_uniq;",
@@ -2831,9 +2848,10 @@ var IgnoreWithDuplicateUniqueKeyKeylessScripts = []ScriptTest{
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:           "INSERT IGNORE INTO keyless VALUES (1, 3)",
-				Expected:        []sql.Row{{types.NewOkResult(0)}},
-				ExpectedWarning: mysql.ERDupEntry,
+				Query:                 "INSERT IGNORE INTO keyless VALUES (1, 3)",
+				Expected:              []sql.Row{{types.NewOkResult(0)}},
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 		},
 	},
@@ -2857,27 +2875,28 @@ var IgnoreWithDuplicateUniqueKeyKeylessScripts = []ScriptTest{
 				ExpectedErr: sql.ErrUniqueKeyViolation,
 			},
 			{
-				Query:           "UPDATE IGNORE keyless SET val = 1 where pk = 1",
-				Expected:        []sql.Row{{newUpdateResult(1, 1)}},
-				ExpectedWarning: mysql.ERDupEntry,
+				Query:    "UPDATE IGNORE keyless SET val = 1 where pk = 1",
+				Expected: []sql.Row{{newUpdateResult(1, 1)}},
 			},
 			{
 				Query:    "ALTER TABLE keyless ADD CONSTRAINT c UNIQUE(val)",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
-				Query:           "UPDATE IGNORE keyless SET val = 3 where pk = 1",
-				Expected:        []sql.Row{{newUpdateResult(1, 0)}},
-				ExpectedWarning: mysql.ERDupEntry,
+				Query:                 "UPDATE IGNORE keyless SET val = 3 where pk = 1",
+				Expected:              []sql.Row{{newUpdateResult(1, 0)}},
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query:    "SELECT * FROM keyless ORDER BY pk",
 				Expected: []sql.Row{{1, 1}, {2, 2}, {3, 3}},
 			},
 			{
-				Query:           "UPDATE IGNORE keyless SET val = val + 1 ORDER BY pk",
-				Expected:        []sql.Row{{newUpdateResult(3, 1)}},
-				ExpectedWarning: mysql.ERDupEntry,
+				Query:                 "UPDATE IGNORE keyless SET val = val + 1 ORDER BY pk",
+				Expected:              []sql.Row{{newUpdateResult(3, 1)}},
+				ExpectedWarningsCount: 2,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query:    "SELECT * FROM keyless ORDER BY pk",
@@ -2915,7 +2934,8 @@ var InsertBrokenScripts = []ScriptTest{
 				Expected: []sql.Row{
 					{types.OkResult{RowsAffected: 1}},
 				},
-				ExpectedWarning: mysql.ERTruncatedWrongValueForField,
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
 			},
 		},
 	},

--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -623,18 +623,20 @@ var UpdateIgnoreScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:           "UPDATE IGNORE pkTable set pk = pk + 1, val = val + 1",
-				Expected:        []sql.Row{{newUpdateResult(3, 1)}},
-				ExpectedWarning: mysql.ERDupEntry,
+				Query:                 "UPDATE IGNORE pkTable set pk = pk + 1, val = val + 1",
+				Expected:              []sql.Row{{newUpdateResult(3, 1)}},
+				ExpectedWarningsCount: 2,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query:    "SELECT * FROM pkTable order by pk",
 				Expected: []sql.Row{{1, 1}, {2, 2}, {4, 4}},
 			},
 			{
-				Query:           "UPDATE IGNORE idxTable set val = val + 1",
-				Expected:        []sql.Row{{newUpdateResult(3, 1)}},
-				ExpectedWarning: mysql.ERDupEntry,
+				Query:                 "UPDATE IGNORE idxTable set val = val + 1",
+				Expected:              []sql.Row{{newUpdateResult(3, 1)}},
+				ExpectedWarningsCount: 2,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query:    "SELECT * FROM idxTable order by pk",
@@ -649,9 +651,10 @@ var UpdateIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{{1, 1}, {2, 3}, {4, 4}},
 			},
 			{
-				Query:           "UPDATE IGNORE pkTable SET pk = NULL",
-				Expected:        []sql.Row{{newUpdateResult(3, 3)}},
-				ExpectedWarning: mysql.ERBadNullError,
+				Query:                 "UPDATE IGNORE pkTable SET pk = NULL",
+				Expected:              []sql.Row{{newUpdateResult(3, 3)}},
+				ExpectedWarningsCount: 3,
+				ExpectedWarning:       mysql.ERBadNullError,
 			},
 			{
 				Query:    "SELECT * FROM pkTable order by pk",
@@ -666,9 +669,10 @@ var UpdateIgnoreScripts = []ScriptTest{
 				Expected: []sql.Row{{0, 0}, {0, 3}, {0, 4}},
 			},
 			{
-				Query:           "UPDATE IGNORE idxTable set pk = pk + 1, val = val + 1", // two bad updates
-				Expected:        []sql.Row{{newUpdateResult(3, 1)}},
-				ExpectedWarning: mysql.ERDupEntry,
+				Query:                 "UPDATE IGNORE idxTable set pk = pk + 1, val = val + 1", // two bad updates
+				Expected:              []sql.Row{{newUpdateResult(3, 1)}},
+				ExpectedWarningsCount: 2,
+				ExpectedWarning:       mysql.ERDupEntry,
 			},
 			{
 				Query:    "SELECT * FROM idxTable order by pk",
@@ -684,18 +688,20 @@ var UpdateIgnoreScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:           "UPDATE IGNORE t1 SET v1 = 'dsddads'",
-				Expected:        []sql.Row{{newUpdateResult(1, 1)}},
-				ExpectedWarning: mysql.ERTruncatedWrongValueForField,
+				Query:                 "UPDATE IGNORE t1 SET v1 = 'dsddads'",
+				Expected:              []sql.Row{{newUpdateResult(1, 1)}},
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
 			},
 			{
 				Query:    "SELECT * FROM t1",
 				Expected: []sql.Row{{1, 0, 1}},
 			},
 			{
-				Query:           "UPDATE IGNORE t1 SET pk = 'dasda', v2 = 'dsddads'",
-				Expected:        []sql.Row{{newUpdateResult(1, 1)}},
-				ExpectedWarning: mysql.ERTruncatedWrongValueForField,
+				Query:                 "UPDATE IGNORE t1 SET pk = 'dasda', v2 = 'dsddads'",
+				Expected:              []sql.Row{{newUpdateResult(1, 1)}},
+				ExpectedWarningsCount: 2,
+				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
 			},
 			{
 				Query:    "SELECT * FROM t1",
@@ -713,9 +719,10 @@ var UpdateIgnoreScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:           "UPDATE IGNORE objects SET color = 'orange' where id = 2",
-				Expected:        []sql.Row{{newUpdateResult(1, 0)}},
-				ExpectedWarning: mysql.ErNoReferencedRow2,
+				Query:                 "UPDATE IGNORE objects SET color = 'orange' where id = 2",
+				Expected:              []sql.Row{{newUpdateResult(1, 0)}},
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ErNoReferencedRow2,
 			},
 			{
 				Query:    "SELECT * FROM objects ORDER BY id",
@@ -732,9 +739,10 @@ var UpdateIgnoreScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:           "UPDATE IGNORE checksTable SET pk = pk + 1 where pk = 4",
-				Expected:        []sql.Row{{newUpdateResult(1, 0)}},
-				ExpectedWarning: mysql.ERUnknownError,
+				Query:                 "UPDATE IGNORE checksTable SET pk = pk + 1 where pk = 4",
+				Expected:              []sql.Row{{newUpdateResult(1, 0)}},
+				ExpectedWarningsCount: 1,
+				ExpectedWarning:       mysql.ERUnknownError,
 			},
 			{
 				Query:    "SELECT * from checksTable ORDER BY pk",


### PR DESCRIPTION
Previously if an error was expected but none was produced the test would pass.