### PR TITLE
fix panic when comparing system set type against other types

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10133,6 +10133,13 @@ from typestable`,
 			{2},
 		},
 	},
+
+	{
+		Query: "select @@sql_mode = 1",
+		Expected: []sql.Row{
+			{false},
+		},
+	},
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/expression/comparison.go
+++ b/sql/expression/comparison.go
@@ -168,11 +168,8 @@ func (c *comparison) Compare(ctx *sql.Context, row sql.Row) (int, error) {
 			return 0, err
 		}
 	}
-	if types.IsTextOnly(compareType) {
+	if _, isSet := compareType.(sql.SetType); !isSet && types.IsTextOnly(compareType) {
 		collationPreference, _ = c.CollationCoercibility(ctx)
-		if err != nil {
-			return 0, err
-		}
 		stringCompareType := compareType.(sql.StringType)
 		compareType = types.MustCreateString(stringCompareType.Type(), stringCompareType.Length(), collationPreference)
 	}


### PR DESCRIPTION
Comparison between `systemSetTypes` and other types is still not correct.
It appears that MySQL actually treats `@@sql_mode` as just a string.

This PR only fixes the panic