### PR TITLE
Unwrap inputs to JSON_OBJECT.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -1907,7 +1907,7 @@ func TestComplexIndexQueriesPrepared(t *testing.T, harness Harness) {
 }
 
 func TestJsonScriptsPrepared(t *testing.T, harness Harness, skippedTests []string) {
-	harness.Setup(setup.MydbData)
+	harness.Setup(setup.MydbData, setup.BlobData)
 	for _, script := range queries.JsonScripts {
 		for _, skippedTest := range skippedTests {
 			if strings.Contains(script.Name, skippedTest) {
@@ -5154,6 +5154,7 @@ func TestNullRanges(t *testing.T, harness Harness) {
 }
 
 func TestJsonScripts(t *testing.T, harness Harness, skippedTests []string) {
+	harness.Setup(setup.MydbData, setup.BlobData)
 	for _, script := range queries.JsonScripts {
 		for _, skippedTest := range skippedTests {
 			if strings.Contains(script.Name, skippedTest) {

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -127,6 +127,17 @@ var JsonScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "json_object works on text values from tables",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `select JSON_OBJECT(t, t) FROM textt where i = 1;`,
+				Expected: []sql.Row{
+					{types.MustJSON("{\"first row\": \"first row\"}")},
+				},
+			},
+		},
+	},
+	{
 		Name: "types survive round-trip into tables",
 		SetUpScript: []string{
 			"CREATE TABLE xy (x bigint primary key, y JSON)",

--- a/sql/expression/function/json/json_object.go
+++ b/sql/expression/function/json/json_object.go
@@ -102,12 +102,19 @@ func (j JSONObject) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return nil, err
 		}
 		if i%2 == 0 {
-			val, _, err := types.LongText.Convert(ctx, val)
+			val, _, err = types.LongText.Convert(ctx, val)
 			if err != nil {
 				return nil, err
 			}
-			key = val.(string)
+			key, _, err = sql.Unwrap[string](ctx, val)
+			if err != nil {
+				return nil, err
+			}
 		} else {
+			val, err = sql.UnwrapAny(ctx, val)
+			if err != nil {
+				return nil, err
+			}
 			if json, ok := val.(sql.JSONWrapper); ok {
 				val, err = json.ToInterface()
 				if err != nil {


### PR DESCRIPTION
The inputs to the JSON_OBJECT function are expected to be strings for the keys, and the expected types for the values. So we need to check whether the inputs are wrapper values and unwrap them.

The safest thing to do is unwrap the value when the document is created, so this PR does that. In theory, allowed wrapped values to be used as document values and unwrapping them at the use site could improve performance for certain queries that create JSON objects in memory but then only read some of the fields. But that's likely an infrequent enough situation that it's not worth the added complexity.