### PR TITLE
Unwrap wrapper values used in JSON aggregation functions, and un-skip accidentally-skipped tests for this behavior.

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5155,12 +5155,14 @@ func TestNullRanges(t *testing.T, harness Harness) {
 
 func TestJsonScripts(t *testing.T, harness Harness, skippedTests []string) {
 	for _, script := range queries.JsonScripts {
-		for _, skippedTest := range skippedTests {
-			if strings.Contains(script.Name, skippedTest) {
-				t.Skip()
+		t.Run(script.Name, func(t *testing.T) {
+			for _, skippedTest := range skippedTests {
+				if strings.Contains(script.Name, skippedTest) {
+					t.Skip()
+				}
 			}
-		}
-		TestScript(t, harness, script)
+			TestScript(t, harness, script)
+		})
 	}
 }
 

--- a/sql/expression/function/aggregation/unary_agg_buffers.go
+++ b/sql/expression/function/aggregation/unary_agg_buffers.go
@@ -646,7 +646,11 @@ func (j *jsonArrayBuffer) Update(ctx *sql.Context, row sql.Row) error {
 		return err
 	}
 
-	// unwrap JSON values
+	// unwrap wrapper values
+	v, err = sql.UnwrapAny(ctx, v)
+	if err != nil {
+		return err
+	}
 	if js, ok := v.(sql.JSONWrapper); ok {
 		v, err = js.ToInterface()
 		if err != nil {

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -1049,7 +1049,11 @@ func (a *WindowedJSONArrayAgg) aggregateVals(ctx *sql.Context, interval sql.Wind
 			return nil, err
 		}
 
-		// unwrap JSON values
+		// unwrap wrapper values
+		v, err = sql.UnwrapAny(ctx, v)
+		if err != nil {
+			return nil, err
+		}
 		if js, ok := v.(sql.JSONWrapper); ok {
 			v, err = js.ToInterface()
 			if err != nil {
@@ -1136,7 +1140,11 @@ func (a *WindowedJSONObjectAgg) aggregateVals(ctx *sql.Context, interval sql.Win
 			return nil, err
 		}
 
-		// unwrap JSON values
+		// unwrap wrapper values
+		val, err = sql.UnwrapAny(ctx, val)
+		if err != nil {
+			return nil, err
+		}
 		if js, ok := val.(sql.JSONWrapper); ok {
 			val, err = js.ToInterface()
 			if err != nil {


### PR DESCRIPTION
We were accidentally skipping most of the tests in `TestJsonScripts`. An error in the test harness meant that skipping one test in this suite would also skip all additional tests.

A few of the skipped tests were for JSON aggregation functions. The recent "Adaptive Encoding / Wrapper Values" optimization wasn't working properly with these functions because the wrapped values provided to these functions weren't being unwrapped before being inserted into JSON documents. These tests would have caught that issue, but didn't because they were disabled.

This PR fixes the issue and also re-enables the test.