### PR TITLE
Optimize ConvertToBytes by avoiding unnecessary string <-> bytes conversions and copies.

### DIFF
--- a/sql/fulltext/fulltext.go
+++ b/sql/fulltext/fulltext.go
@@ -173,7 +173,7 @@ func writeHashedValue(ctx context.Context, h hash.Hash, val interface{}) (valIsN
 			return false, err
 		}
 	case sql.JSONWrapper:
-		str, err := types.StringifyJSON(val)
+		str, err := types.JsonToMySqlString(val)
 		if err != nil {
 			return false, err
 		}

--- a/sql/types/json.go
+++ b/sql/types/json.go
@@ -150,7 +150,7 @@ func (t JsonType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.Va
 		}
 		js := jsVal.(sql.JSONWrapper)
 
-		str, err := StringifyJSON(js)
+		str, err := JsonToMySqlString(js)
 		if err != nil {
 			return sqltypes.NULL, err
 		}

--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -142,6 +142,18 @@ func marshalToMySqlString(val interface{}) (string, error) {
 	return b.String(), nil
 }
 
+// marshalToMySqlBytes is a helper function to marshal a JSONDocument to a byte slice that is
+// compatible with MySQL's JSON output, including spaces.
+func marshalToMySqlBytes(val interface{}) ([]byte, error) {
+	b := NewNoCopyBuilder(1024)
+	err := writeMarshalledValue(b, val)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
 func sortKeys[T any](m map[string]T) []string {
 	var keys []string
 	for k := range m {

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -34,21 +34,22 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
-// JSONStringer can be converted to a string representation that is compatible with MySQL's JSON output, including spaces.
-type JSONStringer interface {
-	JSONString() (string, error)
-}
-
-// StringifyJSON generates a string representation of a sql.JSONWrapper that is compatible with MySQL's JSON output, including spaces.
-func StringifyJSON(jsonWrapper sql.JSONWrapper) (string, error) {
-	if stringer, ok := jsonWrapper.(JSONStringer); ok {
-		return stringer.JSONString()
-	}
+// JsonToMySqlString generates a string representation of a sql.JSONWrapper that is compatible with MySQL's JSON output, including spaces.
+func JsonToMySqlString(jsonWrapper sql.JSONWrapper) (string, error) {
 	val, err := jsonWrapper.ToInterface()
 	if err != nil {
 		return "", err
 	}
 	return marshalToMySqlString(val)
+}
+
+// JsonToMySqlString generates a byte slice representation of a sql.JSONWrapper that is compatible with MySQL's JSON output, including spaces.
+func JsonToMySqlBytes(jsonWrapper sql.JSONWrapper) ([]byte, error) {
+	val, err := jsonWrapper.ToInterface()
+	if err != nil {
+		return nil, err
+	}
+	return marshalToMySqlBytes(val)
 }
 
 // JSONBytes are values which can be represented as JSON.
@@ -202,12 +203,12 @@ func (j *LazyJSONDocument) GetBytes() ([]byte, error) {
 
 // Value implements driver.Valuer for interoperability with other go libraries
 func (j *LazyJSONDocument) Value() (driver.Value, error) {
-	return StringifyJSON(j)
+	return JsonToMySqlString(j)
 }
 
 // LazyJSONDocument implements the fmt.Stringer interface.
 func (j *LazyJSONDocument) String() string {
-	s, err := StringifyJSON(j)
+	s, err := JsonToMySqlString(j)
 	if err != nil {
 		return fmt.Sprintf("error while stringifying JSON: %s", err.Error())
 	}

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/internal/strings"
 	"reflect"
 	"strconv"
 	strings2 "strings"
@@ -30,6 +29,7 @@ import (
 	"github.com/shopspring/decimal"
 	"gopkg.in/src-d/go-errors.v1"
 
+	"github.com/dolthub/go-mysql-server/internal/strings"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/encodings"
 )

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/internal/strings"
 	"reflect"
 	"strconv"
 	strings2 "strings"
@@ -29,7 +30,6 @@ import (
 	"github.com/shopspring/decimal"
 	"gopkg.in/src-d/go-errors.v1"
 
-	"github.com/dolthub/go-mysql-server/internal/strings"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/encodings"
 )
@@ -354,6 +354,9 @@ func ConvertToString(ctx context.Context, v interface{}, t sql.StringType, dest 
 func ConvertToBytes(ctx context.Context, v interface{}, t sql.StringType, dest []byte) ([]byte, error) {
 	var val []byte
 	start := len(dest)
+	// Based on the type of the input, convert it into a byte array, writing it into |dest| to avoid an allocation.
+	// If the current implementation must make a separate allocation anyway, avoid copying it into dest by replacing
+	// |val| entirely (and setting |start| to 0).
 	switch s := v.(type) {
 	case bool:
 		if s {
@@ -394,7 +397,8 @@ func ConvertToBytes(ctx context.Context, v interface{}, t sql.StringType, dest [
 	case string:
 		val = append(dest, s...)
 	case []byte:
-		val = append(dest, s...)
+		val = s
+		start = 0
 	case time.Time:
 		val = s.AppendFormat(dest, sql.TimestampDatetimeLayout)
 	case decimal.Decimal:
@@ -405,24 +409,29 @@ func ConvertToBytes(ctx context.Context, v interface{}, t sql.StringType, dest [
 		}
 		val = append(dest, s.Decimal.String()...)
 	case sql.JSONWrapper:
-		jsonString, err := StringifyJSON(s)
+		var err error
+		val, err = JsonToMySqlBytes(s)
 		if err != nil {
 			return nil, err
 		}
-		st, err := strings.Unquote(jsonString)
+		val, err = strings.UnquoteBytes(val)
 		if err != nil {
 			return nil, err
 		}
-		val = append(dest, st...)
-	case sql.AnyWrapper:
-		unwrapped, err := s.UnwrapAny(ctx)
+		start = 0
+	case sql.Wrapper[string]:
+		unwrapped, err := s.Unwrap(ctx)
 		if err != nil {
 			return nil, err
 		}
-		val, err = ConvertToBytes(ctx, unwrapped, t, dest)
+		val = append(val, unwrapped...)
+	case sql.Wrapper[[]byte]:
+		var err error
+		val, err = s.Unwrap(ctx)
 		if err != nil {
 			return nil, err
 		}
+		start = 0
 	case GeometryValue:
 		return s.Serialize(), nil
 	default:


### PR DESCRIPTION
ConvertToBytes is a commonly called function to get the string representation of a value. However, it has some unnecessary allocations where a child function allocates a byte buffer, only for the result to be copied into the buffer provided by the parent function. In other places we needlessly round-trip between string and []byte.

This PR improves performance by removing some of these unneeded copies. In places where ConvertToBytes calls a function that allocates a buffer (instead of using the buffer that ConvertToBytes can provide), we can optimize by using the returned value without copying it again.

Dolt shows a 7% improvement in the `types_table_scan` benchmark.

We can potentially do even better by allowing these child functions to take a buffer, removing the need for an extra allocation.