### PR TITLE
[no-release-notes] Rollforward "Unwrap inputs to REGEXP_LIKE, RPAD, LPAD, and REPLACE functions."

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -717,7 +717,14 @@ func TestCollationCoercion(t *testing.T) {
 
 func TestRegex(t *testing.T) {
 	harness := enginetest.NewDefaultMemoryHarness()
-	harness.Setup(setup.SimpleSetup...)
+	regexSetup := []setup.SetupScript{
+		{
+			"CREATE TABLE tests(pk int primary key, str text, pattern text, flags text);",
+			"INSERT INTO tests VALUES (1, 'testing', 'TESTING', 'ci');",
+		},
+	}
+	setupsScripts := append(setup.SimpleSetup, regexSetup)
+	harness.Setup(setupsScripts...)
 	engine, err := harness.NewEngine(t)
 	require.NoError(t, err)
 	defer engine.Close()

--- a/enginetest/queries/regex_queries.go
+++ b/enginetest/queries/regex_queries.go
@@ -56,6 +56,10 @@ var RegexTests = []RegexTest{
 		Expected: []sql.Row{{0}},
 	},
 	{
+		Query:    "SELECT REGEXP_LIKE(str, pattern, flags) from tests;",
+		Expected: []sql.Row{{1}},
+	},
+	{
 		Query:    "SELECT REGEXP_LIKE('testing', 'TESTING' COLLATE utf8mb4_0900_ai_ci);",
 		Expected: []sql.Row{{1}},
 	},

--- a/sql/expression/function/reverse_repeat_replace.go
+++ b/sql/expression/function/reverse_repeat_replace.go
@@ -280,9 +280,26 @@ func (r *Replace) Eval(
 		return nil, err
 	}
 
-	if fromStr.(string) == "" {
-		return str, nil
-	}
+	{
+		str, _, err := sql.Unwrap[string](ctx, str)
+		if err != nil {
+			return nil, err
+		}
 
-	return strings.Replace(str.(string), fromStr.(string), toStr.(string), -1), nil
+		fromStr, _, err := sql.Unwrap[string](ctx, fromStr)
+		if err != nil {
+			return nil, err
+		}
+
+		toStr, _, err := sql.Unwrap[string](ctx, toStr)
+		if err != nil {
+			return nil, err
+		}
+
+		if fromStr == "" {
+			return str, nil
+		}
+
+		return strings.Replace(str, fromStr, toStr, -1), nil
+	}
 }

--- a/sql/expression/function/rpad_lpad.go
+++ b/sql/expression/function/rpad_lpad.go
@@ -169,7 +169,19 @@ func (p *Pad) Eval(
 		return nil, err
 	}
 
-	return padString(str.(string), length.(int64), padStr.(string), p.padType)
+	{
+		str, _, err := sql.Unwrap[string](ctx, str)
+		if err != nil {
+			return nil, err
+		}
+
+		padStr, _, err := sql.Unwrap[string](ctx, padStr)
+		if err != nil {
+			return nil, err
+		}
+
+		return padString(str, length.(int64), padStr, p.padType)
+	}
 }
 
 func padString(str string, length int64, padStr string, padType padType) (string, error) {


### PR DESCRIPTION
This is the same PR as https://github.com/dolthub/go-mysql-server/pull/2964, which was accidentally merged despite breaking some tests.

From the original PR:

These are a couple more functions whose inputs aren't being unwrapped. If the inputs come from a column with a TEXT type, then they won't be converted to strings and the functions will fail. This PR fixes this by making sure that the inputs are converted.

We missed this previously because although we have tests for these functions, none of them tested getting the inputs from TEXT columns of a table.
