### PR TITLE
fix `AND` optimization

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7837,6 +7837,12 @@ where
 					{123},
 				},
 			},
+			{
+				Query: "select * from t where ((true and -1) >= 0);",
+				Expected: []sql.Row{
+					{123},
+				},
+			},
 		},
 	},
 	{

--- a/sql/analyzer/optimization_rules.go
+++ b/sql/analyzer/optimization_rules.go
@@ -264,11 +264,11 @@ func simplifyFilters(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 					return e.RightChild, transform.NewTree, nil
 				}
 
-				if isTrue(e.LeftChild) {
+				if isTrue(e.LeftChild) && types.IsBoolean(e.RightChild.Type()) {
 					return e.RightChild, transform.NewTree, nil
 				}
 
-				if isTrue(e.RightChild) {
+				if isTrue(e.RightChild) && types.IsBoolean(e.LeftChild.Type()) {
 					return e.LeftChild, transform.NewTree, nil
 				}
 


### PR DESCRIPTION
This PR fixes `AND` optimizations where `TRUE & x` -> `x`. 
Probably should've seen this coming given our bug fix with `OR` [here](https://github.com/dolthub/go-mysql-server/pull/2921),

fixes: https://github.com/dolthub/dolt/issues/9074