### PR TITLE
Reset BytesBuffer after each rowBatch

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -680,9 +680,6 @@ func (h *Handler) resultForDefaultIter(ctx *sql.Context, c *mysql.Conn, schema s
 				}
 
 				ctx.GetLogger().Tracef("spooling result row %s", outputRow)
-				if len(r.Rows) == 0 {
-					print()
-				}
 				r.Rows = append(r.Rows, outputRow)
 				r.RowsAffected++
 			case <-timer.C:

--- a/server/handler.go
+++ b/server/handler.go
@@ -634,6 +634,12 @@ func (h *Handler) resultForDefaultIter(ctx *sql.Context, c *mysql.Conn, schema s
 	timer := time.NewTimer(waitTime)
 	defer timer.Stop()
 
+	// Wrap the callback to include a BytesBuffer.Reset() to clean out rows that have already been spooled
+	resetCallback := func(r *sqltypes.Result, more bool) error {
+		defer buf.Reset()
+		return callback(r, more)
+	}
+
 	// Reads rows from the channel, converts them to wire format,
 	// and calls |callback| to give them to vitess.
 	eg.Go(func() error {
@@ -645,7 +651,7 @@ func (h *Handler) resultForDefaultIter(ctx *sql.Context, c *mysql.Conn, schema s
 				r = &sqltypes.Result{Fields: resultFields}
 			}
 			if r.RowsAffected == rowsBatch {
-				if err := callback(r, more); err != nil {
+				if err := resetCallback(r, more); err != nil {
 					return err
 				}
 				r = nil
@@ -674,6 +680,9 @@ func (h *Handler) resultForDefaultIter(ctx *sql.Context, c *mysql.Conn, schema s
 				}
 
 				ctx.GetLogger().Tracef("spooling result row %s", outputRow)
+				if len(r.Rows) == 0 {
+					print()
+				}
 				r.Rows = append(r.Rows, outputRow)
 				r.RowsAffected++
 			case <-timer.C:


### PR DESCRIPTION
Once we spool a batch of rows to client, there's no reason to keep them in memory.

Fixes https://github.com/dolthub/dolt/issues/8718