### PR TITLE
`like` match when collation is unspecified

### DIFF
--- a/enginetest/queries/json_table_queries.go
+++ b/enginetest/queries/json_table_queries.go
@@ -139,6 +139,12 @@ var JSONTableQueryTests = []QueryTest{
 			{9},
 		},
 	},
+	{
+		Query: "select * from json_table('[\"foo\", \"bar\"]', \"$[*]\" columns(tag text path '$')) as tags where tag like 'foo';",
+		Expected: []sql.Row{
+			{"foo"},
+		},
+	},
 }
 
 var JSONTableScriptTests = []ScriptTest{

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -120,9 +120,6 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if lm.collation == sql.Collation_Unspecified {
-		return false, nil
-	}
 
 	ok := lm.Match(left.(string))
 	if l.cached {


### PR DESCRIPTION
For some reason the `LikeMatcher` returns false with no error on unspecified collation, so this PR fixes that.

Fixes: https://github.com/dolthub/dolt/issues/9337