### PR TITLE
include `new`/`old` expressions when resolving projections in trigger scope

### DIFF
--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2868,6 +2868,7 @@ end;
 		},
 	},
 
+	// Nested Triggers
 	{
 		Name: "double nested triggers referencing multiple tables",
 		SetUpScript: []string{
@@ -2941,7 +2942,6 @@ for each row
 			},
 		},
 	},
-
 	{
 		Name: "triple nested delete triggers referencing multiple tables",
 		SetUpScript: []string{
@@ -3024,7 +3024,6 @@ for each row
 			},
 		},
 	},
-
 	{
 		Name: "triple nested insert triggers referencing multiple tables",
 		SetUpScript: []string{
@@ -3117,7 +3116,6 @@ for each row
 			},
 		},
 	},
-
 	{
 		Name: "triple nested update triggers referencing multiple tables",
 		SetUpScript: []string{
@@ -3227,6 +3225,170 @@ for each row
 			},
 		},
 	},
+
+	// Triggers with subqueries
+	{
+		Name: "insert trigger with subquery projections",
+		SetUpScript: []string{
+			"create table t (i int primary key, j int);",
+			`
+create trigger trig1 before insert on t
+for each row
+  begin
+	set @a = (select 10 * new.i);
+    set @b = (select 20 * new.j);
+  end;
+`,
+			`
+create trigger trig2 after insert on t
+for each row
+  begin
+	set @c = (select 30 * new.i);
+    set @d = (select 40 * new.j);
+  end;
+`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{nil, nil, nil, nil},
+				},
+			},
+			{
+				Query: "insert into t values (1, 2);",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{10, 40, 30, 80},
+				},
+			},
+			{
+				Query: "insert into t values (1, 200);",
+				ExpectedErrStr: "duplicate primary key given: [1]",
+			},
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{10, 4000, 30, 80},
+				},
+			},
+		},
+	},
+	{
+		Name: "delete trigger with subquery projections",
+		SetUpScript: []string{
+			"create table t (i int primary key, j int);",
+			"insert into t values (1, 2), (3, 4);",
+			`
+create trigger trig1 before delete on t
+for each row
+  begin
+	set @a = (select 10 * old.i);
+    set @b = (select 20 * old.j);
+  end;
+`,
+			`
+create trigger trig2 after delete on t
+for each row
+  begin
+	set @c = (select 30 * old.i);
+    set @d = (select 40 * old.j);
+  end;
+`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{nil, nil, nil, nil},
+				},
+			},
+			{
+				Query: "delete from t where i = 1;",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{10, 40, 30, 80},
+				},
+			},
+			{
+				Query: "delete from t where j = 4;",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{30, 80, 90, 160},
+				},
+			},
+		},
+	},
+	{
+			Name: "update trigger with subquery projections",
+			SetUpScript: []string{
+				"create table t (i int primary key, j int);",
+				"insert into t values (1, 2), (3, 4);",
+				`
+create trigger trig1 before update on t
+for each row
+  begin
+	set @a = (select 10 * old.i + new.i);
+    set @b = (select 20 * old.j + new.j);
+  end;
+`,
+				`
+create trigger trig2 after update on t
+for each row
+  begin
+	set @c = (select 30 * old.i + new.i);
+    set @d = (select 40 * old.j + new.j);
+  end;
+`,
+			},
+			Assertions: []ScriptTestAssertion{
+				{
+					Query: "select @a, @b, @c, @d;",
+					Expected: []sql.Row{
+						{nil, nil, nil, nil},
+					},
+				},
+				{
+					Query: "update t set i = i * 10 where i = 1;",
+					Expected: []sql.Row{
+						{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
+					},
+				},
+				{
+					Query: "select @a, @b, @c, @d;",
+					Expected: []sql.Row{
+						{20, 42, 40, 82},
+					},
+				},
+				{
+					Query: "update t set j = i * 10 where j = 4;",
+					Expected: []sql.Row{
+						{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
+					},
+				},
+				{
+					Query: "select @a, @b, @c, @d;",
+					Expected: []sql.Row{
+						{33, 110, 93, 190},
+					},
+				},
+			},
+		},
 }
 
 var TriggerCreateInSubroutineTests = []ScriptTest{

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3268,7 +3268,7 @@ for each row
 				},
 			},
 			{
-				Query: "insert into t values (1, 200);",
+				Query:          "insert into t values (1, 200);",
 				ExpectedErrStr: "duplicate primary key given: [1]",
 			},
 			{
@@ -3335,11 +3335,11 @@ for each row
 		},
 	},
 	{
-			Name: "update trigger with subquery projections",
-			SetUpScript: []string{
-				"create table t (i int primary key, j int);",
-				"insert into t values (1, 2), (3, 4);",
-				`
+		Name: "update trigger with subquery projections",
+		SetUpScript: []string{
+			"create table t (i int primary key, j int);",
+			"insert into t values (1, 2), (3, 4);",
+			`
 create trigger trig1 before update on t
 for each row
   begin
@@ -3347,7 +3347,7 @@ for each row
     set @b = (select 20 * old.j + new.j);
   end;
 `,
-				`
+			`
 create trigger trig2 after update on t
 for each row
   begin
@@ -3355,40 +3355,40 @@ for each row
     set @d = (select 40 * old.j + new.j);
   end;
 `,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{nil, nil, nil, nil},
+				},
 			},
