### PR TITLE
fix double negatives

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7808,25 +7808,25 @@ where
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "select * from t where 1 = (not(not(i)))",
+				Query: "select * from t where 1 = (not(not(i)))",
 				Expected: []sql.Row{
 					{123},
 				},
 			},
 			{
-				Query:    "select * from t where true = (not(not(i)))",
+				Query: "select * from t where true = (not(not(i)))",
 				Expected: []sql.Row{
 					{123},
 				},
 			},
 			{
-				Query:    "select * from t where true = (not(not(i = 123)))",
+				Query: "select * from t where true = (not(not(i = 123)))",
 				Expected: []sql.Row{
 					{123},
 				},
 			},
 			{
-				Query:    "select * from t where false = (not(not(i != 123)))",
+				Query: "select * from t where false = (not(not(i != 123)))",
 				Expected: []sql.Row{
 					{123},
 				},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7799,6 +7799,40 @@ where
 			},
 		},
 	},
+	{
+		Name:    "not expression optimization",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"insert into t values (123);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from t where 1 = (not(not(i)))",
+				Expected: []sql.Row{
+					{123},
+				},
+			},
+			{
+				Query:    "select * from t where true = (not(not(i)))",
+				Expected: []sql.Row{
+					{123},
+				},
+			},
+			{
+				Query:    "select * from t where true = (not(not(i = 123)))",
+				Expected: []sql.Row{
+					{123},
+				},
+			},
+			{
+				Query:    "select * from t where false = (not(not(i != 123)))",
+				Expected: []sql.Row{
+					{123},
+				},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5165,9 +5165,9 @@ CREATE TABLE tab3 (
 				},
 			},
 			{
-				Query: "select unix_timestamp(d), unix_timestamp(tt) from t;",
+				Query: "select unix_timestamp(d), substring(cast(unix_timestamp(tt) as char(128)), -6) from t;",
 				Expected: []sql.Row{
-					{"1577898000", "1743140096.123456"},
+					{"1577898000", "123456"},
 				},
 			},
 		},

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -431,7 +431,9 @@ func pushNotFiltersHelper(e sql.Expression) (sql.Expression, error) {
 	// NOT(NOT(c))=>c
 	if not, _ := e.(*expression.Not); not != nil {
 		if f, _ := not.Child.(*expression.Not); f != nil {
-			return pushNotFiltersHelper(f.Child)
+			if types.IsBoolean(f.Child.Type()) {
+				return pushNotFiltersHelper(f.Child)
+			}
 		}
 	}
 

--- a/sql/types/typecheck.go
+++ b/sql/types/typecheck.go
@@ -20,6 +20,11 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
+// IsBoolean checks if t is a boolean type.
+func IsBoolean(t sql.Type) bool {
+	return t == Boolean
+}
+
 // IsBlobType checks if t is BLOB
 func IsBlobType(t sql.Type) bool {
 	if t == nil {


### PR DESCRIPTION
We can't apply `NOT(NOT(expr)) -> expr` optimization if there will be a type conversion involved.

This PR also fixes bad test involving current timestamps.

fixes: https://github.com/dolthub/dolt/issues/9054