### PR TITLE
[planbuilder] sort expression aliases always referenced

### DIFF
--- a/enginetest/queries/imdb_plans.go
+++ b/enginetest/queries/imdb_plans.go
@@ -43,7 +43,7 @@ WHERE ci.note LIKE '%(voice)%'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as uncredited_voiced_character, min(t.title):1!null as russian_movie]\n" +
+			" ├─ columns: [min(chn.name):0!null->uncredited_voiced_character:0, min(t.title):1!null->russian_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:16!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -258,7 +258,7 @@ WHERE ci.note LIKE '%(voice)%'
 			"",
 
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as character, min(t.title):1!null as russian_mov_with_actor_producer]\n" +
+			" ├─ columns: [min(chn.name):0!null->character:0, min(t.title):1!null->russian_mov_with_actor_producer:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:16!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -470,7 +470,7 @@ WHERE ci.note LIKE '%(voice)%'
 			"",
 
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as character, min(t.title):1!null as movie_with_american_producer]\n" +
+			" ├─ columns: [min(chn.name):0!null->character:0, min(t.title):1!null->movie_with_american_producer:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:15!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -685,7 +685,7 @@ WHERE cn.country_code !='[pl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as from_company, min(lt.link):1!null as movie_link_type, min(t.title):2!null as non_polish_sequel_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->from_company:0, min(lt.link):1!null->movie_link_type:0, min(t.title):2!null->non_polish_sequel_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:18!null), MIN(lt.link:12!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -960,7 +960,7 @@ WHERE cn.country_code !='[pl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as from_company, min(lt.link):1!null as movie_link_type, min(t.title):2!null as sequel_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->from_company:0, min(lt.link):1!null->movie_link_type:0, min(t.title):2!null->sequel_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:18!null), MIN(lt.link:12!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -1234,7 +1234,7 @@ WHERE cn.country_code !='[pl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as from_company, min(mc.note):1!null as production_note, min(t.title):2!null as movie_based_on_book]\n" +
+			" ├─ columns: [min(cn.name):0!null->from_company:0, min(mc.note):1!null->production_note:0, min(t.title):2!null->movie_based_on_book:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:17!null), MIN(mc.note:10), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -1515,7 +1515,7 @@ WHERE cn.country_code !='[pl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as from_company, min(mc.note):1!null as production_note, min(t.title):2!null as movie_based_on_book]\n" +
+			" ├─ columns: [min(cn.name):0!null->from_company:0, min(mc.note):1!null->production_note:0, min(t.title):2!null->movie_based_on_book:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:17!null), MIN(mc.note:10), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -1780,7 +1780,7 @@ WHERE cn.country_code = '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as drama_horror_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->drama_horror_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:19!null), MIN(mi_idx.info:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -2062,7 +2062,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as budget, min(t.title):1!null as unsuccsessful_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->budget:0, min(t.title):1!null->unsuccsessful_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -2343,7 +2343,7 @@ WHERE cn.country_code = '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as mainstream_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->mainstream_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:19!null), MIN(mi_idx.info:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -2624,7 +2624,7 @@ WHERE cn.country_code ='[de]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as release_date, min(miidx.info):1!null as rating, min(t.title):2!null as german_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->release_date:0, min(miidx.info):1!null->rating:0, min(t.title):2!null->german_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:8!null), MIN(miidx.info:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -2908,7 +2908,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as producing_company, min(miidx.info):1!null as rating, min(t.title):2!null as movie_about_winning]\n" +
+			" ├─ columns: [min(cn.name):0!null->producing_company:0, min(miidx.info):1!null->rating:0, min(t.title):2!null->movie_about_winning:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(miidx.info:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -3205,7 +3205,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as producing_company, min(miidx.info):1!null as rating, min(t.title):2!null as movie_about_winning]\n" +
+			" ├─ columns: [min(cn.name):0!null->producing_company:0, min(miidx.info):1!null->rating:0, min(t.title):2!null->movie_about_winning:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(miidx.info:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -3511,7 +3511,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as producing_company, min(miidx.info):1!null as rating, min(t.title):2!null as movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->producing_company:0, min(miidx.info):1!null->rating:0, min(t.title):2!null->movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(miidx.info:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -3803,7 +3803,7 @@ WHERE it1.info = 'countries'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi_idx.info):0!null as rating, min(t.title):1!null as northern_dark_movie]\n" +
+			" ├─ columns: [min(mi_idx.info):0!null->rating:0, min(t.title):1!null->northern_dark_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -4092,7 +4092,7 @@ WHERE it1.info = 'countries'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi_idx.info):0!null as rating, min(t.title):1!null as western_dark_production]\n" +
+			" ├─ columns: [min(mi_idx.info):0!null->rating:0, min(t.title):1!null->western_dark_production:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -4388,7 +4388,7 @@ WHERE it1.info = 'countries'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi_idx.info):0!null as rating, min(t.title):1!null as north_european_dark_production]\n" +
+			" ├─ columns: [min(mi_idx.info):0!null->rating:0, min(t.title):1!null->north_european_dark_production:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -4672,7 +4672,7 @@ WHERE cn.country_code = '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as release_date, min(t.title):1!null as internet_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->release_date:0, min(t.title):1!null->internet_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -4969,7 +4969,7 @@ WHERE cn.country_code = '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as release_date, min(t.title):1!null as youtube_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->release_date:0, min(t.title):1!null->youtube_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -5273,7 +5273,7 @@ WHERE cn.country_code = '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as release_date, min(t.title):1!null as modern_american_internet_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->release_date:0, min(t.title):1!null->modern_american_internet_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -5563,7 +5563,7 @@ WHERE cn.country_code = '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(at.title):0!null as aka_title, min(t.title):1!null as internet_movie_title]\n" +
+			" ├─ columns: [min(at.title):0!null->aka_title:0, min(t.title):1!null->internet_movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(at.title:18!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -5842,7 +5842,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as cool_actor_pseudonym, min(t.title):1!null as series_named_after_char]\n" +
+			" ├─ columns: [min(an.name):0!null->cool_actor_pseudonym:0, min(t.title):1!null->series_named_after_char:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:15!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -6091,7 +6091,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as cool_actor_pseudonym, min(t.title):1!null as series_named_after_char]\n" +
+			" ├─ columns: [min(an.name):0!null->cool_actor_pseudonym:0, min(t.title):1!null->series_named_after_char:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -6329,7 +6329,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as cool_actor_pseudonym, min(t.title):1!null as series_named_after_char]\n" +
+			" ├─ columns: [min(an.name):0!null->cool_actor_pseudonym:0, min(t.title):1!null->series_named_after_char:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:15!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -6576,7 +6576,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as cool_actor_pseudonym, min(t.title):1!null as series_named_after_char]\n" +
+			" ├─ columns: [min(an.name):0!null->cool_actor_pseudonym:0, min(t.title):1!null->series_named_after_char:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:15!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -6823,7 +6823,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as member_in_charnamed_american_movie, min(n.name):0!null as a1]\n" +
+			" ├─ columns: [min(n.name):0!null->member_in_charnamed_american_movie:0, min(n.name):0!null->a1:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:2!null)\n" +
 			"     ├─ group: \n" +
@@ -7043,7 +7043,7 @@ WHERE k.keyword ='character-name-in-title'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as member_in_charnamed_movie, min(n.name):0!null as a1]\n" +
+			" ├─ columns: [min(n.name):0!null->member_in_charnamed_movie:0, min(n.name):0!null->a1:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:2!null)\n" +
 			"     ├─ group: \n" +
@@ -7255,7 +7255,7 @@ WHERE k.keyword ='character-name-in-title'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as member_in_charnamed_movie, min(n.name):0!null as a1]\n" +
+			" ├─ columns: [min(n.name):0!null->member_in_charnamed_movie:0, min(n.name):0!null->a1:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:2!null)\n" +
 			"     ├─ group: \n" +
@@ -7466,7 +7466,7 @@ WHERE k.keyword ='character-name-in-title'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as member_in_charnamed_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->member_in_charnamed_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:2!null)\n" +
 			"     ├─ group: \n" +
@@ -7671,7 +7671,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as member_in_charnamed_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->member_in_charnamed_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:2!null)\n" +
 			"     ├─ group: \n" +
@@ -7878,7 +7878,7 @@ WHERE k.keyword ='character-name-in-title'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as member_in_charnamed_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->member_in_charnamed_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:2!null)\n" +
 			"     ├─ group: \n" +
@@ -8089,7 +8089,7 @@ WHERE ci.note IN ('(producer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(t.title):2!null as movie_title]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(t.title):2!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:10!null), MIN(mi_idx.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -8329,7 +8329,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(t.title):2!null as movie_title]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(t.title):2!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:10!null), MIN(mi_idx.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -8600,7 +8600,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(t.title):2!null as movie_title]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(t.title):2!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:9!null), MIN(mi_idx.info:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -8854,7 +8854,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as voicing_actress, min(t.title):1!null as voiced_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->voicing_actress:0, min(t.title):1!null->voiced_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -9209,7 +9209,7 @@ WHERE ci.note = '(voice)'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as voicing_actress, min(t.title):1!null as kung_fu_panda]\n" +
+			" ├─ columns: [min(n.name):0!null->voicing_actress:0, min(t.title):1!null->kung_fu_panda:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -9564,7 +9564,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as voicing_actress, min(t.title):1!null as jap_engl_voiced_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->voicing_actress:0, min(t.title):1!null->jap_engl_voiced_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -9899,7 +9899,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as voicing_actress, min(t.title):1!null as jap_engl_voiced_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->voicing_actress:0, min(t.title):1!null->jap_engl_voiced_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -10205,7 +10205,7 @@ WHERE ct.kind = 'production companies'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mc.note):0!null as production_note, min(t.title):2!null as movie_title, min(t.production_year):1!null as movie_year]\n" +
+			" ├─ columns: [min(mc.note):0!null->production_note:0, min(t.title):2!null->movie_title:0, min(t.production_year):1!null->movie_year:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mc.note:7), MIN(t.production_year:2), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -10372,7 +10372,7 @@ WHERE ct.kind = 'production companies'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mc.note):0!null as production_note, min(t.title):2!null as movie_title, min(t.production_year):1!null as movie_year]\n" +
+			" ├─ columns: [min(mc.note):0!null->production_note:0, min(t.title):2!null->movie_title:0, min(t.production_year):1!null->movie_year:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mc.note:7), MIN(t.production_year:2), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -10548,7 +10548,7 @@ WHERE ct.kind = 'production companies'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mc.note):0!null as production_note, min(t.title):2!null as movie_title, min(t.production_year):1!null as movie_year]\n" +
+			" ├─ columns: [min(mc.note):0!null->production_note:0, min(t.title):2!null->movie_title:0, min(t.production_year):1!null->movie_year:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mc.note:7), MIN(t.production_year:2), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -10721,7 +10721,7 @@ WHERE ct.kind = 'production companies'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mc.note):0!null as production_note, min(t.title):2!null as movie_title, min(t.production_year):1!null as movie_year]\n" +
+			" ├─ columns: [min(mc.note):0!null->production_note:0, min(t.title):2!null->movie_title:0, min(t.production_year):1!null->movie_year:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mc.note:7), MIN(t.production_year:2), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -10913,7 +10913,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as complete_downey_ironman_movie]\n" +
+			" ├─ columns: [min(t.title):0!null->complete_downey_ironman_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -11236,7 +11236,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as complete_downey_ironman_movie]\n" +
+			" ├─ columns: [min(t.title):0!null->complete_downey_ironman_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -11567,7 +11567,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as cast_member, min(t.title):1!null as complete_dynamic_hero_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->cast_member:0, min(t.title):1!null->complete_dynamic_hero_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -11893,7 +11893,7 @@ WHERE cn.country_code !='[pl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as company_name, min(lt.link):1!null as link_type, min(t.title):2!null as western_follow_up]\n" +
+			" ├─ columns: [min(cn.name):0!null->company_name:0, min(lt.link):1!null->link_type:0, min(t.title):2!null->western_follow_up:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(lt.link:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -12215,7 +12215,7 @@ WHERE cn.country_code !='[pl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as company_name, min(lt.link):1!null as link_type, min(t.title):2!null as german_follow_up]\n" +
+			" ├─ columns: [min(cn.name):0!null->company_name:0, min(lt.link):1!null->link_type:0, min(t.title):2!null->german_follow_up:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(lt.link:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -12544,7 +12544,7 @@ WHERE cn.country_code !='[pl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as company_name, min(lt.link):1!null as link_type, min(t.title):2!null as western_follow_up]\n" +
+			" ├─ columns: [min(cn.name):0!null->company_name:0, min(lt.link):1!null->link_type:0, min(t.title):2!null->western_follow_up:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(lt.link:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -12877,7 +12877,7 @@ WHERE cn.country_code != '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as western_violent_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->western_violent_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:26!null), MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -13264,7 +13264,7 @@ WHERE cn.country_code != '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as western_violent_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->western_violent_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:26!null), MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -13657,7 +13657,7 @@ WHERE cn.country_code != '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as western_violent_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->western_violent_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:26!null), MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -14048,7 +14048,7 @@ WHERE cn.country_code != '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as western_violent_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->western_violent_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:25!null), MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -14417,7 +14417,7 @@ WHERE cct1.kind = 'complete+verified'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(kt.kind):0!null as movie_kind, min(t.title):1!null as complete_us_internet_movie]\n" +
+			" ├─ columns: [min(kt.kind):0!null->movie_kind:0, min(t.title):1!null->complete_us_internet_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(kt.kind:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -14775,7 +14775,7 @@ WHERE cct1.kind = 'complete+verified'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(kt.kind):0!null as movie_kind, min(t.title):1!null as complete_nerdy_internet_movie]\n" +
+			" ├─ columns: [min(kt.kind):0!null->movie_kind:0, min(t.title):1!null->complete_nerdy_internet_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(kt.kind:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -15137,7 +15137,7 @@ WHERE cct1.kind = 'complete+verified'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(kt.kind):0!null as movie_kind, min(t.title):1!null as complete_us_internet_movie]\n" +
+			" ├─ columns: [min(kt.kind):0!null->movie_kind:0, min(t.title):1!null->complete_us_internet_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(kt.kind:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -15504,7 +15504,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as voiced_char_name, min(n.name):1!null as voicing_actress_name, min(t.title):2!null as voiced_action_movie_jap_eng]\n" +
+			" ├─ columns: [min(chn.name):0!null->voiced_char_name:0, min(n.name):1!null->voicing_actress_name:0, min(t.title):2!null->voiced_action_movie_jap_eng:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:27!null), MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -15918,7 +15918,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as voiced_char_name, min(n.name):1!null as voicing_actress_name, min(t.title):2!null as kung_fu_panda]\n" +
+			" ├─ columns: [min(chn.name):0!null->voiced_char_name:0, min(n.name):1!null->voicing_actress_name:0, min(t.title):2!null->kung_fu_panda:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:28!null), MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -16333,7 +16333,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as male_writer, min(t.title):3!null as violent_movie_title]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->male_writer:0, min(t.title):3!null->violent_movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:12!null), MIN(mi_idx.info:9!null), MIN(n.name:3!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -16650,7 +16650,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as male_writer, min(t.title):3!null as violent_movie_title]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->male_writer:0, min(t.title):3!null->violent_movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:13!null), MIN(mi_idx.info:10!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -16988,7 +16988,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as male_writer, min(t.title):3!null as violent_movie_title]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->male_writer:0, min(t.title):3!null->violent_movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:12!null), MIN(mi_idx.info:9!null), MIN(n.name:3!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -17314,7 +17314,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as character_name, min(mi_idx.info):1!null as rating, min(n.name):2!null as playing_actor, min(t.title):3!null as complete_hero_movie]\n" +
+			" ├─ columns: [min(chn.name):0!null->character_name:0, min(mi_idx.info):1!null->rating:0, min(n.name):2!null->playing_actor:0, min(t.title):3!null->complete_hero_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:21!null), MIN(mi_idx.info:10!null), MIN(n.name:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -17712,7 +17712,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as character_name, min(mi_idx.info):1!null as rating, min(t.title):2!null as complete_hero_movie]\n" +
+			" ├─ columns: [min(chn.name):0!null->character_name:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->complete_hero_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:20!null), MIN(mi_idx.info:9!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -18115,7 +18115,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as character_name, min(mi_idx.info):1!null as rating, min(t.title):2!null as complete_hero_movie]\n" +
+			" ├─ columns: [min(chn.name):0!null->character_name:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->complete_hero_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:20!null), MIN(mi_idx.info:9!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -18511,7 +18511,7 @@ WHERE cct1.kind IN ('cast',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as producing_company, min(lt.link):1!null as link_type, min(t.title):2!null as complete_western_sequel]\n" +
+			" ├─ columns: [min(cn.name):0!null->producing_company:0, min(lt.link):1!null->link_type:0, min(t.title):2!null->complete_western_sequel:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(lt.link:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -18943,7 +18943,7 @@ WHERE cct1.kind IN ('cast',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as producing_company, min(lt.link):1!null as link_type, min(t.title):2!null as complete_western_sequel]\n" +
+			" ├─ columns: [min(cn.name):0!null->producing_company:0, min(lt.link):1!null->link_type:0, min(t.title):2!null->complete_western_sequel:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(lt.link:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -19375,7 +19375,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as producing_company, min(lt.link):1!null as link_type, min(t.title):2!null as complete_western_sequel]\n" +
+			" ├─ columns: [min(cn.name):0!null->producing_company:0, min(lt.link):1!null->link_type:0, min(t.title):2!null->complete_western_sequel:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:20!null), MIN(lt.link:14!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -19825,7 +19825,7 @@ WHERE cct1.kind = 'crew'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as complete_euro_dark_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->complete_euro_dark_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:26!null), MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -20320,7 +20320,7 @@ WHERE cct1.kind = 'crew'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as complete_euro_dark_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->complete_euro_dark_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:26!null), MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -20821,7 +20821,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn.name):0!null as movie_company, min(mi_idx.info):1!null as rating, min(t.title):2!null as complete_euro_dark_movie]\n" +
+			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->complete_euro_dark_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn.name:26!null), MIN(mi_idx.info:8!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -21322,7 +21322,7 @@ WHERE cct1.kind ='cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as voiced_char, min(n.name):1!null as voicing_actress, min(t.title):2!null as voiced_animation]\n" +
+			" ├─ columns: [min(chn.name):0!null->voiced_char:0, min(n.name):1!null->voicing_actress:0, min(t.title):2!null->voiced_animation:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:9!null), MIN(n.name:31!null), MIN(t.title:38!null)\n" +
 			"     ├─ group: \n" +
@@ -21911,7 +21911,7 @@ WHERE cct1.kind ='cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as voiced_char, min(n.name):1!null as voicing_actress, min(t.title):2!null as voiced_animation]\n" +
+			" ├─ columns: [min(chn.name):0!null->voiced_char:0, min(n.name):1!null->voicing_actress:0, min(t.title):2!null->voiced_animation:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:9!null), MIN(n.name:31!null), MIN(t.title:38!null)\n" +
 			"     ├─ group: \n" +
@@ -22496,7 +22496,7 @@ WHERE cct1.kind ='cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(chn.name):0!null as voiced_char, min(n.name):1!null as voicing_actress, min(t.title):2!null as voiced_animation]\n" +
+			" ├─ columns: [min(chn.name):0!null->voiced_char:0, min(n.name):1!null->voicing_actress:0, min(t.title):2!null->voiced_animation:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(chn.name:9!null), MIN(n.name:31!null), MIN(t.title:38!null)\n" +
 			"     ├─ group: \n" +
@@ -23022,7 +23022,7 @@ WHERE cn.country_code ='[de]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as movie_title]\n" +
+			" ├─ columns: [min(t.title):0!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -23174,7 +23174,7 @@ WHERE cn.country_code ='[nl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as movie_title]\n" +
+			" ├─ columns: [min(t.title):0!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -23326,7 +23326,7 @@ WHERE cn.country_code ='[sm]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as movie_title]\n" +
+			" ├─ columns: [min(t.title):0!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -23478,7 +23478,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as movie_title]\n" +
+			" ├─ columns: [min(t.title):0!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -23675,7 +23675,7 @@ WHERE cct1.kind IN ('cast',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as writer, min(t.title):3!null as complete_violent_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->writer:0, min(t.title):3!null->complete_violent_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:13!null), MIN(mi_idx.info:10!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -24114,7 +24114,7 @@ WHERE cct1.kind IN ('cast',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as writer, min(t.title):3!null as complete_gore_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->writer:0, min(t.title):3!null->complete_gore_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:13!null), MIN(mi_idx.info:10!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -24564,7 +24564,7 @@ WHERE cct1.kind = 'cast'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as writer, min(t.title):3!null as complete_violent_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->writer:0, min(t.title):3!null->complete_violent_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:12!null), MIN(mi_idx.info:9!null), MIN(n.name:3!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -24987,7 +24987,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as writer, min(t.title):3!null as violent_liongate_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->writer:0, min(t.title):3!null->violent_liongate_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:12!null), MIN(mi_idx.info:9!null), MIN(n.name:3!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -25388,7 +25388,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as writer, min(t.title):3!null as violent_liongate_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->writer:0, min(t.title):3!null->violent_liongate_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:13!null), MIN(mi_idx.info:10!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -25813,7 +25813,7 @@ WHERE ci.note IN ('(writer)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi.info):0!null as movie_budget, min(mi_idx.info):1!null as movie_votes, min(n.name):2!null as writer, min(t.title):3!null as violent_liongate_movie]\n" +
+			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->writer:0, min(t.title):3!null->violent_liongate_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi.info:11!null), MIN(mi_idx.info:8!null), MIN(n.name:3!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -26164,7 +26164,7 @@ WHERE k.keyword ='10,000-mile-club'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(lt.link):0!null as link_type, min(t1.title):1!null as first_movie, min(t2.title):2!null as second_movie]\n" +
+			" ├─ columns: [min(lt.link):0!null->link_type:0, min(t1.title):1!null->first_movie:0, min(t2.title):2!null->second_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(lt.link:10!null), MIN(t1.title:3!null), MIN(t2.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -26337,7 +26337,7 @@ WHERE k.keyword ='character-name-in-title'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(lt.link):0!null as link_type, min(t1.title):1!null as first_movie, min(t2.title):2!null as second_movie]\n" +
+			" ├─ columns: [min(lt.link):0!null->link_type:0, min(t1.title):1!null->first_movie:0, min(t2.title):2!null->second_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(lt.link:10!null), MIN(t1.title:3!null), MIN(t2.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -26543,7 +26543,7 @@ WHERE cn1.country_code = '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn1.name):0!null as first_company, min(cn2.name):1!null as second_company, min(mi_idx1.info):2!null as first_rating, min(mi_idx2.info):3!null as second_rating, min(t1.title):4!null as first_movie, min(t2.title):5!null as second_movie]\n" +
+			" ├─ columns: [min(cn1.name):0!null->first_company:0, min(cn2.name):1!null->second_company:0, min(mi_idx1.info):2!null->first_rating:0, min(mi_idx2.info):3!null->second_rating:0, min(t1.title):4!null->first_movie:0, min(t2.title):5!null->second_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn1.name:33!null), MIN(cn2.name:31!null), MIN(mi_idx1.info:15!null), MIN(mi_idx2.info:12!null), MIN(t1.title:5!null), MIN(t2.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -26991,7 +26991,7 @@ WHERE cn1.country_code = '[nl]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn1.name):0!null as first_company, min(cn2.name):1!null as second_company, min(mi_idx1.info):2!null as first_rating, min(mi_idx2.info):3!null as second_rating, min(t1.title):4!null as first_movie, min(t2.title):5!null as second_movie]\n" +
+			" ├─ columns: [min(cn1.name):0!null->first_company:0, min(cn2.name):1!null->second_company:0, min(mi_idx1.info):2!null->first_rating:0, min(mi_idx2.info):3!null->second_rating:0, min(t1.title):4!null->first_movie:0, min(t2.title):5!null->second_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn1.name:33!null), MIN(cn2.name:31!null), MIN(mi_idx1.info:15!null), MIN(mi_idx2.info:12!null), MIN(t1.title:5!null), MIN(t2.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -27437,7 +27437,7 @@ WHERE cn1.country_code != '[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(cn1.name):0!null as first_company, min(cn2.name):1!null as second_company, min(mi_idx1.info):2!null as first_rating, min(mi_idx2.info):3!null as second_rating, min(t1.title):4!null as first_movie, min(t2.title):5!null as second_movie]\n" +
+			" ├─ columns: [min(cn1.name):0!null->first_company:0, min(cn2.name):1!null->second_company:0, min(mi_idx1.info):2!null->first_rating:0, min(mi_idx2.info):3!null->second_rating:0, min(t1.title):4!null->first_movie:0, min(t2.title):5!null->second_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(cn1.name:33!null), MIN(cn2.name:31!null), MIN(mi_idx1.info:15!null), MIN(mi_idx2.info:12!null), MIN(t1.title:5!null), MIN(t2.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -27858,7 +27858,7 @@ WHERE k.keyword LIKE '%sequel%'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as movie_title]\n" +
+			" ├─ columns: [min(t.title):0!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -27994,7 +27994,7 @@ WHERE k.keyword LIKE '%sequel%'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as movie_title]\n" +
+			" ├─ columns: [min(t.title):0!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -28139,7 +28139,7 @@ WHERE k.keyword LIKE '%sequel%'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as movie_title]\n" +
+			" ├─ columns: [min(t.title):0!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -28279,7 +28279,7 @@ WHERE it.info ='rating'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi_idx.info):0!null as rating, min(t.title):1!null as movie_title]\n" +
+			" ├─ columns: [min(mi_idx.info):0!null->rating:0, min(t.title):1!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi_idx.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -28448,7 +28448,7 @@ WHERE it.info ='rating'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi_idx.info):0!null as rating, min(t.title):1!null as movie_title]\n" +
+			" ├─ columns: [min(mi_idx.info):0!null->rating:0, min(t.title):1!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi_idx.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -28617,7 +28617,7 @@ WHERE it.info ='rating'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(mi_idx.info):0!null as rating, min(t.title):1!null as movie_title]\n" +
+			" ├─ columns: [min(mi_idx.info):0!null->rating:0, min(t.title):1!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(mi_idx.info:7!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -28793,7 +28793,7 @@ WHERE ct.kind = 'production companies'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as typical_european_movie]\n" +
+			" ├─ columns: [min(t.title):0!null->typical_european_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -28966,7 +28966,7 @@ WHERE ct.kind = 'production companies'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as american_vhs_movie]\n" +
+			" ├─ columns: [min(t.title):0!null->american_vhs_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -29148,7 +29148,7 @@ WHERE ct.kind = 'production companies'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(t.title):0!null as american_movie]\n" +
+			" ├─ columns: [min(t.title):0!null->american_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -29320,7 +29320,7 @@ WHERE k.keyword = 'marvel-cinematic-universe'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(k.keyword):0!null as movie_keyword, min(n.name):1!null as actor_name, min(t.title):2!null as marvel_movie]\n" +
+			" ├─ columns: [min(k.keyword):0!null->movie_keyword:0, min(n.name):1!null->actor_name:0, min(t.title):2!null->marvel_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(k.keyword:8!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -29488,7 +29488,7 @@ WHERE k.keyword IN ('superhero',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(k.keyword):0!null as movie_keyword, min(n.name):1!null as actor_name, min(t.title):2!null as hero_movie]\n" +
+			" ├─ columns: [min(k.keyword):0!null->movie_keyword:0, min(n.name):1!null->actor_name:0, min(t.title):2!null->hero_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(k.keyword:8!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -29649,7 +29649,7 @@ WHERE k.keyword = 'marvel-cinematic-universe'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(k.keyword):0!null as movie_keyword, min(n.name):1!null as actor_name, min(t.title):2!null as marvel_movie]\n" +
+			" ├─ columns: [min(k.keyword):0!null->movie_keyword:0, min(n.name):1!null->actor_name:0, min(t.title):2!null->marvel_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(k.keyword:8!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -29817,7 +29817,7 @@ WHERE k.keyword IN ('superhero',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(k.keyword):0!null as movie_keyword, min(n.name):1!null as actor_name, min(t.title):2!null as hero_movie]\n" +
+			" ├─ columns: [min(k.keyword):0!null->movie_keyword:0, min(n.name):1!null->actor_name:0, min(t.title):2!null->hero_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(k.keyword:8!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -29978,7 +29978,7 @@ WHERE k.keyword = 'marvel-cinematic-universe'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(k.keyword):0!null as movie_keyword, min(n.name):1!null as actor_name, min(t.title):2!null as marvel_movie]\n" +
+			" ├─ columns: [min(k.keyword):0!null->movie_keyword:0, min(n.name):1!null->actor_name:0, min(t.title):2!null->marvel_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(k.keyword:8!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -30145,7 +30145,7 @@ WHERE k.keyword IN ('superhero',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(k.keyword):0!null as movie_keyword, min(n.name):1!null as actor_name, min(t.title):2!null as hero_movie]\n" +
+			" ├─ columns: [min(k.keyword):0!null->movie_keyword:0, min(n.name):1!null->actor_name:0, min(t.title):2!null->hero_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(k.keyword:8!null), MIN(n.name:4!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -30314,7 +30314,7 @@ WHERE an.name LIKE '%a%'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as of_person, min(t.title):1!null as biography_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->of_person:0, min(t.title):1!null->biography_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -30605,7 +30605,7 @@ WHERE an.name LIKE '%a%'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as of_person, min(t.title):1!null as biography_movie]\n" +
+			" ├─ columns: [min(n.name):0!null->of_person:0, min(t.title):1!null->biography_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -30891,7 +30891,7 @@ WHERE an.name IS NOT NULL
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(n.name):0!null as cast_member_name, min(pi.info):1!null as cast_member_info]\n" +
+			" ├─ columns: [min(n.name):0!null->cast_member_name:0, min(pi.info):1!null->cast_member_info:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(n.name:7!null), MIN(pi.info:4!null)\n" +
 			"     ├─ group: \n" +
@@ -31193,7 +31193,7 @@ WHERE ci.note ='(voice: English version)'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an1.name):0!null as actress_pseudonym, min(t.title):1!null as japanese_movie_dubbed]\n" +
+			" ├─ columns: [min(an1.name):0!null->actress_pseudonym:0, min(t.title):1!null->japanese_movie_dubbed:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an1.name:16!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -31434,7 +31434,7 @@ WHERE ci.note ='(voice: English version)'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as acress_pseudonym, min(t.title):1!null as japanese_anime_movie]\n" +
+			" ├─ columns: [min(an.name):0!null->acress_pseudonym:0, min(t.title):1!null->japanese_anime_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:17!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -31697,7 +31697,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(a1.name):0!null as writer_pseudo_name, min(t.title):1!null as movie_title]\n" +
+			" ├─ columns: [min(a1.name):0!null->writer_pseudo_name:0, min(t.title):1!null->movie_title:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(a1.name:13!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -31902,7 +31902,7 @@ WHERE cn.country_code ='[us]'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an1.name):0!null as costume_designer_pseudo, min(t.title):1!null as movie_with_costumes]\n" +
+			" ├─ columns: [min(an1.name):0!null->costume_designer_pseudo:0, min(t.title):1!null->movie_with_costumes:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an1.name:13!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -32120,7 +32120,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as alternative_name, min(chn.name):1!null as character_name, min(t.title):2!null as movie]\n" +
+			" ├─ columns: [min(an.name):0!null->alternative_name:0, min(chn.name):1!null->character_name:0, min(t.title):2!null->movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:21!null), MIN(chn.name:19!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -32398,7 +32398,7 @@ WHERE ci.note = '(voice)'
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as alternative_name, min(chn.name):1!null as voiced_character, min(n.name):2!null as voicing_actress, min(t.title):3!null as american_movie]\n" +
+			" ├─ columns: [min(an.name):0!null->alternative_name:0, min(chn.name):1!null->voiced_character:0, min(n.name):2!null->voicing_actress:0, min(t.title):3!null->american_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:21!null), MIN(chn.name:19!null), MIN(n.name:6!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -32674,7 +32674,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as alternative_name, min(chn.name):1!null as voiced_character_name, min(n.name):2!null as voicing_actress, min(t.title):3!null as american_movie]\n" +
+			" ├─ columns: [min(an.name):0!null->alternative_name:0, min(chn.name):1!null->voiced_character_name:0, min(n.name):2!null->voicing_actress:0, min(t.title):3!null->american_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:19!null), MIN(chn.name:17!null), MIN(n.name:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +
@@ -32927,7 +32927,7 @@ WHERE ci.note IN ('(voice)',
 
 `,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(an.name):0!null as alternative_name, min(chn.name):1!null as voiced_char_name, min(n.name):2!null as voicing_actress, min(t.title):3!null as american_movie]\n" +
+			" ├─ columns: [min(an.name):0!null->alternative_name:0, min(chn.name):1!null->voiced_char_name:0, min(n.name):2!null->voicing_actress:0, min(t.title):3!null->american_movie:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(an.name:19!null), MIN(chn.name:17!null), MIN(n.name:5!null), MIN(t.title:1!null)\n" +
 			"     ├─ group: \n" +

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -16341,7 +16341,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `select pk+1 from comp_vector_index_t0 order by vec_distance('[50,50]', v2) limit 5`,
 		ExpectedPlan: "Limit(5)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [(comp_vector_index_t0.pk:0!null + 1 (tinyint)) as pk+1]\n" +
+			"     ├─ columns: [(comp_vector_index_t0.pk:0!null + 1 (tinyint))->pk+1:0]\n" +
 			"     └─ IndexedTableAccess(comp_vector_index_t0)\n" +
 			"         ├─ index: [comp_vector_index_t0.v2]\n" +
 			"         ├─ order: VEC_DISTANCE_L2_SQUARED('[50,50]', comp_vector_index_t0.v2) LIMIT 5 (bigint)\n" +
@@ -16372,7 +16372,7 @@ var IndexPlanTests = []QueryPlanTest{
 		Query: `select v1+1 from comp_vector_index_t0 order by vec_distance(v2, '[50,50]') limit 5`,
 		ExpectedPlan: "Limit(5)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [(comp_vector_index_t0.v1:0 + 1 (tinyint)) as v1+1]\n" +
+			"     ├─ columns: [(comp_vector_index_t0.v1:0 + 1 (tinyint))->v1+1:0]\n" +
 			"     └─ IndexedTableAccess(comp_vector_index_t0)\n" +
 			"         ├─ index: [comp_vector_index_t0.v2]\n" +
 			"         ├─ order: VEC_DISTANCE_L2_SQUARED(comp_vector_index_t0.v2, '[50,50]') LIMIT 5 (bigint)\n" +

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -128,7 +128,7 @@ WHERE
 	       CL3DT.FBSRS > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [pbmrx.id:4!null as id, pbmrx.TW55N:5!null as TEYBZ, pbmrx.ZH72S:6 as FB6N7]\n" +
+			" ├─ columns: [pbmrx.id:4!null->id:0, pbmrx.TW55N:5!null->TEYBZ:0, pbmrx.ZH72S:6->FB6N7:0]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ NOT\n" +
 			"     │   └─ pbmrx.ZH72S:6 IS NULL\n" +
@@ -148,13 +148,13 @@ WHERE
 			"     │       │       ├─ FBSRS:3!null\n" +
 			"     │       │       └─ 0 (tinyint)\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [ccefl.ZH72S:3 as ZH72S, count(ccefl.zh72s):0!null as JTOA7, min(ccefl.wgbrl):1!null as TTDPM, sum(ccefl.wgbrl):2!null as FBSRS]\n" +
+			"     │           ├─ columns: [ccefl.ZH72S:3->ZH72S:0, count(ccefl.zh72s):0!null->JTOA7:0, min(ccefl.wgbrl):1!null->TTDPM:0, sum(ccefl.wgbrl):2!null->FBSRS:0]\n" +
 			"     │           └─ Having\n" +
 			"     │               ├─ GreaterThan\n" +
 			"     │               │   ├─ JTOA7:5!null\n" +
 			"     │               │   └─ 1 (bigint)\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [count(ccefl.zh72s):0!null, min(ccefl.wgbrl):1!null, sum(ccefl.wgbrl):2!null, ccefl.ZH72S:3, ccefl.ZH72S:3 as ZH72S, count(ccefl.zh72s):0!null as JTOA7, min(ccefl.wgbrl):1!null as TTDPM, sum(ccefl.wgbrl):2!null as FBSRS]\n" +
+			"     │                   ├─ columns: [count(ccefl.zh72s):0!null, min(ccefl.wgbrl):1!null, sum(ccefl.wgbrl):2!null, ccefl.ZH72S:3, ccefl.ZH72S:3->ZH72S:0, count(ccefl.zh72s):0!null->JTOA7:0, min(ccefl.wgbrl):1!null->TTDPM:0, sum(ccefl.wgbrl):2!null->FBSRS:0]\n" +
 			"     │                   └─ GroupBy\n" +
 			"     │                       ├─ select: COUNT(ccefl.ZH72S:1), MIN(ccefl.WGBRL:2), SUM(ccefl.WGBRL:2), ccefl.ZH72S:1\n" +
 			"     │                       ├─ group: ccefl.ZH72S:1\n" +
@@ -166,11 +166,11 @@ WHERE
 			"     │                           ├─ colSet: (31-33)\n" +
 			"     │                           ├─ tableId: 3\n" +
 			"     │                           └─ Project\n" +
-			"     │                               ├─ columns: [nd.id:0!null as id, nd.ZH72S:7 as ZH72S, Subquery\n" +
+			"     │                               ├─ columns: [nd.id:0!null->id:0, nd.ZH72S:7->ZH72S:0, Subquery\n" +
 			"     │                               │   ├─ cacheable: false\n" +
 			"     │                               │   ├─ alias-string: select COUNT(*) from HDDVB where UJ6XY = nd.id\n" +
 			"     │                               │   └─ Project\n" +
-			"     │                               │       ├─ columns: [count(1):20!null as COUNT(*)]\n" +
+			"     │                               │       ├─ columns: [count(1):20!null->COUNT(*):0]\n" +
 			"     │                               │       └─ GroupBy\n" +
 			"     │                               │           ├─ select: COUNT(1 (bigint))\n" +
 			"     │                               │           ├─ group: \n" +
@@ -186,13 +186,13 @@ WHERE
 			"     │                               │                   └─ Table\n" +
 			"     │                               │                       ├─ name: HDDVB\n" +
 			"     │                               │                       └─ columns: [uj6xy]\n" +
-			"     │                               │   as WGBRL]\n" +
+			"     │                               │  ->WGBRL:0]\n" +
 			"     │                               └─ Project\n" +
-			"     │                                   ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null as id, nd.ZH72S:7 as ZH72S, Subquery\n" +
+			"     │                                   ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null->id:0, nd.ZH72S:7->ZH72S:0, Subquery\n" +
 			"     │                                   │   ├─ cacheable: false\n" +
 			"     │                                   │   ├─ alias-string: select COUNT(*) from HDDVB where UJ6XY = nd.id\n" +
 			"     │                                   │   └─ Project\n" +
-			"     │                                   │       ├─ columns: [count(1):17!null as COUNT(*)]\n" +
+			"     │                                   │       ├─ columns: [count(1):17!null->COUNT(*):0]\n" +
 			"     │                                   │       └─ GroupBy\n" +
 			"     │                                   │           ├─ select: COUNT(1 (bigint))\n" +
 			"     │                                   │           ├─ group: \n" +
@@ -208,7 +208,7 @@ WHERE
 			"     │                                   │                   └─ Table\n" +
 			"     │                                   │                       ├─ name: HDDVB\n" +
 			"     │                                   │                       └─ columns: [uj6xy]\n" +
-			"     │                                   │   as WGBRL]\n" +
+			"     │                                   │  ->WGBRL:0]\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
 			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
@@ -530,7 +530,7 @@ WHERE
 			" │               ├─ cacheable: true\n" +
 			" │               ├─ alias-string: select TIZHK.id as FWATE from WGSDC as NHMXW join WRZVO as TIZHK on TIZHK.TVNW2 = NHMXW.NOHHR and TIZHK.ZHITY = NHMXW.AVPYF and TIZHK.SYPKF = NHMXW.SYPKF and TIZHK.IDUT2 = NHMXW.IDUT2 where NHMXW.SWCQV = 0 and NHMXW.id not in (select PRUV2 from HDDVB where PRUV2 is not null)\n" +
 			" │               └─ Project\n" +
-			" │                   ├─ columns: [tizhk.id:19!null as FWATE]\n" +
+			" │                   ├─ columns: [tizhk.id:19!null->FWATE:0]\n" +
 			" │                   └─ Project\n" +
 			" │                       ├─ columns: [WGSDC.id:9!null, WGSDC.NOHHR:10!null, WGSDC.AVPYF:11!null, WGSDC.SYPKF:12!null, WGSDC.IDUT2:13!null, WGSDC.FZXV5:14, WGSDC.DQYGV:15, WGSDC.SWCQV:16!null, WGSDC.YKSSU:17, WGSDC.FHCYT:18, WRZVO.id:19!null, WRZVO.TVNW2:20, WRZVO.ZHITY:21, WRZVO.SYPKF:22, WRZVO.IDUT2:23, WRZVO.O6QJ3:24, WRZVO.NO2JA:25, WRZVO.YKSSU:26, WRZVO.FHCYT:27, WRZVO.QZ6VT:28]\n" +
 			" │                       └─ Filter\n" +
@@ -1216,7 +1216,7 @@ WHERE
 	       CL3DT.FLHXH > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [pbmrx.id:4!null as id, pbmrx.TW55N:5!null as TEYBZ, pbmrx.ZH72S:6 as FB6N7]\n" +
+			" ├─ columns: [pbmrx.id:4!null->id:0, pbmrx.TW55N:5!null->TEYBZ:0, pbmrx.ZH72S:6->FB6N7:0]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ NOT\n" +
 			"     │   └─ pbmrx.ZH72S:6 IS NULL\n" +
@@ -1236,13 +1236,13 @@ WHERE
 			"     │       │       ├─ FLHXH:3!null\n" +
 			"     │       │       └─ 0 (tinyint)\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [wooj5.ZH72S:3 as ZH72S, count(wooj5.zh72s):0!null as JTOA7, min(wooj5.lea4j):1!null as BADTB, sum(wooj5.lea4j):2!null as FLHXH]\n" +
+			"     │           ├─ columns: [wooj5.ZH72S:3->ZH72S:0, count(wooj5.zh72s):0!null->JTOA7:0, min(wooj5.lea4j):1!null->BADTB:0, sum(wooj5.lea4j):2!null->FLHXH:0]\n" +
 			"     │           └─ Having\n" +
 			"     │               ├─ GreaterThan\n" +
 			"     │               │   ├─ JTOA7:5!null\n" +
 			"     │               │   └─ 1 (bigint)\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [count(wooj5.zh72s):0!null, min(wooj5.lea4j):1!null, sum(wooj5.lea4j):2!null, wooj5.ZH72S:3, wooj5.ZH72S:3 as ZH72S, count(wooj5.zh72s):0!null as JTOA7, min(wooj5.lea4j):1!null as BADTB, sum(wooj5.lea4j):2!null as FLHXH]\n" +
+			"     │                   ├─ columns: [count(wooj5.zh72s):0!null, min(wooj5.lea4j):1!null, sum(wooj5.lea4j):2!null, wooj5.ZH72S:3, wooj5.ZH72S:3->ZH72S:0, count(wooj5.zh72s):0!null->JTOA7:0, min(wooj5.lea4j):1!null->BADTB:0, sum(wooj5.lea4j):2!null->FLHXH:0]\n" +
 			"     │                   └─ GroupBy\n" +
 			"     │                       ├─ select: COUNT(wooj5.ZH72S:1), MIN(wooj5.LEA4J:2), SUM(wooj5.LEA4J:2), wooj5.ZH72S:1\n" +
 			"     │                       ├─ group: wooj5.ZH72S:1\n" +
@@ -1254,11 +1254,11 @@ WHERE
 			"     │                           ├─ colSet: (34-36)\n" +
 			"     │                           ├─ tableId: 3\n" +
 			"     │                           └─ Project\n" +
-			"     │                               ├─ columns: [nd.id:0!null as id, nd.ZH72S:7 as ZH72S, Subquery\n" +
+			"     │                               ├─ columns: [nd.id:0!null->id:0, nd.ZH72S:7->ZH72S:0, Subquery\n" +
 			"     │                               │   ├─ cacheable: false\n" +
 			"     │                               │   ├─ alias-string: select COUNT(*) from FLQLP where LUEVY = nd.id\n" +
 			"     │                               │   └─ Project\n" +
-			"     │                               │       ├─ columns: [count(1):20!null as COUNT(*)]\n" +
+			"     │                               │       ├─ columns: [count(1):20!null->COUNT(*):0]\n" +
 			"     │                               │       └─ GroupBy\n" +
 			"     │                               │           ├─ select: COUNT(1 (bigint))\n" +
 			"     │                               │           ├─ group: \n" +
@@ -1274,13 +1274,13 @@ WHERE
 			"     │                               │                   └─ Table\n" +
 			"     │                               │                       ├─ name: FLQLP\n" +
 			"     │                               │                       └─ columns: [luevy]\n" +
-			"     │                               │   as LEA4J]\n" +
+			"     │                               │  ->LEA4J:0]\n" +
 			"     │                               └─ Project\n" +
-			"     │                                   ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null as id, nd.ZH72S:7 as ZH72S, Subquery\n" +
+			"     │                                   ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null->id:0, nd.ZH72S:7->ZH72S:0, Subquery\n" +
 			"     │                                   │   ├─ cacheable: false\n" +
 			"     │                                   │   ├─ alias-string: select COUNT(*) from FLQLP where LUEVY = nd.id\n" +
 			"     │                                   │   └─ Project\n" +
-			"     │                                   │       ├─ columns: [count(1):17!null as COUNT(*)]\n" +
+			"     │                                   │       ├─ columns: [count(1):17!null->COUNT(*):0]\n" +
 			"     │                                   │       └─ GroupBy\n" +
 			"     │                                   │           ├─ select: COUNT(1 (bigint))\n" +
 			"     │                                   │           ├─ group: \n" +
@@ -1296,7 +1296,7 @@ WHERE
 			"     │                                   │                   └─ Table\n" +
 			"     │                                   │                       ├─ name: FLQLP\n" +
 			"     │                                   │                       └─ columns: [luevy]\n" +
-			"     │                                   │   as LEA4J]\n" +
+			"     │                                   │  ->LEA4J:0]\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
 			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
@@ -1508,7 +1508,7 @@ WHERE
 	)
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [ct.id:0!null as id, ci.FTQLQ:33!null as VCGT3, nd.TW55N:15!null as UWBAI, aac.BTXC5:30 as TPXBU, ct.V5DPX:8!null as V5DPX, ct.S3Q3Y:9!null as S3Q3Y, ct.ZRV3B:10!null as ZRV3B]\n" +
+			" ├─ columns: [ct.id:0!null->id:0, ci.FTQLQ:33!null->VCGT3:0, nd.TW55N:15!null->UWBAI:0, aac.BTXC5:30->TPXBU:0, ct.V5DPX:8!null->V5DPX:0, ct.S3Q3Y:9!null->S3Q3Y:0, ct.ZRV3B:10!null->ZRV3B:0]\n" +
 			" └─ Filter\n" +
 			"     ├─ Or\n" +
 			"     │   ├─ AND\n" +
@@ -1579,7 +1579,7 @@ WHERE
 			"     │               ├─ cacheable: true\n" +
 			"     │               ├─ alias-string: select uct.id as FDL23 from EPZU6 as I7HCR join OUBDL as uct on uct.FTQLQ = I7HCR.TOFPN and uct.ZH72S = I7HCR.SJYN2 and uct.LJLUM = I7HCR.BTXC5 where I7HCR.SWCQV = 0 and I7HCR.id not in (select OCA7E from FLQLP where OCA7E is not null)\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [uct.id:45!null as FDL23]\n" +
+			"     │                   ├─ columns: [uct.id:45!null->FDL23:0]\n" +
 			"     │                   └─ Project\n" +
 			"     │                       ├─ columns: [EPZU6.id:37!null, EPZU6.TOFPN:38!null, EPZU6.SJYN2:39!null, EPZU6.BTXC5:40!null, EPZU6.FVUCX:41!null, EPZU6.SWCQV:42!null, EPZU6.YKSSU:43, EPZU6.FHCYT:44, OUBDL.id:45!null, OUBDL.FTQLQ:46, OUBDL.ZH72S:47, OUBDL.SFJ6L:48, OUBDL.V5DPX:49, OUBDL.LJLUM:50, OUBDL.IDPK7:51, OUBDL.NO52D:52, OUBDL.ZRV3B:53, OUBDL.VYO5E:54, OUBDL.YKSSU:55, OUBDL.FHCYT:56, OUBDL.QZ6VT:57]\n" +
 			"     │                       └─ Filter\n" +
@@ -1894,7 +1894,7 @@ WHERE
 			"     │   ├─ tableId: 6\n" +
 			"     │   └─ Distinct\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [ylksy.id:0!null as FDL23]\n" +
+			"     │           ├─ columns: [ylksy.id:0!null->FDL23:0]\n" +
 			"     │           └─ HashJoin\n" +
 			"     │               ├─ Eq\n" +
 			"     │               │   ├─ ci.FTQLQ:6!null\n" +
@@ -2113,7 +2113,7 @@ WHERE
 	   TVTJS.SWCQV = 1
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [ct.id:0!null as id, ci.FTQLQ:13!null as VCGT3, nd.TW55N:9!null as UWBAI, aac.BTXC5:11 as TPXBU, ct.V5DPX:5!null as V5DPX, ct.S3Q3Y:6!null as S3Q3Y, ct.ZRV3B:7!null as ZRV3B]\n" +
+			" ├─ columns: [ct.id:0!null->id:0, ci.FTQLQ:13!null->VCGT3:0, nd.TW55N:9!null->UWBAI:0, aac.BTXC5:11->TPXBU:0, ct.V5DPX:5!null->V5DPX:0, ct.S3Q3Y:6!null->S3Q3Y:0, ct.ZRV3B:7!null->ZRV3B:0]\n" +
 			" └─ HashJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ tvtjs.id:14!null\n" +
@@ -2388,7 +2388,7 @@ WHERE
 	       PV6R5.NUMK2 <> 1
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [rn.id:0!null as id, concat(nsplt.TW55N:18!null,FDNCN (longtext),lqncx.TW55N:16!null) as X37NA, concat(xlza5.TW55N:10!null,FDNCN (longtext),afjmd.TW55N:8!null) as THWCS, rn.HVHRZ:3!null as HVHRZ]\n" +
+			" ├─ columns: [rn.id:0!null->id:0, concat(nsplt.TW55N:18!null,FDNCN (longtext),lqncx.TW55N:16!null)->X37NA:0, concat(xlza5.TW55N:10!null,FDNCN (longtext),afjmd.TW55N:8!null)->THWCS:0, rn.HVHRZ:3!null->HVHRZ:0]\n" +
 			" └─ Filter\n" +
 			"     ├─ Or\n" +
 			"     │   ├─ NOT\n" +
@@ -2653,7 +2653,7 @@ WHERE
 	       rn.WNUNU IS NULL AND rn.HHVLX IS NULL
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sn.id:5!null as DRIWM, concat(oe56m.TW55N:10!null,FDNCN (longtext),cgfrz.TW55N:12!null) as GRVSE, skpm6.id:0!null as JIEVY, concat(v5say.TW55N:14!null,FDNCN (longtext),fqthf.TW55N:4!null) as ENCM3, 1 (decimal(2,1)) as OHD3R]\n" +
+			" ├─ columns: [sn.id:5!null->DRIWM:0, concat(oe56m.TW55N:10!null,FDNCN (longtext),cgfrz.TW55N:12!null)->GRVSE:0, skpm6.id:0!null->JIEVY:0, concat(v5say.TW55N:14!null,FDNCN (longtext),fqthf.TW55N:4!null)->ENCM3:0, 1 (decimal(2,1))->OHD3R:99]\n" +
 			" └─ Filter\n" +
 			"     ├─ AND\n" +
 			"     │   ├─ rn.WNUNU:15!null IS NULL\n" +
@@ -2941,7 +2941,7 @@ WHERE
 			"     │           │                       └─ Table\n" +
 			"     │           │                           ├─ name: TDRVG\n" +
 			"     │           │                           └─ columns: [id sshpj]\n" +
-			"     │           │   as id]\n" +
+			"     │           │  ->id:0]\n" +
 			"     │           └─ Project\n" +
 			"     │               ├─ columns: [s7byt.SSHPJ:5!null, s7byt.SFJ6L:6!null, Subquery\n" +
 			"     │               │   ├─ cacheable: false\n" +
@@ -2962,7 +2962,7 @@ WHERE
 			"     │               │                       └─ Table\n" +
 			"     │               │                           ├─ name: TDRVG\n" +
 			"     │               │                           └─ columns: [id sshpj]\n" +
-			"     │               │   as id]\n" +
+			"     │               │  ->id:0]\n" +
 			"     │               └─ Project\n" +
 			"     │                   ├─ columns: [s7byt.SSHPJ:5!null, s7byt.SFJ6L:6!null]\n" +
 			"     │                   └─ Filter\n" +
@@ -2977,7 +2977,7 @@ WHERE
 			"     │                           │   ├─ tableId: 4\n" +
 			"     │                           │   └─ Distinct\n" +
 			"     │                           │       └─ Project\n" +
-			"     │                           │           ├─ columns: [s5kbm.SSHPJ:7!null as SSHPJ, s5kbm.SFJ6L:8!null as SFJ6L]\n" +
+			"     │                           │           ├─ columns: [s5kbm.SSHPJ:7!null->SSHPJ:0, s5kbm.SFJ6L:8!null->SFJ6L:0]\n" +
 			"     │                           │           └─ LookupJoin\n" +
 			"     │                           │               ├─ TableAlias(nd)\n" +
 			"     │                           │               │   └─ Table\n" +
@@ -3176,7 +3176,7 @@ WHERE
 	       CL3DT.R5CKX > 0
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [pbmrx.id:4!null as id, pbmrx.TW55N:5!null as UYOGN, pbmrx.ZH72S:6 as H4JEA]\n" +
+			" ├─ columns: [pbmrx.id:4!null->id:0, pbmrx.TW55N:5!null->UYOGN:0, pbmrx.ZH72S:6->H4JEA:0]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ NOT\n" +
 			"     │   └─ pbmrx.ZH72S:6 IS NULL\n" +
@@ -3196,13 +3196,13 @@ WHERE
 			"     │       │       ├─ R5CKX:3!null\n" +
 			"     │       │       └─ 0 (tinyint)\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [tq57w.ZH72S:3 as ZH72S, count(tq57w.zh72s):0!null as JTOA7, min(tq57w.tj66d):1!null as B4OVH, sum(tq57w.tj66d):2!null as R5CKX]\n" +
+			"     │           ├─ columns: [tq57w.ZH72S:3->ZH72S:0, count(tq57w.zh72s):0!null->JTOA7:0, min(tq57w.tj66d):1!null->B4OVH:0, sum(tq57w.tj66d):2!null->R5CKX:0]\n" +
 			"     │           └─ Having\n" +
 			"     │               ├─ GreaterThan\n" +
 			"     │               │   ├─ JTOA7:5!null\n" +
 			"     │               │   └─ 1 (bigint)\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [count(tq57w.zh72s):0!null, min(tq57w.tj66d):1!null, sum(tq57w.tj66d):2!null, tq57w.ZH72S:3, tq57w.ZH72S:3 as ZH72S, count(tq57w.zh72s):0!null as JTOA7, min(tq57w.tj66d):1!null as B4OVH, sum(tq57w.tj66d):2!null as R5CKX]\n" +
+			"     │                   ├─ columns: [count(tq57w.zh72s):0!null, min(tq57w.tj66d):1!null, sum(tq57w.tj66d):2!null, tq57w.ZH72S:3, tq57w.ZH72S:3->ZH72S:0, count(tq57w.zh72s):0!null->JTOA7:0, min(tq57w.tj66d):1!null->B4OVH:0, sum(tq57w.tj66d):2!null->R5CKX:0]\n" +
 			"     │                   └─ GroupBy\n" +
 			"     │                       ├─ select: COUNT(tq57w.ZH72S:1), MIN(tq57w.TJ66D:2), SUM(tq57w.TJ66D:2), tq57w.ZH72S:1\n" +
 			"     │                       ├─ group: tq57w.ZH72S:1\n" +
@@ -3214,11 +3214,11 @@ WHERE
 			"     │                           ├─ colSet: (30-32)\n" +
 			"     │                           ├─ tableId: 3\n" +
 			"     │                           └─ Project\n" +
-			"     │                               ├─ columns: [nd.id:0!null as id, nd.ZH72S:7 as ZH72S, Subquery\n" +
+			"     │                               ├─ columns: [nd.id:0!null->id:0, nd.ZH72S:7->ZH72S:0, Subquery\n" +
 			"     │                               │   ├─ cacheable: false\n" +
 			"     │                               │   ├─ alias-string: select COUNT(*) from AMYXQ where LUEVY = nd.id\n" +
 			"     │                               │   └─ Project\n" +
-			"     │                               │       ├─ columns: [count(1):20!null as COUNT(*)]\n" +
+			"     │                               │       ├─ columns: [count(1):20!null->COUNT(*):0]\n" +
 			"     │                               │       └─ GroupBy\n" +
 			"     │                               │           ├─ select: COUNT(1 (bigint))\n" +
 			"     │                               │           ├─ group: \n" +
@@ -3234,13 +3234,13 @@ WHERE
 			"     │                               │                   └─ Table\n" +
 			"     │                               │                       ├─ name: AMYXQ\n" +
 			"     │                               │                       └─ columns: [luevy]\n" +
-			"     │                               │   as TJ66D]\n" +
+			"     │                               │  ->TJ66D:0]\n" +
 			"     │                               └─ Project\n" +
-			"     │                                   ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null as id, nd.ZH72S:7 as ZH72S, Subquery\n" +
+			"     │                                   ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null->id:0, nd.ZH72S:7->ZH72S:0, Subquery\n" +
 			"     │                                   │   ├─ cacheable: false\n" +
 			"     │                                   │   ├─ alias-string: select COUNT(*) from AMYXQ where LUEVY = nd.id\n" +
 			"     │                                   │   └─ Project\n" +
-			"     │                                   │       ├─ columns: [count(1):17!null as COUNT(*)]\n" +
+			"     │                                   │       ├─ columns: [count(1):17!null->COUNT(*):0]\n" +
 			"     │                                   │       └─ GroupBy\n" +
 			"     │                                   │           ├─ select: COUNT(1 (bigint))\n" +
 			"     │                                   │           ├─ group: \n" +
@@ -3256,7 +3256,7 @@ WHERE
 			"     │                                   │                   └─ Table\n" +
 			"     │                                   │                       ├─ name: AMYXQ\n" +
 			"     │                                   │                       └─ columns: [luevy]\n" +
-			"     │                                   │   as TJ66D]\n" +
+			"     │                                   │  ->TJ66D:0]\n" +
 			"     │                                   └─ TableAlias(nd)\n" +
 			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
 			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
@@ -3861,7 +3861,7 @@ WHERE
 	)
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mf.id:0!null as id, cla.FTQLQ:42!null as T4IBQ, nd.TW55N:23!null as UWBAI, aac.BTXC5:18 as TPXBU, mf.FSDY2:10!null as FSDY2]\n" +
+			" ├─ columns: [mf.id:0!null->id:0, cla.FTQLQ:42!null->T4IBQ:0, nd.TW55N:23!null->UWBAI:0, aac.BTXC5:18->TPXBU:0, mf.FSDY2:10!null->FSDY2:0]\n" +
 			" └─ Filter\n" +
 			"     ├─ Or\n" +
 			"     │   ├─ AND\n" +
@@ -3932,7 +3932,7 @@ WHERE
 			"     │               ├─ cacheable: true\n" +
 			"     │               ├─ alias-string: select umf.id as ORB3K from SZW6V as TJ5D2 join NZKPM as umf on umf.T4IBQ = TJ5D2.T4IBQ and umf.FGG57 = TJ5D2.V7UFH and umf.SYPKF = TJ5D2.SYPKF where TJ5D2.SWCQV = 0 and TJ5D2.id not in (select QQV4M from HGMQ6 where QQV4M is not null)\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [umf.id:79!null as ORB3K]\n" +
+			"     │                   ├─ columns: [umf.id:79!null->ORB3K:0]\n" +
 			"     │                   └─ LookupJoin\n" +
 			"     │                       ├─ AND\n" +
 			"     │                       │   ├─ Eq\n" +
@@ -4531,9 +4531,9 @@ WHERE
 			" │   ├─ columns: [convert\n" +
 			" │   │   ├─ type: char\n" +
 			" │   │   └─ T4IBQ:0!null\n" +
-			" │   │   as T4IBQ, DL754:1!null, BDNYB:2!null, ADURZ:3!null, TPXBU:4, NO52D:5!null, IDPK7:6!null]\n" +
+			" │   │  ->T4IBQ:0, DL754:1!null, BDNYB:2!null, ADURZ:3!null, TPXBU:4, NO52D:5!null, IDPK7:6!null]\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sl3s5.TOFPN:62!null as DL754, sn.id:51!null as BDNYB, sl3s5.ADURZ:64!null as ADURZ, Subquery\n" +
+			" │       ├─ columns: [cla.FTQLQ:1!null->T4IBQ:0, sl3s5.TOFPN:62!null->DL754:0, sn.id:51!null->BDNYB:0, sl3s5.ADURZ:64!null->ADURZ:0, Subquery\n" +
 			" │       │   ├─ cacheable: false\n" +
 			" │       │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			" │       │   └─ Project\n" +
@@ -4551,9 +4551,9 @@ WHERE
 			" │       │                   └─ Table\n" +
 			" │       │                       ├─ name: TPXBU\n" +
 			" │       │                       └─ columns: [id btxc5]\n" +
-			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
+			" │       │  ->TPXBU:0, sl3s5.NO52D:65!null->NO52D:0, sl3s5.IDPK7:66!null->IDPK7:0]\n" +
 			" │       └─ Project\n" +
-			" │           ├─ columns: [cla.id:37!null, cla.FTQLQ:38!null, cla.TUXML:39, cla.PAEF5:40, cla.RUCY4:41, cla.TPNJ6:42!null, cla.LBL53:43, cla.NB3QS:44, cla.EO7IV:45, cla.MUHJF:46, cla.FM34L:47, cla.TY5RF:48, cla.ZHTLH:49, cla.NPB7W:50, cla.SX3HH:51, cla.ISBNF:52, cla.YA7YB:53, cla.C5YKB:54, cla.QK7KT:55, cla.FFGE6:56, cla.FIIGJ:57, cla.SH3NC:58, cla.NTENA:59, cla.M4AUB:60, cla.X5AIR:61, cla.SAB6M:62, cla.G5QI5:63, cla.ZVQVD:64, cla.YKSSU:65, cla.FHCYT:66, bs.id:33!null, bs.NFRYN:34!null, bs.IXUXU:35, bs.FHCYT:36, mf.id:16!null, mf.GXLUB:17!null, mf.LUEVY:18!null, mf.M22QN:19!null, mf.TJPT7:20!null, mf.ARN5P:21!null, mf.XOSD4:22!null, mf.IDE43:23, mf.HMW4H:24, mf.ZBT6R:25, mf.FSDY2:26!null, mf.LT7K6:27, mf.SPPYD:28, mf.QCGTS:29, mf.TEUJA:30, mf.QQV4M:31, mf.FHCYT:32, sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, cla.FTQLQ:38!null as T4IBQ, sl3s5.TOFPN:1!null as DL754, sn.id:6!null as BDNYB, sl3s5.ADURZ:3!null as ADURZ, Subquery\n" +
+			" │           ├─ columns: [cla.id:37!null, cla.FTQLQ:38!null, cla.TUXML:39, cla.PAEF5:40, cla.RUCY4:41, cla.TPNJ6:42!null, cla.LBL53:43, cla.NB3QS:44, cla.EO7IV:45, cla.MUHJF:46, cla.FM34L:47, cla.TY5RF:48, cla.ZHTLH:49, cla.NPB7W:50, cla.SX3HH:51, cla.ISBNF:52, cla.YA7YB:53, cla.C5YKB:54, cla.QK7KT:55, cla.FFGE6:56, cla.FIIGJ:57, cla.SH3NC:58, cla.NTENA:59, cla.M4AUB:60, cla.X5AIR:61, cla.SAB6M:62, cla.G5QI5:63, cla.ZVQVD:64, cla.YKSSU:65, cla.FHCYT:66, bs.id:33!null, bs.NFRYN:34!null, bs.IXUXU:35, bs.FHCYT:36, mf.id:16!null, mf.GXLUB:17!null, mf.LUEVY:18!null, mf.M22QN:19!null, mf.TJPT7:20!null, mf.ARN5P:21!null, mf.XOSD4:22!null, mf.IDE43:23, mf.HMW4H:24, mf.ZBT6R:25, mf.FSDY2:26!null, mf.LT7K6:27, mf.SPPYD:28, mf.QCGTS:29, mf.TEUJA:30, mf.QQV4M:31, mf.FHCYT:32, sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, cla.FTQLQ:38!null->T4IBQ:0, sl3s5.TOFPN:1!null->DL754:0, sn.id:6!null->BDNYB:0, sl3s5.ADURZ:3!null->ADURZ:0, Subquery\n" +
 			" │           │   ├─ cacheable: false\n" +
 			" │           │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			" │           │   └─ Project\n" +
@@ -4571,7 +4571,7 @@ WHERE
 			" │           │                   └─ Table\n" +
 			" │           │                       ├─ name: TPXBU\n" +
 			" │           │                       └─ columns: [id btxc5]\n" +
-			" │           │   as TPXBU, sl3s5.NO52D:4!null as NO52D, sl3s5.IDPK7:5!null as IDPK7]\n" +
+			" │           │  ->TPXBU:0, sl3s5.NO52D:4!null->NO52D:0, sl3s5.IDPK7:5!null->IDPK7:0]\n" +
 			" │           └─ LookupJoin\n" +
 			" │               ├─ LookupJoin\n" +
 			" │               │   ├─ LookupJoin\n" +
@@ -4587,7 +4587,7 @@ WHERE
 			" │               │   │   │   │   ├─ colSet: (124-129)\n" +
 			" │               │   │   │   │   ├─ tableId: 11\n" +
 			" │               │   │   │   │   └─ Project\n" +
-			" │               │   │   │   │       ├─ columns: [khjjo.BDNYB:12!null as BDNYB, ci.FTQLQ:1!null as TOFPN, ct.M22QN:4!null as M22QN, cec.ADURZ:10!null as ADURZ, cec.NO52D:9!null as NO52D, ct.S3Q3Y:6!null as IDPK7]\n" +
+			" │               │   │   │   │       ├─ columns: [khjjo.BDNYB:12!null->BDNYB:0, ci.FTQLQ:1!null->TOFPN:0, ct.M22QN:4!null->M22QN:0, cec.ADURZ:10!null->ADURZ:0, cec.NO52D:9!null->NO52D:0, ct.S3Q3Y:6!null->IDPK7:0]\n" +
 			" │               │   │   │   │       └─ HashJoin\n" +
 			" │               │   │   │   │           ├─ Eq\n" +
 			" │               │   │   │   │           │   ├─ ci.id:0!null\n" +
@@ -4650,7 +4650,7 @@ WHERE
 			" │               │   │   │   │                           ├─ tableId: 7\n" +
 			" │               │   │   │   │                           └─ Distinct\n" +
 			" │               │   │   │   │                               └─ Project\n" +
-			" │               │   │   │   │                                   ├─ columns: [mf.M22QN:3!null as M22QN, sn.id:0!null as BDNYB, mf.LUEVY:2!null as LUEVY]\n" +
+			" │               │   │   │   │                                   ├─ columns: [mf.M22QN:3!null->M22QN:0, sn.id:0!null->BDNYB:0, mf.LUEVY:2!null->LUEVY:0]\n" +
 			" │               │   │   │   │                                   └─ LookupJoin\n" +
 			" │               │   │   │   │                                       ├─ TableAlias(sn)\n" +
 			" │               │   │   │   │                                       │   └─ Table\n" +
@@ -4708,7 +4708,7 @@ WHERE
 			" │                               ├─ name: YK2GW\n" +
 			" │                               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [aoev5.t4ibq:0!null as t4ibq, vumuy.DL754:1!null, vumuy.BDNYB:2!null, vumuy.ADURZ:3!null, vumuy.TPXBU:4, vumuy.NO52D:5!null, vumuy.IDPK7:6!null]\n" +
+			"     ├─ columns: [aoev5.t4ibq:0!null->t4ibq:0, vumuy.DL754:1!null, vumuy.BDNYB:2!null, vumuy.ADURZ:3!null, vumuy.TPXBU:4, vumuy.NO52D:5!null, vumuy.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [aoev5.t4ibq:6!null, vumuy.DL754:0!null, vumuy.BDNYB:1!null, vumuy.ADURZ:2!null, vumuy.TPXBU:3, vumuy.NO52D:4!null, vumuy.IDPK7:5!null]\n" +
 			"         └─ CrossHashJoin\n" +
@@ -4720,7 +4720,7 @@ WHERE
 			"             │   ├─ colSet: (207-212)\n" +
 			"             │   ├─ tableId: 21\n" +
 			"             │   └─ Project\n" +
-			"             │       ├─ columns: [sl3s5.TOFPN:11!null as DL754, sn.id:0!null as BDNYB, sl3s5.ADURZ:13!null as ADURZ, Subquery\n" +
+			"             │       ├─ columns: [sl3s5.TOFPN:11!null->DL754:0, sn.id:0!null->BDNYB:0, sl3s5.ADURZ:13!null->ADURZ:0, Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			"             │       │   └─ Project\n" +
@@ -4738,9 +4738,9 @@ WHERE
 			"             │       │                   └─ Table\n" +
 			"             │       │                       ├─ name: TPXBU\n" +
 			"             │       │                       └─ columns: [id btxc5]\n" +
-			"             │       │   as TPXBU, sl3s5.NO52D:14!null as NO52D, sl3s5.IDPK7:15!null as IDPK7]\n" +
+			"             │       │  ->TPXBU:0, sl3s5.NO52D:14!null->NO52D:0, sl3s5.IDPK7:15!null->IDPK7:0]\n" +
 			"             │       └─ Project\n" +
-			"             │           ├─ columns: [sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, sl3s5.TOFPN:1!null as DL754, sn.id:6!null as BDNYB, sl3s5.ADURZ:3!null as ADURZ, Subquery\n" +
+			"             │           ├─ columns: [sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, sl3s5.TOFPN:1!null->DL754:0, sn.id:6!null->BDNYB:0, sl3s5.ADURZ:3!null->ADURZ:0, Subquery\n" +
 			"             │           │   ├─ cacheable: false\n" +
 			"             │           │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			"             │           │   └─ Project\n" +
@@ -4758,7 +4758,7 @@ WHERE
 			"             │           │                   └─ Table\n" +
 			"             │           │                       ├─ name: TPXBU\n" +
 			"             │           │                       └─ columns: [id btxc5]\n" +
-			"             │           │   as TPXBU, sl3s5.NO52D:4!null as NO52D, sl3s5.IDPK7:5!null as IDPK7]\n" +
+			"             │           │  ->TPXBU:0, sl3s5.NO52D:4!null->NO52D:0, sl3s5.IDPK7:5!null->IDPK7:0]\n" +
 			"             │           └─ LookupJoin\n" +
 			"             │               ├─ SubqueryAlias\n" +
 			"             │               │   ├─ name: sl3s5\n" +
@@ -4768,7 +4768,7 @@ WHERE
 			"             │               │   ├─ colSet: (192-197)\n" +
 			"             │               │   ├─ tableId: 19\n" +
 			"             │               │   └─ Project\n" +
-			"             │               │       ├─ columns: [sn.id:0!null as BDNYB, ci.FTQLQ:23!null as TOFPN, ct.M22QN:13!null as M22QN, cec.ADURZ:26!null as ADURZ, cec.NO52D:25!null as NO52D, ct.S3Q3Y:19!null as IDPK7]\n" +
+			"             │               │       ├─ columns: [sn.id:0!null->BDNYB:0, ci.FTQLQ:23!null->TOFPN:0, ct.M22QN:13!null->M22QN:0, cec.ADURZ:26!null->ADURZ:0, cec.NO52D:25!null->NO52D:0, ct.S3Q3Y:19!null->IDPK7:0]\n" +
 			"             │               │       └─ HashJoin\n" +
 			"             │               │           ├─ Eq\n" +
 			"             │               │           │   ├─ cec.id:24!null\n" +
@@ -5413,9 +5413,9 @@ WHERE
 			" │   ├─ columns: [convert\n" +
 			" │   │   ├─ type: char\n" +
 			" │   │   └─ T4IBQ:0!null\n" +
-			" │   │   as T4IBQ, DL754:1!null, BDNYB:2!null, ADURZ:3!null, TPXBU:4, NO52D:5!null, IDPK7:6!null]\n" +
+			" │   │  ->T4IBQ:0, DL754:1!null, BDNYB:2!null, ADURZ:3!null, TPXBU:4, NO52D:5!null, IDPK7:6!null]\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sl3s5.TOFPN:62!null as DL754, sn.id:51!null as BDNYB, sl3s5.ADURZ:64!null as ADURZ, Subquery\n" +
+			" │       ├─ columns: [cla.FTQLQ:1!null->T4IBQ:0, sl3s5.TOFPN:62!null->DL754:0, sn.id:51!null->BDNYB:0, sl3s5.ADURZ:64!null->ADURZ:0, Subquery\n" +
 			" │       │   ├─ cacheable: false\n" +
 			" │       │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			" │       │   └─ Project\n" +
@@ -5433,9 +5433,9 @@ WHERE
 			" │       │                   └─ Table\n" +
 			" │       │                       ├─ name: TPXBU\n" +
 			" │       │                       └─ columns: [id btxc5]\n" +
-			" │       │   as TPXBU, sl3s5.NO52D:65!null as NO52D, sl3s5.IDPK7:66!null as IDPK7]\n" +
+			" │       │  ->TPXBU:0, sl3s5.NO52D:65!null->NO52D:0, sl3s5.IDPK7:66!null->IDPK7:0]\n" +
 			" │       └─ Project\n" +
-			" │           ├─ columns: [cla.id:37!null, cla.FTQLQ:38!null, cla.TUXML:39, cla.PAEF5:40, cla.RUCY4:41, cla.TPNJ6:42!null, cla.LBL53:43, cla.NB3QS:44, cla.EO7IV:45, cla.MUHJF:46, cla.FM34L:47, cla.TY5RF:48, cla.ZHTLH:49, cla.NPB7W:50, cla.SX3HH:51, cla.ISBNF:52, cla.YA7YB:53, cla.C5YKB:54, cla.QK7KT:55, cla.FFGE6:56, cla.FIIGJ:57, cla.SH3NC:58, cla.NTENA:59, cla.M4AUB:60, cla.X5AIR:61, cla.SAB6M:62, cla.G5QI5:63, cla.ZVQVD:64, cla.YKSSU:65, cla.FHCYT:66, bs.id:33!null, bs.NFRYN:34!null, bs.IXUXU:35, bs.FHCYT:36, mf.id:16!null, mf.GXLUB:17!null, mf.LUEVY:18!null, mf.M22QN:19!null, mf.TJPT7:20!null, mf.ARN5P:21!null, mf.XOSD4:22!null, mf.IDE43:23, mf.HMW4H:24, mf.ZBT6R:25, mf.FSDY2:26!null, mf.LT7K6:27, mf.SPPYD:28, mf.QCGTS:29, mf.TEUJA:30, mf.QQV4M:31, mf.FHCYT:32, sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, cla.FTQLQ:38!null as T4IBQ, sl3s5.TOFPN:1!null as DL754, sn.id:6!null as BDNYB, sl3s5.ADURZ:3!null as ADURZ, Subquery\n" +
+			" │           ├─ columns: [cla.id:37!null, cla.FTQLQ:38!null, cla.TUXML:39, cla.PAEF5:40, cla.RUCY4:41, cla.TPNJ6:42!null, cla.LBL53:43, cla.NB3QS:44, cla.EO7IV:45, cla.MUHJF:46, cla.FM34L:47, cla.TY5RF:48, cla.ZHTLH:49, cla.NPB7W:50, cla.SX3HH:51, cla.ISBNF:52, cla.YA7YB:53, cla.C5YKB:54, cla.QK7KT:55, cla.FFGE6:56, cla.FIIGJ:57, cla.SH3NC:58, cla.NTENA:59, cla.M4AUB:60, cla.X5AIR:61, cla.SAB6M:62, cla.G5QI5:63, cla.ZVQVD:64, cla.YKSSU:65, cla.FHCYT:66, bs.id:33!null, bs.NFRYN:34!null, bs.IXUXU:35, bs.FHCYT:36, mf.id:16!null, mf.GXLUB:17!null, mf.LUEVY:18!null, mf.M22QN:19!null, mf.TJPT7:20!null, mf.ARN5P:21!null, mf.XOSD4:22!null, mf.IDE43:23, mf.HMW4H:24, mf.ZBT6R:25, mf.FSDY2:26!null, mf.LT7K6:27, mf.SPPYD:28, mf.QCGTS:29, mf.TEUJA:30, mf.QQV4M:31, mf.FHCYT:32, sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, cla.FTQLQ:38!null->T4IBQ:0, sl3s5.TOFPN:1!null->DL754:0, sn.id:6!null->BDNYB:0, sl3s5.ADURZ:3!null->ADURZ:0, Subquery\n" +
 			" │           │   ├─ cacheable: false\n" +
 			" │           │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			" │           │   └─ Project\n" +
@@ -5453,7 +5453,7 @@ WHERE
 			" │           │                   └─ Table\n" +
 			" │           │                       ├─ name: TPXBU\n" +
 			" │           │                       └─ columns: [id btxc5]\n" +
-			" │           │   as TPXBU, sl3s5.NO52D:4!null as NO52D, sl3s5.IDPK7:5!null as IDPK7]\n" +
+			" │           │  ->TPXBU:0, sl3s5.NO52D:4!null->NO52D:0, sl3s5.IDPK7:5!null->IDPK7:0]\n" +
 			" │           └─ LookupJoin\n" +
 			" │               ├─ LookupJoin\n" +
 			" │               │   ├─ LookupJoin\n" +
@@ -5469,7 +5469,7 @@ WHERE
 			" │               │   │   │   │   ├─ colSet: (124-129)\n" +
 			" │               │   │   │   │   ├─ tableId: 11\n" +
 			" │               │   │   │   │   └─ Project\n" +
-			" │               │   │   │   │       ├─ columns: [khjjo.BDNYB:1!null as BDNYB, ci.FTQLQ:10!null as TOFPN, ct.M22QN:5!null as M22QN, cec.ADURZ:13!null as ADURZ, cec.NO52D:12!null as NO52D, ct.S3Q3Y:7!null as IDPK7]\n" +
+			" │               │   │   │   │       ├─ columns: [khjjo.BDNYB:1!null->BDNYB:0, ci.FTQLQ:10!null->TOFPN:0, ct.M22QN:5!null->M22QN:0, cec.ADURZ:13!null->ADURZ:0, cec.NO52D:12!null->NO52D:0, ct.S3Q3Y:7!null->IDPK7:0]\n" +
 			" │               │   │   │   │       └─ LookupJoin\n" +
 			" │               │   │   │   │           ├─ LookupJoin\n" +
 			" │               │   │   │   │           │   ├─ LookupJoin\n" +
@@ -5485,7 +5485,7 @@ WHERE
 			" │               │   │   │   │           │   │   │   ├─ tableId: 7\n" +
 			" │               │   │   │   │           │   │   │   └─ Distinct\n" +
 			" │               │   │   │   │           │   │   │       └─ Project\n" +
-			" │               │   │   │   │           │   │   │           ├─ columns: [mf.M22QN:3!null as M22QN, sn.id:0!null as BDNYB, mf.LUEVY:2!null as LUEVY]\n" +
+			" │               │   │   │   │           │   │   │           ├─ columns: [mf.M22QN:3!null->M22QN:0, sn.id:0!null->BDNYB:0, mf.LUEVY:2!null->LUEVY:0]\n" +
 			" │               │   │   │   │           │   │   │           └─ LookupJoin\n" +
 			" │               │   │   │   │           │   │   │               ├─ TableAlias(sn)\n" +
 			" │               │   │   │   │           │   │   │               │   └─ Table\n" +
@@ -5578,7 +5578,7 @@ WHERE
 			" │                               ├─ name: YK2GW\n" +
 			" │                               └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [aoev5.t4ibq:0!null as t4ibq, vumuy.DL754:1!null, vumuy.BDNYB:2!null, vumuy.ADURZ:3!null, vumuy.TPXBU:4, vumuy.NO52D:5!null, vumuy.IDPK7:6!null]\n" +
+			"     ├─ columns: [aoev5.t4ibq:0!null->t4ibq:0, vumuy.DL754:1!null, vumuy.BDNYB:2!null, vumuy.ADURZ:3!null, vumuy.TPXBU:4, vumuy.NO52D:5!null, vumuy.IDPK7:6!null]\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [aoev5.t4ibq:6!null, vumuy.DL754:0!null, vumuy.BDNYB:1!null, vumuy.ADURZ:2!null, vumuy.TPXBU:3, vumuy.NO52D:4!null, vumuy.IDPK7:5!null]\n" +
 			"         └─ CrossHashJoin\n" +
@@ -5590,7 +5590,7 @@ WHERE
 			"             │   ├─ colSet: (207-212)\n" +
 			"             │   ├─ tableId: 21\n" +
 			"             │   └─ Project\n" +
-			"             │       ├─ columns: [sl3s5.TOFPN:11!null as DL754, sn.id:0!null as BDNYB, sl3s5.ADURZ:13!null as ADURZ, Subquery\n" +
+			"             │       ├─ columns: [sl3s5.TOFPN:11!null->DL754:0, sn.id:0!null->BDNYB:0, sl3s5.ADURZ:13!null->ADURZ:0, Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			"             │       │   └─ Project\n" +
@@ -5608,9 +5608,9 @@ WHERE
 			"             │       │                   └─ Table\n" +
 			"             │       │                       ├─ name: TPXBU\n" +
 			"             │       │                       └─ columns: [id btxc5]\n" +
-			"             │       │   as TPXBU, sl3s5.NO52D:14!null as NO52D, sl3s5.IDPK7:15!null as IDPK7]\n" +
+			"             │       │  ->TPXBU:0, sl3s5.NO52D:14!null->NO52D:0, sl3s5.IDPK7:15!null->IDPK7:0]\n" +
 			"             │       └─ Project\n" +
-			"             │           ├─ columns: [sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, sl3s5.TOFPN:1!null as DL754, sn.id:6!null as BDNYB, sl3s5.ADURZ:3!null as ADURZ, Subquery\n" +
+			"             │           ├─ columns: [sn.id:6!null, sn.BRQP2:7!null, sn.FFTBJ:8!null, sn.A7XO2:9, sn.KBO7R:10!null, sn.ECDKM:11, sn.NUMK2:12!null, sn.LETOE:13!null, sn.YKSSU:14, sn.FHCYT:15, sl3s5.BDNYB:0!null, sl3s5.TOFPN:1!null, sl3s5.M22QN:2!null, sl3s5.ADURZ:3!null, sl3s5.NO52D:4!null, sl3s5.IDPK7:5!null, sl3s5.TOFPN:1!null->DL754:0, sn.id:6!null->BDNYB:0, sl3s5.ADURZ:3!null->ADURZ:0, Subquery\n" +
 			"             │           │   ├─ cacheable: false\n" +
 			"             │           │   ├─ alias-string: select aac.BTXC5 from TPXBU as aac where aac.id = SL3S5.M22QN\n" +
 			"             │           │   └─ Project\n" +
@@ -5628,7 +5628,7 @@ WHERE
 			"             │           │                   └─ Table\n" +
 			"             │           │                       ├─ name: TPXBU\n" +
 			"             │           │                       └─ columns: [id btxc5]\n" +
-			"             │           │   as TPXBU, sl3s5.NO52D:4!null as NO52D, sl3s5.IDPK7:5!null as IDPK7]\n" +
+			"             │           │  ->TPXBU:0, sl3s5.NO52D:4!null->NO52D:0, sl3s5.IDPK7:5!null->IDPK7:0]\n" +
 			"             │           └─ LookupJoin\n" +
 			"             │               ├─ SubqueryAlias\n" +
 			"             │               │   ├─ name: sl3s5\n" +
@@ -5638,7 +5638,7 @@ WHERE
 			"             │               │   ├─ colSet: (192-197)\n" +
 			"             │               │   ├─ tableId: 19\n" +
 			"             │               │   └─ Project\n" +
-			"             │               │       ├─ columns: [sn.id:0!null as BDNYB, ci.FTQLQ:23!null as TOFPN, ct.M22QN:13!null as M22QN, cec.ADURZ:26!null as ADURZ, cec.NO52D:25!null as NO52D, ct.S3Q3Y:19!null as IDPK7]\n" +
+			"             │               │       ├─ columns: [sn.id:0!null->BDNYB:0, ci.FTQLQ:23!null->TOFPN:0, ct.M22QN:13!null->M22QN:0, cec.ADURZ:26!null->ADURZ:0, cec.NO52D:25!null->NO52D:0, ct.S3Q3Y:19!null->IDPK7:0]\n" +
 			"             │               │       └─ HashJoin\n" +
 			"             │               │           ├─ Eq\n" +
 			"             │               │           │   ├─ cec.id:24!null\n" +
@@ -6170,9 +6170,9 @@ WHERE
 		Query: `
 	SELECT COUNT(*) FROM NOXN3`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as COUNT(*)]\n" +
+			" ├─ columns: [count(1):0!null->COUNT(*):0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [NOXN3.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [NOXN3.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(NOXN3) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -6217,10 +6217,10 @@ WHERE
 	   TYMVL.id = NB6PJ.FFTBJ
 	ORDER BY Y3IOU`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [nb6pj.Y3IOU:0!null as Y3IOU, s7egw.TW55N:9!null as FJVD7, tymvl.TW55N:26!null as KBXXJ, nb6pj.NUMK2:4!null as NUMK2, nb6pj.LETOE:5!null as LETOE]\n" +
-			" └─ Sort(nb6pj.Y3IOU:0!null as Y3IOU ASC nullsFirst)\n" +
+			" ├─ columns: [nb6pj.Y3IOU:0!null->Y3IOU:0, s7egw.TW55N:9!null->FJVD7:0, tymvl.TW55N:26!null->KBXXJ:0, nb6pj.NUMK2:4!null->NUMK2:0, nb6pj.LETOE:5!null->LETOE:0]\n" +
+			" └─ Sort(Y3IOU:40!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [nb6pj.Y3IOU:0!null, nb6pj.id:1!null, nb6pj.BRQP2:2!null, nb6pj.FFTBJ:3!null, nb6pj.NUMK2:4!null, nb6pj.LETOE:5!null, s7egw.id:6!null, s7egw.DKCAJ:7!null, s7egw.KNG7T:8, s7egw.TW55N:9!null, s7egw.QRQXW:10!null, s7egw.ECXAJ:11!null, s7egw.FGG57:12, s7egw.ZH72S:13, s7egw.FSK67:14!null, s7egw.XQDYT:15!null, s7egw.TCE7A:16, s7egw.IWV2H:17, s7egw.HPCMS:18!null, s7egw.N5CC2:19, s7egw.FHCYT:20, s7egw.ETAQ7:21, s7egw.A75X7:22, tymvl.id:23!null, tymvl.DKCAJ:24!null, tymvl.KNG7T:25, tymvl.TW55N:26!null, tymvl.QRQXW:27!null, tymvl.ECXAJ:28!null, tymvl.FGG57:29, tymvl.ZH72S:30, tymvl.FSK67:31!null, tymvl.XQDYT:32!null, tymvl.TCE7A:33, tymvl.IWV2H:34, tymvl.HPCMS:35!null, tymvl.N5CC2:36, tymvl.FHCYT:37, tymvl.ETAQ7:38, tymvl.A75X7:39, nb6pj.Y3IOU:0!null as Y3IOU, s7egw.TW55N:9!null as FJVD7, tymvl.TW55N:26!null as KBXXJ, nb6pj.NUMK2:4!null as NUMK2, nb6pj.LETOE:5!null as LETOE]\n" +
+			"         ├─ columns: [nb6pj.Y3IOU:0!null, nb6pj.id:1!null, nb6pj.BRQP2:2!null, nb6pj.FFTBJ:3!null, nb6pj.NUMK2:4!null, nb6pj.LETOE:5!null, s7egw.id:6!null, s7egw.DKCAJ:7!null, s7egw.KNG7T:8, s7egw.TW55N:9!null, s7egw.QRQXW:10!null, s7egw.ECXAJ:11!null, s7egw.FGG57:12, s7egw.ZH72S:13, s7egw.FSK67:14!null, s7egw.XQDYT:15!null, s7egw.TCE7A:16, s7egw.IWV2H:17, s7egw.HPCMS:18!null, s7egw.N5CC2:19, s7egw.FHCYT:20, s7egw.ETAQ7:21, s7egw.A75X7:22, tymvl.id:23!null, tymvl.DKCAJ:24!null, tymvl.KNG7T:25, tymvl.TW55N:26!null, tymvl.QRQXW:27!null, tymvl.ECXAJ:28!null, tymvl.FGG57:29, tymvl.ZH72S:30, tymvl.FSK67:31!null, tymvl.XQDYT:32!null, tymvl.TCE7A:33, tymvl.IWV2H:34, tymvl.HPCMS:35!null, tymvl.N5CC2:36, tymvl.FHCYT:37, tymvl.ETAQ7:38, tymvl.A75X7:39, nb6pj.Y3IOU:0!null->Y3IOU:0, s7egw.TW55N:9!null->FJVD7:0, tymvl.TW55N:26!null->KBXXJ:0, nb6pj.NUMK2:4!null->NUMK2:0, nb6pj.LETOE:5!null->LETOE:0]\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ LookupJoin\n" +
 			"             │   ├─ SubqueryAlias\n" +
@@ -6231,7 +6231,7 @@ WHERE
 			"             │   │   ├─ colSet: (13-18)\n" +
 			"             │   │   ├─ tableId: 2\n" +
 			"             │   │   └─ Project\n" +
-			"             │   │       ├─ columns: [row_number() over ( order by noxn3.id asc):0!null as Y3IOU, noxn3.id:1!null, noxn3.BRQP2:2!null, noxn3.FFTBJ:3!null, noxn3.NUMK2:4!null, noxn3.LETOE:5!null]\n" +
+			"             │   │       ├─ columns: [row_number() over ( order by noxn3.id asc):0!null->Y3IOU:0, noxn3.id:1!null, noxn3.BRQP2:2!null, noxn3.FFTBJ:3!null, noxn3.NUMK2:4!null, noxn3.LETOE:5!null]\n" +
 			"             │   │       └─ Sort(noxn3.id:1!null ASC nullsFirst)\n" +
 			"             │   │           └─ Window\n" +
 			"             │   │               ├─ row_number() over ( order by noxn3.id ASC)\n" +
@@ -6266,7 +6266,7 @@ WHERE
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [nb6pj.Y3IOU as Y3IOU, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, nb6pj.NUMK2 as NUMK2, nb6pj.LETOE as LETOE]\n" +
-			" └─ Sort(nb6pj.Y3IOU as Y3IOU ASC)\n" +
+			" └─ Sort(Y3IOU ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [nb6pj.Y3IOU, nb6pj.id, nb6pj.BRQP2, nb6pj.FFTBJ, nb6pj.NUMK2, nb6pj.LETOE, s7egw.id, s7egw.DKCAJ, s7egw.KNG7T, s7egw.TW55N, s7egw.QRQXW, s7egw.ECXAJ, s7egw.FGG57, s7egw.ZH72S, s7egw.FSK67, s7egw.XQDYT, s7egw.TCE7A, s7egw.IWV2H, s7egw.HPCMS, s7egw.N5CC2, s7egw.FHCYT, s7egw.ETAQ7, s7egw.A75X7, tymvl.id, tymvl.DKCAJ, tymvl.KNG7T, tymvl.TW55N, tymvl.QRQXW, tymvl.ECXAJ, tymvl.FGG57, tymvl.ZH72S, tymvl.FSK67, tymvl.XQDYT, tymvl.TCE7A, tymvl.IWV2H, tymvl.HPCMS, tymvl.N5CC2, tymvl.FHCYT, tymvl.ETAQ7, tymvl.A75X7, nb6pj.Y3IOU as Y3IOU, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, nb6pj.NUMK2 as NUMK2, nb6pj.LETOE as LETOE]\n" +
 			"         └─ LookupJoin\n" +
@@ -6296,7 +6296,7 @@ WHERE
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [nb6pj.Y3IOU as Y3IOU, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, nb6pj.NUMK2 as NUMK2, nb6pj.LETOE as LETOE]\n" +
-			" └─ Sort(nb6pj.Y3IOU as Y3IOU ASC)\n" +
+			" └─ Sort(Y3IOU ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [nb6pj.Y3IOU, nb6pj.id, nb6pj.BRQP2, nb6pj.FFTBJ, nb6pj.NUMK2, nb6pj.LETOE, s7egw.id, s7egw.DKCAJ, s7egw.KNG7T, s7egw.TW55N, s7egw.QRQXW, s7egw.ECXAJ, s7egw.FGG57, s7egw.ZH72S, s7egw.FSK67, s7egw.XQDYT, s7egw.TCE7A, s7egw.IWV2H, s7egw.HPCMS, s7egw.N5CC2, s7egw.FHCYT, s7egw.ETAQ7, s7egw.A75X7, tymvl.id, tymvl.DKCAJ, tymvl.KNG7T, tymvl.TW55N, tymvl.QRQXW, tymvl.ECXAJ, tymvl.FGG57, tymvl.ZH72S, tymvl.FSK67, tymvl.XQDYT, tymvl.TCE7A, tymvl.IWV2H, tymvl.HPCMS, tymvl.N5CC2, tymvl.FHCYT, tymvl.ETAQ7, tymvl.A75X7, nb6pj.Y3IOU as Y3IOU, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, nb6pj.NUMK2 as NUMK2, nb6pj.LETOE as LETOE]\n" +
 			"         └─ LookupJoin\n" +
@@ -6347,10 +6347,10 @@ WHERE
 	   nd.id = NB6PJ.BRQP2
 	ORDER BY TW55N, Y3IOU`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [nd.TW55N:9!null as TW55N, nb6pj.Y3IOU:0!null as Y3IOU]\n" +
-			" └─ Sort(nd.TW55N:9!null as TW55N ASC nullsFirst, nb6pj.Y3IOU:0!null as Y3IOU ASC nullsFirst)\n" +
+			" ├─ columns: [nd.TW55N:9!null->TW55N:0, nb6pj.Y3IOU:0!null->Y3IOU:0]\n" +
+			" └─ Sort(TW55N:23!null ASC nullsFirst, Y3IOU:24!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [nb6pj.Y3IOU:0!null, nb6pj.id:1!null, nb6pj.BRQP2:2!null, nb6pj.FFTBJ:3!null, nb6pj.NUMK2:4!null, nb6pj.LETOE:5!null, nd.id:6!null, nd.DKCAJ:7!null, nd.KNG7T:8, nd.TW55N:9!null, nd.QRQXW:10!null, nd.ECXAJ:11!null, nd.FGG57:12, nd.ZH72S:13, nd.FSK67:14!null, nd.XQDYT:15!null, nd.TCE7A:16, nd.IWV2H:17, nd.HPCMS:18!null, nd.N5CC2:19, nd.FHCYT:20, nd.ETAQ7:21, nd.A75X7:22, nd.TW55N:9!null as TW55N, nb6pj.Y3IOU:0!null as Y3IOU]\n" +
+			"         ├─ columns: [nb6pj.Y3IOU:0!null, nb6pj.id:1!null, nb6pj.BRQP2:2!null, nb6pj.FFTBJ:3!null, nb6pj.NUMK2:4!null, nb6pj.LETOE:5!null, nd.id:6!null, nd.DKCAJ:7!null, nd.KNG7T:8, nd.TW55N:9!null, nd.QRQXW:10!null, nd.ECXAJ:11!null, nd.FGG57:12, nd.ZH72S:13, nd.FSK67:14!null, nd.XQDYT:15!null, nd.TCE7A:16, nd.IWV2H:17, nd.HPCMS:18!null, nd.N5CC2:19, nd.FHCYT:20, nd.ETAQ7:21, nd.A75X7:22, nd.TW55N:9!null->TW55N:0, nb6pj.Y3IOU:0!null->Y3IOU:0]\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ SubqueryAlias\n" +
 			"             │   ├─ name: nb6pj\n" +
@@ -6360,7 +6360,7 @@ WHERE
 			"             │   ├─ colSet: (13-18)\n" +
 			"             │   ├─ tableId: 2\n" +
 			"             │   └─ Project\n" +
-			"             │       ├─ columns: [row_number() over ( order by noxn3.id asc):0!null as Y3IOU, noxn3.id:1!null, noxn3.BRQP2:2!null, noxn3.FFTBJ:3!null, noxn3.NUMK2:4!null, noxn3.LETOE:5!null]\n" +
+			"             │       ├─ columns: [row_number() over ( order by noxn3.id asc):0!null->Y3IOU:0, noxn3.id:1!null, noxn3.BRQP2:2!null, noxn3.FFTBJ:3!null, noxn3.NUMK2:4!null, noxn3.LETOE:5!null]\n" +
 			"             │       └─ Sort(noxn3.id:1!null ASC nullsFirst)\n" +
 			"             │           └─ Window\n" +
 			"             │               ├─ row_number() over ( order by noxn3.id ASC)\n" +
@@ -6386,7 +6386,7 @@ WHERE
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [nd.TW55N as TW55N, nb6pj.Y3IOU as Y3IOU]\n" +
-			" └─ Sort(nd.TW55N as TW55N ASC, nb6pj.Y3IOU as Y3IOU ASC)\n" +
+			" └─ Sort(TW55N ASC, Y3IOU ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [nb6pj.Y3IOU, nb6pj.id, nb6pj.BRQP2, nb6pj.FFTBJ, nb6pj.NUMK2, nb6pj.LETOE, nd.id, nd.DKCAJ, nd.KNG7T, nd.TW55N, nd.QRQXW, nd.ECXAJ, nd.FGG57, nd.ZH72S, nd.FSK67, nd.XQDYT, nd.TCE7A, nd.IWV2H, nd.HPCMS, nd.N5CC2, nd.FHCYT, nd.ETAQ7, nd.A75X7, nd.TW55N as TW55N, nb6pj.Y3IOU as Y3IOU]\n" +
 			"         └─ LookupJoin\n" +
@@ -6410,7 +6410,7 @@ WHERE
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [nd.TW55N as TW55N, nb6pj.Y3IOU as Y3IOU]\n" +
-			" └─ Sort(nd.TW55N as TW55N ASC, nb6pj.Y3IOU as Y3IOU ASC)\n" +
+			" └─ Sort(TW55N ASC, Y3IOU ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [nb6pj.Y3IOU, nb6pj.id, nb6pj.BRQP2, nb6pj.FFTBJ, nb6pj.NUMK2, nb6pj.LETOE, nd.id, nd.DKCAJ, nd.KNG7T, nd.TW55N, nd.QRQXW, nd.ECXAJ, nd.FGG57, nd.ZH72S, nd.FSK67, nd.XQDYT, nd.TCE7A, nd.IWV2H, nd.HPCMS, nd.N5CC2, nd.FHCYT, nd.ETAQ7, nd.A75X7, nd.TW55N as TW55N, nb6pj.Y3IOU as Y3IOU]\n" +
 			"         └─ LookupJoin\n" +
@@ -6450,10 +6450,10 @@ WHERE
 	   E2I7U TYMVL ON (sn.FFTBJ = TYMVL.id)
 	ORDER BY M6T2N ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [(row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N, s7egw.TW55N:1!null as FJVD7, tymvl.TW55N:2!null as KBXXJ, sn.NUMK2:3!null, sn.LETOE:4!null, sn.id:5!null as XLFIA]\n" +
-			" └─ Sort((row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N ASC nullsFirst)\n" +
+			" ├─ columns: [(row_number() over ( order by sn.id asc):0!null - 1 (tinyint))->M6T2N:0, s7egw.TW55N:1!null->FJVD7:0, tymvl.TW55N:2!null->KBXXJ:0, sn.NUMK2:3!null, sn.LETOE:4!null, sn.id:5!null->XLFIA:0]\n" +
+			" └─ Sort(M6T2N:6!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [row_number() over ( order by sn.id asc):0!null, s7egw.TW55N:1!null, tymvl.TW55N:2!null, sn.NUMK2:3!null, sn.LETOE:4!null, sn.id:5!null, (row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N, s7egw.TW55N:1!null as FJVD7, tymvl.TW55N:2!null as KBXXJ, sn.id:5!null as XLFIA]\n" +
+			"         ├─ columns: [row_number() over ( order by sn.id asc):0!null, s7egw.TW55N:1!null, tymvl.TW55N:2!null, sn.NUMK2:3!null, sn.LETOE:4!null, sn.id:5!null, (row_number() over ( order by sn.id asc):0!null - 1 (tinyint))->M6T2N:0, s7egw.TW55N:1!null->FJVD7:0, tymvl.TW55N:2!null->KBXXJ:0, sn.id:5!null->XLFIA:0]\n" +
 			"         └─ Window\n" +
 			"             ├─ row_number() over ( order by sn.id ASC)\n" +
 			"             ├─ s7egw.TW55N:6!null\n" +
@@ -6498,7 +6498,7 @@ WHERE
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [(row_number() over ( order by sn.id asc) - 1) as M6T2N, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, sn.NUMK2, sn.LETOE, sn.id as XLFIA]\n" +
-			" └─ Sort((row_number() over ( order by sn.id asc) - 1) as M6T2N ASC)\n" +
+			" └─ Sort(M6T2N ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [row_number() over ( order by sn.id asc), s7egw.TW55N, tymvl.TW55N, sn.NUMK2, sn.LETOE, sn.id, (row_number() over ( order by sn.id asc) - 1) as M6T2N, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, sn.id as XLFIA]\n" +
 			"         └─ Window(row_number() over ( order by sn.id ASC), s7egw.TW55N, tymvl.TW55N, sn.NUMK2, sn.LETOE, sn.id)\n" +
@@ -6526,7 +6526,7 @@ WHERE
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [(row_number() over ( order by sn.id asc) - 1) as M6T2N, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, sn.NUMK2, sn.LETOE, sn.id as XLFIA]\n" +
-			" └─ Sort((row_number() over ( order by sn.id asc) - 1) as M6T2N ASC)\n" +
+			" └─ Sort(M6T2N ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [row_number() over ( order by sn.id asc), s7egw.TW55N, tymvl.TW55N, sn.NUMK2, sn.LETOE, sn.id, (row_number() over ( order by sn.id asc) - 1) as M6T2N, s7egw.TW55N as FJVD7, tymvl.TW55N as KBXXJ, sn.id as XLFIA]\n" +
 			"         └─ Window(row_number() over ( order by sn.id ASC), s7egw.TW55N, tymvl.TW55N, sn.NUMK2, sn.LETOE, sn.id)\n" +
@@ -6557,7 +6557,7 @@ WHERE
 		Query: `
 	SELECT id FZZVR, ROW_NUMBER() OVER (ORDER BY sn.id ASC) - 1 M6T2N FROM NOXN3 sn`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sn.id:1!null as FZZVR, (row_number() over ( order by sn.id asc):0!null - 1 (tinyint)) as M6T2N]\n" +
+			" ├─ columns: [sn.id:1!null->FZZVR:0, (row_number() over ( order by sn.id asc):0!null - 1 (tinyint))->M6T2N:0]\n" +
 			" └─ Window\n" +
 			"     ├─ row_number() over ( order by sn.id ASC)\n" +
 			"     ├─ sn.id:0!null\n" +
@@ -6758,7 +6758,7 @@ WHERE
 	   YYKXN
 	`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [athcu.T4IBQ:1!null as T4IBQ, athcu.TW55N:3!null as TW55N, CASE  WHEN fc.OZTQF:8!null IS NULL THEN 0 (tinyint) WHEN IN\n" +
+			" ├─ columns: [athcu.T4IBQ:1!null->T4IBQ:0, athcu.TW55N:3!null->TW55N:0, CASE  WHEN fc.OZTQF:8!null IS NULL THEN 0 (tinyint) WHEN IN\n" +
 			" │   ├─ left: athcu.SJ5DU:5\n" +
 			" │   └─ right: TUPLE(log (longtext), com (longtext), ex (longtext))\n" +
 			" │   THEN 0 (tinyint) WHEN Eq\n" +
@@ -6770,7 +6770,7 @@ WHERE
 			" │   THEN fc.OZTQF:8!null WHEN Eq\n" +
 			" │   ├─ athcu.SOWRY:4!null\n" +
 			" │   └─ o (longtext)\n" +
-			" │   THEN (fc.OZTQF:8!null - 1 (tinyint)) END as OZTQF]\n" +
+			" │   THEN (fc.OZTQF:8!null - 1 (tinyint)) END->OZTQF:0]\n" +
 			" └─ Sort(athcu.YYKXN:2!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ SubqueryAlias\n" +
@@ -6781,7 +6781,7 @@ WHERE
 			"         │   ├─ colSet: (63-68)\n" +
 			"         │   ├─ tableId: 6\n" +
 			"         │   └─ Project\n" +
-			"         │       ├─ columns: [tmdtp.B2TX3:0!null, tmdtp.T4IBQ:1!null, nd.id:2!null as YYKXN, nd.TW55N:5!null as TW55N, nd.FSK67:10!null as SOWRY, Subquery\n" +
+			"         │       ├─ columns: [tmdtp.B2TX3:0!null, tmdtp.T4IBQ:1!null, nd.id:2!null->YYKXN:0, nd.TW55N:5!null->TW55N:0, nd.FSK67:10!null->SOWRY:0, Subquery\n" +
 			"         │       │   ├─ cacheable: false\n" +
 			"         │       │   ├─ alias-string: select nt.DZLIM from F35MI as nt where nt.id = nd.DKCAJ\n" +
 			"         │       │   └─ Project\n" +
@@ -6799,9 +6799,9 @@ WHERE
 			"         │       │                   └─ Table\n" +
 			"         │       │                       ├─ name: F35MI\n" +
 			"         │       │                       └─ columns: [id dzlim]\n" +
-			"         │       │   as SJ5DU]\n" +
+			"         │       │  ->SJ5DU:0]\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [tmdtp.B2TX3:17!null, tmdtp.T4IBQ:18!null, nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null as YYKXN, nd.TW55N:3!null as TW55N, nd.FSK67:8!null as SOWRY, Subquery\n" +
+			"         │           ├─ columns: [tmdtp.B2TX3:17!null, tmdtp.T4IBQ:18!null, nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nd.id:0!null->YYKXN:0, nd.TW55N:3!null->TW55N:0, nd.FSK67:8!null->SOWRY:0, Subquery\n" +
 			"         │           │   ├─ cacheable: false\n" +
 			"         │           │   ├─ alias-string: select nt.DZLIM from F35MI as nt where nt.id = nd.DKCAJ\n" +
 			"         │           │   └─ Project\n" +
@@ -6819,7 +6819,7 @@ WHERE
 			"         │           │                   └─ Table\n" +
 			"         │           │                       ├─ name: F35MI\n" +
 			"         │           │                       └─ columns: [id dzlim]\n" +
-			"         │           │   as SJ5DU]\n" +
+			"         │           │  ->SJ5DU:0]\n" +
 			"         │           └─ CrossHashJoin\n" +
 			"         │               ├─ TableAlias(nd)\n" +
 			"         │               │   └─ Table\n" +
@@ -6838,7 +6838,7 @@ WHERE
 			"         │                       ├─ colSet: (37,38)\n" +
 			"         │                       ├─ tableId: 3\n" +
 			"         │                       └─ Project\n" +
-			"         │                           ├─ columns: [bs.id:2!null as B2TX3, cla.FTQLQ:1!null as T4IBQ]\n" +
+			"         │                           ├─ columns: [bs.id:2!null->B2TX3:0, cla.FTQLQ:1!null->T4IBQ:0]\n" +
 			"         │                           └─ MergeJoin\n" +
 			"         │                               ├─ cmp: Eq\n" +
 			"         │                               │   ├─ cla.id:0!null\n" +
@@ -7128,7 +7128,7 @@ WHERE
 	) XPRW6
 	GROUP BY T4IBQ, ECUWU`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [xprw6.T4IBQ:2!null as T4IBQ, xprw6.ECUWU:3!null as ECUWU, sum(xprw6.b5ouf):0!null as B5OUF, sum(xprw6.sp4si):1!null as SP4SI]\n" +
+			" ├─ columns: [xprw6.T4IBQ:2!null->T4IBQ:0, xprw6.ECUWU:3!null->ECUWU:0, sum(xprw6.b5ouf):0!null->B5OUF:0, sum(xprw6.sp4si):1!null->SP4SI:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: SUM(xprw6.B5OUF:3), SUM(xprw6.SP4SI:4!null), xprw6.T4IBQ:0!null, xprw6.ECUWU:1!null\n" +
 			"     ├─ group: xprw6.T4IBQ:0!null, xprw6.ECUWU:1!null\n" +
@@ -7140,7 +7140,7 @@ WHERE
 			"         ├─ colSet: (221-225)\n" +
 			"         ├─ tableId: 25\n" +
 			"         └─ Project\n" +
-			"             ├─ columns: [nrfj3.T4IBQ:1!null as T4IBQ, nrfj3.ECUWU:2!null as ECUWU, nrfj3.GSTQA:3!null as GSTQA, nrfj3.B5OUF:4 as B5OUF, sum(case  when ((nrfj3.oztqf < 0.5) or (nrfj3.yhylk = 0)) then 1 else 0 end):0!null as SP4SI]\n" +
+			"             ├─ columns: [nrfj3.T4IBQ:1!null->T4IBQ:0, nrfj3.ECUWU:2!null->ECUWU:0, nrfj3.GSTQA:3!null->GSTQA:0, nrfj3.B5OUF:4->B5OUF:0, sum(case  when ((nrfj3.oztqf < 0.5) or (nrfj3.yhylk = 0)) then 1 else 0 end):0!null->SP4SI:0]\n" +
 			"             └─ GroupBy\n" +
 			"                 ├─ select: SUM(CASE  WHEN Or\n" +
 			"                 │   ├─ LessThan\n" +
@@ -7169,7 +7169,7 @@ WHERE
 			"                                 ├─ colSet: (201-207)\n" +
 			"                                 ├─ tableId: 23\n" +
 			"                                 └─ Project\n" +
-			"                                     ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:6!null as ECUWU, pga.DZLIM:12!null as GSTQA, pog.B5OUF:10, fc.OZTQF:20!null, f26zw.YHYLK:24, nd.TW55N:16!null as TW55N]\n" +
+			"                                     ├─ columns: [bs.T4IBQ:1!null->T4IBQ:0, pa.DZLIM:6!null->ECUWU:0, pga.DZLIM:12!null->GSTQA:0, pog.B5OUF:10, fc.OZTQF:20!null, f26zw.YHYLK:24, nd.TW55N:16!null->TW55N:0]\n" +
 			"                                     └─ Filter\n" +
 			"                                         ├─ Eq\n" +
 			"                                         │   ├─ ms.D237E:4!null\n" +
@@ -7203,7 +7203,7 @@ WHERE
 			"                                             │   │   │   │       │   ├─ T4IBQ:1!null\n" +
 			"                                             │   │   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                                             │   │   │   │       └─ Project\n" +
-			"                                             │   │   │   │           ├─ columns: [thnts.id:0!null, yk2gw.FTQLQ:3!null as T4IBQ]\n" +
+			"                                             │   │   │   │           ├─ columns: [thnts.id:0!null, yk2gw.FTQLQ:3!null->T4IBQ:0]\n" +
 			"                                             │   │   │   │           └─ MergeJoin\n" +
 			"                                             │   │   │   │               ├─ cmp: Eq\n" +
 			"                                             │   │   │   │               │   ├─ thnts.IXUXU:1\n" +
@@ -7381,7 +7381,7 @@ WHERE
 			"                                             │               │   └─ Eq\n" +
 			"                                             │               │       ├─ iq.IDWIO:4!null\n" +
 			"                                             │               │       └─ TSG (longtext)\n" +
-			"                                             │               │   THEN 0 (tinyint) ELSE NULL (null) END as YHYLK]\n" +
+			"                                             │               │   THEN 0 (tinyint) ELSE NULL (null) END->YHYLK:0]\n" +
 			"                                             │               └─ LeftOuterHashJoin\n" +
 			"                                             │                   ├─ Eq\n" +
 			"                                             │                   │   ├─ w2mao.YH4XB:6!null\n" +
@@ -7395,7 +7395,7 @@ WHERE
 			"                                             │                   │   │   ├─ colSet: (168-172)\n" +
 			"                                             │                   │   │   ├─ tableId: 17\n" +
 			"                                             │                   │   │   └─ Project\n" +
-			"                                             │                   │   │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.BRQP2:12!null, mf.id:4!null as Z7CP5, mf.FSDY2:7!null, nma.DZLIM:11!null as IDWIO]\n" +
+			"                                             │                   │   │       ├─ columns: [cla.FTQLQ:1!null->T4IBQ:0, sn.BRQP2:12!null, mf.id:4!null->Z7CP5:0, mf.FSDY2:7!null, nma.DZLIM:11!null->IDWIO:0]\n" +
 			"                                             │                   │   │       └─ HashJoin\n" +
 			"                                             │                   │   │           ├─ Eq\n" +
 			"                                             │                   │   │           │   ├─ mf.GXLUB:5!null\n" +
@@ -8003,7 +8003,7 @@ WHERE
 	) XPRW6
 	GROUP BY T4IBQ, ECUWU`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [xprw6.T4IBQ:2!null as T4IBQ, xprw6.ECUWU:3!null as ECUWU, sum(xprw6.b5ouf):0!null as B5OUF, sum(xprw6.sp4si):1!null as SP4SI]\n" +
+			" ├─ columns: [xprw6.T4IBQ:2!null->T4IBQ:0, xprw6.ECUWU:3!null->ECUWU:0, sum(xprw6.b5ouf):0!null->B5OUF:0, sum(xprw6.sp4si):1!null->SP4SI:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: SUM(xprw6.B5OUF:3), SUM(xprw6.SP4SI:4!null), xprw6.T4IBQ:0!null, xprw6.ECUWU:1!null\n" +
 			"     ├─ group: xprw6.T4IBQ:0!null, xprw6.ECUWU:1!null\n" +
@@ -8015,7 +8015,7 @@ WHERE
 			"         ├─ colSet: (221-225)\n" +
 			"         ├─ tableId: 25\n" +
 			"         └─ Project\n" +
-			"             ├─ columns: [nrfj3.T4IBQ:1!null as T4IBQ, nrfj3.ECUWU:2!null as ECUWU, nrfj3.GSTQA:3!null as GSTQA, nrfj3.B5OUF:4 as B5OUF, sum(case  when ((nrfj3.oztqf < 0.5) or (nrfj3.yhylk = 0)) then 1 else 0 end):0!null as SP4SI]\n" +
+			"             ├─ columns: [nrfj3.T4IBQ:1!null->T4IBQ:0, nrfj3.ECUWU:2!null->ECUWU:0, nrfj3.GSTQA:3!null->GSTQA:0, nrfj3.B5OUF:4->B5OUF:0, sum(case  when ((nrfj3.oztqf < 0.5) or (nrfj3.yhylk = 0)) then 1 else 0 end):0!null->SP4SI:0]\n" +
 			"             └─ GroupBy\n" +
 			"                 ├─ select: SUM(CASE  WHEN Or\n" +
 			"                 │   ├─ LessThan\n" +
@@ -8044,7 +8044,7 @@ WHERE
 			"                                 ├─ colSet: (201-207)\n" +
 			"                                 ├─ tableId: 23\n" +
 			"                                 └─ Project\n" +
-			"                                     ├─ columns: [bs.T4IBQ:1!null as T4IBQ, pa.DZLIM:6!null as ECUWU, pga.DZLIM:12!null as GSTQA, pog.B5OUF:10, fc.OZTQF:20!null, f26zw.YHYLK:24, nd.TW55N:16!null as TW55N]\n" +
+			"                                     ├─ columns: [bs.T4IBQ:1!null->T4IBQ:0, pa.DZLIM:6!null->ECUWU:0, pga.DZLIM:12!null->GSTQA:0, pog.B5OUF:10, fc.OZTQF:20!null, f26zw.YHYLK:24, nd.TW55N:16!null->TW55N:0]\n" +
 			"                                     └─ Filter\n" +
 			"                                         ├─ Eq\n" +
 			"                                         │   ├─ ms.D237E:4!null\n" +
@@ -8078,7 +8078,7 @@ WHERE
 			"                                             │   │   │   │       │   ├─ T4IBQ:1!null\n" +
 			"                                             │   │   │   │       │   └─ TUPLE(SQ1 (longtext))\n" +
 			"                                             │   │   │   │       └─ Project\n" +
-			"                                             │   │   │   │           ├─ columns: [thnts.id:0!null, yk2gw.FTQLQ:3!null as T4IBQ]\n" +
+			"                                             │   │   │   │           ├─ columns: [thnts.id:0!null, yk2gw.FTQLQ:3!null->T4IBQ:0]\n" +
 			"                                             │   │   │   │           └─ MergeJoin\n" +
 			"                                             │   │   │   │               ├─ cmp: Eq\n" +
 			"                                             │   │   │   │               │   ├─ thnts.IXUXU:1\n" +
@@ -8256,7 +8256,7 @@ WHERE
 			"                                             │               │   └─ Eq\n" +
 			"                                             │               │       ├─ iq.IDWIO:4!null\n" +
 			"                                             │               │       └─ TSG (longtext)\n" +
-			"                                             │               │   THEN 0 (tinyint) ELSE NULL (null) END as YHYLK]\n" +
+			"                                             │               │   THEN 0 (tinyint) ELSE NULL (null) END->YHYLK:0]\n" +
 			"                                             │               └─ LeftOuterHashJoin\n" +
 			"                                             │                   ├─ Eq\n" +
 			"                                             │                   │   ├─ w2mao.YH4XB:6!null\n" +
@@ -8270,7 +8270,7 @@ WHERE
 			"                                             │                   │   │   ├─ colSet: (168-172)\n" +
 			"                                             │                   │   │   ├─ tableId: 17\n" +
 			"                                             │                   │   │   └─ Project\n" +
-			"                                             │                   │   │       ├─ columns: [cla.FTQLQ:12!null as T4IBQ, sn.BRQP2:0!null, mf.id:5!null as Z7CP5, mf.FSDY2:8!null, nma.DZLIM:4!null as IDWIO]\n" +
+			"                                             │                   │   │       ├─ columns: [cla.FTQLQ:12!null->T4IBQ:0, sn.BRQP2:0!null, mf.id:5!null->Z7CP5:0, mf.FSDY2:8!null, nma.DZLIM:4!null->IDWIO:0]\n" +
 			"                                             │                   │   │       └─ HashJoin\n" +
 			"                                             │                   │   │           ├─ Eq\n" +
 			"                                             │                   │   │           │   ├─ mf.GXLUB:6!null\n" +
@@ -8786,7 +8786,7 @@ WHERE
 	   ON XJ2RD.WNUNU = TUSAY.XLFIA
 	ORDER BY Y46B2 ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [tusay.Y3IOU:3!null as RWGEU]\n" +
+			" ├─ columns: [tusay.Y3IOU:3!null->RWGEU:0]\n" +
 			" └─ Sort(xj2rd.Y46B2:0!null ASC nullsFirst)\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
@@ -8800,7 +8800,7 @@ WHERE
 			"         │   ├─ colSet: (10-12)\n" +
 			"         │   ├─ tableId: 2\n" +
 			"         │   └─ Project\n" +
-			"         │       ├─ columns: [qywqd.id:0!null as Y46B2, qywqd.WNUNU:1!null as WNUNU, qywqd.HVHRZ:2!null as HVHRZ]\n" +
+			"         │       ├─ columns: [qywqd.id:0!null->Y46B2:0, qywqd.WNUNU:1!null->WNUNU:0, qywqd.HVHRZ:2!null->HVHRZ:0]\n" +
 			"         │       └─ Table\n" +
 			"         │           ├─ name: QYWQD\n" +
 			"         │           ├─ columns: [id wnunu hvhrz]\n" +
@@ -8817,7 +8817,7 @@ WHERE
 			"                 ├─ colSet: (26,27)\n" +
 			"                 ├─ tableId: 4\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [row_number() over ( order by noxn3.id asc):0!null as Y3IOU, noxn3.id:1!null as XLFIA]\n" +
+			"                     ├─ columns: [row_number() over ( order by noxn3.id asc):0!null->Y3IOU:0, noxn3.id:1!null->XLFIA:0]\n" +
 			"                     └─ Window\n" +
 			"                         ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                         ├─ noxn3.id:0!null\n" +
@@ -8948,7 +8948,7 @@ WHERE
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [CASE  WHEN NOT\n" +
 			" │   └─ yzxyp.Z35GY:1!null IS NULL\n" +
-			" │   THEN yzxyp.Z35GY:1!null ELSE -1 (tinyint) END as FMSOH]\n" +
+			" │   THEN yzxyp.Z35GY:1!null ELSE -1 (tinyint) END->FMSOH:0]\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: yzxyp\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -8971,7 +8971,7 @@ WHERE
 			"                 │   ├─ colSet: (19)\n" +
 			"                 │   ├─ tableId: 2\n" +
 			"                 │   └─ Project\n" +
-			"                 │       ├─ columns: [e2i7u.id:0!null as T722E]\n" +
+			"                 │       ├─ columns: [e2i7u.id:0!null->T722E:0]\n" +
 			"                 │       └─ Table\n" +
 			"                 │           ├─ name: E2I7U\n" +
 			"                 │           ├─ columns: [id]\n" +
@@ -8988,7 +8988,7 @@ WHERE
 			"                         ├─ colSet: (31,32)\n" +
 			"                         ├─ tableId: 4\n" +
 			"                         └─ Project\n" +
-			"                             ├─ columns: [amyxq.LUEVY:1!null as ZPAIK, max(amyxq.z35gy):0!null as Z35GY]\n" +
+			"                             ├─ columns: [amyxq.LUEVY:1!null->ZPAIK:0, max(amyxq.z35gy):0!null->Z35GY:0]\n" +
 			"                             └─ GroupBy\n" +
 			"                                 ├─ select: MAX(amyxq.Z35GY:1!null), amyxq.LUEVY:0!null\n" +
 			"                                 ├─ group: amyxq.luevy:0!null\n" +
@@ -9129,7 +9129,7 @@ WHERE
 			" │   THEN 2 (tinyint) WHEN Eq\n" +
 			" │   ├─ e2i7u.FSK67:8!null\n" +
 			" │   └─ CRZ2X (longtext)\n" +
-			" │   THEN 0 (tinyint) ELSE 3 (tinyint) END as SZ6KK]\n" +
+			" │   THEN 0 (tinyint) ELSE 3 (tinyint) END->SZ6KK:0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [e2i7u.id:0!null, e2i7u.DKCAJ:1!null, e2i7u.KNG7T:2, e2i7u.TW55N:3!null, e2i7u.QRQXW:4!null, e2i7u.ECXAJ:5!null, e2i7u.FGG57:6, e2i7u.ZH72S:7, e2i7u.FSK67:8!null, e2i7u.XQDYT:9!null, e2i7u.TCE7A:10, e2i7u.IWV2H:11, e2i7u.HPCMS:12!null, e2i7u.N5CC2:13, e2i7u.FHCYT:14, e2i7u.ETAQ7:15, e2i7u.A75X7:16, CASE  WHEN e2i7u.FGG57:6 IS NULL THEN 0 (tinyint) WHEN InSubquery\n" +
 			"     │   ├─ left: e2i7u.id:0!null\n" +
@@ -9162,7 +9162,7 @@ WHERE
 			"     │   THEN 2 (tinyint) WHEN Eq\n" +
 			"     │   ├─ e2i7u.FSK67:8!null\n" +
 			"     │   └─ CRZ2X (longtext)\n" +
-			"     │   THEN 0 (tinyint) ELSE 3 (tinyint) END as SZ6KK]\n" +
+			"     │   THEN 0 (tinyint) ELSE 3 (tinyint) END->SZ6KK:0]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -9326,7 +9326,7 @@ WHERE
 		ExpectedPlan: "Sort(ckele.M6T2N:4!null ASC nullsFirst)\n" +
 			" └─ Distinct\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [oxxei.T4IBQ:0!null, oxxei.Z7CP5:3!null, e52ap.KUXQY:7!null, oxxei.BDNYB:1!null, ckele.M6T2N:12!null, oxxei.BTXC5:2 as BTXC5, oxxei.vaf:4 as vaf, oxxei.QCGTS:5 as QCGTS, oxxei.SNY4H:6!null as SNY4H, e52ap.YHVEZ:9!null as YHVEZ, e52ap.YAZ4X:10!null as YAZ4X]\n" +
+			"         ├─ columns: [oxxei.T4IBQ:0!null, oxxei.Z7CP5:3!null, e52ap.KUXQY:7!null, oxxei.BDNYB:1!null, ckele.M6T2N:12!null, oxxei.BTXC5:2->BTXC5:0, oxxei.vaf:4->vaf:0, oxxei.QCGTS:5->QCGTS:0, oxxei.SNY4H:6!null->SNY4H:0, e52ap.YHVEZ:9!null->YHVEZ:0, e52ap.YAZ4X:10!null->YAZ4X:0]\n" +
 			"         └─ HashJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ ckele.LWQ6O:11!null\n" +
@@ -9343,14 +9343,14 @@ WHERE
 			"             │   │   ├─ colSet: (126-132)\n" +
 			"             │   │   ├─ tableId: 15\n" +
 			"             │   │   └─ Project\n" +
-			"             │   │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:12!null as BDNYB, aac.BTXC5:15 as BTXC5, mf.id:4!null as Z7CP5, CASE  WHEN NOT\n" +
+			"             │   │       ├─ columns: [cla.FTQLQ:1!null->T4IBQ:0, sn.id:12!null->BDNYB:0, aac.BTXC5:15->BTXC5:0, mf.id:4!null->Z7CP5:0, CASE  WHEN NOT\n" +
 			"             │   │       │   └─ mf.LT7K6:9 IS NULL\n" +
-			"             │   │       │   THEN mf.LT7K6:9 ELSE mf.SPPYD:10 END as vaf, CASE  WHEN NOT\n" +
+			"             │   │       │   THEN mf.LT7K6:9 ELSE mf.SPPYD:10 END->vaf:0, CASE  WHEN NOT\n" +
 			"             │   │       │   └─ mf.QCGTS:11 IS NULL\n" +
-			"             │   │       │   THEN mf.QCGTS:11 ELSE 0.5 (decimal(2,1)) END as QCGTS, CASE  WHEN Eq\n" +
+			"             │   │       │   THEN mf.QCGTS:11 ELSE 0.5 (decimal(2,1)) END->QCGTS:0, CASE  WHEN Eq\n" +
 			"             │   │       │   ├─ vc.ZNP4P:19!null\n" +
 			"             │   │       │   └─ L5Q44 (longtext)\n" +
-			"             │   │       │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
+			"             │   │       │   THEN 1 (tinyint) ELSE 0 (tinyint) END->SNY4H:0]\n" +
 			"             │   │       └─ HashJoin\n" +
 			"             │   │           ├─ Eq\n" +
 			"             │   │           │   ├─ vc.id:18!null\n" +
@@ -9454,16 +9454,16 @@ WHERE
 			"             │           ├─ colSet: (133-136)\n" +
 			"             │           ├─ tableId: 16\n" +
 			"             │           └─ Project\n" +
-			"             │               ├─ columns: [nd.TW55N:13!null as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28!null as YHVEZ, CASE  WHEN LessThan\n" +
+			"             │               ├─ columns: [nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
 			"             │               │   ├─ nd.TCE7A:20\n" +
 			"             │               │   └─ 0.9 (decimal(2,1))\n" +
-			"             │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
+			"             │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
 			"             │               └─ Sort(sn.id:0!null ASC nullsFirst)\n" +
 			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id:0!null, sn.BRQP2:1!null, sn.FFTBJ:2!null, sn.A7XO2:3, sn.KBO7R:4!null, sn.ECDKM:5, sn.NUMK2:6!null, sn.LETOE:7!null, sn.YKSSU:8, sn.FHCYT:9, nd.id:10!null, nd.DKCAJ:11!null, nd.KNG7T:12, nd.TW55N:13!null, nd.QRQXW:14!null, nd.ECXAJ:15!null, nd.FGG57:16, nd.ZH72S:17, nd.FSK67:18!null, nd.XQDYT:19!null, nd.TCE7A:20, nd.IWV2H:21, nd.HPCMS:22!null, nd.N5CC2:23, nd.FHCYT:24, nd.ETAQ7:25, nd.A75X7:26, nma.id:27!null, nma.DZLIM:28!null, nma.F3YUE:29, nd.TW55N:13!null as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28!null as YHVEZ, CASE  WHEN LessThan\n" +
+			"             │                       ├─ columns: [sn.id:0!null, sn.BRQP2:1!null, sn.FFTBJ:2!null, sn.A7XO2:3, sn.KBO7R:4!null, sn.ECDKM:5, sn.NUMK2:6!null, sn.LETOE:7!null, sn.YKSSU:8, sn.FHCYT:9, nd.id:10!null, nd.DKCAJ:11!null, nd.KNG7T:12, nd.TW55N:13!null, nd.QRQXW:14!null, nd.ECXAJ:15!null, nd.FGG57:16, nd.ZH72S:17, nd.FSK67:18!null, nd.XQDYT:19!null, nd.TCE7A:20, nd.IWV2H:21, nd.HPCMS:22!null, nd.N5CC2:23, nd.FHCYT:24, nd.ETAQ7:25, nd.A75X7:26, nma.id:27!null, nma.DZLIM:28!null, nma.F3YUE:29, nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
 			"             │                       │   ├─ nd.TCE7A:20\n" +
 			"             │                       │   └─ 0.9 (decimal(2,1))\n" +
-			"             │                       │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
+			"             │                       │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
 			"             │                       └─ Filter\n" +
 			"             │                           ├─ NOT\n" +
 			"             │                           │   └─ Eq\n" +
@@ -9512,7 +9512,7 @@ WHERE
 			"                     ├─ colSet: (150,151)\n" +
 			"                     ├─ tableId: 18\n" +
 			"                     └─ Project\n" +
-			"                         ├─ columns: [noxn3.id:1!null as LWQ6O, row_number() over ( order by noxn3.id asc):0!null as M6T2N]\n" +
+			"                         ├─ columns: [noxn3.id:1!null->LWQ6O:0, row_number() over ( order by noxn3.id asc):0!null->M6T2N:0]\n" +
 			"                         └─ Window\n" +
 			"                             ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                             ├─ noxn3.id:0!null\n" +
@@ -9826,7 +9826,7 @@ WHERE
 		ExpectedPlan: "Sort(ckele.M6T2N:4!null ASC nullsFirst)\n" +
 			" └─ Distinct\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [oxxei.T4IBQ:0!null, oxxei.Z7CP5:3!null, e52ap.KUXQY:7!null, oxxei.BDNYB:1!null, ckele.M6T2N:12!null, oxxei.BTXC5:2 as BTXC5, oxxei.vaf:4 as vaf, oxxei.QCGTS:5 as QCGTS, oxxei.SNY4H:6!null as SNY4H, e52ap.YHVEZ:9!null as YHVEZ, e52ap.YAZ4X:10!null as YAZ4X]\n" +
+			"         ├─ columns: [oxxei.T4IBQ:0!null, oxxei.Z7CP5:3!null, e52ap.KUXQY:7!null, oxxei.BDNYB:1!null, ckele.M6T2N:12!null, oxxei.BTXC5:2->BTXC5:0, oxxei.vaf:4->vaf:0, oxxei.QCGTS:5->QCGTS:0, oxxei.SNY4H:6!null->SNY4H:0, e52ap.YHVEZ:9!null->YHVEZ:0, e52ap.YAZ4X:10!null->YAZ4X:0]\n" +
 			"         └─ HashJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ ckele.LWQ6O:11!null\n" +
@@ -9843,14 +9843,14 @@ WHERE
 			"             │   │   ├─ colSet: (126-132)\n" +
 			"             │   │   ├─ tableId: 15\n" +
 			"             │   │   └─ Project\n" +
-			"             │   │       ├─ columns: [cla.FTQLQ:15!null as T4IBQ, sn.id:0!null as BDNYB, aac.BTXC5:13 as BTXC5, mf.id:2!null as Z7CP5, CASE  WHEN NOT\n" +
+			"             │   │       ├─ columns: [cla.FTQLQ:15!null->T4IBQ:0, sn.id:0!null->BDNYB:0, aac.BTXC5:13->BTXC5:0, mf.id:2!null->Z7CP5:0, CASE  WHEN NOT\n" +
 			"             │   │       │   └─ mf.LT7K6:7 IS NULL\n" +
-			"             │   │       │   THEN mf.LT7K6:7 ELSE mf.SPPYD:8 END as vaf, CASE  WHEN NOT\n" +
+			"             │   │       │   THEN mf.LT7K6:7 ELSE mf.SPPYD:8 END->vaf:0, CASE  WHEN NOT\n" +
 			"             │   │       │   └─ mf.QCGTS:9 IS NULL\n" +
-			"             │   │       │   THEN mf.QCGTS:9 ELSE 0.5 (decimal(2,1)) END as QCGTS, CASE  WHEN Eq\n" +
+			"             │   │       │   THEN mf.QCGTS:9 ELSE 0.5 (decimal(2,1)) END->QCGTS:0, CASE  WHEN Eq\n" +
 			"             │   │       │   ├─ vc.ZNP4P:19!null\n" +
 			"             │   │       │   └─ L5Q44 (longtext)\n" +
-			"             │   │       │   THEN 1 (tinyint) ELSE 0 (tinyint) END as SNY4H]\n" +
+			"             │   │       │   THEN 1 (tinyint) ELSE 0 (tinyint) END->SNY4H:0]\n" +
 			"             │   │       └─ HashJoin\n" +
 			"             │   │           ├─ Eq\n" +
 			"             │   │           │   ├─ vc.id:18!null\n" +
@@ -9948,16 +9948,16 @@ WHERE
 			"             │           ├─ colSet: (133-136)\n" +
 			"             │           ├─ tableId: 16\n" +
 			"             │           └─ Project\n" +
-			"             │               ├─ columns: [nd.TW55N:13!null as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28!null as YHVEZ, CASE  WHEN LessThan\n" +
+			"             │               ├─ columns: [nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
 			"             │               │   ├─ nd.TCE7A:20\n" +
 			"             │               │   └─ 0.9 (decimal(2,1))\n" +
-			"             │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
+			"             │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
 			"             │               └─ Sort(sn.id:0!null ASC nullsFirst)\n" +
 			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id:0!null, sn.BRQP2:1!null, sn.FFTBJ:2!null, sn.A7XO2:3, sn.KBO7R:4!null, sn.ECDKM:5, sn.NUMK2:6!null, sn.LETOE:7!null, sn.YKSSU:8, sn.FHCYT:9, nd.id:10!null, nd.DKCAJ:11!null, nd.KNG7T:12, nd.TW55N:13!null, nd.QRQXW:14!null, nd.ECXAJ:15!null, nd.FGG57:16, nd.ZH72S:17, nd.FSK67:18!null, nd.XQDYT:19!null, nd.TCE7A:20, nd.IWV2H:21, nd.HPCMS:22!null, nd.N5CC2:23, nd.FHCYT:24, nd.ETAQ7:25, nd.A75X7:26, nma.id:27!null, nma.DZLIM:28!null, nma.F3YUE:29, nd.TW55N:13!null as KUXQY, sn.id:0!null as BDNYB, nma.DZLIM:28!null as YHVEZ, CASE  WHEN LessThan\n" +
+			"             │                       ├─ columns: [sn.id:0!null, sn.BRQP2:1!null, sn.FFTBJ:2!null, sn.A7XO2:3, sn.KBO7R:4!null, sn.ECDKM:5, sn.NUMK2:6!null, sn.LETOE:7!null, sn.YKSSU:8, sn.FHCYT:9, nd.id:10!null, nd.DKCAJ:11!null, nd.KNG7T:12, nd.TW55N:13!null, nd.QRQXW:14!null, nd.ECXAJ:15!null, nd.FGG57:16, nd.ZH72S:17, nd.FSK67:18!null, nd.XQDYT:19!null, nd.TCE7A:20, nd.IWV2H:21, nd.HPCMS:22!null, nd.N5CC2:23, nd.FHCYT:24, nd.ETAQ7:25, nd.A75X7:26, nma.id:27!null, nma.DZLIM:28!null, nma.F3YUE:29, nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
 			"             │                       │   ├─ nd.TCE7A:20\n" +
 			"             │                       │   └─ 0.9 (decimal(2,1))\n" +
-			"             │                       │   THEN 1 (tinyint) ELSE 0 (tinyint) END as YAZ4X]\n" +
+			"             │                       │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
 			"             │                       └─ Filter\n" +
 			"             │                           ├─ NOT\n" +
 			"             │                           │   └─ Eq\n" +
@@ -10006,7 +10006,7 @@ WHERE
 			"                     ├─ colSet: (150,151)\n" +
 			"                     ├─ tableId: 18\n" +
 			"                     └─ Project\n" +
-			"                         ├─ columns: [noxn3.id:1!null as LWQ6O, row_number() over ( order by noxn3.id asc):0!null as M6T2N]\n" +
+			"                         ├─ columns: [noxn3.id:1!null->LWQ6O:0, row_number() over ( order by noxn3.id asc):0!null->M6T2N:0]\n" +
 			"                         └─ Window\n" +
 			"                             ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                             ├─ noxn3.id:0!null\n" +
@@ -10418,7 +10418,7 @@ WHERE
 	   (SELECT * FROM TPXBU) aac
 	ON aac.id = MJR3D.M22QN`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mf.FTQLQ:21!null as T4IBQ, CASE  WHEN NOT\n" +
+			" ├─ columns: [mf.FTQLQ:21!null->T4IBQ:0, CASE  WHEN NOT\n" +
 			" │   └─ mjr3d.QNI57:9!null IS NULL\n" +
 			" │   THEN Subquery\n" +
 			" │   ├─ cacheable: false\n" +
@@ -10437,7 +10437,7 @@ WHERE
 			" │               ├─ colSet: (256,257)\n" +
 			" │               ├─ tableId: 27\n" +
 			" │               └─ Project\n" +
-			" │                   ├─ columns: [noxn3.id:35!null, (row_number() over ( order by noxn3.id asc):34!null - 1 (tinyint)) as M6T2N]\n" +
+			" │                   ├─ columns: [noxn3.id:35!null, (row_number() over ( order by noxn3.id asc):34!null - 1 (tinyint))->M6T2N:0]\n" +
 			" │                   └─ Window\n" +
 			" │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			" │                       ├─ noxn3.id:34!null\n" +
@@ -10465,7 +10465,7 @@ WHERE
 			" │               ├─ colSet: (258,259)\n" +
 			" │               ├─ tableId: 28\n" +
 			" │               └─ Project\n" +
-			" │                   ├─ columns: [noxn3.id:35!null, (row_number() over ( order by noxn3.id asc):34!null - 1 (tinyint)) as M6T2N]\n" +
+			" │                   ├─ columns: [noxn3.id:35!null, (row_number() over ( order by noxn3.id asc):34!null - 1 (tinyint))->M6T2N:0]\n" +
 			" │                   └─ Window\n" +
 			" │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			" │                       ├─ noxn3.id:34!null\n" +
@@ -10474,9 +10474,9 @@ WHERE
 			" │                           ├─ columns: [id]\n" +
 			" │                           ├─ colSet: (1-10)\n" +
 			" │                           └─ tableId: 1\n" +
-			" │   END as M6T2N, mjr3d.GE5EL:4 as GE5EL, mjr3d.F7A4Q:5 as F7A4Q, mjr3d.CC4AX:7 as CC4AX, mjr3d.SL76B:8!null as SL76B, aac.BTXC5:25 as YEBDJ, mjr3d.PSMU6:2!null]\n" +
+			" │   END->M6T2N:0, mjr3d.GE5EL:4->GE5EL:0, mjr3d.F7A4Q:5->F7A4Q:0, mjr3d.CC4AX:7->CC4AX:0, mjr3d.SL76B:8!null->SL76B:0, aac.BTXC5:25->YEBDJ:0, mjr3d.PSMU6:2!null]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [mjr3d.FJDP5:0!null, mjr3d.BJUF2:1!null, mjr3d.PSMU6:2!null, mjr3d.M22QN:3!null, mjr3d.GE5EL:4, mjr3d.F7A4Q:5, mjr3d.ESFVY:6!null, mjr3d.CC4AX:7, mjr3d.SL76B:8!null, mjr3d.QNI57:9!null, mjr3d.TDEIU:10!null, sn.id:11!null, sn.BRQP2:12!null, sn.FFTBJ:13!null, sn.A7XO2:14, sn.KBO7R:15!null, sn.ECDKM:16, sn.NUMK2:17!null, sn.LETOE:18!null, sn.YKSSU:19, sn.FHCYT:20, mf.FTQLQ:21!null, mf.LUEVY:22!null, mf.M22QN:23!null, aac.id:24!null, aac.BTXC5:25, aac.FHCYT:26, mf.FTQLQ:21!null as T4IBQ, CASE  WHEN NOT\n" +
+			"     ├─ columns: [mjr3d.FJDP5:0!null, mjr3d.BJUF2:1!null, mjr3d.PSMU6:2!null, mjr3d.M22QN:3!null, mjr3d.GE5EL:4, mjr3d.F7A4Q:5, mjr3d.ESFVY:6!null, mjr3d.CC4AX:7, mjr3d.SL76B:8!null, mjr3d.QNI57:9!null, mjr3d.TDEIU:10!null, sn.id:11!null, sn.BRQP2:12!null, sn.FFTBJ:13!null, sn.A7XO2:14, sn.KBO7R:15!null, sn.ECDKM:16, sn.NUMK2:17!null, sn.LETOE:18!null, sn.YKSSU:19, sn.FHCYT:20, mf.FTQLQ:21!null, mf.LUEVY:22!null, mf.M22QN:23!null, aac.id:24!null, aac.BTXC5:25, aac.FHCYT:26, mf.FTQLQ:21!null->T4IBQ:0, CASE  WHEN NOT\n" +
 			"     │   └─ mjr3d.QNI57:9!null IS NULL\n" +
 			"     │   THEN Subquery\n" +
 			"     │   ├─ cacheable: false\n" +
@@ -10495,7 +10495,7 @@ WHERE
 			"     │               ├─ colSet: (256,257)\n" +
 			"     │               ├─ tableId: 27\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [noxn3.id:28!null, (row_number() over ( order by noxn3.id asc):27!null - 1 (tinyint)) as M6T2N]\n" +
+			"     │                   ├─ columns: [noxn3.id:28!null, (row_number() over ( order by noxn3.id asc):27!null - 1 (tinyint))->M6T2N:0]\n" +
 			"     │                   └─ Window\n" +
 			"     │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"     │                       ├─ noxn3.id:27!null\n" +
@@ -10523,7 +10523,7 @@ WHERE
 			"     │               ├─ colSet: (258,259)\n" +
 			"     │               ├─ tableId: 28\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [noxn3.id:28!null, (row_number() over ( order by noxn3.id asc):27!null - 1 (tinyint)) as M6T2N]\n" +
+			"     │                   ├─ columns: [noxn3.id:28!null, (row_number() over ( order by noxn3.id asc):27!null - 1 (tinyint))->M6T2N:0]\n" +
 			"     │                   └─ Window\n" +
 			"     │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"     │                       ├─ noxn3.id:27!null\n" +
@@ -10532,7 +10532,7 @@ WHERE
 			"     │                           ├─ columns: [id]\n" +
 			"     │                           ├─ colSet: (1-10)\n" +
 			"     │                           └─ tableId: 1\n" +
-			"     │   END as M6T2N, mjr3d.GE5EL:4 as GE5EL, mjr3d.F7A4Q:5 as F7A4Q, mjr3d.CC4AX:7 as CC4AX, mjr3d.SL76B:8!null as SL76B, aac.BTXC5:25 as YEBDJ]\n" +
+			"     │   END->M6T2N:0, mjr3d.GE5EL:4->GE5EL:0, mjr3d.F7A4Q:5->F7A4Q:0, mjr3d.CC4AX:7->CC4AX:0, mjr3d.SL76B:8!null->SL76B:0, aac.BTXC5:25->YEBDJ:0]\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ aac.id:24!null\n" +
@@ -10646,13 +10646,13 @@ WHERE
 			"         │   │   │       │   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, convert\n" +
 			"         │   │   │       │   │   ├─ type: char\n" +
 			"         │   │   │       │   │   └─ jchir.QNI57:9!null\n" +
-			"         │   │   │       │   │   as QNI57, TDEIU:10 as TDEIU]\n" +
+			"         │   │   │       │   │  ->QNI57:0, TDEIU:10->TDEIU:0]\n" +
 			"         │   │   │       │   └─ Union distinct\n" +
 			"         │   │   │       │       ├─ Project\n" +
 			"         │   │   │       │       │   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, convert\n" +
 			"         │   │   │       │       │   │   ├─ type: char\n" +
 			"         │   │   │       │       │   │   └─ jchir.TDEIU:10!null\n" +
-			"         │   │   │       │       │   │   as TDEIU]\n" +
+			"         │   │   │       │       │   │  ->TDEIU:0]\n" +
 			"         │   │   │       │       │   └─ SubqueryAlias\n" +
 			"         │   │   │       │       │       ├─ name: jchir\n" +
 			"         │   │   │       │       │       ├─ outerVisibility: false\n" +
@@ -10671,7 +10671,7 @@ WHERE
 			"         │   │   │       │       │           │       └─ NOT\n" +
 			"         │   │   │       │       │           │           └─ TDEIU:10!null IS NULL\n" +
 			"         │   │   │       │       │           └─ Project\n" +
-			"         │   │   │       │       │               ├─ columns: [ism.FV24E:0!null as FJDP5, cpmfe.id:12!null as BJUF2, cpmfe.TW55N:13!null as PSMU6, ism.M22QN:2!null as M22QN, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
+			"         │   │   │       │       │               ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
 			"         │   │   │       │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
 			"         │   │   │       │       │               │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"         │   │   │       │       │               │   THEN 0 (tinyint) WHEN IN\n" +
@@ -10683,7 +10683,7 @@ WHERE
 			"         │   │   │       │       │               │   THEN 2 (tinyint) WHEN IN\n" +
 			"         │   │   │       │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
 			"         │   │   │       │       │               │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"         │   │   │       │       │               │   THEN 3 (tinyint) END as CC4AX, g3yxs.SL76B:7!null as SL76B, yqif4.id:15!null as QNI57, yvhjz.id:18!null as TDEIU]\n" +
+			"         │   │   │       │       │               │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
 			"         │   │   │       │       │               └─ Filter\n" +
 			"         │   │   │       │       │                   ├─ Or\n" +
 			"         │   │   │       │       │                   │   ├─ NOT\n" +
@@ -10769,9 +10769,9 @@ WHERE
 			"         │   │   │       │           ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, convert\n" +
 			"         │   │   │       │           │   ├─ type: char\n" +
 			"         │   │   │       │           │   └─ TDEIU:10\n" +
-			"         │   │   │       │           │   as TDEIU]\n" +
+			"         │   │   │       │           │  ->TDEIU:0]\n" +
 			"         │   │   │       │           └─ Project\n" +
-			"         │   │   │       │               ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, NULL (null) as TDEIU]\n" +
+			"         │   │   │       │               ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, NULL (null)->TDEIU:120]\n" +
 			"         │   │   │       │               └─ SubqueryAlias\n" +
 			"         │   │   │       │                   ├─ name: jchir\n" +
 			"         │   │   │       │                   ├─ outerVisibility: false\n" +
@@ -10786,7 +10786,7 @@ WHERE
 			"         │   │   │       │                       │   └─ NOT\n" +
 			"         │   │   │       │                       │       └─ TDEIU:10!null IS NULL\n" +
 			"         │   │   │       │                       └─ Project\n" +
-			"         │   │   │       │                           ├─ columns: [ism.FV24E:0!null as FJDP5, cpmfe.id:12!null as BJUF2, cpmfe.TW55N:13!null as PSMU6, ism.M22QN:2!null as M22QN, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
+			"         │   │   │       │                           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
 			"         │   │   │       │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
 			"         │   │   │       │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"         │   │   │       │                           │   THEN 0 (tinyint) WHEN IN\n" +
@@ -10798,7 +10798,7 @@ WHERE
 			"         │   │   │       │                           │   THEN 2 (tinyint) WHEN IN\n" +
 			"         │   │   │       │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
 			"         │   │   │       │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"         │   │   │       │                           │   THEN 3 (tinyint) END as CC4AX, g3yxs.SL76B:7!null as SL76B, yqif4.id:15!null as QNI57, yvhjz.id:18!null as TDEIU]\n" +
+			"         │   │   │       │                           │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
 			"         │   │   │       │                           └─ Filter\n" +
 			"         │   │   │       │                               ├─ Or\n" +
 			"         │   │   │       │                               │   ├─ NOT\n" +
@@ -10884,12 +10884,12 @@ WHERE
 			"         │   │   │           ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, convert\n" +
 			"         │   │   │           │   ├─ type: char\n" +
 			"         │   │   │           │   └─ QNI57:9\n" +
-			"         │   │   │           │   as QNI57, convert\n" +
+			"         │   │   │           │  ->QNI57:0, convert\n" +
 			"         │   │   │           │   ├─ type: char\n" +
 			"         │   │   │           │   └─ jchir.TDEIU:10!null\n" +
-			"         │   │   │           │   as TDEIU]\n" +
+			"         │   │   │           │  ->TDEIU:0]\n" +
 			"         │   │   │           └─ Project\n" +
-			"         │   │   │               ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, NULL (null) as QNI57, jchir.TDEIU:10!null]\n" +
+			"         │   │   │               ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, NULL (null)->QNI57:132, jchir.TDEIU:10!null]\n" +
 			"         │   │   │               └─ SubqueryAlias\n" +
 			"         │   │   │                   ├─ name: jchir\n" +
 			"         │   │   │                   ├─ outerVisibility: false\n" +
@@ -10904,7 +10904,7 @@ WHERE
 			"         │   │   │                       │   └─ NOT\n" +
 			"         │   │   │                       │       └─ TDEIU:10!null IS NULL\n" +
 			"         │   │   │                       └─ Project\n" +
-			"         │   │   │                           ├─ columns: [ism.FV24E:0!null as FJDP5, cpmfe.id:12!null as BJUF2, cpmfe.TW55N:13!null as PSMU6, ism.M22QN:2!null as M22QN, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
+			"         │   │   │                           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
 			"         │   │   │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
 			"         │   │   │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
 			"         │   │   │                           │   THEN 0 (tinyint) WHEN IN\n" +
@@ -10916,7 +10916,7 @@ WHERE
 			"         │   │   │                           │   THEN 2 (tinyint) WHEN IN\n" +
 			"         │   │   │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
 			"         │   │   │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"         │   │   │                           │   THEN 3 (tinyint) END as CC4AX, g3yxs.SL76B:7!null as SL76B, yqif4.id:15!null as QNI57, yvhjz.id:18!null as TDEIU]\n" +
+			"         │   │   │                           │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
 			"         │   │   │                           └─ Filter\n" +
 			"         │   │   │                               ├─ Or\n" +
 			"         │   │   │                               │   ├─ NOT\n" +
@@ -11911,7 +11911,7 @@ WHERE
            ZMSPR
    )`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [fs.T4IBQ:0!null as T4IBQ, fs.M6T2N:1 as M6T2N, fs.TUV25:3 as TUV25, fs.BTXC5:2 as YEBDJ]\n" +
+			" ├─ columns: [fs.T4IBQ:0!null->T4IBQ:0, fs.M6T2N:1->M6T2N:0, fs.TUV25:3->TUV25:0, fs.BTXC5:2->YEBDJ:0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [fs.T4IBQ:0!null, fs.M6T2N:1, fs.BTXC5:2, fs.TUV25:3]\n" +
 			"     └─ Filter\n" +
@@ -11934,7 +11934,7 @@ WHERE
 			"             │   ├─ colSet: (260-263)\n" +
 			"             │   ├─ tableId: 36\n" +
 			"             │   └─ Project\n" +
-			"             │       ├─ columns: [rsa3y.T4IBQ:3!null as T4IBQ, jmhie.M6T2N:0 as M6T2N, jmhie.BTXC5:1 as BTXC5, jmhie.TUV25:2 as TUV25]\n" +
+			"             │       ├─ columns: [rsa3y.T4IBQ:3!null->T4IBQ:0, jmhie.M6T2N:0->M6T2N:0, jmhie.BTXC5:1->BTXC5:0, jmhie.TUV25:2->TUV25:0]\n" +
 			"             │       └─ CrossHashJoin\n" +
 			"             │           ├─ SubqueryAlias\n" +
 			"             │           │   ├─ name: jmhie\n" +
@@ -11973,7 +11973,7 @@ WHERE
 			"             │           │                   │               ├─ colSet: (210,211)\n" +
 			"             │           │                   │               ├─ tableId: 24\n" +
 			"             │           │                   │               └─ Project\n" +
-			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                   │                   └─ Window\n" +
 			"             │           │                   │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                   │                       ├─ noxn3.id:25!null\n" +
@@ -12001,7 +12001,7 @@ WHERE
 			"             │           │                   │               ├─ colSet: (212,213)\n" +
 			"             │           │                   │               ├─ tableId: 25\n" +
 			"             │           │                   │               └─ Project\n" +
-			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                   │                   └─ Window\n" +
 			"             │           │                   │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                   │                       ├─ noxn3.id:25!null\n" +
@@ -12010,7 +12010,7 @@ WHERE
 			"             │           │                   │                           ├─ columns: [id]\n" +
 			"             │           │                   │                           ├─ colSet: (1-10)\n" +
 			"             │           │                   │                           └─ tableId: 1\n" +
-			"             │           │                   │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"             │           │                   │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"             │           │                   └─ Project\n" +
 			"             │           │                       ├─ columns: [mjr3d.FJDP5:0!null, mjr3d.BJUF2:1!null, mjr3d.M22QN:2!null, mjr3d.TUV25:3, mjr3d.ESFVY:4!null, mjr3d.QNI57:5!null, mjr3d.TDEIU:6!null, aac.id:7!null, aac.BTXC5:8, aac.FHCYT:9, sn.id:10!null, sn.BRQP2:11!null, sn.FFTBJ:12!null, sn.A7XO2:13, sn.KBO7R:14!null, sn.ECDKM:15, sn.NUMK2:16!null, sn.LETOE:17!null, sn.YKSSU:18, sn.FHCYT:19, CASE  WHEN NOT\n" +
 			"             │           │                       │   └─ mjr3d.QNI57:5!null IS NULL\n" +
@@ -12031,7 +12031,7 @@ WHERE
 			"             │           │                       │               ├─ colSet: (210,211)\n" +
 			"             │           │                       │               ├─ tableId: 24\n" +
 			"             │           │                       │               └─ Project\n" +
-			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                       │                   └─ Window\n" +
 			"             │           │                       │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                       │                       ├─ noxn3.id:20!null\n" +
@@ -12059,7 +12059,7 @@ WHERE
 			"             │           │                       │               ├─ colSet: (212,213)\n" +
 			"             │           │                       │               ├─ tableId: 25\n" +
 			"             │           │                       │               └─ Project\n" +
-			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                       │                   └─ Window\n" +
 			"             │           │                       │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                       │                       ├─ noxn3.id:20!null\n" +
@@ -12068,7 +12068,7 @@ WHERE
 			"             │           │                       │                           ├─ columns: [id]\n" +
 			"             │           │                       │                           ├─ colSet: (1-10)\n" +
 			"             │           │                       │                           └─ tableId: 1\n" +
-			"             │           │                       │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"             │           │                       │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"             │           │                       └─ LeftOuterJoin\n" +
 			"             │           │                           ├─ Or\n" +
 			"             │           │                           │   ├─ Or\n" +
@@ -12168,7 +12168,7 @@ WHERE
 			"             │           │                           │   │   ├─ tableId: 18\n" +
 			"             │           │                           │   │   └─ Distinct\n" +
 			"             │           │                           │   │       └─ Project\n" +
-			"             │           │                           │   │           ├─ columns: [ism.FV24E:0!null as FJDP5, cpmfe.id:10!null as BJUF2, ism.M22QN:2!null as M22QN, g3yxs.TUV25:7 as TUV25, g3yxs.ESFVY:6!null as ESFVY, yqif4.id:12!null as QNI57, yvhjz.id:15!null as TDEIU]\n" +
+			"             │           │                           │   │           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:10!null->BJUF2:0, ism.M22QN:2!null->M22QN:0, g3yxs.TUV25:7->TUV25:0, g3yxs.ESFVY:6!null->ESFVY:0, yqif4.id:12!null->QNI57:0, yvhjz.id:15!null->TDEIU:0]\n" +
 			"             │           │                           │   │           └─ Filter\n" +
 			"             │           │                           │   │               ├─ Or\n" +
 			"             │           │                           │   │               │   ├─ NOT\n" +
@@ -12289,7 +12289,7 @@ WHERE
 			"             │                               ├─ colSet: (232-234)\n" +
 			"             │                               ├─ tableId: 17\n" +
 			"             │                               └─ Project\n" +
-			"             │                                   ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
+			"             │                                   ├─ columns: [cla.FTQLQ:1!null->T4IBQ:0, sn.id:7!null->BDNYB:0, mf.M22QN:6!null->M22QN:0]\n" +
 			"             │                                   └─ HashJoin\n" +
 			"             │                                       ├─ Eq\n" +
 			"             │                                       │   ├─ bs.id:2!null\n" +
@@ -12357,7 +12357,7 @@ WHERE
 			"                     ├─ tableId: 35\n" +
 			"                     └─ Distinct\n" +
 			"                         └─ Project\n" +
-			"                             ├─ columns: [cld.T4IBQ:0!null as T4IBQ, p4pjz.M6T2N:3 as M6T2N, p4pjz.BTXC5:4 as BTXC5, p4pjz.TUV25:7 as TUV25]\n" +
+			"                             ├─ columns: [cld.T4IBQ:0!null->T4IBQ:0, p4pjz.M6T2N:3->M6T2N:0, p4pjz.BTXC5:4->BTXC5:0, p4pjz.TUV25:7->TUV25:0]\n" +
 			"                             └─ Filter\n" +
 			"                                 ├─ NOT\n" +
 			"                                 │   └─ p4pjz.M6T2N:3 IS NULL\n" +
@@ -12377,7 +12377,7 @@ WHERE
 			"                                     │   ├─ colSet: (244-246)\n" +
 			"                                     │   ├─ tableId: 32\n" +
 			"                                     │   └─ Project\n" +
-			"                                     │       ├─ columns: [cla.FTQLQ:1!null as T4IBQ, sn.id:7!null as BDNYB, mf.M22QN:6!null as M22QN]\n" +
+			"                                     │       ├─ columns: [cla.FTQLQ:1!null->T4IBQ:0, sn.id:7!null->BDNYB:0, mf.M22QN:6!null->M22QN:0]\n" +
 			"                                     │       └─ HashJoin\n" +
 			"                                     │           ├─ Eq\n" +
 			"                                     │           │   ├─ bs.id:2!null\n" +
@@ -12463,7 +12463,7 @@ WHERE
 			"                                                 │               ├─ colSet: (210,211)\n" +
 			"                                                 │               ├─ tableId: 24\n" +
 			"                                                 │               └─ Project\n" +
-			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                 │                   └─ Window\n" +
 			"                                                 │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                 │                       ├─ noxn3.id:25!null\n" +
@@ -12491,7 +12491,7 @@ WHERE
 			"                                                 │               ├─ colSet: (212,213)\n" +
 			"                                                 │               ├─ tableId: 25\n" +
 			"                                                 │               └─ Project\n" +
-			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                 │                   └─ Window\n" +
 			"                                                 │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                 │                       ├─ noxn3.id:25!null\n" +
@@ -12500,7 +12500,7 @@ WHERE
 			"                                                 │                           ├─ columns: [id]\n" +
 			"                                                 │                           ├─ colSet: (1-10)\n" +
 			"                                                 │                           └─ tableId: 1\n" +
-			"                                                 │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"                                                 │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"                                                 └─ Project\n" +
 			"                                                     ├─ columns: [mjr3d.FJDP5:0!null, mjr3d.BJUF2:1!null, mjr3d.M22QN:2!null, mjr3d.TUV25:3, mjr3d.ESFVY:4!null, mjr3d.QNI57:5!null, mjr3d.TDEIU:6!null, aac.id:7!null, aac.BTXC5:8, aac.FHCYT:9, sn.id:10!null, sn.BRQP2:11!null, sn.FFTBJ:12!null, sn.A7XO2:13, sn.KBO7R:14!null, sn.ECDKM:15, sn.NUMK2:16!null, sn.LETOE:17!null, sn.YKSSU:18, sn.FHCYT:19, CASE  WHEN NOT\n" +
 			"                                                     │   └─ mjr3d.QNI57:5!null IS NULL\n" +
@@ -12521,7 +12521,7 @@ WHERE
 			"                                                     │               ├─ colSet: (210,211)\n" +
 			"                                                     │               ├─ tableId: 24\n" +
 			"                                                     │               └─ Project\n" +
-			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                     │                   └─ Window\n" +
 			"                                                     │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                     │                       ├─ noxn3.id:20!null\n" +
@@ -12549,7 +12549,7 @@ WHERE
 			"                                                     │               ├─ colSet: (212,213)\n" +
 			"                                                     │               ├─ tableId: 25\n" +
 			"                                                     │               └─ Project\n" +
-			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                     │                   └─ Window\n" +
 			"                                                     │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                     │                       ├─ noxn3.id:20!null\n" +
@@ -12558,7 +12558,7 @@ WHERE
 			"                                                     │                           ├─ columns: [id]\n" +
 			"                                                     │                           ├─ colSet: (1-10)\n" +
 			"                                                     │                           └─ tableId: 1\n" +
-			"                                                     │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"                                                     │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"                                                     └─ LeftOuterJoin\n" +
 			"                                                         ├─ Or\n" +
 			"                                                         │   ├─ Or\n" +
@@ -12658,7 +12658,7 @@ WHERE
 			"                                                         │   │   ├─ tableId: 18\n" +
 			"                                                         │   │   └─ Distinct\n" +
 			"                                                         │   │       └─ Project\n" +
-			"                                                         │   │           ├─ columns: [ism.FV24E:0!null as FJDP5, cpmfe.id:10!null as BJUF2, ism.M22QN:2!null as M22QN, g3yxs.TUV25:7 as TUV25, g3yxs.ESFVY:6!null as ESFVY, yqif4.id:12!null as QNI57, yvhjz.id:15!null as TDEIU]\n" +
+			"                                                         │   │           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:10!null->BJUF2:0, ism.M22QN:2!null->M22QN:0, g3yxs.TUV25:7->TUV25:0, g3yxs.ESFVY:6!null->ESFVY:0, yqif4.id:12!null->QNI57:0, yvhjz.id:15!null->TDEIU:0]\n" +
 			"                                                         │   │           └─ Filter\n" +
 			"                                                         │   │               ├─ Or\n" +
 			"                                                         │   │               │   ├─ NOT\n" +
@@ -13895,7 +13895,7 @@ WHERE
            ZMSPR
    )`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [fs.T4IBQ:0!null as T4IBQ, fs.M6T2N:1 as M6T2N, fs.TUV25:3 as TUV25, fs.BTXC5:2 as YEBDJ]\n" +
+			" ├─ columns: [fs.T4IBQ:0!null->T4IBQ:0, fs.M6T2N:1->M6T2N:0, fs.TUV25:3->TUV25:0, fs.BTXC5:2->YEBDJ:0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [fs.T4IBQ:0!null, fs.M6T2N:1, fs.BTXC5:2, fs.TUV25:3]\n" +
 			"     └─ Filter\n" +
@@ -13918,7 +13918,7 @@ WHERE
 			"             │   ├─ colSet: (260-263)\n" +
 			"             │   ├─ tableId: 36\n" +
 			"             │   └─ Project\n" +
-			"             │       ├─ columns: [rsa3y.T4IBQ:3!null as T4IBQ, jmhie.M6T2N:0 as M6T2N, jmhie.BTXC5:1 as BTXC5, jmhie.TUV25:2 as TUV25]\n" +
+			"             │       ├─ columns: [rsa3y.T4IBQ:3!null->T4IBQ:0, jmhie.M6T2N:0->M6T2N:0, jmhie.BTXC5:1->BTXC5:0, jmhie.TUV25:2->TUV25:0]\n" +
 			"             │       └─ CrossHashJoin\n" +
 			"             │           ├─ SubqueryAlias\n" +
 			"             │           │   ├─ name: jmhie\n" +
@@ -13957,7 +13957,7 @@ WHERE
 			"             │           │                   │               ├─ colSet: (210,211)\n" +
 			"             │           │                   │               ├─ tableId: 24\n" +
 			"             │           │                   │               └─ Project\n" +
-			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                   │                   └─ Window\n" +
 			"             │           │                   │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                   │                       ├─ noxn3.id:25!null\n" +
@@ -13985,7 +13985,7 @@ WHERE
 			"             │           │                   │               ├─ colSet: (212,213)\n" +
 			"             │           │                   │               ├─ tableId: 25\n" +
 			"             │           │                   │               └─ Project\n" +
-			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                   │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                   │                   └─ Window\n" +
 			"             │           │                   │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                   │                       ├─ noxn3.id:25!null\n" +
@@ -13994,7 +13994,7 @@ WHERE
 			"             │           │                   │                           ├─ columns: [id]\n" +
 			"             │           │                   │                           ├─ colSet: (1-10)\n" +
 			"             │           │                   │                           └─ tableId: 1\n" +
-			"             │           │                   │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"             │           │                   │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"             │           │                   └─ Project\n" +
 			"             │           │                       ├─ columns: [mjr3d.FJDP5:0!null, mjr3d.BJUF2:1!null, mjr3d.M22QN:2!null, mjr3d.TUV25:3, mjr3d.ESFVY:4!null, mjr3d.QNI57:5!null, mjr3d.TDEIU:6!null, aac.id:7!null, aac.BTXC5:8, aac.FHCYT:9, sn.id:10!null, sn.BRQP2:11!null, sn.FFTBJ:12!null, sn.A7XO2:13, sn.KBO7R:14!null, sn.ECDKM:15, sn.NUMK2:16!null, sn.LETOE:17!null, sn.YKSSU:18, sn.FHCYT:19, CASE  WHEN NOT\n" +
 			"             │           │                       │   └─ mjr3d.QNI57:5!null IS NULL\n" +
@@ -14015,7 +14015,7 @@ WHERE
 			"             │           │                       │               ├─ colSet: (210,211)\n" +
 			"             │           │                       │               ├─ tableId: 24\n" +
 			"             │           │                       │               └─ Project\n" +
-			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                       │                   └─ Window\n" +
 			"             │           │                       │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                       │                       ├─ noxn3.id:20!null\n" +
@@ -14043,7 +14043,7 @@ WHERE
 			"             │           │                       │               ├─ colSet: (212,213)\n" +
 			"             │           │                       │               ├─ tableId: 25\n" +
 			"             │           │                       │               └─ Project\n" +
-			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"             │           │                       │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"             │           │                       │                   └─ Window\n" +
 			"             │           │                       │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"             │           │                       │                       ├─ noxn3.id:20!null\n" +
@@ -14052,7 +14052,7 @@ WHERE
 			"             │           │                       │                           ├─ columns: [id]\n" +
 			"             │           │                       │                           ├─ colSet: (1-10)\n" +
 			"             │           │                       │                           └─ tableId: 1\n" +
-			"             │           │                       │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"             │           │                       │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"             │           │                       └─ LeftOuterJoin\n" +
 			"             │           │                           ├─ Or\n" +
 			"             │           │                           │   ├─ Or\n" +
@@ -14152,7 +14152,7 @@ WHERE
 			"             │           │                           │   │   ├─ tableId: 18\n" +
 			"             │           │                           │   │   └─ Distinct\n" +
 			"             │           │                           │   │       └─ Project\n" +
-			"             │           │                           │   │           ├─ columns: [ism.FV24E:0!null as FJDP5, cpmfe.id:10!null as BJUF2, ism.M22QN:2!null as M22QN, g3yxs.TUV25:7 as TUV25, g3yxs.ESFVY:6!null as ESFVY, yqif4.id:12!null as QNI57, yvhjz.id:15!null as TDEIU]\n" +
+			"             │           │                           │   │           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:10!null->BJUF2:0, ism.M22QN:2!null->M22QN:0, g3yxs.TUV25:7->TUV25:0, g3yxs.ESFVY:6!null->ESFVY:0, yqif4.id:12!null->QNI57:0, yvhjz.id:15!null->TDEIU:0]\n" +
 			"             │           │                           │   │           └─ Filter\n" +
 			"             │           │                           │   │               ├─ Or\n" +
 			"             │           │                           │   │               │   ├─ NOT\n" +
@@ -14273,7 +14273,7 @@ WHERE
 			"             │                               ├─ colSet: (232-234)\n" +
 			"             │                               ├─ tableId: 17\n" +
 			"             │                               └─ Project\n" +
-			"             │                                   ├─ columns: [cla.FTQLQ:8!null as T4IBQ, sn.id:0!null as BDNYB, mf.M22QN:4!null as M22QN]\n" +
+			"             │                                   ├─ columns: [cla.FTQLQ:8!null->T4IBQ:0, sn.id:0!null->BDNYB:0, mf.M22QN:4!null->M22QN:0]\n" +
 			"             │                                   └─ HashJoin\n" +
 			"             │                                       ├─ Eq\n" +
 			"             │                                       │   ├─ bs.id:5!null\n" +
@@ -14335,7 +14335,7 @@ WHERE
 			"                     ├─ tableId: 35\n" +
 			"                     └─ Distinct\n" +
 			"                         └─ Project\n" +
-			"                             ├─ columns: [cld.T4IBQ:0!null as T4IBQ, p4pjz.M6T2N:3 as M6T2N, p4pjz.BTXC5:4 as BTXC5, p4pjz.TUV25:7 as TUV25]\n" +
+			"                             ├─ columns: [cld.T4IBQ:0!null->T4IBQ:0, p4pjz.M6T2N:3->M6T2N:0, p4pjz.BTXC5:4->BTXC5:0, p4pjz.TUV25:7->TUV25:0]\n" +
 			"                             └─ Filter\n" +
 			"                                 ├─ NOT\n" +
 			"                                 │   └─ p4pjz.M6T2N:3 IS NULL\n" +
@@ -14355,7 +14355,7 @@ WHERE
 			"                                     │   ├─ colSet: (244-246)\n" +
 			"                                     │   ├─ tableId: 32\n" +
 			"                                     │   └─ Project\n" +
-			"                                     │       ├─ columns: [cla.FTQLQ:8!null as T4IBQ, sn.id:0!null as BDNYB, mf.M22QN:4!null as M22QN]\n" +
+			"                                     │       ├─ columns: [cla.FTQLQ:8!null->T4IBQ:0, sn.id:0!null->BDNYB:0, mf.M22QN:4!null->M22QN:0]\n" +
 			"                                     │       └─ HashJoin\n" +
 			"                                     │           ├─ Eq\n" +
 			"                                     │           │   ├─ bs.id:5!null\n" +
@@ -14435,7 +14435,7 @@ WHERE
 			"                                                 │               ├─ colSet: (210,211)\n" +
 			"                                                 │               ├─ tableId: 24\n" +
 			"                                                 │               └─ Project\n" +
-			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                 │                   └─ Window\n" +
 			"                                                 │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                 │                       ├─ noxn3.id:25!null\n" +
@@ -14463,7 +14463,7 @@ WHERE
 			"                                                 │               ├─ colSet: (212,213)\n" +
 			"                                                 │               ├─ tableId: 25\n" +
 			"                                                 │               └─ Project\n" +
-			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                 │                   ├─ columns: [noxn3.id:26!null, (row_number() over ( order by noxn3.id asc):25!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                 │                   └─ Window\n" +
 			"                                                 │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                 │                       ├─ noxn3.id:25!null\n" +
@@ -14472,7 +14472,7 @@ WHERE
 			"                                                 │                           ├─ columns: [id]\n" +
 			"                                                 │                           ├─ colSet: (1-10)\n" +
 			"                                                 │                           └─ tableId: 1\n" +
-			"                                                 │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"                                                 │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"                                                 └─ Project\n" +
 			"                                                     ├─ columns: [mjr3d.FJDP5:0!null, mjr3d.BJUF2:1!null, mjr3d.M22QN:2!null, mjr3d.TUV25:3, mjr3d.ESFVY:4!null, mjr3d.QNI57:5!null, mjr3d.TDEIU:6!null, aac.id:7!null, aac.BTXC5:8, aac.FHCYT:9, sn.id:10!null, sn.BRQP2:11!null, sn.FFTBJ:12!null, sn.A7XO2:13, sn.KBO7R:14!null, sn.ECDKM:15, sn.NUMK2:16!null, sn.LETOE:17!null, sn.YKSSU:18, sn.FHCYT:19, CASE  WHEN NOT\n" +
 			"                                                     │   └─ mjr3d.QNI57:5!null IS NULL\n" +
@@ -14493,7 +14493,7 @@ WHERE
 			"                                                     │               ├─ colSet: (210,211)\n" +
 			"                                                     │               ├─ tableId: 24\n" +
 			"                                                     │               └─ Project\n" +
-			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                     │                   └─ Window\n" +
 			"                                                     │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                     │                       ├─ noxn3.id:20!null\n" +
@@ -14521,7 +14521,7 @@ WHERE
 			"                                                     │               ├─ colSet: (212,213)\n" +
 			"                                                     │               ├─ tableId: 25\n" +
 			"                                                     │               └─ Project\n" +
-			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint)) as M6T2N]\n" +
+			"                                                     │                   ├─ columns: [noxn3.id:21!null, (row_number() over ( order by noxn3.id asc):20!null - 1 (tinyint))->M6T2N:0]\n" +
 			"                                                     │                   └─ Window\n" +
 			"                                                     │                       ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                                                     │                       ├─ noxn3.id:20!null\n" +
@@ -14530,7 +14530,7 @@ WHERE
 			"                                                     │                           ├─ columns: [id]\n" +
 			"                                                     │                           ├─ colSet: (1-10)\n" +
 			"                                                     │                           └─ tableId: 1\n" +
-			"                                                     │   END as M6T2N, aac.BTXC5:8 as BTXC5, aac.id:7!null as NTOFG, sn.id:10!null as LWQ6O, mjr3d.TUV25:3 as TUV25]\n" +
+			"                                                     │   END->M6T2N:0, aac.BTXC5:8->BTXC5:0, aac.id:7!null->NTOFG:0, sn.id:10!null->LWQ6O:0, mjr3d.TUV25:3->TUV25:0]\n" +
 			"                                                     └─ LeftOuterJoin\n" +
 			"                                                         ├─ Or\n" +
 			"                                                         │   ├─ Or\n" +
@@ -14630,7 +14630,7 @@ WHERE
 			"                                                         │   │   ├─ tableId: 18\n" +
 			"                                                         │   │   └─ Distinct\n" +
 			"                                                         │   │       └─ Project\n" +
-			"                                                         │   │           ├─ columns: [ism.FV24E:0!null as FJDP5, cpmfe.id:10!null as BJUF2, ism.M22QN:2!null as M22QN, g3yxs.TUV25:7 as TUV25, g3yxs.ESFVY:6!null as ESFVY, yqif4.id:12!null as QNI57, yvhjz.id:15!null as TDEIU]\n" +
+			"                                                         │   │           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:10!null->BJUF2:0, ism.M22QN:2!null->M22QN:0, g3yxs.TUV25:7->TUV25:0, g3yxs.ESFVY:6!null->ESFVY:0, yqif4.id:12!null->QNI57:0, yvhjz.id:15!null->TDEIU:0]\n" +
 			"                                                         │   │           └─ Filter\n" +
 			"                                                         │   │               ├─ Or\n" +
 			"                                                         │   │               │   ├─ NOT\n" +
@@ -15774,9 +15774,9 @@ ORDER BY id ASC`,
 		Query: `
 SELECT COUNT(*) FROM E2I7U`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as COUNT(*)]\n" +
+			" ├─ columns: [count(1):0!null->COUNT(*):0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [E2I7U.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [E2I7U.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(E2I7U) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -15800,7 +15800,7 @@ SELECT
 FROM
    E2I7U`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [(row_number() over ( order by e2i7u.id asc):0!null - 1 (tinyint)) as DICQO, e2i7u.TW55N:1!null]\n" +
+			" ├─ columns: [(row_number() over ( order by e2i7u.id asc):0!null - 1 (tinyint))->DICQO:0, e2i7u.TW55N:1!null]\n" +
 			" └─ Window\n" +
 			"     ├─ row_number() over ( order by e2i7u.id ASC)\n" +
 			"     ├─ e2i7u.TW55N:1!null\n" +
@@ -15845,7 +15845,7 @@ INNER JOIN
    ON XJ2RD.HHVLX = TUSAY.XLFIA
 ORDER BY Y46B2 ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [tusay.Y3IOU:3!null as Q7H3X]\n" +
+			" ├─ columns: [tusay.Y3IOU:3!null->Q7H3X:0]\n" +
 			" └─ Sort(xj2rd.Y46B2:0!null ASC nullsFirst)\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
@@ -15859,7 +15859,7 @@ ORDER BY Y46B2 ASC`,
 			"         │   ├─ colSet: (10-12)\n" +
 			"         │   ├─ tableId: 2\n" +
 			"         │   └─ Project\n" +
-			"         │       ├─ columns: [qywqd.id:0!null as Y46B2, qywqd.HHVLX:1!null as HHVLX, qywqd.HVHRZ:2!null as HVHRZ]\n" +
+			"         │       ├─ columns: [qywqd.id:0!null->Y46B2:0, qywqd.HHVLX:1!null->HHVLX:0, qywqd.HVHRZ:2!null->HVHRZ:0]\n" +
 			"         │       └─ Table\n" +
 			"         │           ├─ name: QYWQD\n" +
 			"         │           ├─ columns: [id hhvlx hvhrz]\n" +
@@ -15876,7 +15876,7 @@ ORDER BY Y46B2 ASC`,
 			"                 ├─ colSet: (26,27)\n" +
 			"                 ├─ tableId: 4\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [row_number() over ( order by noxn3.id asc):0!null as Y3IOU, noxn3.id:1!null as XLFIA]\n" +
+			"                     ├─ columns: [row_number() over ( order by noxn3.id asc):0!null->Y3IOU:0, noxn3.id:1!null->XLFIA:0]\n" +
 			"                     └─ Window\n" +
 			"                         ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                         ├─ noxn3.id:0!null\n" +
@@ -15995,9 +15995,9 @@ ORDER BY sn.XLFIA ASC`,
 			"         │   ├─ colSet: (12,13)\n" +
 			"         │   ├─ tableId: 2\n" +
 			"         │   └─ Project\n" +
-			"         │       ├─ columns: [noxn3.id:0!null as XLFIA, noxn3.BRQP2:1!null]\n" +
+			"         │       ├─ columns: [noxn3.id:0!null->XLFIA:0, noxn3.BRQP2:1!null]\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [noxn3.id:0!null, noxn3.BRQP2:1!null, noxn3.FFTBJ:2!null, noxn3.A7XO2:3, noxn3.KBO7R:4!null, noxn3.ECDKM:5, noxn3.NUMK2:6!null, noxn3.LETOE:7!null, noxn3.YKSSU:8, noxn3.FHCYT:9, noxn3.id:0!null as XLFIA]\n" +
+			"         │           ├─ columns: [noxn3.id:0!null, noxn3.BRQP2:1!null, noxn3.FFTBJ:2!null, noxn3.A7XO2:3, noxn3.KBO7R:4!null, noxn3.ECDKM:5, noxn3.NUMK2:6!null, noxn3.LETOE:7!null, noxn3.YKSSU:8, noxn3.FHCYT:9, noxn3.id:0!null->XLFIA:0]\n" +
 			"         │           └─ IndexedTableAccess(NOXN3)\n" +
 			"         │               ├─ index: [NOXN3.id]\n" +
 			"         │               ├─ static: [{[NULL, ∞)}]\n" +
@@ -16020,7 +16020,7 @@ ORDER BY sn.XLFIA ASC`,
 			"                     ├─ columns: [nd.LUEVY:0!null, CASE  WHEN Eq\n" +
 			"                     │   ├─ nma.DZLIM:3!null\n" +
 			"                     │   └─ Q5I4E (longtext)\n" +
-			"                     │   THEN 1 (tinyint) ELSE 0 (tinyint) END as R2SR7]\n" +
+			"                     │   THEN 1 (tinyint) ELSE 0 (tinyint) END->R2SR7:0]\n" +
 			"                     └─ LeftOuterHashJoin\n" +
 			"                         ├─ Eq\n" +
 			"                         │   ├─ nd.HPCMS:1!null\n" +
@@ -16033,7 +16033,7 @@ ORDER BY sn.XLFIA ASC`,
 			"                         │   ├─ colSet: (33,34)\n" +
 			"                         │   ├─ tableId: 4\n" +
 			"                         │   └─ Project\n" +
-			"                         │       ├─ columns: [e2i7u.id:0!null as LUEVY, e2i7u.HPCMS:1!null as HPCMS]\n" +
+			"                         │       ├─ columns: [e2i7u.id:0!null->LUEVY:0, e2i7u.HPCMS:1!null->HPCMS:0]\n" +
 			"                         │       └─ Table\n" +
 			"                         │           ├─ name: E2I7U\n" +
 			"                         │           ├─ columns: [id hpcms]\n" +
@@ -16050,7 +16050,7 @@ ORDER BY sn.XLFIA ASC`,
 			"                                 ├─ colSet: (39,40)\n" +
 			"                                 ├─ tableId: 6\n" +
 			"                                 └─ Project\n" +
-			"                                     ├─ columns: [tnmxi.id:0!null as MLECF, tnmxi.DZLIM:1!null]\n" +
+			"                                     ├─ columns: [tnmxi.id:0!null->MLECF:0, tnmxi.DZLIM:1!null]\n" +
 			"                                     └─ Table\n" +
 			"                                         ├─ name: TNMXI\n" +
 			"                                         ├─ columns: [id dzlim]\n" +
@@ -16185,7 +16185,7 @@ LEFT JOIN
     ON QI2IE.VIBZI = GRRB6.AHMDT
 ORDER BY GRRB6.XLFIA ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [qi2ie.DICQO:2!null as DICQO]\n" +
+			" ├─ columns: [qi2ie.DICQO:2!null->DICQO:0]\n" +
 			" └─ Sort(grrb6.XLFIA:0!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterHashJoin\n" +
 			"         ├─ Eq\n" +
@@ -16199,7 +16199,7 @@ ORDER BY GRRB6.XLFIA ASC`,
 			"         │   ├─ colSet: (13,14)\n" +
 			"         │   ├─ tableId: 2\n" +
 			"         │   └─ Project\n" +
-			"         │       ├─ columns: [noxn3.id:0!null as XLFIA, noxn3.BRQP2:1!null as AHMDT]\n" +
+			"         │       ├─ columns: [noxn3.id:0!null->XLFIA:0, noxn3.BRQP2:1!null->AHMDT:0]\n" +
 			"         │       └─ Table\n" +
 			"         │           ├─ name: NOXN3\n" +
 			"         │           ├─ columns: [id brqp2]\n" +
@@ -16216,7 +16216,7 @@ ORDER BY GRRB6.XLFIA ASC`,
 			"                 ├─ colSet: (35,36)\n" +
 			"                 ├─ tableId: 4\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [row_number() over ( order by e2i7u.id asc):0!null as DICQO, e2i7u.id:1!null as VIBZI]\n" +
+			"                     ├─ columns: [row_number() over ( order by e2i7u.id asc):0!null->DICQO:0, e2i7u.id:1!null->VIBZI:0]\n" +
 			"                     └─ Window\n" +
 			"                         ├─ row_number() over ( order by e2i7u.id ASC)\n" +
 			"                         ├─ e2i7u.id:0!null\n" +
@@ -16777,7 +16777,7 @@ LEFT JOIN XGSJM YBBG5
     ON YPGDA.I3L5A = YBBG5.id
 ORDER BY LUEVY`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [ypgda.LUEVY:0!null as LUEVY, ypgda.TW55N:1!null as TW55N, ypgda.IYDZV:2 as IYDZV,  (longtext) as IIISV, ypgda.QRQXW:3!null as QRQXW, ypgda.CAECS:4 as CAECS, ypgda.CJLLY:5!null as CJLLY, ypgda.SHP7H:6!null as SHP7H, ypgda.HARAZ:7 as HARAZ,  (longtext) as ECUWU,  (longtext) as LDMO7, CASE  WHEN Eq\n" +
+			" ├─ columns: [ypgda.LUEVY:0!null->LUEVY:0, ypgda.TW55N:1!null->TW55N:0, ypgda.IYDZV:2->IYDZV:0,  (longtext)->IIISV:59, ypgda.QRQXW:3!null->QRQXW:0, ypgda.CAECS:4->CAECS:0, ypgda.CJLLY:5!null->CJLLY:0, ypgda.SHP7H:6!null->SHP7H:0, ypgda.HARAZ:7->HARAZ:0,  (longtext)->ECUWU:65,  (longtext)->LDMO7:66, CASE  WHEN Eq\n" +
 			" │   ├─ ybbg5.DZLIM:13!null\n" +
 			" │   └─ HGUEM (longtext)\n" +
 			" │   THEN s30 (longtext) WHEN Eq\n" +
@@ -16792,10 +16792,10 @@ ORDER BY LUEVY`,
 			" │   THEN s (longtext) WHEN Eq\n" +
 			" │   ├─ ybbg5.DZLIM:13!null\n" +
 			" │   └─ AX25H (longtext)\n" +
-			" │   THEN r70 (longtext) WHEN ybbg5.DZLIM:13!null IS NULL THEN  (longtext) ELSE ybbg5.DZLIM:13!null END as UBUYI, ypgda.FUG6J:9 as FUG6J, ypgda.NF5AM:10 as NF5AM, ypgda.FRCVC:11!null as FRCVC]\n" +
-			" └─ Sort(ypgda.LUEVY:0!null as LUEVY ASC nullsFirst)\n" +
+			" │   THEN r70 (longtext) WHEN ybbg5.DZLIM:13!null IS NULL THEN  (longtext) ELSE ybbg5.DZLIM:13!null END->UBUYI:0, ypgda.FUG6J:9->FUG6J:0, ypgda.NF5AM:10->NF5AM:0, ypgda.FRCVC:11!null->FRCVC:0]\n" +
+			" └─ Sort(LUEVY:15!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [ypgda.LUEVY:0!null, ypgda.TW55N:1!null, ypgda.IYDZV:2, ypgda.QRQXW:3!null, ypgda.CAECS:4, ypgda.CJLLY:5!null, ypgda.SHP7H:6!null, ypgda.HARAZ:7, ypgda.I3L5A:8, ypgda.FUG6J:9, ypgda.NF5AM:10, ypgda.FRCVC:11!null, ybbg5.id:12!null, ybbg5.DZLIM:13!null, ybbg5.F3YUE:14, ypgda.LUEVY:0!null as LUEVY, ypgda.TW55N:1!null as TW55N, ypgda.IYDZV:2 as IYDZV,  (longtext) as IIISV, ypgda.QRQXW:3!null as QRQXW, ypgda.CAECS:4 as CAECS, ypgda.CJLLY:5!null as CJLLY, ypgda.SHP7H:6!null as SHP7H, ypgda.HARAZ:7 as HARAZ,  (longtext) as ECUWU,  (longtext) as LDMO7, CASE  WHEN Eq\n" +
+			"         ├─ columns: [ypgda.LUEVY:0!null, ypgda.TW55N:1!null, ypgda.IYDZV:2, ypgda.QRQXW:3!null, ypgda.CAECS:4, ypgda.CJLLY:5!null, ypgda.SHP7H:6!null, ypgda.HARAZ:7, ypgda.I3L5A:8, ypgda.FUG6J:9, ypgda.NF5AM:10, ypgda.FRCVC:11!null, ybbg5.id:12!null, ybbg5.DZLIM:13!null, ybbg5.F3YUE:14, ypgda.LUEVY:0!null->LUEVY:0, ypgda.TW55N:1!null->TW55N:0, ypgda.IYDZV:2->IYDZV:0,  (longtext)->IIISV:59, ypgda.QRQXW:3!null->QRQXW:0, ypgda.CAECS:4->CAECS:0, ypgda.CJLLY:5!null->CJLLY:0, ypgda.SHP7H:6!null->SHP7H:0, ypgda.HARAZ:7->HARAZ:0,  (longtext)->ECUWU:65,  (longtext)->LDMO7:66, CASE  WHEN Eq\n" +
 			"         │   ├─ ybbg5.DZLIM:13!null\n" +
 			"         │   └─ HGUEM (longtext)\n" +
 			"         │   THEN s30 (longtext) WHEN Eq\n" +
@@ -16810,7 +16810,7 @@ ORDER BY LUEVY`,
 			"         │   THEN s (longtext) WHEN Eq\n" +
 			"         │   ├─ ybbg5.DZLIM:13!null\n" +
 			"         │   └─ AX25H (longtext)\n" +
-			"         │   THEN r70 (longtext) WHEN ybbg5.DZLIM:13!null IS NULL THEN  (longtext) ELSE ybbg5.DZLIM:13!null END as UBUYI, ypgda.FUG6J:9 as FUG6J, ypgda.NF5AM:10 as NF5AM, ypgda.FRCVC:11!null as FRCVC]\n" +
+			"         │   THEN r70 (longtext) WHEN ybbg5.DZLIM:13!null IS NULL THEN  (longtext) ELSE ybbg5.DZLIM:13!null END->UBUYI:0, ypgda.FUG6J:9->FUG6J:0, ypgda.NF5AM:10->NF5AM:0, ypgda.FRCVC:11!null->FRCVC:0]\n" +
 			"         └─ LeftOuterHashJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ ypgda.I3L5A:8\n" +
@@ -16823,7 +16823,7 @@ ORDER BY LUEVY`,
 			"             │   ├─ colSet: (41-52)\n" +
 			"             │   ├─ tableId: 4\n" +
 			"             │   └─ Project\n" +
-			"             │       ├─ columns: [nd.id:0!null as LUEVY, nd.TW55N:3!null as TW55N, nd.FGG57:6 as IYDZV, nd.QRQXW:4!null as QRQXW, nd.IWV2H:11 as CAECS, nd.ECXAJ:5!null as CJLLY, nma.DZLIM:18!null as SHP7H, nd.N5CC2:13 as HARAZ, Subquery\n" +
+			"             │       ├─ columns: [nd.id:0!null->LUEVY:0, nd.TW55N:3!null->TW55N:0, nd.FGG57:6->IYDZV:0, nd.QRQXW:4!null->QRQXW:0, nd.IWV2H:11->CAECS:0, nd.ECXAJ:5!null->CJLLY:0, nma.DZLIM:18!null->SHP7H:0, nd.N5CC2:13->HARAZ:0, Subquery\n" +
 			"             │       │   ├─ cacheable: false\n" +
 			"             │       │   ├─ alias-string: select XQDYT from AMYXQ where LUEVY = nd.id limit 1\n" +
 			"             │       │   └─ Limit(1)\n" +
@@ -16841,9 +16841,9 @@ ORDER BY LUEVY`,
 			"             │       │                   └─ Table\n" +
 			"             │       │                       ├─ name: AMYXQ\n" +
 			"             │       │                       └─ columns: [luevy xqdyt]\n" +
-			"             │       │   as I3L5A, nd.ETAQ7:15 as FUG6J, nd.A75X7:16 as NF5AM, nd.FSK67:8!null as FRCVC]\n" +
+			"             │       │  ->I3L5A:0, nd.ETAQ7:15->FUG6J:0, nd.A75X7:16->NF5AM:0, nd.FSK67:8!null->FRCVC:0]\n" +
 			"             │       └─ Project\n" +
-			"             │           ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nma.id:17!null, nma.DZLIM:18!null, nma.F3YUE:19, nd.id:0!null as LUEVY, nd.TW55N:3!null as TW55N, nd.FGG57:6 as IYDZV, nd.QRQXW:4!null as QRQXW, nd.IWV2H:11 as CAECS, nd.ECXAJ:5!null as CJLLY, nma.DZLIM:18!null as SHP7H, nd.N5CC2:13 as HARAZ, Subquery\n" +
+			"             │           ├─ columns: [nd.id:0!null, nd.DKCAJ:1!null, nd.KNG7T:2, nd.TW55N:3!null, nd.QRQXW:4!null, nd.ECXAJ:5!null, nd.FGG57:6, nd.ZH72S:7, nd.FSK67:8!null, nd.XQDYT:9!null, nd.TCE7A:10, nd.IWV2H:11, nd.HPCMS:12!null, nd.N5CC2:13, nd.FHCYT:14, nd.ETAQ7:15, nd.A75X7:16, nma.id:17!null, nma.DZLIM:18!null, nma.F3YUE:19, nd.id:0!null->LUEVY:0, nd.TW55N:3!null->TW55N:0, nd.FGG57:6->IYDZV:0, nd.QRQXW:4!null->QRQXW:0, nd.IWV2H:11->CAECS:0, nd.ECXAJ:5!null->CJLLY:0, nma.DZLIM:18!null->SHP7H:0, nd.N5CC2:13->HARAZ:0, Subquery\n" +
 			"             │           │   ├─ cacheable: false\n" +
 			"             │           │   ├─ alias-string: select XQDYT from AMYXQ where LUEVY = nd.id limit 1\n" +
 			"             │           │   └─ Limit(1)\n" +
@@ -16861,7 +16861,7 @@ ORDER BY LUEVY`,
 			"             │           │                   └─ Table\n" +
 			"             │           │                       ├─ name: AMYXQ\n" +
 			"             │           │                       └─ columns: [luevy xqdyt]\n" +
-			"             │           │   as I3L5A, nd.ETAQ7:15 as FUG6J, nd.A75X7:16 as NF5AM, nd.FSK67:8!null as FRCVC]\n" +
+			"             │           │  ->I3L5A:0, nd.ETAQ7:15->FUG6J:0, nd.A75X7:16->NF5AM:0, nd.FSK67:8!null->FRCVC:0]\n" +
 			"             │           └─ LeftOuterLookupJoin\n" +
 			"             │               ├─ TableAlias(nd)\n" +
 			"             │               │   └─ Table\n" +
@@ -16889,7 +16889,7 @@ ORDER BY LUEVY`,
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [ypgda.LUEVY as LUEVY, ypgda.TW55N as TW55N, ypgda.IYDZV as IYDZV, '' as IIISV, ypgda.QRQXW as QRQXW, ypgda.CAECS as CAECS, ypgda.CJLLY as CJLLY, ypgda.SHP7H as SHP7H, ypgda.HARAZ as HARAZ, '' as ECUWU, '' as LDMO7, CASE  WHEN (ybbg5.DZLIM = 'HGUEM') THEN 's30' WHEN (ybbg5.DZLIM = 'YUHMV') THEN 'r90' WHEN (ybbg5.DZLIM = 'T3JIU') THEN 'r50' WHEN (ybbg5.DZLIM = 's') THEN 's' WHEN (ybbg5.DZLIM = 'AX25H') THEN 'r70' WHEN ybbg5.DZLIM IS NULL THEN '' ELSE ybbg5.DZLIM END as UBUYI, ypgda.FUG6J as FUG6J, ypgda.NF5AM as NF5AM, ypgda.FRCVC as FRCVC]\n" +
-			" └─ Sort(ypgda.LUEVY as LUEVY ASC)\n" +
+			" └─ Sort(LUEVY ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [ypgda.LUEVY, ypgda.TW55N, ypgda.IYDZV, ypgda.QRQXW, ypgda.CAECS, ypgda.CJLLY, ypgda.SHP7H, ypgda.HARAZ, ypgda.I3L5A, ypgda.FUG6J, ypgda.NF5AM, ypgda.FRCVC, ybbg5.id, ybbg5.DZLIM, ybbg5.F3YUE, ypgda.LUEVY as LUEVY, ypgda.TW55N as TW55N, ypgda.IYDZV as IYDZV, '' as IIISV, ypgda.QRQXW as QRQXW, ypgda.CAECS as CAECS, ypgda.CJLLY as CJLLY, ypgda.SHP7H as SHP7H, ypgda.HARAZ as HARAZ, '' as ECUWU, '' as LDMO7, CASE  WHEN (ybbg5.DZLIM = 'HGUEM') THEN 's30' WHEN (ybbg5.DZLIM = 'YUHMV') THEN 'r90' WHEN (ybbg5.DZLIM = 'T3JIU') THEN 'r50' WHEN (ybbg5.DZLIM = 's') THEN 's' WHEN (ybbg5.DZLIM = 'AX25H') THEN 'r70' WHEN ybbg5.DZLIM IS NULL THEN '' ELSE ybbg5.DZLIM END as UBUYI, ypgda.FUG6J as FUG6J, ypgda.NF5AM as NF5AM, ypgda.FRCVC as FRCVC]\n" +
 			"         └─ LeftOuterHashJoin\n" +
@@ -16943,7 +16943,7 @@ ORDER BY LUEVY`,
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [ypgda.LUEVY as LUEVY, ypgda.TW55N as TW55N, ypgda.IYDZV as IYDZV, '' as IIISV, ypgda.QRQXW as QRQXW, ypgda.CAECS as CAECS, ypgda.CJLLY as CJLLY, ypgda.SHP7H as SHP7H, ypgda.HARAZ as HARAZ, '' as ECUWU, '' as LDMO7, CASE  WHEN (ybbg5.DZLIM = 'HGUEM') THEN 's30' WHEN (ybbg5.DZLIM = 'YUHMV') THEN 'r90' WHEN (ybbg5.DZLIM = 'T3JIU') THEN 'r50' WHEN (ybbg5.DZLIM = 's') THEN 's' WHEN (ybbg5.DZLIM = 'AX25H') THEN 'r70' WHEN ybbg5.DZLIM IS NULL THEN '' ELSE ybbg5.DZLIM END as UBUYI, ypgda.FUG6J as FUG6J, ypgda.NF5AM as NF5AM, ypgda.FRCVC as FRCVC]\n" +
-			" └─ Sort(ypgda.LUEVY as LUEVY ASC)\n" +
+			" └─ Sort(LUEVY ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [ypgda.LUEVY, ypgda.TW55N, ypgda.IYDZV, ypgda.QRQXW, ypgda.CAECS, ypgda.CJLLY, ypgda.SHP7H, ypgda.HARAZ, ypgda.I3L5A, ypgda.FUG6J, ypgda.NF5AM, ypgda.FRCVC, ybbg5.id, ybbg5.DZLIM, ybbg5.F3YUE, ypgda.LUEVY as LUEVY, ypgda.TW55N as TW55N, ypgda.IYDZV as IYDZV, '' as IIISV, ypgda.QRQXW as QRQXW, ypgda.CAECS as CAECS, ypgda.CJLLY as CJLLY, ypgda.SHP7H as SHP7H, ypgda.HARAZ as HARAZ, '' as ECUWU, '' as LDMO7, CASE  WHEN (ybbg5.DZLIM = 'HGUEM') THEN 's30' WHEN (ybbg5.DZLIM = 'YUHMV') THEN 'r90' WHEN (ybbg5.DZLIM = 'T3JIU') THEN 'r50' WHEN (ybbg5.DZLIM = 's') THEN 's' WHEN (ybbg5.DZLIM = 'AX25H') THEN 'r70' WHEN ybbg5.DZLIM IS NULL THEN '' ELSE ybbg5.DZLIM END as UBUYI, ypgda.FUG6J as FUG6J, ypgda.NF5AM as NF5AM, ypgda.FRCVC as FRCVC]\n" +
 			"         └─ LeftOuterHashJoin\n" +
@@ -17076,7 +17076,7 @@ LEFT JOIN
     ON sn.A7XO2 = it.id
 ORDER BY sn.id ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [tvqg4.TW55N:11!null as FJVD7, lsm32.TW55N:13!null as KBXXJ, sn.NUMK2:6!null as NUMK2, CASE  WHEN it.DZLIM:15!null IS NULL THEN N/A (longtext) ELSE it.DZLIM:15!null END as TP6BK, sn.ECDKM:5 as ECDKM, sn.KBO7R:4!null as KBO7R, CASE  WHEN sn.YKSSU:8 IS NULL THEN N/A (longtext) ELSE sn.YKSSU:8 END as RQI4M, CASE  WHEN sn.FHCYT:9 IS NULL THEN N/A (longtext) ELSE sn.FHCYT:9 END as RNVLS, sn.LETOE:7!null as LETOE]\n" +
+			" ├─ columns: [tvqg4.TW55N:11!null->FJVD7:0, lsm32.TW55N:13!null->KBXXJ:0, sn.NUMK2:6!null->NUMK2:0, CASE  WHEN it.DZLIM:15!null IS NULL THEN N/A (longtext) ELSE it.DZLIM:15!null END->TP6BK:0, sn.ECDKM:5->ECDKM:0, sn.KBO7R:4!null->KBO7R:0, CASE  WHEN sn.YKSSU:8 IS NULL THEN N/A (longtext) ELSE sn.YKSSU:8 END->RQI4M:0, CASE  WHEN sn.FHCYT:9 IS NULL THEN N/A (longtext) ELSE sn.FHCYT:9 END->RNVLS:0, sn.LETOE:7!null->LETOE:0]\n" +
 			" └─ Sort(sn.id:0!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ LeftOuterLookupJoin\n" +
@@ -17259,7 +17259,7 @@ LEFT JOIN
     ON AYFCD.FFTBJ = FA75Y.id
 ORDER BY rn.id ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sdllr.TW55N:15!null as FZX4Y, jgt2h.LETOE:9!null as QWTOI, riiw6.TW55N:17!null as PDX5Y, ayfcd.NUMK2:12!null as V45YB, ayfcd.LETOE:13!null as DAGQN, fa75y.TW55N:19!null as SFQTS, rn.HVHRZ:3!null as HVHRZ, CASE  WHEN rn.YKSSU:4 IS NULL THEN N/A (longtext) ELSE rn.YKSSU:4 END as RQI4M, CASE  WHEN rn.FHCYT:5 IS NULL THEN N/A (longtext) ELSE rn.FHCYT:5 END as RNVLS]\n" +
+			" ├─ columns: [sdllr.TW55N:15!null->FZX4Y:0, jgt2h.LETOE:9!null->QWTOI:0, riiw6.TW55N:17!null->PDX5Y:0, ayfcd.NUMK2:12!null->V45YB:0, ayfcd.LETOE:13!null->DAGQN:0, fa75y.TW55N:19!null->SFQTS:0, rn.HVHRZ:3!null->HVHRZ:0, CASE  WHEN rn.YKSSU:4 IS NULL THEN N/A (longtext) ELSE rn.YKSSU:4 END->RQI4M:0, CASE  WHEN rn.FHCYT:5 IS NULL THEN N/A (longtext) ELSE rn.FHCYT:5 END->RNVLS:0]\n" +
 			" └─ Sort(rn.id:0!null ASC nullsFirst)\n" +
 			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ LeftOuterLookupJoin\n" +
@@ -17468,7 +17468,7 @@ ORDER BY id ASC`,
 			"             │   ├─ noxn3.NUMK2:2!null\n" +
 			"             │   └─ 4 (int)\n" +
 			"             └─ Project\n" +
-			"                 ├─ columns: [row_number() over ( order by noxn3.id asc):0!null as Y3IOU, noxn3.id:1!null, noxn3.NUMK2:2!null, noxn3.ECDKM:3]\n" +
+			"                 ├─ columns: [row_number() over ( order by noxn3.id asc):0!null->Y3IOU:0, noxn3.id:1!null, noxn3.NUMK2:2!null, noxn3.ECDKM:3]\n" +
 			"                 └─ Window\n" +
 			"                     ├─ row_number() over ( order by noxn3.id ASC)\n" +
 			"                     ├─ noxn3.id:0!null\n" +
@@ -17559,7 +17559,7 @@ SELECT
 			" ├─ columns: [CASE  WHEN Eq\n" +
 			" │   ├─ noxn3.NUMK2:2!null\n" +
 			" │   └─ 2 (int)\n" +
-			" │   THEN noxn3.ECDKM:1 ELSE 0 (tinyint) END as RGXLL]\n" +
+			" │   THEN noxn3.ECDKM:1 ELSE 0 (tinyint) END->RGXLL:0]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
 			"     ├─ static: [{[NULL, ∞)}]\n" +
@@ -17595,7 +17595,7 @@ INNER JOIN E2I7U nd
 INNER JOIN XOAOP pa
     ON QNRBH.CH3FR = pa.id`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [pa.DZLIM:5!null as ECUWU, nd.TW55N:3!null]\n" +
+			" ├─ columns: [pa.DZLIM:5!null->ECUWU:0, nd.TW55N:3!null]\n" +
 			" └─ LookupJoin\n" +
 			"     ├─ LookupJoin\n" +
 			"     │   ├─ TableAlias(qnrbh)\n" +
@@ -17932,7 +17932,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, NFRYN:1!null, IXUXU:2, FHCYT:3]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:35, Subquery\n" +
 			"     │       │   ├─ cacheable: true\n" +
 			"     │       │   ├─ alias-string: select id from JMRQL where DZLIM = 'T4IBQ'\n" +
 			"     │       │   └─ Project\n" +
@@ -17945,9 +17945,9 @@ WHERE
 			"     │       │           └─ Table\n" +
 			"     │       │               ├─ name: JMRQL\n" +
 			"     │       │               └─ columns: [id dzlim]\n" +
-			"     │       │   as NFRYN, yk2gw.id:0!null as IXUXU, NULL (null) as FHCYT]\n" +
+			"     │       │  ->NFRYN:0, yk2gw.id:0!null->IXUXU:0, NULL (null)->FHCYT:41]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [yk2gw.id:0!null, yk2gw.FTQLQ:1!null, yk2gw.TUXML:2, yk2gw.PAEF5:3, yk2gw.RUCY4:4, yk2gw.TPNJ6:5!null, yk2gw.LBL53:6, yk2gw.NB3QS:7, yk2gw.EO7IV:8, yk2gw.MUHJF:9, yk2gw.FM34L:10, yk2gw.TY5RF:11, yk2gw.ZHTLH:12, yk2gw.NPB7W:13, yk2gw.SX3HH:14, yk2gw.ISBNF:15, yk2gw.YA7YB:16, yk2gw.C5YKB:17, yk2gw.QK7KT:18, yk2gw.FFGE6:19, yk2gw.FIIGJ:20, yk2gw.SH3NC:21, yk2gw.NTENA:22, yk2gw.M4AUB:23, yk2gw.X5AIR:24, yk2gw.SAB6M:25, yk2gw.G5QI5:26, yk2gw.ZVQVD:27, yk2gw.YKSSU:28, yk2gw.FHCYT:29, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │           ├─ columns: [yk2gw.id:0!null, yk2gw.FTQLQ:1!null, yk2gw.TUXML:2, yk2gw.PAEF5:3, yk2gw.RUCY4:4, yk2gw.TPNJ6:5!null, yk2gw.LBL53:6, yk2gw.NB3QS:7, yk2gw.EO7IV:8, yk2gw.MUHJF:9, yk2gw.FM34L:10, yk2gw.TY5RF:11, yk2gw.ZHTLH:12, yk2gw.NPB7W:13, yk2gw.SX3HH:14, yk2gw.ISBNF:15, yk2gw.YA7YB:16, yk2gw.C5YKB:17, yk2gw.QK7KT:18, yk2gw.FFGE6:19, yk2gw.FIIGJ:20, yk2gw.SH3NC:21, yk2gw.NTENA:22, yk2gw.M4AUB:23, yk2gw.X5AIR:24, yk2gw.SAB6M:25, yk2gw.G5QI5:26, yk2gw.ZVQVD:27, yk2gw.YKSSU:28, yk2gw.FHCYT:29, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:35, Subquery\n" +
 			"     │           │   ├─ cacheable: true\n" +
 			"     │           │   ├─ alias-string: select id from JMRQL where DZLIM = 'T4IBQ'\n" +
 			"     │           │   └─ Project\n" +
@@ -17960,7 +17960,7 @@ WHERE
 			"     │           │           └─ Table\n" +
 			"     │           │               ├─ name: JMRQL\n" +
 			"     │           │               └─ columns: [id dzlim]\n" +
-			"     │           │   as NFRYN, yk2gw.id:0!null as IXUXU, NULL (null) as FHCYT]\n" +
+			"     │           │  ->NFRYN:0, yk2gw.id:0!null->IXUXU:0, NULL (null)->FHCYT:41]\n" +
 			"     │           └─ IndexedTableAccess(YK2GW)\n" +
 			"     │               ├─ index: [YK2GW.id]\n" +
 			"     │               ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
@@ -18030,7 +18030,7 @@ FROM
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, WNUNU:1!null, HHVLX:2!null, HVHRZ:3!null, YKSSU:4, FHCYT:5]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, itwml.DRIWM:0!null as WNUNU, itwml.JIEVY:1!null as HHVLX, 1 (decimal(2,1)) as HVHRZ, NULL (null) as YKSSU, NULL (null) as FHCYT]\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:39, itwml.DRIWM:0!null->WNUNU:0, itwml.JIEVY:1!null->HHVLX:0, 1 (decimal(2,1))->HVHRZ:42, NULL (null)->YKSSU:43, NULL (null)->FHCYT:44]\n" +
 			"     │       └─ SubqueryAlias\n" +
 			"     │           ├─ name: itwml\n" +
 			"     │           ├─ outerVisibility: false\n" +
@@ -18039,7 +18039,7 @@ FROM
 			"     │           ├─ colSet: (36-38)\n" +
 			"     │           ├─ tableId: 5\n" +
 			"     │           └─ Project\n" +
-			"     │               ├─ columns: [sn.id:0!null as DRIWM, skpm6.id:4!null as JIEVY, sn.ECDKM:2 as HVHRZ]\n" +
+			"     │               ├─ columns: [sn.id:0!null->DRIWM:0, skpm6.id:4!null->JIEVY:0, sn.ECDKM:2->HVHRZ:0]\n" +
 			"     │               └─ Filter\n" +
 			"     │                   ├─ AND\n" +
 			"     │                   │   ├─ rn.WNUNU:6!null IS NULL\n" +
@@ -18161,7 +18161,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, QZ7E7:1!null, SSHPJ:2!null, FHCYT:3]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [tdrvg.id:0!null, tdrvg.SFJ6L:2!null, tdrvg.SSHPJ:1!null, NULL (null) as FHCYT]\n" +
+			"     │       ├─ columns: [tdrvg.id:0!null, tdrvg.SFJ6L:2!null, tdrvg.SSHPJ:1!null, NULL (null)->FHCYT:10]\n" +
 			"     │       └─ IndexedTableAccess(TDRVG)\n" +
 			"     │           ├─ index: [TDRVG.id]\n" +
 			"     │           ├─ static: [{[1, 1]}, {[2, 2]}, {[3, 3]}]\n" +
@@ -18267,7 +18267,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, GXLUB:1!null, LUEVY:2!null, XQDYT:3!null, AMYXQ:4!null, OZTQF:5!null, Z35GY:6!null, KKGN5:7]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:40, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select /*+ JOIN_ORDER(cla, bs) */ bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ufc.T4IBQ\n" +
 			"     │       │   └─ Project\n" +
@@ -18298,7 +18298,7 @@ WHERE
 			"     │       │                       └─ Table\n" +
 			"     │       │                           ├─ name: THNTS\n" +
 			"     │       │                           └─ columns: [id ixuxu]\n" +
-			"     │       │   as GXLUB, nd.id:11!null as LUEVY, nd.XQDYT:20!null as XQDYT, (ufc.AMYXQ:3 + 0 (decimal(2,1))) as AMYXQ, CASE  WHEN Eq\n" +
+			"     │       │  ->GXLUB:0, nd.id:11!null->LUEVY:0, nd.XQDYT:20!null->XQDYT:0, (ufc.AMYXQ:3 + 0 (decimal(2,1)))->AMYXQ:0, CASE  WHEN Eq\n" +
 			"     │       │   ├─ ybbg5.DZLIM:29!null\n" +
 			"     │       │   └─ KTNZ2 (longtext)\n" +
 			"     │       │   THEN (ufc.KTNZ2:4 + 0 (decimal(2,1))) WHEN Eq\n" +
@@ -18313,9 +18313,9 @@ WHERE
 			"     │       │   THEN (ufc.VVKNB:7 + 0 (decimal(2,1))) WHEN Eq\n" +
 			"     │       │   ├─ ybbg5.DZLIM:29!null\n" +
 			"     │       │   └─ DN3OQ (longtext)\n" +
-			"     │       │   THEN (ufc.DN3OQ:6 + 0 (decimal(2,1))) ELSE NULL (null) END as OZTQF, (ufc.SRZZO:9 + 0 (decimal(2,1))) as Z35GY, ufc.id:0!null as KKGN5]\n" +
+			"     │       │   THEN (ufc.DN3OQ:6 + 0 (decimal(2,1))) ELSE NULL (null) END->OZTQF:0, (ufc.SRZZO:9 + 0 (decimal(2,1)))->Z35GY:0, ufc.id:0!null->KKGN5:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10, nd.id:11!null, nd.DKCAJ:12!null, nd.KNG7T:13, nd.TW55N:14!null, nd.QRQXW:15!null, nd.ECXAJ:16!null, nd.FGG57:17, nd.ZH72S:18, nd.FSK67:19!null, nd.XQDYT:20!null, nd.TCE7A:21, nd.IWV2H:22, nd.HPCMS:23!null, nd.N5CC2:24, nd.FHCYT:25, nd.ETAQ7:26, nd.A75X7:27, ybbg5.id:28!null, ybbg5.DZLIM:29!null, ybbg5.F3YUE:30, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │           ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10, nd.id:11!null, nd.DKCAJ:12!null, nd.KNG7T:13, nd.TW55N:14!null, nd.QRQXW:15!null, nd.ECXAJ:16!null, nd.FGG57:17, nd.ZH72S:18, nd.FSK67:19!null, nd.XQDYT:20!null, nd.TCE7A:21, nd.IWV2H:22, nd.HPCMS:23!null, nd.N5CC2:24, nd.FHCYT:25, nd.ETAQ7:26, nd.A75X7:27, ybbg5.id:28!null, ybbg5.DZLIM:29!null, ybbg5.F3YUE:30, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:40, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select /*+ JOIN_ORDER(cla, bs) */ bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ufc.T4IBQ\n" +
 			"     │           │   └─ Project\n" +
@@ -18346,7 +18346,7 @@ WHERE
 			"     │           │                       └─ Table\n" +
 			"     │           │                           ├─ name: THNTS\n" +
 			"     │           │                           └─ columns: [id ixuxu]\n" +
-			"     │           │   as GXLUB, nd.id:11!null as LUEVY, nd.XQDYT:20!null as XQDYT, (ufc.AMYXQ:3 + 0 (decimal(2,1))) as AMYXQ, CASE  WHEN Eq\n" +
+			"     │           │  ->GXLUB:0, nd.id:11!null->LUEVY:0, nd.XQDYT:20!null->XQDYT:0, (ufc.AMYXQ:3 + 0 (decimal(2,1)))->AMYXQ:0, CASE  WHEN Eq\n" +
 			"     │           │   ├─ ybbg5.DZLIM:29!null\n" +
 			"     │           │   └─ KTNZ2 (longtext)\n" +
 			"     │           │   THEN (ufc.KTNZ2:4 + 0 (decimal(2,1))) WHEN Eq\n" +
@@ -18361,7 +18361,7 @@ WHERE
 			"     │           │   THEN (ufc.VVKNB:7 + 0 (decimal(2,1))) WHEN Eq\n" +
 			"     │           │   ├─ ybbg5.DZLIM:29!null\n" +
 			"     │           │   └─ DN3OQ (longtext)\n" +
-			"     │           │   THEN (ufc.DN3OQ:6 + 0 (decimal(2,1))) ELSE NULL (null) END as OZTQF, (ufc.SRZZO:9 + 0 (decimal(2,1))) as Z35GY, ufc.id:0!null as KKGN5]\n" +
+			"     │           │   THEN (ufc.DN3OQ:6 + 0 (decimal(2,1))) ELSE NULL (null) END->OZTQF:0, (ufc.SRZZO:9 + 0 (decimal(2,1)))->Z35GY:0, ufc.id:0!null->KKGN5:0]\n" +
 			"     │           └─ InnerJoin\n" +
 			"     │               ├─ Eq\n" +
 			"     │               │   ├─ nd.ZH72S:18\n" +
@@ -18481,7 +18481,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, GXLUB:1!null, CH3FR:2!null, D237E:3!null, JOGI6:4]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │       │   └─ Project\n" +
@@ -18512,7 +18512,7 @@ WHERE
 			"     │       │                       └─ Table\n" +
 			"     │       │                           ├─ name: YK2GW\n" +
 			"     │       │                           └─ columns: [id ftqlq]\n" +
-			"     │       │   as GXLUB, Subquery\n" +
+			"     │       │  ->GXLUB:0, Subquery\n" +
 			"     │       │   ├─ cacheable: true\n" +
 			"     │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'NER'\n" +
 			"     │       │   └─ Project\n" +
@@ -18525,15 +18525,15 @@ WHERE
 			"     │       │           └─ Table\n" +
 			"     │       │               ├─ name: XOAOP\n" +
 			"     │       │               └─ columns: [id dzlim]\n" +
-			"     │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │       │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │       │   ├─ ums.ner:2\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
 			"     │       │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │       │   ├─ ums.ner:2\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
-			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │           │   └─ Project\n" +
@@ -18564,7 +18564,7 @@ WHERE
 			"     │           │                       └─ Table\n" +
 			"     │           │                           ├─ name: YK2GW\n" +
 			"     │           │                           └─ columns: [id ftqlq]\n" +
-			"     │           │   as GXLUB, Subquery\n" +
+			"     │           │  ->GXLUB:0, Subquery\n" +
 			"     │           │   ├─ cacheable: true\n" +
 			"     │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'NER'\n" +
 			"     │           │   └─ Project\n" +
@@ -18577,13 +18577,13 @@ WHERE
 			"     │           │           └─ Table\n" +
 			"     │           │               ├─ name: XOAOP\n" +
 			"     │           │               └─ columns: [id dzlim]\n" +
-			"     │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │           │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │           │   ├─ ums.ner:2\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
 			"     │           │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │           │   ├─ ums.ner:2\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
-			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │           └─ TableAlias(ums)\n" +
 			"     │               └─ IndexedTableAccess(FG26Y)\n" +
 			"     │                   ├─ index: [FG26Y.id]\n" +
@@ -18673,7 +18673,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, GXLUB:1!null, CH3FR:2!null, D237E:3!null, JOGI6:4]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │       │   └─ Project\n" +
@@ -18704,7 +18704,7 @@ WHERE
 			"     │       │                       └─ Table\n" +
 			"     │       │                           ├─ name: YK2GW\n" +
 			"     │       │                           └─ columns: [id ftqlq]\n" +
-			"     │       │   as GXLUB, Subquery\n" +
+			"     │       │  ->GXLUB:0, Subquery\n" +
 			"     │       │   ├─ cacheable: true\n" +
 			"     │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'BER'\n" +
 			"     │       │   └─ Project\n" +
@@ -18717,15 +18717,15 @@ WHERE
 			"     │       │           └─ Table\n" +
 			"     │       │               ├─ name: XOAOP\n" +
 			"     │       │               └─ columns: [id dzlim]\n" +
-			"     │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │       │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │       │   ├─ ums.ber:3\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
 			"     │       │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │       │   ├─ ums.ber:3\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
-			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │           │   └─ Project\n" +
@@ -18756,7 +18756,7 @@ WHERE
 			"     │           │                       └─ Table\n" +
 			"     │           │                           ├─ name: YK2GW\n" +
 			"     │           │                           └─ columns: [id ftqlq]\n" +
-			"     │           │   as GXLUB, Subquery\n" +
+			"     │           │  ->GXLUB:0, Subquery\n" +
 			"     │           │   ├─ cacheable: true\n" +
 			"     │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'BER'\n" +
 			"     │           │   └─ Project\n" +
@@ -18769,13 +18769,13 @@ WHERE
 			"     │           │           └─ Table\n" +
 			"     │           │               ├─ name: XOAOP\n" +
 			"     │           │               └─ columns: [id dzlim]\n" +
-			"     │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │           │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │           │   ├─ ums.ber:3\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
 			"     │           │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │           │   ├─ ums.ber:3\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
-			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │           └─ TableAlias(ums)\n" +
 			"     │               └─ IndexedTableAccess(FG26Y)\n" +
 			"     │                   ├─ index: [FG26Y.id]\n" +
@@ -18865,7 +18865,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, GXLUB:1!null, CH3FR:2!null, D237E:3!null, JOGI6:4]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │       │   └─ Project\n" +
@@ -18896,7 +18896,7 @@ WHERE
 			"     │       │                       └─ Table\n" +
 			"     │       │                           ├─ name: YK2GW\n" +
 			"     │       │                           └─ columns: [id ftqlq]\n" +
-			"     │       │   as GXLUB, Subquery\n" +
+			"     │       │  ->GXLUB:0, Subquery\n" +
 			"     │       │   ├─ cacheable: true\n" +
 			"     │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'HR'\n" +
 			"     │       │   └─ Project\n" +
@@ -18909,15 +18909,15 @@ WHERE
 			"     │       │           └─ Table\n" +
 			"     │       │               ├─ name: XOAOP\n" +
 			"     │       │               └─ columns: [id dzlim]\n" +
-			"     │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │       │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │       │   ├─ ums.hr:4\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
 			"     │       │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │       │   ├─ ums.hr:4\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
-			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │           │   └─ Project\n" +
@@ -18948,7 +18948,7 @@ WHERE
 			"     │           │                       └─ Table\n" +
 			"     │           │                           ├─ name: YK2GW\n" +
 			"     │           │                           └─ columns: [id ftqlq]\n" +
-			"     │           │   as GXLUB, Subquery\n" +
+			"     │           │  ->GXLUB:0, Subquery\n" +
 			"     │           │   ├─ cacheable: true\n" +
 			"     │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'HR'\n" +
 			"     │           │   └─ Project\n" +
@@ -18961,13 +18961,13 @@ WHERE
 			"     │           │           └─ Table\n" +
 			"     │           │               ├─ name: XOAOP\n" +
 			"     │           │               └─ columns: [id dzlim]\n" +
-			"     │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │           │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │           │   ├─ ums.hr:4\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
 			"     │           │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │           │   ├─ ums.hr:4\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
-			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │           └─ TableAlias(ums)\n" +
 			"     │               └─ IndexedTableAccess(FG26Y)\n" +
 			"     │                   ├─ index: [FG26Y.id]\n" +
@@ -19057,7 +19057,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, GXLUB:1!null, CH3FR:2!null, D237E:3!null, JOGI6:4]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │       │   └─ Project\n" +
@@ -19088,7 +19088,7 @@ WHERE
 			"     │       │                       └─ Table\n" +
 			"     │       │                           ├─ name: YK2GW\n" +
 			"     │       │                           └─ columns: [id ftqlq]\n" +
-			"     │       │   as GXLUB, Subquery\n" +
+			"     │       │  ->GXLUB:0, Subquery\n" +
 			"     │       │   ├─ cacheable: true\n" +
 			"     │       │   ├─ alias-string: select id from XOAOP where DZLIM = 'MMR'\n" +
 			"     │       │   └─ Project\n" +
@@ -19101,15 +19101,15 @@ WHERE
 			"     │       │           └─ Table\n" +
 			"     │       │               ├─ name: XOAOP\n" +
 			"     │       │               └─ columns: [id dzlim]\n" +
-			"     │       │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │       │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │       │   ├─ ums.mmr:5\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
 			"     │       │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │       │   ├─ ums.mmr:5\n" +
 			"     │       │   └─ 0.5 (decimal(2,1))\n" +
-			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │       │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │           ├─ columns: [ums.id:0!null, ums.T4IBQ:1, ums.ner:2, ums.ber:3, ums.hr:4, ums.mmr:5, ums.QZ6VT:6, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:13, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select bs.id from THNTS as bs join YK2GW as cla on cla.id = bs.IXUXU where cla.FTQLQ = ums.T4IBQ\n" +
 			"     │           │   └─ Project\n" +
@@ -19140,7 +19140,7 @@ WHERE
 			"     │           │                       └─ Table\n" +
 			"     │           │                           ├─ name: YK2GW\n" +
 			"     │           │                           └─ columns: [id ftqlq]\n" +
-			"     │           │   as GXLUB, Subquery\n" +
+			"     │           │  ->GXLUB:0, Subquery\n" +
 			"     │           │   ├─ cacheable: true\n" +
 			"     │           │   ├─ alias-string: select id from XOAOP where DZLIM = 'MMR'\n" +
 			"     │           │   └─ Project\n" +
@@ -19153,13 +19153,13 @@ WHERE
 			"     │           │           └─ Table\n" +
 			"     │           │               ├─ name: XOAOP\n" +
 			"     │           │               └─ columns: [id dzlim]\n" +
-			"     │           │   as CH3FR, CASE  WHEN GreaterThan\n" +
+			"     │           │  ->CH3FR:0, CASE  WHEN GreaterThan\n" +
 			"     │           │   ├─ ums.mmr:5\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
 			"     │           │   THEN 1 (tinyint) WHEN LessThan\n" +
 			"     │           │   ├─ ums.mmr:5\n" +
 			"     │           │   └─ 0.5 (decimal(2,1))\n" +
-			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END as D237E, ums.id:0!null as JOGI6]\n" +
+			"     │           │   THEN 0 (tinyint) ELSE NULL (null) END->D237E:0, ums.id:0!null->JOGI6:0]\n" +
 			"     │           └─ TableAlias(ums)\n" +
 			"     │               └─ IndexedTableAccess(FG26Y)\n" +
 			"     │                   ├─ index: [FG26Y.id]\n" +
@@ -19247,7 +19247,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, BTXC5:1, FHCYT:2]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, ncvd2.BTXC5:0 as BTXC5, NULL (null) as FHCYT]\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:34, ncvd2.BTXC5:0->BTXC5:0, NULL (null)->FHCYT:36]\n" +
 			"     │       └─ SubqueryAlias\n" +
 			"     │           ├─ name: ncvd2\n" +
 			"     │           ├─ outerVisibility: false\n" +
@@ -19257,7 +19257,7 @@ WHERE
 			"     │           ├─ tableId: 4\n" +
 			"     │           └─ Distinct\n" +
 			"     │               └─ Project\n" +
-			"     │                   ├─ columns: [umf.SYPKF:8 as BTXC5]\n" +
+			"     │                   ├─ columns: [umf.SYPKF:8->BTXC5:0]\n" +
 			"     │                   └─ Filter\n" +
 			"     │                       ├─ AND\n" +
 			"     │                       │   ├─ AND\n" +
@@ -19423,7 +19423,7 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, GXLUB:1!null, LUEVY:2!null, M22QN:3!null, TJPT7:4!null, ARN5P:5!null, XOSD4:6!null, IDE43:7, HMW4H:8, ZBT6R:9, FSDY2:10!null, LT7K6:11, SPPYD:12, QCGTS:13, TEUJA:14, QQV4M:15, FHCYT:16]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [umf.id:0!null as id, bs.id:63!null as GXLUB, CASE  WHEN NOT\n" +
+			"     │       ├─ columns: [umf.id:0!null->id:0, bs.id:63!null->GXLUB:0, CASE  WHEN NOT\n" +
 			"     │       │   └─ tj5d2.id:25!null IS NULL\n" +
 			"     │       │   THEN Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
@@ -19461,7 +19461,7 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │       │                   └─ Table\n" +
 			"     │       │                       ├─ name: E2I7U\n" +
 			"     │       │                       └─ columns: [id fgg57]\n" +
-			"     │       │   END as LUEVY, CASE  WHEN Eq\n" +
+			"     │       │   END->LUEVY:0, CASE  WHEN Eq\n" +
 			"     │       │   ├─ umf.SYPKF:8\n" +
 			"     │       │   └─ N/A (longtext)\n" +
 			"     │       │   THEN Subquery\n" +
@@ -19495,33 +19495,33 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │       │                   └─ Table\n" +
 			"     │       │                       ├─ name: TPXBU\n" +
 			"     │       │                       └─ columns: [id btxc5]\n" +
-			"     │       │   END as M22QN, umf.TJPT7:6 as TJPT7, umf.ARN5P:7 as ARN5P, umf.XOSD4:13 as XOSD4, umf.IDE43:10 as IDE43, CASE  WHEN NOT\n" +
+			"     │       │   END->M22QN:0, umf.TJPT7:6->TJPT7:0, umf.ARN5P:7->ARN5P:0, umf.XOSD4:13->XOSD4:0, umf.IDE43:10->IDE43:0, CASE  WHEN NOT\n" +
 			"     │       │   └─ Eq\n" +
 			"     │       │       ├─ umf.HMW4H:14\n" +
 			"     │       │       └─ N/A (longtext)\n" +
-			"     │       │   THEN umf.HMW4H:14 ELSE NULL (null) END as HMW4H, CASE  WHEN NOT\n" +
+			"     │       │   THEN umf.HMW4H:14 ELSE NULL (null) END->HMW4H:0, CASE  WHEN NOT\n" +
 			"     │       │   └─ Eq\n" +
 			"     │       │       ├─ umf.S76OM:15\n" +
 			"     │       │       └─ N/A (longtext)\n" +
-			"     │       │   THEN (umf.S76OM:15 + 0 (tinyint)) ELSE NULL (null) END as ZBT6R, CASE  WHEN NOT\n" +
+			"     │       │   THEN (umf.S76OM:15 + 0 (tinyint)) ELSE NULL (null) END->ZBT6R:0, CASE  WHEN NOT\n" +
 			"     │       │   └─ Eq\n" +
 			"     │       │       ├─ umf.FSDY2:12\n" +
 			"     │       │       └─ N/A (longtext)\n" +
-			"     │       │   THEN umf.FSDY2:12 ELSE VUS (longtext) END as FSDY2, CASE  WHEN NOT\n" +
+			"     │       │   THEN umf.FSDY2:12 ELSE VUS (longtext) END->FSDY2:0, CASE  WHEN NOT\n" +
 			"     │       │   └─ Eq\n" +
 			"     │       │       ├─ umf.vaf:16\n" +
 			"     │       │       └─  (longtext)\n" +
-			"     │       │   THEN (umf.vaf:16 + 0 (decimal(2,1))) ELSE NULL (null) END as LT7K6, CASE  WHEN NOT\n" +
+			"     │       │   THEN (umf.vaf:16 + 0 (decimal(2,1))) ELSE NULL (null) END->LT7K6:0, CASE  WHEN NOT\n" +
 			"     │       │   └─ Eq\n" +
 			"     │       │       ├─ umf.ZROH6:17\n" +
 			"     │       │       └─  (longtext)\n" +
-			"     │       │   THEN (umf.ZROH6:17 + 0 (decimal(2,1))) ELSE NULL (null) END as SPPYD, CASE  WHEN NOT\n" +
+			"     │       │   THEN (umf.ZROH6:17 + 0 (decimal(2,1))) ELSE NULL (null) END->SPPYD:0, CASE  WHEN NOT\n" +
 			"     │       │   └─ Eq\n" +
 			"     │       │       ├─ umf.QCGTS:18\n" +
 			"     │       │       └─  (longtext)\n" +
-			"     │       │   THEN (umf.QCGTS:18 + 0 (decimal(2,1))) ELSE NULL (null) END as QCGTS, umf.id:0!null as TEUJA, tj5d2.id:25!null as QQV4M, umf.FHCYT:23 as FHCYT]\n" +
+			"     │       │   THEN (umf.QCGTS:18 + 0 (decimal(2,1))) ELSE NULL (null) END->QCGTS:0, umf.id:0!null->TEUJA:0, tj5d2.id:25!null->QQV4M:0, umf.FHCYT:23->FHCYT:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [umf.id:0!null, umf.T4IBQ:1, umf.FGG57:2, umf.SSHPJ:3, umf.NLA6O:4, umf.SFJ6L:5, umf.TJPT7:6, umf.ARN5P:7, umf.SYPKF:8, umf.IVFMK:9, umf.IDE43:10, umf.AZ6SP:11, umf.FSDY2:12, umf.XOSD4:13, umf.HMW4H:14, umf.S76OM:15, umf.vaf:16, umf.ZROH6:17, umf.QCGTS:18, umf.LNFM6:19, umf.TVAWL:20, umf.HDLCL:21, umf.BHHW6:22, umf.FHCYT:23, umf.QZ6VT:24, tj5d2.id:25!null, tj5d2.T4IBQ:26!null, tj5d2.V7UFH:27!null, tj5d2.SYPKF:28!null, tj5d2.H4DMT:29!null, tj5d2.SWCQV:30!null, tj5d2.YKSSU:31, tj5d2.FHCYT:32, cla.id:33!null, cla.FTQLQ:34!null, cla.TUXML:35, cla.PAEF5:36, cla.RUCY4:37, cla.TPNJ6:38!null, cla.LBL53:39, cla.NB3QS:40, cla.EO7IV:41, cla.MUHJF:42, cla.FM34L:43, cla.TY5RF:44, cla.ZHTLH:45, cla.NPB7W:46, cla.SX3HH:47, cla.ISBNF:48, cla.YA7YB:49, cla.C5YKB:50, cla.QK7KT:51, cla.FFGE6:52, cla.FIIGJ:53, cla.SH3NC:54, cla.NTENA:55, cla.M4AUB:56, cla.X5AIR:57, cla.SAB6M:58, cla.G5QI5:59, cla.ZVQVD:60, cla.YKSSU:61, cla.FHCYT:62, bs.id:63!null, bs.NFRYN:64!null, bs.IXUXU:65, bs.FHCYT:66, umf.id:0!null as id, bs.id:63!null as GXLUB, CASE  WHEN NOT\n" +
+			"     │           ├─ columns: [umf.id:0!null, umf.T4IBQ:1, umf.FGG57:2, umf.SSHPJ:3, umf.NLA6O:4, umf.SFJ6L:5, umf.TJPT7:6, umf.ARN5P:7, umf.SYPKF:8, umf.IVFMK:9, umf.IDE43:10, umf.AZ6SP:11, umf.FSDY2:12, umf.XOSD4:13, umf.HMW4H:14, umf.S76OM:15, umf.vaf:16, umf.ZROH6:17, umf.QCGTS:18, umf.LNFM6:19, umf.TVAWL:20, umf.HDLCL:21, umf.BHHW6:22, umf.FHCYT:23, umf.QZ6VT:24, tj5d2.id:25!null, tj5d2.T4IBQ:26!null, tj5d2.V7UFH:27!null, tj5d2.SYPKF:28!null, tj5d2.H4DMT:29!null, tj5d2.SWCQV:30!null, tj5d2.YKSSU:31, tj5d2.FHCYT:32, cla.id:33!null, cla.FTQLQ:34!null, cla.TUXML:35, cla.PAEF5:36, cla.RUCY4:37, cla.TPNJ6:38!null, cla.LBL53:39, cla.NB3QS:40, cla.EO7IV:41, cla.MUHJF:42, cla.FM34L:43, cla.TY5RF:44, cla.ZHTLH:45, cla.NPB7W:46, cla.SX3HH:47, cla.ISBNF:48, cla.YA7YB:49, cla.C5YKB:50, cla.QK7KT:51, cla.FFGE6:52, cla.FIIGJ:53, cla.SH3NC:54, cla.NTENA:55, cla.M4AUB:56, cla.X5AIR:57, cla.SAB6M:58, cla.G5QI5:59, cla.ZVQVD:60, cla.YKSSU:61, cla.FHCYT:62, bs.id:63!null, bs.NFRYN:64!null, bs.IXUXU:65, bs.FHCYT:66, umf.id:0!null->id:0, bs.id:63!null->GXLUB:0, CASE  WHEN NOT\n" +
 			"     │           │   └─ tj5d2.id:25!null IS NULL\n" +
 			"     │           │   THEN Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
@@ -19559,7 +19559,7 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │           │                   └─ Table\n" +
 			"     │           │                       ├─ name: E2I7U\n" +
 			"     │           │                       └─ columns: [id fgg57]\n" +
-			"     │           │   END as LUEVY, CASE  WHEN Eq\n" +
+			"     │           │   END->LUEVY:0, CASE  WHEN Eq\n" +
 			"     │           │   ├─ umf.SYPKF:8\n" +
 			"     │           │   └─ N/A (longtext)\n" +
 			"     │           │   THEN Subquery\n" +
@@ -19593,31 +19593,31 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │           │                   └─ Table\n" +
 			"     │           │                       ├─ name: TPXBU\n" +
 			"     │           │                       └─ columns: [id btxc5]\n" +
-			"     │           │   END as M22QN, umf.TJPT7:6 as TJPT7, umf.ARN5P:7 as ARN5P, umf.XOSD4:13 as XOSD4, umf.IDE43:10 as IDE43, CASE  WHEN NOT\n" +
+			"     │           │   END->M22QN:0, umf.TJPT7:6->TJPT7:0, umf.ARN5P:7->ARN5P:0, umf.XOSD4:13->XOSD4:0, umf.IDE43:10->IDE43:0, CASE  WHEN NOT\n" +
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ umf.HMW4H:14\n" +
 			"     │           │       └─ N/A (longtext)\n" +
-			"     │           │   THEN umf.HMW4H:14 ELSE NULL (null) END as HMW4H, CASE  WHEN NOT\n" +
+			"     │           │   THEN umf.HMW4H:14 ELSE NULL (null) END->HMW4H:0, CASE  WHEN NOT\n" +
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ umf.S76OM:15\n" +
 			"     │           │       └─ N/A (longtext)\n" +
-			"     │           │   THEN (umf.S76OM:15 + 0 (tinyint)) ELSE NULL (null) END as ZBT6R, CASE  WHEN NOT\n" +
+			"     │           │   THEN (umf.S76OM:15 + 0 (tinyint)) ELSE NULL (null) END->ZBT6R:0, CASE  WHEN NOT\n" +
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ umf.FSDY2:12\n" +
 			"     │           │       └─ N/A (longtext)\n" +
-			"     │           │   THEN umf.FSDY2:12 ELSE VUS (longtext) END as FSDY2, CASE  WHEN NOT\n" +
+			"     │           │   THEN umf.FSDY2:12 ELSE VUS (longtext) END->FSDY2:0, CASE  WHEN NOT\n" +
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ umf.vaf:16\n" +
 			"     │           │       └─  (longtext)\n" +
-			"     │           │   THEN (umf.vaf:16 + 0 (decimal(2,1))) ELSE NULL (null) END as LT7K6, CASE  WHEN NOT\n" +
+			"     │           │   THEN (umf.vaf:16 + 0 (decimal(2,1))) ELSE NULL (null) END->LT7K6:0, CASE  WHEN NOT\n" +
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ umf.ZROH6:17\n" +
 			"     │           │       └─  (longtext)\n" +
-			"     │           │   THEN (umf.ZROH6:17 + 0 (decimal(2,1))) ELSE NULL (null) END as SPPYD, CASE  WHEN NOT\n" +
+			"     │           │   THEN (umf.ZROH6:17 + 0 (decimal(2,1))) ELSE NULL (null) END->SPPYD:0, CASE  WHEN NOT\n" +
 			"     │           │   └─ Eq\n" +
 			"     │           │       ├─ umf.QCGTS:18\n" +
 			"     │           │       └─  (longtext)\n" +
-			"     │           │   THEN (umf.QCGTS:18 + 0 (decimal(2,1))) ELSE NULL (null) END as QCGTS, umf.id:0!null as TEUJA, tj5d2.id:25!null as QQV4M, umf.FHCYT:23 as FHCYT]\n" +
+			"     │           │   THEN (umf.QCGTS:18 + 0 (decimal(2,1))) ELSE NULL (null) END->QCGTS:0, umf.id:0!null->TEUJA:0, tj5d2.id:25!null->QQV4M:0, umf.FHCYT:23->FHCYT:0]\n" +
 			"     │           └─ LookupJoin\n" +
 			"     │               ├─ LookupJoin\n" +
 			"     │               │   ├─ LeftOuterJoin\n" +
@@ -19822,7 +19822,7 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			" └─ Project\n" +
 			"     ├─ columns: [id:0!null, Z7CP5:1!null, YH4XB:2!null]\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, c6pud.id:2!null as Z7CP5, vc.id:0!null as YH4XB]\n" +
+			"         ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:56, c6pud.id:2!null->Z7CP5:0, vc.id:0!null->YH4XB:0]\n" +
 			"         └─ InnerJoin\n" +
 			"             ├─ c6pud.AZ6SP LIKE concat(concat('%',vc.TWMSR),'%')\n" +
 			"             ├─ TableAlias(vc)\n" +
@@ -19838,7 +19838,7 @@ INNER JOIN D34QP vc ON C6PUD.AZ6SP LIKE CONCAT(CONCAT('%', vc.TWMSR), '%')`,
 			"                 ├─ colSet: (48,49)\n" +
 			"                 ├─ tableId: 4\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [mf.id:2!null as id, umf.AZ6SP:1 as AZ6SP]\n" +
+			"                     ├─ columns: [mf.id:2!null->id:0, umf.AZ6SP:1->AZ6SP:0]\n" +
 			"                     └─ InnerJoin\n" +
 			"                         ├─ Eq\n" +
 			"                         │   ├─ umf.id:0!null\n" +
@@ -19980,15 +19980,15 @@ FROM
 			"         │   ├─ columns: [id:0!null, convert\n" +
 			"         │   │   ├─ type: char\n" +
 			"         │   │   └─ FV24E:1!null\n" +
-			"         │   │   as FV24E, convert\n" +
+			"         │   │  ->FV24E:0, convert\n" +
 			"         │   │   ├─ type: char\n" +
 			"         │   │   └─ UJ6XY:2!null\n" +
-			"         │   │   as UJ6XY, M22QN:3!null, NZ4MQ:4, ETPQV:5!null, convert\n" +
+			"         │   │  ->UJ6XY:0, M22QN:3!null, NZ4MQ:4, ETPQV:5!null, convert\n" +
 			"         │   │   ├─ type: char\n" +
 			"         │   │   └─ PRUV2:6\n" +
-			"         │   │   as PRUV2, YKSSU:7, FHCYT:8]\n" +
+			"         │   │  ->PRUV2:0, YKSSU:7, FHCYT:8]\n" +
 			"         │   └─ Project\n" +
-			"         │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, bpnw2.FV24E:1!null as FV24E, bpnw2.UJ6XY:2!null as UJ6XY, bpnw2.M22QN:3!null as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, NULL (null) as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
+			"         │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:106, bpnw2.FV24E:1!null->FV24E:0, bpnw2.UJ6XY:2!null->UJ6XY:0, bpnw2.M22QN:3!null->M22QN:0, bpnw2.NZ4MQ:4->NZ4MQ:0, bpnw2.MU3KG:0!null->ETPQV:0, NULL (null)->PRUV2:112, bpnw2.YKSSU:6->YKSSU:0, bpnw2.FHCYT:5->FHCYT:0]\n" +
 			"         │       └─ SubqueryAlias\n" +
 			"         │           ├─ name: bpnw2\n" +
 			"         │           ├─ outerVisibility: false\n" +
@@ -19998,7 +19998,7 @@ FROM
 			"         │           ├─ tableId: 9\n" +
 			"         │           └─ Distinct\n" +
 			"         │               └─ Project\n" +
-			"         │                   ├─ columns: [tizhk.id:0!null as MU3KG, j4jyp.id:20!null as FV24E, rhuzn.id:37!null as UJ6XY, aac.id:71!null as M22QN, Subquery\n" +
+			"         │                   ├─ columns: [tizhk.id:0!null->MU3KG:0, j4jyp.id:20!null->FV24E:0, rhuzn.id:37!null->UJ6XY:0, aac.id:71!null->M22QN:0, Subquery\n" +
 			"         │                   │   ├─ cacheable: false\n" +
 			"         │                   │   ├─ alias-string: select G3YXS.id from YYBCX as G3YXS where CONCAT(G3YXS.ESFVY, '(MI:', G3YXS.SL76B, ')') = TIZHK.IDUT2\n" +
 			"         │                   │   └─ Project\n" +
@@ -20013,9 +20013,9 @@ FROM
 			"         │                   │                   ├─ columns: [id esfvy sl76b]\n" +
 			"         │                   │                   ├─ colSet: (88-95)\n" +
 			"         │                   │                   └─ tableId: 8\n" +
-			"         │                   │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU]\n" +
+			"         │                   │  ->NZ4MQ:0, NULL (null)->FHCYT:97, NULL (null)->YKSSU:98]\n" +
 			"         │                   └─ Project\n" +
-			"         │                       ├─ columns: [tizhk.id:0!null, tizhk.TVNW2:1, tizhk.ZHITY:2, tizhk.SYPKF:3, tizhk.IDUT2:4, tizhk.O6QJ3:5, tizhk.NO2JA:6, tizhk.YKSSU:7, tizhk.FHCYT:8, tizhk.QZ6VT:9, nhmxw.id:10!null, nhmxw.NOHHR:11!null, nhmxw.AVPYF:12!null, nhmxw.SYPKF:13!null, nhmxw.IDUT2:14!null, nhmxw.FZXV5:15, nhmxw.DQYGV:16, nhmxw.SWCQV:17!null, nhmxw.YKSSU:18, nhmxw.FHCYT:19, j4jyp.id:20!null, j4jyp.DKCAJ:21!null, j4jyp.KNG7T:22, j4jyp.TW55N:23!null, j4jyp.QRQXW:24!null, j4jyp.ECXAJ:25!null, j4jyp.FGG57:26, j4jyp.ZH72S:27, j4jyp.FSK67:28!null, j4jyp.XQDYT:29!null, j4jyp.TCE7A:30, j4jyp.IWV2H:31, j4jyp.HPCMS:32!null, j4jyp.N5CC2:33, j4jyp.FHCYT:34, j4jyp.ETAQ7:35, j4jyp.A75X7:36, rhuzn.id:57!null, rhuzn.DKCAJ:58!null, rhuzn.KNG7T:59, rhuzn.TW55N:60!null, rhuzn.QRQXW:61!null, rhuzn.ECXAJ:62!null, rhuzn.FGG57:63, rhuzn.ZH72S:64, rhuzn.FSK67:65!null, rhuzn.XQDYT:66!null, rhuzn.TCE7A:67, rhuzn.IWV2H:68, rhuzn.HPCMS:69!null, rhuzn.N5CC2:70, rhuzn.FHCYT:71, rhuzn.ETAQ7:72, rhuzn.A75X7:73, mf.id:37!null, mf.GXLUB:38!null, mf.LUEVY:39!null, mf.M22QN:40!null, mf.TJPT7:41!null, mf.ARN5P:42!null, mf.XOSD4:43!null, mf.IDE43:44, mf.HMW4H:45, mf.ZBT6R:46, mf.FSDY2:47!null, mf.LT7K6:48, mf.SPPYD:49, mf.QCGTS:50, mf.TEUJA:51, mf.QQV4M:52, mf.FHCYT:53, aac.id:54!null, aac.BTXC5:55, aac.FHCYT:56, tizhk.id:0!null as MU3KG, j4jyp.id:20!null as FV24E, rhuzn.id:57!null as UJ6XY, aac.id:54!null as M22QN, Subquery\n" +
+			"         │                       ├─ columns: [tizhk.id:0!null, tizhk.TVNW2:1, tizhk.ZHITY:2, tizhk.SYPKF:3, tizhk.IDUT2:4, tizhk.O6QJ3:5, tizhk.NO2JA:6, tizhk.YKSSU:7, tizhk.FHCYT:8, tizhk.QZ6VT:9, nhmxw.id:10!null, nhmxw.NOHHR:11!null, nhmxw.AVPYF:12!null, nhmxw.SYPKF:13!null, nhmxw.IDUT2:14!null, nhmxw.FZXV5:15, nhmxw.DQYGV:16, nhmxw.SWCQV:17!null, nhmxw.YKSSU:18, nhmxw.FHCYT:19, j4jyp.id:20!null, j4jyp.DKCAJ:21!null, j4jyp.KNG7T:22, j4jyp.TW55N:23!null, j4jyp.QRQXW:24!null, j4jyp.ECXAJ:25!null, j4jyp.FGG57:26, j4jyp.ZH72S:27, j4jyp.FSK67:28!null, j4jyp.XQDYT:29!null, j4jyp.TCE7A:30, j4jyp.IWV2H:31, j4jyp.HPCMS:32!null, j4jyp.N5CC2:33, j4jyp.FHCYT:34, j4jyp.ETAQ7:35, j4jyp.A75X7:36, rhuzn.id:57!null, rhuzn.DKCAJ:58!null, rhuzn.KNG7T:59, rhuzn.TW55N:60!null, rhuzn.QRQXW:61!null, rhuzn.ECXAJ:62!null, rhuzn.FGG57:63, rhuzn.ZH72S:64, rhuzn.FSK67:65!null, rhuzn.XQDYT:66!null, rhuzn.TCE7A:67, rhuzn.IWV2H:68, rhuzn.HPCMS:69!null, rhuzn.N5CC2:70, rhuzn.FHCYT:71, rhuzn.ETAQ7:72, rhuzn.A75X7:73, mf.id:37!null, mf.GXLUB:38!null, mf.LUEVY:39!null, mf.M22QN:40!null, mf.TJPT7:41!null, mf.ARN5P:42!null, mf.XOSD4:43!null, mf.IDE43:44, mf.HMW4H:45, mf.ZBT6R:46, mf.FSDY2:47!null, mf.LT7K6:48, mf.SPPYD:49, mf.QCGTS:50, mf.TEUJA:51, mf.QQV4M:52, mf.FHCYT:53, aac.id:54!null, aac.BTXC5:55, aac.FHCYT:56, tizhk.id:0!null->MU3KG:0, j4jyp.id:20!null->FV24E:0, rhuzn.id:57!null->UJ6XY:0, aac.id:54!null->M22QN:0, Subquery\n" +
 			"         │                       │   ├─ cacheable: false\n" +
 			"         │                       │   ├─ alias-string: select G3YXS.id from YYBCX as G3YXS where CONCAT(G3YXS.ESFVY, '(MI:', G3YXS.SL76B, ')') = TIZHK.IDUT2\n" +
 			"         │                       │   └─ Project\n" +
@@ -20030,7 +20030,7 @@ FROM
 			"         │                       │                   ├─ columns: [id esfvy sl76b]\n" +
 			"         │                       │                   ├─ colSet: (88-95)\n" +
 			"         │                       │                   └─ tableId: 8\n" +
-			"         │                       │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU]\n" +
+			"         │                       │  ->NZ4MQ:0, NULL (null)->FHCYT:97, NULL (null)->YKSSU:98]\n" +
 			"         │                       └─ Filter\n" +
 			"         │                           ├─ AND\n" +
 			"         │                           │   ├─ Eq\n" +
@@ -20113,12 +20113,12 @@ FROM
 			"         │                                           ├─ name: E2I7U\n" +
 			"         │                                           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"         └─ Project\n" +
-			"             ├─ columns: [id:0!null, FV24E:1 as FV24E, UJ6XY:2 as UJ6XY, M22QN:3, NZ4MQ:4, ETPQV:5!null, convert\n" +
+			"             ├─ columns: [id:0!null, FV24E:1->FV24E:0, UJ6XY:2->UJ6XY:0, M22QN:3, NZ4MQ:4, ETPQV:5!null, convert\n" +
 			"             │   ├─ type: char\n" +
 			"             │   └─ PRUV2:6!null\n" +
-			"             │   as PRUV2, YKSSU:7, FHCYT:8]\n" +
+			"             │  ->PRUV2:0, YKSSU:7, FHCYT:8]\n" +
 			"             └─ Project\n" +
-			"                 ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, bpnw2.FV24E:1 as FV24E, bpnw2.UJ6XY:2 as UJ6XY, Subquery\n" +
+			"                 ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:227, bpnw2.FV24E:1->FV24E:0, bpnw2.UJ6XY:2->UJ6XY:0, Subquery\n" +
 			"                 │   ├─ cacheable: false\n" +
 			"                 │   ├─ alias-string: select aac.id from TPXBU as aac where aac.BTXC5 = BPNW2.SYPKF\n" +
 			"                 │   └─ Project\n" +
@@ -20136,9 +20136,9 @@ FROM
 			"                 │                   └─ Table\n" +
 			"                 │                       ├─ name: TPXBU\n" +
 			"                 │                       └─ columns: [id btxc5]\n" +
-			"                 │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
+			"                 │  ->M22QN:0, bpnw2.NZ4MQ:4->NZ4MQ:0, bpnw2.MU3KG:0!null->ETPQV:0, bpnw2.I4NDZ:7!null->PRUV2:0, bpnw2.YKSSU:6->YKSSU:0, bpnw2.FHCYT:5->FHCYT:0]\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [bpnw2.MU3KG:0!null, bpnw2.FV24E:1, bpnw2.UJ6XY:2, bpnw2.SYPKF:3, bpnw2.NZ4MQ:4, bpnw2.FHCYT:5, bpnw2.YKSSU:6, bpnw2.I4NDZ:7!null, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, bpnw2.FV24E:1 as FV24E, bpnw2.UJ6XY:2 as UJ6XY, Subquery\n" +
+			"                     ├─ columns: [bpnw2.MU3KG:0!null, bpnw2.FV24E:1, bpnw2.UJ6XY:2, bpnw2.SYPKF:3, bpnw2.NZ4MQ:4, bpnw2.FHCYT:5, bpnw2.YKSSU:6, bpnw2.I4NDZ:7!null, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:227, bpnw2.FV24E:1->FV24E:0, bpnw2.UJ6XY:2->UJ6XY:0, Subquery\n" +
 			"                     │   ├─ cacheable: false\n" +
 			"                     │   ├─ alias-string: select aac.id from TPXBU as aac where aac.BTXC5 = BPNW2.SYPKF\n" +
 			"                     │   └─ Project\n" +
@@ -20156,7 +20156,7 @@ FROM
 			"                     │                   └─ Table\n" +
 			"                     │                       ├─ name: TPXBU\n" +
 			"                     │                       └─ columns: [id btxc5]\n" +
-			"                     │   as M22QN, bpnw2.NZ4MQ:4 as NZ4MQ, bpnw2.MU3KG:0!null as ETPQV, bpnw2.I4NDZ:7!null as PRUV2, bpnw2.YKSSU:6 as YKSSU, bpnw2.FHCYT:5 as FHCYT]\n" +
+			"                     │  ->M22QN:0, bpnw2.NZ4MQ:4->NZ4MQ:0, bpnw2.MU3KG:0!null->ETPQV:0, bpnw2.I4NDZ:7!null->PRUV2:0, bpnw2.YKSSU:6->YKSSU:0, bpnw2.FHCYT:5->FHCYT:0]\n" +
 			"                     └─ SubqueryAlias\n" +
 			"                         ├─ name: bpnw2\n" +
 			"                         ├─ outerVisibility: false\n" +
@@ -20166,7 +20166,7 @@ FROM
 			"                         ├─ tableId: 17\n" +
 			"                         └─ Distinct\n" +
 			"                             └─ Project\n" +
-			"                                 ├─ columns: [tizhk.id:0!null as MU3KG, CASE  WHEN NOT\n" +
+			"                                 ├─ columns: [tizhk.id:0!null->MU3KG:0, CASE  WHEN NOT\n" +
 			"                                 │   └─ nhmxw.FZXV5:15 IS NULL\n" +
 			"                                 │   THEN Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
@@ -20186,7 +20186,7 @@ FROM
 			"                                 │                   └─ Table\n" +
 			"                                 │                       ├─ name: E2I7U\n" +
 			"                                 │                       └─ columns: [id tw55n]\n" +
-			"                                 │   ELSE j4jyp.id:20!null END as FV24E, CASE  WHEN NOT\n" +
+			"                                 │   ELSE j4jyp.id:20!null END->FV24E:0, CASE  WHEN NOT\n" +
 			"                                 │   └─ nhmxw.DQYGV:16 IS NULL\n" +
 			"                                 │   THEN Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
@@ -20206,7 +20206,7 @@ FROM
 			"                                 │                   └─ Table\n" +
 			"                                 │                       ├─ name: E2I7U\n" +
 			"                                 │                       └─ columns: [id tw55n]\n" +
-			"                                 │   ELSE rhuzn.id:37!null END as UJ6XY, tizhk.SYPKF:3 as SYPKF, Subquery\n" +
+			"                                 │   ELSE rhuzn.id:37!null END->UJ6XY:0, tizhk.SYPKF:3->SYPKF:0, Subquery\n" +
 			"                                 │   ├─ cacheable: false\n" +
 			"                                 │   ├─ alias-string: select G3YXS.id from YYBCX as G3YXS where CONCAT(G3YXS.ESFVY, '(MI:', G3YXS.SL76B, ')') = TIZHK.IDUT2\n" +
 			"                                 │   └─ Project\n" +
@@ -20221,9 +20221,9 @@ FROM
 			"                                 │                   ├─ columns: [id esfvy sl76b]\n" +
 			"                                 │                   ├─ colSet: (207-214)\n" +
 			"                                 │                   └─ tableId: 16\n" +
-			"                                 │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU, nhmxw.id:10!null as I4NDZ]\n" +
+			"                                 │  ->NZ4MQ:0, NULL (null)->FHCYT:216, NULL (null)->YKSSU:217, nhmxw.id:10!null->I4NDZ:0]\n" +
 			"                                 └─ Project\n" +
-			"                                     ├─ columns: [tizhk.id:0!null, tizhk.TVNW2:1, tizhk.ZHITY:2, tizhk.SYPKF:3, tizhk.IDUT2:4, tizhk.O6QJ3:5, tizhk.NO2JA:6, tizhk.YKSSU:7, tizhk.FHCYT:8, tizhk.QZ6VT:9, nhmxw.id:10!null, nhmxw.NOHHR:11!null, nhmxw.AVPYF:12!null, nhmxw.SYPKF:13!null, nhmxw.IDUT2:14!null, nhmxw.FZXV5:15, nhmxw.DQYGV:16, nhmxw.SWCQV:17!null, nhmxw.YKSSU:18, nhmxw.FHCYT:19, j4jyp.id:20!null, j4jyp.DKCAJ:21!null, j4jyp.KNG7T:22, j4jyp.TW55N:23!null, j4jyp.QRQXW:24!null, j4jyp.ECXAJ:25!null, j4jyp.FGG57:26, j4jyp.ZH72S:27, j4jyp.FSK67:28!null, j4jyp.XQDYT:29!null, j4jyp.TCE7A:30, j4jyp.IWV2H:31, j4jyp.HPCMS:32!null, j4jyp.N5CC2:33, j4jyp.FHCYT:34, j4jyp.ETAQ7:35, j4jyp.A75X7:36, rhuzn.id:37!null, rhuzn.DKCAJ:38!null, rhuzn.KNG7T:39, rhuzn.TW55N:40!null, rhuzn.QRQXW:41!null, rhuzn.ECXAJ:42!null, rhuzn.FGG57:43, rhuzn.ZH72S:44, rhuzn.FSK67:45!null, rhuzn.XQDYT:46!null, rhuzn.TCE7A:47, rhuzn.IWV2H:48, rhuzn.HPCMS:49!null, rhuzn.N5CC2:50, rhuzn.FHCYT:51, rhuzn.ETAQ7:52, rhuzn.A75X7:53, tizhk.id:0!null as MU3KG, CASE  WHEN NOT\n" +
+			"                                     ├─ columns: [tizhk.id:0!null, tizhk.TVNW2:1, tizhk.ZHITY:2, tizhk.SYPKF:3, tizhk.IDUT2:4, tizhk.O6QJ3:5, tizhk.NO2JA:6, tizhk.YKSSU:7, tizhk.FHCYT:8, tizhk.QZ6VT:9, nhmxw.id:10!null, nhmxw.NOHHR:11!null, nhmxw.AVPYF:12!null, nhmxw.SYPKF:13!null, nhmxw.IDUT2:14!null, nhmxw.FZXV5:15, nhmxw.DQYGV:16, nhmxw.SWCQV:17!null, nhmxw.YKSSU:18, nhmxw.FHCYT:19, j4jyp.id:20!null, j4jyp.DKCAJ:21!null, j4jyp.KNG7T:22, j4jyp.TW55N:23!null, j4jyp.QRQXW:24!null, j4jyp.ECXAJ:25!null, j4jyp.FGG57:26, j4jyp.ZH72S:27, j4jyp.FSK67:28!null, j4jyp.XQDYT:29!null, j4jyp.TCE7A:30, j4jyp.IWV2H:31, j4jyp.HPCMS:32!null, j4jyp.N5CC2:33, j4jyp.FHCYT:34, j4jyp.ETAQ7:35, j4jyp.A75X7:36, rhuzn.id:37!null, rhuzn.DKCAJ:38!null, rhuzn.KNG7T:39, rhuzn.TW55N:40!null, rhuzn.QRQXW:41!null, rhuzn.ECXAJ:42!null, rhuzn.FGG57:43, rhuzn.ZH72S:44, rhuzn.FSK67:45!null, rhuzn.XQDYT:46!null, rhuzn.TCE7A:47, rhuzn.IWV2H:48, rhuzn.HPCMS:49!null, rhuzn.N5CC2:50, rhuzn.FHCYT:51, rhuzn.ETAQ7:52, rhuzn.A75X7:53, tizhk.id:0!null->MU3KG:0, CASE  WHEN NOT\n" +
 			"                                     │   └─ nhmxw.FZXV5:15 IS NULL\n" +
 			"                                     │   THEN Subquery\n" +
 			"                                     │   ├─ cacheable: false\n" +
@@ -20243,7 +20243,7 @@ FROM
 			"                                     │                   └─ Table\n" +
 			"                                     │                       ├─ name: E2I7U\n" +
 			"                                     │                       └─ columns: [id tw55n]\n" +
-			"                                     │   ELSE j4jyp.id:20!null END as FV24E, CASE  WHEN NOT\n" +
+			"                                     │   ELSE j4jyp.id:20!null END->FV24E:0, CASE  WHEN NOT\n" +
 			"                                     │   └─ nhmxw.DQYGV:16 IS NULL\n" +
 			"                                     │   THEN Subquery\n" +
 			"                                     │   ├─ cacheable: false\n" +
@@ -20263,7 +20263,7 @@ FROM
 			"                                     │                   └─ Table\n" +
 			"                                     │                       ├─ name: E2I7U\n" +
 			"                                     │                       └─ columns: [id tw55n]\n" +
-			"                                     │   ELSE rhuzn.id:37!null END as UJ6XY, tizhk.SYPKF:3 as SYPKF, Subquery\n" +
+			"                                     │   ELSE rhuzn.id:37!null END->UJ6XY:0, tizhk.SYPKF:3->SYPKF:0, Subquery\n" +
 			"                                     │   ├─ cacheable: false\n" +
 			"                                     │   ├─ alias-string: select G3YXS.id from YYBCX as G3YXS where CONCAT(G3YXS.ESFVY, '(MI:', G3YXS.SL76B, ')') = TIZHK.IDUT2\n" +
 			"                                     │   └─ Project\n" +
@@ -20278,7 +20278,7 @@ FROM
 			"                                     │                   ├─ columns: [id esfvy sl76b]\n" +
 			"                                     │                   ├─ colSet: (207-214)\n" +
 			"                                     │                   └─ tableId: 16\n" +
-			"                                     │   as NZ4MQ, NULL (null) as FHCYT, NULL (null) as YKSSU, nhmxw.id:10!null as I4NDZ]\n" +
+			"                                     │  ->NZ4MQ:0, NULL (null)->FHCYT:216, NULL (null)->YKSSU:217, nhmxw.id:10!null->I4NDZ:0]\n" +
 			"                                     └─ Filter\n" +
 			"                                         ├─ NOT\n" +
 			"                                         │   └─ nhmxw.id:10!null IS NULL\n" +
@@ -20449,7 +20449,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, NO52D:1!null, VYO5E:2, DKCAJ:3!null, ADURZ:4!null, FHCYT:5]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, rs.NO52D:0 as NO52D, rs.VYO5E:1 as VYO5E, rs.DKCAJ:2!null as DKCAJ, CASE  WHEN AND\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:72, rs.NO52D:0->NO52D:0, rs.VYO5E:1->VYO5E:0, rs.DKCAJ:2!null->DKCAJ:0, CASE  WHEN AND\n" +
 			"     │       │   ├─ Eq\n" +
 			"     │       │   │   ├─ rs.NO52D:0\n" +
 			"     │       │   │   └─ FZB3D (longtext)\n" +
@@ -20490,7 +20490,7 @@ WHERE
 			"     │       │   THEN 1 (tinyint) WHEN Eq\n" +
 			"     │       │   ├─ rs.NO52D:0\n" +
 			"     │       │   └─ Kd (longtext)\n" +
-			"     │       │   THEN 2 (tinyint) ELSE NULL (null) END as ADURZ, NULL (null) as FHCYT]\n" +
+			"     │       │   THEN 2 (tinyint) ELSE NULL (null) END->ADURZ:0, NULL (null)->FHCYT:77]\n" +
 			"     │       └─ Filter\n" +
 			"     │           ├─ Or\n" +
 			"     │           │   ├─ AND\n" +
@@ -20538,10 +20538,10 @@ WHERE
 			"     │               ├─ tableId: 7\n" +
 			"     │               └─ Distinct\n" +
 			"     │                   └─ Project\n" +
-			"     │                       ├─ columns: [nk7fp.NO52D:0 as NO52D, CASE  WHEN Eq\n" +
+			"     │                       ├─ columns: [nk7fp.NO52D:0->NO52D:0, CASE  WHEN Eq\n" +
 			"     │                       │   ├─ nk7fp.VYO5E:1\n" +
 			"     │                       │   └─ N/A (longtext)\n" +
-			"     │                       │   THEN NULL (null) ELSE nk7fp.VYO5E:1 END as VYO5E, nt.id:7!null as DKCAJ, nt.DZLIM:8!null as F35MI]\n" +
+			"     │                       │   THEN NULL (null) ELSE nk7fp.VYO5E:1 END->VYO5E:0, nt.id:7!null->DKCAJ:0, nt.DZLIM:8!null->F35MI:0]\n" +
 			"     │                       └─ HashJoin\n" +
 			"     │                           ├─ Eq\n" +
 			"     │                           │   ├─ nt.id:7!null\n" +
@@ -20775,7 +20775,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, FZ2R5:1!null, LUEVY:2!null, M22QN:3!null, OVE3E:4!null, NRURT:5, OCA7E:6, XMM6Q:7, V5DPX:8!null, S3Q3Y:9!null, ZRV3B:10!null, FHCYT:11]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, pqsxb.FZ2R5:0 as FZ2R5, nd.id:12!null as LUEVY, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:120, pqsxb.FZ2R5:0->FZ2R5:0, nd.id:12!null->LUEVY:0, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select aac.id from TPXBU as aac where aac.BTXC5 = PQSXB.BTXC5\n" +
 			"     │       │   └─ Project\n" +
@@ -20793,9 +20793,9 @@ WHERE
 			"     │       │                   └─ Table\n" +
 			"     │       │                       ├─ name: TPXBU\n" +
 			"     │       │                       └─ columns: [id btxc5]\n" +
-			"     │       │   as M22QN, pqsxb.OVE3E:1 as OVE3E, pqsxb.NRURT:2!null as NRURT, pqsxb.OCA7E:3!null as OCA7E, pqsxb.XMM6Q:4 as XMM6Q, pqsxb.V5DPX:5 as V5DPX, pqsxb.S3Q3Y:6 as S3Q3Y, pqsxb.ZRV3B:7 as ZRV3B, pqsxb.FHCYT:8 as FHCYT]\n" +
+			"     │       │  ->M22QN:0, pqsxb.OVE3E:1->OVE3E:0, pqsxb.NRURT:2!null->NRURT:0, pqsxb.OCA7E:3!null->OCA7E:0, pqsxb.XMM6Q:4->XMM6Q:0, pqsxb.V5DPX:5->V5DPX:0, pqsxb.S3Q3Y:6->S3Q3Y:0, pqsxb.ZRV3B:7->ZRV3B:0, pqsxb.FHCYT:8->FHCYT:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [pqsxb.FZ2R5:0, pqsxb.OVE3E:1, pqsxb.NRURT:2!null, pqsxb.OCA7E:3!null, pqsxb.XMM6Q:4, pqsxb.V5DPX:5, pqsxb.S3Q3Y:6, pqsxb.ZRV3B:7, pqsxb.FHCYT:8, pqsxb.K3B6V:9, pqsxb.BTXC5:10, pqsxb.H4DMT:11!null, nd.id:12!null, nd.DKCAJ:13!null, nd.KNG7T:14, nd.TW55N:15!null, nd.QRQXW:16!null, nd.ECXAJ:17!null, nd.FGG57:18, nd.ZH72S:19, nd.FSK67:20!null, nd.XQDYT:21!null, nd.TCE7A:22, nd.IWV2H:23, nd.HPCMS:24!null, nd.N5CC2:25, nd.FHCYT:26, nd.ETAQ7:27, nd.A75X7:28, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, pqsxb.FZ2R5:0 as FZ2R5, nd.id:12!null as LUEVY, Subquery\n" +
+			"     │           ├─ columns: [pqsxb.FZ2R5:0, pqsxb.OVE3E:1, pqsxb.NRURT:2!null, pqsxb.OCA7E:3!null, pqsxb.XMM6Q:4, pqsxb.V5DPX:5, pqsxb.S3Q3Y:6, pqsxb.ZRV3B:7, pqsxb.FHCYT:8, pqsxb.K3B6V:9, pqsxb.BTXC5:10, pqsxb.H4DMT:11!null, nd.id:12!null, nd.DKCAJ:13!null, nd.KNG7T:14, nd.TW55N:15!null, nd.QRQXW:16!null, nd.ECXAJ:17!null, nd.FGG57:18, nd.ZH72S:19, nd.FSK67:20!null, nd.XQDYT:21!null, nd.TCE7A:22, nd.IWV2H:23, nd.HPCMS:24!null, nd.N5CC2:25, nd.FHCYT:26, nd.ETAQ7:27, nd.A75X7:28, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:120, pqsxb.FZ2R5:0->FZ2R5:0, nd.id:12!null->LUEVY:0, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select aac.id from TPXBU as aac where aac.BTXC5 = PQSXB.BTXC5\n" +
 			"     │           │   └─ Project\n" +
@@ -20813,7 +20813,7 @@ WHERE
 			"     │           │                   └─ Table\n" +
 			"     │           │                       ├─ name: TPXBU\n" +
 			"     │           │                       └─ columns: [id btxc5]\n" +
-			"     │           │   as M22QN, pqsxb.OVE3E:1 as OVE3E, pqsxb.NRURT:2!null as NRURT, pqsxb.OCA7E:3!null as OCA7E, pqsxb.XMM6Q:4 as XMM6Q, pqsxb.V5DPX:5 as V5DPX, pqsxb.S3Q3Y:6 as S3Q3Y, pqsxb.ZRV3B:7 as ZRV3B, pqsxb.FHCYT:8 as FHCYT]\n" +
+			"     │           │  ->M22QN:0, pqsxb.OVE3E:1->OVE3E:0, pqsxb.NRURT:2!null->NRURT:0, pqsxb.OCA7E:3!null->OCA7E:0, pqsxb.XMM6Q:4->XMM6Q:0, pqsxb.V5DPX:5->V5DPX:0, pqsxb.S3Q3Y:6->S3Q3Y:0, pqsxb.ZRV3B:7->ZRV3B:0, pqsxb.FHCYT:8->FHCYT:0]\n" +
 			"     │           └─ Filter\n" +
 			"     │               ├─ NOT\n" +
 			"     │               │   └─ pqsxb.OVE3E:1 IS NULL\n" +
@@ -20855,7 +20855,7 @@ WHERE
 			"     │                   │       │               └─ Table\n" +
 			"     │                   │       │                   ├─ name: JDLNA\n" +
 			"     │                   │       │                   └─ columns: [id ftqlq]\n" +
-			"     │                   │       │   as FZ2R5, Subquery\n" +
+			"     │                   │       │  ->FZ2R5:0, Subquery\n" +
 			"     │                   │       │   ├─ cacheable: false\n" +
 			"     │                   │       │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = uct.NO52D and (SFEGG.VYO5E = uct.VYO5E or (SFEGG.VYO5E is null and (uct.VYO5E is null or uct.VYO5E = 'N/A' or uct.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end)\n" +
 			"     │                   │       │   └─ Project\n" +
@@ -20924,12 +20924,12 @@ WHERE
 			"     │                   │       │           │               │                   └─ Table\n" +
 			"     │                   │       │           │               │                       ├─ name: E2I7U\n" +
 			"     │                   │       │           │               │                       └─ columns: [dkcaj tw55n]\n" +
-			"     │                   │       │           │               │   END as CASE\n" +
+			"     │                   │       │           │               │   END->CASE\n" +
 			"     │                   │       │           │               │                          WHEN I7HCR.FVUCX IS NULL\n" +
 			"     │                   │       │           │               │                              THEN (SELECT nd.DKCAJ FROM E2I7U nd WHERE nd.ZH72S = uct.ZH72S LIMIT 1)\n" +
 			"     │                   │       │           │               │                          ELSE\n" +
 			"     │                   │       │           │               │                              (SELECT nd.DKCAJ FROM E2I7U nd WHERE nd.TW55N = I7HCR.FVUCX)\n" +
-			"     │                   │       │           │               │                      END]\n" +
+			"     │                   │       │           │               │                      END:0]\n" +
 			"     │                   │       │           │               └─ Project\n" +
 			"     │                   │       │           │                   ├─ columns: [dual.:39!null]\n" +
 			"     │                   │       │           │                   └─ Table\n" +
@@ -20945,11 +20945,11 @@ WHERE
 			"     │                   │       │               └─ Table\n" +
 			"     │                   │       │                   ├─ name: SFEGG\n" +
 			"     │                   │       │                   └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
-			"     │                   │       │   as OVE3E, uct.id:0!null as NRURT, i7hcr.id:13!null as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN NOT\n" +
+			"     │                   │       │  ->OVE3E:0, uct.id:0!null->NRURT:0, i7hcr.id:13!null->OCA7E:0, NULL (null)->XMM6Q:83, uct.V5DPX:4->V5DPX:0, (uct.IDPK7:6 + 0 (decimal(2,1)))->S3Q3Y:0, uct.ZRV3B:8->ZRV3B:0, CASE  WHEN NOT\n" +
 			"     │                   │       │   └─ Eq\n" +
 			"     │                   │       │       ├─ uct.FHCYT:11\n" +
 			"     │                   │       │       └─ N/A (longtext)\n" +
-			"     │                   │       │   THEN uct.FHCYT:11 ELSE NULL (null) END as FHCYT, uct.ZH72S:2 as K3B6V, uct.LJLUM:5 as BTXC5, i7hcr.FVUCX:17!null as H4DMT]\n" +
+			"     │                   │       │   THEN uct.FHCYT:11 ELSE NULL (null) END->FHCYT:0, uct.ZH72S:2->K3B6V:0, uct.LJLUM:5->BTXC5:0, i7hcr.FVUCX:17!null->H4DMT:0]\n" +
 			"     │                   │       └─ Project\n" +
 			"     │                   │           ├─ columns: [uct.id:0!null, uct.FTQLQ:1, uct.ZH72S:2, uct.SFJ6L:3, uct.V5DPX:4, uct.LJLUM:5, uct.IDPK7:6, uct.NO52D:7, uct.ZRV3B:8, uct.VYO5E:9, uct.YKSSU:10, uct.FHCYT:11, uct.QZ6VT:12, i7hcr.id:13!null, i7hcr.TOFPN:14!null, i7hcr.SJYN2:15!null, i7hcr.BTXC5:16!null, i7hcr.FVUCX:17!null, i7hcr.SWCQV:18!null, i7hcr.YKSSU:19, i7hcr.FHCYT:20, Subquery\n" +
 			"     │                   │           │   ├─ cacheable: false\n" +
@@ -20968,7 +20968,7 @@ WHERE
 			"     │                   │           │               └─ Table\n" +
 			"     │                   │           │                   ├─ name: JDLNA\n" +
 			"     │                   │           │                   └─ columns: [id ftqlq]\n" +
-			"     │                   │           │   as FZ2R5, Subquery\n" +
+			"     │                   │           │  ->FZ2R5:0, Subquery\n" +
 			"     │                   │           │   ├─ cacheable: false\n" +
 			"     │                   │           │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = uct.NO52D and (SFEGG.VYO5E = uct.VYO5E or (SFEGG.VYO5E is null and (uct.VYO5E is null or uct.VYO5E = 'N/A' or uct.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select case when I7HCR.FVUCX is null then (select nd.DKCAJ from E2I7U as nd where nd.ZH72S = uct.ZH72S limit 1) else (select nd.DKCAJ from E2I7U as nd where nd.TW55N = I7HCR.FVUCX) end)\n" +
 			"     │                   │           │   └─ Project\n" +
@@ -21037,12 +21037,12 @@ WHERE
 			"     │                   │           │           │               │                   └─ Table\n" +
 			"     │                   │           │           │               │                       ├─ name: E2I7U\n" +
 			"     │                   │           │           │               │                       └─ columns: [dkcaj tw55n]\n" +
-			"     │                   │           │           │               │   END as CASE\n" +
+			"     │                   │           │           │               │   END->CASE\n" +
 			"     │                   │           │           │               │                          WHEN I7HCR.FVUCX IS NULL\n" +
 			"     │                   │           │           │               │                              THEN (SELECT nd.DKCAJ FROM E2I7U nd WHERE nd.ZH72S = uct.ZH72S LIMIT 1)\n" +
 			"     │                   │           │           │               │                          ELSE\n" +
 			"     │                   │           │           │               │                              (SELECT nd.DKCAJ FROM E2I7U nd WHERE nd.TW55N = I7HCR.FVUCX)\n" +
-			"     │                   │           │           │               │                      END]\n" +
+			"     │                   │           │           │               │                      END:0]\n" +
 			"     │                   │           │           │               └─ Project\n" +
 			"     │                   │           │           │                   ├─ columns: [dual.:27!null]\n" +
 			"     │                   │           │           │                   └─ Table\n" +
@@ -21058,11 +21058,11 @@ WHERE
 			"     │                   │           │               └─ Table\n" +
 			"     │                   │           │                   ├─ name: SFEGG\n" +
 			"     │                   │           │                   └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
-			"     │                   │           │   as OVE3E, uct.id:0!null as NRURT, i7hcr.id:13!null as OCA7E, NULL (null) as XMM6Q, uct.V5DPX:4 as V5DPX, (uct.IDPK7:6 + 0 (decimal(2,1))) as S3Q3Y, uct.ZRV3B:8 as ZRV3B, CASE  WHEN NOT\n" +
+			"     │                   │           │  ->OVE3E:0, uct.id:0!null->NRURT:0, i7hcr.id:13!null->OCA7E:0, NULL (null)->XMM6Q:83, uct.V5DPX:4->V5DPX:0, (uct.IDPK7:6 + 0 (decimal(2,1)))->S3Q3Y:0, uct.ZRV3B:8->ZRV3B:0, CASE  WHEN NOT\n" +
 			"     │                   │           │   └─ Eq\n" +
 			"     │                   │           │       ├─ uct.FHCYT:11\n" +
 			"     │                   │           │       └─ N/A (longtext)\n" +
-			"     │                   │           │   THEN uct.FHCYT:11 ELSE NULL (null) END as FHCYT, uct.ZH72S:2 as K3B6V, uct.LJLUM:5 as BTXC5, i7hcr.FVUCX:17!null as H4DMT]\n" +
+			"     │                   │           │   THEN uct.FHCYT:11 ELSE NULL (null) END->FHCYT:0, uct.ZH72S:2->K3B6V:0, uct.LJLUM:5->BTXC5:0, i7hcr.FVUCX:17!null->H4DMT:0]\n" +
 			"     │                   │           └─ LeftOuterJoin\n" +
 			"     │                   │               ├─ AND\n" +
 			"     │                   │               │   ├─ AND\n" +
@@ -21216,7 +21216,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, NO52D:1!null, VYO5E:2, DKCAJ:3!null, ADURZ:4!null, FHCYT:5]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, rs.NO52D:0!null as NO52D, rs.VYO5E:1 as VYO5E, rs.DKCAJ:2!null as DKCAJ, CASE  WHEN AND\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:60, rs.NO52D:0!null->NO52D:0, rs.VYO5E:1->VYO5E:0, rs.DKCAJ:2!null->DKCAJ:0, CASE  WHEN AND\n" +
 			"     │       │   ├─ Eq\n" +
 			"     │       │   │   ├─ rs.NO52D:0!null\n" +
 			"     │       │   │   └─ FZB3D (longtext)\n" +
@@ -21257,7 +21257,7 @@ WHERE
 			"     │       │   THEN 1 (tinyint) WHEN Eq\n" +
 			"     │       │   ├─ rs.NO52D:0!null\n" +
 			"     │       │   └─ Kd (longtext)\n" +
-			"     │       │   THEN 2 (tinyint) ELSE NULL (null) END as ADURZ, NULL (null) as FHCYT]\n" +
+			"     │       │   THEN 2 (tinyint) ELSE NULL (null) END->ADURZ:0, NULL (null)->FHCYT:65]\n" +
 			"     │       └─ Filter\n" +
 			"     │           ├─ Or\n" +
 			"     │           │   ├─ AND\n" +
@@ -21305,7 +21305,7 @@ WHERE
 			"     │               ├─ tableId: 5\n" +
 			"     │               └─ Distinct\n" +
 			"     │                   └─ Project\n" +
-			"     │                       ├─ columns: [tvtjs.NO52D:2!null as NO52D, tvtjs.VYO5E:3 as VYO5E, nt.id:6!null as DKCAJ, nt.DZLIM:7!null as F35MI]\n" +
+			"     │                       ├─ columns: [tvtjs.NO52D:2!null->NO52D:0, tvtjs.VYO5E:3->VYO5E:0, nt.id:6!null->DKCAJ:0, nt.DZLIM:7!null->F35MI:0]\n" +
 			"     │                       └─ LookupJoin\n" +
 			"     │                           ├─ LookupJoin\n" +
 			"     │                           │   ├─ TableAlias(tvtjs)\n" +
@@ -21427,7 +21427,7 @@ WHERE
 			"     ├─ Project\n" +
 			"     │   ├─ columns: [id:0!null, FZ2R5:1!null, LUEVY:2!null, M22QN:3!null, OVE3E:4!null, NRURT:5, OCA7E:6, XMM6Q:7, V5DPX:8!null, S3Q3Y:9!null, ZRV3B:10!null, FHCYT:11]\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │       ├─ columns: [lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:26, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select id from JDLNA where JDLNA.FTQLQ = TVTJS.TOFPN\n" +
 			"     │       │   └─ Project\n" +
@@ -21444,7 +21444,7 @@ WHERE
 			"     │       │               └─ Table\n" +
 			"     │       │                   ├─ name: JDLNA\n" +
 			"     │       │                   └─ columns: [id ftqlq]\n" +
-			"     │       │   as FZ2R5, Subquery\n" +
+			"     │       │  ->FZ2R5:0, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select id from E2I7U where TW55N = TVTJS.I3VTA\n" +
 			"     │       │   └─ Project\n" +
@@ -21461,7 +21461,7 @@ WHERE
 			"     │       │               └─ Table\n" +
 			"     │       │                   ├─ name: E2I7U\n" +
 			"     │       │                   └─ columns: [id tw55n]\n" +
-			"     │       │   as LUEVY, Subquery\n" +
+			"     │       │  ->LUEVY:0, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select id from TPXBU where BTXC5 = TVTJS.LJLUM\n" +
 			"     │       │   └─ Project\n" +
@@ -21478,7 +21478,7 @@ WHERE
 			"     │       │               └─ Table\n" +
 			"     │       │                   ├─ name: TPXBU\n" +
 			"     │       │                   └─ columns: [id btxc5]\n" +
-			"     │       │   as M22QN, Subquery\n" +
+			"     │       │  ->M22QN:0, Subquery\n" +
 			"     │       │   ├─ cacheable: false\n" +
 			"     │       │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = TVTJS.NO52D and (SFEGG.VYO5E = TVTJS.VYO5E or (SFEGG.VYO5E is null and (TVTJS.VYO5E is null or TVTJS.VYO5E = 'N/A' or TVTJS.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select nd.DKCAJ from E2I7U as nd where nd.TW55N = TVTJS.I3VTA)\n" +
 			"     │       │   └─ Project\n" +
@@ -21532,9 +21532,9 @@ WHERE
 			"     │       │               └─ Table\n" +
 			"     │       │                   ├─ name: SFEGG\n" +
 			"     │       │                   └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
-			"     │       │   as OVE3E, NULL (null) as NRURT, NULL (null) as OCA7E, tvtjs.id:0!null as XMM6Q, tvtjs.V5DPX:4!null as V5DPX, (tvtjs.IDPK7:6!null + 0 (decimal(2,1))) as S3Q3Y, tvtjs.ZRV3B:8!null as ZRV3B, tvtjs.FHCYT:12 as FHCYT]\n" +
+			"     │       │  ->OVE3E:0, NULL (null)->NRURT:79, NULL (null)->OCA7E:80, tvtjs.id:0!null->XMM6Q:0, tvtjs.V5DPX:4!null->V5DPX:0, (tvtjs.IDPK7:6!null + 0 (decimal(2,1)))->S3Q3Y:0, tvtjs.ZRV3B:8!null->ZRV3B:0, tvtjs.FHCYT:12->FHCYT:0]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [tvtjs.id:0!null, tvtjs.TOFPN:1!null, tvtjs.I3VTA:2!null, tvtjs.SFJ6L:3, tvtjs.V5DPX:4!null, tvtjs.LJLUM:5!null, tvtjs.IDPK7:6!null, tvtjs.NO52D:7!null, tvtjs.ZRV3B:8!null, tvtjs.VYO5E:9, tvtjs.SWCQV:10!null, tvtjs.YKSSU:11, tvtjs.FHCYT:12, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0') as id, Subquery\n" +
+			"     │           ├─ columns: [tvtjs.id:0!null, tvtjs.TOFPN:1!null, tvtjs.I3VTA:2!null, tvtjs.SFJ6L:3, tvtjs.V5DPX:4!null, tvtjs.LJLUM:5!null, tvtjs.IDPK7:6!null, tvtjs.NO52D:7!null, tvtjs.ZRV3B:8!null, tvtjs.VYO5E:9, tvtjs.SWCQV:10!null, tvtjs.YKSSU:11, tvtjs.FHCYT:12, lpad(lower(concat(concat(hex((rand() * 4294967296)),lower(hex((rand() * 4294967296))),lower(hex((rand() * 4294967296)))))), 24, '0')->id:26, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select id from JDLNA where JDLNA.FTQLQ = TVTJS.TOFPN\n" +
 			"     │           │   └─ Project\n" +
@@ -21551,7 +21551,7 @@ WHERE
 			"     │           │               └─ Table\n" +
 			"     │           │                   ├─ name: JDLNA\n" +
 			"     │           │                   └─ columns: [id ftqlq]\n" +
-			"     │           │   as FZ2R5, Subquery\n" +
+			"     │           │  ->FZ2R5:0, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select id from E2I7U where TW55N = TVTJS.I3VTA\n" +
 			"     │           │   └─ Project\n" +
@@ -21568,7 +21568,7 @@ WHERE
 			"     │           │               └─ Table\n" +
 			"     │           │                   ├─ name: E2I7U\n" +
 			"     │           │                   └─ columns: [id tw55n]\n" +
-			"     │           │   as LUEVY, Subquery\n" +
+			"     │           │  ->LUEVY:0, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select id from TPXBU where BTXC5 = TVTJS.LJLUM\n" +
 			"     │           │   └─ Project\n" +
@@ -21585,7 +21585,7 @@ WHERE
 			"     │           │               └─ Table\n" +
 			"     │           │                   ├─ name: TPXBU\n" +
 			"     │           │                   └─ columns: [id btxc5]\n" +
-			"     │           │   as M22QN, Subquery\n" +
+			"     │           │  ->M22QN:0, Subquery\n" +
 			"     │           │   ├─ cacheable: false\n" +
 			"     │           │   ├─ alias-string: select id from SFEGG where SFEGG.NO52D = TVTJS.NO52D and (SFEGG.VYO5E = TVTJS.VYO5E or (SFEGG.VYO5E is null and (TVTJS.VYO5E is null or TVTJS.VYO5E = 'N/A' or TVTJS.VYO5E = 'NA'))) and SFEGG.DKCAJ = (select nd.DKCAJ from E2I7U as nd where nd.TW55N = TVTJS.I3VTA)\n" +
 			"     │           │   └─ Project\n" +
@@ -21639,7 +21639,7 @@ WHERE
 			"     │           │               └─ Table\n" +
 			"     │           │                   ├─ name: SFEGG\n" +
 			"     │           │                   └─ columns: [id no52d vyo5e dkcaj adurz fhcyt]\n" +
-			"     │           │   as OVE3E, NULL (null) as NRURT, NULL (null) as OCA7E, tvtjs.id:0!null as XMM6Q, tvtjs.V5DPX:4!null as V5DPX, (tvtjs.IDPK7:6!null + 0 (decimal(2,1))) as S3Q3Y, tvtjs.ZRV3B:8!null as ZRV3B, tvtjs.FHCYT:12 as FHCYT]\n" +
+			"     │           │  ->OVE3E:0, NULL (null)->NRURT:79, NULL (null)->OCA7E:80, tvtjs.id:0!null->XMM6Q:0, tvtjs.V5DPX:4!null->V5DPX:0, (tvtjs.IDPK7:6!null + 0 (decimal(2,1)))->S3Q3Y:0, tvtjs.ZRV3B:8!null->ZRV3B:0, tvtjs.FHCYT:12->FHCYT:0]\n" +
 			"     │           └─ TableAlias(tvtjs)\n" +
 			"     │               └─ IndexedTableAccess(HU5A5)\n" +
 			"     │                   ├─ index: [HU5A5.id]\n" +

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -9454,53 +9454,48 @@ WHERE
 			"             │           ├─ colSet: (133-136)\n" +
 			"             │           ├─ tableId: 16\n" +
 			"             │           └─ Project\n" +
-			"             │               ├─ columns: [nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
-			"             │               │   ├─ nd.TCE7A:20\n" +
+			"             │               ├─ columns: [nd.TW55N:3!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:7!null->YHVEZ:0, CASE  WHEN LessThan\n" +
+			"             │               │   ├─ nd.TCE7A:4\n" +
 			"             │               │   └─ 0.9 (decimal(2,1))\n" +
 			"             │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
 			"             │               └─ Sort(sn.id:0!null ASC nullsFirst)\n" +
-			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id:0!null, sn.BRQP2:1!null, sn.FFTBJ:2!null, sn.A7XO2:3, sn.KBO7R:4!null, sn.ECDKM:5, sn.NUMK2:6!null, sn.LETOE:7!null, sn.YKSSU:8, sn.FHCYT:9, nd.id:10!null, nd.DKCAJ:11!null, nd.KNG7T:12, nd.TW55N:13!null, nd.QRQXW:14!null, nd.ECXAJ:15!null, nd.FGG57:16, nd.ZH72S:17, nd.FSK67:18!null, nd.XQDYT:19!null, nd.TCE7A:20, nd.IWV2H:21, nd.HPCMS:22!null, nd.N5CC2:23, nd.FHCYT:24, nd.ETAQ7:25, nd.A75X7:26, nma.id:27!null, nma.DZLIM:28!null, nma.F3YUE:29, nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
-			"             │                       │   ├─ nd.TCE7A:20\n" +
-			"             │                       │   └─ 0.9 (decimal(2,1))\n" +
-			"             │                       │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
-			"             │                       └─ Filter\n" +
-			"             │                           ├─ NOT\n" +
-			"             │                           │   └─ Eq\n" +
-			"             │                           │       ├─ nma.DZLIM:28!null\n" +
-			"             │                           │       └─ Q5I4E (longtext)\n" +
-			"             │                           └─ LeftOuterLookupJoin\n" +
-			"             │                               ├─ LeftOuterMergeJoin\n" +
-			"             │                               │   ├─ cmp: Eq\n" +
-			"             │                               │   │   ├─ sn.BRQP2:1!null\n" +
-			"             │                               │   │   └─ nd.id:10!null\n" +
-			"             │                               │   ├─ TableAlias(sn)\n" +
-			"             │                               │   │   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                               │   │       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │                               │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                               │   │       ├─ colSet: (88-97)\n" +
-			"             │                               │   │       ├─ tableId: 10\n" +
-			"             │                               │   │       └─ Table\n" +
-			"             │                               │   │           ├─ name: NOXN3\n" +
-			"             │                               │   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
-			"             │                               │   └─ TableAlias(nd)\n" +
-			"             │                               │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                               │           ├─ index: [E2I7U.id]\n" +
-			"             │                               │           ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                               │           ├─ colSet: (98-114)\n" +
-			"             │                               │           ├─ tableId: 11\n" +
-			"             │                               │           └─ Table\n" +
-			"             │                               │               ├─ name: E2I7U\n" +
-			"             │                               │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               └─ TableAlias(nma)\n" +
-			"             │                                   └─ IndexedTableAccess(TNMXI)\n" +
-			"             │                                       ├─ index: [TNMXI.id]\n" +
-			"             │                                       ├─ keys: [nd.HPCMS:22!null]\n" +
-			"             │                                       ├─ colSet: (115-117)\n" +
-			"             │                                       ├─ tableId: 12\n" +
-			"             │                                       └─ Table\n" +
-			"             │                                           ├─ name: TNMXI\n" +
-			"             │                                           └─ columns: [id dzlim f3yue]\n" +
+			"             │                   └─ Filter\n" +
+			"             │                       ├─ NOT\n" +
+			"             │                       │   └─ Eq\n" +
+			"             │                       │       ├─ nma.DZLIM:7!null\n" +
+			"             │                       │       └─ Q5I4E (longtext)\n" +
+			"             │                       └─ LeftOuterLookupJoin\n" +
+			"             │                           ├─ LeftOuterMergeJoin\n" +
+			"             │                           │   ├─ cmp: Eq\n" +
+			"             │                           │   │   ├─ sn.BRQP2:1!null\n" +
+			"             │                           │   │   └─ nd.id:2!null\n" +
+			"             │                           │   ├─ TableAlias(sn)\n" +
+			"             │                           │   │   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                           │   │       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │                           │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │   │       ├─ colSet: (88-97)\n" +
+			"             │                           │   │       ├─ tableId: 10\n" +
+			"             │                           │   │       └─ Table\n" +
+			"             │                           │   │           ├─ name: NOXN3\n" +
+			"             │                           │   │           └─ columns: [id brqp2]\n" +
+			"             │                           │   └─ TableAlias(nd)\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │           ├─ index: [E2I7U.id]\n" +
+			"             │                           │           ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │           ├─ colSet: (98-114)\n" +
+			"             │                           │           ├─ tableId: 11\n" +
+			"             │                           │           └─ Table\n" +
+			"             │                           │               ├─ name: E2I7U\n" +
+			"             │                           │               └─ columns: [id tw55n tce7a hpcms]\n" +
+			"             │                           └─ TableAlias(nma)\n" +
+			"             │                               └─ IndexedTableAccess(TNMXI)\n" +
+			"             │                                   ├─ index: [TNMXI.id]\n" +
+			"             │                                   ├─ keys: [nd.HPCMS:5!null]\n" +
+			"             │                                   ├─ colSet: (115-117)\n" +
+			"             │                                   ├─ tableId: 12\n" +
+			"             │                                   └─ Table\n" +
+			"             │                                       ├─ name: TNMXI\n" +
+			"             │                                       └─ columns: [id dzlim]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ left-key: TUPLE(oxxei.BDNYB:1!null)\n" +
 			"                 ├─ right-key: TUPLE(ckele.LWQ6O:0!null)\n" +
@@ -9602,28 +9597,26 @@ WHERE
 			"             │           └─ Project\n" +
 			"             │               ├─ columns: [nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
 			"             │               └─ Sort(sn.id ASC)\n" +
-			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, nd.id, nd.DKCAJ, nd.KNG7T, nd.TW55N, nd.QRQXW, nd.ECXAJ, nd.FGG57, nd.ZH72S, nd.FSK67, nd.XQDYT, nd.TCE7A, nd.IWV2H, nd.HPCMS, nd.N5CC2, nd.FHCYT, nd.ETAQ7, nd.A75X7, nma.id, nma.DZLIM, nma.F3YUE, nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
-			"             │                       └─ Filter\n" +
-			"             │                           ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
-			"             │                           └─ LeftOuterLookupJoin\n" +
-			"             │                               ├─ LeftOuterMergeJoin\n" +
-			"             │                               │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
-			"             │                               │   ├─ TableAlias(sn)\n" +
-			"             │                               │   │   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                               │   │       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │                               │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
-			"             │                               │   └─ TableAlias(nd)\n" +
-			"             │                               │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                               │           ├─ index: [E2I7U.id]\n" +
-			"             │                               │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               └─ TableAlias(nma)\n" +
-			"             │                                   └─ IndexedTableAccess(TNMXI)\n" +
-			"             │                                       ├─ index: [TNMXI.id]\n" +
-			"             │                                       ├─ columns: [id dzlim f3yue]\n" +
-			"             │                                       └─ keys: nd.HPCMS\n" +
+			"             │                   └─ Filter\n" +
+			"             │                       ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
+			"             │                       └─ LeftOuterLookupJoin\n" +
+			"             │                           ├─ LeftOuterMergeJoin\n" +
+			"             │                           │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
+			"             │                           │   ├─ TableAlias(sn)\n" +
+			"             │                           │   │   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                           │   │       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │                           │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │   │       └─ columns: [id brqp2]\n" +
+			"             │                           │   └─ TableAlias(nd)\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │           ├─ index: [E2I7U.id]\n" +
+			"             │                           │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │           └─ columns: [id tw55n tce7a hpcms]\n" +
+			"             │                           └─ TableAlias(nma)\n" +
+			"             │                               └─ IndexedTableAccess(TNMXI)\n" +
+			"             │                                   ├─ index: [TNMXI.id]\n" +
+			"             │                                   ├─ columns: [id dzlim]\n" +
+			"             │                                   └─ keys: nd.HPCMS\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ left-key: (oxxei.BDNYB)\n" +
 			"                 ├─ right-key: (ckele.LWQ6O)\n" +
@@ -9719,28 +9712,26 @@ WHERE
 			"             │           └─ Project\n" +
 			"             │               ├─ columns: [nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
 			"             │               └─ Sort(sn.id ASC)\n" +
-			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, nd.id, nd.DKCAJ, nd.KNG7T, nd.TW55N, nd.QRQXW, nd.ECXAJ, nd.FGG57, nd.ZH72S, nd.FSK67, nd.XQDYT, nd.TCE7A, nd.IWV2H, nd.HPCMS, nd.N5CC2, nd.FHCYT, nd.ETAQ7, nd.A75X7, nma.id, nma.DZLIM, nma.F3YUE, nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
-			"             │                       └─ Filter\n" +
-			"             │                           ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
-			"             │                           └─ LeftOuterLookupJoin\n" +
-			"             │                               ├─ LeftOuterMergeJoin\n" +
-			"             │                               │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
-			"             │                               │   ├─ TableAlias(sn)\n" +
-			"             │                               │   │   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                               │   │       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │                               │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
-			"             │                               │   └─ TableAlias(nd)\n" +
-			"             │                               │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                               │           ├─ index: [E2I7U.id]\n" +
-			"             │                               │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               └─ TableAlias(nma)\n" +
-			"             │                                   └─ IndexedTableAccess(TNMXI)\n" +
-			"             │                                       ├─ index: [TNMXI.id]\n" +
-			"             │                                       ├─ columns: [id dzlim f3yue]\n" +
-			"             │                                       └─ keys: nd.HPCMS\n" +
+			"             │                   └─ Filter\n" +
+			"             │                       ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
+			"             │                       └─ LeftOuterLookupJoin\n" +
+			"             │                           ├─ LeftOuterMergeJoin\n" +
+			"             │                           │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
+			"             │                           │   ├─ TableAlias(sn)\n" +
+			"             │                           │   │   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                           │   │       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │                           │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │   │       └─ columns: [id brqp2]\n" +
+			"             │                           │   └─ TableAlias(nd)\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │           ├─ index: [E2I7U.id]\n" +
+			"             │                           │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │           └─ columns: [id tw55n tce7a hpcms]\n" +
+			"             │                           └─ TableAlias(nma)\n" +
+			"             │                               └─ IndexedTableAccess(TNMXI)\n" +
+			"             │                                   ├─ index: [TNMXI.id]\n" +
+			"             │                                   ├─ columns: [id dzlim]\n" +
+			"             │                                   └─ keys: nd.HPCMS\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ left-key: (oxxei.BDNYB)\n" +
 			"                 ├─ right-key: (ckele.LWQ6O)\n" +
@@ -9948,53 +9939,48 @@ WHERE
 			"             │           ├─ colSet: (133-136)\n" +
 			"             │           ├─ tableId: 16\n" +
 			"             │           └─ Project\n" +
-			"             │               ├─ columns: [nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
-			"             │               │   ├─ nd.TCE7A:20\n" +
+			"             │               ├─ columns: [nd.TW55N:3!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:7!null->YHVEZ:0, CASE  WHEN LessThan\n" +
+			"             │               │   ├─ nd.TCE7A:4\n" +
 			"             │               │   └─ 0.9 (decimal(2,1))\n" +
 			"             │               │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
 			"             │               └─ Sort(sn.id:0!null ASC nullsFirst)\n" +
-			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id:0!null, sn.BRQP2:1!null, sn.FFTBJ:2!null, sn.A7XO2:3, sn.KBO7R:4!null, sn.ECDKM:5, sn.NUMK2:6!null, sn.LETOE:7!null, sn.YKSSU:8, sn.FHCYT:9, nd.id:10!null, nd.DKCAJ:11!null, nd.KNG7T:12, nd.TW55N:13!null, nd.QRQXW:14!null, nd.ECXAJ:15!null, nd.FGG57:16, nd.ZH72S:17, nd.FSK67:18!null, nd.XQDYT:19!null, nd.TCE7A:20, nd.IWV2H:21, nd.HPCMS:22!null, nd.N5CC2:23, nd.FHCYT:24, nd.ETAQ7:25, nd.A75X7:26, nma.id:27!null, nma.DZLIM:28!null, nma.F3YUE:29, nd.TW55N:13!null->KUXQY:0, sn.id:0!null->BDNYB:0, nma.DZLIM:28!null->YHVEZ:0, CASE  WHEN LessThan\n" +
-			"             │                       │   ├─ nd.TCE7A:20\n" +
-			"             │                       │   └─ 0.9 (decimal(2,1))\n" +
-			"             │                       │   THEN 1 (tinyint) ELSE 0 (tinyint) END->YAZ4X:0]\n" +
-			"             │                       └─ Filter\n" +
-			"             │                           ├─ NOT\n" +
-			"             │                           │   └─ Eq\n" +
-			"             │                           │       ├─ nma.DZLIM:28!null\n" +
-			"             │                           │       └─ Q5I4E (longtext)\n" +
-			"             │                           └─ LeftOuterLookupJoin\n" +
-			"             │                               ├─ LeftOuterMergeJoin\n" +
-			"             │                               │   ├─ cmp: Eq\n" +
-			"             │                               │   │   ├─ sn.BRQP2:1!null\n" +
-			"             │                               │   │   └─ nd.id:10!null\n" +
-			"             │                               │   ├─ TableAlias(sn)\n" +
-			"             │                               │   │   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                               │   │       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │                               │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                               │   │       ├─ colSet: (88-97)\n" +
-			"             │                               │   │       ├─ tableId: 10\n" +
-			"             │                               │   │       └─ Table\n" +
-			"             │                               │   │           ├─ name: NOXN3\n" +
-			"             │                               │   │           └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
-			"             │                               │   └─ TableAlias(nd)\n" +
-			"             │                               │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                               │           ├─ index: [E2I7U.id]\n" +
-			"             │                               │           ├─ static: [{[NULL, ∞)}]\n" +
-			"             │                               │           ├─ colSet: (98-114)\n" +
-			"             │                               │           ├─ tableId: 11\n" +
-			"             │                               │           └─ Table\n" +
-			"             │                               │               ├─ name: E2I7U\n" +
-			"             │                               │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               └─ TableAlias(nma)\n" +
-			"             │                                   └─ IndexedTableAccess(TNMXI)\n" +
-			"             │                                       ├─ index: [TNMXI.id]\n" +
-			"             │                                       ├─ keys: [nd.HPCMS:22!null]\n" +
-			"             │                                       ├─ colSet: (115-117)\n" +
-			"             │                                       ├─ tableId: 12\n" +
-			"             │                                       └─ Table\n" +
-			"             │                                           ├─ name: TNMXI\n" +
-			"             │                                           └─ columns: [id dzlim f3yue]\n" +
+			"             │                   └─ Filter\n" +
+			"             │                       ├─ NOT\n" +
+			"             │                       │   └─ Eq\n" +
+			"             │                       │       ├─ nma.DZLIM:7!null\n" +
+			"             │                       │       └─ Q5I4E (longtext)\n" +
+			"             │                       └─ LeftOuterLookupJoin\n" +
+			"             │                           ├─ LeftOuterMergeJoin\n" +
+			"             │                           │   ├─ cmp: Eq\n" +
+			"             │                           │   │   ├─ sn.BRQP2:1!null\n" +
+			"             │                           │   │   └─ nd.id:2!null\n" +
+			"             │                           │   ├─ TableAlias(sn)\n" +
+			"             │                           │   │   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                           │   │       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │                           │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │   │       ├─ colSet: (88-97)\n" +
+			"             │                           │   │       ├─ tableId: 10\n" +
+			"             │                           │   │       └─ Table\n" +
+			"             │                           │   │           ├─ name: NOXN3\n" +
+			"             │                           │   │           └─ columns: [id brqp2]\n" +
+			"             │                           │   └─ TableAlias(nd)\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │           ├─ index: [E2I7U.id]\n" +
+			"             │                           │           ├─ static: [{[NULL, ∞)}]\n" +
+			"             │                           │           ├─ colSet: (98-114)\n" +
+			"             │                           │           ├─ tableId: 11\n" +
+			"             │                           │           └─ Table\n" +
+			"             │                           │               ├─ name: E2I7U\n" +
+			"             │                           │               └─ columns: [id tw55n tce7a hpcms]\n" +
+			"             │                           └─ TableAlias(nma)\n" +
+			"             │                               └─ IndexedTableAccess(TNMXI)\n" +
+			"             │                                   ├─ index: [TNMXI.id]\n" +
+			"             │                                   ├─ keys: [nd.HPCMS:5!null]\n" +
+			"             │                                   ├─ colSet: (115-117)\n" +
+			"             │                                   ├─ tableId: 12\n" +
+			"             │                                   └─ Table\n" +
+			"             │                                       ├─ name: TNMXI\n" +
+			"             │                                       └─ columns: [id dzlim]\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ left-key: TUPLE(oxxei.BDNYB:1!null)\n" +
 			"                 ├─ right-key: TUPLE(ckele.LWQ6O:0!null)\n" +
@@ -10094,28 +10080,26 @@ WHERE
 			"             │           └─ Project\n" +
 			"             │               ├─ columns: [nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
 			"             │               └─ Sort(sn.id ASC)\n" +
-			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, nd.id, nd.DKCAJ, nd.KNG7T, nd.TW55N, nd.QRQXW, nd.ECXAJ, nd.FGG57, nd.ZH72S, nd.FSK67, nd.XQDYT, nd.TCE7A, nd.IWV2H, nd.HPCMS, nd.N5CC2, nd.FHCYT, nd.ETAQ7, nd.A75X7, nma.id, nma.DZLIM, nma.F3YUE, nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
-			"             │                       └─ Filter\n" +
-			"             │                           ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
-			"             │                           └─ LeftOuterLookupJoin\n" +
-			"             │                               ├─ LeftOuterMergeJoin\n" +
-			"             │                               │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
-			"             │                               │   ├─ TableAlias(sn)\n" +
-			"             │                               │   │   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                               │   │       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │                               │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
-			"             │                               │   └─ TableAlias(nd)\n" +
-			"             │                               │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                               │           ├─ index: [E2I7U.id]\n" +
-			"             │                               │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               └─ TableAlias(nma)\n" +
-			"             │                                   └─ IndexedTableAccess(TNMXI)\n" +
-			"             │                                       ├─ index: [TNMXI.id]\n" +
-			"             │                                       ├─ columns: [id dzlim f3yue]\n" +
-			"             │                                       └─ keys: nd.HPCMS\n" +
+			"             │                   └─ Filter\n" +
+			"             │                       ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
+			"             │                       └─ LeftOuterLookupJoin\n" +
+			"             │                           ├─ LeftOuterMergeJoin\n" +
+			"             │                           │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
+			"             │                           │   ├─ TableAlias(sn)\n" +
+			"             │                           │   │   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                           │   │       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │                           │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │   │       └─ columns: [id brqp2]\n" +
+			"             │                           │   └─ TableAlias(nd)\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │           ├─ index: [E2I7U.id]\n" +
+			"             │                           │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │           └─ columns: [id tw55n tce7a hpcms]\n" +
+			"             │                           └─ TableAlias(nma)\n" +
+			"             │                               └─ IndexedTableAccess(TNMXI)\n" +
+			"             │                                   ├─ index: [TNMXI.id]\n" +
+			"             │                                   ├─ columns: [id dzlim]\n" +
+			"             │                                   └─ keys: nd.HPCMS\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ left-key: (oxxei.BDNYB)\n" +
 			"                 ├─ right-key: (ckele.LWQ6O)\n" +
@@ -10209,28 +10193,26 @@ WHERE
 			"             │           └─ Project\n" +
 			"             │               ├─ columns: [nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
 			"             │               └─ Sort(sn.id ASC)\n" +
-			"             │                   └─ Project\n" +
-			"             │                       ├─ columns: [sn.id, sn.BRQP2, sn.FFTBJ, sn.A7XO2, sn.KBO7R, sn.ECDKM, sn.NUMK2, sn.LETOE, sn.YKSSU, sn.FHCYT, nd.id, nd.DKCAJ, nd.KNG7T, nd.TW55N, nd.QRQXW, nd.ECXAJ, nd.FGG57, nd.ZH72S, nd.FSK67, nd.XQDYT, nd.TCE7A, nd.IWV2H, nd.HPCMS, nd.N5CC2, nd.FHCYT, nd.ETAQ7, nd.A75X7, nma.id, nma.DZLIM, nma.F3YUE, nd.TW55N as KUXQY, sn.id as BDNYB, nma.DZLIM as YHVEZ, CASE  WHEN (nd.TCE7A < 0.9) THEN 1 ELSE 0 END as YAZ4X]\n" +
-			"             │                       └─ Filter\n" +
-			"             │                           ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
-			"             │                           └─ LeftOuterLookupJoin\n" +
-			"             │                               ├─ LeftOuterMergeJoin\n" +
-			"             │                               │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
-			"             │                               │   ├─ TableAlias(sn)\n" +
-			"             │                               │   │   └─ IndexedTableAccess(NOXN3)\n" +
-			"             │                               │   │       ├─ index: [NOXN3.BRQP2]\n" +
-			"             │                               │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │   │       └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
-			"             │                               │   └─ TableAlias(nd)\n" +
-			"             │                               │       └─ IndexedTableAccess(E2I7U)\n" +
-			"             │                               │           ├─ index: [E2I7U.id]\n" +
-			"             │                               │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"             │                               │           └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"             │                               └─ TableAlias(nma)\n" +
-			"             │                                   └─ IndexedTableAccess(TNMXI)\n" +
-			"             │                                       ├─ index: [TNMXI.id]\n" +
-			"             │                                       ├─ columns: [id dzlim f3yue]\n" +
-			"             │                                       └─ keys: nd.HPCMS\n" +
+			"             │                   └─ Filter\n" +
+			"             │                       ├─ (NOT((nma.DZLIM = 'Q5I4E')))\n" +
+			"             │                       └─ LeftOuterLookupJoin\n" +
+			"             │                           ├─ LeftOuterMergeJoin\n" +
+			"             │                           │   ├─ cmp: (sn.BRQP2 = nd.id)\n" +
+			"             │                           │   ├─ TableAlias(sn)\n" +
+			"             │                           │   │   └─ IndexedTableAccess(NOXN3)\n" +
+			"             │                           │   │       ├─ index: [NOXN3.BRQP2]\n" +
+			"             │                           │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │   │       └─ columns: [id brqp2]\n" +
+			"             │                           │   └─ TableAlias(nd)\n" +
+			"             │                           │       └─ IndexedTableAccess(E2I7U)\n" +
+			"             │                           │           ├─ index: [E2I7U.id]\n" +
+			"             │                           │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"             │                           │           └─ columns: [id tw55n tce7a hpcms]\n" +
+			"             │                           └─ TableAlias(nma)\n" +
+			"             │                               └─ IndexedTableAccess(TNMXI)\n" +
+			"             │                                   ├─ index: [TNMXI.id]\n" +
+			"             │                                   ├─ columns: [id dzlim]\n" +
+			"             │                                   └─ keys: nd.HPCMS\n" +
 			"             └─ HashLookup\n" +
 			"                 ├─ left-key: (oxxei.BDNYB)\n" +
 			"                 ├─ right-key: (ckele.LWQ6O)\n" +
@@ -15996,16 +15978,14 @@ ORDER BY sn.XLFIA ASC`,
 			"         │   ├─ tableId: 2\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [noxn3.id:0!null->XLFIA:0, noxn3.BRQP2:1!null]\n" +
-			"         │       └─ Project\n" +
-			"         │           ├─ columns: [noxn3.id:0!null, noxn3.BRQP2:1!null, noxn3.FFTBJ:2!null, noxn3.A7XO2:3, noxn3.KBO7R:4!null, noxn3.ECDKM:5, noxn3.NUMK2:6!null, noxn3.LETOE:7!null, noxn3.YKSSU:8, noxn3.FHCYT:9, noxn3.id:0!null->XLFIA:0]\n" +
-			"         │           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │               ├─ index: [NOXN3.id]\n" +
-			"         │               ├─ static: [{[NULL, ∞)}]\n" +
-			"         │               ├─ colSet: (1-10)\n" +
-			"         │               ├─ tableId: 1\n" +
-			"         │               └─ Table\n" +
-			"         │                   ├─ name: NOXN3\n" +
-			"         │                   └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			"         │       └─ IndexedTableAccess(NOXN3)\n" +
+			"         │           ├─ index: [NOXN3.id]\n" +
+			"         │           ├─ static: [{[NULL, ∞)}]\n" +
+			"         │           ├─ colSet: (1-10)\n" +
+			"         │           ├─ tableId: 1\n" +
+			"         │           └─ Table\n" +
+			"         │               ├─ name: NOXN3\n" +
+			"         │               └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: TUPLE(sn.BRQP2:1!null)\n" +
 			"             ├─ right-key: TUPLE(i2gj5.LUEVY:0!null)\n" +
@@ -16069,12 +16049,10 @@ ORDER BY sn.XLFIA ASC`,
 			"         │   ├─ cacheable: true\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
-			"         │       └─ Project\n" +
-			"         │           ├─ columns: [noxn3.id, noxn3.BRQP2, noxn3.FFTBJ, noxn3.A7XO2, noxn3.KBO7R, noxn3.ECDKM, noxn3.NUMK2, noxn3.LETOE, noxn3.YKSSU, noxn3.FHCYT, noxn3.id as XLFIA]\n" +
-			"         │           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │               ├─ index: [NOXN3.id]\n" +
-			"         │               ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			"         │       └─ IndexedTableAccess(NOXN3)\n" +
+			"         │           ├─ index: [NOXN3.id]\n" +
+			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
 			"             ├─ right-key: (i2gj5.LUEVY)\n" +
@@ -16123,12 +16101,10 @@ ORDER BY sn.XLFIA ASC`,
 			"         │   ├─ cacheable: true\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
-			"         │       └─ Project\n" +
-			"         │           ├─ columns: [noxn3.id, noxn3.BRQP2, noxn3.FFTBJ, noxn3.A7XO2, noxn3.KBO7R, noxn3.ECDKM, noxn3.NUMK2, noxn3.LETOE, noxn3.YKSSU, noxn3.FHCYT, noxn3.id as XLFIA]\n" +
-			"         │           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │               ├─ index: [NOXN3.id]\n" +
-			"         │               ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			"         │       └─ IndexedTableAccess(NOXN3)\n" +
+			"         │           ├─ index: [NOXN3.id]\n" +
+			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
 			"             ├─ right-key: (i2gj5.LUEVY)\n" +

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6617,6 +6617,14 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{1}, {2}, {3}},
 	},
 	{
+		Query:    "select distinct abs(c5) as a from one_pk where c2 in (1,11,31) order by a",
+		Expected: []sql.Row{{4}, {14}, {34}},
+	},
+	{
+		Query:    "select distinct abs(c5) as a from one_pk order by a",
+		Expected: []sql.Row{{4}, {14}, {24}, {34}},
+	},
+	{
 		Query:    "select ceil(i + 0.5) from mytable order by 1",
 		Expected: []sql.Row{{"2"}, {"3"}, {"4"}},
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -114,7 +114,7 @@ offset 1;`,
 			" │   ├─ cacheable: true\n" +
 			" │   ├─ alias-string: select SUM(x) from cte\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [sum(cte.x):2!null as SUM(x)]\n" +
+			" │       ├─ columns: [sum(cte.x):2!null->SUM(x):0]\n" +
 			" │       └─ GroupBy\n" +
 			" │           ├─ select: SUM(cte.x:2!null)\n" +
 			" │           ├─ group: \n" +
@@ -130,7 +130,7 @@ offset 1;`,
 			" │                   ├─ columns: [x y]\n" +
 			" │                   ├─ colSet: (1,2)\n" +
 			" │                   └─ tableId: 1\n" +
-			" │   as xy]\n" +
+			" │  ->xy:0]\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: cte\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -343,9 +343,9 @@ offset 1;`,
 	{
 		Query: `select count(i) from mytable`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(mytable.i):0!null as count(i)]\n" +
+			" ├─ columns: [count(mytable.i):0!null->count(i):0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [mytable.COUNT(mytable.i):0!null as COUNT(mytable.i)]\n" +
+			"     ├─ columns: [mytable.COUNT(mytable.i):0!null->COUNT(mytable.i):0]\n" +
 			"     └─ table_count(mytable) as COUNT(mytable.i)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -364,7 +364,7 @@ offset 1;`,
 	{
 		Query: `select count(pk1) from two_pk`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(two_pk.pk1):0!null as count(pk1)]\n" +
+			" ├─ columns: [count(two_pk.pk1):0!null->count(pk1):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(two_pk.pk1:0!null)\n" +
 			"     ├─ group: \n" +
@@ -576,7 +576,7 @@ From xy;`,
 			" │                           └─ Table\n" +
 			" │                               ├─ name: uv\n" +
 			" │                               └─ columns: [u]\n" +
-			" │   THEN 1 (tinyint) ELSE 2 (tinyint) END as s]\n" +
+			" │   THEN 1 (tinyint) ELSE 2 (tinyint) END->s:0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [xy.x:0!null, xy.y:1, CASE  WHEN xy.x:0!null IS NULL THEN 0 (tinyint) WHEN InSubquery\n" +
 			"     │   ├─ left: xy.x:0!null\n" +
@@ -609,7 +609,7 @@ From xy;`,
 			"     │                           └─ Table\n" +
 			"     │                               ├─ name: uv\n" +
 			"     │                               └─ columns: [u]\n" +
-			"     │   THEN 1 (tinyint) ELSE 2 (tinyint) END as s]\n" +
+			"     │   THEN 1 (tinyint) ELSE 2 (tinyint) END->s:0]\n" +
 			"     └─ ProcessTable\n" +
 			"         └─ Table\n" +
 			"             ├─ name: xy\n" +
@@ -739,7 +739,7 @@ From xy;`,
 	{
 		Query: `select /*+ JOIN_ORDER(uv,xy) */ count(*) from xy where y in (select distinct v from uv);`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*)]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
@@ -800,7 +800,7 @@ From xy;`,
 	{
 		Query: `SELECT /*+ JOIN_ORDER(uv,xy) */ count(*) from xy where y in (select distinct u from uv);`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*)]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
@@ -860,9 +860,9 @@ From xy;`,
 	{
 		Query: `select count(*) from mytable`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*)]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [mytable.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [mytable.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(mytable) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -881,9 +881,9 @@ From xy;`,
 	{
 		Query: `select count(*) as cnt from mytable`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as cnt]\n" +
+			" ├─ columns: [count(1):0!null->cnt:0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [mytable.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [mytable.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(mytable) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -902,7 +902,7 @@ From xy;`,
 	{
 		Query: `select count(*) from keyless`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*)]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
@@ -933,9 +933,9 @@ From xy;`,
 	{
 		Query: `select count(*) from xy`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*)]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [xy.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(xy) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -956,7 +956,7 @@ From xy;`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [count(1):0!null]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [mytable.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [mytable.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(mytable) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -977,7 +977,7 @@ From xy;`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [count(1):0!null]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [xy.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(xy) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -1047,9 +1047,9 @@ From xy;`,
 			" ├─ colSet: (4)\n" +
 			" ├─ tableId: 2\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [count(1):0!null as count(*)]\n" +
+			"     ├─ columns: [count(1):0!null->count(*):0]\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [xy.COUNT(1):0!null as COUNT(1)]\n" +
+			"         ├─ columns: [xy.COUNT(1):0!null->COUNT(1):0]\n" +
 			"         └─ table_count(xy) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "SubqueryAlias\n" +
@@ -1082,19 +1082,19 @@ From xy;`,
 			" │   ├─ cacheable: true\n" +
 			" │   ├─ alias-string: select count(*) from xy\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [count(1):1!null as count(*)]\n" +
+			" │       ├─ columns: [count(1):1!null->count(*):0]\n" +
 			" │       └─ Project\n" +
-			" │           ├─ columns: [xy.COUNT(1):1!null as COUNT(1)]\n" +
+			" │           ├─ columns: [xy.COUNT(1):1!null->COUNT(1):0]\n" +
 			" │           └─ table_count(xy) as COUNT(1)\n" +
-			" │   as (select count(*) from xy), Subquery\n" +
+			" │  ->(select count(*) from xy):0, Subquery\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   ├─ alias-string: select count(*) from uv\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [count(1):1!null as count(*)]\n" +
+			" │       ├─ columns: [count(1):1!null->count(*):0]\n" +
 			" │       └─ Project\n" +
-			" │           ├─ columns: [uv.COUNT(1):1!null as COUNT(1)]\n" +
+			" │           ├─ columns: [uv.COUNT(1):1!null->COUNT(1):0]\n" +
 			" │           └─ table_count(uv) as COUNT(1)\n" +
-			" │   as (select count(*) from uv)]\n" +
+			" │  ->(select count(*) from uv):0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [dual.:0!null]\n" +
 			"     └─ ProcessTable\n" +
@@ -1152,21 +1152,21 @@ From xy;`,
 			" │   ├─ cacheable: true\n" +
 			" │   ├─ alias-string: select count(*) from xy\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [count(1):1!null as count(*)]\n" +
+			" │       ├─ columns: [count(1):1!null->count(*):0]\n" +
 			" │       └─ Project\n" +
-			" │           ├─ columns: [xy.COUNT(1):1!null as COUNT(1)]\n" +
+			" │           ├─ columns: [xy.COUNT(1):1!null->COUNT(1):0]\n" +
 			" │           └─ table_count(xy) as COUNT(1)\n" +
-			" │   as (select count(*) from xy), Subquery\n" +
+			" │  ->(select count(*) from xy):0, Subquery\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   ├─ alias-string: select count(*) from uv\n" +
 			" │   └─ Project\n" +
-			" │       ├─ columns: [count(1):1!null as count(*)]\n" +
+			" │       ├─ columns: [count(1):1!null->count(*):0]\n" +
 			" │       └─ Project\n" +
-			" │           ├─ columns: [uv.COUNT(1):1!null as COUNT(1)]\n" +
+			" │           ├─ columns: [uv.COUNT(1):1!null->COUNT(1):0]\n" +
 			" │           └─ table_count(uv) as COUNT(1)\n" +
-			" │   as (select count(*) from uv), count(1):0!null as count(*)]\n" +
+			" │  ->(select count(*) from uv):0, count(1):0!null->count(*):0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [ab.COUNT(1):0!null as COUNT(1)]\n" +
+			"     ├─ columns: [ab.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     └─ table_count(ab) as COUNT(1)\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
@@ -1223,7 +1223,7 @@ WHERE
  s_i_id=ol_i_id AND
  s_quantity < 15;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [countdistinct([stock1.s_i_id]):0!null as COUNT(DISTINCT (s_i_id))]\n" +
+			" ├─ columns: [countdistinct([stock1.s_i_id]):0!null->COUNT(DISTINCT (s_i_id)):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNTDISTINCT([stock1.s_i_id])\n" +
 			"     ├─ group: \n" +
@@ -1585,7 +1585,7 @@ where
 	{
 		Query: `SELECT col1->'$.key1' from (SELECT JSON_OBJECT('key1', 1, 'key2', 'abc')) as dt(col1);`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [json_extract(dt.col1, '$.key1') as col1->'$.key1']\n" +
+			" ├─ columns: [json_extract(dt.col1, '$.key1')->col1->'$.key1':0]\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: dt\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -1594,7 +1594,7 @@ where
 			"     ├─ colSet: (1)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [json_object('key1',1,'key2','abc') as JSON_OBJECT('key1', 1, 'key2', 'abc')]\n" +
+			"         ├─ columns: [json_object('key1',1,'key2','abc')->JSON_OBJECT('key1', 1, 'key2', 'abc')]\n" +
 			"         └─ Table\n" +
 			"             ├─ name: \n" +
 			"             ├─ columns: []\n" +
@@ -1629,7 +1629,7 @@ where
 	{
 		Query: `SELECT col1->>'$.key1' from (SELECT JSON_OBJECT('key1', 1, 'key2', 'abc')) as dt(col1);`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [json_unquote(json_extract(dt.col1, '$.key1')) as col1->>'$.key1']\n" +
+			" ├─ columns: [json_unquote(json_extract(dt.col1, '$.key1'))->col1->>'$.key1':0]\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: dt\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -1638,7 +1638,7 @@ where
 			"     ├─ colSet: (1)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [json_object('key1',1,'key2','abc') as JSON_OBJECT('key1', 1, 'key2', 'abc')]\n" +
+			"         ├─ columns: [json_object('key1',1,'key2','abc')->JSON_OBJECT('key1', 1, 'key2', 'abc')]\n" +
 			"         └─ Table\n" +
 			"             ├─ name: \n" +
 			"             ├─ columns: []\n" +
@@ -1683,7 +1683,7 @@ where
 			FROM included_parts
 			GROUP BY sub_part`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [included_parts.sub_part:1!null, sum(included_parts.quantity):0!null as total_quantity]\n" +
+			" ├─ columns: [included_parts.sub_part:1!null, sum(included_parts.quantity):0!null->total_quantity:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: SUM(included_parts.quantity:2!null), included_parts.sub_part:0!null\n" +
 			"     ├─ group: included_parts.sub_part:0!null\n" +
@@ -1920,7 +1920,7 @@ Select * from (
 			" ├─ tableId: 7\n" +
 			" └─ Union distinct\n" +
 			"     ├─ Project\n" +
-			"     │   ├─ columns: [cte.s:0!null as s]\n" +
+			"     │   ├─ columns: [cte.s:0!null->s:0]\n" +
 			"     │   └─ SubqueryAlias\n" +
 			"     │       ├─ name: cte\n" +
 			"     │       ├─ outerVisibility: false\n" +
@@ -1953,7 +1953,7 @@ Select * from (
 			"         ├─ columns: [convert\n" +
 			"         │   ├─ type: signed\n" +
 			"         │   └─ xy.x:0!null\n" +
-			"         │   as x]\n" +
+			"         │  ->x:0]\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [xy.x:0!null]\n" +
 			"             └─ Filter\n" +
@@ -2138,7 +2138,7 @@ Select * from (
 			" ├─ tableId: 7\n" +
 			" └─ Union distinct\n" +
 			"     ├─ Project\n" +
-			"     │   ├─ columns: [cte.s:0!null as s]\n" +
+			"     │   ├─ columns: [cte.s:0!null->s:0]\n" +
 			"     │   └─ SubqueryAlias\n" +
 			"     │       ├─ name: cte\n" +
 			"     │       ├─ outerVisibility: false\n" +
@@ -2171,7 +2171,7 @@ Select * from (
 			"         ├─ columns: [convert\n" +
 			"         │   ├─ type: signed\n" +
 			"         │   └─ xy.x:0!null\n" +
-			"         │   as x]\n" +
+			"         │  ->x:0]\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [xy.x:1!null]\n" +
 			"             └─ LookupJoin\n" +
@@ -2547,7 +2547,7 @@ Select * from (
 			"     │           │           └─ Table\n" +
 			"     │           │               ├─ name: uv\n" +
 			"     │           │               └─ columns: [u]\n" +
-			"     │           │   as (select u from uv where u = sq.p)]\n" +
+			"     │           │  ->(select u from uv where u = sq.p):0]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: sq\n" +
 			"     │               ├─ outerVisibility: true\n" +
@@ -3469,7 +3469,7 @@ Select * from (
 			" │               └─ Table\n" +
 			" │                   ├─ name: uv\n" +
 			" │                   └─ columns: [u]\n" +
-			" │   as is_one]\n" +
+			" │  ->is_one:0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [xy.x:2!null, xy.y:3, uv.u:0!null, uv.v:1, Subquery\n" +
 			"     │   ├─ cacheable: false\n" +
@@ -3492,7 +3492,7 @@ Select * from (
 			"     │               └─ Table\n" +
 			"     │                   ├─ name: uv\n" +
 			"     │                   └─ columns: [u]\n" +
-			"     │   as is_one]\n" +
+			"     │  ->is_one:0]\n" +
 			"     └─ Sort(xy.y:3 ASC nullsFirst)\n" +
 			"         └─ LookupJoin\n" +
 			"             ├─ ProcessTable\n" +
@@ -3598,7 +3598,7 @@ Select * from (
 			"         │               ├─ columns: []\n" +
 			"         │               ├─ colSet: ()\n" +
 			"         │               └─ tableId: 0\n" +
-			"         │   as is_one]\n" +
+			"         │  ->is_one:0]\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [xy.x:2!null, xy.y:3, uv.u:0!null, uv.v:1, Subquery\n" +
 			"             │   ├─ cacheable: false\n" +
@@ -3614,7 +3614,7 @@ Select * from (
 			"             │               ├─ columns: []\n" +
 			"             │               ├─ colSet: ()\n" +
 			"             │               └─ tableId: 0\n" +
-			"             │   as is_one]\n" +
+			"             │  ->is_one:0]\n" +
 			"             └─ LookupJoin\n" +
 			"                 ├─ Table\n" +
 			"                 │   ├─ name: uv\n" +
@@ -3714,7 +3714,7 @@ Select * from (
 			" │               ├─ columns: []\n" +
 			" │               ├─ colSet: ()\n" +
 			" │               └─ tableId: 0\n" +
-			" │   as is_one]\n" +
+			" │  ->is_one:0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [xy.x:2!null, xy.y:3, uv.u:0!null, uv.v:1, Subquery\n" +
 			"     │   ├─ cacheable: false\n" +
@@ -3730,7 +3730,7 @@ Select * from (
 			"     │               ├─ columns: []\n" +
 			"     │               ├─ colSet: ()\n" +
 			"     │               └─ tableId: 0\n" +
-			"     │   as is_one]\n" +
+			"     │  ->is_one:0]\n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ ProcessTable\n" +
 			"         │   └─ Table\n" +
@@ -3863,7 +3863,7 @@ Select * from (
 			"     └─ RecursiveCTE\n" +
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
-			"             │   ├─ columns: [bus_routes.origin:0!null as dst]\n" +
+			"             │   ├─ columns: [bus_routes.origin:0!null->dst:0]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
 			"             │       ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
@@ -4096,8 +4096,8 @@ Select * from (
 	{
 		Query: `select i+0.0/(lag(i) over (order by s)) from mytable order by 1;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [(mytable.i:1!null + (0 (decimal(2,1)) / lag(mytable.i, 1) over ( order by mytable.s asc):0)) as i+0.0/(lag(i) over (order by s))]\n" +
-			" └─ Sort((mytable.i:1!null + (0 (decimal(2,1)) / lag(mytable.i, 1) over ( order by mytable.s asc):0)) as i+0.0/(lag(i) over (order by s)) ASC nullsFirst)\n" +
+			" ├─ columns: [(mytable.i:1!null + (0 (decimal(2,1)) / lag(mytable.i, 1) over ( order by mytable.s asc):0))->i+0.0/(lag(i) over (order by s)):0]\n" +
+			" └─ Sort((mytable.i:1!null + (0 (decimal(2,1)) / lag(mytable.i, 1) over ( order by mytable.s asc):0))->i+0.0/(lag(i) over (order by s)):0 ASC nullsFirst)\n" +
 			"     └─ Window\n" +
 			"         ├─ lag(mytable.i, 1) over ( order by mytable.s ASC)\n" +
 			"         ├─ mytable.i:0!null\n" +
@@ -4126,8 +4126,8 @@ Select * from (
 	{
 		Query: `select f64/f32, f32/(lag(i) over (order by f64)) from floattable order by 1,2;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [(floattable.f64:1!null / floattable.f32:2!null) as f64/f32, (floattable.f32:2!null / lag(floattable.i, 1) over ( order by floattable.f64 asc):0) as f32/(lag(i) over (order by f64))]\n" +
-			" └─ Sort((floattable.f64:1!null / floattable.f32:2!null) as f64/f32 ASC nullsFirst, (floattable.f32:2!null / lag(floattable.i, 1) over ( order by floattable.f64 asc):0) as f32/(lag(i) over (order by f64)) ASC nullsFirst)\n" +
+			" ├─ columns: [(floattable.f64:1!null / floattable.f32:2!null)->f64/f32:0, (floattable.f32:2!null / lag(floattable.i, 1) over ( order by floattable.f64 asc):0)->f32/(lag(i) over (order by f64)):0]\n" +
+			" └─ Sort((floattable.f64:1!null / floattable.f32:2!null)->f64/f32:0 ASC nullsFirst, (floattable.f32:2!null / lag(floattable.i, 1) over ( order by floattable.f64 asc):0)->f32/(lag(i) over (order by f64)):0 ASC nullsFirst)\n" +
 			"     └─ Window\n" +
 			"         ├─ lag(floattable.i, 1) over ( order by floattable.f64 ASC)\n" +
 			"         ├─ floattable.f64:2!null\n" +
@@ -4559,7 +4559,7 @@ Select * from (
 			" │                   └─ Table\n" +
 			" │                       ├─ name: ab\n" +
 			" │                       └─ columns: [a b]\n" +
-			" │   as s]\n" +
+			" │  ->s:0]\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [xy.x:0!null, xy.y:1, InSubquery\n" +
 			"     │   ├─ left: 1 (tinyint)\n" +
@@ -4588,7 +4588,7 @@ Select * from (
 			"     │                   └─ Table\n" +
 			"     │                       ├─ name: ab\n" +
 			"     │                       └─ columns: [a b]\n" +
-			"     │   as s]\n" +
+			"     │  ->s:0]\n" +
 			"     └─ ProcessTable\n" +
 			"         └─ Table\n" +
 			"             ├─ name: xy\n" +
@@ -4874,7 +4874,7 @@ Select * from (
 	{
 		Query: `SELECT count(*), i, concat(i, i), 123, 'abc', concat('abc', 'def') FROM emptytable;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*), emptytable.i:1!null, concat(emptytable.i:1!null,emptytable.i:1!null) as concat(i, i), 123 (tinyint), abc (longtext), concat(abc (longtext),def (longtext)) as concat('abc', 'def')]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0, emptytable.i:1!null, concat(emptytable.i:1!null,emptytable.i:1!null)->concat(i, i):0, 123 (tinyint), abc (longtext), concat('abc','def')->concat('abc', 'def')]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint)), emptytable.i:0!null\n" +
 			"     ├─ group: \n" +
@@ -4905,7 +4905,7 @@ Select * from (
 	{
 		Query: `SELECT count(*), i, concat(i, i), 123, 'abc', concat('abc', 'def') FROM mytable where false;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*), mytable.i:1!null, concat(mytable.i:1!null,mytable.i:1!null) as concat(i, i), 123 (tinyint), abc (longtext), concat(abc (longtext),def (longtext)) as concat('abc', 'def')]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0, mytable.i:1!null, concat(mytable.i:1!null,mytable.i:1!null)->concat(i, i):0, 123 (tinyint), abc (longtext), concat('abc','def')->concat('abc', 'def')]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint)), mytable.i:0!null\n" +
 			"     ├─ group: \n" +
@@ -4929,7 +4929,7 @@ Select * from (
 	{
 		Query: `select count(*) cnt from ab where exists (select * from xy where x = a) group by a`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as cnt]\n" +
+			" ├─ columns: [count(1):0!null->cnt:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: ab.a:0!null\n" +
@@ -5013,9 +5013,9 @@ Select * from (
 			"     │   ├─ colSet: (12,13)\n" +
 			"     │   ├─ tableId: 3\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [count(1):0!null as u, 123 (tinyint) as v]\n" +
+			"     │       ├─ columns: [count(1):0!null->u:0, 123 (tinyint)->v:11]\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [emptytable.COUNT(1):0!null as COUNT(1)]\n" +
+			"     │           ├─ columns: [emptytable.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     │           └─ table_count(emptytable) as COUNT(1)\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: TUPLE(uv.u:0!null)\n" +
@@ -5084,7 +5084,7 @@ Select * from (
 			"     │   ├─ colSet: (12,13)\n" +
 			"     │   ├─ tableId: 3\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [count(1):0!null as u, 123 (tinyint) as v]\n" +
+			"     │       ├─ columns: [count(1):0!null->u:0, 123 (tinyint)->v:11]\n" +
 			"     │       └─ GroupBy\n" +
 			"     │           ├─ select: COUNT(1 (bigint))\n" +
 			"     │           ├─ group: \n" +
@@ -5153,9 +5153,9 @@ Select * from (
 			"     │       ├─ cacheable: true\n" +
 			"     │       ├─ alias-string: select count(*) u, 123 v from emptytable\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [count(1):6!null as u, 123 (tinyint) as v]\n" +
+			"     │           ├─ columns: [count(1):6!null->u:0, 123 (tinyint)->v:11]\n" +
 			"     │           └─ Project\n" +
-			"     │               ├─ columns: [emptytable.COUNT(1):6!null as COUNT(1)]\n" +
+			"     │               ├─ columns: [emptytable.COUNT(1):6!null->COUNT(1):0]\n" +
 			"     │               └─ table_count(emptytable) as COUNT(1)\n" +
 			"     └─ ProcessTable\n" +
 			"         └─ Table\n" +
@@ -5204,7 +5204,7 @@ Select * from (
 			"     │       ├─ cacheable: true\n" +
 			"     │       ├─ alias-string: select count(*) u, 123 v from mytable where false\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [count(1):6!null as u, 123 (tinyint) as v]\n" +
+			"     │           ├─ columns: [count(1):6!null->u:0, 123 (tinyint)->v:11]\n" +
 			"     │           └─ GroupBy\n" +
 			"     │               ├─ select: COUNT(1 (bigint))\n" +
 			"     │               ├─ group: \n" +
@@ -5261,9 +5261,9 @@ Select * from (
 			"     │       ├─ colSet: (8,9)\n" +
 			"     │       ├─ tableId: 3\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [count(1):0!null as u, 123 (tinyint) as v]\n" +
+			"     │           ├─ columns: [count(1):0!null->u:0, 123 (tinyint)->v:7]\n" +
 			"     │           └─ Project\n" +
-			"     │               ├─ columns: [emptytable.COUNT(1):0!null as COUNT(1)]\n" +
+			"     │               ├─ columns: [emptytable.COUNT(1):0!null->COUNT(1):0]\n" +
 			"     │               └─ table_count(emptytable) as COUNT(1)\n" +
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: TUPLE()\n" +
@@ -5317,7 +5317,7 @@ Select * from (
 	{
 		Query: `SELECT count(*), (SELECT i FROM mytable WHERE i = 1 group by i);`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*), Subquery\n" +
+			" ├─ columns: [count(1):0!null->count(*):0, Subquery\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   ├─ alias-string: select i from mytable where i = 1 group by i\n" +
 			" │   └─ GroupBy\n" +
@@ -5331,7 +5331,7 @@ Select * from (
 			" │           └─ Table\n" +
 			" │               ├─ name: mytable\n" +
 			" │               └─ columns: [i]\n" +
-			" │   as (SELECT i FROM mytable WHERE i = 1 group by i)]\n" +
+			" │  ->(SELECT i FROM mytable WHERE i = 1 group by i):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
@@ -6515,9 +6515,9 @@ inner join pq on true
 	{
 		Query: `SELECT pk1 AS one, pk2 AS two FROM two_pk ORDER BY pk1, pk2`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
+			" ├─ columns: [two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
+			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
@@ -6549,9 +6549,9 @@ inner join pq on true
 	{
 		Query: `SELECT pk1 AS one, pk2 AS two FROM two_pk ORDER BY one, two`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
+			" ├─ columns: [two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null as one, two_pk.pk2:1!null as two]\n" +
+			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
 			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
@@ -6642,8 +6642,8 @@ inner join pq on true
 		Query: `select row_number() over (order by i desc), mytable.i as i2
 				from mytable join othertable on i = i2 order by 1`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [row_number() over ( order by mytable.i desc):0!null as row_number() over (order by i desc), mytable.i:1!null as i2]\n" +
-			" └─ Sort(row_number() over ( order by mytable.i desc):0!null as row_number() over (order by i desc) ASC nullsFirst)\n" +
+			" ├─ columns: [row_number() over ( order by mytable.i desc):0!null->row_number() over (order by i desc):0, mytable.i:1!null->i2:0]\n" +
+			" └─ Sort(row_number() over ( order by mytable.i desc):0!null->row_number() over (order by i desc):0 ASC nullsFirst)\n" +
 			"     └─ Window\n" +
 			"         ├─ row_number() over ( order by mytable.i DESC)\n" +
 			"         ├─ mytable.i:0!null\n" +
@@ -6808,8 +6808,8 @@ inner join pq on true
 				where mytable.i = 2
 				order by 1`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [row_number() over ( order by mytable.i desc):0!null as row_number() over (order by i desc), mytable.i:1!null as i2]\n" +
-			" └─ Sort(row_number() over ( order by mytable.i desc):0!null as row_number() over (order by i desc) ASC nullsFirst)\n" +
+			" ├─ columns: [row_number() over ( order by mytable.i desc):0!null->row_number() over (order by i desc):0, mytable.i:1!null->i2:0]\n" +
+			" └─ Sort(row_number() over ( order by mytable.i desc):0!null->row_number() over (order by i desc):0 ASC nullsFirst)\n" +
 			"     └─ Window\n" +
 			"         ├─ row_number() over ( order by mytable.i DESC)\n" +
 			"         ├─ mytable.i:0!null\n" +
@@ -7951,7 +7951,7 @@ inner join pq on true
 			"         ├─ colSet: (20,21)\n" +
 			"         ├─ tableId: 4\n" +
 			"         └─ Project\n" +
-			"             ├─ columns: [one_pk.pk:0!null, rand() as r]\n" +
+			"             ├─ columns: [one_pk.pk:0!null, rand()->r:19]\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: one_pk\n" +
 			"                 ├─ columns: [pk]\n" +
@@ -8054,7 +8054,7 @@ inner join pq on true
 			"         ├─ colSet: (20,21)\n" +
 			"         ├─ tableId: 4\n" +
 			"         └─ Project\n" +
-			"             ├─ columns: [one_pk.pk:0!null, rand() as r]\n" +
+			"             ├─ columns: [one_pk.pk:0!null, rand()->r:19]\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: one_pk\n" +
 			"                 ├─ columns: [pk]\n" +
@@ -8129,7 +8129,7 @@ inner join pq on true
 			" └─ Project\n" +
 			"     ├─ columns: [i:0!null, s:1!null]\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [(sub.i:0!null + 10 (tinyint)) as sub.i + 10, ot.s2:3!null]\n" +
+			"         ├─ columns: [(sub.i:0!null + 10 (tinyint))->sub.i + 10:0, ot.s2:3!null]\n" +
 			"         └─ HashJoin\n" +
 			"             ├─ Eq\n" +
 			"             │   ├─ sub.i:0!null\n" +
@@ -16290,7 +16290,7 @@ inner join pq on true
 	{
 		Query: `SELECT pk,pk1,pk2,one_pk.c1 AS foo, two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 ORDER BY 1,2,3`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [one_pk.pk:0!null, two_pk.pk1:2!null, two_pk.pk2:3!null, one_pk.c1:1 as foo, two_pk.c1:4!null as bar]\n" +
+			" ├─ columns: [one_pk.pk:0!null, two_pk.pk1:2!null, two_pk.pk2:3!null, one_pk.c1:1->foo:0, two_pk.c1:4!null->bar:0]\n" +
 			" └─ Sort(one_pk.pk:0!null ASC nullsFirst, two_pk.pk1:2!null ASC nullsFirst, two_pk.pk2:3!null ASC nullsFirst)\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
@@ -16342,7 +16342,7 @@ inner join pq on true
 	{
 		Query: `SELECT pk,pk1,pk2,one_pk.c1 AS foo,two_pk.c1 AS bar FROM one_pk JOIN two_pk ON one_pk.c1=two_pk.c1 WHERE one_pk.c1=10`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [one_pk.pk:3!null, two_pk.pk1:0!null, two_pk.pk2:1!null, one_pk.c1:4 as foo, two_pk.c1:2!null as bar]\n" +
+			" ├─ columns: [one_pk.pk:3!null, two_pk.pk1:0!null, two_pk.pk2:1!null, one_pk.c1:4->foo:0, two_pk.c1:2!null->bar:0]\n" +
 			" └─ HashJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ one_pk.c1:4\n" +
@@ -16723,7 +16723,7 @@ inner join pq on true
 			" │           └─ Table\n" +
 			" │               ├─ name: one_pk\n" +
 			" │               └─ columns: [pk]\n" +
-			" │   as (SELECT pk from one_pk where pk = 1 limit 1)]\n" +
+			" │  ->(SELECT pk from one_pk where pk = 1 limit 1):0]\n" +
 			" └─ Sort(t1.pk:7!null ASC nullsFirst, t2.pk2:1!null ASC nullsFirst)\n" +
 			"     └─ CrossJoin\n" +
 			"         ├─ Filter\n" +
@@ -16791,7 +16791,7 @@ inner join pq on true
 	{
 		Query: `SELECT ROW_NUMBER() OVER (ORDER BY s2 ASC) idx, i2, s2 FROM othertable WHERE s2 <> 'second' ORDER BY i2 ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null as idx, othertable.i2:1!null, othertable.s2:2!null]\n" +
+			" ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null->idx:0, othertable.i2:1!null, othertable.s2:2!null]\n" +
 			" └─ Sort(othertable.i2:1!null ASC nullsFirst)\n" +
 			"     └─ Window\n" +
 			"         ├─ row_number() over ( order by othertable.s2 ASC)\n" +
@@ -16840,7 +16840,7 @@ inner join pq on true
 			"     │       ├─ othertable.s2:2!null\n" +
 			"     │       └─ second (longtext)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null as idx, othertable.i2:1!null, othertable.s2:2!null]\n" +
+			"         ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null->idx:0, othertable.i2:1!null, othertable.s2:2!null]\n" +
 			"         └─ Sort(othertable.i2:1!null ASC nullsFirst)\n" +
 			"             └─ Window\n" +
 			"                 ├─ row_number() over ( order by othertable.s2 ASC)\n" +
@@ -16886,7 +16886,7 @@ inner join pq on true
 	{
 		Query: `SELECT ROW_NUMBER() OVER (ORDER BY s2 ASC) idx, i2, s2 FROM othertable WHERE i2 < 2 OR i2 > 2 ORDER BY i2 ASC`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null as idx, othertable.i2:1!null, othertable.s2:2!null]\n" +
+			" ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null->idx:0, othertable.i2:1!null, othertable.s2:2!null]\n" +
 			" └─ Sort(othertable.i2:1!null ASC nullsFirst)\n" +
 			"     └─ Window\n" +
 			"         ├─ row_number() over ( order by othertable.s2 ASC)\n" +
@@ -16938,7 +16938,7 @@ inner join pq on true
 			"     │       ├─ othertable.i2:1!null\n" +
 			"     │       └─ 2 (bigint)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null as idx, othertable.i2:1!null, othertable.s2:2!null]\n" +
+			"         ├─ columns: [row_number() over ( order by othertable.s2 asc):0!null->idx:0, othertable.i2:1!null, othertable.s2:2!null]\n" +
 			"         └─ Sort(othertable.i2:1!null ASC nullsFirst)\n" +
 			"             └─ Window\n" +
 			"                 ├─ row_number() over ( order by othertable.s2 ASC)\n" +
@@ -16984,7 +16984,7 @@ inner join pq on true
 	{
 		Query: `SELECT t, n, lag(t, 1, t+1) over (partition by n) FROM bigtable`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [bigtable.t:1!null, bigtable.n:2, lag(bigtable.t, 1, (bigtable.t + 1)) over ( partition by bigtable.n rows between unbounded preceding and unbounded following):0 as lag(t, 1, t+1) over (partition by n)]\n" +
+			" ├─ columns: [bigtable.t:1!null, bigtable.n:2, lag(bigtable.t, 1, (bigtable.t + 1)) over ( partition by bigtable.n rows between unbounded preceding and unbounded following):0->lag(t, 1, t+1) over (partition by n):0]\n" +
 			" └─ Window\n" +
 			"     ├─ lag(bigtable.t, 1, (bigtable.t + 1)) over ( partition by bigtable.n ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)\n" +
 			"     ├─ bigtable.t:0!null\n" +
@@ -17012,7 +17012,7 @@ inner join pq on true
 	{
 		Query: `select i, row_number() over (w3) from mytable window w1 as (w2), w2 as (), w3 as (w1)`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mytable.i:1!null, row_number() over ( rows between unbounded preceding and unbounded following):0!null as row_number() over (w3)]\n" +
+			" ├─ columns: [mytable.i:1!null, row_number() over ( rows between unbounded preceding and unbounded following):0!null->row_number() over (w3):0]\n" +
 			" └─ Window\n" +
 			"     ├─ row_number() over ( ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)\n" +
 			"     ├─ mytable.i:0!null\n" +
@@ -17039,7 +17039,7 @@ inner join pq on true
 	{
 		Query: `select i, row_number() over (w1 partition by s) from mytable window w1 as (order by i asc)`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mytable.i:1!null, row_number() over ( partition by mytable.s order by mytable.i asc rows between unbounded preceding and unbounded following):0!null as row_number() over (w1 partition by s)]\n" +
+			" ├─ columns: [mytable.i:1!null, row_number() over ( partition by mytable.s order by mytable.i asc rows between unbounded preceding and unbounded following):0!null->row_number() over (w1 partition by s):0]\n" +
 			" └─ Window\n" +
 			"     ├─ row_number() over ( partition by mytable.s order by mytable.i ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)\n" +
 			"     ├─ mytable.i:0!null\n" +
@@ -20349,7 +20349,7 @@ inner join pq on true
 	{
 		Query: `WITH recursive n(i) as (SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i+1 <= 10 LIMIT 5) SELECT count(i) FROM n;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(n.i):0!null as count(i)]\n" +
+			" ├─ columns: [count(n.i):0!null->count(i):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(n.i:0!null)\n" +
 			"     ├─ group: \n" +
@@ -20371,7 +20371,7 @@ inner join pq on true
 			"                 │       ├─ colSet: ()\n" +
 			"                 │       └─ tableId: 0\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [(n.i:0!null + 1 (tinyint)) as i + 1]\n" +
+			"                     ├─ columns: [(n.i:0!null + 1 (tinyint))->i + 1:0]\n" +
 			"                     └─ Filter\n" +
 			"                         ├─ LessThanOrEqual\n" +
 			"                         │   ├─ (n.i:0!null + 1 (tinyint))\n" +
@@ -20428,7 +20428,7 @@ inner join pq on true
 	{
 		Query: `WITH recursive n(i) as (SELECT 1 UNION ALL SELECT i + 1 FROM n GROUP BY i HAVING i+1 <= 10) SELECT count(i) FROM n;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(n.i):0!null as count(i)]\n" +
+			" ├─ columns: [count(n.i):0!null->count(i):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(n.i:0!null)\n" +
 			"     ├─ group: \n" +
@@ -20449,7 +20449,7 @@ inner join pq on true
 			"                 │       ├─ colSet: ()\n" +
 			"                 │       └─ tableId: 0\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [(n.i:0!null + 1 (tinyint)) as i + 1]\n" +
+			"                     ├─ columns: [(n.i:0!null + 1 (tinyint))->i + 1:0]\n" +
 			"                     └─ Having\n" +
 			"                         ├─ LessThanOrEqual\n" +
 			"                         │   ├─ (n.i:0!null + 1 (tinyint))\n" +
@@ -20511,7 +20511,7 @@ inner join pq on true
 	{
 		Query: `WITH recursive n(i) as (SELECT 1 UNION ALL SELECT i + 1 FROM n WHERE i+1 <= 10 LIMIT 1) SELECT count(i) FROM n;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(n.i):0!null as count(i)]\n" +
+			" ├─ columns: [count(n.i):0!null->count(i):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(n.i:0!null)\n" +
 			"     ├─ group: \n" +
@@ -20533,7 +20533,7 @@ inner join pq on true
 			"                 │       ├─ colSet: ()\n" +
 			"                 │       └─ tableId: 0\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [(n.i:0!null + 1 (tinyint)) as i + 1]\n" +
+			"                     ├─ columns: [(n.i:0!null + 1 (tinyint))->i + 1:0]\n" +
 			"                     └─ Filter\n" +
 			"                         ├─ LessThanOrEqual\n" +
 			"                         │   ├─ (n.i:0!null + 1 (tinyint))\n" +
@@ -20871,7 +20871,7 @@ inner join pq on true
 	{
 		Query: `With recursive a(x) as (select 1 union select 4 union select * from (select 2 union select 3) b union select x+1 from a where x < 10) select count(*) from a;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as count(*)]\n" +
+			" ├─ columns: [count(1):0!null->count(*):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
@@ -20923,7 +20923,7 @@ inner join pq on true
 			"                 │                   ├─ colSet: ()\n" +
 			"                 │                   └─ tableId: 0\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [(a.x:0!null + 1 (tinyint)) as x+1]\n" +
+			"                     ├─ columns: [(a.x:0!null + 1 (tinyint))->x+1:0]\n" +
 			"                     └─ Filter\n" +
 			"                         ├─ LessThan\n" +
 			"                         │   ├─ a.x:0!null\n" +
@@ -21133,7 +21133,7 @@ inner join pq on true
 			" ├─ limit: 1\n" +
 			" ├─ Union distinct\n" +
 			" │   ├─ Project\n" +
-			" │   │   ├─ columns: [t1.j:0!null as k]\n" +
+			" │   │   ├─ columns: [t1.j:0!null->k:0]\n" +
 			" │   │   └─ HashJoin\n" +
 			" │   │       ├─ Eq\n" +
 			" │   │       │   ├─ t1.j:0!null\n" +
@@ -21302,7 +21302,7 @@ inner join pq on true
 			" ├─ limit: 2\n" +
 			" ├─ Union distinct\n" +
 			" │   ├─ Project\n" +
-			" │   │   ├─ columns: [t1.j:0!null as k]\n" +
+			" │   │   ├─ columns: [t1.j:0!null->k:0]\n" +
 			" │   │   └─ HashJoin\n" +
 			" │   │       ├─ Eq\n" +
 			" │   │       │   ├─ t1.j:0!null\n" +
@@ -22835,7 +22835,7 @@ WHERE keyless.c0 IN (
    WHERE cte.j = keyless.c0
 );`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as COUNT(*)]\n" +
+			" ├─ columns: [count(1):0!null->COUNT(*):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
@@ -22874,7 +22874,7 @@ WHERE keyless.c0 IN (
 			"         │                   │           │               ├─ colSet: (3,4)\n" +
 			"         │                   │           │               └─ tableId: 2\n" +
 			"         │                   │           └─ Project\n" +
-			"         │                   │               ├─ columns: [(cte.depth:4!null + 1 (tinyint)) as cte.depth + 1, cte.i:5, (t2.c1:3 + 1 (tinyint)) as T2.c1 + 1]\n" +
+			"         │                   │               ├─ columns: [(cte.depth:4!null + 1 (tinyint))->cte.depth + 1:0, cte.i:5, (t2.c1:3 + 1 (tinyint))->T2.c1 + 1:0]\n" +
 			"         │                   │               └─ InnerJoin\n" +
 			"         │                   │                   ├─ Eq\n" +
 			"         │                   │                   │   ├─ cte.depth:4!null\n" +
@@ -23021,7 +23021,7 @@ WHERE keyless.c0 IN (
    WHERE cte.j = keyless.c0
 );`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(1):0!null as COUNT(*)]\n" +
+			" ├─ columns: [count(1):0!null->COUNT(*):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(1 (bigint))\n" +
 			"     ├─ group: \n" +
@@ -23060,7 +23060,7 @@ WHERE keyless.c0 IN (
 			"         │                   │           │               ├─ colSet: (3,4)\n" +
 			"         │                   │           │               └─ tableId: 2\n" +
 			"         │                   │           └─ Project\n" +
-			"         │                   │               ├─ columns: [(cte.depth:4!null + 1 (tinyint)) as cte.depth + 1, cte.i:5, (t2.c1:3 + 1 (tinyint)) as T2.c1 + 1]\n" +
+			"         │                   │               ├─ columns: [(cte.depth:4!null + 1 (tinyint))->cte.depth + 1:0, cte.i:5, (t2.c1:3 + 1 (tinyint))->T2.c1 + 1:0]\n" +
 			"         │                   │               └─ InnerJoin\n" +
 			"         │                   │                   ├─ Eq\n" +
 			"         │                   │                   │   ├─ cte.depth:4!null\n" +
@@ -23372,7 +23372,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select pk1, pk2, row_number() over (partition by pk1 order by c1 desc) from two_pk order by 1,2;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [two_pk.pk1:1!null, two_pk.pk2:2!null, row_number() over ( partition by two_pk.pk1 order by two_pk.c1 desc):0!null as row_number() over (partition by pk1 order by c1 desc)]\n" +
+			" ├─ columns: [two_pk.pk1:1!null, two_pk.pk2:2!null, row_number() over ( partition by two_pk.pk1 order by two_pk.c1 desc):0!null->row_number() over (partition by pk1 order by c1 desc):0]\n" +
 			" └─ Sort(two_pk.pk1:1!null ASC nullsFirst, two_pk.pk2:2!null ASC nullsFirst)\n" +
 			"     └─ Window\n" +
 			"         ├─ row_number() over ( partition by two_pk.pk1 order by two_pk.c1 DESC)\n" +
@@ -23793,9 +23793,9 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select x as xx, y as yy from xy_hasnull_idx order by yy desc`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [xy_hasnull_idx.x:0!null as xx, xy_hasnull_idx.y:1 as yy]\n" +
+			" ├─ columns: [xy_hasnull_idx.x:0!null->xx:0, xy_hasnull_idx.y:1->yy:0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy_hasnull_idx.x:0!null, xy_hasnull_idx.y:1, xy_hasnull_idx.x:0!null as xx, xy_hasnull_idx.y:1 as yy]\n" +
+			"     ├─ columns: [xy_hasnull_idx.x:0!null, xy_hasnull_idx.y:1, xy_hasnull_idx.x:0!null->xx:0, xy_hasnull_idx.y:1->yy:0]\n" +
 			"     └─ IndexedTableAccess(xy_hasnull_idx)\n" +
 			"         ├─ index: [xy_hasnull_idx.y]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -23830,9 +23830,9 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select x as xx, y as yy from xy_hasnull_idx order by YY desc`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [xy_hasnull_idx.x:0!null as xx, xy_hasnull_idx.y:1 as yy]\n" +
+			" ├─ columns: [xy_hasnull_idx.x:0!null->xx:0, xy_hasnull_idx.y:1->yy:0]\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy_hasnull_idx.x:0!null, xy_hasnull_idx.y:1, xy_hasnull_idx.x:0!null as xx, xy_hasnull_idx.y:1 as yy]\n" +
+			"     ├─ columns: [xy_hasnull_idx.x:0!null, xy_hasnull_idx.y:1, xy_hasnull_idx.x:0!null->xx:0, xy_hasnull_idx.y:1->yy:0]\n" +
 			"     └─ IndexedTableAccess(xy_hasnull_idx)\n" +
 			"         ├─ index: [xy_hasnull_idx.y]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -23893,7 +23893,7 @@ WHERE keyless.c0 IN (
 		Query: `select max(x) from xy`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.x:0!null as max(x)]\n" +
+			"     ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -23927,7 +23927,7 @@ WHERE keyless.c0 IN (
 		Query: `select min(x) from xy`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.x:0!null as min(x)]\n" +
+			"     ├─ columns: [xy.x:0!null->min(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -23957,7 +23957,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select max(y) from xy`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [max(xy.y):0!null as max(y)]\n" +
+			" ├─ columns: [max(xy.y):0!null->max(y):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MAX(xy.y:0)\n" +
 			"     ├─ group: \n" +
@@ -23989,7 +23989,7 @@ WHERE keyless.c0 IN (
 		Query: `select max(x)+100 from xy`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [(xy.x:0!null + 100 (tinyint)) as max(x)+100]\n" +
+			"     ├─ columns: [(xy.x:0!null + 100 (tinyint))->max(x)+100:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -24023,7 +24023,7 @@ WHERE keyless.c0 IN (
 		Query: `select max(x) as xx from xy`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.x:0!null as xx]\n" +
+			"     ├─ columns: [xy.x:0!null->xx:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -24057,7 +24057,7 @@ WHERE keyless.c0 IN (
 		Query: `select 1, 2.0, '3', max(x) from xy`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [1 (tinyint), 2 (decimal(2,1)), 3 (longtext), xy.x:0!null as max(x)]\n" +
+			"     ├─ columns: [1 (tinyint), 2 (decimal(2,1)), 3 (longtext), xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         ├─ static: [{[NULL, ∞)}]\n" +
@@ -24091,7 +24091,7 @@ WHERE keyless.c0 IN (
 		Query: `select min(x) from xy where x > 0`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.x:0!null as min(x)]\n" +
+			"     ├─ columns: [xy.x:0!null->min(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         ├─ static: [{(0, ∞)}]\n" +
@@ -24122,7 +24122,7 @@ WHERE keyless.c0 IN (
 		Query: `select max(x) from xy where x < 3`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [xy.x:0!null as max(x)]\n" +
+			"     ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
 			"         ├─ static: [{(NULL, 3)}]\n" +
@@ -24155,7 +24155,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select min(x) from xy where y > 0`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [min(xy.x):0!null as min(x)]\n" +
+			" ├─ columns: [min(xy.x):0!null->min(x):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MIN(xy.x:0!null)\n" +
 			"     ├─ group: \n" +
@@ -24192,7 +24192,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select max(x) from xy where y < 3`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [max(xy.x):0!null as max(x)]\n" +
+			" ├─ columns: [max(xy.x):0!null->max(x):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MAX(xy.x:0!null)\n" +
 			"     ├─ group: \n" +
@@ -24237,7 +24237,7 @@ WHERE keyless.c0 IN (
 			" ├─ tableId: 2\n" +
 			" └─ Limit(1)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [xy.x:0!null as max(x)]\n" +
+			"         ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
 			"             ├─ static: [{[NULL, ∞)}]\n" +
@@ -24280,7 +24280,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `with cte(i) as (select max(x) from xy) select i + 100 from cte`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [(cte.i:0!null + 100 (tinyint)) as i + 100]\n" +
+			" ├─ columns: [(cte.i:0!null + 100 (tinyint))->i + 100:0]\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: cte\n" +
 			"     ├─ outerVisibility: false\n" +
@@ -24290,7 +24290,7 @@ WHERE keyless.c0 IN (
 			"     ├─ tableId: 3\n" +
 			"     └─ Limit(1)\n" +
 			"         └─ Project\n" +
-			"             ├─ columns: [xy.x:0!null as max(x)]\n" +
+			"             ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
 			"                 ├─ static: [{[NULL, ∞)}]\n" +
@@ -24337,7 +24337,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `with cte(i) as (select x from xy) select max(i) from cte`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [max(cte.i):0!null as max(i)]\n" +
+			" ├─ columns: [max(cte.i):0!null->max(i):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MAX(cte.i:0!null)\n" +
 			"     ├─ group: \n" +
@@ -24386,7 +24386,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select max(x) from xy group by y`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [max(xy.x):0!null as max(x)]\n" +
+			" ├─ columns: [max(xy.x):0!null->max(x):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MAX(xy.x:0!null)\n" +
 			"     ├─ group: xy.y:1\n" +
@@ -24417,7 +24417,7 @@ WHERE keyless.c0 IN (
 	{
 		Query: `select max(x) from xy join uv where x = u`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [max(xy.x):0!null as max(x)]\n" +
+			" ├─ columns: [max(xy.x):0!null->max(x):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: MAX(xy.x:1!null)\n" +
 			"     ├─ group: \n" +
@@ -24752,7 +24752,7 @@ order by xy.x, xy.y, uv.u, uv.v;`,
 			"         │       ├─ cacheable: false\n" +
 			"         │       ├─ alias-string: select max(v) from uv where xy.x = uv.u\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [max(uv.v):4!null as max(v)]\n" +
+			"         │           ├─ columns: [max(uv.v):4!null->max(v):0]\n" +
 			"         │           └─ GroupBy\n" +
 			"         │               ├─ select: MAX(uv.v:5)\n" +
 			"         │               ├─ group: \n" +
@@ -24850,7 +24850,7 @@ where exists (
 			" │       ├─ cacheable: false\n" +
 			" │       ├─ alias-string: select max(v) from uv where uv.v = ab2.a and uv.v = ab.a\n" +
 			" │       └─ Project\n" +
-			" │           ├─ columns: [max(uv.v):4!null as max(v)]\n" +
+			" │           ├─ columns: [max(uv.v):4!null->max(v):0]\n" +
 			" │           └─ GroupBy\n" +
 			" │               ├─ select: MAX(uv.v:4)\n" +
 			" │               ├─ group: \n" +
@@ -24942,7 +24942,7 @@ order by x, y;
 			"     │       ├─ cacheable: false\n" +
 			"     │       ├─ alias-string: select max(v) from uv where uv.v = xy2.x and uv.v = xy.x\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [max(uv.v):4!null as max(v)]\n" +
+			"     │           ├─ columns: [max(uv.v):4!null->max(v):0]\n" +
 			"     │           └─ GroupBy\n" +
 			"     │               ├─ select: MAX(uv.v:4)\n" +
 			"     │               ├─ group: \n" +
@@ -25029,7 +25029,7 @@ order by x, y;
 			"     │   ├─ colSet: (2)\n" +
 			"     │   ├─ tableId: 1\n" +
 			"     │   └─ Project\n" +
-			"     │       ├─ columns: [k (longtext) as k]\n" +
+			"     │       ├─ columns: [k (longtext)->k:1]\n" +
 			"     │       └─ Table\n" +
 			"     │           ├─ name: \n" +
 			"     │           ├─ columns: []\n" +
@@ -25486,7 +25486,7 @@ order by x, y;
 		Query: `select distinct pk1 + 1 from two_pk order by pk1 + 1`,
 		ExpectedPlan: "Distinct\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [(two_pk.pk1:0!null + 1 (tinyint)) as pk1 + 1]\n" +
+			"     ├─ columns: [(two_pk.pk1:0!null + 1 (tinyint))->pk1 + 1:0]\n" +
 			"     └─ Sort((two_pk.pk1:0!null + 1 (tinyint)) ASC nullsFirst)\n" +
 			"         └─ ProcessTable\n" +
 			"             └─ Table\n" +
@@ -25514,7 +25514,7 @@ order by x, y;
 		Query: `select distinct pk2 + 1 from two_pk order by pk2 + 1`,
 		ExpectedPlan: "Distinct\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [(two_pk.pk2:0!null + 1 (tinyint)) as pk2 + 1]\n" +
+			"     ├─ columns: [(two_pk.pk2:0!null + 1 (tinyint))->pk2 + 1:0]\n" +
 			"     └─ Sort((two_pk.pk2:0!null + 1 (tinyint)) ASC nullsFirst)\n" +
 			"         └─ ProcessTable\n" +
 			"             └─ Table\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -6516,34 +6516,28 @@ inner join pq on true
 		Query: `SELECT pk1 AS one, pk2 AS two FROM two_pk ORDER BY pk1, pk2`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
-			" └─ Project\n" +
-			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
-			"     └─ IndexedTableAccess(two_pk)\n" +
-			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			"         ├─ colSet: (1-7)\n" +
-			"         ├─ tableId: 1\n" +
-			"         └─ Table\n" +
-			"             ├─ name: two_pk\n" +
-			"             └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
+			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-7)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: two_pk\n" +
+			"         └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
-			" └─ Project\n" +
-			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
-			"     └─ IndexedTableAccess(two_pk)\n" +
-			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
+			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
-			" └─ Project\n" +
-			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
-			"     └─ IndexedTableAccess(two_pk)\n" +
-			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
-			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			" └─ IndexedTableAccess(two_pk)\n" +
+			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/sysbench_plans.go
+++ b/enginetest/queries/sysbench_plans.go
@@ -131,7 +131,7 @@ var SysbenchPlanTests = []QueryPlanTest{
 	{
 		Query: `SELECT year_col, count(year_col), max(big_int_col), avg(small_int_col) FROM sbtest1 WHERE big_int_col > 0 GROUP BY set_col ORDER BY year_col`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sbtest1.year_col:3!null, count(sbtest1.year_col):1!null as count(year_col), max(sbtest1.big_int_col):2!null as max(big_int_col), avg(sbtest1.small_int_col):0 as avg(small_int_col)]\n" +
+			" ├─ columns: [sbtest1.year_col:3!null, count(sbtest1.year_col):1!null->count(year_col):0, max(sbtest1.big_int_col):2!null->max(big_int_col):0, avg(sbtest1.small_int_col):0->avg(small_int_col):0]\n" +
 			" └─ Sort(sbtest1.year_col:3!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: AVG(sbtest1.small_int_col:0!null), COUNT(sbtest1.year_col:3!null), MAX(sbtest1.big_int_col:1!null), sbtest1.year_col:3!null\n" +
@@ -171,7 +171,7 @@ var SysbenchPlanTests = []QueryPlanTest{
 	{
 		Query: `SELECT count(id) FROM sbtest1 WHERE big_int_col > 0`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(sbtest1.id):0!null as count(id)]\n" +
+			" ├─ columns: [count(sbtest1.id):0!null->count(id):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(sbtest1.id:0!null)\n" +
 			"     ├─ group: \n" +

--- a/enginetest/queries/tpcc_plans.go
+++ b/enginetest/queries/tpcc_plans.go
@@ -177,7 +177,7 @@ SELECT c_discount, c_last, c_credit, w_tax FROM customer2, warehouse2 WHERE w_id
 	{
 		Query: `SELECT s_quantity, s_data, s_dist_09 s_dist FROM stock2 WHERE s_i_id = 2532 AND s_w_id= 1 FOR UPDATE`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [stock2.s_quantity:2, stock2.s_data:4, stock2.s_dist_09:3 as s_dist]\n" +
+			" ├─ columns: [stock2.s_quantity:2, stock2.s_data:4, stock2.s_dist_09:3->s_dist:0]\n" +
 			" └─ IndexedTableAccess(stock2)\n" +
 			"     ├─ index: [stock2.s_w_id,stock2.s_i_id]\n" +
 			"     ├─ static: [{[1, 1], [2532, 2532]}]\n" +
@@ -263,7 +263,7 @@ SELECT i_price, i_name, i_data FROM item2 WHERE i_id = 2532`,
 	{
 		Query: `SELECT s_quantity, s_data, s_dist_09 s_dist FROM stock2 WHERE s_i_id = 2532 AND s_w_id= 1 FOR UPDATE`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [stock2.s_quantity:2, stock2.s_data:4, stock2.s_dist_09:3 as s_dist]\n" +
+			" ├─ columns: [stock2.s_quantity:2, stock2.s_data:4, stock2.s_dist_09:3->s_dist:0]\n" +
 			" └─ IndexedTableAccess(stock2)\n" +
 			"     ├─ index: [stock2.s_w_id,stock2.s_i_id]\n" +
 			"     ├─ static: [{[1, 1], [2532, 2532]}]\n" +
@@ -405,7 +405,7 @@ UPDATE warehouse2 SET w_ytd = w_ytd + 1767 WHERE w_id = 1`,
 	{
 		Query: `SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 5 AND c_last='ESEEINGABLE'`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(customer2.c_id):0!null as namecnt]\n" +
+			" ├─ columns: [count(customer2.c_id):0!null->namecnt:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(customer2.c_id:0!null)\n" +
 			"     ├─ group: \n" +
@@ -530,7 +530,7 @@ UPDATE warehouse2 SET w_ytd = w_ytd + 1767 WHERE w_id = 1`,
 -- cycle 3
 SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_last='PRIESEPRES'`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [count(customer2.c_id):0!null as namecnt]\n" +
+			" ├─ columns: [count(customer2.c_id):0!null->namecnt:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNT(customer2.c_id:0!null)\n" +
 			"     ├─ group: \n" +
@@ -687,7 +687,7 @@ SELECT d_next_o_id FROM district2 WHERE d_id = 5 AND d_w_id= 1`,
 	{
 		Query: `SELECT COUNT(DISTINCT (s_i_id)) FROM order_line2, stock2 WHERE ol_w_id = 1 AND ol_d_id = 5 AND ol_o_id < 3003 AND ol_o_id >= 2983 AND s_w_id= 1 AND s_i_id=ol_i_id AND s_quantity < 18`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [countdistinct([stock2.s_i_id]):0!null as COUNT(DISTINCT (s_i_id))]\n" +
+			" ├─ columns: [countdistinct([stock2.s_i_id]):0!null->COUNT(DISTINCT (s_i_id)):0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: COUNTDISTINCT([stock2.s_i_id])\n" +
 			"     ├─ group: \n" +
@@ -763,7 +763,7 @@ WHERE
   o_c_id = 20001 AND
   o_id = (SELECT MAX(o_id) FROM orders2 WHERE o_w_id = 1 AND o_d_id = 3 AND o_c_id = 20001)`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [orders2.o_id:0!null, orders2.o_entry_d:4, coalesce(orders2.o_carrier_id:5,0 (tinyint)) as COALESCE(o_carrier_id,0)]\n" +
+			" ├─ columns: [orders2.o_id:0!null, orders2.o_entry_d:4, coalesce(orders2.o_carrier_id:5,0 (tinyint))->COALESCE(o_carrier_id,0):0]\n" +
 			" └─ Filter\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ orders2.o_id:0!null\n" +
@@ -771,7 +771,7 @@ WHERE
 			"     │       ├─ cacheable: true\n" +
 			"     │       ├─ alias-string: select MAX(o_id) from orders2 where o_w_id = 1 and o_d_id = 3 and o_c_id = 20001\n" +
 			"     │       └─ Project\n" +
-			"     │           ├─ columns: [max(orders2.o_id):8!null as MAX(o_id)]\n" +
+			"     │           ├─ columns: [max(orders2.o_id):8!null->MAX(o_id):0]\n" +
 			"     │           └─ GroupBy\n" +
 			"     │               ├─ select: MAX(orders2.o_id:8!null)\n" +
 			"     │               ├─ group: \n" +
@@ -862,7 +862,7 @@ from
 			"         │   ├─ tableId: 3\n" +
 			"         │   └─ Limit(1)\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [orders2.o_c_id:1, orders2.o_w_id:2!null, orders2.o_d_id:3!null, countdistinct([orders2.o_id]):0!null as count(distinct o_id)]\n" +
+			"         │           ├─ columns: [orders2.o_c_id:1, orders2.o_w_id:2!null, orders2.o_d_id:3!null, countdistinct([orders2.o_id]):0!null->count(distinct o_id):0]\n" +
 			"         │           └─ Having\n" +
 			"         │               ├─ GreaterThan\n" +
 			"         │               │   ├─ countdistinct([orders2.o_id]):0!null\n" +

--- a/enginetest/queries/tpch_plans.go
+++ b/enginetest/queries/tpch_plans.go
@@ -42,7 +42,7 @@ order by
 	l_returnflag,
 	l_linestatus;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [lineitem.l_returnflag:8!null, lineitem.l_linestatus:9!null, sum(lineitem.l_quantity):7!null as sum_qty, sum(lineitem.l_extendedprice):6!null as sum_base_price, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):5!null as sum_disc_price, sum(((lineitem.l_extendedprice * (1 - lineitem.l_discount)) * (1 + lineitem.l_tax))):4!null as sum_charge, avg(lineitem.l_quantity):2 as avg_qty, avg(lineitem.l_extendedprice):1 as avg_price, avg(lineitem.l_discount):0 as avg_disc, count(1):3!null as count_order]\n" +
+			" ├─ columns: [lineitem.l_returnflag:8!null, lineitem.l_linestatus:9!null, sum(lineitem.l_quantity):7!null->sum_qty:0, sum(lineitem.l_extendedprice):6!null->sum_base_price:0, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):5!null->sum_disc_price:0, sum(((lineitem.l_extendedprice * (1 - lineitem.l_discount)) * (1 + lineitem.l_tax))):4!null->sum_charge:0, avg(lineitem.l_quantity):2->avg_qty:0, avg(lineitem.l_extendedprice):1->avg_price:0, avg(lineitem.l_discount):0->avg_disc:0, count(1):3!null->count_order:0]\n" +
 			" └─ Sort(lineitem.l_returnflag:8!null ASC nullsFirst, lineitem.l_linestatus:9!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: AVG(lineitem.l_discount:2!null), AVG(lineitem.l_extendedprice:1!null), AVG(lineitem.l_quantity:0!null), COUNT(1 (bigint)), SUM(((lineitem.l_extendedprice:1!null * (1 (tinyint) - lineitem.l_discount:2!null)) * (1 (tinyint) + lineitem.l_tax:3!null))), SUM((lineitem.l_extendedprice:1!null * (1 (tinyint) - lineitem.l_discount:2!null))), SUM(lineitem.l_extendedprice:1!null), SUM(lineitem.l_quantity:0!null), lineitem.l_returnflag:4!null, lineitem.l_linestatus:5!null\n" +
@@ -137,7 +137,7 @@ order by
 			"         │       ├─ cacheable: false\n" +
 			"         │       ├─ alias-string: select min(ps_supplycost) from partsupp, supplier, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE'\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [min(partsupp.ps_supplycost):28!null as min(ps_supplycost)]\n" +
+			"         │           ├─ columns: [min(partsupp.ps_supplycost):28!null->min(ps_supplycost):0]\n" +
 			"         │           └─ GroupBy\n" +
 			"         │               ├─ select: MIN(partsupp.ps_supplycost:30!null)\n" +
 			"         │               ├─ group: \n" +
@@ -384,10 +384,10 @@ order by
 	revenue desc,
 	o_orderdate;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [lineitem.l_orderkey:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue, orders.o_orderdate:2!null, orders.o_shippriority:3!null]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue DESC nullsFirst, orders.o_orderdate:2!null ASC nullsFirst)\n" +
+			" ├─ columns: [lineitem.l_orderkey:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->revenue:0, orders.o_orderdate:2!null, orders.o_shippriority:3!null]\n" +
+			" └─ Sort(revenue:4!null DESC nullsFirst, orders.o_orderdate:2!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null, lineitem.l_orderkey:1!null, orders.o_orderdate:2!null, orders.o_shippriority:3!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue]\n" +
+			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null, lineitem.l_orderkey:1!null, orders.o_orderdate:2!null, orders.o_shippriority:3!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->revenue:0]\n" +
 			"         └─ GroupBy\n" +
 			"             ├─ select: SUM((lineitem.l_extendedprice:5!null * (1 (tinyint) - lineitem.l_discount:6!null))), lineitem.l_orderkey:4!null, orders.o_orderdate:2!null, orders.o_shippriority:3!null\n" +
 			"             ├─ group: lineitem.l_orderkey:4!null, orders.o_orderdate:2!null, orders.o_shippriority:3!null\n" +
@@ -435,7 +435,7 @@ order by
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue, orders.o_orderdate, orders.o_shippriority]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue DESC, orders.o_orderdate ASC)\n" +
+			" └─ Sort(revenue DESC, orders.o_orderdate ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))), lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
 			"         └─ GroupBy\n" +
@@ -465,7 +465,7 @@ order by
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue, orders.o_orderdate, orders.o_shippriority]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue DESC, orders.o_orderdate ASC)\n" +
+			" └─ Sort(revenue DESC, orders.o_orderdate ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))), lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
 			"         └─ GroupBy\n" +
@@ -519,7 +519,7 @@ group by
 order by
 	o_orderpriority;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [orders.o_orderpriority:1!null, count(1):0!null as order_count]\n" +
+			" ├─ columns: [orders.o_orderpriority:1!null, count(1):0!null->order_count:0]\n" +
 			" └─ Sort(orders.o_orderpriority:1!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: COUNT(1 (bigint)), orders.o_orderpriority:5!null\n" +
@@ -638,10 +638,10 @@ group by
 order by
 	revenue desc;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [nation.n_name:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue DESC nullsFirst)\n" +
+			" ├─ columns: [nation.n_name:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->revenue:0]\n" +
+			" └─ Sort(revenue:2!null DESC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null, nation.n_name:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue]\n" +
+			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null, nation.n_name:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->revenue:0]\n" +
 			"         └─ GroupBy\n" +
 			"             ├─ select: SUM((lineitem.l_extendedprice:12!null * (1 (tinyint) - lineitem.l_discount:13!null))), nation.n_name:6!null\n" +
 			"             ├─ group: nation.n_name:6!null\n" +
@@ -716,7 +716,7 @@ order by
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [nation.n_name, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue DESC)\n" +
+			" └─ Sort(revenue DESC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))), nation.n_name, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
 			"         └─ GroupBy\n" +
@@ -758,7 +758,7 @@ order by
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [nation.n_name, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue DESC)\n" +
+			" └─ Sort(revenue DESC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))), nation.n_name, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
 			"         └─ GroupBy\n" +
@@ -812,7 +812,7 @@ where
 	and l_discount between .06 - 0.01 and .06 + 0.01
 	and l_quantity < 24;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sum((lineitem.l_extendedprice * lineitem.l_discount)):0!null as revenue]\n" +
+			" ├─ columns: [sum((lineitem.l_extendedprice * lineitem.l_discount)):0!null->revenue:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: SUM((lineitem.l_extendedprice:1!null * lineitem.l_discount:2!null))\n" +
 			"     ├─ group: \n" +
@@ -907,7 +907,7 @@ order by
 	cust_nation,
 	l_year;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [shipping.supp_nation:1!null, shipping.cust_nation:2!null, shipping.l_year:3!null, sum(shipping.volume):0!null as revenue]\n" +
+			" ├─ columns: [shipping.supp_nation:1!null, shipping.cust_nation:2!null, shipping.l_year:3!null, sum(shipping.volume):0!null->revenue:0]\n" +
 			" └─ Sort(shipping.supp_nation:1!null ASC nullsFirst, shipping.cust_nation:2!null ASC nullsFirst, shipping.l_year:3!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: SUM(shipping.volume:3!null), shipping.supp_nation:0!null, shipping.cust_nation:1!null, shipping.l_year:2!null\n" +
@@ -920,7 +920,7 @@ order by
 			"             ├─ colSet: (53-56)\n" +
 			"             ├─ tableId: 7\n" +
 			"             └─ Project\n" +
-			"                 ├─ columns: [n1.n_name:12!null as supp_nation, n2.n_name:14!null as cust_nation, extract('YEAR' from lineitem.l_shipdate) as l_year, (lineitem.l_extendedprice:2!null * (1 (tinyint) - lineitem.l_discount:3!null)) as volume]\n" +
+			"                 ├─ columns: [n1.n_name:12!null->supp_nation:0, n2.n_name:14!null->cust_nation:0, extract('YEAR' from lineitem.l_shipdate)->l_year:0, (lineitem.l_extendedprice:2!null * (1 (tinyint) - lineitem.l_discount:3!null))->volume:0]\n" +
 			"                 └─ Filter\n" +
 			"                     ├─ Or\n" +
 			"                     │   ├─ AND\n" +
@@ -1146,7 +1146,7 @@ group by
 order by
 	o_year;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [all_nations.o_year:2!null, (sum(case  when (all_nations.nation = 'brazil') then all_nations.volume else 0 end):0!null / sum(all_nations.volume):1!null) as mkt_share]\n" +
+			" ├─ columns: [all_nations.o_year:2!null, (sum(case  when (all_nations.nation = 'brazil') then all_nations.volume else 0 end):0!null / sum(all_nations.volume):1!null)->mkt_share:0]\n" +
 			" └─ Sort(all_nations.o_year:2!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: SUM(CASE  WHEN Eq\n" +
@@ -1162,7 +1162,7 @@ order by
 			"             ├─ colSet: (64-66)\n" +
 			"             ├─ tableId: 9\n" +
 			"             └─ Project\n" +
-			"                 ├─ columns: [extract('YEAR' from orders.o_orderdate) as o_year, (lineitem.l_extendedprice:12!null * (1 (tinyint) - lineitem.l_discount:13!null)) as volume, n2.n_name:19!null as nation]\n" +
+			"                 ├─ columns: [extract('YEAR' from orders.o_orderdate)->o_year:0, (lineitem.l_extendedprice:12!null * (1 (tinyint) - lineitem.l_discount:13!null))->volume:0, n2.n_name:19!null->nation:0]\n" +
 			"                 └─ LookupJoin\n" +
 			"                     ├─ LookupJoin\n" +
 			"                     │   ├─ LookupJoin\n" +
@@ -1407,7 +1407,7 @@ order by
 	nation,
 	o_year desc;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [profit.nation:1!null, profit.o_year:2!null, sum(profit.amount):0!null as sum_profit]\n" +
+			" ├─ columns: [profit.nation:1!null, profit.o_year:2!null, sum(profit.amount):0!null->sum_profit:0]\n" +
 			" └─ Sort(profit.nation:1!null ASC nullsFirst, profit.o_year:2!null DESC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: SUM(profit.amount:2!null), profit.nation:0!null, profit.o_year:1!null\n" +
@@ -1420,7 +1420,7 @@ order by
 			"             ├─ colSet: (54-56)\n" +
 			"             ├─ tableId: 7\n" +
 			"             └─ Project\n" +
-			"                 ├─ columns: [nation.n_name:16!null as nation, extract('YEAR' from orders.o_orderdate) as o_year, ((lineitem.l_extendedprice:9!null * (1 (tinyint) - lineitem.l_discount:10!null)) - (partsupp.ps_supplycost:4!null * lineitem.l_quantity:8!null)) as amount]\n" +
+			"                 ├─ columns: [nation.n_name:16!null->nation:0, extract('YEAR' from orders.o_orderdate)->o_year:0, ((lineitem.l_extendedprice:9!null * (1 (tinyint) - lineitem.l_discount:10!null)) - (partsupp.ps_supplycost:4!null * lineitem.l_quantity:8!null))->amount:0]\n" +
 			"                 └─ LookupJoin\n" +
 			"                     ├─ HashJoin\n" +
 			"                     │   ├─ AND\n" +
@@ -1639,10 +1639,10 @@ group by
 order by
 	revenue desc;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [customer.c_custkey:1!null, customer.c_name:2!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue, customer.c_acctbal:3!null, nation.n_name:4!null, customer.c_address:5!null, customer.c_phone:6!null, customer.c_comment:7!null]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue DESC nullsFirst)\n" +
+			" ├─ columns: [customer.c_custkey:1!null, customer.c_name:2!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->revenue:0, customer.c_acctbal:3!null, nation.n_name:4!null, customer.c_address:5!null, customer.c_phone:6!null, customer.c_comment:7!null]\n" +
+			" └─ Sort(revenue:8!null DESC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null, customer.c_custkey:1!null, customer.c_name:2!null, customer.c_acctbal:3!null, nation.n_name:4!null, customer.c_address:5!null, customer.c_phone:6!null, customer.c_comment:7!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue]\n" +
+			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null, customer.c_custkey:1!null, customer.c_name:2!null, customer.c_acctbal:3!null, nation.n_name:4!null, customer.c_address:5!null, customer.c_phone:6!null, customer.c_comment:7!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->revenue:0]\n" +
 			"         └─ GroupBy\n" +
 			"             ├─ select: SUM((lineitem.l_extendedprice:4!null * (1 (tinyint) - lineitem.l_discount:5!null))), customer.c_custkey:7!null, customer.c_name:8!null, customer.c_acctbal:12!null, nation.n_name:15!null, customer.c_address:9!null, customer.c_phone:11!null, customer.c_comment:13!null\n" +
 			"             ├─ group: customer.c_custkey:7!null, customer.c_name:8!null, customer.c_acctbal:12!null, customer.c_phone:11!null, nation.n_name:15!null, customer.c_address:9!null, customer.c_comment:13!null\n" +
@@ -1699,7 +1699,7 @@ order by
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue, customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue DESC)\n" +
+			" └─ Sort(revenue DESC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))), customer.c_custkey, customer.c_name, customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
 			"         └─ GroupBy\n" +
@@ -1732,7 +1732,7 @@ order by
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue, customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment]\n" +
-			" └─ Sort(sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue DESC)\n" +
+			" └─ Sort(revenue DESC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))), customer.c_custkey, customer.c_name, customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))) as revenue]\n" +
 			"         └─ GroupBy\n" +
@@ -1795,8 +1795,8 @@ group by
 order by
 	value desc;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [partsupp.ps_partkey:1!null, sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null as value]\n" +
-			" └─ Sort(sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null as value DESC nullsFirst)\n" +
+			" ├─ columns: [partsupp.ps_partkey:1!null, sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null->value:0]\n" +
+			" └─ Sort(value:4!null DESC nullsFirst)\n" +
 			"     └─ Having\n" +
 			"         ├─ GreaterThan\n" +
 			"         │   ├─ sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null\n" +
@@ -1804,7 +1804,7 @@ order by
 			"         │       ├─ cacheable: true\n" +
 			"         │       ├─ alias-string: select sum(ps_supplycost * ps_availqty) * 0.0001000000 from partsupp, supplier, nation where ps_suppkey = s_suppkey and s_nationkey = n_nationkey and n_name = 'GERMANY'\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null * 0.0001 (decimal(11,10))) as sum(ps_supplycost * ps_availqty) * 0.0001000000]\n" +
+			"         │           ├─ columns: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null * 0.0001 (decimal(11,10)))->sum(ps_supplycost * ps_availqty) * 0.0001000000:0]\n" +
 			"         │           └─ LookupJoin\n" +
 			"         │               ├─ LookupJoin\n" +
 			"         │               │   ├─ Table\n" +
@@ -1833,7 +1833,7 @@ order by
 			"         │                           ├─ name: nation\n" +
 			"         │                           └─ columns: [n_nationkey n_name]\n" +
 			"         └─ Project\n" +
-			"             ├─ columns: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null, partsupp.ps_partkey:1!null, partsupp.PS_SUPPLYCOST:2!null, partsupp.PS_AVAILQTY:3!null, sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null as value]\n" +
+			"             ├─ columns: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null, partsupp.ps_partkey:1!null, partsupp.PS_SUPPLYCOST:2!null, partsupp.PS_AVAILQTY:3!null, sum((partsupp.ps_supplycost * partsupp.ps_availqty)):0!null->value:0]\n" +
 			"             └─ GroupBy\n" +
 			"                 ├─ select: SUM((partsupp.ps_supplycost:3!null * partsupp.ps_availqty:2!null)), partsupp.ps_partkey:0!null, partsupp.PS_SUPPLYCOST:3!null, partsupp.PS_AVAILQTY:2!null\n" +
 			"                 ├─ group: partsupp.ps_partkey:0!null\n" +
@@ -1866,7 +1866,7 @@ order by
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty)) as value]\n" +
-			" └─ Sort(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) as value DESC)\n" +
+			" └─ Sort(value DESC)\n" +
 			"     └─ Having((sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > Subquery\n" +
 			"         ├─ cacheable: true\n" +
 			"         └─ Project\n" +
@@ -1907,7 +1907,7 @@ order by
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty)) as value]\n" +
-			" └─ Sort(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) as value DESC)\n" +
+			" └─ Sort(value DESC)\n" +
 			"     └─ Having((sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > Subquery\n" +
 			"         ├─ cacheable: true\n" +
 			"         └─ Project\n" +
@@ -1979,7 +1979,7 @@ group by
 order by
 	l_shipmode;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [lineitem.l_shipmode:2!null, sum(case  when ((orders.o_orderpriority = '1-urgent') or (orders.o_orderpriority = '2-high')) then 1 else 0 end):1!null as high_line_count, sum(case  when ((not((orders.o_orderpriority = '1-urgent'))) and (not((orders.o_orderpriority = '2-high')))) then 1 else 0 end):0!null as low_line_count]\n" +
+			" ├─ columns: [lineitem.l_shipmode:2!null, sum(case  when ((orders.o_orderpriority = '1-urgent') or (orders.o_orderpriority = '2-high')) then 1 else 0 end):1!null->high_line_count:0, sum(case  when ((not((orders.o_orderpriority = '1-urgent'))) and (not((orders.o_orderpriority = '2-high')))) then 1 else 0 end):0!null->low_line_count:0]\n" +
 			" └─ Sort(lineitem.l_shipmode:2!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: SUM(CASE  WHEN AND\n" +
@@ -2104,10 +2104,10 @@ order by
 	custdist desc,
 	c_count desc;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [c_orders.c_count:1!null, count(1):0!null as custdist]\n" +
-			" └─ Sort(count(1):0!null as custdist DESC nullsFirst, c_orders.c_count:1!null DESC nullsFirst)\n" +
+			" ├─ columns: [c_orders.c_count:1!null, count(1):0!null->custdist:0]\n" +
+			" └─ Sort(custdist:2!null DESC nullsFirst, c_orders.c_count:1!null DESC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [count(1):0!null, c_orders.c_count:1!null, count(1):0!null as custdist]\n" +
+			"         ├─ columns: [count(1):0!null, c_orders.c_count:1!null, count(1):0!null->custdist:0]\n" +
 			"         └─ GroupBy\n" +
 			"             ├─ select: COUNT(1 (bigint)), c_orders.c_count:1!null\n" +
 			"             ├─ group: c_orders.c_count:1!null\n" +
@@ -2119,7 +2119,7 @@ order by
 			"                 ├─ colSet: (19,20)\n" +
 			"                 ├─ tableId: 3\n" +
 			"                 └─ Project\n" +
-			"                     ├─ columns: [customer.c_custkey:1!null, count(orders.o_orderkey):0!null as count(o_orderkey)]\n" +
+			"                     ├─ columns: [customer.c_custkey:1!null, count(orders.o_orderkey):0!null->count(o_orderkey):0]\n" +
 			"                     └─ GroupBy\n" +
 			"                         ├─ select: COUNT(orders.o_orderkey:1!null), customer.c_custkey:0!null\n" +
 			"                         ├─ group: customer.c_custkey:0!null\n" +
@@ -2143,7 +2143,7 @@ order by
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [c_orders.c_count, count(1) as custdist]\n" +
-			" └─ Sort(count(1) as custdist DESC, c_orders.c_count DESC)\n" +
+			" └─ Sort(custdist DESC, c_orders.c_count DESC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [count(1), c_orders.c_count, count(1) as custdist]\n" +
 			"         └─ GroupBy\n" +
@@ -2170,7 +2170,7 @@ order by
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [c_orders.c_count, count(1) as custdist]\n" +
-			" └─ Sort(count(1) as custdist DESC, c_orders.c_count DESC)\n" +
+			" └─ Sort(custdist DESC, c_orders.c_count DESC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [count(1), c_orders.c_count, count(1) as custdist]\n" +
 			"         └─ GroupBy\n" +
@@ -2213,7 +2213,7 @@ where
 	and l_shipdate >= '1995-09-01'
 	and l_shipdate < '1995-09-01' + interval '1' month;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [((100 (decimal(5,2)) * sum(case  when part.p_type like 'promo%' then (lineitem.l_extendedprice * (1 - lineitem.l_discount)) else 0 end):1!null) / sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null) as promo_revenue]\n" +
+			" ├─ columns: [((100 (decimal(5,2)) * sum(case  when part.p_type like 'promo%' then (lineitem.l_extendedprice * (1 - lineitem.l_discount)) else 0 end):1!null) / sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null)->promo_revenue:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: SUM((lineitem.l_extendedprice:1!null * (1 (tinyint) - lineitem.l_discount:2!null))), SUM(CASE  WHEN part.p_type LIKE 'PROMO%' THEN (lineitem.l_extendedprice:1!null * (1 (tinyint) - lineitem.l_discount:2!null)) ELSE 0 (tinyint) END)\n" +
 			"     ├─ group: \n" +
@@ -2315,7 +2315,7 @@ order by
 			"         │       ├─ cacheable: true\n" +
 			"         │       ├─ alias-string: select max(total_revenue) from revenue0\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [max(revenue0.total_revenue):9!null as max(total_revenue)]\n" +
+			"         │           ├─ columns: [max(revenue0.total_revenue):9!null->max(total_revenue):0]\n" +
 			"         │           └─ GroupBy\n" +
 			"         │               ├─ select: MAX(revenue0.total_revenue:10!null)\n" +
 			"         │               ├─ group: \n" +
@@ -2327,7 +2327,7 @@ order by
 			"         │                   ├─ colSet: (29,30)\n" +
 			"         │                   ├─ tableId: 4\n" +
 			"         │                   └─ Project\n" +
-			"         │                       ├─ columns: [lineitem.l_suppkey:10!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):9!null as sum(l_extendedprice * (1 - l_discount))]\n" +
+			"         │                       ├─ columns: [lineitem.l_suppkey:10!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):9!null->sum(l_extendedprice * (1 - l_discount)):0]\n" +
 			"         │                       └─ GroupBy\n" +
 			"         │                           ├─ select: SUM((lineitem.l_extendedprice:10!null * (1 (tinyint) - lineitem.l_discount:11!null))), lineitem.l_suppkey:9!null\n" +
 			"         │                           ├─ group: lineitem.l_suppkey:9!null\n" +
@@ -2353,7 +2353,7 @@ order by
 			"             │   ├─ colSet: (27,28)\n" +
 			"             │   ├─ tableId: 3\n" +
 			"             │   └─ Project\n" +
-			"             │       ├─ columns: [lineitem.l_suppkey:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as sum(l_extendedprice * (1 - l_discount))]\n" +
+			"             │       ├─ columns: [lineitem.l_suppkey:1!null, sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->sum(l_extendedprice * (1 - l_discount)):0]\n" +
 			"             │       └─ GroupBy\n" +
 			"             │           ├─ select: SUM((lineitem.l_extendedprice:1!null * (1 (tinyint) - lineitem.l_discount:2!null))), lineitem.l_suppkey:0!null\n" +
 			"             │           ├─ group: lineitem.l_suppkey:0!null\n" +
@@ -2508,10 +2508,10 @@ order by
 	p_type,
 	p_size;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [part.p_brand:1!null, part.p_type:2!null, part.p_size:3!null, countdistinct([partsupp.ps_suppkey]):0!null as supplier_cnt]\n" +
-			" └─ Sort(countdistinct([partsupp.ps_suppkey]):0!null as supplier_cnt DESC nullsFirst, part.p_brand:1!null ASC nullsFirst, part.p_type:2!null ASC nullsFirst, part.p_size:3!null ASC nullsFirst)\n" +
+			" ├─ columns: [part.p_brand:1!null, part.p_type:2!null, part.p_size:3!null, countdistinct([partsupp.ps_suppkey]):0!null->supplier_cnt:0]\n" +
+			" └─ Sort(supplier_cnt:4!null DESC nullsFirst, part.p_brand:1!null ASC nullsFirst, part.p_type:2!null ASC nullsFirst, part.p_size:3!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [countdistinct([partsupp.ps_suppkey]):0!null, part.p_brand:1!null, part.p_type:2!null, part.p_size:3!null, countdistinct([partsupp.ps_suppkey]):0!null as supplier_cnt]\n" +
+			"         ├─ columns: [countdistinct([partsupp.ps_suppkey]):0!null, part.p_brand:1!null, part.p_type:2!null, part.p_size:3!null, countdistinct([partsupp.ps_suppkey]):0!null->supplier_cnt:0]\n" +
 			"         └─ GroupBy\n" +
 			"             ├─ select: COUNTDISTINCT([partsupp.ps_suppkey]), part.p_brand:8!null, part.p_type:9!null, part.p_size:10!null\n" +
 			"             ├─ group: part.p_brand:8!null, part.p_type:9!null, part.p_size:10!null\n" +
@@ -2572,7 +2572,7 @@ order by
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [part.p_brand, part.p_type, part.p_size, countdistinct([partsupp.ps_suppkey]) as supplier_cnt]\n" +
-			" └─ Sort(countdistinct([partsupp.ps_suppkey]) as supplier_cnt DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC)\n" +
+			" └─ Sort(supplier_cnt DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [countdistinct([partsupp.ps_suppkey]), part.p_brand, part.p_type, part.p_size, countdistinct([partsupp.ps_suppkey]) as supplier_cnt]\n" +
 			"         └─ GroupBy\n" +
@@ -2603,7 +2603,7 @@ order by
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [part.p_brand, part.p_type, part.p_size, countdistinct([partsupp.ps_suppkey]) as supplier_cnt]\n" +
-			" └─ Sort(countdistinct([partsupp.ps_suppkey]) as supplier_cnt DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC)\n" +
+			" └─ Sort(supplier_cnt DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [countdistinct([partsupp.ps_suppkey]), part.p_brand, part.p_type, part.p_size, countdistinct([partsupp.ps_suppkey]) as supplier_cnt]\n" +
 			"         └─ GroupBy\n" +
@@ -2654,7 +2654,7 @@ where
 			l_partkey = p_partkey
 	);`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [(sum(lineitem.l_extendedprice):0!null / 7 (decimal(2,1))) as avg_yearly]\n" +
+			" ├─ columns: [(sum(lineitem.l_extendedprice):0!null / 7 (decimal(2,1)))->avg_yearly:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: SUM(lineitem.l_extendedprice:5!null)\n" +
 			"     ├─ group: \n" +
@@ -2665,7 +2665,7 @@ where
 			"         │       ├─ cacheable: false\n" +
 			"         │       ├─ alias-string: select 0.2 * avg(l_quantity) from lineitem where l_partkey = p_partkey\n" +
 			"         │       └─ Project\n" +
-			"         │           ├─ columns: [(0.2 (decimal(2,1)) * avg(lineitem.l_quantity):25) as 0.2 * avg(l_quantity)]\n" +
+			"         │           ├─ columns: [(0.2 (decimal(2,1)) * avg(lineitem.l_quantity):25)->0.2 * avg(l_quantity):0]\n" +
 			"         │           └─ GroupBy\n" +
 			"         │               ├─ select: AVG(lineitem.l_quantity:26!null)\n" +
 			"         │               ├─ group: \n" +
@@ -2793,7 +2793,7 @@ order by
 	o_totalprice desc,
 	o_orderdate;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [customer.c_name:1!null, customer.c_custkey:2!null, orders.o_orderkey:3!null, orders.o_orderdate:4!null, orders.o_totalprice:5!null, sum(lineitem.l_quantity):0!null as sum(l_quantity)]\n" +
+			" ├─ columns: [customer.c_name:1!null, customer.c_custkey:2!null, orders.o_orderkey:3!null, orders.o_orderdate:4!null, orders.o_totalprice:5!null, sum(lineitem.l_quantity):0!null->sum(l_quantity):0]\n" +
 			" └─ Sort(orders.o_totalprice:5!null DESC nullsFirst, orders.o_orderdate:4!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: SUM(lineitem.l_quantity:21!null), customer.c_name:1!null, customer.c_custkey:0!null, orders.o_orderkey:8!null, orders.o_orderdate:12!null, orders.o_totalprice:11!null\n" +
@@ -2934,7 +2934,7 @@ where
 		and l_shipinstruct = 'DELIVER IN PERSON'
 	);`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null as revenue]\n" +
+			" ├─ columns: [sum((lineitem.l_extendedprice * (1 - lineitem.l_discount))):0!null->revenue:0]\n" +
 			" └─ GroupBy\n" +
 			"     ├─ select: SUM((lineitem.l_extendedprice:2!null * (1 (tinyint) - lineitem.l_discount:3!null)))\n" +
 			"     ├─ group: \n" +
@@ -3186,7 +3186,7 @@ order by
 			"         │   │           │       ├─ cacheable: false\n" +
 			"         │   │           │       ├─ alias-string: select 0.5 * sum(l_quantity) from lineitem where l_partkey = ps_partkey and l_suppkey = ps_suppkey and l_shipdate >= '1994-01-01' and l_shipdate < '1994-01-01' + interval '1' year\n" +
 			"         │   │           │       └─ Project\n" +
-			"         │   │           │           ├─ columns: [(0.5 (decimal(2,1)) * sum(lineitem.l_quantity):5!null) as 0.5 * sum(l_quantity)]\n" +
+			"         │   │           │           ├─ columns: [(0.5 (decimal(2,1)) * sum(lineitem.l_quantity):5!null)->0.5 * sum(l_quantity):0]\n" +
 			"         │   │           │           └─ GroupBy\n" +
 			"         │   │           │               ├─ select: SUM(lineitem.l_quantity:7!null)\n" +
 			"         │   │           │               ├─ group: \n" +
@@ -3424,10 +3424,10 @@ order by
 	numwait desc,
 	s_name;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [supplier.s_name:1!null, count(1):0!null as numwait]\n" +
-			" └─ Sort(count(1):0!null as numwait DESC nullsFirst, supplier.s_name:1!null ASC nullsFirst)\n" +
+			" ├─ columns: [supplier.s_name:1!null, count(1):0!null->numwait:0]\n" +
+			" └─ Sort(numwait:2!null DESC nullsFirst, supplier.s_name:1!null ASC nullsFirst)\n" +
 			"     └─ Project\n" +
-			"         ├─ columns: [count(1):0!null, supplier.s_name:1!null, count(1):0!null as numwait]\n" +
+			"         ├─ columns: [count(1):0!null, supplier.s_name:1!null, count(1):0!null->numwait:0]\n" +
 			"         └─ GroupBy\n" +
 			"             ├─ select: COUNT(1 (bigint)), supplier.s_name:26!null\n" +
 			"             ├─ group: supplier.s_name:26!null\n" +
@@ -3517,7 +3517,7 @@ order by
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [supplier.s_name, count(1) as numwait]\n" +
-			" └─ Sort(count(1) as numwait DESC, supplier.s_name ASC)\n" +
+			" └─ Sort(numwait DESC, supplier.s_name ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [count(1), supplier.s_name, count(1) as numwait]\n" +
 			"         └─ GroupBy\n" +
@@ -3564,7 +3564,7 @@ order by
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [supplier.s_name, count(1) as numwait]\n" +
-			" └─ Sort(count(1) as numwait DESC, supplier.s_name ASC)\n" +
+			" └─ Sort(numwait DESC, supplier.s_name ASC)\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [count(1), supplier.s_name, count(1) as numwait]\n" +
 			"         └─ GroupBy\n" +
@@ -3651,7 +3651,7 @@ group by
 order by
 	cntrycode;`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [custsale.cntrycode:2!null, count(1):0!null as numcust, sum(custsale.c_acctbal):1!null as totacctbal]\n" +
+			" ├─ columns: [custsale.cntrycode:2!null, count(1):0!null->numcust:0, sum(custsale.c_acctbal):1!null->totacctbal:0]\n" +
 			" └─ Sort(custsale.cntrycode:2!null ASC nullsFirst)\n" +
 			"     └─ GroupBy\n" +
 			"         ├─ select: COUNT(1 (bigint)), SUM(custsale.c_acctbal:1!null), custsale.cntrycode:0!null\n" +
@@ -3664,7 +3664,7 @@ order by
 			"             ├─ colSet: (28,29)\n" +
 			"             ├─ tableId: 4\n" +
 			"             └─ Project\n" +
-			"                 ├─ columns: [SUBSTRING(customer.c_phone, 1, 2) as cntrycode, customer.c_acctbal:5!null]\n" +
+			"                 ├─ columns: [SUBSTRING(customer.c_phone, 1, 2)->cntrycode:0, customer.c_acctbal:5!null]\n" +
 			"                 └─ Filter\n" +
 			"                     ├─ GreaterThan\n" +
 			"                     │   ├─ customer.c_acctbal:5!null\n" +
@@ -3672,7 +3672,7 @@ order by
 			"                     │       ├─ cacheable: true\n" +
 			"                     │       ├─ alias-string: select avg(c_acctbal) from customer where c_acctbal > 0.00 and substr(c_phone, 1, 2) in ('13', '31', '23', '29', '30', '18', '17')\n" +
 			"                     │       └─ Project\n" +
-			"                     │           ├─ columns: [avg(customer.c_acctbal):8 as avg(c_acctbal)]\n" +
+			"                     │           ├─ columns: [avg(customer.c_acctbal):8->avg(c_acctbal):0]\n" +
 			"                     │           └─ GroupBy\n" +
 			"                     │               ├─ select: AVG(customer.c_acctbal:9!null)\n" +
 			"                     │               ├─ group: \n" +

--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -136,7 +136,11 @@ func (e *Alias) String() string {
 }
 
 func (e *Alias) DebugString() string {
-	return fmt.Sprintf("%s as %s", sql.DebugString(e.Child), e.name)
+	if e.unreferencable {
+		return fmt.Sprintf("%s->%s", e.Child, e.name)
+	} else {
+		return fmt.Sprintf("%s->%s:%d", sql.DebugString(e.Child), e.name, e.id)
+	}
 }
 
 // WithChildren implements the Expression interface.

--- a/sql/expression/function/absval.go
+++ b/sql/expression/function/absval.go
@@ -116,6 +116,10 @@ func (t *AbsVal) String() string {
 	return fmt.Sprintf("%s(%s)", t.FunctionName(), t.Child.String())
 }
 
+func (t *AbsVal) DebugString() string {
+	return fmt.Sprintf("%s(%s)", t.FunctionName(), sql.DebugString(t.Child))
+}
+
 // IsNullable implements the Expression interface.
 func (t *AbsVal) IsNullable() bool {
 	return t.Child.IsNullable()

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -694,7 +694,11 @@ func (d *Week) Description() string {
 	return "returns the week number."
 }
 
-func (d *Week) String() string { return fmt.Sprintf("WEEK(%s, %d)", d.date, d.mode) }
+func (d *Week) String() string { return fmt.Sprintf("WEEK(%s, %s)", d.date, d.mode.String()) }
+
+func (d *Week) DebugString() string {
+	return fmt.Sprintf("WEEK(%s, %s)", sql.DebugString(d.date), sql.DebugString(d.mode))
+}
 
 // Type implements the Expression interface.
 func (d *Week) Type() sql.Type { return types.Int32 }

--- a/sql/planbuilder/factory.go
+++ b/sql/planbuilder/factory.go
@@ -195,7 +195,7 @@ func (f *factory) buildTableAlias(name string, child sql.Node) (plan.TableIdNode
 // else
 //
 //	sort(project(table)) -> distinct(sort(project(table)))
-func (f *factory) buildDistinct(child sql.Node) sql.Node {
+func (f *factory) buildDistinct(child sql.Node, refsSubquery bool) (sql.Node, error) {
 	if proj, isProj := child.(*plan.Project); isProj {
 		// TODO: if projection columns are just primary key, distinct is no-op
 		// TODO: distinct literals are just one row
@@ -213,12 +213,17 @@ func (f *factory) buildDistinct(child sql.Node) sql.Node {
 			}
 			if !hasDiff {
 				proj.Child = sort.Child
+				// collapse potential redundant project->project
+				proj, err := f.buildProject(proj, refsSubquery)
+				if err != nil {
+					return nil, err
+				}
 				sort.Child = plan.NewDistinct(proj)
-				return sort
+				return sort, nil
 			}
 		}
 	}
-	return plan.NewDistinct(child)
+	return plan.NewDistinct(child), nil
 }
 
 func (f *factory) buildSort(child sql.Node, exprs []sql.SortField, deps sql.ColSet, subquery bool) (sql.Node, error) {
@@ -226,7 +231,7 @@ func (f *factory) buildSort(child sql.Node, exprs []sql.SortField, deps sql.ColS
 		// The default binder behavior adds a projection before and after
 		// sort nodes for alias dependency correctness. In many cases the sort
 		// does not reference an alias, and it is beneficial to hoist the inner
-		// projection which lets the optimizer (1) remove redundant projcetions
+		// projection which lets the optimizer (1) remove redundant projections
 		// and usually (2) more aggressively prune table columns.
 		// (proj ->) sort -> proj -> child
 		// =>

--- a/sql/planbuilder/factory.go
+++ b/sql/planbuilder/factory.go
@@ -240,12 +240,13 @@ func (f *factory) buildSort(child sql.Node, exprs []sql.SortField, deps sql.ColS
 		// (proj ->) sort -> child
 		if p, ok := child.(*plan.Project); ok {
 			var aliases []sql.Expression
+			var aliasCols sql.ColSet
 			for _, p := range p.Projections {
-				if _, ok := p.(*expression.Alias); ok {
+				if a, ok := p.(*expression.Alias); ok {
+					aliasCols.Add(a.Id())
 					aliases = append(aliases, p)
 				}
 			}
-			aliasCols := plan.ExprDeps(aliases...)
 			if !aliasCols.Intersects(deps) {
 				newP := plan.NewProject(p.Projections, plan.NewSort(exprs, p.Child))
 				return f.buildProject(newP, subquery)

--- a/sql/planbuilder/orderby.go
+++ b/sql/planbuilder/orderby.go
@@ -55,6 +55,10 @@ func (b *Builder) analyzeOrderBy(fromScope, projScope *scope, order ast.OrderBy)
 			colName := strings.ToLower(e.Name.String())
 			c, ok := projScope.resolveColumn(dbName, tblName, colName, false, false)
 			if ok {
+				if _, ok := c.scalar.(*expression.Alias); ok {
+					// take ref dependency on expression lower in tree
+					c.scalar = nil
+				}
 				c.descending = descending
 				outScope.addColumn(c)
 				continue

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -49,7 +49,7 @@ type planErrTest struct {
 func TestPlanBuilder(t *testing.T) {
 	var verbose, rewrite bool
 	//verbose = true
-	rewrite = true
+	//rewrite = true
 
 	var tests = []planTest{
 		{
@@ -117,6 +117,21 @@ Project
                  ├─ columns: [x y z]
                  ├─ colSet: (1-3)
                  └─ tableId: 1
+`,
+		},
+		{
+			Query: "select abs(y) as a from xy order by a",
+			ExpectedPlan: `
+Project
+ ├─ columns: [abs(xy.y:2!null)->a:4]
+ └─ Sort(a:4!null ASC nullsFirst)
+     └─ Project
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, abs(xy.y:2!null)->a:4]
+         └─ Table
+             ├─ name: xy
+             ├─ columns: [x y z]
+             ├─ colSet: (1-3)
+             └─ tableId: 1
 `,
 		},
 		{
@@ -1238,13 +1253,11 @@ Project
 Project
  ├─ columns: [xy.x:1!null, xy.y:2!null->x:4]
  └─ Sort(xy.y:2!null ASC nullsFirst)
-     └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.y:2!null->x:4]
-         └─ Table
-             ├─ name: xy
-             ├─ columns: [x y z]
-             ├─ colSet: (1-3)
-             └─ tableId: 1
+     └─ Table
+         ├─ name: xy
+         ├─ columns: [x y z]
+         ├─ colSet: (1-3)
+         └─ tableId: 1
 `,
 		},
 		{
@@ -1828,14 +1841,12 @@ Project
 Project
  ├─ columns: [s.x:1!null->y:4, s.y:2!null]
  └─ Sort(s.x:1!null DESC nullsFirst)
-     └─ Project
-         ├─ columns: [s.x:1!null, s.y:2!null, s.z:3!null, s.x:1!null->y:4]
-         └─ TableAlias(s)
-             └─ Table
-                 ├─ name: xy
-                 ├─ columns: [x y z]
-                 ├─ colSet: (1-3)
-                 └─ tableId: 1
+     └─ TableAlias(s)
+         └─ Table
+             ├─ name: xy
+             ├─ columns: [x y z]
+             ├─ colSet: (1-3)
+             └─ tableId: 1
 `,
 		},
 		{

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -49,7 +49,7 @@ type planErrTest struct {
 func TestPlanBuilder(t *testing.T) {
 	var verbose, rewrite bool
 	//verbose = true
-	//rewrite = true
+	rewrite = true
 
 	var tests = []planTest{
 		{
@@ -60,7 +60,7 @@ Project
  │   ├─ cacheable: true
  │   ├─ alias-string: select SUM(x) from cte
  │   └─ Project
- │       ├─ columns: [sum(cte.x):13!null as SUM(x)]
+ │       ├─ columns: [sum(cte.x)->SUM(x)]
  │       └─ GroupBy
  │           ├─ select: SUM(cte.x:10!null)
  │           ├─ group: 
@@ -78,13 +78,13 @@ Project
  │                       ├─ columns: [x y z]
  │                       ├─ colSet: (1-3)
  │                       └─ tableId: 1
- │   as xy]
+ │  ->xy:14]
  └─ Project
      ├─ columns: [cte.x:7!null, cte.y:8!null, cte.z:9!null, Subquery
      │   ├─ cacheable: true
      │   ├─ alias-string: select SUM(x) from cte
      │   └─ Project
-     │       ├─ columns: [sum(cte.x):13!null as SUM(x)]
+     │       ├─ columns: [sum(cte.x)->SUM(x)]
      │       └─ GroupBy
      │           ├─ select: SUM(cte.x:10!null)
      │           ├─ group: 
@@ -102,7 +102,7 @@ Project
      │                       ├─ columns: [x y z]
      │                       ├─ colSet: (1-3)
      │                       └─ tableId: 1
-     │   as xy]
+     │  ->xy:14]
      └─ SubqueryAlias
          ├─ name: cte
          ├─ outerVisibility: false
@@ -120,19 +120,84 @@ Project
 `,
 		},
 		{
+			Query: "select abs(y) as a from xy order by abs(y)",
+			ExpectedPlan: `
+Project
+ ├─ columns: [abs(xy.y:2!null)->a:4]
+ └─ Sort(abs(xy.y:2!null) ASC nullsFirst)
+     └─ Table
+         ├─ name: xy
+         ├─ columns: [x y z]
+         ├─ colSet: (1-3)
+         └─ tableId: 1
+`,
+		},
+		{
+			Query: "select distinct abs(y) as a from xy order by abs(y)",
+			ExpectedPlan: `
+Distinct
+ └─ Project
+     ├─ columns: [abs(xy.y:2!null)->a:4]
+     └─ Sort(abs(xy.y:2!null) ASC nullsFirst)
+         └─ Table
+             ├─ name: xy
+             ├─ columns: [x y z]
+             ├─ colSet: (1-3)
+             └─ tableId: 1
+`,
+		},
+		{
+			Query: "select distinct abs(y) as a from xy where x = 1 order by abs(y)",
+			ExpectedPlan: `
+Distinct
+ └─ Project
+     ├─ columns: [abs(xy.y:2!null)->a:4]
+     └─ Sort(abs(xy.y:2!null) ASC nullsFirst)
+         └─ Filter
+             ├─ Eq
+             │   ├─ xy.x:1!null
+             │   └─ 1 (bigint)
+             └─ Table
+                 ├─ name: xy
+                 ├─ columns: [x y z]
+                 ├─ colSet: (1-3)
+                 └─ tableId: 1
+`,
+		},
+		{
+			Query: "select distinct abs(y) as a from xy where x = 1 order by a",
+			ExpectedPlan: `
+Distinct
+ └─ Project
+     ├─ columns: [abs(xy.y:2!null)->a:4]
+     └─ Sort(a:4!null ASC nullsFirst)
+         └─ Project
+             ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, abs(xy.y:2!null)->a:4]
+             └─ Filter
+                 ├─ Eq
+                 │   ├─ xy.x:1!null
+                 │   └─ 1 (bigint)
+                 └─ Table
+                     ├─ name: xy
+                     ├─ columns: [x y z]
+                     ├─ colSet: (1-3)
+                     └─ tableId: 1
+`,
+		},
+		{
 			Query: "select 0 as col1, 1 as col2, 2 as col2 group by col2 having col2 = 1",
 			ExpectedPlan: `
 Project
- ├─ columns: [0 (tinyint) as col1, 1 (tinyint) as col2, 2 (tinyint) as col2]
+ ├─ columns: [0 (tinyint)->col1:1, 1 (tinyint)->col2:2, 2 (tinyint)->col2:3]
  └─ Having
      ├─ Eq
      │   ├─ col2:2!null
      │   └─ 1 (tinyint)
      └─ Project
-         ├─ columns: [0 (tinyint) as col1, 1 (tinyint) as col2, 2 (tinyint) as col2]
+         ├─ columns: [0 (tinyint)->col1:1, 1 (tinyint)->col2:2, 2 (tinyint)->col2:3]
          └─ GroupBy
              ├─ select: 
-             ├─ group: 1 (tinyint) as col2
+             ├─ group: 1 (tinyint)->col2:2
              └─ Table
                  ├─ name: 
                  ├─ columns: []
@@ -144,13 +209,13 @@ Project
 			Query: "with cte(x) as (select 1 as x) select 1 as x from cte having avg(x) > 0",
 			ExpectedPlan: `
 Project
- ├─ columns: [1 (tinyint) as x]
+ ├─ columns: [1 (tinyint)->x:4]
  └─ Having
      ├─ GreaterThan
      │   ├─ avg(cte.x):5
      │   └─ 0 (tinyint)
      └─ Project
-         ├─ columns: [avg(cte.x):5, cte.x:3!null, 1 (tinyint) as x]
+         ├─ columns: [avg(cte.x):5, cte.x:3!null, 1 (tinyint)->x:4]
          └─ GroupBy
              ├─ select: AVG(cte.x:3!null), cte.x:3!null
              ├─ group: 
@@ -162,7 +227,7 @@ Project
                  ├─ colSet: (3)
                  ├─ tableId: 2
                  └─ Project
-                     ├─ columns: [1 (tinyint) as x]
+                     ├─ columns: [1 (tinyint)->x:1]
                      └─ Table
                          ├─ name: 
                          ├─ columns: []
@@ -174,13 +239,13 @@ Project
 			Query: "select 1 as x from xy having AVG(x) > 0",
 			ExpectedPlan: `
 Project
- ├─ columns: [1 (tinyint) as x]
+ ├─ columns: [1 (tinyint)->x:4]
  └─ Having
      ├─ GreaterThan
      │   ├─ avg(xy.x):5
      │   └─ 0 (tinyint)
      └─ Project
-         ├─ columns: [avg(xy.x):5, xy.x:1!null, 1 (tinyint) as x]
+         ├─ columns: [avg(xy.x):5, xy.x:1!null, 1 (tinyint)->x:4]
          └─ GroupBy
              ├─ select: AVG(xy.x:1!null), xy.x:1!null
              ├─ group: 
@@ -195,13 +260,13 @@ Project
 			Query: "select x as x from xy having avg(x) > 0",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as x]
+ ├─ columns: [xy.x:1!null->x:4]
  └─ Having
      ├─ GreaterThan
      │   ├─ avg(xy.x):5
      │   └─ 0 (tinyint)
      └─ Project
-         ├─ columns: [avg(xy.x):5, xy.x:1!null, xy.x:1!null as x]
+         ├─ columns: [avg(xy.x):5, xy.x:1!null, xy.x:1!null->x:4]
          └─ GroupBy
              ├─ select: AVG(xy.x:1!null), xy.x:1!null
              ├─ group: 
@@ -229,10 +294,10 @@ Project
 			Query: "select t1.x as x, t1.x as x from xy t1, xy t2 order by x;",
 			ExpectedPlan: `
 Project
- ├─ columns: [t1.x:1!null as x, t1.x:1!null as x]
- └─ Sort(t1.x:1!null as x ASC nullsFirst)
+ ├─ columns: [t1.x:1!null->x:7, t1.x:1!null->x:8]
+ └─ Sort(x:7!null ASC nullsFirst)
      └─ Project
-         ├─ columns: [t1.x:1!null, t1.y:2!null, t1.z:3!null, t2.x:4!null, t2.y:5!null, t2.z:6!null, t1.x:1!null as x, t1.x:1!null as x]
+         ├─ columns: [t1.x:1!null, t1.y:2!null, t1.z:3!null, t2.x:4!null, t2.y:5!null, t2.z:6!null, t1.x:1!null->x:7, t1.x:1!null->x:8]
          └─ CrossJoin
              ├─ TableAlias(t1)
              │   └─ Table
@@ -259,7 +324,7 @@ update histogram  xy.(x,y) using {"statistic":{"avg_size":0,"buckets":[],"column
 			Query: "SELECT b.y as s1, a.y as s2, first_value(a.z) over (partition by a.y) from xy a join xy b on a.y = b.y",
 			ExpectedPlan: `
 Project
- ├─ columns: [b.y:5!null as s1, a.y:2!null as s2, first_value(a.z) over ( partition by a.y rows between unbounded preceding and unbounded following):9!null as first_value(a.z) over (partition by a.y)]
+ ├─ columns: [b.y:5!null->s1:7, a.y:2!null->s2:8, first_value(a.z) over ( partition by a.y rows between unbounded preceding and unbounded following)->first_value(a.z) over (partition by a.y)]
  └─ Window
      ├─ first_value(a.z) over ( partition by a.y ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
      ├─ b.y:5!null
@@ -286,7 +351,7 @@ Project
 			Query: "select a.x, b.y as s1, a.y as s2 from xy a join xy b on a.y = b.y group by b.y",
 			ExpectedPlan: `
 Project
- ├─ columns: [a.x:1!null, b.y:5!null as s1, a.y:2!null as s2]
+ ├─ columns: [a.x:1!null, b.y:5!null->s1:7, a.y:2!null->s2:8]
  └─ GroupBy
      ├─ select: a.x:1!null, b.y:5!null, a.y:2!null
      ├─ group: b.y:5!null
@@ -454,7 +519,7 @@ Project
 			Query: "select y as x from xy",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null as x]
+ ├─ columns: [xy.y:2!null->x:4]
  └─ Table
      ├─ name: xy
      ├─ columns: [x y z]
@@ -577,7 +642,7 @@ SubqueryAlias
 			Query: "select x, sum(y) from xy group by x order by x - count(y)",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, sum(xy.y):4!null as sum(y)]
+ ├─ columns: [xy.x:1!null, sum(xy.y)->sum(y)]
  └─ Sort((xy.x:1!null - count(xy.y):5!null) ASC nullsFirst)
      └─ GroupBy
          ├─ select: COUNT(xy.y:2!null), SUM(xy.y:2!null), xy.x:1!null
@@ -593,7 +658,7 @@ Project
 			Query: "select sum(x) from xy group by x order by y",
 			ExpectedPlan: `
 Project
- ├─ columns: [sum(xy.x):4!null as sum(x)]
+ ├─ columns: [sum(xy.x)->sum(x)]
  └─ Sort(xy.y:2!null ASC nullsFirst)
      └─ GroupBy
          ├─ select: SUM(xy.x:1!null), xy.y:2!null
@@ -609,7 +674,7 @@ Project
 			Query: "SELECT y, count(x) FROM xy GROUP BY y ORDER BY count(x) DESC",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, count(xy.x):4!null as count(x)]
+ ├─ columns: [xy.y:2!null, count(xy.x)->count(x)]
  └─ Sort(count(xy.x):4!null DESC nullsFirst)
      └─ GroupBy
          ├─ select: COUNT(xy.x:1!null), xy.y:2!null
@@ -625,7 +690,7 @@ Project
 			Query: "select count(x) from xy",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(xy.x):4!null as count(x)]
+ ├─ columns: [count(xy.x)->count(x)]
  └─ GroupBy
      ├─ select: COUNT(xy.x:1!null)
      ├─ group: 
@@ -640,7 +705,7 @@ Project
 			Query: "SELECT y, count(x) FROM xy GROUP BY y ORDER BY y DESC",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, count(xy.x):4!null as count(x)]
+ ├─ columns: [xy.y:2!null, count(xy.x)->count(x)]
  └─ Sort(xy.y:2!null DESC nullsFirst)
      └─ GroupBy
          ├─ select: COUNT(xy.x:1!null), xy.y:2!null
@@ -656,7 +721,7 @@ Project
 			Query: "SELECT y, count(x) FROM xy GROUP BY y ORDER BY y",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, count(xy.x):4!null as count(x)]
+ ├─ columns: [xy.y:2!null, count(xy.x)->count(x)]
  └─ Sort(xy.y:2!null ASC nullsFirst)
      └─ GroupBy
          ├─ select: COUNT(xy.x:1!null), xy.y:2!null
@@ -672,7 +737,7 @@ Project
 			Query: "SELECT count(xy.x) AS count_1, xy.y + xy.z AS lx FROM xy GROUP BY xy.x + xy.z",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(xy.x):4!null as count_1, (xy.y:2!null + xy.z:3!null) as lx]
+ ├─ columns: [count(xy.x):4!null->count_1:5, (xy.y:2!null + xy.z:3!null)->lx:6]
  └─ GroupBy
      ├─ select: COUNT(xy.x:1!null), xy.y:2!null, xy.z:3!null
      ├─ group: (xy.x:1!null + xy.z:3!null)
@@ -687,7 +752,7 @@ Project
 			Query: "SELECT count(xy.x) AS count_1, xy.x + xy.z AS lx FROM xy GROUP BY xy.x + xy.z",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(xy.x):4!null as count_1, (xy.x:1!null + xy.z:3!null) as lx]
+ ├─ columns: [count(xy.x):4!null->count_1:5, (xy.x:1!null + xy.z:3!null)->lx:6]
  └─ GroupBy
      ├─ select: COUNT(xy.x:1!null), xy.x:1!null, xy.z:3!null
      ├─ group: (xy.x:1!null + xy.z:3!null)
@@ -715,7 +780,7 @@ Project
 			Query: "select count(*) from (select count(*) from xy) dt",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(1):6!null as count(*)]
+ ├─ columns: [count(1)->count(*)]
  └─ GroupBy
      ├─ select: COUNT(1 (bigint))
      ├─ group: 
@@ -727,7 +792,7 @@ Project
          ├─ colSet: (5)
          ├─ tableId: 2
          └─ Project
-             ├─ columns: [count(1):4!null as count(*)]
+             ├─ columns: [count(1)->count(*)]
              └─ GroupBy
                  ├─ select: COUNT(1 (bigint))
                  ├─ group: 
@@ -749,7 +814,7 @@ SubqueryAlias
  ├─ colSet: (6)
  ├─ tableId: 2
  └─ Project
-     ├─ columns: [count(1):4!null as s]
+     ├─ columns: [count(1):4!null->s:5]
      └─ GroupBy
          ├─ select: COUNT(1 (bigint))
          ├─ group: 
@@ -764,7 +829,7 @@ SubqueryAlias
 			Query: "SELECT count(*), x+y AS r FROM xy GROUP BY x, y",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(1):4!null as count(*), (xy.x:1!null + xy.y:2!null) as r]
+ ├─ columns: [count(1)->count(*), (xy.x:1!null + xy.y:2!null)->r:5]
  └─ GroupBy
      ├─ select: COUNT(1 (bigint)), xy.x:1!null, xy.y:2!null
      ├─ group: xy.x:1!null, xy.y:2!null
@@ -779,7 +844,7 @@ Project
 			Query: "SELECT count(*), x+y AS r FROM xy GROUP BY x+y",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(1):4!null as count(*), (xy.x:1!null + xy.y:2!null) as r]
+ ├─ columns: [count(1)->count(*), (xy.x:1!null + xy.y:2!null)->r:5]
  └─ GroupBy
      ├─ select: COUNT(1 (bigint)), xy.x:1!null, xy.y:2!null
      ├─ group: (xy.x:1!null + xy.y:2!null)
@@ -794,7 +859,7 @@ Project
 			Query: "SELECT count(*) FROM xy GROUP BY 1+2",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(1):4!null as count(*)]
+ ├─ columns: [count(1)->count(*)]
  └─ GroupBy
      ├─ select: COUNT(1 (bigint))
      ├─ group: (1 (tinyint) + 2 (tinyint))
@@ -809,7 +874,7 @@ Project
 			Query: "SELECT count(*), upper(x) FROM xy GROUP BY upper(x)",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(1):4!null as count(*), upper(xy.x) as upper(x)]
+ ├─ columns: [count(1)->count(*), upper(xy.x)->upper(x)]
  └─ GroupBy
      ├─ select: COUNT(1 (bigint)), xy.x:1!null
      ├─ group: upper(xy.x)
@@ -824,7 +889,7 @@ Project
 			Query: "SELECT y, count(*), z FROM xy GROUP BY 1, 3",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, count(1):4!null as count(*), xy.z:3!null]
+ ├─ columns: [xy.y:2!null, count(1)->count(*), xy.z:3!null]
  └─ GroupBy
      ├─ select: COUNT(1 (bigint)), xy.y:2!null, xy.z:3!null
      ├─ group: xy.y:2!null, xy.z:3!null
@@ -839,7 +904,7 @@ Project
 			Query: "SELECT x, sum(x) FROM xy group by 1 having avg(x) > 1 order by 1",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, sum(xy.x):4!null as sum(x)]
+ ├─ columns: [xy.x:1!null, sum(xy.x)->sum(x)]
  └─ Sort(xy.x:1!null ASC nullsFirst)
      └─ Having
          ├─ GreaterThan
@@ -859,7 +924,7 @@ Project
 			Query: "SELECT y, SUM(x) FROM xy GROUP BY y ORDER BY SUM(x) + 1 ASC",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, sum(xy.x):4!null as SUM(x)]
+ ├─ columns: [xy.y:2!null, sum(xy.x)->SUM(x)]
  └─ Sort((sum(xy.x):4!null + 1 (tinyint)) ASC nullsFirst)
      └─ GroupBy
          ├─ select: SUM(xy.x:1!null), xy.y:2!null
@@ -875,7 +940,7 @@ Project
 			Query: "SELECT y, SUM(x) FROM xy GROUP BY y ORDER BY COUNT(*) ASC",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, sum(xy.x):4!null as SUM(x)]
+ ├─ columns: [xy.y:2!null, sum(xy.x)->SUM(x)]
  └─ Sort(count(1):5!null ASC nullsFirst)
      └─ GroupBy
          ├─ select: COUNT(1 (bigint)), SUM(xy.x:1!null), xy.y:2!null
@@ -891,7 +956,7 @@ Project
 			Query: "SELECT y, SUM(x) FROM xy GROUP BY y ORDER BY SUM(x) % 2, SUM(x), AVG(x) ASC",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, sum(xy.x):4!null as SUM(x)]
+ ├─ columns: [xy.y:2!null, sum(xy.x)->SUM(x)]
  └─ Sort((sum(xy.x):4!null % 2 (tinyint)) ASC nullsFirst, sum(xy.x):4!null ASC nullsFirst, avg(xy.x):7 ASC nullsFirst)
      └─ GroupBy
          ├─ select: AVG(xy.x:1!null), SUM(xy.x:1!null), xy.y:2!null
@@ -907,7 +972,7 @@ Project
 			Query: "SELECT y, SUM(x) FROM xy GROUP BY y ORDER BY AVG(x) ASC",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.y:2!null, sum(xy.x):4!null as SUM(x)]
+ ├─ columns: [xy.y:2!null, sum(xy.x)->SUM(x)]
  └─ Sort(avg(xy.x):5 ASC nullsFirst)
      └─ GroupBy
          ├─ select: AVG(xy.x:1!null), SUM(xy.x:1!null), xy.y:2!null
@@ -923,8 +988,8 @@ Project
 			Query: "SELECT x, sum(x) FROM xy group by 1 having avg(x) > 1 order by 2",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, sum(xy.x):4!null as sum(x)]
- └─ Sort(sum(xy.x):4!null as sum(x) ASC nullsFirst)
+ ├─ columns: [xy.x:1!null, sum(xy.x)->sum(x)]
+ └─ Sort(sum(xy.x)->sum(x) ASC nullsFirst)
      └─ Having
          ├─ GreaterThan
          │   ├─ avg(xy.x):5
@@ -943,7 +1008,7 @@ Project
 			Query: "SELECT x, sum(y * z) FROM xy group by x having sum(y * z) > 1",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, sum((xy.y * xy.z)):4!null as sum(y * z)]
+ ├─ columns: [xy.x:1!null, sum((xy.y * xy.z))->sum(y * z)]
  └─ Having
      ├─ GreaterThan
      │   ├─ sum((xy.y * xy.z)):4!null
@@ -964,19 +1029,13 @@ Project
 Project
  ├─ columns: [Subquery
  │   ├─ cacheable: false
- │   ├─ alias-string: select u from uv where x = u
  │   └─ Project
- │       ├─ columns: [uv.u:4!null]
+ │       ├─ columns: [uv.u]
  │       └─ Filter
- │           ├─ Eq
- │           │   ├─ xy.x:1!null
- │           │   └─ uv.u:4!null
+ │           ├─ (xy.x = uv.u)
  │           └─ Table
- │               ├─ name: uv
- │               ├─ columns: [u v w]
- │               ├─ colSet: (4-6)
- │               └─ tableId: 2
- │   as (select u from uv where x = u)]
+ │               └─ name: uv
+ │  ->(select u from uv where x = u)]
  └─ GroupBy
      ├─ select: 
      ├─ group: Subquery
@@ -1020,7 +1079,7 @@ Project
      │           ├─ colSet: (8)
      │           ├─ tableId: 3
      │           └─ Project
-     │               ├─ columns: [uv.u:4!null as u]
+     │               ├─ columns: [uv.u:4!null->u:7]
      │               └─ Filter
      │                   ├─ Eq
      │                   │   ├─ uv.v:5!null
@@ -1056,7 +1115,7 @@ Project
      │           ├─ colSet: (8)
      │           ├─ tableId: 3
      │           └─ Project
-     │               ├─ columns: [uv.u:4!null as u]
+     │               ├─ columns: [uv.u:4!null->u:7]
      │               └─ Filter
      │                   ├─ Eq
      │                   │   ├─ uv.v:5!null
@@ -1079,26 +1138,18 @@ Project
 Project
  ├─ columns: [Subquery
  │   ├─ cacheable: false
- │   ├─ alias-string: select dt.z from (select uv.u as z from uv where uv.v = xy.y) as dt
  │   └─ SubqueryAlias
  │       ├─ name: dt
  │       ├─ outerVisibility: false
  │       ├─ isLateral: false
  │       ├─ cacheable: false
- │       ├─ colSet: (8)
- │       ├─ tableId: 3
  │       └─ Project
- │           ├─ columns: [uv.u:4!null as z]
+ │           ├─ columns: [uv.u as z]
  │           └─ Filter
- │               ├─ Eq
- │               │   ├─ uv.v:5!null
- │               │   └─ xy.y:2!null
+ │               ├─ (uv.v = xy.y)
  │               └─ Table
- │                   ├─ name: uv
- │                   ├─ columns: [u v w]
- │                   ├─ colSet: (4-6)
- │                   └─ tableId: 2
- │   as (SELECT dt.z FROM (SELECT uv.u AS z FROM uv WHERE uv.v = xy.y) dt)]
+ │                   └─ name: uv
+ │  ->(SELECT dt.z FROM (SELECT uv.u AS z FROM uv WHERE uv.v = xy.y) dt)]
  └─ Table
      ├─ name: xy
      ├─ columns: [x y z]
@@ -1112,31 +1163,23 @@ Project
 Project
  ├─ columns: [Subquery
  │   ├─ cacheable: false
- │   ├─ alias-string: select max(dt.z) from (select uv.u as z from uv where uv.v = xy.y) as dt
  │   └─ Project
- │       ├─ columns: [max(dt.z):9!null]
+ │       ├─ columns: [max(dt.z)]
  │       └─ GroupBy
- │           ├─ select: MAX(dt.z:8!null)
- │           ├─ group: 
+ │           ├─ SelectedExprs(MAX(dt.z))
+ │           ├─ Grouping()
  │           └─ SubqueryAlias
  │               ├─ name: dt
  │               ├─ outerVisibility: false
  │               ├─ isLateral: false
  │               ├─ cacheable: false
- │               ├─ colSet: (8)
- │               ├─ tableId: 3
  │               └─ Project
- │                   ├─ columns: [uv.u:4!null as z]
+ │                   ├─ columns: [uv.u as z]
  │                   └─ Filter
- │                       ├─ Eq
- │                       │   ├─ uv.v:5!null
- │                       │   └─ xy.y:2!null
+ │                       ├─ (uv.v = xy.y)
  │                       └─ Table
- │                           ├─ name: uv
- │                           ├─ columns: [u v w]
- │                           ├─ colSet: (4-6)
- │                           └─ tableId: 2
- │   as (SELECT max(dt.z) FROM (SELECT uv.u AS z FROM uv WHERE uv.v = xy.y) dt)]
+ │                           └─ name: uv
+ │  ->(SELECT max(dt.z) FROM (SELECT uv.u AS z FROM uv WHERE uv.v = xy.y) dt)]
  └─ Table
      ├─ name: xy
      ├─ columns: [x y z]
@@ -1150,31 +1193,23 @@ Project
 Project
  ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, Subquery
  │   ├─ cacheable: false
- │   ├─ alias-string: select max(dt.u) from (select uv.u as u from uv where uv.v = xy.y) as dt
  │   └─ Project
- │       ├─ columns: [max(dt.u):9!null]
+ │       ├─ columns: [max(dt.u)]
  │       └─ GroupBy
- │           ├─ select: MAX(dt.u:8!null)
- │           ├─ group: 
+ │           ├─ SelectedExprs(MAX(dt.u))
+ │           ├─ Grouping()
  │           └─ SubqueryAlias
  │               ├─ name: dt
  │               ├─ outerVisibility: false
  │               ├─ isLateral: false
  │               ├─ cacheable: false
- │               ├─ colSet: (8)
- │               ├─ tableId: 3
  │               └─ Project
- │                   ├─ columns: [uv.u:4!null as u]
+ │                   ├─ columns: [uv.u as u]
  │                   └─ Filter
- │                       ├─ Eq
- │                       │   ├─ uv.v:5!null
- │                       │   └─ xy.y:2!null
+ │                       ├─ (uv.v = xy.y)
  │                       └─ Table
- │                           ├─ name: uv
- │                           ├─ columns: [u v w]
- │                           ├─ colSet: (4-6)
- │                           └─ tableId: 2
- │   as (SELECT max(dt.u) FROM (SELECT uv.u AS u FROM uv WHERE uv.v = xy.y) dt)]
+ │                           └─ name: uv
+ │  ->(SELECT max(dt.u) FROM (SELECT uv.u AS u FROM uv WHERE uv.v = xy.y) dt)]
  └─ Table
      ├─ name: xy
      ├─ columns: [x y z]
@@ -1186,10 +1221,10 @@ Project
 			Query: "select x, x as y from xy order by y",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, xy.x:1!null as y]
- └─ Sort(xy.x:1!null as y ASC nullsFirst)
+ ├─ columns: [xy.x:1!null, xy.x:1!null->y:4]
+ └─ Sort(y:4!null ASC nullsFirst)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null as y]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null->y:4]
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -1201,10 +1236,10 @@ Project
 			Query: "select x, y as x from xy order by y",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, xy.y:2!null as x]
+ ├─ columns: [xy.x:1!null, xy.y:2!null->x:4]
  └─ Sort(xy.y:2!null ASC nullsFirst)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.y:2!null as x]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.y:2!null->x:4]
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -1216,10 +1251,10 @@ Project
 			Query: "select sum(x) as `count(x)` from xy order by `count(x)`;",
 			ExpectedPlan: `
 Project
- ├─ columns: [sum(xy.x):4!null as count(x)]
- └─ Sort(sum(xy.x):4!null as count(x) ASC nullsFirst)
+ ├─ columns: [sum(xy.x):4!null->count(x):5]
+ └─ Sort(count(x):5!null ASC nullsFirst)
      └─ Project
-         ├─ columns: [sum(xy.x):4!null, sum(xy.x):4!null as count(x)]
+         ├─ columns: [sum(xy.x):4!null, sum(xy.x):4!null->count(x):5]
          └─ GroupBy
              ├─ select: SUM(xy.x:1!null)
              ├─ group: 
@@ -1234,16 +1269,16 @@ Project
 			Query: "select (1+x) s from xy group by 1 having s = 1",
 			ExpectedPlan: `
 Project
- ├─ columns: [(1 (tinyint) + xy.x:1!null) as s]
+ ├─ columns: [(1 (tinyint) + xy.x:1!null)->s:4]
  └─ Having
      ├─ Eq
      │   ├─ s:4!null
      │   └─ 1 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, (1 (tinyint) + xy.x:1!null) as s]
+         ├─ columns: [xy.x:1!null, (1 (tinyint) + xy.x:1!null)->s:4]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: (1 (tinyint) + xy.x:1!null) as s
+             ├─ group: (1 (tinyint) + xy.x:1!null)->s:4
              └─ Table
                  ├─ name: xy
                  ├─ columns: [x y z]
@@ -1255,16 +1290,16 @@ Project
 			Query: "select (1+x) s from xy join uv on (1+x) = (1+u) group by 1 having s = 1",
 			ExpectedPlan: `
 Project
- ├─ columns: [(1 (tinyint) + xy.x:1!null) as s]
+ ├─ columns: [(1 (tinyint) + xy.x:1!null)->s:7]
  └─ Having
      ├─ Eq
      │   ├─ s:7!null
      │   └─ 1 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, (1 (tinyint) + xy.x:1!null) as s]
+         ├─ columns: [xy.x:1!null, (1 (tinyint) + xy.x:1!null)->s:7]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: (1 (tinyint) + xy.x:1!null) as s
+             ├─ group: (1 (tinyint) + xy.x:1!null)->s:7
              └─ InnerJoin
                  ├─ Eq
                  │   ├─ (1 (tinyint) + xy.x:1!null)
@@ -1291,10 +1326,10 @@ Project
 			from xy`,
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, (xy.x:1!null * xy.y:2!null) as x*y, row_number() over ( partition by xy.x rows between unbounded preceding and unbounded following):4!null as row_num1, sum
+ ├─ columns: [xy.x:1!null, (xy.x * xy.y)->x*y, row_number() over ( partition by xy.x rows between unbounded preceding and unbounded following):4!null->row_num1:5, sum
  │   ├─ over ( partition by xy.y order by xy.x asc)
  │   └─ xy.x
- │  :6!null as sum]
+ │  :6!null->sum:7]
  └─ Window
      ├─ row_number() over ( partition by xy.x ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
      ├─ SUM
@@ -1318,10 +1353,10 @@ Project
 			having x > 1;`,
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + 1 (tinyint)) as x, sum
+ ├─ columns: [(xy.x:1!null + 1 (tinyint))->x:4, sum
  │   ├─ over ( partition by xy.y order by xy.x asc)
  │   └─ xy.x
- │  :5!null as sum]
+ │  :5!null->sum:6]
  └─ Having
      ├─ GreaterThan
      │   ├─ x:4!null
@@ -1330,10 +1365,10 @@ Project
          ├─ columns: [sum
          │   ├─ over ( partition by xy.y order by xy.x asc)
          │   └─ xy.x
-         │  :5!null, xy.x:1!null, (xy.x:1!null + 1 (tinyint)) as x, sum
+         │  :5!null, xy.x:1!null, (xy.x:1!null + 1 (tinyint))->x:4, sum
          │   ├─ over ( partition by xy.y order by xy.x asc)
          │   └─ xy.x
-         │  :5!null as sum]
+         │  :5!null->sum:6]
          └─ Window
              ├─ SUM
              │   ├─ over ( partition by xy.y order by xy.x ASC)
@@ -1357,7 +1392,7 @@ Project
 			WINDOW w AS (PARTITION BY y ORDER BY x);`,
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, row_number() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):4!null as row_number, rank() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):6!null as rank, dense_rank() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):8!null as dense_rank]
+ ├─ columns: [xy.x:1!null, row_number() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):4!null->row_number:5, rank() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):6!null->rank:7, dense_rank() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):8!null->dense_rank:9]
  └─ Window
      ├─ row_number() over ( partition by xy.y order by xy.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
      ├─ rank() over ( partition by xy.y order by xy.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
@@ -1374,7 +1409,7 @@ Project
 			Query: "select x, row_number() over (w3) from xy window w1 as (w2), w2 as (), w3 as (w1)",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, row_number() over ( rows between unbounded preceding and unbounded following):4!null as row_number() over (w3)]
+ ├─ columns: [xy.x:1!null, row_number() over ( rows between unbounded preceding and unbounded following)->row_number() over (w3)]
  └─ Window
      ├─ row_number() over ( ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
      ├─ xy.x:1!null
@@ -1389,7 +1424,7 @@ Project
 			Query: "SELECT x, first_value(z) over (partition by y) FROM xy order by x*y,x",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, first_value(xy.z) over ( partition by xy.y rows between unbounded preceding and unbounded following):4!null as first_value(z) over (partition by y)]
+ ├─ columns: [xy.x:1!null, first_value(xy.z) over ( partition by xy.y rows between unbounded preceding and unbounded following)->first_value(z) over (partition by y)]
  └─ Sort((xy.x:1!null * xy.y:2!null) ASC nullsFirst, xy.x:1!null ASC nullsFirst)
      └─ Window
          ├─ first_value(xy.z) over ( partition by xy.y ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
@@ -1406,7 +1441,7 @@ Project
 			Query: "SELECT x, avg(x) FROM xy group by x order by sum(x)",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, avg(xy.x):4 as avg(x)]
+ ├─ columns: [xy.x:1!null, avg(xy.x)->avg(x)]
  └─ Sort(sum(xy.x):5!null ASC nullsFirst)
      └─ GroupBy
          ├─ select: AVG(xy.x:1!null), SUM(xy.x:1!null), xy.x:1!null
@@ -1422,7 +1457,7 @@ Project
 			Query: "SELECT x, avg(x) FROM xy group by x order by avg(x)",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, avg(xy.x):4 as avg(x)]
+ ├─ columns: [xy.x:1!null, avg(xy.x)->avg(x)]
  └─ Sort(avg(xy.x):4 ASC nullsFirst)
      └─ GroupBy
          ├─ select: AVG(xy.x:1!null), xy.x:1!null
@@ -1438,7 +1473,7 @@ Project
 			Query: "SELECT x, avg(x) FROM xy group by x order by avg(y)",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, avg(xy.x):4 as avg(x)]
+ ├─ columns: [xy.x:1!null, avg(xy.x)->avg(x)]
  └─ Sort(avg(xy.y):5 ASC nullsFirst)
      └─ GroupBy
          ├─ select: AVG(xy.x:1!null), AVG(xy.y:2!null), xy.x:1!null
@@ -1454,7 +1489,7 @@ Project
 			Query: "SELECT x, avg(x) FROM xy group by x order by avg(y)+y",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, avg(xy.x):4 as avg(x)]
+ ├─ columns: [xy.x:1!null, avg(xy.x)->avg(x)]
  └─ Sort((avg(xy.y):5 + xy.y:2!null) ASC nullsFirst)
      └─ GroupBy
          ├─ select: AVG(xy.x:1!null), AVG(xy.y:2!null), xy.x:1!null, xy.y:2!null
@@ -1470,7 +1505,7 @@ Project
 			Query: "SELECT x, lead(x) over (partition by y order by x) FROM xy order by x;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, lead(xy.x, 1) over ( partition by xy.y order by xy.x asc):4 as lead(x) over (partition by y order by x)]
+ ├─ columns: [xy.x:1!null, lead(xy.x, 1) over ( partition by xy.y order by xy.x asc)->lead(x) over (partition by y order by x)]
  └─ Sort(xy.x:1!null ASC nullsFirst)
      └─ Window
          ├─ lead(xy.x, 1) over ( partition by xy.y order by xy.x ASC)
@@ -1486,11 +1521,7 @@ Project
 			Query: "SELECT CAST(10.56789 as CHAR(3));",
 			ExpectedPlan: `
 Project
- ├─ columns: [convert
- │   ├─ type: char
- │   ├─ typeLength: 3
- │   └─ 10.56789 (decimal(7,5))
- │   as CAST(10.56789 as CHAR(3))]
+ ├─ columns: [convert(10.56789, char(3))->CAST(10.56789 as CHAR(3))]
  └─ Table
      ├─ name: 
      ├─ columns: []
@@ -1502,13 +1533,13 @@ Project
 			Query: "select x+y as X from xy where x < 1 having x > 1",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + xy.y:2!null) as X]
+ ├─ columns: [(xy.x:1!null + xy.y:2!null)->X:4]
  └─ Having
      ├─ GreaterThan
      │   ├─ x:4!null
      │   └─ 1 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + xy.y:2!null) as X]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + xy.y:2!null)->X:4]
          └─ Filter
              ├─ LessThan
              │   ├─ xy.x:1!null
@@ -1527,7 +1558,7 @@ Project
  ├─ columns: [xy.x:1!null, count
  │   ├─ over ( order by xy.y asc)
  │   └─ 1
- │  :4!null as count(*) over (order by y)]
+ │  ->count(*) over (order by y)]
  └─ Sort(xy.x:1!null ASC nullsFirst)
      └─ Window
          ├─ COUNT
@@ -1545,7 +1576,7 @@ Project
 			Query: "select x+y as s from xy having exists (select * from xy where y = s)",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + xy.y:2!null) as s]
+ ├─ columns: [(xy.x:1!null + xy.y:2!null)->s:4]
  └─ Having
      ├─ EXISTS Subquery
      │   ├─ cacheable: false
@@ -1562,7 +1593,7 @@ Project
      │               ├─ colSet: (5-7)
      │               └─ tableId: 2
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + xy.y:2!null) as s]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + xy.y:2!null)->s:4]
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -1574,13 +1605,13 @@ Project
 			Query: "select x, count(x) as cnt from xy group by x having x > 1",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, count(xy.x):4!null as cnt]
+ ├─ columns: [xy.x:1!null, count(xy.x):4!null->cnt:5]
  └─ Having
      ├─ GreaterThan
      │   ├─ xy.x:0!null
      │   └─ 1 (bigint)
      └─ Project
-         ├─ columns: [count(xy.x):4!null, xy.x:1!null, count(xy.x):4!null as cnt]
+         ├─ columns: [count(xy.x):4!null, xy.x:1!null, count(xy.x):4!null->cnt:5]
          └─ GroupBy
              ├─ select: COUNT(xy.x:1!null), xy.x:1!null
              ├─ group: xy.x:1!null
@@ -1607,13 +1638,13 @@ Project
      │   ├─ cacheable: false
      │   ├─ alias-string: select count(u) count_1 from uv where y = u group by u having count(u) > 1
      │   └─ Project
-     │       ├─ columns: [count(uv.u):7!null as count_1]
+     │       ├─ columns: [count(uv.u):7!null->count_1:8]
      │       └─ Having
      │           ├─ GreaterThan
      │           │   ├─ count(uv.u):7!null
      │           │   └─ 1 (bigint)
      │           └─ Project
-     │               ├─ columns: [count(uv.u):7!null, uv.u:4!null, count(uv.u):7!null as count_1]
+     │               ├─ columns: [count(uv.u):7!null, uv.u:4!null, count(uv.u):7!null->count_1:8]
      │               └─ GroupBy
      │                   ├─ select: COUNT(uv.u:4!null), uv.u:4!null
      │                   ├─ group: uv.u:4!null
@@ -1659,7 +1690,7 @@ SubqueryAlias
  └─ RecursiveCTE
      └─ Union all
          ├─ Project
-         │   ├─ columns: [1 (tinyint) as depth, NULL (null) as foo]
+         │   ├─ columns: [1 (tinyint)->depth:6, NULL (null)->foo:7]
          │   └─ SubqueryAlias
          │       ├─ name: rt
          │       ├─ outerVisibility: false
@@ -1670,21 +1701,21 @@ SubqueryAlias
          │       └─ RecursiveCTE
          │           └─ Union all
          │               ├─ Project
-         │               │   ├─ columns: [1 (tinyint) as foo]
+         │               │   ├─ columns: [1 (tinyint)->foo:1]
          │               │   └─ Table
          │               │       ├─ name: 
          │               │       ├─ columns: []
          │               │       ├─ colSet: ()
          │               │       └─ tableId: 0
          │               └─ Project
-         │                   ├─ columns: [(rt.foo:3!null + 1 (tinyint)) as foo]
+         │                   ├─ columns: [(rt.foo:3!null + 1 (tinyint))->foo:4]
          │                   └─ Filter
          │                       ├─ LessThan
          │                       │   ├─ rt.foo:3!null
          │                       │   └─ 5 (bigint)
          │                       └─ RecursiveTable(rt)
          └─ Project
-             ├─ columns: [(ladder.depth:10!null + 1 (tinyint)) as depth, rt.foo:12!null]
+             ├─ columns: [(ladder.depth:10!null + 1 (tinyint))->depth:13, rt.foo:12!null]
              └─ Filter
                  ├─ Eq
                  │   ├─ ladder.foo:11
@@ -1701,14 +1732,14 @@ SubqueryAlias
                          └─ RecursiveCTE
                              └─ Union all
                                  ├─ Project
-                                 │   ├─ columns: [1 (tinyint) as foo]
+                                 │   ├─ columns: [1 (tinyint)->foo:1]
                                  │   └─ Table
                                  │       ├─ name: 
                                  │       ├─ columns: []
                                  │       ├─ colSet: ()
                                  │       └─ tableId: 0
                                  └─ Project
-                                     ├─ columns: [(rt.foo:3!null + 1 (tinyint)) as foo]
+                                     ├─ columns: [(rt.foo:3!null + 1 (tinyint))->foo:4]
                                      └─ Filter
                                          ├─ LessThan
                                          │   ├─ rt.foo:3!null
@@ -1720,7 +1751,7 @@ SubqueryAlias
 			Query: "select x as cOl, y as COL FROM xy",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as cOl, xy.y:2!null as COL]
+ ├─ columns: [xy.x:1!null->cOl:4, xy.y:2!null->COL:5]
  └─ Table
      ├─ name: xy
      ├─ columns: [x y z]
@@ -1732,26 +1763,19 @@ Project
 			Query: "SELECT x as alias1, (SELECT alias1+1 group by alias1 having alias1 > 0) FROM xy where x > 1;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as alias1, Subquery
+ ├─ columns: [xy.x:1!null->alias1:4, Subquery
  │   ├─ cacheable: false
- │   ├─ alias-string: select alias1 + 1 group by alias1 having alias1 > 0
  │   └─ Project
- │       ├─ columns: [(alias1:4!null + 1 (tinyint)) as alias1+1]
- │       └─ Having
- │           ├─ GreaterThan
- │           │   ├─ alias1:4!null
- │           │   └─ 0 (bigint)
+ │       ├─ columns: [(alias1 + 1) as alias1+1]
+ │       └─ Having((alias1 > 0))
  │           └─ GroupBy
- │               ├─ select: alias1:4!null
- │               ├─ group: xy.x:1!null as alias1
+ │               ├─ SelectedExprs(alias1)
+ │               ├─ Grouping(xy.x as alias1)
  │               └─ Table
- │                   ├─ name: 
- │                   ├─ columns: []
- │                   ├─ colSet: ()
- │                   └─ tableId: 0
- │   as (SELECT alias1+1 group by alias1 having alias1 > 0)]
+ │                   └─ name: 
+ │  ->(SELECT alias1+1 group by alias1 having alias1 > 0)]
  └─ Project
-     ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null as alias1]
+     ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null->alias1:4]
      └─ Filter
          ├─ GreaterThan
          │   ├─ xy.x:1!null
@@ -1767,7 +1791,7 @@ Project
 			Query: "select count(*) from xy group by x having count(*) < x",
 			ExpectedPlan: `
 Project
- ├─ columns: [count(1):4!null as count(*)]
+ ├─ columns: [count(1)->count(*)]
  └─ Having
      ├─ LessThan
      │   ├─ count(1):4!null
@@ -1786,7 +1810,7 @@ Project
 			Query: "select - SUM(DISTINCT - - 71) as col2 from xy cor0",
 			ExpectedPlan: `
 Project
- ├─ columns: [-sum(distinct 71) as col2]
+ ├─ columns: [-sum(distinct 71)->col2:5]
  └─ GroupBy
      ├─ select: SUM(DISTINCT 71)
      ├─ group: 
@@ -1802,10 +1826,10 @@ Project
 			Query: "select x as y, y from xy s order by x desc",
 			ExpectedPlan: `
 Project
- ├─ columns: [s.x:1!null as y, s.y:2!null]
+ ├─ columns: [s.x:1!null->y:4, s.y:2!null]
  └─ Sort(s.x:1!null DESC nullsFirst)
      └─ Project
-         ├─ columns: [s.x:1!null, s.y:2!null, s.z:3!null, s.x:1!null as y]
+         ├─ columns: [s.x:1!null, s.y:2!null, s.z:3!null, s.x:1!null->y:4]
          └─ TableAlias(s)
              └─ Table
                  ├─ name: xy
@@ -1818,19 +1842,15 @@ Project
 			Query: "select x+1 as x, (select x) from xy;",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + 1 (tinyint)) as x, Subquery
+ ├─ columns: [(xy.x:1!null + 1 (tinyint))->x:4, Subquery
  │   ├─ cacheable: false
- │   ├─ alias-string: select x
  │   └─ Project
- │       ├─ columns: [xy.x:1!null]
+ │       ├─ columns: [xy.x]
  │       └─ Table
- │           ├─ name: 
- │           ├─ columns: []
- │           ├─ colSet: ()
- │           └─ tableId: 0
- │   as (select x)]
+ │           └─ name: 
+ │  ->(select x)]
  └─ Project
-     ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + 1 (tinyint)) as x]
+     ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + 1 (tinyint))->x:4]
      └─ Table
          ├─ name: xy
          ├─ columns: [x y z]
@@ -1848,7 +1868,7 @@ Project
 		ORDER BY COUNT(*) ASC, fi`,
 			ExpectedPlan: `
 Project
- ├─ columns: [t.fi:5!null, count(1):6!null as COUNT(*)]
+ ├─ columns: [t.fi:5!null, count(1)->COUNT(*)]
  └─ Sort(count(1):6!null ASC nullsFirst, t.fi:5!null ASC nullsFirst)
      └─ GroupBy
          ├─ select: COUNT(1 (bigint)), t.fi:5!null
@@ -1861,7 +1881,7 @@ Project
              ├─ colSet: (5)
              ├─ tableId: 2
              └─ Project
-                 ├─ columns: [tbl.x:1!null as fi]
+                 ├─ columns: [tbl.x:1!null->fi:4]
                  └─ TableAlias(tbl)
                      └─ Table
                          ├─ name: xy
@@ -1876,7 +1896,7 @@ Project
 Union distinct
  ├─ sortFields: k:4!null
  ├─ Project
- │   ├─ columns: [xy.y:2!null as k]
+ │   ├─ columns: [xy.y:2!null->k:4]
  │   └─ Table
  │       ├─ name: xy
  │       ├─ columns: [x y z]
@@ -1898,7 +1918,7 @@ Project
  ├─ columns: [sum
  │   ├─ over ( partition by xy.z order by xy.x asc rows between unbounded preceding and unbounded following)
  │   └─ xy.y
- │  :4!null as sum(y) over w]
+ │  ->sum(y) over w]
  └─ Sort(xy.x:1!null ASC nullsFirst)
      └─ Window
          ├─ SUM
@@ -1916,7 +1936,7 @@ Project
 			Query: "select 1 as a, (select a) as a",
 			ExpectedPlan: `
 Project
- ├─ columns: [1 (tinyint) as a, Subquery
+ ├─ columns: [1 (tinyint)->a:1, Subquery
  │   ├─ cacheable: false
  │   ├─ alias-string: select a
  │   └─ Project
@@ -1926,9 +1946,9 @@ Project
  │           ├─ columns: []
  │           ├─ colSet: ()
  │           └─ tableId: 0
- │   as a]
+ │  ->a:2]
  └─ Project
-     ├─ columns: [dual.:0!null, 1 (tinyint) as a, Subquery
+     ├─ columns: [dual.:0!null, 1 (tinyint)->a:1, Subquery
      │   ├─ cacheable: false
      │   ├─ alias-string: select a
      │   └─ Project
@@ -1938,7 +1958,7 @@ Project
      │           ├─ columns: []
      │           ├─ colSet: ()
      │           └─ tableId: 0
-     │   as a]
+     │  ->a:2]
      └─ Table
          ├─ name: 
          ├─ columns: []
@@ -1950,7 +1970,7 @@ Project
 			Query: "SELECT max(x), (select max(dt.a) from (SELECT x as a) as dt(a)) as a1 from xy group by a1;",
 			ExpectedPlan: `
 Project
- ├─ columns: [max(xy.x):4!null as max(x), Subquery
+ ├─ columns: [max(xy.x)->max(x), Subquery
  │   ├─ cacheable: false
  │   ├─ alias-string: select max(dt.a) from (select x as a) as dt (a)
  │   └─ Project
@@ -1966,13 +1986,13 @@ Project
  │               ├─ colSet: (6)
  │               ├─ tableId: 2
  │               └─ Project
- │                   ├─ columns: [xy.x:1!null as a]
+ │                   ├─ columns: [xy.x:1!null->a:5]
  │                   └─ Table
  │                       ├─ name: 
  │                       ├─ columns: []
  │                       ├─ colSet: ()
  │                       └─ tableId: 0
- │   as a1]
+ │  ->a1:8]
  └─ Project
      ├─ columns: [max(xy.x):4!null, Subquery
      │   ├─ cacheable: false
@@ -1990,13 +2010,13 @@ Project
      │               ├─ colSet: (6)
      │               ├─ tableId: 2
      │               └─ Project
-     │                   ├─ columns: [xy.x:1!null as a]
+     │                   ├─ columns: [xy.x:1!null->a:5]
      │                   └─ Table
      │                       ├─ name: 
      │                       ├─ columns: []
      │                       ├─ colSet: ()
      │                       └─ tableId: 0
-     │   as a1]
+     │  ->a1:8]
      └─ GroupBy
          ├─ select: MAX(xy.x:1!null)
          ├─ group: Subquery
@@ -2015,13 +2035,13 @@ Project
          │               ├─ colSet: (6)
          │               ├─ tableId: 2
          │               └─ Project
-         │                   ├─ columns: [xy.x:1!null as a]
+         │                   ├─ columns: [xy.x:1!null->a:5]
          │                   └─ Table
          │                       ├─ name: 
          │                       ├─ columns: []
          │                       ├─ colSet: ()
          │                       └─ tableId: 0
-         │   as a1
+         │  ->a1:8
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -2033,7 +2053,7 @@ Project
 			Query: "select x as s, y as s from xy",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as s, xy.y:2!null as s]
+ ├─ columns: [xy.x:1!null->s:4, xy.y:2!null->s:5]
  └─ Table
      ├─ name: xy
      ├─ columns: [x y z]
@@ -2075,12 +2095,12 @@ Create table myTable
 			Query: "SELECT x as y FROM xy GROUP BY x HAVING AVG(-y) IS NOT NULL",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as y]
+ ├─ columns: [xy.x:1!null->y:4]
  └─ Having
      ├─ NOT
      │   └─ avg(-xy.y):5 IS NULL
      └─ Project
-         ├─ columns: [avg(-xy.y):5, xy.x:1!null, xy.y:2!null, xy.x:1!null as y]
+         ├─ columns: [avg(-xy.y):5, xy.x:1!null, xy.y:2!null, xy.x:1!null->y:4]
          └─ GroupBy
              ├─ select: AVG(-xy.y), xy.x:1!null, xy.y:2!null
              ├─ group: xy.x:1!null
@@ -2095,16 +2115,16 @@ Project
 			Query: "select x as xx from xy group by xx having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xx:4!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.x:1!null->xx:4]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: xy.x:1!null as xx
+             ├─ group: xy.x:1!null->xx:4
              └─ Table
                  ├─ name: xy
                  ├─ columns: [x y z]
@@ -2116,13 +2136,13 @@ Project
 			Query: "select x as xx from xy having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xx:4!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null->xx:4]
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -2134,16 +2154,16 @@ Project
 			Query: "select x as xx from xy group by xx having x = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.x:1!null->xx:4]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: xy.x:1!null as xx
+             ├─ group: xy.x:1!null->xx:4
              └─ Table
                  ├─ name: xy
                  ├─ columns: [x y z]
@@ -2155,13 +2175,13 @@ Project
 			Query: "select x as xx from xy having x = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null->xx:4]
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -2173,16 +2193,16 @@ Project
 			Query: "select x + 1 as xx from xy group by xx having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + 1 (tinyint)) as xx]
+ ├─ columns: [(xy.x:1!null + 1 (tinyint))->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xx:4!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, (xy.x:1!null + 1 (tinyint)) as xx]
+         ├─ columns: [xy.x:1!null, (xy.x:1!null + 1 (tinyint))->xx:4]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: (xy.x:1!null + 1 (tinyint)) as xx
+             ├─ group: (xy.x:1!null + 1 (tinyint))->xx:4
              └─ Table
                  ├─ name: xy
                  ├─ columns: [x y z]
@@ -2194,13 +2214,13 @@ Project
 			Query: "select x + 1 as xx from xy having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + 1 (tinyint)) as xx]
+ ├─ columns: [(xy.x:1!null + 1 (tinyint))->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xx:4!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + 1 (tinyint)) as xx]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, (xy.x:1!null + 1 (tinyint))->xx:4]
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -2212,13 +2232,13 @@ Project
 			Query: "select x as xx from xy group by x having x = xx;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ xx:4!null
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.x:1!null->xx:4]
          └─ GroupBy
              ├─ select: xy.x:1!null
              ├─ group: xy.x:1!null
@@ -2233,16 +2253,16 @@ Project
 			Query: "select x as xx from xy group by xx having x = xx;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ xx:4!null
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.x:1!null->xx:4]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: xy.x:1!null as xx
+             ├─ group: xy.x:1!null->xx:4
              └─ Table
                  ├─ name: xy
                  ├─ columns: [x y z]
@@ -2254,16 +2274,16 @@ Project
 			Query: "select x as xx from xy group by x, xx having x = xx;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ xx:4!null
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.x:1!null->xx:4]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: xy.x:1!null, xy.x:1!null as xx
+             ├─ group: xy.x:1!null, xy.x:1!null->xx:4
              └─ Table
                  ├─ name: xy
                  ├─ columns: [x y z]
@@ -2275,13 +2295,13 @@ Project
 			Query: "select x as xx from xy having x = xx;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:4]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ xx:4!null
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, xy.x:1!null->xx:4]
          └─ Table
              ├─ name: xy
              ├─ columns: [x y z]
@@ -2293,13 +2313,13 @@ Project
 			Query: "select -x as y from xy group by x, y having -x > y;",
 			ExpectedPlan: `
 Project
- ├─ columns: [-xy.x as y]
+ ├─ columns: [-xy.x->y:4]
  └─ Having
      ├─ GreaterThan
      │   ├─ -xy.x
      │   └─ xy.y:2!null
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, -xy.x as y]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, -xy.x->y:4]
          └─ GroupBy
              ├─ select: xy.x:1!null, xy.y:2!null
              ├─ group: xy.x:1!null, xy.y:2!null
@@ -2314,16 +2334,16 @@ Project
 			Query: "select x as xx from xy join uv on (x = u) group by xx having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:7]
  └─ Having
      ├─ Eq
      │   ├─ xx:7!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.x:1!null->xx:7]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: xy.x:1!null as xx
+             ├─ group: xy.x:1!null->xx:7
              └─ InnerJoin
                  ├─ Eq
                  │   ├─ xy.x:1!null
@@ -2344,13 +2364,13 @@ Project
 			Query: "select x as xx from xy join uv on (x = u) having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:7]
  └─ Having
      ├─ Eq
      │   ├─ xx:7!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, uv.u:4!null, uv.v:5!null, uv.w:6!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, uv.u:4!null, uv.v:5!null, uv.w:6!null, xy.x:1!null->xx:7]
          └─ InnerJoin
              ├─ Eq
              │   ├─ xy.x:1!null
@@ -2371,16 +2391,16 @@ Project
 			Query: "select x as xx from xy join uv on (x = u) group by xx having x = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:7]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.x:1!null->xx:7]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: xy.x:1!null as xx
+             ├─ group: xy.x:1!null->xx:7
              └─ InnerJoin
                  ├─ Eq
                  │   ├─ xy.x:1!null
@@ -2401,13 +2421,13 @@ Project
 			Query: "select x as xx from xy join uv on (x = u) having x = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null as xx]
+ ├─ columns: [xy.x:1!null->xx:7]
  └─ Having
      ├─ Eq
      │   ├─ xy.x:1!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, uv.u:4!null, uv.v:5!null, uv.w:6!null, xy.x:1!null as xx]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, uv.u:4!null, uv.v:5!null, uv.w:6!null, xy.x:1!null->xx:7]
          └─ InnerJoin
              ├─ Eq
              │   ├─ xy.x:1!null
@@ -2428,16 +2448,16 @@ Project
 			Query: "select x + 1 as xx from xy join uv on (x = u) group by xx having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + 1 (tinyint)) as xx]
+ ├─ columns: [(xy.x:1!null + 1 (tinyint))->xx:7]
  └─ Having
      ├─ Eq
      │   ├─ xx:7!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, (xy.x:1!null + 1 (tinyint)) as xx]
+         ├─ columns: [xy.x:1!null, (xy.x:1!null + 1 (tinyint))->xx:7]
          └─ GroupBy
              ├─ select: xy.x:1!null
-             ├─ group: (xy.x:1!null + 1 (tinyint)) as xx
+             ├─ group: (xy.x:1!null + 1 (tinyint))->xx:7
              └─ InnerJoin
                  ├─ Eq
                  │   ├─ xy.x:1!null
@@ -2458,13 +2478,13 @@ Project
 			Query: "select x + 1 as xx from xy join uv on (x = u) having xx = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + 1 (tinyint)) as xx]
+ ├─ columns: [(xy.x:1!null + 1 (tinyint))->xx:7]
  └─ Having
      ├─ Eq
      │   ├─ xx:7!null
      │   └─ 123 (bigint)
      └─ Project
-         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, uv.u:4!null, uv.v:5!null, uv.w:6!null, (xy.x:1!null + 1 (tinyint)) as xx]
+         ├─ columns: [xy.x:1!null, xy.y:2!null, xy.z:3!null, uv.u:4!null, uv.v:5!null, uv.w:6!null, (xy.x:1!null + 1 (tinyint))->xx:7]
          └─ InnerJoin
              ├─ Eq
              │   ├─ xy.x:1!null
@@ -2485,13 +2505,13 @@ Project
 			Query: "select x +1  as xx from xy join uv on (x = u) group by x having avg(x) = 123;",
 			ExpectedPlan: `
 Project
- ├─ columns: [(xy.x:1!null + 1 (tinyint)) as xx]
+ ├─ columns: [(xy.x:1!null + 1 (tinyint))->xx:7]
  └─ Having
      ├─ Eq
      │   ├─ avg(xy.x):8
      │   └─ 123 (tinyint)
      └─ Project
-         ├─ columns: [avg(xy.x):8, xy.x:1!null, (xy.x:1!null + 1 (tinyint)) as xx]
+         ├─ columns: [avg(xy.x):8, xy.x:1!null, (xy.x:1!null + 1 (tinyint))->xx:7]
          └─ GroupBy
              ├─ select: AVG(xy.x:1!null), xy.x:1!null
              ├─ group: xy.x:1!null
@@ -2519,7 +2539,7 @@ Project
 			Query: "select name_const('abc', 123);",
 			ExpectedPlan: `
 Project
- ├─ columns: [123 (tinyint) as abc]
+ ├─ columns: [123 (tinyint)->abc:1]
  └─ Table
      ├─ name: 
      ├─ columns: []
@@ -2531,7 +2551,7 @@ Project
 			Query: "select icu_version();",
 			ExpectedPlan: `
 Project
- ├─ columns: [73.1 (varchar(4)) as icu_version()]
+ ├─ columns: ['73.1'->icu_version()]
  └─ Table
      ├─ name: 
      ├─ columns: []

--- a/sql/planbuilder/select.go
+++ b/sql/planbuilder/select.go
@@ -107,7 +107,9 @@ func (b *Builder) buildSelect(inScope *scope, s *ast.Select) (outScope *scope) {
 	b.buildProjection(outScope, projScope)
 	outScope = projScope
 
-	b.buildDistinct(outScope, s.QueryOpts.Distinct)
+	if err := b.buildDistinct(outScope, s.QueryOpts.Distinct); err != nil {
+		b.handleErr(err)
+	}
 
 	// OFFSET and LIMIT are last
 	offset := b.buildOffset(outScope, s.Limit)
@@ -194,11 +196,13 @@ func (b *Builder) typeCoerceLiteral(e sql.Expression) sql.Expression {
 
 // buildDistinct creates a new plan.Distinct node if the query has a DISTINCT option.
 // If the query has both DISTINCT and ALL, an error is returned.
-func (b *Builder) buildDistinct(inScope *scope, distinct bool) {
+func (b *Builder) buildDistinct(inScope *scope, distinct bool) error {
 	if !distinct {
-		return
+		return nil
 	}
-	inScope.node = b.f.buildDistinct(inScope.node)
+	var err error
+	inScope.node, err = b.f.buildDistinct(inScope.node, inScope.refsSubquery)
+	return err
 }
 
 func (b *Builder) currentDb() sql.Database {


### PR DESCRIPTION
This fixes a bug where a sort expression alias computed in the lower projection fails to index the nested expression.

Below, the first plan's sort searches for `c5:6` in the child, but only finds `a:7`. The second plan fixes the correctness issue. Obviously there are more desirable projection organizations that version two, but this is small enough of an edge case that I think rewriting projection management with proper expression interning would be overkill right now. The rest of the plan tests look OK/improvements.

```sql
select distinct abs(c5) as a from one_pk where c2 in (1,11,31) order by a

before: 

Sort(abs(one_pk.c5:6)->a:7 ASC nullsFirst)
 └─ Distinct
     └─ Project
         ├─ columns: [abs(one_pk.c5:1)->a:0]
         └─ Filter
             ├─ HashIn
             │   ├─ one_pk.c2:0
             │   └─ TUPLE(1 (tinyint), 11 (tinyint), 31 (tinyint))
             └─ ProcessTable
                 └─ Table
                     ├─ name: one_pk
                     └─ columns: [c2 c5]

after:

Distinct
 └─ Project
     ├─ columns: [abs(one_pk.c5:5)->a:0]
     └─ Sort(a:6 ASC nullsFirst)
         └─ Project
             ├─ columns: [one_pk.pk:0!null, one_pk.c1:1, one_pk.c2:2, one_pk.c3:3, one_pk.c4:4, one_pk.c5:5, abs(one_pk.c5:5)->a:0]
             └─ Filter
                 ├─ HashIn
                 │   ├─ one_pk.c2:2
                 │   └─ TUPLE(1 (tinyint), 11 (tinyint), 31 (tinyint))
                 └─ ProcessTable
                     └─ Table
                         ├─ name: one_pk
                         └─ columns: [pk c1 c2 c3 c4 c5]
```