### PR TITLE
implement `drop temporary table ...` and display `temporary in show create table statements`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20241215010122-db690dd53c90
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250122225556-e8e0549e1bcd
+	github.com/dolthub/vitess v0.0.0-20250123002143-3b45b8cacbfa
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20241215010122-db690dd53c90
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250122194149-eae2927a6092
+	github.com/dolthub/vitess v0.0.0-20250122225556-e8e0549e1bcd
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20241215010122-db690dd53c90
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250115003116-d6f17c220028
+	github.com/dolthub/vitess v0.0.0-20250122194149-eae2927a6092
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20250122225556-e8e0549e1bcd h1://wdLxG/u56LT96vkQzEtSaVgb5EV+coWqomyEtC2nI=
-github.com/dolthub/vitess v0.0.0-20250122225556-e8e0549e1bcd/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250123002143-3b45b8cacbfa h1:kyoPzxViSXAyqfO0Mab7Qo1UogFIrxZKKyBU6kBOl+E=
+github.com/dolthub/vitess v0.0.0-20250123002143-3b45b8cacbfa/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20250122194149-eae2927a6092 h1:DXG7Tw0jCM3VUG0C2pWEHGexEzmZuhQTPGqIn5aE+k0=
-github.com/dolthub/vitess v0.0.0-20250122194149-eae2927a6092/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250122225556-e8e0549e1bcd h1://wdLxG/u56LT96vkQzEtSaVgb5EV+coWqomyEtC2nI=
+github.com/dolthub/vitess v0.0.0-20250122225556-e8e0549e1bcd/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,12 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20241220202600-b18f18d0cde7 h1:w130WLeARGGNYWmhGPugsHXzJEelKKimt3kTWg6/Puk=
-github.com/dolthub/vitess v0.0.0-20241220202600-b18f18d0cde7/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
-github.com/dolthub/vitess v0.0.0-20241231200706-18992bb25fdc h1:3FuwEDwyue/JuHdnwGSbQhE9xKAFM+k1y3uXi58h7Gk=
-github.com/dolthub/vitess v0.0.0-20241231200706-18992bb25fdc/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
-github.com/dolthub/vitess v0.0.0-20250115003116-d6f17c220028 h1:lgcIsCUaNDde+lS+aYGYGML95qrQlBMEpaXFN1Pmk+4=
-github.com/dolthub/vitess v0.0.0-20250115003116-d6f17c220028/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250122194149-eae2927a6092 h1:DXG7Tw0jCM3VUG0C2pWEHGexEzmZuhQTPGqIn5aE+k0=
+github.com/dolthub/vitess v0.0.0-20250122194149-eae2927a6092/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -253,6 +253,11 @@ func (b *Builder) buildDropTable(inScope *scope, c *ast.DDL) (outScope *scope) {
 
 		tableScope, ok := b.buildResolvedTableForTablename(inScope, t, nil)
 		if ok {
+			// attempting to drop a non-temporary table with DROP TEMPORARY, results in Unknown table
+			if _, isTmpTbl := tableScope.node.(sql.TemporaryTable); !isTmpTbl && c.Temporary {
+				err := sql.ErrUnknownTable.New(tableName)
+				b.handleErr(err)
+			}
 			dropTables = append(dropTables, tableScope.node)
 		} else if !c.IfExists {
 			err := sql.ErrTableNotFound.New(tableName)

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -254,9 +254,11 @@ func (b *Builder) buildDropTable(inScope *scope, c *ast.DDL) (outScope *scope) {
 		tableScope, ok := b.buildResolvedTableForTablename(inScope, t, nil)
 		if ok {
 			// attempting to drop a non-temporary table with DROP TEMPORARY, results in Unknown table
-			if _, isTmpTbl := tableScope.node.(sql.TemporaryTable); !isTmpTbl && c.Temporary {
-				err := sql.ErrUnknownTable.New(tableName)
-				b.handleErr(err)
+			if tbl, ok := tableScope.node.(sql.Table); ok {
+				if tmpTbl := getTempTable(tbl); tmpTbl != nil && !tmpTbl.IsTemporary() && c.Temporary {
+					err := sql.ErrUnknownTable.New(tableName)
+					b.handleErr(err)
+				}
 			}
 			dropTables = append(dropTables, tableScope.node)
 		} else if !c.IfExists {
@@ -267,6 +269,19 @@ func (b *Builder) buildDropTable(inScope *scope, c *ast.DDL) (outScope *scope) {
 
 	outScope.node = plan.NewDropTable(dropTables, c.IfExists)
 	return
+}
+
+func getTempTable(t sql.Table) sql.TemporaryTable {
+	switch t := t.(type) {
+	case sql.TemporaryTable:
+		return t
+	case sql.TableWrapper:
+		return getTempTable(t.Underlying())
+	case *plan.ResolvedTable:
+		return getTempTable(t.Table)
+	default:
+		return nil
+	}
 }
 
 func (b *Builder) buildTruncateTable(inScope *scope, c *ast.DDL) (outScope *scope) {

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -498,7 +498,12 @@ func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, tab
 		}
 	}
 
-	return sql.GenerateCreateTableStatement(table.Name(), colStmts, autoInc, table.Collation().CharacterSet().Name(), table.Collation().Name(), comment), nil
+	temp := ""
+	if _, ok := table.(sql.TemporaryTable); ok {
+		temp = " TEMPORARY"
+	}
+
+	return sql.GenerateCreateTableStatement(table.Name(), colStmts, temp, autoInc, table.Collation().CharacterSet().Name(), table.Collation().Name(), comment), nil
 }
 
 func produceCreateViewStatement(view *plan.SubqueryAlias) string {

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -499,7 +499,7 @@ func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, tab
 	}
 
 	temp := ""
-	if _, ok := table.(sql.TemporaryTable); ok {
+	if tbl := getTempTable(table); tbl != nil && tbl.IsTemporary() {
 		temp = " TEMPORARY"
 	}
 
@@ -539,6 +539,19 @@ func getAutoIncrementTable(t sql.Table) sql.AutoIncrementTable {
 		return getAutoIncrementTable(t.Underlying())
 	case *plan.ResolvedTable:
 		return getAutoIncrementTable(t.Table)
+	default:
+		return nil
+	}
+}
+
+func getTempTable(t sql.Table) sql.TemporaryTable {
+	switch t := t.(type) {
+	case sql.TemporaryTable:
+		return t
+	case sql.TableWrapper:
+		return getTempTable(t.Underlying())
+	case *plan.ResolvedTable:
+		return getTempTable(t.Table)
 	default:
 		return nil
 	}

--- a/sql/sqlfmt.go
+++ b/sql/sqlfmt.go
@@ -26,7 +26,7 @@ import (
 
 // GenerateCreateTableStatement returns 'CREATE TABLE' statement with given table names
 // and column definition statements in order and the collation and character set names for the table
-func GenerateCreateTableStatement(tblName string, colStmts []string, autoInc, tblCharsetName, tblCollName, comment string) string {
+func GenerateCreateTableStatement(tblName string, colStmts []string, temp, autoInc, tblCharsetName, tblCollName, comment string) string {
 	if comment != "" {
 		// Escape any single quotes in the comment and add the COMMENT keyword
 		comment = strings.ReplaceAll(comment, "'", "''")
@@ -38,7 +38,8 @@ func GenerateCreateTableStatement(tblName string, colStmts []string, autoInc, tb
 	}
 
 	return fmt.Sprintf(
-		"CREATE TABLE %s (\n%s\n) ENGINE=InnoDB%s DEFAULT CHARSET=%s COLLATE=%s%s",
+		"CREATE%s TABLE %s (\n%s\n) ENGINE=InnoDB%s DEFAULT CHARSET=%s COLLATE=%s%s",
+		temp,
 		QuoteIdentifier(tblName),
 		strings.Join(colStmts, ",\n"),
 		autoInc,


### PR DESCRIPTION
In-memory database doesn't support temporary tables, so tests are here: https://github.com/dolthub/dolt/pull/8781

fixes: https://github.com/dolthub/dolt/issues/7992