### PR TITLE
don't erase dual table projection

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10218,7 +10218,6 @@ from typestable`,
 			{"     └─ name: "},
 		},
 	},
-
 }
 
 var KeylessQueries = []QueryTest{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10171,6 +10171,18 @@ from typestable`,
 			{2},
 		},
 	},
+	{
+		Query: "select ''",
+		Expected: []sql.Row{
+			{""},
+		},
+	},
+	{
+		Query: "select '' from dual",
+		Expected: []sql.Row{
+			{""},
+		},
+	},
 
 	{
 		Query: "select @@sql_mode = 1",
@@ -10206,6 +10218,7 @@ from typestable`,
 			{"     └─ name: "},
 		},
 	},
+
 }
 
 var KeylessQueries = []QueryTest{

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -15,7 +15,8 @@
 package analyzer
 
 import (
-	"strings"
+	"github.com/dolthub/go-mysql-server/memory"
+"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -43,7 +44,9 @@ func eraseProjection(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 	return transform.Node(node, func(node sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		project, ok := node.(*plan.Project)
 		if ok {
-			if project.Schema().CaseSensitiveEquals(project.Child.Schema()) {
+			projSch := project.Schema()
+			childSch := project.Child.Schema()
+			if projSch.CaseSensitiveEquals(childSch) && !childSch.Equals(memory.DualTableSchema.Schema) {
 				a.Log("project erased")
 				return project.Child, transform.NewTree, nil
 			}

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -15,8 +15,9 @@
 package analyzer
 
 import (
+	"strings"
+
 	"github.com/dolthub/go-mysql-server/memory"
-"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"


### PR DESCRIPTION
The rule `eraseProjection` erases the projection from `select ''`, which causes `validateSchemaSource` to error.
Adding a case in `validateSchemaSource` resulted in dummy rows being outputted, so I think this is the best solution for now.


fixes: https://github.com/dolthub/dolt/issues/8977