### PR TITLE
pool wire write buffer

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5760,7 +5760,7 @@ func TestTypesOverWire(t *testing.T, harness ClientHarness, sessionBuilder serve
 							break
 						}
 						expectedEngineRow := make([]*string, len(engineRow))
-						row, err := server.RowToSQL(ctx, sch, engineRow, nil)
+						row, err := server.RowToSQL(ctx, sch, engineRow, nil, nil)
 						if !assert.NoError(t, err) {
 							break
 						}

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5743,6 +5743,7 @@ func TestTypesOverWire(t *testing.T, harness ClientHarness, sessionBuilder serve
 					require.NoError(t, err)
 					expectedRowSet := script.Results[queryIdx]
 					expectedRowIdx := 0
+					buf := sql.NewByteBuffer(1000)
 					var engineRow sql.Row
 					for engineRow, err = engineIter.Next(ctx); err == nil; engineRow, err = engineIter.Next(ctx) {
 						if !assert.True(t, r.Next()) {
@@ -5760,7 +5761,7 @@ func TestTypesOverWire(t *testing.T, harness ClientHarness, sessionBuilder serve
 							break
 						}
 						expectedEngineRow := make([]*string, len(engineRow))
-						row, err := server.RowToSQL(ctx, sch, engineRow, nil, nil)
+						row, err := server.RowToSQL(ctx, sch, engineRow, nil, buf)
 						if !assert.NoError(t, err) {
 							break
 						}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20241215010122-db690dd53c90
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20241211024425-b00987f7ba54
+	github.com/dolthub/vitess v0.0.0-20241220202600-b18f18d0cde7
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20241211024425-b00987f7ba54 h1:nzBnC0Rt1gFtscJEz4veYd/mazZEdbdmed+tujdaKOo=
-github.com/dolthub/vitess v0.0.0-20241211024425-b00987f7ba54/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20241220202600-b18f18d0cde7 h1:w130WLeARGGNYWmhGPugsHXzJEelKKimt3kTWg6/Puk=
+github.com/dolthub/vitess v0.0.0-20241220202600-b18f18d0cde7/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/server/handler.go
+++ b/server/handler.go
@@ -933,15 +933,10 @@ func updateMaxUsedConnectionsStatusVariable() {
 
 func toSqlHelper(ctx *sql.Context, typ sql.Type, buf *sql.ByteBuffer, val interface{}) (sqltypes.Value, error) {
 	if buf == nil {
-		return typ.SQL(ctx, buf.Get(), val)
+		return typ.SQL(ctx, nil, val)
 	}
-	spare := buf.Spare()
 	ret, err := typ.SQL(ctx, buf.Get(), val)
-	if ret.Len() > spare {
-		buf.Double()
-	} else {
-		buf.Advance(ret.Len())
-	}
+	buf.Update(ret.Raw())
 	return ret, err
 }
 

--- a/server/handler.go
+++ b/server/handler.go
@@ -944,7 +944,14 @@ func RowToSQL(ctx *sql.Context, sch sql.Schema, row sql.Row, projs []sql.Express
 				continue
 			}
 			var err error
-			outVals[i], err = col.Type.SQL(ctx, buf.Get(100), row[i])
+			spare := buf.Spare()
+			outVals[i], err = col.Type.SQL(ctx, buf.Get(), row[i])
+			if outVals[i].Len() > spare {
+				buf.Double()
+			} else {
+				buf.Advance(outVals[i].Len())
+			}
+
 			if err != nil {
 				return nil, err
 			}
@@ -961,7 +968,13 @@ func RowToSQL(ctx *sql.Context, sch sql.Schema, row sql.Row, projs []sql.Express
 			outVals[i] = sqltypes.NULL
 			continue
 		}
-		outVals[i], err = col.Type.SQL(ctx, buf.Get(100), field)
+		spare := buf.Spare()
+		outVals[i], err = col.Type.SQL(ctx, buf.Get(), row[i])
+		if outVals[i].Len() > spare {
+			buf.Double()
+		} else {
+			buf.Advance(outVals[i].Len())
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/server/handler.go
+++ b/server/handler.go
@@ -969,7 +969,7 @@ func RowToSQL(ctx *sql.Context, sch sql.Schema, row sql.Row, projs []sql.Express
 			continue
 		}
 		spare := buf.Spare()
-		outVals[i], err = col.Type.SQL(ctx, buf.Get(), row[i])
+		outVals[i], err = col.Type.SQL(ctx, buf.Get(), field)
 		if outVals[i].Len() > spare {
 			buf.Double()
 		} else {

--- a/server/handler.go
+++ b/server/handler.go
@@ -936,7 +936,7 @@ func toSqlHelper(ctx *sql.Context, typ sql.Type, buf *sql.ByteBuffer, val interf
 		return typ.SQL(ctx, nil, val)
 	}
 	ret, err := typ.SQL(ctx, buf.Get(), val)
-	buf.Update(ret.Raw())
+	buf.Grow(ret.Len())
 	return ret, err
 }
 

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -800,7 +800,8 @@ func TestHandlerKillQuery(t *testing.T) {
 		})
 	}()
 
-	time.Sleep(100 * time.Millisecond)
+	wg.Wait()
+	wg.Add(1)
 	var sleepQueryID string
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Query, 0, ...    , SELECT SLEEP(1000)
@@ -825,7 +826,6 @@ func TestHandlerKillQuery(t *testing.T) {
 	})
 	require.NoError(err)
 
-	time.Sleep(100 * time.Millisecond)
 	err = handler.ComQuery(context.Background(), conn2, "KILL QUERY "+sleepQueryID, func(res *sqltypes.Result, more bool) error {
 		return nil
 	})
@@ -833,7 +833,6 @@ func TestHandlerKillQuery(t *testing.T) {
 	wg.Wait()
 	require.Error(sleepErr)
 
-	time.Sleep(100 * time.Millisecond)
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Sleep, 0,        ,
 		// 2,  ,  , test, Query, 0, running, SHOW PROCESSLIST

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -800,8 +800,7 @@ func TestHandlerKillQuery(t *testing.T) {
 		})
 	}()
 
-	wg.Wait()
-	wg.Add(1)
+	time.Sleep(100 * time.Millisecond)
 	var sleepQueryID string
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Query, 0, ...    , SELECT SLEEP(1000)
@@ -826,6 +825,7 @@ func TestHandlerKillQuery(t *testing.T) {
 	})
 	require.NoError(err)
 
