### PR TITLE
Replace `golang.org/x/exp` with stdlib

### DIFF
--- a/enginetest/histogram_test.go
+++ b/enginetest/histogram_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/rand"
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
@@ -21,10 +20,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/stats"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
-
-func init() {
-	rand.Seed(0)
-}
 
 type statsTest struct {
 	name       string

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/otel v1.31.0
 	go.opentelemetry.io/otel/trace v1.31.0
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/sync v0.3.0
 	golang.org/x/sys v0.12.0
 	golang.org/x/text v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,6 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/sql/encodings/generate/main.go
+++ b/sql/encodings/generate/main.go
@@ -15,15 +15,15 @@
 package main
 
 import (
+	"cmp"
 	"encoding/binary"
 	"fmt"
 	"hash/fnv"
+	"maps"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 	"unsafe"
-
-	"golang.org/x/exp/constraints"
 )
 
 var Header = `// Copyright 2023 Dolthub, Inc.
@@ -89,7 +89,7 @@ func main() {
 				weightKeys = append(weightKeys[:j], weightKeys[j+1:]...)
 			}
 		}
-		sort.Strings(duplicateKeyNames)
+		slices.Sort(duplicateKeyNames)
 		// Find the common prefix of all names if they exist, else concatenate all names
 		if len(duplicateKeyNames) > 0 {
 			// Grab the duplicated map and delete the first key
@@ -337,13 +337,8 @@ var WeightMaps = map[string]map[rune]int32{
 
 var FileContentHashes = map[string]uint64{}
 
-func SortedMapKeys[K constraints.Ordered, V any](m map[K]V) []K {
-	keys := make([]K, 0, len(m))
-	for key := range m {
-		keys = append(keys, key)
-	}
-	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
-	return keys
+func SortedMapKeys[K cmp.Ordered, V any](m map[K]V) []K {
+	return slices.Sorted(maps.Keys(m))
 }
 
 func CommonPrefix(str1 string, str2 string) string {

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -21,15 +21,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/dolthub/jsonpath"
 	"github.com/shopspring/decimal"
-	"golang.org/x/exp/maps"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )
@@ -728,7 +728,7 @@ func jsonObjectKeyIntersection(a, b JsonObject) (ks []string) {
 			ks = append(ks, key)
 		}
 	}
-	sort.Strings(ks)
+	slices.Sort(ks)
 	return
 }
 
@@ -1196,10 +1196,7 @@ type JSONIter struct {
 
 func NewJSONIter(json JsonObject) JSONIter {
 	json = maps.Clone(json)
-	keys := maps.Keys(json)
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i] < keys[j]
-	})
+	keys := slices.Sorted(maps.Keys(json))
 	return JSONIter{
 		doc:  &json,
 		keys: keys,


### PR DESCRIPTION
These experimental packages are now available in the Go standard library.

1. `golang.org/x/exp/slices` -> `slices` (https://go.dev/doc/go1.21#slices)
2. `golang.org/x/exp/maps` -> `maps` (https://go.dev/doc/go1.21#maps)
3. `golang.org/x/exp/constraints` -> `cmp` (https://go.dev/doc/go1.21#cmp)
4. `golang.org/x/exp/rand` -> `math/rand/v2` (https://go.dev/doc/go1.22#math_rand_v2)