### PR TITLE
Simplify implementation of `hasSingleOutput`

### DIFF
--- a/sql/analyzer/apply_hash_in.go
+++ b/sql/analyzer/apply_hash_in.go
@@ -56,16 +56,13 @@ func applyHashIn(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, s
 
 // hasSingleOutput checks if an expression evaluates to a single output
 func hasSingleOutput(e sql.Expression) bool {
-	return !transform.InspectExpr(e, func(expr sql.Expression) bool {
+	return transform.InspectExpr(e, func(expr sql.Expression) bool {
 		switch expr.(type) {
-		case expression.Tuple, *expression.Literal, *expression.GetField,
-			expression.Comparer, *expression.Convert, sql.FunctionExpression,
-			*expression.IsTrue, *expression.IsNull, expression.ArithmeticOp:
+		case *plan.Subquery:
 			return false
 		default:
 			return true
 		}
-		return false
 	})
 }
 


### PR DESCRIPTION
As part of adding support for `IS NULL` and `IS NOT NULL` implementations that can match Postgres's behavior for records, I've been digging through the references to `expression.IsNull` in GMS so that we can have a separate implementation for Doltgres that GMS can still analyze correctly. 

One reference to `expression.IsNull` is in the `hasSingleOutput` which is used to determine if an expression result has a single row or more than one row. The only expression implementation I was able to find that actually returns multiple rows is `plan.Subquery`, so I simplified this function to remove the reference to `expression.IsNull`. 