### PR TITLE
fix: Fix create new server in example.

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -73,7 +73,7 @@ func main() {
 		Protocol: "tcp",
 		Address:  fmt.Sprintf("%s:%d", address, port),
 	}
-	s, err := server.NewServer(config, engine, memory.NewSessionBuilder(pro), nil)
+	s, err := server.NewServer(config, engine, sql.NewContext, memory.NewSessionBuilder(pro), nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
I found that the parameters did not match when creating the server in the example, so I fixed it.