### PR TITLE
Allow `drop trigger ...` when trigger is invalid

### DIFF
--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -3784,6 +3784,42 @@ end;
 			},
 		},
 	},
+
+	// Invalid triggers
+	{
+		Name: "insert trigger with subquery projections",
+		SetUpScript: []string{
+			"create table t (i int);",
+			"create trigger trig before insert on t for each row begin replace into t select 1; end;",
+			"alter table t add column j int;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "show create trigger trig",
+				Expected: []sql.Row{
+					{
+						"trig",
+						"",
+						"create trigger trig before insert on t for each row begin replace into t select 1; end",
+						sql.Collation_Default.CharacterSet().String(),
+						sql.Collation_Default.String(),
+						sql.Collation_Default.String(),
+						time.Unix(0, 0).UTC(),
+					},
+				},
+			},
+			{
+				Query:       "insert into t values (1, 2);",
+				ExpectedErr: sql.ErrInsertIntoMismatchValueCount,
+			},
+			{
+				Query: "drop trigger trig;",
+				Expected: []sql.Row{
+					{types.NewOkResult(0)},
+				},
+			},
+		},
+	},
 }
 
 var TriggerCreateInSubroutineTests = []ScriptTest{

--- a/sql/analyzer/load_triggers.go
+++ b/sql/analyzer/load_triggers.go
@@ -44,7 +44,6 @@ func loadTriggers(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, 
 			}
 			return &newShowTriggers, transform.NewTree, nil
 		case *plan.DropTrigger:
-			// TODO: load triggers without parsing
 			loadedTriggers, err := loadTriggersFromDb(ctx, a, node.Database(), true)
 			if err != nil {
 				return nil, transform.SameTree, err
@@ -113,7 +112,8 @@ func loadTriggersFromDb(ctx *sql.Context, a *Analyzer, db sql.Database, ignorePa
 				if !ignoreParseErrors {
 					return nil, err
 				}
-				// TODO: we won't have TriggerOrder information for this unparseable trigger.
+				// TODO: we won't have TriggerOrder information for this unparseable trigger,
+				//   but it will still be referenced by any valid triggers.
 				fakeTrigger := &plan.CreateTrigger{
 					TriggerName: trigger.Name,
 				}

--- a/sql/analyzer/load_triggers.go
+++ b/sql/analyzer/load_triggers.go
@@ -114,7 +114,9 @@ func loadTriggersFromDb(ctx *sql.Context, a *Analyzer, db sql.Database, ignorePa
 					return nil, err
 				}
 				// TODO: we won't have TriggerOrder information for this unparseable trigger.
-				fakeTrigger := &plan.CreateTrigger{TriggerName: trigger.Name}
+				fakeTrigger := &plan.CreateTrigger{
+					TriggerName: trigger.Name,
+				}
 				loadedTriggers = append(loadedTriggers, fakeTrigger)
 				continue
 			}

--- a/sql/analyzer/process_truncate.go
+++ b/sql/analyzer/process_truncate.go
@@ -100,7 +100,7 @@ func deleteToTruncate(ctx *sql.Context, a *Analyzer, deletePlan *plan.DeleteFrom
 		return deletePlan, transform.SameTree, nil
 	}
 
-	triggers, err := loadTriggersFromDb(ctx, a, currentDb)
+	triggers, err := loadTriggersFromDb(ctx, a, currentDb, false)
 	if err != nil {
 		return nil, transform.SameTree, err
 	}


### PR DESCRIPTION
We should ignore parser errors when trying to drop triggers that are invalid.

fixes: https://github.com/dolthub/dolt/issues/9359

