### PR TITLE
reintroduce `last_insert_id` discrepancy

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -629,7 +629,7 @@ var InsertQueries = []WriteQueryTest{
 	},
 	{
 		WriteQuery:          `INSERT INTO auto_increment_tbl VALUES ('4', 44)`,
-		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected:1, InsertID:4}}},
+		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 4}}},
 		SelectQuery:         `SELECT * from auto_increment_tbl where pk=4`,
 		ExpectedSelect: []sql.Row{
 			{4, 44},

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -571,7 +571,7 @@ var InsertQueries = []WriteQueryTest{
 	},
 	{
 		WriteQuery:          "INSERT INTO auto_increment_tbl values (5, 44)",
-		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 0}}},
+		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 5}}},
 		SelectQuery:         "SELECT * FROM auto_increment_tbl ORDER BY pk",
 		ExpectedSelect: []sql.Row{
 			{1, 11},
@@ -629,7 +629,7 @@ var InsertQueries = []WriteQueryTest{
 	},
 	{
 		WriteQuery:          `INSERT INTO auto_increment_tbl VALUES ('4', 44)`,
-		ExpectedWriteResult: []sql.Row{{types.NewOkResult(1)}},
+		ExpectedWriteResult: []sql.Row{{types.OkResult{RowsAffected:1, InsertID:4}}},
 		SelectQuery:         `SELECT * from auto_increment_tbl where pk=4`,
 		ExpectedSelect: []sql.Row{
 			{4, 44},
@@ -1354,7 +1354,7 @@ var InsertScripts = []ScriptTest{
 			{
 				Query: "insert into auto values (1)",
 				Expected: []sql.Row{
-					{types.OkResult{RowsAffected: 1, InsertID: 0}},
+					{types.OkResult{RowsAffected: 1, InsertID: 1}},
 				},
 			},
 			{
@@ -1373,7 +1373,7 @@ var InsertScripts = []ScriptTest{
 			{
 				Query: "insert into auto_pk values (0), (1), (NULL), ()",
 				Expected: []sql.Row{
-					{types.OkResult{RowsAffected: 4, InsertID: 2}},
+					{types.OkResult{RowsAffected: 4}},
 				},
 			},
 			{
@@ -2804,7 +2804,7 @@ var InsertIgnoreScripts = []ScriptTest{
 			},
 			{
 				Query:    "insert ignore into test_table values (1, 'invalid'), (2, 'bye'), (3, null)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 3}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, InsertID: 1}}},
 				//ExpectedWarning: mysql.ERWarnDataTruncated, // TODO: incorrect code
 			},
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -15,7 +15,8 @@
 package queries
 
 import (
-	"time"
+	"math"
+"time"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
@@ -2057,7 +2058,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    "insert into a (x,y) values (1,1)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 0}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 1}}},
 			},
 			{
 				Query:    "select last_insert_id()",
@@ -2082,7 +2083,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    "insert into b (x) values (1), (2)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 3}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 0}}},
 			},
 			{
 				// The above query doesn't have an auto increment column, so last_insert_id is unchanged
@@ -2093,7 +2094,7 @@ CREATE TABLE tab3 (
 				Query: "insert into a (x, y) values (-100, 10)",
 				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 1,
-					InsertID:     3,
+					InsertID:     math.MaxUint64 - 100 + 1,
 				}}},
 			},
 			{
@@ -2105,7 +2106,7 @@ CREATE TABLE tab3 (
 				Query: "insert into a (x, y) values (100, 10)",
 				Expected: []sql.Row{{types.OkResult{
 					RowsAffected: 1,
-					InsertID:     3,
+					InsertID:     100,
 				}}},
 			},
 			{
@@ -2200,7 +2201,7 @@ CREATE TABLE tab3 (
 
 			{
 				Query:    "insert into t(pk) values (10), (default);",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 11}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 10}}},
 			},
 			{
 				Query: "select last_insert_id()",
@@ -2224,7 +2225,7 @@ CREATE TABLE tab3 (
 
 			{
 				Query:    "insert into t(pk) values (20), (default), (default);",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, InsertID: 21}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 3, InsertID: 20}}},
 			},
 			{
 				Query: "select last_insert_id()",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -16,7 +16,7 @@ package queries
 
 import (
 	"math"
-"time"
+	"time"
 
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/sqlparser"

--- a/enginetest/queries/transaction_queries.go
+++ b/enginetest/queries/transaction_queries.go
@@ -837,7 +837,7 @@ var TransactionTests = []TransactionTest{
 			// Client a does a skip ahead
 			{
 				Query:    "/* client a */ insert into t values (10, 10)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 12}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 10}}},
 			},
 			{
 				Query:    "/* client b */ insert into t (y) values (11)",
@@ -846,7 +846,7 @@ var TransactionTests = []TransactionTest{
 			// Client c skips ahead
 			{
 				Query:    "/* client c */ insert into t values (50, 50)",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 11}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 50}}},
 			},
 			{
 				Query:    "/* client b */ insert into t (y) values (51)",

--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -2592,7 +2592,11 @@ end;`,
 			},
 			{
 				Query:    "INSERT INTO `film` VALUES (3,'ADAPTATION HOLES','An Astounding Reflection in A Baloon Factory'),(4,'AFFAIR PREJUDICE','A Fanciful Documentary in A Shark Tank')",
-				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 0}}},
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2, InsertID: 3}}},
+			},
+			{
+				Query:    "SELECT last_insert_id();",
+				Expected: []sql.Row{{uint64(0)}},
 			},
 			{
 				Query:    "SELECT COUNT(*) FROM film",
@@ -2653,7 +2657,11 @@ INSERT INTO t0 (v1, v2) VALUES (i, s); END;`,
 			{
 				SkipResultCheckOnServerEngine: true, // call depends on stored procedure stmt for whether to use 'query' or 'exec' from go sql driver.
 				Query:                         "CALL add_entry(4, 'aaa');",
-				Expected:                      []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 1}}},
+				Expected:                      []sql.Row{{types.OkResult{RowsAffected: 1, InsertID: 3}}},
+			},
+			{
+				Query:    "SELECT last_insert_id();",
+				Expected: []sql.Row{{uint64(1)}},
 			},
 			{
 				Query:    "SELECT * FROM t0;",

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -338,7 +338,17 @@ type insertRowHandler struct {
 
 func (i *insertRowHandler) handleRowUpdate(row sql.Row) error {
 	i.rowsAffected++
+	if !i.updatedAutoIncrementValue {
+		i.updatedAutoIncrementValue = true
+		if i.lastInsertIdGetter != nil {
+			i.lastInsertId = uint64(i.lastInsertIdGetter(row))
+		}
+	}
 	return nil
+}
+
+func (i *insertRowHandler) getLastInsertId() uint64 {
+	return i.lastInsertId
 }
 
 func (i *insertRowHandler) okResult() types.OkResult {
@@ -564,7 +574,9 @@ func getRowHandler(clientFoundRowsToggled bool, iter sql.RowIter) accumulatorRow
 		if i.updater != nil {
 			return &onDuplicateUpdateHandler{schema: i.schema, clientFoundRowsCapability: clientFoundRowsToggled}
 		}
-		return &insertRowHandler{}
+		return &insertRowHandler{
+			lastInsertIdGetter: i.getAutoIncVal,
+		}
 	case *deleteIter:
 		return &deleteRowHandler{}
 	default:
@@ -636,10 +648,12 @@ func (a *accumulatorIter) Next(ctx *sql.Context) (r sql.Row, err error) {
 			// For some update accumulators, we don't accurately track the last insert ID in the handler and need to set
 			// it manually in the result by getting it from the session. This doesn't work correctly in all cases and needs
 			// to be fixed. See comment in buildRowUpdateAccumulator in rowexec/dml.go
-			switch a.updateRowHandler.(type) {
-			case *onDuplicateUpdateHandler, *replaceRowHandler, *insertRowHandler:
+			switch rowHandler := a.updateRowHandler.(type) {
+			case *onDuplicateUpdateHandler, *replaceRowHandler:
 				lastInsertId := ctx.Session.GetLastQueryInfoInt(sql.LastInsertId)
 				res.InsertID = uint64(lastInsertId)
+			case *insertRowHandler:
+				res.InsertID = rowHandler.lastInsertId
 			}
 
 			// By definition, ROW_COUNT() is equal to RowsAffected.


### PR DESCRIPTION
Apparently the `last_insert_id` in ok result, is not the same as `select last_insert_id()`.
When there is an auto_increment column, the insert_id in the OKResult is the first value that increments the auto_increment value.

Reverts some changes from: https://github.com/dolthub/go-mysql-server/pull/2616
fixes: https://github.com/dolthub/dolt/issues/8914