### PR TITLE
Generalize types in `IFNULL`

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -8712,6 +8712,25 @@ where
 			},
 		},
 	},
+	{
+		Name: "tinyint column does not restrict IF or IFNULL output",
+		// https://github.com/dolthub/dolt/issues/9321
+		SetUpScript: []string{
+			"create table t0 (c0 tinyint);",
+			"insert into t0 values (null);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select ifnull(t0.c0, 128) as ref0 from t0",
+				Expected: []sql.Row{
+					{128},
+				},
+			},
+			{
+				Query: "select if(t0.c0 = 1, t0.c0, 128) as ref0 from t0",
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/expression/function/if.go
+++ b/sql/expression/function/if.go
@@ -95,17 +95,7 @@ func (f *If) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 // Type implements the Expression interface.
 func (f *If) Type() sql.Type {
-	// if either type is string type, this should be a string type, regardless need to promote
-	typ1 := f.ifTrue.Type()
-	typ2 := f.ifFalse.Type()
-	if types.IsText(typ1) || types.IsText(typ2) {
-		return types.Text
-	}
-
-	if typ1 == types.Null {
-		return typ2.Promote()
-	}
-	return typ1.Promote()
+	return types.GeneralizeTypes(f.ifTrue.Type(), f.ifFalse.Type())
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.

--- a/sql/expression/function/ifnull.go
+++ b/sql/expression/function/ifnull.go
@@ -69,13 +69,7 @@ func (f *IfNull) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 // Type implements the Expression interface.
 func (f *IfNull) Type() sql.Type {
-	if types.IsNull(f.LeftChild) {
-		if types.IsNull(f.RightChild) {
-			return types.Null
-		}
-		return f.RightChild.Type()
-	}
-	return f.LeftChild.Type()
+	return types.GeneralizeTypes(f.LeftChild.Type(), f.RightChild.Type())
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.

--- a/sql/expression/function/ifnull.go
+++ b/sql/expression/function/ifnull.go
@@ -57,14 +57,16 @@ func (f *IfNull) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 	if left != nil {
-		return left, nil
+		left, _, err = f.Type().Convert(ctx, left)
+		return left, err
 	}
 
 	right, err := f.RightChild.Eval(ctx, row)
 	if err != nil {
 		return nil, err
 	}
-	return right, nil
+	right, _, err = f.Type().Convert(ctx, right)
+	return right, err
 }
 
 // Type implements the Expression interface.

--- a/sql/expression/function/ifnull_test.go
+++ b/sql/expression/function/ifnull_test.go
@@ -26,25 +26,28 @@ import (
 
 func TestIfNull(t *testing.T) {
 	testCases := []struct {
-		expression interface{}
-		value      interface{}
-		expected   interface{}
+		expression     interface{}
+		expressionType sql.Type
+		value          interface{}
+		valueType      sql.Type
+		expected       interface{}
+		expectedType   sql.Type
 	}{
-		{"foo", "bar", "foo"},
-		{"foo", "foo", "foo"},
-		{nil, "foo", "foo"},
-		{"foo", nil, "foo"},
-		{nil, nil, nil},
-		{"", nil, ""},
+		{"foo", types.LongText, "bar", types.LongText, "foo", types.LongText},
+		{"foo", types.LongText, "foo", types.LongText, "foo", types.LongText},
+		{nil, types.LongText, "foo", types.LongText, "foo", types.LongText},
+		{"foo", types.LongText, nil, types.LongText, "foo", types.LongText},
+		{nil, types.LongText, nil, types.LongText, nil, types.LongText},
+		{"", types.LongText, nil, types.LongText, "", types.LongText},
+		{nil, types.Int8, 128, types.Int64, int64(128), types.Int64},
 	}
 
-	f := NewIfNull(
-		expression.NewGetField(0, types.LongText, "expression", true),
-		expression.NewGetField(1, types.LongText, "value", true),
-	)
-	require.Equal(t, types.LongText, f.Type())
-
 	for _, tc := range testCases {
+		f := NewIfNull(
+			expression.NewGetField(0, tc.expressionType, "expression", true),
+			expression.NewGetField(1, tc.valueType, "value", true),
+		)
+		require.Equal(t, tc.expectedType, f.Type())
 		v, err := f.Eval(sql.NewEmptyContext(), sql.NewRow(tc.expression, tc.value))
 		require.NoError(t, err)
 		require.Equal(t, tc.expected, v)

--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -558,11 +558,13 @@ func TypesEqual(a, b sql.Type) bool {
 // GeneralizeTypes returns the more "general" of two types as defined by
 // https://dev.mysql.com/doc/refman/8.4/en/flow-control-functions.html#function_if and
 // https://dev.mysql.com/doc/refman/8.4/en/flow-control-functions.html#function_ifnull
-// TODO: Currently returns the most general type. Update to match MySQL (pick the more general of the two given types)
+// TODO: Currently returns the most general type via Promote(). Update to match MySQL (pick the more general of the two
+//
+//	given types)
 func GeneralizeTypes(a, b sql.Type) sql.Type {
 	if IsText(a) || IsText(b) {
 		// TODO: handle case-sensitive strings
-		return Text
+		return LongText
 	}
 
 	if IsFloat(a) || IsFloat(b) {

--- a/sql/types/conversion.go
+++ b/sql/types/conversion.go
@@ -554,3 +554,24 @@ func TypesEqual(a, b sql.Type) bool {
 		return a.Equals(b)
 	}
 }
+
+// GeneralizeTypes returns the more "general" of two types as defined by
+// https://dev.mysql.com/doc/refman/8.4/en/flow-control-functions.html#function_if and
+// https://dev.mysql.com/doc/refman/8.4/en/flow-control-functions.html#function_ifnull
+// TODO: Currently returns the most general type. Update to match MySQL (pick the more general of the two given types)
+func GeneralizeTypes(a, b sql.Type) sql.Type {
+	if IsText(a) || IsText(b) {
+		// TODO: handle case-sensitive strings
+		return Text
+	}
+
+	if IsFloat(a) || IsFloat(b) {
+		return Float64
+	}
+
+	if a == Null {
+		return b.Promote()
+	}
+
+	return a.Promote()
+}

--- a/sql/types/conversion_test.go
+++ b/sql/types/conversion_test.go
@@ -119,7 +119,7 @@ func TestColumnTypeToType_Time(t *testing.T) {
 }
 
 func TestColumnCharTypes(t *testing.T) {
-	test := []struct {
+	tests := []struct {
 		typ string
 		len int64
 		exp sql.Type
@@ -146,7 +146,7 @@ func TestColumnCharTypes(t *testing.T) {
 		},
 	}
 
-	for _, test := range test {
+	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v %v", test.typ, test.exp), func(t *testing.T) {
 			ct := &sqlparser.ColumnType{
 				Type:   test.typ,
@@ -155,6 +155,28 @@ func TestColumnCharTypes(t *testing.T) {
 			res, err := ColumnTypeToType(ct)
 			assert.NoError(t, err)
 			assert.Equal(t, test.exp, res)
+		})
+	}
+}
+
+func TestGeneralizeTypes(t *testing.T) {
+	tests := []struct {
+		typeA    sql.Type
+		typeB    sql.Type
+		expected sql.Type
+	}{
+		{Text, Text, LongText},
+		{Text, Float64, LongText},
+		{Int64, Text, LongText},
+		{Float32, Float32, Float64},
+		{Int64, Float64, Float64},
+		{Int32, Int32, Int64},
+		{Null, Null, Null},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v %v %v", test.typeA, test.typeB, test.expected), func(t *testing.T) {
+			res := GeneralizeTypes(test.typeA, test.typeB)
+			assert.Equal(t, test.expected, res)
 		})
 	}
 }


### PR DESCRIPTION
Fixes dolthub/dolt#9321
Generalize types in `IFNULL` as described by [MySQL docs](https://dev.mysql.com/doc/refman/8.4/en/flow-control-functions.html#function_ifnull)

`GeneralizeTypes` function is also used to get type in `If.Type()`