### PR TITLE
fix indexing for `GROUP BY`s and `WINDOW`s in `INSERT` and `REPLACE` statements in `TRIGGERS`

### DIFF
--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -67,6 +67,7 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 			//		scope = &plan.Scope{}
 			//	}
 			//}
+			scope.InInsertSource = true // TODO: use a setter?
 			source, _, err = a.analyzeWithSelector(ctx, insert.Source, scope, SelectAllBatches, newInsertSourceSelector(sel), qFlags)
 			if err != nil {
 				return nil, transform.SameTree, err

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -67,7 +67,9 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 			//		scope = &plan.Scope{}
 			//	}
 			//}
-			scope.InInsertSource = true // TODO: use a setter?
+			if scope != nil {
+				scope.InInsertSource = true // TODO: use a setter?
+			}
 			source, _, err = a.analyzeWithSelector(ctx, insert.Source, scope, SelectAllBatches, newInsertSourceSelector(sel), qFlags)
 			if err != nil {
 				return nil, transform.SameTree, err

--- a/sql/analyzer/inserts.go
+++ b/sql/analyzer/inserts.go
@@ -59,17 +59,7 @@ func resolveInsertRows(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 					plan.NewSubqueryAlias("dummy", "", insert.Source),
 				))
 			}
-			//if proj, ok := insert.Source.(*plan.Project); ok {
-			//	if _, ok := proj.Child.(*plan.GroupBy); ok {
-			//		scope = &plan.Scope{}
-			//	}
-			//	if _, ok := proj.Child.(*plan.Window); ok {
-			//		scope = &plan.Scope{}
-			//	}
-			//}
-			if scope != nil {
-				scope.InInsertSource = true // TODO: use a setter?
-			}
+			scope.SetInInsertSource(true)
 			source, _, err = a.analyzeWithSelector(ctx, insert.Source, scope, SelectAllBatches, newInsertSourceSelector(sel), qFlags)
 			if err != nil {
 				return nil, transform.SameTree, err

--- a/sql/plan/scope.go
+++ b/sql/plan/scope.go
@@ -44,6 +44,8 @@ type Scope struct {
 	inLateralJoin bool
 	joinSiblings  []sql.Node
 	JoinTrees     []string
+
+	InInsertSource bool
 }
 
 func (s *Scope) SetJoin(b bool) {

--- a/sql/plan/scope.go
+++ b/sql/plan/scope.go
@@ -45,21 +45,7 @@ type Scope struct {
 	joinSiblings  []sql.Node
 	JoinTrees     []string
 
-	InInsertSource bool
-}
-
-func (s *Scope) SetJoin(b bool) {
-	if s == nil {
-		return
-	}
-	s.inJoin = b
-}
-
-func (s *Scope) SetLateralJoin(b bool) {
-	if s == nil {
-		return
-	}
-	s.inLateralJoin = b
+	inInsertSource bool
 }
 
 func (s *Scope) IsEmpty() bool {
@@ -320,18 +306,37 @@ func (s *Scope) Schema() sql.Schema {
 	return schema
 }
 
-func (s *Scope) InJoin() bool {
+func (s *Scope) SetJoin(b bool) {
 	if s == nil {
-		return false
+		return
 	}
-	return s.inJoin
+	s.inJoin = b
+}
+
+func (s *Scope) SetLateralJoin(b bool) {
+	if s == nil {
+		return
+	}
+	s.inLateralJoin = b
+}
+
+func (s *Scope) SetInInsertSource(b bool) {
+	if s == nil {
+		return
+	}
+	s.inInsertSource = b
+}
+
+func (s *Scope) InJoin() bool {
+	return s != nil && s.inJoin
 }
 
 func (s *Scope) InLateralJoin() bool {
-	if s == nil {
-		return false
-	}
-	return s.inLateralJoin
+	return s != nil && s.inLateralJoin
+}
+
+func (s *Scope) InInsertSource() bool {
+	return s != nil && s.inInsertSource
 }
 
 func (s *Scope) JoinSiblings() []sql.Node {

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -76,6 +76,7 @@ func (b *BaseBuilder) buildDescribeQuery(ctx *sql.Context, n *plan.DescribeQuery
 	var rows []sql.Row
 	if n.Format.Plan {
 		formatString := sql.Describe(n.Child, n.Format)
+		formatString = strings.Replace(formatString, "\r", "", -1)
 		for _, l := range strings.Split(formatString, "\n") {
 			if strings.TrimSpace(l) != "" {
 				rows = append(rows, sql.NewRow(l))


### PR DESCRIPTION
Using aggregation and window functions inside a select statement inside an insert source inside a trigger was causing problems.  For example, a trigger defined like so:
```
create trigger trig before insert on t1
for each row
begin
  insert into t2
  select 
     max(id),
     first_value(id) over (partition by id order by id),
     ...
  from
     t3;
end;
```

The issue involved the `Projections` over the `Group By`s. The scope for the `group by`s already contained the trigger's columns and are indexed uniquely, so we shouldn't include the trigger/parent scope.