### PR TITLE
check group by ordinal range

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7782,32 +7782,6 @@ where
 			},
 		},
 	},
-	{
-		Name:    "group by ordinal tests",
-		Dialect: "mysql",
-		SetUpScript: []string{
-			"create table t (i int, j int);",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query: "select 1 from t group by 'abc';",
-				ExpectedErrStr: "expected integer order by literal",
-			},
-			{
-				// TODO: this actually works in MySQL
-				Query: "select 1 from t group by -123;",
-				ExpectedErrStr: "expected positive integer order by literal",
-			},
-			{
-				Query: "select 1 from t group by 0;",
-				ExpectedErrStr: "expected positive integer order by literal",
-			},
-			{
-				Query: "select 1 from t group by 100;",
-				ExpectedErrStr: "column ordinal out of range: 100",
-			},
-		},
-	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7782,6 +7782,32 @@ where
 			},
 		},
 	},
+	{
+		Name:    "group by ordinal tests",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table t (i int, j int);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select 1 from t group by 'abc';",
+				ExpectedErrStr: "expected integer order by literal",
+			},
+			{
+				// TODO: this actually works in MySQL
+				Query: "select 1 from t group by -123;",
+				ExpectedErrStr: "expected positive integer order by literal",
+			},
+			{
+				Query: "select 1 from t group by 0;",
+				ExpectedErrStr: "expected positive integer order by literal",
+			},
+			{
+				Query: "select 1 from t group by 100;",
+				ExpectedErrStr: "column ordinal out of range: 100",
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -131,7 +131,11 @@ func (b *Builder) buildGroupingCols(fromScope, projScope *scope, groupby ast.Gro
 				b.handleErr(fmt.Errorf("expected integer order by literal"))
 			}
 			if intIdx < 1 {
+				// TODO: this actually works in MySQL
 				b.handleErr(fmt.Errorf("expected positive integer order by literal"))
+			}
+			if int(intIdx) > len(selects) {
+				b.handleErr(fmt.Errorf("column ordinal out of range: %d", intIdx))
 			}
 			col = projScope.cols[intIdx-1]
 		default:

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -2950,6 +2950,25 @@ func TestPlanBuilderErr(t *testing.T) {
 			Query: "select x + 1 as xx from xy join uv on (x = u) having x = 123;",
 			Err:   "column \"x\" could not be found in any table in scope",
 		},
+
+		// Test GroupBy Ordinals
+		{
+			Query: "select 1 from xy group by 'abc';",
+			Err:   "expected integer order by literal",
+		},
+		{
+			// TODO: this actually works in MySQL
+			Query: "select 1 from xy group by -123;",
+			Err:   "expected positive integer order by literal",
+		},
+		{
+			Query: "select 1 from xy group by 0;",
+			Err:   "expected positive integer order by literal",
+		},
+		{
+			Query: "select 1 from xy group by 100;",
+			Err:   "column ordinal out of range: 100",
+		},
 	}
 
 	db := memory.NewDatabase("mydb")


### PR DESCRIPTION
This PR adds an error check when attempting to group by a column index that is out of range.

fixes: https://github.com/dolthub/dolt/issues/9037