### PR TITLE
Allow SHOW CREATE to display auto increment for tables that store AutoIncrement but don't support writing it.

### DIFF
--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -531,9 +531,9 @@ func getForeignKeyTable(t sql.Table) (sql.ForeignKeyTable, error) {
 	}
 }
 
-func getAutoIncrementTable(t sql.Table) sql.AutoIncrementTable {
+func getAutoIncrementTable(t sql.Table) sql.AutoIncrementGetter {
 	switch t := t.(type) {
-	case sql.AutoIncrementTable:
+	case sql.AutoIncrementGetter:
 		return t
 	case sql.TableWrapper:
 		return getAutoIncrementTable(t.Underlying())

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -342,6 +342,13 @@ type AutoIncrementTable interface {
 	AutoIncrementSetter(*Context) AutoIncrementSetter
 }
 
+// AutoIncrementGetter provides support for reading a table's AUTO_INCREMENT value.
+// This can include tables that don't implement AutoIncrementTable if the table is a read-only snapshot
+// of an auto-incremented table.
+type AutoIncrementGetter interface {
+	PeekNextAutoIncrementValue(ctx *Context) (uint64, error)
+}
+
 // AutoIncrementSetter provides support for altering a table's
 // AUTO_INCREMENT sequence, eg 'ALTER TABLE t AUTO_INCREMENT = 10;'
 type AutoIncrementSetter interface {


### PR DESCRIPTION
This is the GMS side of an issue to properly display diffs when the autoincrement counter on a table changes.

We add a new interface, `AutoIncrementGetter` for tables that store AutoIncrement info, even if they can't generate autoincremented ids (because they're immutable snapshots of a table with an autoincrement column)