### PR TITLE
Correctly map enum values when altering an enum column.

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -7625,7 +7625,7 @@ where
 		Name: "preserve enums through alter statements",
 		SetUpScript: []string{
 			"create table t (i int primary key, e enum('a', 'b', 'c'));",
-			"insert into t values (0, 0);",
+			"insert ignore into t values (0, 'error');",
 			"insert into t values (1, 'a');",
 			"insert into t values (2, 'b');",
 			"insert into t values (3, 'c');",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -181,7 +181,7 @@ CREATE TABLE teams (
 			},
 			{
 				Query:       "alter table xy modify y enum('a')",
-				ExpectedErr: types.ErrConvertingToEnum,
+				ExpectedErr: types.ErrDataTruncatedForColumn,
 			},
 		},
 	},
@@ -7625,6 +7625,7 @@ where
 		Name: "preserve enums through alter statements",
 		SetUpScript: []string{
 			"create table t (i int primary key, e enum('a', 'b', 'c'));",
+			"insert into t values (0, 0);",
 			"insert into t values (1, 'a');",
 			"insert into t values (2, 'b');",
 			"insert into t values (3, 'c');",
@@ -7633,6 +7634,7 @@ where
 			{
 				Query: "select i, e, e + 0 from t;",
 				Expected: []sql.Row{
+					{0, "", float64(0)},
 					{1, "a", float64(1)},
 					{2, "b", float64(2)},
 					{3, "c", float64(3)},
@@ -7647,6 +7649,7 @@ where
 			{
 				Query: "select i, e, e + 0 from t;",
 				Expected: []sql.Row{
+					{0, "", float64(0)},
 					{1, "a", float64(2)},
 					{2, "b", float64(3)},
 					{3, "c", float64(1)},
@@ -7661,6 +7664,7 @@ where
 			{
 				Query: "select i, e, e + 0 from t;",
 				Expected: []sql.Row{
+					{0, "", float64(0)},
 					{1, "a", float64(2)},
 					{2, "b", float64(3)},
 					{3, "c", float64(4)},
@@ -7675,14 +7679,30 @@ where
 			{
 				Query: "select i, e, e + 0 from t;",
 				Expected: []sql.Row{
+					{0, "", float64(0)},
 					{1, "a", float64(2)},
 					{2, "b", float64(3)},
 					{3, "c", float64(4)},
 				},
 			},
 			{
+				Query: "alter table t modify column e enum('a', 'b', 'c');",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "select i, e, e + 0 from t;",
+				Expected: []sql.Row{
+					{0, "", float64(0)},
+					{1, "a", float64(1)},
+					{2, "b", float64(2)},
+					{3, "c", float64(3)},
+				},
+			},
+			{
 				Query:       "alter table t modify column e enum('abc');",
-				ExpectedErr: types.ErrConvertingToEnum,
+				ExpectedErr: types.ErrDataTruncatedForColumn,
 			},
 		},
 	},


### PR DESCRIPTION
When altering the possible values of an enum column, the mapping between enum strings and their indexes may change. In order to alter the column correctly, we need to map the old indexes onto the new ones.

This PR fixes two bugs in that mapping process:
- Previously, we were converting the row to the new schema before setting the enums to their new index. This means that if the old row had an index that didn't exist in the new schema, this conversion would fail. By setting the enums to their new index before we convert the row to the new schema, we avoid this problem.
- Enum indexes are 1-indexed, with the 0 value representing an "invalid" value. One way to get an invalid enum in MySQL is an `INSERT IGNORE` statement where the provided value for the enum is out of range. Dolt also allows setting the column to 0 directly, although MySQL does not. Previously, we were not able to alter enum columns if they contained a 0 value, but now we can.