### PR TITLE
Bug fix: ensure `DropCheck.IfExists` gets copied over to new instances

### DIFF
--- a/sql/plan/alter_check.go
+++ b/sql/plan/alter_check.go
@@ -128,7 +128,10 @@ func (d *DropCheck) WithChildren(children ...sql.Node) (sql.Node, error) {
 	if len(children) != 1 {
 		return nil, sql.ErrInvalidChildrenNumber.New(d, len(children), 1)
 	}
-	return NewAlterDropCheck(children[0].(*ResolvedTable), d.Name), nil
+
+	newAlterDropCheck := NewAlterDropCheck(children[0].(*ResolvedTable), d.Name)
+	newAlterDropCheck.IfExists = d.IfExists
+	return newAlterDropCheck, nil
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.


### PR DESCRIPTION
This change doesn't affect Dolt, but is needed by Doltgres to make sure `IF EXISTS` logic for dropping a constraint is correctly executed. 