### PR TITLE
Properly escape special characters in comments

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -202,18 +202,20 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	// t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "AS OF propagates to nested CALLs",
-			SetUpScript: []string{
-				`create table t (i int comment "single quote \' | newline \n | return \r | backslash \\ | NUL \0 \x00");`,
-				//"create table t (pk int comment 'this, it''s the way to go')",
-				//`create table t (pk int comment "\'")`,
-			},
+			Name:        "AS OF propagates to nested CALLs",
+			SetUpScript: []string{},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query: "show create table t",
+					Query: "create procedure create_proc() create table t (i int primary key, j int);",
+					Expected: []sql.Row{
+						{types.NewOkResult(0)},
+					},
+				},
+				{
+					Query: "call create_proc()",
 					Expected: []sql.Row{
 						{types.NewOkResult(0)},
 					},

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -202,20 +202,18 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	// t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name:        "AS OF propagates to nested CALLs",
-			SetUpScript: []string{},
+			Name: "AS OF propagates to nested CALLs",
+			SetUpScript: []string{
+				`create table t (i int comment "single quote \' | newline \n | return \r | backslash \\ | NUL \0 \x00");`,
+				//"create table t (pk int comment 'this, it''s the way to go')",
+				//`create table t (pk int comment "\'")`,
+			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query: "create procedure create_proc() create table t (i int primary key, j int);",
-					Expected: []sql.Row{
-						{types.NewOkResult(0)},
-					},
-				},
-				{
-					Query: "call create_proc()",
+					Query: "show create table t",
 					Expected: []sql.Row{
 						{types.NewOkResult(0)},
 					},

--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -1029,6 +1029,23 @@ var AlterTableScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "alter table comments are escaped",
+		SetUpScript: []string{
+			"create table t (i int);",
+			`alter table t modify column i int comment "newline \n | return \r | backslash \\ | NUL \0 \x00"`,
+			`alter table t add column j int comment "newline \n | return \r | backslash \\ | NUL \0 \x00"`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show create table t",
+				Expected: []sql.Row{{
+					"t",
+					"CREATE TABLE `t` (\n  `i` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'," +
+						"\n  `j` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+			},
+		},
+	},
 }
 
 var RenameTableScripts = []ScriptTest{

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -41,6 +41,18 @@ var CreateTableQueries = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT='~!@ #$ %^ &* ()'"}},
 	},
 	{
+		WriteQuery:          `create table tableWithComment (pk int) COMMENT "'"`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
+		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT=''''"}},
+	},
+	{
+		WriteQuery:          `create table tableWithColumnComment (pk int COMMENT "'")`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithColumnComment",
+		ExpectedSelect:      []sql.Row{{"tableWithColumnComment", "CREATE TABLE `tableWithColumnComment` (\n  `pk` int COMMENT ''''\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+	},
+	{
 		WriteQuery:          `create table floattypedefs (a float(10), b float(10, 2), c double(10, 2))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE floattypedefs",
@@ -1118,18 +1130,6 @@ var CreateTableAutoIncrementTests = []ScriptTest{
 }
 
 var BrokenCreateTableQueries = []WriteQueryTest{
-	{
-		// TODO: We don't support table comments that contain single quotes due to how table options are parsed.
-		//       Vitess parses them, but turns any double quotes into single quotes and puts all table options back
-		//       into a string that GMS has to reparse. This means we can't tell if the single quote is the end of
-		//       the quoted string, or if it was a single quote inside of double quotes and needs to be escaped.
-		//       To fix this, Vitess should return the parsed table options as structured data, instead of as a
-		//       single string.
-		WriteQuery:          `create table tableWithComment (pk int) COMMENT "'"`,
-		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
-		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
-		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT=''''"}},
-	},
 	{
 		WriteQuery:          `create table t1 (b blob, primary key(b(1)))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -47,6 +47,18 @@ var CreateTableQueries = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT=''''"}},
 	},
 	{
+		WriteQuery:          `create table tableWithComment (pk int) COMMENT "\'"`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
+		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT=''''"}},
+	},
+	{
+		WriteQuery:          `create table tableWithComment (pk int) COMMENT "newline \n | return \r | backslash \\ | NUL \0 \x00"`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
+		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT='newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'"}},
+	},
+	{
 		WriteQuery:          `create table tableWithColumnComment (pk int COMMENT "'")`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE tableWithColumnComment",

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -53,6 +53,18 @@ var CreateTableQueries = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{"tableWithColumnComment", "CREATE TABLE `tableWithColumnComment` (\n  `pk` int COMMENT ''''\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
+		WriteQuery:          `create table tableWithColumnComment (pk int COMMENT "\'")`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithColumnComment",
+		ExpectedSelect:      []sql.Row{{"tableWithColumnComment", "CREATE TABLE `tableWithColumnComment` (\n  `pk` int COMMENT ''''\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+	},
+	{
+		WriteQuery:          `create table tableWithColumnComment (pk int COMMENT "newline \n | return \r | backslash \\ | NUL \0 \x00")`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithColumnComment",
+		ExpectedSelect:      []sql.Row{{"tableWithColumnComment", "CREATE TABLE `tableWithColumnComment` (\n  `pk` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+	},
+	{
 		WriteQuery:          `create table floattypedefs (a float(10), b float(10, 2), c double(10, 2))`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE floattypedefs",

--- a/sql/parser.go
+++ b/sql/parser.go
@@ -134,14 +134,12 @@ func RemoveSpaceAndDelimiter(query string, d rune) string {
 }
 
 func EscapeSpecialCharactersInComment(comment string) string {
-	panic("here!")
 	commentString := comment
 	commentString = strings.ReplaceAll(commentString, "'", "''")
 	commentString = strings.ReplaceAll(commentString, "\\", "\\\\")
 	commentString = strings.ReplaceAll(commentString, "\"", "\\\"")
 	commentString = strings.ReplaceAll(commentString, "\n", "\\n")
 	commentString = strings.ReplaceAll(commentString, "\r", "\\r")
-
 	commentString = strings.ReplaceAll(commentString, "\x00", "\\0")
 	return commentString
 }
@@ -152,7 +150,6 @@ var _ SchemaFormatter = &MySqlSchemaFormatter{}
 
 // GenerateCreateTableStatement implements the SchemaFormatter interface.
 func (m *MySqlSchemaFormatter) GenerateCreateTableStatement(tblName string, colStmts []string, temp, autoInc, tblCharsetName, tblCollName, comment string) string {
-	panic("here! 1")
 	if comment != "" {
 		// Escape any single quotes in the comment and add the COMMENT keyword
 		comment = fmt.Sprintf(" COMMENT='%s'", EscapeSpecialCharactersInComment(comment))
@@ -176,7 +173,6 @@ func (m *MySqlSchemaFormatter) GenerateCreateTableStatement(tblName string, colS
 
 // GenerateCreateTableColumnDefinition implements the SchemaFormatter interface.
 func (m *MySqlSchemaFormatter) GenerateCreateTableColumnDefinition(col *Column, colDefault, onUpdate string, tableCollation CollationID) string {
-	panic("here! 2")
 	var colTypeString string
 	if collationType, ok := col.Type.(TypeWithCollation); ok {
 		colTypeString = collationType.StringWithTableCollation(tableCollation)

--- a/sql/parser.go
+++ b/sql/parser.go
@@ -133,6 +133,10 @@ func RemoveSpaceAndDelimiter(query string, d rune) string {
 	})
 }
 
+func EscapeSingleQuotesInComment(comment string) string {
+	return strings.ReplaceAll(comment, "'", "''")
+}
+
 type MySqlSchemaFormatter struct{}
 
 var _ SchemaFormatter = &MySqlSchemaFormatter{}
@@ -141,8 +145,7 @@ var _ SchemaFormatter = &MySqlSchemaFormatter{}
 func (m *MySqlSchemaFormatter) GenerateCreateTableStatement(tblName string, colStmts []string, temp, autoInc, tblCharsetName, tblCollName, comment string) string {
 	if comment != "" {
 		// Escape any single quotes in the comment and add the COMMENT keyword
-		comment = strings.ReplaceAll(comment, "'", "''")
-		comment = fmt.Sprintf(" COMMENT='%s'", comment)
+		comment = fmt.Sprintf(" COMMENT='%s'", EscapeSingleQuotesInComment(comment))
 	}
 
 	if autoInc != "" {
@@ -201,7 +204,7 @@ func (m *MySqlSchemaFormatter) GenerateCreateTableColumnDefinition(col *Column, 
 	}
 
 	if col.Comment != "" {
-		stmt = fmt.Sprintf("%s COMMENT '%s'", stmt, col.Comment)
+		stmt = fmt.Sprintf("%s COMMENT '%s'", stmt, EscapeSingleQuotesInComment(col.Comment))
 	}
 	return stmt
 }

--- a/sql/parser.go
+++ b/sql/parser.go
@@ -133,8 +133,17 @@ func RemoveSpaceAndDelimiter(query string, d rune) string {
 	})
 }
 
-func EscapeSingleQuotesInComment(comment string) string {
-	return strings.ReplaceAll(comment, "'", "''")
+func EscapeSpecialCharactersInComment(comment string) string {
+	panic("here!")
+	commentString := comment
+	commentString = strings.ReplaceAll(commentString, "'", "''")
+	commentString = strings.ReplaceAll(commentString, "\\", "\\\\")
+	commentString = strings.ReplaceAll(commentString, "\"", "\\\"")
+	commentString = strings.ReplaceAll(commentString, "\n", "\\n")
+	commentString = strings.ReplaceAll(commentString, "\r", "\\r")
+
+	commentString = strings.ReplaceAll(commentString, "\x00", "\\0")
+	return commentString
 }
 
 type MySqlSchemaFormatter struct{}
@@ -143,9 +152,10 @@ var _ SchemaFormatter = &MySqlSchemaFormatter{}
 
 // GenerateCreateTableStatement implements the SchemaFormatter interface.
 func (m *MySqlSchemaFormatter) GenerateCreateTableStatement(tblName string, colStmts []string, temp, autoInc, tblCharsetName, tblCollName, comment string) string {
+	panic("here! 1")
 	if comment != "" {
 		// Escape any single quotes in the comment and add the COMMENT keyword
-		comment = fmt.Sprintf(" COMMENT='%s'", EscapeSingleQuotesInComment(comment))
+		comment = fmt.Sprintf(" COMMENT='%s'", EscapeSpecialCharactersInComment(comment))
 	}
 
 	if autoInc != "" {
@@ -166,6 +176,7 @@ func (m *MySqlSchemaFormatter) GenerateCreateTableStatement(tblName string, colS
 
 // GenerateCreateTableColumnDefinition implements the SchemaFormatter interface.
 func (m *MySqlSchemaFormatter) GenerateCreateTableColumnDefinition(col *Column, colDefault, onUpdate string, tableCollation CollationID) string {
+	panic("here! 2")
 	var colTypeString string
 	if collationType, ok := col.Type.(TypeWithCollation); ok {
 		colTypeString = collationType.StringWithTableCollation(tableCollation)
@@ -204,7 +215,7 @@ func (m *MySqlSchemaFormatter) GenerateCreateTableColumnDefinition(col *Column, 
 	}
 
 	if col.Comment != "" {
-		stmt = fmt.Sprintf("%s COMMENT '%s'", stmt, EscapeSingleQuotesInComment(col.Comment))
+		stmt = fmt.Sprintf("%s COMMENT '%s'", stmt, EscapeSpecialCharactersInComment(col.Comment))
 	}
 	return stmt
 }


### PR DESCRIPTION
Mostly fixes dolthub/dolt#8509 (does not handle Control+Z)