### PR TITLE
Persist and load superusers

### DIFF
--- a/sql/mysql_db/user.go
+++ b/sql/mysql_db/user.go
@@ -36,6 +36,9 @@ type User struct {
 	Attributes          *string
 	Identity            string
 	IsSuperUser         bool
+	// IsEphemeral is true if this user is ephemeral, meaning it will only exist
+	// for the lifetime of the server process and will not be persisted to disk.
+	IsEphemeral bool
 	//TODO: add the remaining fields
 
 	// IsRole is an additional field that states whether the User represents a role or user. In MySQL this must be a

--- a/sql/mysql_db/user_table.go
+++ b/sql/mysql_db/user_table.go
@@ -215,7 +215,7 @@ func init() {
 	}
 }
 
-func addSuperUser(ed *Editor, username string, host string, authString string) {
+func addSuperUser(ed *Editor, username string, host string, authString string, ephemeral bool) {
 	ed.PutUser(&User{
 		User:                username,
 		Host:                host,
@@ -227,6 +227,7 @@ func addSuperUser(ed *Editor, username string, host string, authString string) {
 		Attributes:          nil,
 		IsRole:              false,
 		IsSuperUser:         true,
+		IsEphemeral:         ephemeral,
 	})
 }
 


### PR DESCRIPTION
Previously, superusers were persisted to disk, but never loaded back again when the database was restarted. This essentially made all superusers ephemeral, since they only lasted for the duration of a SQL server process. 

This change loads persisted superusers from disk, and also adds a new function to create ephemeral superusers that do not get persisted to disk. 

This also includes a fix for the event scheduler to use a privileged account so that it can load events from all databases. 
