### PR TITLE
Bug fix: resolve column default expressions for ALTER COLUMN nodes

### DIFF
--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -1065,7 +1065,11 @@ func (b *Builder) buildAlterAutoIncrement(inScope *scope, ddl *ast.DDL, table *p
 func (b *Builder) buildAlterNotNull(inScope *scope, ddl *ast.DDL, table *plan.ResolvedTable) (outScope *scope) {
 	outScope = inScope
 	spec := ddl.NotNullSpec
-	for _, c := range table.Schema() {
+
+	// Resolve the schema defaults, so we don't leave around any UnresolvedColumnDefault expressions,
+	// otherwise Doltgres won't be able to process these nodes.
+	resolvedSchema := b.resolveSchemaDefaults(inScope, table.Schema())
+	for _, c := range resolvedSchema {
 		if strings.EqualFold(c.Name, spec.Column.String()) {
 			colCopy := *c
 			switch strings.ToLower(spec.Action) {
@@ -1093,7 +1097,11 @@ func (b *Builder) buildAlterNotNull(inScope *scope, ddl *ast.DDL, table *plan.Re
 func (b *Builder) buildAlterChangeColumnType(inScope *scope, ddl *ast.DDL, table *plan.ResolvedTable) (outScope *scope) {
 	outScope = inScope
 	spec := ddl.ColumnTypeSpec
-	for _, c := range table.Schema() {
+
+	// Resolve the schema defaults, so we don't leave around any UnresolvedColumnDefault expressions,
+	// otherwise Doltgres won't be able to process these nodes.
+	resolvedSchema := b.resolveSchemaDefaults(inScope, table.Schema())
+	for _, c := range resolvedSchema {
 		if strings.EqualFold(c.Name, spec.Column.String()) {
 			colCopy := *c
 			typ, err := types.ColumnTypeToType(&spec.Type)


### PR DESCRIPTION
When building plan nodes to handle altering a column's nullability or type, without respecifying the full column definition, the built node should ensure any column default expressions are resolved. 

This originally showed up as a panic in Doltgres, because Doltgres' `TypeSanitzer` found the `UnresolvedColumnDefault` instance and tried to invoke operations on it. 

Note that it's not currently possible to trigger this issue with Dolt or GMS because MySQL has a more limited syntax than Postgres for altering a column without respecfiying its full column definition, and Dolt/GMS does not support that syntax currently (e.g. `ALTER TABLE t ALTER COLUMN SET VISIBLE`).