### PR TITLE
implement `if [not] exists` logic for DDL around `view`s and `index`es

### DIFF
--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4338,4 +4338,57 @@ var IndexQueries = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "indexes and if exists",
+		SetUpScript: []string{
+			"create table t (i int, j int);",
+			"create index idx on t (i);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "create index idx on t(j)",
+				ExpectedErr: sql.ErrDuplicateKey,
+			},
+			{
+				Query: "create index if not exists idx on t(j)",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "show create table t",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int,\n" +
+						"  `j` int,\n" +
+						"  KEY `idx` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query:       "alter table t add index idx (j)",
+				ExpectedErr: sql.ErrDuplicateKey,
+			},
+			{
+				Query: "alter table t add index if not exists idx (j)",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query: "show create table t",
+				Expected: []sql.Row{
+					{"t", "CREATE TABLE `t` (\n" +
+						"  `i` int,\n" +
+						"  `j` int,\n" +
+						"  KEY `idx` (`i`)\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+			{
+				Query:       "alter table t drop index notanidx",
+				ExpectedErr: sql.ErrDuplicateKey,
+			},
+		},
+	},
 }

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4387,7 +4387,13 @@ var IndexQueries = []ScriptTest{
 			},
 			{
 				Query:       "alter table t drop index notanidx",
-				ExpectedErr: sql.ErrDuplicateKey,
+				ExpectedErr: sql.ErrCantDropFieldOrKey,
+			},
+			{
+				Query: "alter table t drop index if exists notanidx",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
 			},
 		},
 	},

--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -29,7 +29,7 @@ var ViewScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "create if not exists view v as select 2;",
+				Query: "create view if not exists v as select 2;",
 				Expected: []sql.Row{
 					{types.NewOkResult(0)},
 				},
