### PR TITLE
Add support for `IS NULL` expressions with records

### DIFF
--- a/sql/expression/isnull.go
+++ b/sql/expression/isnull.go
@@ -54,6 +54,17 @@ func (e *IsNull) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 
+	// Slices of typed values (e.g. Record and Composite types in Postgres) evaluate
+	// to NULL if all of their entries are NULL.
+	if tupleValue, ok := v.([]types.TupleValue); ok {
+		for _, typedValue := range tupleValue {
+			if typedValue.Value != nil {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
+
 	return v == nil, nil
 }
 

--- a/sql/types/tuple_value.go
+++ b/sql/types/tuple_value.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+// TupleValue represents a value and its associated type information. TupleValue is used by collections of
+// values where the type information is not consistent across all values (e.g. Records in Postgres).
+type TupleValue struct {
+	Value any
+	Type  sql.Type
+}


### PR DESCRIPTION
The implementation in GMS for `IS NULL` checks if the value is `NULL` or not. For record and composite types in Postgres, `IS NULL` needs to check if each value in the record or composite type is `NULL` to determine if the value is `NULL`.  See https://github.com/dolthub/doltgresql/pull/1520 for more details. 

This change creates a new shared type, named `TupleValue`, in GMS that is used for record values (and eventually, composite type values). I also considered giving Doltgres it's own, custom `IsNull` implementation, but the analyzer does specific checks and optimizations when it looks for `*expression.IsNull` instances, which would stop working correctly. 