### PR TITLE
Doltgres literal support

### DIFF
--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -577,7 +577,7 @@ func getFinalScale(ctx *sql.Context, row sql.Row, expr sql.Expression, divOpCnt 
 
 	var fScale uint8
 	if lit, isLit := expr.(*Literal); isLit {
-		_, fScale = GetPrecisionAndScale(lit.value)
+		_, fScale = GetPrecisionAndScale(lit.Val)
 	}
 	typ := expr.Type()
 	if dt, dok := typ.(sql.DecimalType); dok {

--- a/sql/expression/literal.go
+++ b/sql/expression/literal.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/dolthub/vitess/go/vt/proto/query"
+	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"github.com/shopspring/decimal"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -35,6 +36,7 @@ type Literal struct {
 var _ sql.Expression = &Literal{}
 var _ sql.Expression2 = &Literal{}
 var _ sql.CollationCoercible = &Literal{}
+var _ sqlparser.Injectable = &Literal{}
 
 // NewLiteral creates a new Literal expression.
 func NewLiteral(value interface{}, fieldType sql.Type) *Literal {
@@ -149,4 +151,11 @@ func (lit *Literal) Type2() sql.Type2 {
 // Value returns the literal value.
 func (p *Literal) Value() interface{} {
 	return p.value
+}
+
+func (lit *Literal) WithResolvedChildren(children []any) (any, error) {
+	if len(children) != 0 {
+		return nil, sql.ErrInvalidChildrenNumber.New(lit, len(children), 0)
+	}
+	return lit, nil
 }


### PR DESCRIPTION
This makes literal expression implement the sqlparser.Injectable interface so they can be used in Doltgres AST conversion.

Also exports fields so literals can be edited in place (required for how Doltgres processes these in a couple places).

This is an alternative to https://github.com/dolthub/go-mysql-server/pull/2946.