### PR TITLE
Clean up `regex.Regex` disposal 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dolthub/go-mysql-server
 require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-icu-regex v0.0.0-20250303123116-549b8d7cad00
+	github.com/dolthub/go-icu-regex v0.0.0-20250319212010-451ea8d003fa
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
 	github.com/dolthub/vitess v0.0.0-20250304211657-920ca9ec2b9a

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1G
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2/go.mod h1:mIEZOHnFx4ZMQeawhw9rhsj+0zwQj7adVsnBX7t+eKY=
 github.com/dolthub/go-icu-regex v0.0.0-20250303123116-549b8d7cad00 h1:rh2ij2yTYKJWlX+c8XRg4H5OzqPewbU1lPK8pcfVmx8=
 github.com/dolthub/go-icu-regex v0.0.0-20250303123116-549b8d7cad00/go.mod h1:ylU4XjUpsMcvl/BKeRRMXSH7e7WBrPXdSLvnRJYrxEA=
+github.com/dolthub/go-icu-regex v0.0.0-20250319212010-451ea8d003fa h1:NFbzJ4wjWRz32nz2EimbrHpRx1Xt6k+IaR8N+j4x62k=
+github.com/dolthub/go-icu-regex v0.0.0-20250319212010-451ea8d003fa/go.mod h1:ylU4XjUpsMcvl/BKeRRMXSH7e7WBrPXdSLvnRJYrxEA=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTEtT5tOBsCuCrlYnLRKpbJVJkDbrTRhwQ=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=

--- a/sql/expression/function/regexp_init.go
+++ b/sql/expression/function/regexp_init.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	regex "github.com/dolthub/go-icu-regex"
+	"github.com/sirupsen/logrus"
+)
+
+func init() {
+	// By default, the dolthub/go-icu-regex package will panic if a regex object is
+	// finalized without having the Dispose() method called. Instead of panicing, we
+	// add a RegexLeakHandler to log an error.
+	regex.SetRegexLeakHandler(func() {
+		logrus.Error("Detected leaked go-icu-regex.Regex instance")
+	})
+}

--- a/sql/expression/function/regexp_instr.go
+++ b/sql/expression/function/regexp_instr.go
@@ -146,7 +146,13 @@ func (r *RegexpInstr) WithChildren(children ...sql.Expression) (sql.Expression, 
 	if len(children) != required {
 		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), required)
 	}
-	return NewRegexpInstr(children...)
+
+	// Copy over the regex instance, in case it has already been set to avoid leaking it.
+	instr, err := NewRegexpInstr(children...)
+	if r.re != nil && instr != nil {
+		instr.(*RegexpInstr).re = r.re
+	}
+	return instr, err
 }
 
 // String implements the sql.Expression interface.

--- a/sql/expression/function/regexp_like.go
+++ b/sql/expression/function/regexp_like.go
@@ -112,7 +112,14 @@ func (r *RegexpLike) WithChildren(children ...sql.Expression) (sql.Expression, e
 	if len(children) != required {
 		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), required)
 	}
-	return NewRegexpLike(children...)
+
+	// Copy over the regex instance, in case it has already been set to avoid leaking it.
+	like, err := NewRegexpLike(children...)
+	if like != nil && r.re != nil {
+		like.(*RegexpLike).re = r.re
+	}
+
+	return like, err
 }
 
 // String implements the sql.Expression interface.

--- a/sql/expression/function/regexp_substr.go
+++ b/sql/expression/function/regexp_substr.go
@@ -133,7 +133,13 @@ func (r *RegexpSubstr) WithChildren(children ...sql.Expression) (sql.Expression,
 	if len(children) != required {
 		return nil, sql.ErrInvalidChildrenNumber.New(r, len(children), required)
 	}
-	return NewRegexpSubstr(children...)
+
+	// Copy over the regex instance, in case it has already been set to avoid leaking it.
+	substr, err := NewRegexpSubstr(children...)
+	if r.re != nil && substr != nil {
+		substr.(*RegexpSubstr).re = r.re
+	}
+	return substr, err
 }
 
 // String implements the sql.Expression interface.


### PR DESCRIPTION
Preserves `Regex` instances when creating new nodes from `WithChildren()` for `RegexpInstr `, `RegexpLike`, and `RegexpSubstr` instances. Disables panics when detecting a leaked Regex and installs a custom function to log an error.
