### PR TITLE
Add lock_warnings system variable.

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -269,6 +269,8 @@ func clearWarnings(ctx *sql.Context, node sql.Node) {
 		// `show warning limit x offset y` is valid, so we need to recurse
 		clearWarnings(ctx, n.Children()[0])
 	case *plan.Set:
+		// We want to maintain warnings when setting the warnings_lock variable.
+		// Set statements also can't produce warnings, so we don't care about clearing them.
 	case plan.ShowWarnings:
 		// ShowWarnings should not clear the warnings, but should still reset the warning count.
 		ctx.ClearWarningCount()

--- a/engine.go
+++ b/engine.go
@@ -414,7 +414,7 @@ func (e *Engine) QueryWithBindings(ctx *sql.Context, query string, parsed sqlpar
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if shouldLock == true {
+	if shouldLock.(int8) == 1 {
 		ctx.LockWarnings()
 		defer ctx.UnlockWarnings()
 	}

--- a/engine.go
+++ b/engine.go
@@ -268,7 +268,7 @@ func clearWarnings(ctx *sql.Context, node sql.Node) {
 	case *plan.Offset, *plan.Limit:
 		// `show warning limit x offset y` is valid, so we need to recurse
 		clearWarnings(ctx, n.Children()[0])
-	case plan.ShowWarnings:
+	case plan.ShowWarnings, *plan.Set:
 		// ShowWarnings should not clear the warnings, but should still reset the warning count.
 		ctx.ClearWarningCount()
 	default:
@@ -408,6 +408,15 @@ func (e *Engine) QueryWithBindings(ctx *sql.Context, query string, parsed sqlpar
 	err = e.beginTransaction(ctx)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+
+	shouldLock, err := ctx.GetSessionVariable(ctx, "lock_warnings")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if shouldLock == true {
+		ctx.LockWarnings()
+		defer ctx.UnlockWarnings()
 	}
 
 	// planbuilding can produce warnings, so we need to preserve them

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -575,6 +575,36 @@ var VariableQueries = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "locked warnings stay after query",
+		SetUpScript: []string{
+			"set @@lock_warnings = 1",
+			"select 1/0,1/0",
+			"select 1/1",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show warnings",
+				Expected: []sql.Row{
+					{"Warning", 1365, "Division by 0"},
+					{"Warning", 1365, "Division by 0"}},
+			},
+		},
+	},
+	{
+		Name: "unlocked warnings clear after query",
+		SetUpScript: []string{
+			"set @@lock_warnings = 0",
+			"select 1/0,1/0",
+			"select 1/1",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "show warnings",
+				Expected: []sql.Row{},
+			},
+		},
+	},
 	//TODO: do not override tables with user-var-like names...but why would you do this??
 	//{
 	//	Name: "user var table name no conflict",

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -590,10 +590,8 @@ var VariableQueries = []ScriptTest{
 					{"Warning", 1365, "Division by 0"}},
 			},
 			{
-				Query: "select 1/0",
-				Expected: []sql.Row{
-					{interface{}(nil)},
-				},
+				Query:            "select 1/0",
+				SkipResultsCheck: true,
 			},
 			{
 				Query: "show warnings",

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -589,6 +589,20 @@ var VariableQueries = []ScriptTest{
 					{"Warning", 1365, "Division by 0"},
 					{"Warning", 1365, "Division by 0"}},
 			},
+			{
+				Query: "select 1/0",
+				Expected: []sql.Row{
+					{"NULL"},
+				},
+			},
+			{
+				Query: "show warnings",
+				Expected: []sql.Row{
+					{"Warning", 1365, "Division by 0"},
+					{"Warning", 1365, "Division by 0"},
+					{"Warning", 1365, "Division by 0"},
+				},
+			},
 		},
 	},
 	{
@@ -602,6 +616,22 @@ var VariableQueries = []ScriptTest{
 			{
 				Query:    "show warnings",
 				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		Name: "warnings persist after locking between queries",
+		SetUpScript: []string{
+			"select 1/0",
+			"set @@lock_warnings = 1",
+			"select 1/1",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show warnings",
+				Expected: []sql.Row{
+					{"Warning", 1365, "Division by 0"},
+				},
 			},
 		},
 	},

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -592,7 +592,7 @@ var VariableQueries = []ScriptTest{
 			{
 				Query: "select 1/0",
 				Expected: []sql.Row{
-					{"NULL"},
+					{interface{}(nil)},
 				},
 			},
 			{

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -1255,11 +1255,20 @@ var systemVars = map[string]sql.SystemVariable{
 	},
 	"lock_warnings": &sql.MysqlSystemVariable{
 		Name:              "lock_warnings",
-		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Both),
+		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Session),
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemBoolType("lock_warnings"),
 		Default:           int8(0),
+		NotifyChanged: func(ctx *sql.Context, _ sql.SystemVariableScope, value sql.SystemVarValue) error {
+			switch value.Val.(int8) {
+			case 0:
+				ctx.UnlockWarnings()
+			case 1:
+				ctx.LockWarnings()
+			}
+			return nil
+		},
 	},
 	"log_bin": &sql.MysqlSystemVariable{
 		Name:              "log_bin",

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -1253,6 +1253,14 @@ var systemVars = map[string]sql.SystemVariable{
 		Type:              types.NewSystemIntType("lock_wait_timeout", 1, 31536000, false),
 		Default:           int64(31536000),
 	},
+	"lock_warnings": &sql.MysqlSystemVariable{
+		Name:              "lock_warnings",
+		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Both),
+		Dynamic:           true,
+		SetVarHintApplies: false,
+		Type:              types.NewSystemBoolType("lock_warnings"),
+		Default:           int8(0),
+	},
 	"log_bin": &sql.MysqlSystemVariable{
 		Name:              "log_bin",
 		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Persist),


### PR DESCRIPTION
Adds a session variable for locking warnings, allowing you to run background queries without clearing the warnings from the last user-generated command.