### PR TITLE
Fix alter table panics

### DIFF
--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -46,6 +46,19 @@ var AlterTableScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "issue 8917: exec error nested in block doesn't panic",
+		SetUpScript: []string{
+			"CREATE TABLE b(b int primary key)",
+			"CREATE TABLE a(a int primary key, b int, CONSTRAINT `fk` FOREIGN KEY (b) REFERENCES b (b))",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "alter table a add column c varchar(100), modify column b varchar(100)",
+				ExpectedErr: sql.ErrForeignKeyTypeChange,
+			},
+		},
+	},
+	{
 		Name: "variety of alter column statements in a single statement",
 		SetUpScript: []string{
 			"CREATE TABLE t32(pk BIGINT PRIMARY KEY, v1 int, v2 int, v3 int default (v1), toRename int)",

--- a/sql/rowexec/other.go
+++ b/sql/rowexec/other.go
@@ -160,6 +160,10 @@ func (b *BaseBuilder) buildBlock(ctx *sql.Context, n *plan.Block, row sql.Row) (
 		}
 
 		handleError := func(err error) error {
+			if n.Pref == nil {
+				// alter table blocks do not have a proc reference
+				return err
+			}
 			scope := n.Pref.InnermostScope
 			for i := len(scope.Handlers) - 1; i >= 0; i-- {
 				if !scope.Handlers[i].Cond.Matches(err) {


### PR DESCRIPTION
Multi-alters are executed with `Block` iterators. Block error handling always assumed the calling context was a stored procedure, which doesn't appear to be true in this case. Rather than create a new iterator, error handling noops to the default error if a proc reference is not found.

fixes: https://github.com/dolthub/dolt/issues/8917