### PR TITLE
Distinguish nils in firstBuffer

### DIFF
--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -326,11 +326,23 @@ var OrderByGroupByScriptTests = []ScriptTest{
 		SetUpScript: []string{
 			"create table t0(c0 int, c1 int)",
 			"insert into t0(c0, c1) values(NULL,1),(1,NULL)",
+			"create table t1(id int primary key, c0 int, c1 int)",
+			"insert into t1(id, c0, c1) values(1,NULL,NULL),(2,1,1),(3,1,NULL),(4,2,1),(5,NULL,1)",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "select t0.c0 = t0.c1 as ref0, sum(1) as ref1 from t0 group by ref0",
-				Expected: []sql.Row{{nil, float64(2)}},
+				Query: "select t0.c0 = t0.c1 as ref0, sum(1) as ref1 from t0 group by ref0",
+				Expected: []sql.Row{
+					{nil, float64(2)},
+				},
+			},
+			{
+				Query: "select t1.c0 = t1.c1 as ref0, sum(1) as ref1 from t1 group by ref0",
+				Expected: []sql.Row{
+					{nil, float64(3)},
+					{true, float64(1)},
+					{false, float64(1)},
+				},
 			},
 		},
 	},

--- a/enginetest/queries/order_by_group_by_queries.go
+++ b/enginetest/queries/order_by_group_by_queries.go
@@ -320,4 +320,18 @@ var OrderByGroupByScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "Group by null = 1",
+		// https://github.com/dolthub/dolt/issues/9035
+		SetUpScript: []string{
+			"create table t0(c0 int, c1 int)",
+			"insert into t0(c0, c1) values(NULL,1),(1,NULL)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select t0.c0 = t0.c1 as ref0, sum(1) as ref1 from t0 group by ref0",
+				Expected: []sql.Row{{nil, float64(2)}},
+			},
+		},
+	},
 }

--- a/sql/expression/function/aggregation/unary_agg_buffers.go
+++ b/sql/expression/function/aggregation/unary_agg_buffers.go
@@ -500,17 +500,19 @@ func (c *countBuffer) Dispose() {
 }
 
 type firstBuffer struct {
-	val  interface{}
-	expr sql.Expression
+	val interface{}
+	// writtenNil means that val is supposed to be nil and should not be overwritten
+	writtenNil bool
+	expr       sql.Expression
 }
 
 func NewFirstBuffer(child sql.Expression) *firstBuffer {
-	return &firstBuffer{nil, child}
+	return &firstBuffer{nil, false, child}
 }
 
 // Update implements the AggregationBuffer interface.
 func (f *firstBuffer) Update(ctx *sql.Context, row sql.Row) error {
-	if f.val != nil {
+	if f.val != nil || f.writtenNil {
 		return nil
 	}
 
@@ -520,6 +522,7 @@ func (f *firstBuffer) Update(ctx *sql.Context, row sql.Row) error {
 	}
 
 	if v == nil {
+		f.writtenNil = true
 		return nil
 	}
 


### PR DESCRIPTION
Fixes dolthub/dolt#9035

In `AggregationBuffer.firstBuffer `, the buffer should not update if the first row has already been written. However, there was no way of distinguishing between a `nil `because the buffer is empty and a `nil` because the value in that column of the first row is `nil`.

When you have two rows `(NULL, 1)` and `(1, NULL)`, the first row gets written into `[]firstBuffer.val` as `{nil, 1}`. Because there's no way to tell whether the first value is supposed to be `nil`, it ends up getting overwritten by the `1` in the second row. Because the second value is not `nil`, `Update` skips it. As a result, we end up with a row `{1, 1}` that matches neither of the original rows and evaluates to `TRUE` when grouped by `c0 = c1`, even though the original rows evaluate to `NULL`.

This isn't an issue when the rows are `(NULL, 1), (NULL, 1)` or `(1, NULL), (1, NULL)` because the `nil` value remains a `nil` value when `Update` is called on the second row.

I fixed this by adding a `writtenNil` flag to `firstBuffer` to indicate that the `nil` value is meant to be there and should not be overwritten.