+	time.Sleep(100 * time.Millisecond)
 	err = handler.ComQuery(context.Background(), conn2, "KILL QUERY "+sleepQueryID, func(res *sqltypes.Result, more bool) error {
 		return nil
 	})
@@ -833,6 +833,7 @@ func TestHandlerKillQuery(t *testing.T) {
 	wg.Wait()
 	require.Error(sleepErr)
 
+	time.Sleep(100 * time.Millisecond)
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Sleep, 0,        ,
 		// 2,  ,  , test, Query, 0, running, SHOW PROCESSLIST

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -789,7 +789,7 @@ func TestHandlerKillQuery(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	sleepQuery := "SELECT SLEEP(2)"
+	sleepQuery := "SELECT SLEEP(5)"
 	go func() {
 		defer wg.Done()
 		err = handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -794,10 +794,10 @@ func TestHandlerKillQuery(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		// need a local |err| variable to avoid being overwritten
-		err := handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {
+		serr := handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {
 			return nil
 		})
-		require.Error(err)
+		require.Error(serr)
 	}()
 
 	var sleepQueryID string

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -800,6 +800,7 @@ func TestHandlerKillQuery(t *testing.T) {
 		//require.Error(serr)
 	}()
 
+	time.Sleep(100 * time.Millisecond)
 	var sleepQueryID string
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Query, 0, ...    , SELECT SLEEP(1000)
@@ -824,11 +825,13 @@ func TestHandlerKillQuery(t *testing.T) {
 	})
 	require.NoError(err)
 
+	time.Sleep(100 * time.Millisecond)
 	err = handler.ComQuery(context.Background(), conn2, "KILL QUERY "+sleepQueryID, func(res *sqltypes.Result, more bool) error {
 		return nil
 	})
 	require.NoError(err)
 	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Sleep, 0,        ,
 		// 2,  ,  , test, Query, 0, running, SHOW PROCESSLIST

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -794,10 +794,10 @@ func TestHandlerKillQuery(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		// need a local |err| variable to avoid being overwritten
-		serr := handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {
+		_ = handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {
 			return nil
 		})
-		require.Error(serr)
+		//require.Error(serr)
 	}()
 
 	var sleepQueryID string
@@ -806,6 +806,8 @@ func TestHandlerKillQuery(t *testing.T) {
 		// 2,  ,  , test, Query, 0, running, SHOW PROCESSLIST
 		require.Equal(2, len(res.Rows))
 		hasSleepQuery := false
+		fmt.Println(res.Rows[0][0], res.Rows[0][4], res.Rows[0][7])
+		fmt.Println(res.Rows[1][0], res.Rows[1][4], res.Rows[1][7])
 		for _, row := range res.Rows {
 			if row[7].ToString() != sleepQuery {
 				continue

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -789,7 +789,7 @@ func TestHandlerKillQuery(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	sleepQuery := "SELECT SLEEP(1)"
+	sleepQuery := "SELECT SLEEP(2)"
 	go func() {
 		defer wg.Done()
 		err = handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -799,19 +800,21 @@ func TestHandlerKillQuery(t *testing.T) {
 	}()
 
 	time.Sleep(100 * time.Millisecond)
-	var sleepQueryID string
+	var sleepQueryID []byte
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Query, 0, ...    , SELECT SLEEP(1000)
 		// 2,  ,  , test, Query, 0, running, SHOW PROCESSLIST
 		require.Equal(2, len(res.Rows))
 		hasSleepQuery := false
+		fmt.Println(res.Rows[0][0].ToString(), res.Rows[0][7].ToString())
+		fmt.Println(res.Rows[1][0].ToString(), res.Rows[1][7].ToString())
 		for _, row := range res.Rows {
-			if row[7].ToString() != sleepQuery {
+			if !bytes.Equal(row[7].Raw(), []byte(sleepQuery)) {
 				continue
 			}
 			hasSleepQuery = true
-			sleepQueryID = row[0].ToString()
-			require.Equal("Query", row[4].ToString())
+			sleepQueryID = row[0].Raw()
+			require.Equal([]byte("Query"), row[4].Raw())
 		}
 		require.True(hasSleepQuery)
 		return nil
@@ -819,7 +822,7 @@ func TestHandlerKillQuery(t *testing.T) {
 	require.NoError(err)
 
 	time.Sleep(100 * time.Millisecond)
-	err = handler.ComQuery(context.Background(), conn2, "KILL QUERY "+sleepQueryID, func(res *sqltypes.Result, more bool) error {
+	err = handler.ComQuery(context.Background(), conn2, "KILL QUERY "+string(sleepQueryID), func(res *sqltypes.Result, more bool) error {
 		return nil
 	})
 	require.NoError(err)
@@ -832,12 +835,12 @@ func TestHandlerKillQuery(t *testing.T) {
 		require.Equal(2, len(res.Rows))
 		hasSleepQueryID := false
 		for _, row := range res.Rows {
-			if row[0].ToString() != sleepQueryID {
+			if !bytes.Equal(row[0].ToBytes(), sleepQueryID) {
 				continue
 			}
 			hasSleepQueryID = true
-			require.Equal("Sleep", row[4].ToString())
-			require.Equal("", row[7].ToString())
+			require.Equal([]byte("Sleep"), row[4].ToBytes())
+			require.Equal([]byte{}, row[7].ToBytes())
 		}
 		require.True(hasSleepQueryID)
 		return nil

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -791,13 +791,13 @@ func TestHandlerKillQuery(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	sleepQuery := "SELECT SLEEP(100000)"
+	var sleepErr error
 	go func() {
 		defer wg.Done()
 		// need a local |err| variable to avoid being overwritten
-		_ = handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {
+		sleepErr = handler.ComQuery(context.Background(), conn1, sleepQuery, func(res *sqltypes.Result, more bool) error {
 			return nil
 		})
-		//require.Error(serr)
 	}()
 
 	time.Sleep(100 * time.Millisecond)
@@ -831,6 +831,8 @@ func TestHandlerKillQuery(t *testing.T) {
 	})
 	require.NoError(err)
 	wg.Wait()
+	require.Error(sleepErr)
+
 	time.Sleep(100 * time.Millisecond)
 	err = handler.ComQuery(context.Background(), conn2, "SHOW PROCESSLIST", func(res *sqltypes.Result, more bool) error {
 		// 1,  ,  , test, Sleep, 0,        ,

--- a/sql/byte_buffer.go
+++ b/sql/byte_buffer.go
@@ -22,24 +22,32 @@ func NewByteBuffer(initCap int) *ByteBuffer {
 	return &ByteBuffer{buf: buf}
 }
 
-func (b *ByteBuffer) Update(buf []byte) {
-	if b.i+len(buf) > len(b.buf) {
+// Grow records the latest used byte position. Callers
+// are responsible for accurately reporting which bytes
+// they expect to be protected.
+func (b *ByteBuffer) Grow(n int) {
+	if b.i+n > len(b.buf) {
 		// Runtime alloc'd into a separate backing array, but it chooses
 		// the doubling cap using the non-optimal |cap(b.buf)-b.i|*2.
 		// We do not need to increment |b.i| b/c the latest value is in
 		// the other array.
 		b.Double()
 	} else {
-		b.i += len(buf)
+		b.i += n
 	}
 }
 
+// Double expands the backing array by 2x. We do this
+// here because the runtime only doubles based on slice
+// length.
 func (b *ByteBuffer) Double() {
 	buf := make([]byte, len(b.buf)*2)
 	copy(buf, b.buf)
 	b.buf = buf
 }
 
+// Get returns a zero length slice beginning at a safe
+// write position.
 func (b *ByteBuffer) Get() []byte {
 	return b.buf[b.i:b.i]
 }

--- a/sql/byte_buffer.go
+++ b/sql/byte_buffer.go
@@ -1,0 +1,57 @@
+package sql
+
+var SingletonBuf = NewByteBuffer(1000)
+
+type ByteBuffer struct {
+	buf []byte
+	i   int
+}
+
+func NewByteBuffer(initCap int) *ByteBuffer {
+	return &ByteBuffer{buf: make([]byte, initCap)}
+}
+
+func (b *ByteBuffer) Bytes() []byte {
+	return b.buf
+}
+
+func (b *ByteBuffer) GetFull(i int) []byte {
+	start := b.i
+	b.i = start + i
+	if b.i > len(b.buf) {
+		newBuf := make([]byte, len(b.buf)*2)
+		copy(newBuf, b.buf[:])
+		b.buf = newBuf
+	}
+	return b.buf[start:b.i]
+}
+
+func (b *ByteBuffer) Double() {
+	newBuf := make([]byte, len(b.buf)*2)
+	copy(newBuf, b.buf[:])
+	b.buf = newBuf
+}
+
+func (b *ByteBuffer) Advance(i int) {
+	b.i += i
+}
+
+func (b *ByteBuffer) Spare() int {
+	return len(b.buf) - b.i
+}
+
+func (b *ByteBuffer) Get() []byte {
+	//start := b.i
+	//b.i = start + i
+	//if b.i > len(b.buf) {
+	//	newBuf := make([]byte, len(b.buf)*2)
+	//	copy(newBuf, b.buf[:])
+	//	b.buf = newBuf
+	//}
+	//return b.buf[start:b.i][:0]
+	return b.buf[b.i:b.i]
+}
+
+func (b *ByteBuffer) Reset() {
+	b.i = 0
+}

--- a/sql/byte_buffer.go
+++ b/sql/byte_buffer.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-const defaultByteBuffCap = 1024
+const defaultByteBuffCap = 10
 
 var ByteBufPool = sync.Pool{
 	New: func() any {
@@ -13,23 +13,37 @@ var ByteBufPool = sync.Pool{
 }
 
 type ByteBuffer struct {
+	i   int
 	buf []byte
 }
 
 func NewByteBuffer(initCap int) *ByteBuffer {
-	return &ByteBuffer{buf: make([]byte, 0, initCap)}
+	buf := make([]byte, initCap)
+	return &ByteBuffer{buf: buf}
 }
 
 func (b *ByteBuffer) Update(buf []byte) {
-	if cap(buf) > cap(b.buf) {
-		b.buf = buf
+	if b.i+len(buf) > len(b.buf) {
+		// Runtime alloc'd into a separate backing array, but it chooses
+		// the doubling cap using the non-optimal |cap(b.buf)-b.i|*2.
+		// We do not need to increment |b.i| b/c the latest value is in
+		// the other array.
+		b.Double()
+	} else {
+		b.i += len(buf)
 	}
 }
 
+func (b *ByteBuffer) Double() {
+	buf := make([]byte, len(b.buf)*2)
+	copy(buf, b.buf)
+	b.buf = buf
+}
+
 func (b *ByteBuffer) Get() []byte {
-	return b.buf[len(b.buf):]
+	return b.buf[b.i:b.i]
 }
 
 func (b *ByteBuffer) Reset() {
-	b.buf = b.buf[:0]
+	b.i = 0
 }

--- a/sql/byte_buffer.go
+++ b/sql/byte_buffer.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-const defaultByteBuffCap = 10
+const defaultByteBuffCap = 4096
 
 var ByteBufPool = sync.Pool{
 	New: func() any {

--- a/sql/byte_buffer.go
+++ b/sql/byte_buffer.go
@@ -4,69 +4,32 @@ import (
 	"sync"
 )
 
-var SingletonBuf = NewByteBuffer(16000)
-
-var defaultByteBuffCap = 1000
+const defaultByteBuffCap = 1024
 
 var ByteBufPool = sync.Pool{
 	New: func() any {
-		// The Pool's New function should generally only return pointer
-		// types, since a pointer can be put into the return interface
-		// value without an allocation:
 		return NewByteBuffer(defaultByteBuffCap)
 	},
 }
 
 type ByteBuffer struct {
 	buf []byte
-	i   int
 }
 
 func NewByteBuffer(initCap int) *ByteBuffer {
-	return &ByteBuffer{buf: make([]byte, initCap)}
+	return &ByteBuffer{buf: make([]byte, 0, initCap)}
 }
 
-func (b *ByteBuffer) Bytes() []byte {
-	return b.buf
-}
-
-func (b *ByteBuffer) GetFull(i int) []byte {
-	start := b.i
-	b.i = start + i
-	if b.i > len(b.buf) {
-		newBuf := make([]byte, len(b.buf)*2)
-		copy(newBuf, b.buf[:])
-		b.buf = newBuf
+func (b *ByteBuffer) Update(buf []byte) {
+	if cap(buf) > cap(b.buf) {
+		b.buf = buf
 	}
-	return b.buf[start:b.i]
-}
-
-func (b *ByteBuffer) Double() {
-	newBuf := make([]byte, len(b.buf)*2)
-	copy(newBuf, b.buf[:])
-	b.buf = newBuf
-}
-
-func (b *ByteBuffer) Advance(i int) {
-	b.i += i
-}
-
-func (b *ByteBuffer) Spare() int {
-	return len(b.buf) - b.i
 }
 
 func (b *ByteBuffer) Get() []byte {
-	//start := b.i
-	//b.i = start + i
-	//if b.i > len(b.buf) {
-	//	newBuf := make([]byte, len(b.buf)*2)
-	//	copy(newBuf, b.buf[:])
-	//	b.buf = newBuf
-	//}
-	//return b.buf[start:b.i][:0]
-	return b.buf[b.i:b.i]
+	return b.buf[len(b.buf):]
 }
 
 func (b *ByteBuffer) Reset() {
-	b.i = 0
+	b.buf = b.buf[:0]
 }

--- a/sql/byte_buffer.go
+++ b/sql/byte_buffer.go
@@ -1,6 +1,21 @@
 package sql
 
+import (
+	"sync"
+)
+
 var SingletonBuf = NewByteBuffer(16000)
+
+var defaultByteBuffCap = 1000
+
+var ByteBufPool = sync.Pool{
+	New: func() any {
+		// The Pool's New function should generally only return pointer
+		// types, since a pointer can be put into the return interface
+		// value without an allocation:
+		return NewByteBuffer(defaultByteBuffCap)
+	},
+}
 
 type ByteBuffer struct {
 	buf []byte

--- a/sql/byte_buffer.go
+++ b/sql/byte_buffer.go
@@ -1,6 +1,6 @@
 package sql
 
-var SingletonBuf = NewByteBuffer(1000)
+var SingletonBuf = NewByteBuffer(16000)
 
 type ByteBuffer struct {
 	buf []byte

--- a/sql/byte_buffer_test.go
+++ b/sql/byte_buffer_test.go
@@ -1,0 +1,71 @@
+// Copyright 2024 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestGrowByteBuffer(t *testing.T) {
+	b := NewByteBuffer(10)
+
+	// grow less than boundary
+	src1 := []byte{1, 1, 1}
+	obj1 := append(b.Get(), src1...)
+	b.Grow(len(src1))
+
+	require.Equal(t, 10, len(b.buf))
+	require.Equal(t, 3, b.i)
+	require.Equal(t, 10, cap(obj1))
+
+	// grow to boundary
+	src2 := []byte{0, 0, 0, 0, 0, 0, 0}
+	obj2 := append(b.Get(), src2...)
+	b.Grow(len(src2))
+
+	require.Equal(t, 20, len(b.buf))
+	require.Equal(t, 10, b.i)
+	require.Equal(t, 7, cap(obj2))
+
+	src3 := []byte{2, 2, 2, 2, 2}
+	obj3 := append(b.Get(), src3...)
+	b.Grow(len(src3))
+
+	require.Equal(t, 20, len(b.buf))
+	require.Equal(t, 15, b.i)
+	require.Equal(t, 10, cap(obj3))
+
+	// grow exceeds boundary
+
+	src4 := []byte{3, 3, 3, 3, 3, 3, 3, 3}
+	obj4 := append(b.Get(), src4...)
+	b.Grow(len(src4))
+
+	require.Equal(t, 40, len(b.buf))
+	require.Equal(t, 15, b.i)
+	require.Equal(t, 16, cap(obj4))
+
+	// objects are all valid after doubling
+	require.Equal(t, src1, obj1)
+	require.Equal(t, src2, obj2)
+	require.Equal(t, src3, obj3)
+	require.Equal(t, src4, obj4)
+
+	// reset
+	b.Reset()
+	require.Equal(t, 40, len(b.buf))
+	require.Equal(t, 0, b.i)
+}

--- a/sql/byte_buffer_test.go
+++ b/sql/byte_buffer_test.go
@@ -15,8 +15,9 @@
 package sql
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGrowByteBuffer(t *testing.T) {

--- a/sql/types/bit.go
+++ b/sql/types/bit.go
@@ -214,7 +214,7 @@ func (t BitType_) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 	for i, j := 0, len(data)-1; i < j; i, j = i+1, j-1 {
 		data[i], data[j] = data[j], data[i]
 	}
-	val := AppendAndSliceBytes(dest, data)
+	val := data
 
 	return sqltypes.MakeTrusted(sqltypes.Bit, val), nil
 }

--- a/sql/types/datetime.go
+++ b/sql/types/datetime.go
@@ -410,7 +410,7 @@ func (t datetimeType) SQL(_ *sql.Context, dest []byte, v interface{}) (sqltypes.
 		return sqltypes.Value{}, sql.ErrInvalidBaseType.New(t.baseType.String(), "datetime")
 	}
 
-	valBytes := AppendAndSliceBytes(dest, val)
+	valBytes := val
 
 	return sqltypes.MakeTrusted(typ, valBytes), nil
 }

--- a/sql/types/enum.go
+++ b/sql/types/enum.go
@@ -257,7 +257,7 @@ func (t EnumType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 		snippet = strings.ToValidUTF8(snippet, string(utf8.RuneError))
 		return sqltypes.Value{}, sql.ErrCharSetFailedToEncode.New(resultCharset.Name(), utf8.ValidString(value), snippet)
 	}
-	val := AppendAndSliceBytes(dest, encodedBytes)
+	val := encodedBytes
 
 	return sqltypes.MakeTrusted(sqltypes.Enum, val), nil
 }

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -140,7 +140,7 @@ func (t JsonType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 		if err != nil {
 			return sqltypes.NULL, err
 		}
-		val = AppendAndSliceBytes(dest, str)
+		val = str
 	} else {
 		// Convert to jsonType
 		jsVal, _, err := t.Convert(v)

--- a/sql/types/number.go
+++ b/sql/types/number.go
@@ -613,6 +613,8 @@ func (t NumberTypeImpl_) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqlt
 		default:
 			return sqltypes.Value{}, err
 		}
+	} else if err != nil {
+		return sqltypes.Value{}, err
 	}
 
 	val := dest[stop:]

--- a/sql/types/set.go
+++ b/sql/types/set.go
@@ -246,7 +246,7 @@ func (t SetType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Val
 		snippet = strings.ToValidUTF8(snippet, string(utf8.RuneError))
 		return sqltypes.Value{}, sql.ErrCharSetFailedToEncode.New(resultCharset.Name(), utf8.ValidString(value), snippet)
 	}
-	val := AppendAndSliceBytes(dest, encodedBytes)
+	val := encodedBytes
 
 	return sqltypes.MakeTrusted(sqltypes.Set, val), nil
 }

--- a/sql/types/sql_test.go
+++ b/sql/types/sql_test.go
@@ -28,7 +28,7 @@ func BenchmarkVarchar10SQL(b *testing.B) {
 	ctx := sql.NewEmptyContext()
 	for i := 0; i < b.N; i++ {
 		res, _ = t.SQL(ctx, buf.Get(), "char")
-		buf.Advance(res.Len())
+		buf.Update(res.Raw())
 		buf.Reset()
 	}
 	result_ = res

--- a/sql/types/sql_test.go
+++ b/sql/types/sql_test.go
@@ -28,7 +28,7 @@ func BenchmarkVarchar10SQL(b *testing.B) {
 	ctx := sql.NewEmptyContext()
 	for i := 0; i < b.N; i++ {
 		res, _ = t.SQL(ctx, buf.Get(), "char")
-		buf.Update(res.Raw())
+		buf.Grow(res.Len())
 		buf.Reset()
 	}
 	result_ = res

--- a/sql/types/sql_test.go
+++ b/sql/types/sql_test.go
@@ -24,9 +24,12 @@ func BenchmarkNumI64SQL(b *testing.B) {
 func BenchmarkVarchar10SQL(b *testing.B) {
 	var res sqltypes.Value
 	t := MustCreateStringWithDefaults(sqltypes.VarChar, 10)
+	buf := sql.NewByteBuffer(1000)
 	ctx := sql.NewEmptyContext()
 	for i := 0; i < b.N; i++ {
-		res, _ = t.SQL(ctx, nil, "char")
+		res, _ = t.SQL(ctx, buf.Get(), "char")
+		buf.Advance(res.Len())
+		buf.Reset()
 	}
 	result_ = res
 }

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -540,7 +540,8 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 		case []byte:
 			valueBytes = v
 		case string:
-			valueBytes = []byte(v)
+			dest = append(dest, v...)
+			valueBytes = dest[start:]
 		case int, int8, int16, int32, int64:
 			num, _, err := convertToInt64(Int64.(NumberTypeImpl_), v)
 			if err != nil {
@@ -555,10 +556,11 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 			valueBytes = strconv.AppendUint(dest, num, 10)
 		case bool:
 			if v {
-				valueBytes = append(dest, '1')
+				dest = append(dest, '1')
 			} else {
-				valueBytes = append(dest, '0')
+				dest = append(dest, '0')
 			}
+			valueBytes = dest[start:]
 		case float64:
 			valueBytes = strconv.AppendFloat(dest, v, 'f', -1, 64)
 			if valueBytes[start] == '-' {

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -524,11 +524,10 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 	start := len(dest)
 	var val []byte
 	if IsBinaryType(t) {
-		v, err = ConvertToBytes(v, t, dest)
+		val, err = ConvertToBytes(v, t, dest)
 		if err != nil {
 			return sqltypes.Value{}, err
 		}
-		val = AppendAndSliceBytes(dest, v.([]byte))
 	} else {
 		var valueBytes []byte
 		switch v := v.(type) {
@@ -602,7 +601,8 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 			snippetStr := strings2.ToValidUTF8(string(snippet), string(utf8.RuneError))
 			return sqltypes.Value{}, sql.ErrCharSetFailedToEncode.New(resultCharset.Name(), utf8.ValidString(snippetStr), snippet)
 		}
-		val = AppendAndSliceBytes(dest, encodedBytes)
+		//val = AppendAndSliceBytes(dest, encodedBytes)
+		val = encodedBytes
 	}
 
 	return sqltypes.MakeTrusted(t.baseType, val), nil

--- a/sql/types/time.go
+++ b/sql/types/time.go
@@ -271,7 +271,7 @@ func (t TimespanType_) SQL(_ *sql.Context, dest []byte, v interface{}) (sqltypes
 		return sqltypes.Value{}, err
 	}
 
-	val := AppendAndSliceBytes(dest, ti.Bytes())
+	val := ti.Bytes()
 	return sqltypes.MakeTrusted(sqltypes.Time, val), nil
 }
 


### PR DESCRIPTION
`BytesBuffer` is a class that lets us avoid most allocations for spooling values to wire. Notably, the object is responsible for doubling the backing array size when appropriate, and a `Grow(n int)` interface is necessary to track when this should happen. Letting the runtime do all of this would be preferable, but the runtime doubles based on slice size, and the refactors required to make that workable are more invasive.  We pay for 2 mallocs on doubling, because the first one is never big enough. Not calling `Grow` after allocing, or growing by too small of length compared to the allocations used will stomp previously written memory.

As long as we track bytes used with the `Grow` interface this works smoothly and shaves ~30% off of tablescans.

perf here: https://github.com/dolthub/dolt/pull/8693