### PR TITLE
allow before insert trigger to specify missing column, but better

### DIFF
--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -506,6 +506,91 @@ var TriggerTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "insert trigger with missing column default value",
+		SetUpScript: []string{
+			"CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);",
+			`
+CREATE TRIGGER trig BEFORE INSERT ON t 
+FOR EACH ROW
+BEGIN
+    SET new.j = 10;
+END;`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "INSERT INTO t (i) VALUES (1);",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "INSERT INTO t (i, j) VALUES (2, null);",
+				Expected: []sql.Row{
+					{types.OkResult{RowsAffected: 1}},
+				},
+			},
+			{
+				Query: "SELECT * FROM t;",
+				Expected: []sql.Row{
+					{1, 10},
+					{2, 10},
+				},
+			},
+		},
+	},
+	{
+		Name: "not null column with trigger that sets null should error",
+		SetUpScript: []string{
+			"CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);",
+			`
+CREATE TRIGGER trig BEFORE INSERT ON t 
+FOR EACH ROW
+BEGIN
+    SET new.j = null;
+END;`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "INSERT INTO t (i) VALUES (1);",
+				ExpectedErr: sql.ErrInsertIntoNonNullableDefaultNullColumn,
+			},
+			{
+				Query:       "INSERT INTO t (i, j) VALUES (1, 2);",
+				ExpectedErr: sql.ErrInsertIntoNonNullableProvidedNull,
+			},
+		},
+	},
+	{
+		Name: "not null column with before insert trigger should error",
+		SetUpScript: []string{
+			"CREATE TABLE t (i INT PRIMARY KEY, j INT NOT NULL);",
+			`
+CREATE TRIGGER trig BEFORE INSERT ON t 
+FOR EACH ROW
+BEGIN
+    SET new.i = 10 * new.i;
+END;`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "INSERT INTO t (i) VALUES (1);",
+				ExpectedErr: sql.ErrInsertIntoNonNullableDefaultNullColumn,
+			},
+			{
+				Query: "INSERT INTO t (i, j) VALUES (1, 2);",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "SELECT * FROM t;",
+				Expected: []sql.Row{
+					{10, 2},
+				},
+			},
+		},
+	},
 
 	// UPDATE triggers
 	{

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -574,7 +574,7 @@ END;`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "INSERT INTO t (i) VALUES (1);",
+				Query:       "INSERT INTO t (i) VALUES (1);",
 				ExpectedErr: sql.ErrInsertIntoNonNullableDefaultNullColumn,
 			},
 			{

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -94,8 +94,8 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 		}
 
 		return insert.WithSource(project).
-			WithAutoIncrementIdx(firstGeneratedAutoIncRowIdx).
-			WithMissingValFlags(missingValFlags),
+				WithAutoIncrementIdx(firstGeneratedAutoIncRowIdx).
+				WithMissingValFlags(missingValFlags),
 			transform.NewTree,
 			nil
 	})

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -142,7 +142,7 @@ func wrapRowSource(ctx *sql.Context, insertSource sql.Node, destTbl sql.Table, s
 				defaultExpr = col.Generated
 			}
 			if !col.Nullable && defaultExpr == nil && !col.AutoIncrement {
-				missingVals[colIdx] = true
+				missingVals[i] = true
 			}
 
 			var err error

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -73,8 +73,8 @@ type InsertInto struct {
 	// FirstGenerateAutoIncRowIdx is the index of the first row inserted that increments last_insert_id.
 	FirstGeneratedAutoIncRowIdx int
 
-	// MissingValFlags marks which columns in the destination schema are expected to have default values.
-	MissingValFlags []bool
+	// DeferredDefaults marks which columns in the destination schema are expected to have default values.
+	DeferredDefaults sql.FastIntSet
 }
 
 var _ sql.Databaser = (*InsertInto)(nil)
@@ -204,11 +204,11 @@ func (ii *InsertInto) WithAutoIncrementIdx(firstGeneratedAutoIncRowIdx int) *Ins
 	return &np
 }
 
-// WithMissingValFlags sets the flags for the insert destination columns, which mark which of the columns are expected
+// WithDeferredDefaults sets the flags for the insert destination columns, which mark which of the columns are expected
 // to be filled with the DEFAULT or GENERATED value.
-func (ii *InsertInto) WithMissingValFlags(missingValFlags []bool) *InsertInto {
+func (ii *InsertInto) WithDeferredDefaults(deferredDefaults sql.FastIntSet) *InsertInto {
 	np := *ii
-	np.MissingValFlags = missingValFlags
+	np.DeferredDefaults = deferredDefaults
 	return &np
 }
 

--- a/sql/plan/insert.go
+++ b/sql/plan/insert.go
@@ -72,6 +72,9 @@ type InsertInto struct {
 
 	// FirstGenerateAutoIncRowIdx is the index of the first row inserted that increments last_insert_id.
 	FirstGeneratedAutoIncRowIdx int
+
+	// MissingValFlags marks which columns in the destination schema are expected to have default values.
+	MissingValFlags []bool
 }
 
 var _ sql.Databaser = (*InsertInto)(nil)
@@ -198,6 +201,14 @@ func (ii *InsertInto) WithSource(src sql.Node) *InsertInto {
 func (ii *InsertInto) WithAutoIncrementIdx(firstGeneratedAutoIncRowIdx int) *InsertInto {
 	np := *ii
 	np.FirstGeneratedAutoIncRowIdx = firstGeneratedAutoIncRowIdx
+	return &np
+}
+
+// WithMissingValFlags sets the flags for the insert destination columns, which mark which of the columns are expected
+// to be filled with the DEFAULT or GENERATED value.
+func (ii *InsertInto) WithMissingValFlags(missingValFlags []bool) *InsertInto {
+	np := *ii
+	np.MissingValFlags = missingValFlags
 	return &np
 }
 

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -90,7 +90,7 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		ctx:                         ctx,
 		ignore:                      ii.Ignore,
 		firstGeneratedAutoIncRowIdx: ii.FirstGeneratedAutoIncRowIdx,
-		deferredDefaults:             ii.DeferredDefaults,
+		deferredDefaults:            ii.DeferredDefaults,
 	}
 
 	var ed sql.EditOpenerCloser

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -90,7 +90,7 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		ctx:                         ctx,
 		ignore:                      ii.Ignore,
 		firstGeneratedAutoIncRowIdx: ii.FirstGeneratedAutoIncRowIdx,
-		missingValFlags:             ii.MissingValFlags,
+		deferredDefaults:             ii.DeferredDefaults,
 	}
 
 	var ed sql.EditOpenerCloser

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -90,6 +90,7 @@ func (b *BaseBuilder) buildInsertInto(ctx *sql.Context, ii *plan.InsertInto, row
 		ctx:                         ctx,
 		ignore:                      ii.Ignore,
 		firstGeneratedAutoIncRowIdx: ii.FirstGeneratedAutoIncRowIdx,
+		missingValFlags:             ii.MissingValFlags,
 	}
 
 	var ed sql.EditOpenerCloser

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -46,7 +46,7 @@ type insertIter struct {
 
 	firstGeneratedAutoIncRowIdx int
 
-	missingValFlags []bool
+	deferredDefaults sql.FastIntSet
 }
 
 func getInsertExpressions(values sql.Node) []sql.Expression {
@@ -398,7 +398,7 @@ func (i *insertIter) validateNullability(ctx *sql.Context, dstSchema sql.Schema,
 		if !col.Nullable && row[count] == nil {
 			// In the case of an IGNORE we set the nil value to a default and add a warning
 			if !i.ignore {
-				if i.missingValFlags[count] {
+				if i.deferredDefaults.Contains(count) {
 					return sql.ErrInsertIntoNonNullableDefaultNullColumn.New(col.Name)
 				}
 				return sql.ErrInsertIntoNonNullableProvidedNull.New(col.Name)

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -46,7 +46,7 @@ type insertIter struct {
 
 	firstGeneratedAutoIncRowIdx int
 
-	missingFlagVal []bool
+	missingValFlags []bool
 }
 
 func getInsertExpressions(values sql.Node) []sql.Expression {
@@ -398,7 +398,7 @@ func (i *insertIter) validateNullability(ctx *sql.Context, dstSchema sql.Schema,
 		if !col.Nullable && row[count] == nil {
 			// In the case of an IGNORE we set the nil value to a default and add a warning
 			if !i.ignore {
-				if i.missingFlagVal[count] {
+				if i.missingValFlags[count] {
 					return sql.ErrInsertIntoNonNullableDefaultNullColumn.New(col.Name)
 				}
 				return sql.ErrInsertIntoNonNullableProvidedNull.New(col.Name)


### PR DESCRIPTION
It is possible that a `BEFORE INSERT TRIGGER` fills in the values for a column when it is otherwise missing. This should not trigger a missing default value error.

Fixes: https://github.com/dolthub/dolt/issues/8926
This PR is an improvement on: https://github.com/dolthub/go-mysql-server/pull/2876