### PR TITLE
Support `ALTER TABLE ... ADD COLUMN` with an inline check constraint

### DIFF
--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -514,6 +514,22 @@ var AlterTableScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "add column with inline check constraint definition",
+		SetUpScript: []string{
+			"create table t (pk int primary key);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "alter table t add column c int CONSTRAINT chk_c check(c > 10);",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:          "insert into t values (1, 9);",
+				ExpectedErrStr: `Check constraint "chk_c" violated`,
+			},
+		},
+	},
+	{
 		Name: "multi-alter ddl column errors",
 		SetUpScript: []string{
 			"create table tbl_i (i int primary key)",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20250319212010-451ea8d003fa
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250304211657-920ca9ec2b9a
+	github.com/dolthub/vitess v0.0.0-20250320220029-0c8b8926a290
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/dolthub/vitess v0.0.0-20250303224041-5cc89c183bc4 h1:wtS9ZWEyEeYzLCcq
 github.com/dolthub/vitess v0.0.0-20250303224041-5cc89c183bc4/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dolthub/vitess v0.0.0-20250304211657-920ca9ec2b9a h1:HIH9g4z+yXr4DIFyT6L5qOIEGJ1zVtlj6baPyHAG4Yw=
 github.com/dolthub/vitess v0.0.0-20250304211657-920ca9ec2b9a/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250320220029-0c8b8926a290 h1:xSbRaPJLIqpAV6wq2iUpo9hM87P2AIn/E5XV5F39vU4=
+github.com/dolthub/vitess v0.0.0-20250320220029-0c8b8926a290/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -594,7 +594,7 @@ func (b *Builder) buildAlterTableClause(inScope *scope, ddl *ast.DDL) []*scope {
 
 		if ddl.ColumnAction != "" {
 			columnActionOutscope := b.buildAlterTableColumnAction(tableScope, ddl, rt)
-			outScopes = append(outScopes, columnActionOutscope)
+			outScopes = append(outScopes, columnActionOutscope.copy())
 
 			if ddl.TableSpec != nil {
 				if len(ddl.TableSpec.Columns) != 1 {


### PR DESCRIPTION
Adds support for adding a column to a table with an inline constraint declared. Previously, the inline constraint was parsing, but ignored. 

Depends on: https://github.com/dolthub/vitess/pull/405

Originally discovered as part of testing DoltHub's Postgres schema with Doltgres. 