-			Assertions: []ScriptTestAssertion{
-				{
-					Query: "select @a, @b, @c, @d;",
-					Expected: []sql.Row{
-						{nil, nil, nil, nil},
-					},
+			{
+				Query: "update t set i = i * 10 where i = 1;",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
 				},
-				{
-					Query: "update t set i = i * 10 where i = 1;",
-					Expected: []sql.Row{
-						{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
-					},
+			},
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{20, 42, 40, 82},
 				},
-				{
-					Query: "select @a, @b, @c, @d;",
-					Expected: []sql.Row{
-						{20, 42, 40, 82},
-					},
+			},
+			{
+				Query: "update t set j = i * 10 where j = 4;",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
 				},
-				{
-					Query: "update t set j = i * 10 where j = 4;",
-					Expected: []sql.Row{
-						{types.OkResult{RowsAffected: 1, Info: plan.UpdateInfo{Matched: 1, Updated: 1}}},
-					},
-				},
-				{
-					Query: "select @a, @b, @c, @d;",
-					Expected: []sql.Row{
-						{33, 110, 93, 190},
-					},
+			},
+			{
+				Query: "select @a, @b, @c, @d;",
+				Expected: []sql.Row{
+					{33, 110, 93, 190},
 				},
 			},
 		},
+	},
 }
 
 var TriggerCreateInSubroutineTests = []ScriptTest{

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -93,6 +93,9 @@ func (b *Builder) buildCreateTrigger(inScope *scope, subQuery string, fullQuery 
 	triggerScope.addColumns(newScope.cols)
 	triggerScope.addColumns(oldScope.cols)
 
+	triggerScope.addExpressions(newScope.exprs)
+	triggerScope.addExpressions(oldScope.exprs)
+
 	bodyStr := strings.TrimSpace(fullQuery[c.SubStatementPositionStart:c.SubStatementPositionEnd])
 	bodyScope := b.buildSubquery(triggerScope, c.TriggerSpec.Body, bodyStr, fullQuery)
 	definer := getCurrentUserForDefiner(b.ctx, c.TriggerSpec.Definer)

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -73,12 +73,15 @@ func (b *Builder) analyzeSelectList(inScope, outScope *scope, selectExprs ast.Se
 		}
 		if subqueryFound {
 			outScope.refsSubquery = true
-
 		}
 
 		switch e := pe.(type) {
 		case *expression.GetField:
 			exprs = append(exprs, e)
+			tmp := e.String()
+			if tmp == "new.i" {
+				print()
+			}
 			id, ok := inScope.getExpr(e.String(), true)
 			if !ok {
 				err := sql.ErrColumnNotFound.New(e.String())

--- a/sql/planbuilder/project.go
+++ b/sql/planbuilder/project.go
@@ -78,10 +78,6 @@ func (b *Builder) analyzeSelectList(inScope, outScope *scope, selectExprs ast.Se
 		switch e := pe.(type) {
 		case *expression.GetField:
 			exprs = append(exprs, e)
-			tmp := e.String()
-			if tmp == "new.i" {
-				print()
-			}
 			id, ok := inScope.getExpr(e.String(), true)
 			if !ok {
 				err := sql.ErrColumnNotFound.New(e.String())

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -541,6 +541,15 @@ func (s *scope) addColumns(cols []scopeColumn) {
 	s.cols = append(s.cols, cols...)
 }
 
+func (s *scope) addExpressions(newExprs map[string]columnId) {
+	if s.exprs == nil {
+		s.exprs = make(map[string]columnId)
+	}
+	for k, v := range newExprs {
+		s.exprs[k] = v
+	}
+}
+
 // appendColumnsFromScope merges column definitions for
 // multi-relational expressions.
 func (s *scope) appendColumnsFromScope(src *scope) {

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -357,4 +357,3 @@ func (b *Builder) simplifySetExpr(name *ast.ColName, varScope ast.SetScope, val 
 	}
 	return nil, false
 }
-

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -357,3 +357,4 @@ func (b *Builder) simplifySetExpr(name *ast.ColName, varScope ast.SetScope, val 
 	}
 	return nil, false
 }
+


### PR DESCRIPTION
When creating the trigger scope, we copy over the columns and rewrite with the `new` and `old` scope, but we don't copy over their expressions as well. This PR fixes that.

fixes: https://github.com/dolthub/dolt/issues/8886