### PR TITLE
Apply foreign key constraints to `UPDATE JOIN`

### DIFF
--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -482,8 +482,6 @@ var UpdateScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				// TODO: Foreign key constraints are not honored for UDPATE ... JOIN statements
-				Skip:        true,
 				Query:       "UPDATE orders o JOIN customers c ON o.customer_id = c.id SET o.customer_id = 123 where o.customer_id != 1;",
 				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
@@ -510,16 +508,12 @@ var UpdateScriptTests = []ScriptTest{
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				// TODO: Foreign key constraints are not honored for UDPATE ... JOIN statements
-				Skip: true,
 				Query: `UPDATE child1 c1
 						JOIN child2 c2 ON c1.id = 10 AND c2.id = 20
 						SET c1.p1_id = 999, c2.p2_id = 3;`,
 				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
-				// TODO: Foreign key constraints are not honored for UDPATE ... JOIN statements
-				Skip: true,
 				Query: `UPDATE child1 c1
 						JOIN child2 c2 ON c1.id = 10 AND c2.id = 20
 						SET c1.p1_id = 3, c2.p2_id = 999;`,

--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -485,7 +485,7 @@ var UpdateScriptTests = []ScriptTest{
 				// TODO: Foreign key constraints are not honored for UDPATE ... JOIN statements
 				Skip:        true,
 				Query:       "UPDATE orders o JOIN customers c ON o.customer_id = c.id SET o.customer_id = 123 where o.customer_id != 1;",
-				ExpectedErr: sql.ErrCheckConstraintViolated,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query: "SELECT * FROM orders;",

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -449,7 +449,7 @@ func getForeignKeyRefActions(ctx *sql.Context, a *Analyzer, tbl sql.ForeignKeyTa
 }
 
 // getForeignKeyHandlerFromUpdateTarget creates a ForeignKeyHandler from a given update target Node. It is used for
-// applying foreign key constrains to Update nodes
+// applying foreign key constraints to Update nodes
 func getForeignKeyHandlerFromUpdateTarget(updateTarget sql.Node, ctx *sql.Context, a *Analyzer,
 	cache *foreignKeyCache, fkChain foreignKeyChain) (*plan.ForeignKeyHandler, error) {
 	updateDest, err := plan.GetUpdatable(updateTarget)

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -129,7 +129,7 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 			for tableName, updateTarget := range updateTargets {
 				fkHandlerMap[tableName] = updateTarget
 				fkHandler, err :=
-					getForeignKeyHandlerFromUpdateTarget(updateTarget, ctx, a, cache, fkChain)
+					getForeignKeyHandlerFromUpdateTarget(ctx, a, updateTarget, cache, fkChain)
 				if err != nil {
 					return nil, transform.SameTree, err
 				}
@@ -143,7 +143,7 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 			nn, err := n.WithChildren(uj)
 			return nn, transform.NewTree, err
 		}
-		fkHandler, err := getForeignKeyHandlerFromUpdateTarget(n.Child, ctx, a, cache, fkChain)
+		fkHandler, err := getForeignKeyHandlerFromUpdateTarget(ctx, a, n.Child, cache, fkChain)
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
@@ -450,7 +450,7 @@ func getForeignKeyRefActions(ctx *sql.Context, a *Analyzer, tbl sql.ForeignKeyTa
 
 // getForeignKeyHandlerFromUpdateTarget creates a ForeignKeyHandler from a given update target Node. It is used for
 // applying foreign key constraints to Update nodes
-func getForeignKeyHandlerFromUpdateTarget(updateTarget sql.Node, ctx *sql.Context, a *Analyzer,
+func getForeignKeyHandlerFromUpdateTarget(ctx *sql.Context, a *Analyzer, updateTarget sql.Node,
 	cache *foreignKeyCache, fkChain foreignKeyChain) (*plan.ForeignKeyHandler, error) {
 	updateDest, err := plan.GetUpdatable(updateTarget)
 	if err != nil {

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -122,8 +122,6 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 		if plan.IsEmptyTable(n.Child) {
 			return n, transform.SameTree, nil
 		}
-		// TODO: UPDATE JOIN can update multiple tables. Because updatableJoinTable does not implement
-		//       sql.ForeignKeyTable, we do not currenly support FK checks for UPDATE JOIN statements.
 		updateDest, err := plan.GetUpdatable(n.Child)
 		if err != nil {
 			return nil, transform.SameTree, err
@@ -459,6 +457,8 @@ func getForeignKeyRefActions(ctx *sql.Context, a *Analyzer, tbl sql.ForeignKeyTa
 	return fkEditor, nil
 }
 
+// getForeignKeyHandlerFromUpdateDestination creates a ForeignKeyHandler from a given UpdatableTable. It's used in
+// applying foreign keys to Update nodes
 func getForeignKeyHandlerFromUpdateDestination(updateDest sql.UpdatableTable, ctx *sql.Context, a *Analyzer,
 	cache *foreignKeyCache, fkChain foreignKeyChain, originalNode sql.Node) (*plan.ForeignKeyHandler, error) {
 	fkTbl, ok := updateDest.(sql.ForeignKeyTable)

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -122,8 +122,6 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 		if plan.IsEmptyTable(n.Child) {
 			return n, transform.SameTree, nil
 		}
-		// TODO: UPDATE JOIN can update multiple tables. Because updatableJoinTable does not implement
-		//       sql.ForeignKeyTable, we do not currenly support FK checks for UPDATE JOIN statements.
 		targets := n.GetUpdateTargets()
 		foreignKeyHandlers := make([]sql.Node, len(targets))
 		copy(foreignKeyHandlers, targets)

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -147,6 +147,7 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 				Table:        tbl,
 				Sch:          updateDest.Schema(),
 				OriginalNode: targets[i],
+				Editor:       fkEditor,
 				AllUpdaters:  fkChain.GetUpdaters(),
 			}
 		}

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -122,44 +122,33 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 		if plan.IsEmptyTable(n.Child) {
 			return n, transform.SameTree, nil
 		}
-		targets := n.GetUpdateTargets()
-		foreignKeyHandlers := make([]sql.Node, len(targets))
-		copy(foreignKeyHandlers, targets)
-
-		for i, node := range targets {
-			updateDest, err := plan.GetUpdatable(node)
-			if err != nil {
-				return nil, transform.SameTree, err
-			}
-
-			tbl, ok := updateDest.(sql.ForeignKeyTable)
-			if !ok {
-				continue
-			}
-			fkEditor, err := getForeignKeyEditor(ctx, a, tbl, cache, fkChain, false)
-			if err != nil {
-				return nil, transform.SameTree, err
-			}
-			if fkEditor == nil {
-				continue
-			}
-			foreignKeyHandlers[i] = &plan.ForeignKeyHandler{
-				Table:        tbl,
-				Sch:          updateDest.Schema(),
-				OriginalNode: targets[i],
-				Editor:       fkEditor,
-				AllUpdaters:  fkChain.GetUpdaters(),
-			}
+		// TODO: UPDATE JOIN can update multiple tables. Because updatableJoinTable does not implement
+		//       sql.ForeignKeyTable, we do not currenly support FK checks for UPDATE JOIN statements.
+		updateDest, err := plan.GetUpdatable(n.Child)
+		if err != nil {
+			return nil, transform.SameTree, err
 		}
-		if n.IsJoin {
-			return n.WithUpdateJoinTargets(foreignKeyHandlers), transform.NewTree, nil
-		} else {
-			newNode, err := n.WithChildren(foreignKeyHandlers...)
-			if err != nil {
-				return nil, transform.SameTree, err
-			}
-			return newNode, transform.NewTree, nil
+		fkTbl, ok := updateDest.(sql.ForeignKeyTable)
+		// If foreign keys aren't supported then we return
+		if !ok {
+			return n, transform.SameTree, nil
 		}
+
+		fkEditor, err := getForeignKeyEditor(ctx, a, fkTbl, cache, fkChain, false)
+		if err != nil {
+			return nil, transform.SameTree, err
+		}
+		if fkEditor == nil {
+			return n, transform.SameTree, nil
+		}
+		nn, err := n.WithChildren(&plan.ForeignKeyHandler{
+			Table:        fkTbl,
+			Sch:          updateDest.Schema(),
+			OriginalNode: n.Child,
+			Editor:       fkEditor,
+			AllUpdaters:  fkChain.GetUpdaters(),
+		})
+		return nn, transform.NewTree, err
 	case *plan.DeleteFrom:
 		if plan.IsEmptyTable(n.Child) {
 			return n, transform.SameTree, nil

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -34,6 +34,7 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 			return n, transform.SameTree, nil
 		}
 
+		n.IsJoin = true
 		updateTargets, err := getUpdateTargetsByTable(us, jn)
 		if err != nil {
 			return nil, transform.SameTree, err

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -52,7 +52,7 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 	return n, transform.SameTree, nil
 }
 
-// getUpdateTargetsByTable maps a set of table names to their corresponding update target Node
+// getUpdateTargetsByTable maps a set of table names and aliases to their corresponding update target Node
 func getUpdateTargetsByTable(node sql.Node, ij sql.Node) (map[string]sql.Node, error) {
 	namesOfTableToBeUpdated := getTablesToBeUpdated(node)
 	resolvedTables := getTablesByName(ij)

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -34,7 +34,7 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 			return n, transform.SameTree, nil
 		}
 
-		updateTargets, err := targetsByTable(us, jn)
+		updateTargets, err := getUpdateTargetsByTable(us, jn)
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
@@ -51,8 +51,8 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 	return n, transform.SameTree, nil
 }
 
-// targetsByTable maps a set of table names to their corresponding Node
-func targetsByTable(node sql.Node, ij sql.Node) (map[string]sql.Node, error) {
+// getUpdateTargetsByTable maps a set of table names to their corresponding update target Node
+func getUpdateTargetsByTable(node sql.Node, ij sql.Node) (map[string]sql.Node, error) {
 	namesOfTableToBeUpdated := getTablesToBeUpdated(node)
 	resolvedTables := getTablesByName(ij)
 

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -34,7 +34,7 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 			return n, transform.SameTree, nil
 		}
 
-		updateTargets, err := updateTargetsByTable(us, jn)
+		updateTargets, err := targetsByTable(us, jn)
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
@@ -51,8 +51,8 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 	return n, transform.SameTree, nil
 }
 
-// rowUpdatersByTable maps a set of tables to their RowUpdater objects.
-func updateTargetsByTable(node sql.Node, ij sql.Node) (map[string]sql.Node, error) {
+// targetsByTable maps a set of table names to their corresponding Node
+func targetsByTable(node sql.Node, ij sql.Node) (map[string]sql.Node, error) {
 	namesOfTableToBeUpdated := getTablesToBeUpdated(node)
 	resolvedTables := getTablesByName(ij)
 

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -34,55 +34,63 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 			return n, transform.SameTree, nil
 		}
 
-		updateJoinTargets, err := getTablesToBeUpdated(us, jn)
+		updatables, err := updatablesByTable(us, jn)
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
-		ret := n.WithUpdateJoinTargets(updateJoinTargets)
-		ret = ret.WithJoinSchema(jn.Schema())
+
+		uj := plan.NewUpdateJoin(updatables, us)
+		ret, err := n.WithChildren(uj)
+		if err != nil {
+			return nil, transform.SameTree, err
+		}
+
 		return ret, transform.NewTree, nil
 	}
 
 	return n, transform.SameTree, nil
 }
 
-func getTablesToBeUpdated(us sql.Node, jn sql.Node) ([]sql.Node, error) {
-	namesOfTablesToBeUpdated := getNamesOfTablesToBeUpdated(us)
-	resolvedTables := getTablesByName(jn)
-	tablesToBeUpdated := make([]sql.Node, len(namesOfTablesToBeUpdated))
+// rowUpdatersByTable maps a set of tables to their RowUpdater objects.
+func updatablesByTable(node sql.Node, ij sql.Node) (map[string]sql.UpdatableTable, error) {
+	namesOfTableToBeUpdated := getTablesToBeUpdated(node)
+	resolvedTables := getTablesByName(ij)
 
-	for i, tableName := range namesOfTablesToBeUpdated {
-		resolvedTable, ok := resolvedTables[tableName]
+	updatables := make(map[string]sql.UpdatableTable)
+	for tableToBeUpdated, _ := range namesOfTableToBeUpdated {
+		resolvedTable, ok := resolvedTables[tableToBeUpdated]
 		if !ok {
-			return nil, plan.ErrUpdateForTableNotSupported.New(tableName)
+			return nil, plan.ErrUpdateForTableNotSupported.New(tableToBeUpdated)
 		}
 
 		var table = resolvedTable.UnderlyingTable()
 
+		// If there is no UpdatableTable for a table being updated, error out
 		updatable, ok := table.(sql.UpdatableTable)
 		if !ok && updatable == nil {
-			return nil, plan.ErrUpdateForTableNotSupported.New(tableName)
+			return nil, plan.ErrUpdateForTableNotSupported.New(tableToBeUpdated)
 		}
 
 		keyless := sql.IsKeyless(updatable.Schema())
 		if keyless {
 			return nil, sql.ErrUnsupportedFeature.New("error: keyless tables unsupported for UPDATE JOIN")
 		}
-		tablesToBeUpdated[i] = resolvedTable
+
+		updatables[tableToBeUpdated] = updatable
 	}
 
-	return tablesToBeUpdated, nil
+	return updatables, nil
 }
 
-// getNamesOfTablesToBeUpdated takes a node and looks for the tables to modified by a SetField.
-func getNamesOfTablesToBeUpdated(node sql.Node) []string {
-	ret := make([]string, 0)
+// getTablesToBeUpdated takes a node and looks for the tables to modified by a SetField.
+func getTablesToBeUpdated(node sql.Node) map[string]struct{} {
+	ret := make(map[string]struct{})
 
 	transform.InspectExpressions(node, func(e sql.Expression) bool {
 		switch e := e.(type) {
 		case *expression.SetField:
 			gf := e.LeftChild.(*expression.GetField)
-			ret = append(ret, strings.ToLower(gf.Table()))
+			ret[strings.ToLower(gf.Table())] = struct{}{}
 			return false
 		}
 

--- a/sql/plan/update.go
+++ b/sql/plan/update.go
@@ -203,6 +203,45 @@ func (u Update) WithExpressions(newExprs ...sql.Expression) (sql.Node, error) {
 	return &u, nil
 }
 
+// UpdateInfo is the Info for OKResults returned by Update nodes.
+type UpdateInfo struct {
+	Matched, Updated, Warnings int
+}
+
+// String implements fmt.Stringer
+func (ui UpdateInfo) String() string {
+	return fmt.Sprintf("Rows matched: %d  Changed: %d  Warnings: %d", ui.Matched, ui.Updated, ui.Warnings)
+}
+
+// WithChildren implements the Node interface.
+func (u *Update) WithChildren(children ...sql.Node) (sql.Node, error) {
+	if len(children) != 1 {
+		return nil, sql.ErrInvalidChildrenNumber.New(u, len(children), 1)
+	}
+	np := *u
+	np.Child = children[0]
+	return &np, nil
+}
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*Update) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 7
+}
+
+func (u *Update) String() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("Update")
+	_ = pr.WriteChildren(u.Child.String())
+	return pr.String()
+}
+
+func (u *Update) DebugString() string {
+	pr := sql.NewTreePrinter()
+	_ = pr.WriteNode("Update")
+	_ = pr.WriteChildren(sql.DebugString(u.Child))
+	return pr.String()
+}
+
 // WithUpdateJoinTargets returns a new Update node instance with the specified |targets| set as the update join targets
 // of the update operation
 func (u *Update) WithUpdateJoinTargets(targets []sql.Node) *Update {
@@ -252,43 +291,4 @@ func (u *joinUpdater) Update(ctx *sql.Context, old sql.Row, new sql.Row) error {
 }
 func (u *joinUpdater) Close(ctx *sql.Context) error {
 	return nil
-}
-
-// UpdateInfo is the Info for OKResults returned by Update nodes.
-type UpdateInfo struct {
-	Matched, Updated, Warnings int
-}
-
-// String implements fmt.Stringer
-func (ui UpdateInfo) String() string {
-	return fmt.Sprintf("Rows matched: %d  Changed: %d  Warnings: %d", ui.Matched, ui.Updated, ui.Warnings)
-}
-
-// WithChildren implements the Node interface.
-func (u *Update) WithChildren(children ...sql.Node) (sql.Node, error) {
-	if len(children) != 1 {
-		return nil, sql.ErrInvalidChildrenNumber.New(u, len(children), 1)
-	}
-	np := *u
-	np.Child = children[0]
-	return &np, nil
-}
-
-// CollationCoercibility implements the interface sql.CollationCoercible.
-func (*Update) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
-	return sql.Collation_binary, 7
-}
-
-func (u *Update) String() string {
-	pr := sql.NewTreePrinter()
-	_ = pr.WriteNode("Update")
-	_ = pr.WriteChildren(u.Child.String())
-	return pr.String()
-}
-
-func (u *Update) DebugString() string {
-	pr := sql.NewTreePrinter()
-	_ = pr.WriteNode("Update")
-	_ = pr.WriteChildren(sql.DebugString(u.Child))
-	return pr.String()
 }

--- a/sql/plan/update_join.go
+++ b/sql/plan/update_join.go
@@ -21,14 +21,14 @@ import (
 )
 
 type UpdateJoin struct {
-	UpdateTargets map[string]sql.Node
+	updateTargets map[string]sql.Node
 	UnaryNode
 }
 
 // NewUpdateJoin returns a new *UpdateJoin node.
 func NewUpdateJoin(updateTargets map[string]sql.Node, child sql.Node) *UpdateJoin {
 	return &UpdateJoin{
-		UpdateTargets: updateTargets,
+		updateTargets: updateTargets,
 		UnaryNode:     UnaryNode{Child: child},
 	}
 }
@@ -55,7 +55,7 @@ func (u *UpdateJoin) DebugString() string {
 // GetUpdatable returns an updateJoinTable which implements sql.UpdatableTable.
 func (u *UpdateJoin) GetUpdatable() sql.UpdatableTable {
 	return &UpdatableJoinTable{
-		UpdateTargets: u.UpdateTargets,
+		UpdateTargets: u.updateTargets,
 		joinNode:      u.Child.(*UpdateSource).Child,
 	}
 }
@@ -66,7 +66,7 @@ func (u *UpdateJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
 		return nil, sql.ErrInvalidChildrenNumber.New(u, len(children), 1)
 	}
 
-	return NewUpdateJoin(u.UpdateTargets, children[0]), nil
+	return NewUpdateJoin(u.updateTargets, children[0]), nil
 }
 
 func (u *UpdateJoin) IsReadOnly() bool {
@@ -79,7 +79,7 @@ func (u *UpdateJoin) CollationCoercibility(ctx *sql.Context) (collation sql.Coll
 }
 
 func (u *UpdateJoin) GetUpdaters(ctx *sql.Context) (map[string]sql.RowUpdater, error) {
-	return getUpdaters(u.UpdateTargets, ctx)
+	return getUpdaters(u.updateTargets, ctx)
 }
 
 func getUpdaters(updateTargets map[string]sql.Node, ctx *sql.Context) (map[string]sql.RowUpdater, error) {

--- a/sql/plan/update_join.go
+++ b/sql/plan/update_join.go
@@ -54,8 +54,8 @@ func (u *UpdateJoin) DebugString() string {
 
 // GetUpdatable returns an updateJoinTable which implements sql.UpdatableTable.
 func (u *UpdateJoin) GetUpdatable() sql.UpdatableTable {
-	return &UpdatableJoinTable{
-		UpdateTargets: u.UpdateTargets,
+	return &updatableJoinTable{
+		updateTargets: u.UpdateTargets,
 		joinNode:      u.Child.(*UpdateSource).Child,
 	}
 }
@@ -94,47 +94,47 @@ func getUpdaters(updateTargets map[string]sql.Node, ctx *sql.Context) (map[strin
 	return updaterMap, nil
 }
 
-// UpdatableJoinTable manages the update of multiple tables.
-type UpdatableJoinTable struct {
-	UpdateTargets map[string]sql.Node
+// updatableJoinTable manages the update of multiple tables.
+type updatableJoinTable struct {
+	updateTargets map[string]sql.Node
 	joinNode      sql.Node
 }
 
-var _ sql.UpdatableTable = (*UpdatableJoinTable)(nil)
+var _ sql.UpdatableTable = (*updatableJoinTable)(nil)
 
 // Partitions implements the sql.UpdatableTable interface.
-func (u *UpdatableJoinTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
+func (u *updatableJoinTable) Partitions(context *sql.Context) (sql.PartitionIter, error) {
 	panic("this method should not be called")
 }
 
 // PartitionsRows implements the sql.UpdatableTable interface.
-func (u *UpdatableJoinTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
+func (u *updatableJoinTable) PartitionRows(context *sql.Context, partition sql.Partition) (sql.RowIter, error) {
 	panic("this method should not be called")
 }
 
 // Name implements the sql.UpdatableTable interface.
-func (u *UpdatableJoinTable) Name() string {
+func (u *updatableJoinTable) Name() string {
 	panic("this method should not be called")
 }
 
 // String implements the sql.UpdatableTable interface.
-func (u *UpdatableJoinTable) String() string {
+func (u *updatableJoinTable) String() string {
 	panic("this method should not be called")
 }
 
 // Schema implements the sql.UpdatableTable interface.
-func (u *UpdatableJoinTable) Schema() sql.Schema {
+func (u *updatableJoinTable) Schema() sql.Schema {
 	return u.joinNode.Schema()
 }
 
 // Collation implements the sql.Table interface.
-func (u *UpdatableJoinTable) Collation() sql.CollationID {
+func (u *updatableJoinTable) Collation() sql.CollationID {
 	return sql.Collation_Default
 }
 
 // Updater implements the sql.UpdatableTable interface.
-func (u *UpdatableJoinTable) Updater(ctx *sql.Context) sql.RowUpdater {
-	updaters, _ := getUpdaters(u.UpdateTargets, ctx)
+func (u *updatableJoinTable) Updater(ctx *sql.Context) sql.RowUpdater {
+	updaters, _ := getUpdaters(u.updateTargets, ctx)
 	return &updatableJoinUpdater{
 		updaterMap: updaters,
 		schemaMap:  RecreateTableSchemaFromJoinSchema(u.joinNode.Schema()),

--- a/sql/plan/update_join.go
+++ b/sql/plan/update_join.go
@@ -25,7 +25,7 @@ type UpdateJoin struct {
 	UnaryNode
 }
 
-// NewUpdateJoin returns an *UpdateJoin node.
+// NewUpdateJoin returns a new *UpdateJoin node.
 func NewUpdateJoin(updateTargets map[string]sql.Node, child sql.Node) *UpdateJoin {
 	return &UpdateJoin{
 		UpdateTargets: updateTargets,
@@ -54,11 +54,6 @@ func (u *UpdateJoin) DebugString() string {
 
 // GetUpdatable returns an updateJoinTable which implements sql.UpdatableTable.
 func (u *UpdateJoin) GetUpdatable() sql.UpdatableTable {
-	// TODO: UpdateJoin can update multiple tables, but this interface only allows for a single table.
-	//       Additionally, updatableJoinTable doesn't implement interfaces that other parts of the code
-	//       expect, so UpdateJoins don't always work correctly. For example, because updatableJoinTable
-	//       doesn't implement ForeignKeyTable, UpdateJoin statements don't enforce foreign key checks.
-	//       We should revamp this function so that we can communicate multiple tables being updated.
 	return &UpdatableJoinTable{
 		UpdateTargets: u.UpdateTargets,
 		joinNode:      u.Child.(*UpdateSource).Child,
@@ -72,10 +67,6 @@ func (u *UpdateJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
 	}
 
 	return NewUpdateJoin(u.UpdateTargets, children[0]), nil
-}
-
-func (u *UpdateJoin) WithUpdateTargets(updateTargets map[string]sql.Node) *UpdateJoin {
-	return NewUpdateJoin(updateTargets, u.Child)
 }
 
 func (u *UpdateJoin) IsReadOnly() bool {
@@ -103,7 +94,7 @@ func getUpdaters(updateTargets map[string]sql.Node, ctx *sql.Context) (map[strin
 	return updaterMap, nil
 }
 
-// updatableJoinTable manages the update of multiple tables.
+// UpdatableJoinTable manages the update of multiple tables.
 type UpdatableJoinTable struct {
 	UpdateTargets map[string]sql.Node
 	joinNode      sql.Node

--- a/sql/plan/update_join.go
+++ b/sql/plan/update_join.go
@@ -21,14 +21,14 @@ import (
 )
 
 type UpdateJoin struct {
-	updateTargets map[string]sql.Node
+	UpdateTargets map[string]sql.Node
 	UnaryNode
 }
 
 // NewUpdateJoin returns a new *UpdateJoin node.
 func NewUpdateJoin(updateTargets map[string]sql.Node, child sql.Node) *UpdateJoin {
 	return &UpdateJoin{
-		updateTargets: updateTargets,
+		UpdateTargets: updateTargets,
 		UnaryNode:     UnaryNode{Child: child},
 	}
 }
@@ -55,7 +55,7 @@ func (u *UpdateJoin) DebugString() string {
 // GetUpdatable returns an updateJoinTable which implements sql.UpdatableTable.
 func (u *UpdateJoin) GetUpdatable() sql.UpdatableTable {
 	return &UpdatableJoinTable{
-		UpdateTargets: u.updateTargets,
+		UpdateTargets: u.UpdateTargets,
 		joinNode:      u.Child.(*UpdateSource).Child,
 	}
 }
@@ -66,7 +66,7 @@ func (u *UpdateJoin) WithChildren(children ...sql.Node) (sql.Node, error) {
 		return nil, sql.ErrInvalidChildrenNumber.New(u, len(children), 1)
 	}
 
-	return NewUpdateJoin(u.updateTargets, children[0]), nil
+	return NewUpdateJoin(u.UpdateTargets, children[0]), nil
 }
 
 func (u *UpdateJoin) IsReadOnly() bool {
@@ -79,7 +79,7 @@ func (u *UpdateJoin) CollationCoercibility(ctx *sql.Context) (collation sql.Coll
 }
 
 func (u *UpdateJoin) GetUpdaters(ctx *sql.Context) (map[string]sql.RowUpdater, error) {
-	return getUpdaters(u.updateTargets, ctx)
+	return getUpdaters(u.UpdateTargets, ctx)
 }
 
 func getUpdaters(updateTargets map[string]sql.Node, ctx *sql.Context) (map[string]sql.RowUpdater, error) {

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -157,18 +157,9 @@ func (b *BaseBuilder) buildForeignKeyHandler(ctx *sql.Context, n *plan.ForeignKe
 }
 
 func (b *BaseBuilder) buildUpdate(ctx *sql.Context, n *plan.Update, row sql.Row) (sql.RowIter, error) {
-	var updater sql.RowUpdater
-	var schema sql.Schema
-	if n.IsJoin {
-		updater = n.JoinUpdater()
-		schema = n.Schema()
-	} else {
-		updatable, err := plan.GetUpdatable(n.Child)
-		if err != nil {
-			return nil, err
-		}
-		updater = updatable.Updater(ctx)
-		schema = updatable.Schema()
+	updater, schema, err := n.GetUpdaterAndSchema(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	iter, err := b.buildNodeExec(ctx, n.Child, row)

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -416,10 +416,14 @@ func (b *BaseBuilder) buildUpdateJoin(ctx *sql.Context, n *plan.UpdateJoin, row 
 		return nil, err
 	}
 
+	updaters, err := n.GetUpdaters(ctx)
+	if err != nil {
+		return nil, err
+	}
 	return &updateJoinIter{
 		updateSourceIter: ji,
 		joinSchema:       n.Child.(*plan.UpdateSource).Child.Schema(),
-		updaters:         n.GetUpdaters(ctx),
+		updaters:         updaters,
 		caches:           make(map[string]sql.KeyValueCache),
 		disposals:        make(map[string]sql.DisposeFunc),
 		joinNode:         n.Child.(*plan.UpdateSource).Child,


### PR DESCRIPTION
Modified UpdateJoin to be able to apply foreign key constraints

Part of dolthub/dolt#9356