### PR TITLE
fix `coalesce` with `JSON` types

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -627,7 +627,7 @@ var JsonScripts = []ScriptTest{
 		SetUpScript: []string{
 			"create table t (pk int primary key, col1 JSON, col2 JSON);",
 			`insert into t values (1, JSON_OBJECT('key1', 1, 'key2', '"abc"'), JSON_ARRAY(3,10,5,17,"z"));`,
-			`insert into t values (2, JSON_OBJECT('key1', 100, 'key2', '"ghi"'), JSON_ARRAY(3,10,5,17,JSON_ARRAY(22,"y",66)));`,
+			`insert into t values (2, JSON_OBJECT('key1', 100, 'key2', 'ghi'), JSON_ARRAY(3,10,5,17,JSON_ARRAY(22,"y",66)));`,
 			`CREATE TABLE t2 (i INT PRIMARY KEY, j JSON);`,
 			`INSERT INTO t2 VALUES (0, '{"a": "123", "outer": {"inner": 456}}');`,
 		},
@@ -637,15 +637,22 @@ var JsonScripts = []ScriptTest{
 				Expected: []sql.Row{{types.MustJSON("1")}, {types.MustJSON("100")}},
 			},
 			{
+				Query: `select col1->'$.key2' from t;`,
+				Expected: []sql.Row{
+					{types.JSONDocument{Val: "\"abc\""}},
+					{types.JSONDocument{Val: "ghi"}},
+				},
+			},
+			{
 				Query:    `select col1->>'$.key2' from t;`,
-				Expected: []sql.Row{{"abc"}, {"ghi"}},
+				Expected: []sql.Row{{"\"abc\""}, {"ghi"}},
 			},
 			{
 				Query:    `select pk, col1 from t where col1->'$.key1' = 1;`,
 				Expected: []sql.Row{{1, types.MustJSON(`{"key1":1, "key2":"\"abc\""}`)}},
 			},
 			{
-				Query:    `select pk, col1 from t where col1->>'$.key2' = 'abc';`,
+				Query:    `select pk, col1 from t where col1->>'$.key2' = '"abc"';`,
 				Expected: []sql.Row{{1, types.MustJSON(`{"key1":1, "key2":"\"abc\""}`)}},
 			},
 			{

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5413,6 +5413,12 @@ SELECT * FROM cte WHERE  d = 2;`,
 		},
 	},
 	{
+		Query: `SELECT COALESCE(CAST('{"a": "one \\n two"}' as json), '');`,
+		Expected: []sql.Row{
+			{"{\"a\": \"one \\n two\"}"},
+		},
+	},
+	{
 		Query: "SELECT concat(s, i) FROM mytable",
 		Expected: []sql.Row{
 			{string("first row1")},

--- a/sql/expression/function/coalesce_test.go
+++ b/sql/expression/function/coalesce_test.go
@@ -153,6 +153,16 @@ func TestCoalesce(t *testing.T) {
 			nullable: false,
 		},
 		{
+			name: "coalesce(json({'a': 'a \n b'}), '')",
+			input: []sql.Expression{
+				expression.NewLiteral("{\"a\": \"one \\n two\"}", types.JSON),
+				expression.NewLiteral("", types.LongText),
+			},
+			expected: "{\"a\": \"one \\n two\"}",
+			typ:      types.LongText,
+			nullable: false,
+		},
+		{
 			name: "coalesce(sysInt, sysInt)",
 			input: []sql.Expression{
 				expression.NewLiteral(1, types.NewSystemIntType("int1", 0, 10, false)),

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -630,8 +630,8 @@ func compareJSONArray(a JsonArray, b interface{}) (int, error) {
 func compareJSONObject(a JsonObject, b interface{}) (int, error) {
 	switch b := b.(type) {
 	case
-			bool,
-			JsonArray:
+		bool,
+		JsonArray:
 		// a is lower precedence
 		return -1, nil
 
@@ -662,9 +662,9 @@ func compareJSONObject(a JsonObject, b interface{}) (int, error) {
 func compareJSONString(a string, b interface{}) (int, error) {
 	switch b := b.(type) {
 	case
-			bool,
-			JsonArray,
-			JsonObject:
+		bool,
+		JsonArray,
+		JsonObject:
 		// a is lower precedence
 		return -1, nil
 
@@ -680,10 +680,10 @@ func compareJSONString(a string, b interface{}) (int, error) {
 func compareJSONNumber(a float64, b interface{}) (int, error) {
 	switch b := b.(type) {
 	case
-			bool,
-			JsonArray,
-			JsonObject,
-			string:
+		bool,
+		JsonArray,
+		JsonObject,
+		string:
 		// a is lower precedence
 		return -1, nil
 	case int:

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -43,7 +43,7 @@ func JsonToMySqlString(jsonWrapper sql.JSONWrapper) (string, error) {
 	return marshalToMySqlString(val)
 }
 
-// JsonToMySqlString generates a byte slice representation of a sql.JSONWrapper that is compatible with MySQL's JSON output, including spaces.
+// JsonToMySqlBytes generates a byte slice representation of a sql.JSONWrapper that is compatible with MySQL's JSON output, including spaces.
 func JsonToMySqlBytes(jsonWrapper sql.JSONWrapper) ([]byte, error) {
 	val, err := jsonWrapper.ToInterface()
 	if err != nil {
@@ -630,8 +630,8 @@ func compareJSONArray(a JsonArray, b interface{}) (int, error) {
 func compareJSONObject(a JsonObject, b interface{}) (int, error) {
 	switch b := b.(type) {
 	case
-		bool,
-		JsonArray:
+			bool,
+			JsonArray:
 		// a is lower precedence
 		return -1, nil
 
@@ -662,9 +662,9 @@ func compareJSONObject(a JsonObject, b interface{}) (int, error) {
 func compareJSONString(a string, b interface{}) (int, error) {
 	switch b := b.(type) {
 	case
-		bool,
-		JsonArray,
-		JsonObject:
+			bool,
+			JsonArray,
+			JsonObject:
 		// a is lower precedence
 		return -1, nil
 
@@ -680,10 +680,10 @@ func compareJSONString(a string, b interface{}) (int, error) {
 func compareJSONNumber(a float64, b interface{}) (int, error) {
 	switch b := b.(type) {
 	case
-		bool,
-		JsonArray,
-		JsonObject,
-		string:
+			bool,
+			JsonArray,
+			JsonObject,
+			string:
 		// a is lower precedence
 		return -1, nil
 	case int:

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -415,11 +415,6 @@ func ConvertToBytes(ctx context.Context, v interface{}, t sql.StringType, dest [
 		if err != nil {
 			return nil, err
 		}
-		// TODO: why do we do this?
-		//val, err = strings.UnquoteBytes(val)
-		if err != nil {
-			return nil, err
-		}
 		start = 0
 	case sql.Wrapper[string]:
 		unwrapped, err := s.Unwrap(ctx)

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -29,7 +29,6 @@ import (
 	"github.com/shopspring/decimal"
 	"gopkg.in/src-d/go-errors.v1"
 
-	"github.com/dolthub/go-mysql-server/internal/strings"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/encodings"
 )
@@ -416,7 +415,8 @@ func ConvertToBytes(ctx context.Context, v interface{}, t sql.StringType, dest [
 		if err != nil {
 			return nil, err
 		}
-		val, err = strings.UnquoteBytes(val)
+		// TODO: why do we do this?
+		//val, err = strings.UnquoteBytes(val)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR removes the call to strings.Unquote when converting from `JSON` to `StringType`.
Additionally, this fixes a test where we were incorrectly expecting an unquoted string from the `JsonUnquote` function.

fixes: https://github.com/dolthub/dolt/issues/9133