### PR TITLE
`disable_merge_join` corner case

### DIFF
--- a/sql/memo/select_hints.go
+++ b/sql/memo/select_hints.go
@@ -390,7 +390,7 @@ type joinHints struct {
 }
 
 func (h joinHints) isEmpty() bool {
-	return len(h.ops) == 0 && h.order == nil && !h.leftDeep
+	return len(h.ops) == 0 && h.order == nil && !h.leftDeep && len(h.block) == 0
 }
 
 // satisfiedBy returns whether a RelExpr satisfies every join hint. This


### PR DESCRIPTION
Disable merge join previously could only kick in if other hints were applied. We also want it to work in the absence of hints.