### PR TITLE
Allow using vector index when the queried vector is provided in a user variable.

### DIFF
--- a/sql/analyzer/replace_order_by_distance.go
+++ b/sql/analyzer/replace_order_by_distance.go
@@ -60,6 +60,8 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 			return n, transform.SameTree, nil
 		}
 
+		// We currently require that the query vector to the distance function is a constant value that does not
+		// depend on the row. Right now that can be a Literal or a UserVar.
 		isLiteral := func(expr sql.Expression) bool {
 			switch expr.(type) {
 			case *expression.Literal, *expression.UserVar:

--- a/sql/analyzer/replace_order_by_distance.go
+++ b/sql/analyzer/replace_order_by_distance.go
@@ -59,15 +59,22 @@ func replaceIdxOrderByDistanceHelper(ctx *sql.Context, scope *plan.Scope, node s
 		if !isDistance {
 			return n, transform.SameTree, nil
 		}
+
+		isLiteral := func(expr sql.Expression) bool {
+			switch expr.(type) {
+			case *expression.Literal, *expression.UserVar:
+				return true
+			}
+			return false
+		}
+
 		var column sql.Expression
 		var literal sql.Expression
-		_, leftIsLiteral := distance.LeftChild.(*expression.Literal)
-		if leftIsLiteral {
+		if isLiteral(distance.LeftChild) {
 			column = distance.RightChild
 			literal = distance.LeftChild
 		} else {
-			_, rightIsLiteral := distance.RightChild.(*expression.Literal)
-			if rightIsLiteral {
+			if isLiteral(distance.RightChild) {
 				column = distance.LeftChild
 				literal = distance.RightChild
 			} else {


### PR DESCRIPTION
Right now, vector indexes are very narrowly applied. One of the inputs to the DISTANCE function needs to be a constant. Before we required it to be a Literal expression, but UserVar expressions should also work.