### PR TITLE
Unwrap wrapped values before computing their hash.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3046,7 +3046,7 @@ func TestRenameColumn(t *testing.T, harness Harness) {
 		TestQueryWithContext(t, ctx, e, harness, "ALTER TABLE mydb.tabletest RENAME COLUMN s TO i1", []sql.Row{{types.NewOkResult(0)}}, nil, nil, nil)
 		TestQueryWithContext(t, ctx, e, harness, "SHOW FULL COLUMNS FROM mydb.tabletest", []sql.Row{
 			{"i", "int", nil, "NO", "PRI", nil, "", "", ""},
-			{"i1", "varchar(20)", "utf8mb4_0900_bin", "NO", "", nil, "", "", ""},
+			{"i1", "text", "utf8mb4_0900_bin", "NO", "", nil, "", "", ""},
 		}, nil, nil, nil)
 	})
 }

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5666,6 +5666,18 @@ SELECT * FROM cte WHERE  d = 2;`,
 		},
 	},
 	{
+		Query:    "select * from mytable intersect select * from tabletest",
+		Expected: []sql.Row{{1, "first row"}, {2, "second row"}, {3, "third row"}},
+	},
+	{
+		Query:    "select * from mytable union distinct select * from tabletest",
+		Expected: []sql.Row{{1, "first row"}, {2, "second row"}, {3, "third row"}},
+	},
+	{
+		Query:    "select * from mytable except select * from tabletest",
+		Expected: []sql.Row{},
+	},
+	{
 		SkipPrepared: true,
 		Query:        "",
 		Expected:     []sql.Row{},
@@ -6773,11 +6785,19 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{"first "}, {"second "}, {"third "}},
 	},
 	{
+		Query:    "select replace(s, 'row', '') from tabletest order by i",
+		Expected: []sql.Row{{"first "}, {"second "}, {"third "}},
+	},
+	{
 		Query:    "select rpad(s, 13, ' ') from mytable order by i",
 		Expected: []sql.Row{{"first row    "}, {"second row   "}, {"third row    "}},
 	},
 	{
 		Query:    "select lpad(s, 13, ' ') from mytable order by i",
+		Expected: []sql.Row{{"    first row"}, {"   second row"}, {"    third row"}},
+	},
+	{
+		Query:    "select lpad(s, 13, ' ') from tabletest order by i",
 		Expected: []sql.Row{{"    first row"}, {"   second row"}, {"    third row"}},
 	},
 	{

--- a/enginetest/scriptgen/setup/scripts/tabletest
+++ b/enginetest/scriptgen/setup/scripts/tabletest
@@ -1,7 +1,7 @@
 exec
 create table tabletest (
     i int primary key,
-    s varchar(20) not null
+    s text not null
 )
 ----
 

--- a/enginetest/scriptgen/setup/setup_data.sg.go
+++ b/enginetest/scriptgen/setup/setup_data.sg.go
@@ -3251,7 +3251,7 @@ var SysbenchData = []SetupScript{{
 var TabletestData = []SetupScript{{
 	`create table tabletest (
     i int primary key,
-    s varchar(20) not null
+    s text not null
 )`,
 	`insert into tabletest values
     (1, 'first row'),

--- a/memory/table.go
+++ b/memory/table.go
@@ -1971,7 +1971,7 @@ func (t *Table) DropCheck(ctx *sql.Context, chName string) error {
 	return fmt.Errorf("check '%s' was not found on the table", chName)
 }
 
