### PR TITLE
Don't force a table rewrite when appending extra values to the end of an enum.

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7621,6 +7621,20 @@ where
 				},
 			},
 			{
+				Query: "alter table t modify column e enum('asdf', 'a', 'b', 'c', 'd');",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "select i, e, e + 0 from t;",
+				Expected: []sql.Row{
+					{1, "a", float64(2)},
+					{2, "b", float64(3)},
+					{3, "c", float64(4)},
+				},
+			},
+			{
 				Query:       "alter table t modify column e enum('abc');",
 				ExpectedErr: types.ErrConvertingToEnum,
 			},

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -525,7 +525,7 @@ func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTabl
 
 	oldEnum, isOldEnum := oldCol.Type.(sql.EnumType)
 	newEnum, isNewEnum := newCol.Type.(sql.EnumType)
-	if isOldEnum && isNewEnum && !oldEnum.Equals(newEnum) {
+	if isOldEnum && isNewEnum && !oldEnum.IsSubsetOf(newEnum) {
 		rewriteRequired = true
 	}
 

--- a/sql/type.go
+++ b/sql/type.go
@@ -186,6 +186,9 @@ type EnumType interface {
 	Collation() CollationID
 	// IndexOf returns the index of the given string. If the string was not found, then this returns -1.
 	IndexOf(v string) int
+	// IsSubsetOf returns whether every element in this is also in |otherType|, with the same indexes.
+	// |otherType| may contain additional elements not in this.
+	IsSubsetOf(otherType EnumType) bool
 	// NumberOfElements returns the number of enumerations.
 	NumberOfElements() uint16
 	// Values returns the elements, in order, of every enumeration.

--- a/sql/types/enum.go
+++ b/sql/types/enum.go
@@ -335,6 +335,19 @@ func (t EnumType) IndexOf(v string) int {
 	return -1
 }
 
+// IsSubsetOf implements the sql.EnumType interface.
+func (t EnumType) IsSubsetOf(otherType sql.EnumType) bool {
+	if ot, ok := otherType.(EnumType); ok && t.collation.Equals(ot.collation) && len(t.idxToVal) <= len(ot.idxToVal) {
+		for i, val := range t.idxToVal {
+			if ot.idxToVal[i] != val {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // NumberOfElements implements EnumType interface.
 func (t EnumType) NumberOfElements() uint16 {
 	return uint16(len(t.idxToVal))


### PR DESCRIPTION
Adding extra strings to the end of an enum type doesn't change the values for any of the existing strings. A table rewrite isn't necessary in this case.

If a specific table implementation _does_ need to be rewritten when an enum type changes this way, they can still implement `ShouldRewriteTable` in order to force a rewrite anyway.
