### PR TITLE
Add support for SSL connections to a source MySQL server

### DIFF
--- a/sql/binlogreplication/binlog_replication.go
+++ b/sql/binlogreplication/binlog_replication.go
@@ -131,6 +131,7 @@ type BinaryLogStatus struct {
 type ReplicaStatus struct {
 	SourceHost            string
 	SourceUser            string
+	SourceSsl             bool
 	SourcePort            uint
 	ConnectRetry          uint32
 	SourceRetryCount      uint64

--- a/sql/mysql_db/replica_source_info.go
+++ b/sql/mysql_db/replica_source_info.go
@@ -73,10 +73,7 @@ func ReplicaSourceInfoFromRow(ctx *sql.Context, row sql.Row) (*ReplicaSourceInfo
 		return nil, err
 	}
 
-	ssl := false
-	if row[replicaSourceInfoTblColIndex_Enabled_ssl] == 1 {
-		ssl = true
-	}
+	ssl := row[replicaSourceInfoTblColIndex_Enabled_ssl] == 1
 
 	return &ReplicaSourceInfo{
 		Host:                 row[replicaSourceInfoTblColIndex_Host].(string),

--- a/sql/mysql_db/replica_source_info.go
+++ b/sql/mysql_db/replica_source_info.go
@@ -27,6 +27,7 @@ import (
 type ReplicaSourceInfo struct {
 	Host                 string
 	User                 string
+	Ssl                  bool
 	Password             string
 	Port                 uint16
 	Uuid                 string
@@ -58,6 +59,12 @@ func ReplicaSourceInfoToRow(ctx *sql.Context, v *ReplicaSourceInfo) (sql.Row, er
 	row[replicaSourceInfoTblColIndex_Connect_retry] = v.ConnectRetryInterval
 	row[replicaSourceInfoTblColIndex_Retry_count] = v.ConnectRetryCount
 
+	if v.Ssl {
+		row[replicaSourceInfoTblColIndex_Enabled_ssl] = 1
+	} else {
+		row[replicaSourceInfoTblColIndex_Enabled_ssl] = 0
+	}
+
 	return row, nil
 }
 
@@ -66,9 +73,15 @@ func ReplicaSourceInfoFromRow(ctx *sql.Context, row sql.Row) (*ReplicaSourceInfo
 		return nil, err
 	}
 
+	ssl := false
+	if row[replicaSourceInfoTblColIndex_Enabled_ssl] == 1 {
+		ssl = true
+	}
+
 	return &ReplicaSourceInfo{
 		Host:                 row[replicaSourceInfoTblColIndex_Host].(string),
 		User:                 row[replicaSourceInfoTblColIndex_User_name].(string),
+		Ssl:                  ssl,
 		Password:             row[replicaSourceInfoTblColIndex_User_password].(string),
 		Port:                 row[replicaSourceInfoTblColIndex_Port].(uint16),
 		Uuid:                 row[replicaSourceInfoTblColIndex_Uuid].(string),
@@ -79,6 +92,7 @@ func ReplicaSourceInfoFromRow(ctx *sql.Context, row sql.Row) (*ReplicaSourceInfo
 
 func ReplicaSourceInfoEquals(left, right *ReplicaSourceInfo) bool {
 	return left.User == right.User &&
+		left.Ssl == right.Ssl &&
 		left.Host == right.Host &&
 		left.Port == right.Port &&
 		left.Password == right.Password &&

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -807,6 +807,11 @@ func (b *BaseBuilder) buildShowReplicaStatus(ctx *sql.Context, n *plan.ShowRepli
 	lastIoErrorTimestamp := formatReplicaStatusTimestamp(status.LastIoErrorTimestamp)
 	lastSqlErrorTimestamp := formatReplicaStatusTimestamp(status.LastSqlErrorTimestamp)
 
+	sslAllowed := "No"
+	if status.SourceSsl {
+		sslAllowed = "Yes"
+	}
+
 	row = sql.Row{
 		"",                       // Replica_IO_State
 		status.SourceHost,        // Source_Host
@@ -834,7 +839,7 @@ func (b *BaseBuilder) buildShowReplicaStatus(ctx *sql.Context, n *plan.ShowRepli
 		"None",                   // Until_Condition
 		nil,                      // Until_Log_File
 		nil,                      // Until_Log_Pos
-		"Ignored",                // Source_SSL_Allowed
+		sslAllowed,               // Source_SSL_Allowed
 		nil,                      // Source_SSL_CA_File
 		nil,                      // Source_SSL_CA_Path
 		nil,                      // Source_SSL_Cert


### PR DESCRIPTION
Adds GMS support for the `SOURCE_SSL` MySQL replication configuration param. 