### PR TITLE
Unwrap inputs to REGEXP_LIKE, REPLACE, and RPAD/LPAD functions.

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -717,7 +717,13 @@ func TestCollationCoercion(t *testing.T) {
 
 func TestRegex(t *testing.T) {
 	harness := enginetest.NewDefaultMemoryHarness()
-	setupsScripts := append(setup.SimpleSetup, queries.RegexSetup)
+	regexSetup := []setup.SetupScript{
+		{
+			"CREATE TABLE tests(pk int primary key, str text, pattern text, flags text);",
+			"INSERT INTO tests VALUES (1, 'testing', 'TESTING', 'ci');",
+		},
+	}
+	setupsScripts := append(setup.SimpleSetup, regexSetup)
 	harness.Setup(setupsScripts...)
 	engine, err := harness.NewEngine(t)
 	require.NoError(t, err)

--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -717,7 +717,8 @@ func TestCollationCoercion(t *testing.T) {
 
 func TestRegex(t *testing.T) {
 	harness := enginetest.NewDefaultMemoryHarness()
-	harness.Setup(setup.SimpleSetup...)
+	setupsScripts := append(setup.SimpleSetup, queries.RegexSetup)
+	harness.Setup(setupsScripts...)
 	engine, err := harness.NewEngine(t)
 	require.NoError(t, err)
 	defer engine.Close()

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3046,7 +3046,7 @@ func TestRenameColumn(t *testing.T, harness Harness) {
 		TestQueryWithContext(t, ctx, e, harness, "ALTER TABLE mydb.tabletest RENAME COLUMN s TO i1", []sql.Row{{types.NewOkResult(0)}}, nil, nil, nil)
 		TestQueryWithContext(t, ctx, e, harness, "SHOW FULL COLUMNS FROM mydb.tabletest", []sql.Row{
 			{"i", "int", nil, "NO", "PRI", nil, "", "", ""},
-			{"i1", "varchar(20)", "utf8mb4_0900_bin", "NO", "", nil, "", "", ""},
+			{"i1", "text", "utf8mb4_0900_bin", "NO", "", nil, "", "", ""},
 		}, nil, nil, nil)
 	})
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6773,11 +6773,19 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{"first "}, {"second "}, {"third "}},
 	},
 	{
+		Query:    "select replace(s, 'row', '') from tabletest order by i",
+		Expected: []sql.Row{{"first "}, {"second "}, {"third "}},
+	},
+	{
 		Query:    "select rpad(s, 13, ' ') from mytable order by i",
 		Expected: []sql.Row{{"first row    "}, {"second row   "}, {"third row    "}},
 	},
 	{
 		Query:    "select lpad(s, 13, ' ') from mytable order by i",
+		Expected: []sql.Row{{"    first row"}, {"   second row"}, {"    third row"}},
+	},
+	{
+		Query:    "select lpad(s, 13, ' ') from tabletest order by i",
 		Expected: []sql.Row{{"    first row"}, {"   second row"}, {"    third row"}},
 	},
 	{

--- a/enginetest/queries/regex_queries.go
+++ b/enginetest/queries/regex_queries.go
@@ -34,13 +34,6 @@ type RegexTest struct {
 	ExpectedErr *errors.Kind
 }
 
-var RegexSetup = []setup.SetupScript{
-	{
-		"CREATE TABLE tests(pk int primary key, str text, pattern text, flags text);",
-		"INSERT INTO tests VALUES (1, 'testing', 'TESTING', 'ci');",
-	},
-}
-
 var RegexTests = []RegexTest{
 	{
 		Query:    "SELECT REGEXP_LIKE('testing', 'TESTING');",

--- a/enginetest/queries/regex_queries.go
+++ b/enginetest/queries/regex_queries.go
@@ -21,6 +21,7 @@
 package queries
 
 import (
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
 	"gopkg.in/src-d/go-errors.v1"
 
 	regex "github.com/dolthub/go-icu-regex"
@@ -32,6 +33,13 @@ type RegexTest struct {
 	Query       string
 	Expected    []sql.Row
 	ExpectedErr *errors.Kind
+}
+
+var RegexSetup = []setup.SetupScript{
+	{
+		"CREATE TABLE tests(pk int primary key, str text, pattern text, flags text);",
+		"INSERT INTO tests VALUES (1, 'testing', 'TESTING', 'ci');",
+	},
 }
 
 var RegexTests = []RegexTest{
@@ -54,6 +62,10 @@ var RegexTests = []RegexTest{
 	{
 		Query:    "SELECT REGEXP_LIKE('testing', 'TESTING', 'ic');",
 		Expected: []sql.Row{{0}},
+	},
+	{
+		Query:    "SELECT REGEXP_LIKE(str, pattern, flags) from tests;",
+		Expected: []sql.Row{{1}},
 	},
 	{
 		Query:    "SELECT REGEXP_LIKE('testing', 'TESTING' COLLATE utf8mb4_0900_ai_ci);",

--- a/enginetest/queries/regex_queries.go
+++ b/enginetest/queries/regex_queries.go
@@ -24,7 +24,6 @@ import (
 	regex "github.com/dolthub/go-icu-regex"
 	"gopkg.in/src-d/go-errors.v1"
 
-	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
 	"github.com/dolthub/go-mysql-server/sql"
 )
 

--- a/enginetest/queries/regex_queries.go
+++ b/enginetest/queries/regex_queries.go
@@ -21,11 +21,10 @@
 package queries
 
 import (
-	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
+	regex "github.com/dolthub/go-icu-regex"
 	"gopkg.in/src-d/go-errors.v1"
 
-	regex "github.com/dolthub/go-icu-regex"
-
+	"github.com/dolthub/go-mysql-server/enginetest/scriptgen/setup"
 	"github.com/dolthub/go-mysql-server/sql"
 )
 

--- a/enginetest/scriptgen/setup/scripts/tabletest
+++ b/enginetest/scriptgen/setup/scripts/tabletest
@@ -1,7 +1,7 @@
 exec
 create table tabletest (
     i int primary key,
-    s varchar(20) not null
+    s text not null
 )
 ----
 

--- a/enginetest/scriptgen/setup/setup_data.sg.go
+++ b/enginetest/scriptgen/setup/setup_data.sg.go
@@ -3251,7 +3251,7 @@ var SysbenchData = []SetupScript{{
 var TabletestData = []SetupScript{{
 	`create table tabletest (
     i int primary key,
-    s varchar(20) not null
+    s text not null
 )`,
 	`insert into tabletest values
     (1, 'first row'),

--- a/sql/expression/function/reverse_repeat_replace.go
+++ b/sql/expression/function/reverse_repeat_replace.go
@@ -280,9 +280,26 @@ func (r *Replace) Eval(
 		return nil, err
 	}
 
-	if fromStr.(string) == "" {
-		return str, nil
-	}
+	{
+		str, _, err := sql.Unwrap[string](ctx, str)
+		if err != nil {
+			return nil, err
+		}
 
-	return strings.Replace(str.(string), fromStr.(string), toStr.(string), -1), nil
+		fromStr, _, err := sql.Unwrap[string](ctx, fromStr)
+		if err != nil {
+			return nil, err
+		}
+
+		toStr, _, err := sql.Unwrap[string](ctx, toStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if fromStr == "" {
+			return str, nil
+		}
+
+		return strings.Replace(str, fromStr, toStr, -1), nil
+	}
 }

--- a/sql/expression/function/rpad_lpad.go
+++ b/sql/expression/function/rpad_lpad.go
@@ -169,7 +169,19 @@ func (p *Pad) Eval(
 		return nil, err
 	}
 
-	return padString(str.(string), length.(int64), padStr.(string), p.padType)
+	{
+		str, _, err := sql.Unwrap[string](ctx, str)
+		if err != nil {
+			return nil, err
+		}
+
+		padStr, _, err := sql.Unwrap[string](ctx, padStr)
+		if err != nil {
+			return nil, err
+		}
+
+		return padString(str, length.(int64), padStr, p.padType)
+	}
 }
 
 func padString(str string, length int64, padStr string, padType padType) (string, error) {


### PR DESCRIPTION
These are a couple more functions whose inputs aren't being unwrapped. If the inputs come from a column with a `TEXT` type, then they won't be converted to strings and the functions will fail. This PR fixes this by making sure that the inputs are converted.

We missed this previously because although we have tests for these functions, none of them tested getting the inputs from TEXT columns of a table.