### PR TITLE
Allow primary keys to contain address columns sorted by their resolved values.

### DIFF
--- a/sql/types/extended.go
+++ b/sql/types/extended.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"context"
 	"encoding/hex"
 	"errors"
 
@@ -26,11 +27,11 @@ type ExtendedType interface {
 	sql.Type
 	// SerializedCompare compares two byte slices that each represent a serialized value, without first deserializing
 	// the value. This should return the same result as the Compare function.
-	SerializedCompare(v1 []byte, v2 []byte) (int, error)
+	SerializedCompare(ctx context.Context, v1 []byte, v2 []byte) (int, error)
 	// SerializeValue converts the given value into a binary representation.
-	SerializeValue(val any) ([]byte, error)
+	SerializeValue(ctx context.Context, val any) ([]byte, error)
 	// DeserializeValue converts a binary representation of a value into its canonical type.
-	DeserializeValue(val []byte) (any, error)
+	DeserializeValue(ctx context.Context, val []byte) (any, error)
 	// FormatValue returns a string version of the value. Primarily intended for display.
 	FormatValue(val any) (string, error)
 	// MaxSerializedWidth returns the maximum size that the serialized value may represent.


### PR DESCRIPTION
This is the GMS part of this change.

Dolt PR: https://github.com/dolthub/dolt/pull/8870
Doltgres PR: https://github.com/dolthub/doltgresql/pull/1214

The goal of the change is to allow for indexes to use an out-of-line variable-length type (like TEXT or BLOB) as a primary key while still storing just the address in the index (instead of being forced to store a prefix of the value).

As a result of this change, any tuple comparison operation may need to resolve a hash in the NodeStore. This poses two complications:

1. The tuple logic exists at a much lower level than the node store and can't depend on it without creating a dependency cycle. We get around this with a new `ValueStore` interface that can store and retrieve variable-length bytestrings by their content hash. `NodeStore` is the only implementation of this interface, but decoupling the interface from the implementation allows us to not depend on `NodeStore`'s internals when passing it to lower-level code.

2. Tuple comparison operations can now end up doing disk IO, which means they need a context parameter.