### PR TITLE
PlanBuilder: Fix spelling in error message s/prodecure/procedure

### DIFF
--- a/sql/planbuilder/select.go
+++ b/sql/planbuilder/select.go
@@ -149,7 +149,7 @@ func (b *Builder) buildOffset(inScope *scope, limit *ast.Limit) sql.Expression {
 }
 
 // buildLimitVal resolves a literal numeric type or a numeric
-// prodecure parameter
+// procedure parameter
 func (b *Builder) buildLimitVal(inScope *scope, e ast.Expr) sql.Expression {
 	switch e := e.(type) {
 	case *ast.ColName:
@@ -165,7 +165,7 @@ func (b *Builder) buildLimitVal(inScope *scope, e ast.Expr) sql.Expression {
 				}
 			}
 		}
-		err := fmt.Errorf("limit expression expected to be numeric or prodecure parameter, found invalid column: %s", e.String())
+		err := fmt.Errorf("limit expression expected to be numeric or procedure parameter, found invalid column: %s", e.String())
 		b.handleErr(err)
 	default:
 		l := b.buildScalar(inScope, e)


### PR DESCRIPTION
Fix spelling of word "procedure".

Since this is trivial, if it makes it easier for maintainers to make a commit like this themselves, or include as part of something else -- I don't mind.