### PR TITLE
Bug fix: ensure an active transaction is set before preparing a query

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -240,6 +240,9 @@ func (e *Engine) PrepareParsedQuery(
 	statementKey, query string,
 	stmt sqlparser.Statement,
 ) (sql.Node, error) {
+	// Make sure there is an active transaction if one hasn't been started yet
+	e.beginTransaction(ctx)
+
 	binder := planbuilder.New(ctx, e.Analyzer.Catalog, e.EventScheduler, e.Parser)
 	node, _, err := binder.BindOnly(stmt, query, nil)
 

--- a/enginetest/queries/transaction_queries.go
+++ b/enginetest/queries/transaction_queries.go
@@ -1447,4 +1447,35 @@ var TransactionTests = []TransactionTest{
 			},
 		},
 	},
+	{
+		// Repro for https://github.com/dolthub/dolt/issues/3402
+		//       and https://github.com/dolthub/dolt/issues/9213 (similar issue, just with prepared statements)
+		Name: "DDL changes from transactions are available before analyzing statements in other sessions (autocommit on)",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "/* client a */ select @@autocommit;",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "/* client b */ select @@autocommit;",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "/* client a */ show tables like 't';",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "/* client b */ show tables like 't';",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "/* client a */ create table t(pk int primary key);",
+				Expected: []sql.Row{{types.OkResult{}}},
+			},
+			{
+				Query:    "/* client b */ select count(*) from t;",
+				Expected: []sql.Row{{0}},
+			},
+		},
+	},
 }


### PR DESCRIPTION
Also adds support for running transaction tests with prepared statements.

Fixes: https://github.com/dolthub/dolt/issues/9213