### PR TITLE
Correct JSON_LENGTH with an object parameter

### DIFF
--- a/sql/expression/function/json/json_length.go
+++ b/sql/expression/function/json/json_length.go
@@ -117,7 +117,7 @@ func (j *JsonLength) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return nil, nil
 		}
 		return len(v), nil
-	case map[any]any:
+	case map[string]interface{}:
 		return len(v), nil
 	default:
 		return 1, nil

--- a/sql/expression/function/json/jsontests/json_length_test.go
+++ b/sql/expression/function/json/jsontests/json_length_test.go
@@ -74,7 +74,11 @@ func TestJsonLength(t *testing.T) {
 			row: sql.Row{`{"a": 1}`},
 			exp: 1,
 		},
-
+		{
+			f:   f1,
+			row: sql.Row{`{"a": 1, "b": 2}`},
+			exp: 2,
+		},
 		{
 			f:   f2,
 			row: sql.Row{`{"a": [1, false]}`, nil},


### PR DESCRIPTION
When JSON_LENGTH is passed a JSON object, it should always return the number of fields in the object. However, due to a typo, it currently only returns `1` for objects. This PR corrects that behavior.