@@ -39,7 +39,7 @@ var ViewScripts = []ScriptTest{
 				Expected: []sql.Row{{1}},
 			},
 			{
-				Query: "create if not exists view t as select 2;",
+				Query: "create view if not exists t as select 2;",
 				Expected: []sql.Row{
 					{types.NewOkResult(0)},
 				},

--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -21,6 +21,36 @@ import (
 
 var ViewScripts = []ScriptTest{
 	{
+		Name: "existing views",
+		SetUpScript: []string{
+			"create view v as select 1;",
+			"create table t (i int);",
+			"insert into t values (1);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "create if not exists view v as select 2;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query:    "select * from v;",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query: "create if not exists view t as select 2;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+			{
+				Query:    "select * from t;",
+				Expected: []sql.Row{{1}},
+			},
+		},
+	},
+	{
 		Name: "multi database view",
 		SetUpScript: []string{
 			"Create database base;",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250530231040-bfd522856394
+	github.com/dolthub/vitess v0.0.0-20250602225627-4801223c968b
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250604183723-cad71bbe21d0
+	github.com/dolthub/vitess v0.0.0-20250605180032-fa2a634c215b
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20250327004329-6799764f2dad
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81
-	github.com/dolthub/vitess v0.0.0-20250602225627-4801223c968b
+	github.com/dolthub/vitess v0.0.0-20250604183826-4944a453aecb
 	github.com/go-kit/kit v0.10.0
 	github.com/go-sql-driver/mysql v1.7.2-0.20231213112541-0004702b931d
 	github.com/gocraft/dbr/v2 v2.7.2

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20250530231040-bfd522856394 h1:sMwntvk7O9dttaJLqnOvy8zgk0ah9qnyWkAahfOgnIo=
-github.com/dolthub/vitess v0.0.0-20250530231040-bfd522856394/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250602225627-4801223c968b h1:O/n2gfcFb/IDIiCq/aBnK70TtGujQiHkYd6JZGDpVEI=
+github.com/dolthub/vitess v0.0.0-20250602225627-4801223c968b/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20250530231040-bfd522856394 h1:sMwntvk7O9dttaJLqnOvy8zgk0ah9qnyWkAahfOgnIo=
-github.com/dolthub/vitess v0.0.0-20250530231040-bfd522856394/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
-github.com/dolthub/vitess v0.0.0-20250604183723-cad71bbe21d0 h1:esaEESlRNds2thjx9mEiDRIp1Cm5nM9K2PbYqPKei5Q=
-github.com/dolthub/vitess v0.0.0-20250604183723-cad71bbe21d0/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250605180032-fa2a634c215b h1:rgZXgRYZ3SZbb4Tz5Y6vnzvB7P9pFvEP+Q7UGfRC9uY=
+github.com/dolthub/vitess v0.0.0-20250605180032-fa2a634c215b/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81 h1:7/v8q9XGFa6q5Ap4Z/OhNkAMBaK5YeuEzwJt+NZdhiE=
 github.com/dolthub/sqllogictest/go v0.0.0-20201107003712-816f3ae12d81/go.mod h1:siLfyv2c92W1eN/R4QqG/+RjjX5W2+gCTRjZxBjI3TY=
-github.com/dolthub/vitess v0.0.0-20250602225627-4801223c968b h1:O/n2gfcFb/IDIiCq/aBnK70TtGujQiHkYd6JZGDpVEI=
-github.com/dolthub/vitess v0.0.0-20250602225627-4801223c968b/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
+github.com/dolthub/vitess v0.0.0-20250604183826-4944a453aecb h1:/Tti0IJASR0xHMA5TRFalVUTGLKZsjcAhpWpCtJMadY=
+github.com/dolthub/vitess v0.0.0-20250604183826-4944a453aecb/go.mod h1:1gQZs/byeHLMSul3Lvl3MzioMtOW1je79QYGyi2fd70=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/memory/database.go
+++ b/memory/database.go
@@ -555,7 +555,7 @@ func (d *Database) Database() *BaseDatabase {
 func (d *Database) CreateView(ctx *sql.Context, name string, selectStatement, createViewStmt string) error {
 	_, ok := d.views[strings.ToLower(name)]
 	if ok {
-		return sql.ErrExistingView.New(name)
+		return sql.ErrExistingView.New(d.Name(), name)
 	}
 
 	sqlMode := sql.LoadSqlMode(ctx)

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -657,6 +657,9 @@ func validateAlterIndex(ctx *sql.Context, initialSch, sch sql.Schema, ai *plan.A
 			}
 		}
 		if savedIdx == -1 {
+			if ai.IfExists {
+				return nil, nil
+			}
 			return nil, sql.ErrCantDropFieldOrKey.New(ai.IndexName)
 		}
 		// Remove the index from the list

--- a/sql/index_driver.go
+++ b/sql/index_driver.go
@@ -120,7 +120,7 @@ var (
 	ErrIndexExpressionAlreadyRegistered = errors.NewKind("there is already an index registered for the expressions: %s")
 
 	// ErrIndexNotFound is returned when the index could not be found.
-	ErrIndexNotFound = errors.NewKind("index %q	was not found")
+	ErrIndexNotFound = errors.NewKind("index %q was not found")
 
 	// ErrIndexDeleteInvalidStatus is returned when the index trying to delete
 	// does not have a ready or outdated state.

--- a/sql/plan/create_view.go
+++ b/sql/plan/create_view.go
@@ -31,6 +31,7 @@ type CreateView struct {
 	database         sql.Database
 	targetSchema     sql.Schema
 	Name             string
+	IfNotExists      bool
 	IsReplace        bool
 	Definition       *SubqueryAlias
 	CreateViewString string
@@ -46,11 +47,12 @@ var _ sql.SchemaTarget = (*CreateView)(nil)
 
 // NewCreateView creates a CreateView node with the specified parameters,
 // setting its catalog to nil.
-func NewCreateView(database sql.Database, name string, definition *SubqueryAlias, isReplace bool, createViewStr, algorithm, definer, security string) *CreateView {
+func NewCreateView(database sql.Database, name string, definition *SubqueryAlias, ifNotExists, isReplace bool, createViewStr, algorithm, definer, security string) *CreateView {
 	return &CreateView{
 		UnaryNode:        UnaryNode{Child: definition},
 		database:         database,
 		Name:             name,
+		IfNotExists:      ifNotExists,
 		IsReplace:        isReplace,
 		Definition:       definition,
 		CreateViewString: createViewStr,

--- a/sql/planbuilder/create_ddl.go
+++ b/sql/planbuilder/create_ddl.go
@@ -672,7 +672,7 @@ func (b *Builder) buildCreateView(inScope *scope, subQuery string, fullQuery str
 	if !ok {
 		b.handleErr(sql.ErrDatabaseSchemaNotFound.New(c.Table.SchemaQualifier.String()))
 	}
-	createView := plan.NewCreateView(db, c.ViewSpec.ViewName.Name.String(), queryAlias, c.OrReplace, subQuery, c.ViewSpec.Algorithm, definer, c.ViewSpec.Security)
+	createView := plan.NewCreateView(db, c.ViewSpec.ViewName.Name.String(), queryAlias, c.IfNotExists, c.OrReplace, subQuery, c.ViewSpec.Algorithm, definer, c.ViewSpec.Security)
 	outScope.node = b.modifySchemaTarget(queryScope, createView, createView.Definition.Schema())
 
 	return outScope

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -612,6 +612,7 @@ func (b *Builder) buildAlterTableClause(inScope *scope, ddl *ast.DDL) []*scope {
 					createIndex := plan.NewAlterCreateIndex(
 						rt.Database(),
 						rt,
+						ddl.IfNotExists,
 						column.Name.String(),
 						sql.IndexUsing_BTree,
 						sql.IndexConstraint_Unique,
@@ -994,7 +995,16 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 			b.handleErr(err)
 		}
 
-		createIndex := plan.NewAlterCreateIndex(table.SqlDatabase, table, ddl.IndexSpec.ToName.String(), using, constraint, columns, comment)
+		createIndex := plan.NewAlterCreateIndex(
+			table.SqlDatabase,
+			table,
+			ddl.IfNotExists,
+			ddl.IndexSpec.ToName.String(),
+			using,
+			constraint,
+			columns,
+			comment,
+		)
 		outScope.node = b.modifySchemaTarget(inScope, createIndex, table.Schema())
 		return
 	case ast.DropStr:
@@ -1002,7 +1012,7 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 			outScope.node = plan.NewAlterDropPk(table.SqlDatabase, table)
 			return
 		}
-		outScope.node = plan.NewAlterDropIndex(table.Database(), table, ddl.IndexSpec.ToName.String())
+		outScope.node = plan.NewAlterDropIndex(table.Database(), table, ddl.IfExists, ddl.IndexSpec.ToName.String())
 		return
 	case ast.RenameStr:
 		outScope.node = plan.NewAlterRenameIndex(table.Database(), table, ddl.IndexSpec.FromName.String(), ddl.IndexSpec.ToName.String())

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2123,6 +2123,9 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 		}
 		err = idxAltTbl.DropIndex(ctx, n.IndexName)
 		if err != nil {
+			if sql.ErrIndexNotFound.Is(err) && n.IfExists {
+				return nil
+			}
 			return err
 		}
 		return nil

--- a/sql/rowexec/drop_view_test.go
+++ b/sql/rowexec/drop_view_test.go
@@ -47,7 +47,7 @@ func setupView(t *testing.T, db memory.MemoryDatabase) (*sql.Context, *sql.View)
 		),
 	)
 
-	createView := plan.NewCreateView(db, subqueryAlias.Name(), subqueryAlias, false, "CREATE VIEW myview AS SELECT i FROM mytable", "", "", "")
+	createView := plan.NewCreateView(db, subqueryAlias.Name(), subqueryAlias, false, false, "CREATE VIEW myview AS SELECT i FROM mytable", "", "", "")
 
 	ctx := sql.NewContext(context.Background())
 


### PR DESCRIPTION
This PR adds support for queries:
- `create view if not exists ...`
- `create index if not exists ...`
- `alter table ... add index if not exists ...`
- `drop index if exists ...`


fixes: https://github.com/dolthub/dolt/issues/9293
companion pr: https://github.com/dolthub/vitess/pull/417