-func (t *Table) createIndex(data *TableData, name string, columns []sql.IndexColumn, constraint sql.IndexConstraint, comment string) (sql.Index, error) {
+func (t *Table) createIndex(ctx *sql.Context, data *TableData, name string, columns []sql.IndexColumn, constraint sql.IndexConstraint, comment string) (sql.Index, error) {
 	if name == "" {
 		for _, column := range columns {
 			name += column.Name + "_"
@@ -2005,7 +2005,7 @@ func (t *Table) createIndex(data *TableData, name string, columns []sql.IndexCol
 	}
 
 	if constraint == sql.IndexConstraint_Unique {
-		err := data.errIfDuplicateEntryExist(colNames, name)
+		err := data.errIfDuplicateEntryExist(ctx, colNames, name)
 		if err != nil {
 			return nil, err
 		}
@@ -2041,7 +2041,7 @@ func (t *Table) CreateIndex(ctx *sql.Context, idx sql.IndexDef) error {
 		data.indexes = make(map[string]sql.Index)
 	}
 
-	index, err := t.createIndex(data, idx.Name, idx.Columns, idx.Constraint, idx.Comment)
+	index, err := t.createIndex(ctx, data, idx.Name, idx.Columns, idx.Constraint, idx.Comment)
 	if err != nil {
 		return err
 	}
@@ -2107,7 +2107,7 @@ func (t *Table) CreateFulltextIndex(ctx *sql.Context, indexDef sql.IndexDef, key
 		data.indexes = make(map[string]sql.Index)
 	}
 
-	index, err := t.createIndex(data, indexDef.Name, indexDef.Columns, indexDef.Constraint, indexDef.Comment)
+	index, err := t.createIndex(ctx, data, indexDef.Name, indexDef.Columns, indexDef.Constraint, indexDef.Comment)
 	if err != nil {
 		return err
 	}
@@ -2138,7 +2138,7 @@ func (t *Table) CreateVectorIndex(ctx *sql.Context, idx sql.IndexDef, distanceTy
 		data.indexes = make(map[string]sql.Index)
 	}
 
-	index, err := t.createIndex(data, idx.Name, idx.Columns, idx.Constraint, idx.Comment)
+	index, err := t.createIndex(ctx, data, idx.Name, idx.Columns, idx.Constraint, idx.Comment)
 	if err != nil {
 		return err
 	}

--- a/memory/table_data.go
+++ b/memory/table_data.go
@@ -15,6 +15,7 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
@@ -274,7 +275,7 @@ func (td *TableData) numRows(ctx *sql.Context) (uint64, error) {
 }
 
 // throws an error if any two or more rows share the same |cols| values.
-func (td *TableData) errIfDuplicateEntryExist(cols []string, idxName string) error {
+func (td *TableData) errIfDuplicateEntryExist(ctx context.Context, cols []string, idxName string) error {
 	columnMapping, err := td.columnIndexes(cols)
 
 	// We currently skip validating duplicates on unique virtual columns.
@@ -296,7 +297,7 @@ func (td *TableData) errIfDuplicateEntryExist(cols []string, idxName string) err
 			if hasNulls(idxPrefixKey) {
 				continue
 			}
-			h, err := sql.HashOf(idxPrefixKey)
+			h, err := sql.HashOf(ctx, idxPrefixKey)
 			if err != nil {
 				return err
 			}

--- a/sql/cache.go
+++ b/sql/cache.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sync"
@@ -25,7 +26,7 @@ import (
 )
 
 // HashOf returns a hash of the given value to be used as key in a cache.
-func HashOf(v Row) (uint64, error) {
+func HashOf(ctx context.Context, v Row) (uint64, error) {
 	hash := digestPool.Get().(*xxhash.Digest)
 	hash.Reset()
 	defer digestPool.Put(hash)
@@ -36,7 +37,10 @@ func HashOf(v Row) (uint64, error) {
 				return 0, err
 			}
 		}
-
+		x, err := UnwrapAny(ctx, x)
+		if err != nil {
+			return 0, err
+		}
 		// TODO: probably much faster to do this with a type switch
 		// TODO: we don't have the type info necessary to appropriately encode the value of a string with a non-standard
 		//  collation, which means that two strings that differ only in their collations will hash to the same value.

--- a/sql/cache_test.go
+++ b/sql/cache_test.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -179,10 +180,11 @@ func TestRowsCache(t *testing.T) {
 }
 
 func BenchmarkHashOf(b *testing.B) {
+	ctx := context.Background()
 	row := NewRow(1, "1")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		sum, err := HashOf(row)
+		sum, err := HashOf(ctx, row)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -193,11 +195,12 @@ func BenchmarkHashOf(b *testing.B) {
 }
 
 func BenchmarkParallelHashOf(b *testing.B) {
+	ctx := context.Background()
 	row := NewRow(1, "1")
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			sum, err := HashOf(row)
+			sum, err := HashOf(ctx, row)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -571,7 +571,7 @@ func (di *distinctIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, err
 		}
 
-		hash, err := sql.HashOf(row)
+		hash, err := sql.HashOf(ctx, row)
 		if err != nil {
 			return nil, err
 		}
@@ -647,7 +647,7 @@ func (ii *IntersectIter) Next(ctx *sql.Context) (sql.Row, error) {
 				return nil, err
 			}
 
-			hash, herr := sql.HashOf(res)
+			hash, herr := sql.HashOf(ctx, res)
 			if herr != nil {
 				return nil, herr
 			}
@@ -669,7 +669,7 @@ func (ii *IntersectIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, err
 		}
 
-		hash, herr := sql.HashOf(res)
+		hash, herr := sql.HashOf(ctx, res)
 		if herr != nil {
 			return nil, herr
 		}
@@ -714,7 +714,7 @@ func (ei *ExceptIter) Next(ctx *sql.Context) (sql.Row, error) {
 				return nil, err
 			}
 
-			hash, herr := sql.HashOf(res)
+			hash, herr := sql.HashOf(ctx, res)
 			if herr != nil {
 				return nil, herr
 			}
@@ -736,7 +736,7 @@ func (ei *ExceptIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, err
 		}
 
-		hash, herr := sql.HashOf(res)
+		hash, herr := sql.HashOf(ctx, res)
 		if herr != nil {
 			return nil, herr
 		}

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -127,7 +127,7 @@ func (n *HashLookup) GetHashKey(ctx *sql.Context, e sql.Expression, row sql.Row)
 		return nil, err
 	}
 	if s, ok := key.([]interface{}); ok {
-		return sql.HashOf(s)
+		return sql.HashOf(ctx, s)
 	}
 	// byte slices are not hashable
 	if k, ok := key.([]byte); ok {

--- a/sql/plan/insubquery.go
+++ b/sql/plan/insubquery.go
@@ -47,7 +47,7 @@ func NewInSubquery(left sql.Expression, right sql.Expression) *InSubquery {
 	return &InSubquery{expression.BinaryExpressionStub{LeftChild: left, RightChild: right}}
 }
 
-var nilKey, _ = sql.HashOf(sql.NewRow(nil))
+var nilKey, _ = sql.HashOf(nil, sql.NewRow(nil))
 
 // Eval implements the Expression interface.
 func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
@@ -96,7 +96,7 @@ func (in *InSubquery) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return false, nil
 		}
 
-		key, err := sql.HashOf(sql.NewRow(nLeft))
+		key, err := sql.HashOf(ctx, sql.NewRow(nLeft))
 		if err != nil {
 			return nil, err
 		}

--- a/sql/plan/subquery.go
+++ b/sql/plan/subquery.go
@@ -477,7 +477,7 @@ func putAllRows(ctx *sql.Context, cache sql.KeyValueCache, vals []interface{}) e
 		if err != nil {
 			return err
 		}
-		rowKey, err := sql.HashOf(sql.NewRow(val))
+		rowKey, err := sql.HashOf(ctx, sql.NewRow(val))
 		if err != nil {
 			return err
 		}

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -462,7 +462,7 @@ func (i *fullJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 		rightRow, err := i.r.Next(ctx)
 		if err == io.EOF {
-			key, err := sql.HashOf(i.leftRow)
+			key, err := sql.HashOf(ctx, i.leftRow)
 			if err != nil {
 				return nil, err
 			}
@@ -485,12 +485,12 @@ func (i *fullJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 		if !sql.IsTrue(matches) {
 			continue
 		}
-		rkey, err := sql.HashOf(rightRow)
+		rkey, err := sql.HashOf(ctx, rightRow)
 		if err != nil {
 			return nil, err
 		}
 		i.seenRight[rkey] = struct{}{}
-		lKey, err := sql.HashOf(i.leftRow)
+		lKey, err := sql.HashOf(ctx, i.leftRow)
 		if err != nil {
 			return nil, err
 		}
@@ -517,7 +517,7 @@ func (i *fullJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			return nil, io.EOF
 		}
 
-		key, err := sql.HashOf(rightRow)
+		key, err := sql.HashOf(ctx, rightRow)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/rowexec/other_iters.go
+++ b/sql/rowexec/other_iters.go
@@ -334,7 +334,7 @@ func (ci *concatIter) Next(ctx *sql.Context) (sql.Row, error) {
 		if err != nil {
 			return nil, err
 		}
-		hash, err := sql.HashOf(res)
+		hash, err := sql.HashOf(ctx, res)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/rowexec/rel_iters.go
+++ b/sql/rowexec/rel_iters.go
@@ -446,7 +446,7 @@ func (r *recursiveCteIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 		var key uint64
 		if r.deduplicate {
-			key, _ = sql.HashOf(row)
+			key, _ = sql.HashOf(ctx, row)
 			if k, _ := r.cache.Get(key); k != nil {
 				// skip duplicate
 				continue

--- a/sql/rowexec/update.go
+++ b/sql/rowexec/update.go
@@ -248,7 +248,7 @@ func (u *updateJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 
 			// Determine whether this row in the table has already been updated
 			cache := u.getOrCreateCache(ctx, tableName)
-			hash, err := sql.HashOf(oldTableRow)
+			hash, err := sql.HashOf(ctx, oldTableRow)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
(This PR changes the types in one of the tables used in tests. This improves the test coverage for `TEXT` columns, especially when they're used in conjunction with other tables with `VARCHAR` columns. None of the existing tests were testing the original type: this should be strictly increasing our test coverage.)

The following plans involve computing a hash of rows to store in an in-memory hash set:
- Intersect, Except, and Distinct 
- HashLookup
- InSubquery
- HashSubquery
- FullJoinIter
- ConcatJoin
- Recursive CTE
- UpdateJoinIter

We weren't previously unwrapping wrapped values before computing hashes. The default hash implementation used the struct's `%v` representation to compute the hash, which has two problems:
- The hash of the `%v` representation of a wrapper struct is not the same as the hash of the value that the wrapper is semantically equivalent to.
- The hash of the `%v` representation of a wrapper struct depends on internal state, such as whether the wrapped has already been unwrapped once before (and cached the unwrapped value in an internal buffer)

The simplest fix is to unwrap values before computing a row hash in the `HashOf` function.

However, this fix comes at a cost: it now requires the engine to unwrap all values if they get used in any of the above plans. This will hurt performance for any of the above plans if they don't actually need to unwrap the value. For example, an UpdateJoinIter on a table with a `TEXT` column will now load that column from disk, even if its value is never used.

A better fix might be to use the `Hash()` function that is already defined on the `sql.Wrapper` interface. For all existing Wrapper implementations, this returns the Dolt content address of the value, and is the same regardless of whether or not that address has previously been resolved. However, this would still return a different hash than an equivalent string. If we wanted them to return the same hash, Dolt would need to define a custom hash for strings that computes the Dolt content address of the string if it were to be stored as a Dolt chunk. This would likely be slower than Go's builtin hash for strings, although the performance *might* be comparable? This would likely result in worse performance for plans that don't use `TEXT` columns.

