### PR TITLE
Fix 7998 json escape double quotes

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -212,7 +212,7 @@ var JsonScripts = []ScriptTest{
 	{
 		Name: "json_object with escaped k:v pairs from table",
 		SetUpScript: []string{
-			`CREATE TABLE textt_7998 (t text) IF NOT EXISTS;`,
+			`CREATE TABLE IF NOT EXISTS textt_7998 (t text);`,
 			`INSERT INTO textt_7998 VALUES ('first row\n\\'), ('second row"');`,
 		},
 		Assertions: []ScriptTestAssertion{

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -188,6 +188,28 @@ var JsonScripts = []ScriptTest{
 		},
 	},
 	{
+		Name: "json_object preserves escaped characters in key and values",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `select cast(JSON_OBJECT('key"with"quotes\n','3"\\') as char);`,
+				Expected: []sql.Row{
+					{`{"key\"with\"quotes\n": "3\"\\"}`},
+				},
+			},
+		},
+	},
+	{
+		Name: "json conversion works with escaped characters",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `select cast(cast(JSON_OBJECT('key"with"quotes', 1) as char) as json);`,
+				Expected: []sql.Row{
+					{`{"key\"with\"quotes": 1}`},
+				},
+			},
+		},
+	},
+	{
 		Name: "json_value preserves types",
 		Assertions: []ScriptTestAssertion{
 			{

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -212,8 +212,8 @@ var JsonScripts = []ScriptTest{
 	{
 		Name: "json_object with escaped k:v pairs from table",
 		SetUpScript: []string{
-			`CREATE TABLE textt (t text);`,
-			`INSERT INTO textt VALUES ('first row\n\\'), ('second row"');`,
+			`CREATE TABLE textt_7998 (t text) IF NOT EXISTS;`,
+			`INSERT INTO textt_7998 VALUES ('first row\n\\'), ('second row"');`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -202,9 +202,25 @@ var JsonScripts = []ScriptTest{
 		Name: "json conversion works with escaped characters",
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: `select cast(cast(JSON_OBJECT('key"with"quotes', 1) as char) as json);`,
+				Query: `SELECT CAST(CAST(JSON_OBJECT('key"with"quotes', 1) as CHAR) as JSON);`,
 				Expected: []sql.Row{
 					{`{"key\"with\"quotes": 1}`},
+				},
+			},
+		},
+	},
+	{
+		Name: "json_object with escaped k:v pairs from table",
+		SetUpScript: []string{
+			`CREATE TABLE textt (t text);`,
+			`INSERT INTO textt VALUES ('first row\n\\'), ('second row"');`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `SELECT JSON_OBJECT(t, t) FROM textt;`,
+				Expected: []sql.Row{
+					{types.MustJSON(`{"first row\n\\": "first row\n\\"}`)},
+					{types.MustJSON(`{"second row\"": "second row\""}`)},
 				},
 			},
 		},

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -217,7 +217,7 @@ var JsonScripts = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: `SELECT JSON_OBJECT(t, t) FROM textt;`,
+				Query: `SELECT JSON_OBJECT(t, t) FROM textt_7998;`,
 				Expected: []sql.Row{
 					{types.MustJSON(`{"first row\n\\": "first row\n\\"}`)},
 					{types.MustJSON(`{"second row\"": "second row\""}`)},

--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -210,10 +210,12 @@ func writeMarshalledValue(writer io.Writer, val interface{}) error {
 
 		writer.Write([]byte{'{'})
 		for i, k := range keys {
-			writer.Write([]byte{'"'})
-			writer.Write([]byte(k))
-			writer.Write([]byte(`": `))
-			err := writeMarshalledValue(writer, val[k])
+			err := writeMarshalledValue(writer, k)
+			if err != nil {
+				return err
+			}
+			writer.Write([]byte(`: `))
+			err = writeMarshalledValue(writer, val[k])
 			if err != nil {
 				return err
 			}

--- a/sql/types/json_encode_test.go
+++ b/sql/types/json_encode_test.go
@@ -106,6 +106,14 @@ newlines
 			val:      decimal.New(123, -2),
 			expected: "1.23",
 		},
+		{
+			name: "formatted key strings",
+			val: map[string]interface{}{
+				"baz\n\\n": "qux",
+				"foo\"":    "bar\t",
+			},
+			expected: `{"foo\"": "bar\t", "baz\n\\n": "qux"}`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Key write now uses same recursive call to `writeMarshalledValue()` as value under `json_encode.go`
Fixes: https://github.com/dolthub/dolt/issues/7998