### PR TITLE
[no-release-notes] Revert "Unwrap inputs to REGEXP_LIKE, REPLACE, and RPAD/LPAD functions."

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -717,14 +717,7 @@ func TestCollationCoercion(t *testing.T) {
 
 func TestRegex(t *testing.T) {
 	harness := enginetest.NewDefaultMemoryHarness()
-	regexSetup := []setup.SetupScript{
-		{
-			"CREATE TABLE tests(pk int primary key, str text, pattern text, flags text);",
-			"INSERT INTO tests VALUES (1, 'testing', 'TESTING', 'ci');",
-		},
-	}
-	setupsScripts := append(setup.SimpleSetup, regexSetup)
-	harness.Setup(setupsScripts...)
+	harness.Setup(setup.SimpleSetup...)
 	engine, err := harness.NewEngine(t)
 	require.NoError(t, err)
 	defer engine.Close()

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3046,7 +3046,7 @@ func TestRenameColumn(t *testing.T, harness Harness) {
 		TestQueryWithContext(t, ctx, e, harness, "ALTER TABLE mydb.tabletest RENAME COLUMN s TO i1", []sql.Row{{types.NewOkResult(0)}}, nil, nil, nil)
 		TestQueryWithContext(t, ctx, e, harness, "SHOW FULL COLUMNS FROM mydb.tabletest", []sql.Row{
 			{"i", "int", nil, "NO", "PRI", nil, "", "", ""},
-			{"i1", "text", "utf8mb4_0900_bin", "NO", "", nil, "", "", ""},
+			{"i1", "varchar(20)", "utf8mb4_0900_bin", "NO", "", nil, "", "", ""},
 		}, nil, nil, nil)
 	})
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -6773,19 +6773,11 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{"first "}, {"second "}, {"third "}},
 	},
 	{
-		Query:    "select replace(s, 'row', '') from tabletest order by i",
-		Expected: []sql.Row{{"first "}, {"second "}, {"third "}},
-	},
-	{
 		Query:    "select rpad(s, 13, ' ') from mytable order by i",
 		Expected: []sql.Row{{"first row    "}, {"second row   "}, {"third row    "}},
 	},
 	{
 		Query:    "select lpad(s, 13, ' ') from mytable order by i",
-		Expected: []sql.Row{{"    first row"}, {"   second row"}, {"    third row"}},
-	},
-	{
-		Query:    "select lpad(s, 13, ' ') from tabletest order by i",
 		Expected: []sql.Row{{"    first row"}, {"   second row"}, {"    third row"}},
 	},
 	{

--- a/enginetest/queries/regex_queries.go
+++ b/enginetest/queries/regex_queries.go
@@ -21,8 +21,9 @@
 package queries
 
 import (
-	regex "github.com/dolthub/go-icu-regex"
 	"gopkg.in/src-d/go-errors.v1"
+
+	regex "github.com/dolthub/go-icu-regex"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )
@@ -53,10 +54,6 @@ var RegexTests = []RegexTest{
 	{
 		Query:    "SELECT REGEXP_LIKE('testing', 'TESTING', 'ic');",
 		Expected: []sql.Row{{0}},
-	},
-	{
-		Query:    "SELECT REGEXP_LIKE(str, pattern, flags) from tests;",
-		Expected: []sql.Row{{1}},
 	},
 	{
 		Query:    "SELECT REGEXP_LIKE('testing', 'TESTING' COLLATE utf8mb4_0900_ai_ci);",

--- a/enginetest/scriptgen/setup/scripts/tabletest
+++ b/enginetest/scriptgen/setup/scripts/tabletest
@@ -1,7 +1,7 @@
 exec
 create table tabletest (
     i int primary key,
-    s text not null
+    s varchar(20) not null
 )
 ----
 

--- a/enginetest/scriptgen/setup/setup_data.sg.go
+++ b/enginetest/scriptgen/setup/setup_data.sg.go
@@ -3251,7 +3251,7 @@ var SysbenchData = []SetupScript{{
 var TabletestData = []SetupScript{{
 	`create table tabletest (
     i int primary key,
-    s text not null
+    s varchar(20) not null
 )`,
 	`insert into tabletest values
     (1, 'first row'),

--- a/sql/expression/function/regexp_like.go
+++ b/sql/expression/function/regexp_like.go
@@ -179,12 +179,8 @@ func (r *RegexpLike) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	textStr, _, err := sql.Unwrap[string](ctx, text)
-	if err != nil {
-		return nil, err
-	}
 
-	err = r.re.SetMatchString(ctx, textStr)
+	err = r.re.SetMatchString(ctx, text.(string))
 	if err != nil {
 		return nil, err
 	}
@@ -224,13 +220,9 @@ func compileRegex(ctx *sql.Context, pattern, text, flags sql.Expression, funcNam
 	if err != nil {
 		return nil, err
 	}
-	patternValStr, _, err := sql.Unwrap[string](ctx, patternVal)
-	if err != nil {
-		return nil, err
-	}
 
 	// Empty regex, throw illegal argument
-	if len(patternValStr) == 0 {
+	if len(patternVal.(string)) == 0 {
 		return nil, errors.NewKind("Illegal argument to regular expression.").New()
 	}
 
@@ -258,10 +250,7 @@ func compileRegex(ctx *sql.Context, pattern, text, flags sql.Expression, funcNam
 			return nil, err
 		}
 
-		flagsStr, _, err = sql.Unwrap[string](ctx, f)
-		if err != nil {
-			return nil, err
-		}
+		flagsStr = f.(string)
 		flagsStr, err = consolidateRegexpFlags(flagsStr, funcName)
 		if err != nil {
 			return nil, err
@@ -290,7 +279,7 @@ func compileRegex(ctx *sql.Context, pattern, text, flags sql.Expression, funcNam
 		ctx.Warn(1193, `System variable for regular expressions "regexp_buffer_size" is missing`)
 	}
 	re := regex.CreateRegex(bufferSize)
-	if err = re.SetRegexString(ctx, patternValStr, regexFlags); err != nil {
+	if err = re.SetRegexString(ctx, patternVal.(string), regexFlags); err != nil {
 		_ = re.Close()
 		return nil, err
 	}

--- a/sql/expression/function/reverse_repeat_replace.go
+++ b/sql/expression/function/reverse_repeat_replace.go
@@ -280,26 +280,9 @@ func (r *Replace) Eval(
 		return nil, err
 	}
 
-	{
-		str, _, err := sql.Unwrap[string](ctx, str)
-		if err != nil {
-			return nil, err
-		}
-
-		fromStr, _, err := sql.Unwrap[string](ctx, fromStr)
-		if err != nil {
-			return nil, err
-		}
-
-		toStr, _, err := sql.Unwrap[string](ctx, toStr)
-		if err != nil {
-			return nil, err
-		}
-
-		if fromStr == "" {
-			return str, nil
-		}
-
-		return strings.Replace(str, fromStr, toStr, -1), nil
+	if fromStr.(string) == "" {
+		return str, nil
 	}
+
+	return strings.Replace(str.(string), fromStr.(string), toStr.(string), -1), nil
 }

--- a/sql/expression/function/rpad_lpad.go
+++ b/sql/expression/function/rpad_lpad.go
@@ -169,19 +169,7 @@ func (p *Pad) Eval(
 		return nil, err
 	}
 
-	{
-		str, _, err := sql.Unwrap[string](ctx, str)
-		if err != nil {
-			return nil, err
-		}
-
-		padStr, _, err := sql.Unwrap[string](ctx, padStr)
-		if err != nil {
-			return nil, err
-		}
-
-		return padString(str, length.(int64), padStr, p.padType)
-	}
+	return padString(str.(string), length.(int64), padStr.(string), p.padType)
 }
 
 func padString(str string, length int64, padStr string, padType padType) (string, error) {


### PR DESCRIPTION
Reverts dolthub/go-mysql-server#2964

I misread the CI results. Shame me.