### PR TITLE
Fix schema for call to `hash.HashOf()` in `HashLookups`

### DIFF
--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -1161,6 +1161,25 @@ var JoinScriptTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		// Since hash.HashOf takes in a sql.Schema to convert and hash keys,
+		//  we need to pass in the right keys.
+		Name: "HashLookups regression test",
+		SetUpScript: []string{
+			"create table t1 (i int primary key, j varchar(1), k int);",
+			"create table t2 (i int primary key, k int);",
+			"insert into t1 values (111111, 'a', 111111);",
+			"insert into t2 values (111111, 111111);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select /*+ HASH_JOIN(t1, t2) */ * from t1 join t2 on t1.i = t2.i and t1.k = t2.k;",
+				Expected: []sql.Row{
+					{111111, "a", 111111, 111111, 111111},
+				},
+			},
+		},
+	},
 }
 
 var LateralJoinScriptTests = []ScriptTest{

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -1173,11 +1173,6 @@ var JoinScriptTests = []ScriptTest{
 			"create table t2 (i int primary key, j varchar(1), k int);",
 			"insert into t1 values (111111, 111111);",
 			"insert into t2 values (111111, 'a', 111111);",
-
-			"create table tt2 (i int primary key, j varchar(128) collate utf8mb4_0900_ai_ci);",
-			"create table tt1 (i int primary key, j varchar(128) collate utf8mb4_0900_ai_ci);",
-			"insert into tt1 values (1, 'ABCDE');",
-			"insert into tt2 values (1, 'abcde');",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1186,8 +1181,19 @@ var JoinScriptTests = []ScriptTest{
 					{111111, 111111, 111111, "a", 111111},
 				},
 			},
+		},
+	},
+	{
+		Name: "HashLookup on multiple columns with collations",
+		SetUpScript: []string{
+			"create table t1 (i int primary key, j varchar(128) collate utf8mb4_0900_ai_ci);",
+			"create table t2 (i int primary key, j varchar(128) collate utf8mb4_0900_ai_ci);",
+			"insert into t1 values (1, 'ABCDE');",
+			"insert into t2 values (1, 'abcde');",
+		},
+		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select /*+ HASH_JOIN(tt1, tt2) */ * from tt1 join tt2 on tt1.i = tt2.i and tt1.j = tt2.j;",
+				Query: "select /*+ HASH_JOIN(t1, t2) */ * from t1 join t2 on t1.i = t2.i and t1.j = t2.j;",
 				Expected: []sql.Row{
 					{1, "ABCDE", 1, "abcde"},
 				},

--- a/sql/hash/hash.go
+++ b/sql/hash/hash.go
@@ -33,7 +33,7 @@ var digestPool = sync.Pool{
 // ExprsToSchema converts a list of sql.Expression to a sql.Schema.
 // This is used for functions that use HashOf, but don't already have a schema.
 // The generated schema ONLY contains the types of the expressions without any column names or any other info.
-func ExprsToSchema(exprs... sql.Expression) sql.Schema {
+func ExprsToSchema(exprs ...sql.Expression) sql.Schema {
 	var sch sql.Schema
 	for _, expr := range exprs {
 		sch = append(sch, &sql.Column{Type: expr.Type()})

--- a/sql/hash/hash.go
+++ b/sql/hash/hash.go
@@ -30,6 +30,17 @@ var digestPool = sync.Pool{
 	},
 }
 
+// ExprsToSchema converts a list of sql.Expression to a sql.Schema.
+// This is used for functions that use HashOf, but don't already have a schema.
+// The generated schema ONLY contains the types of the expressions without any column names or any other info.
+func ExprsToSchema(exprs... sql.Expression) sql.Schema {
+	var sch sql.Schema
+	for _, expr := range exprs {
+		sch = append(sch, &sql.Column{Type: expr.Type()})
+	}
+	return sch
+}
+
 // HashOf returns a hash of the given value to be used as key in a cache.
 func HashOf(ctx *sql.Context, sch sql.Schema, row sql.Row) (uint64, error) {
 	hash := digestPool.Get().(*xxhash.Digest)

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -16,8 +16,9 @@ package plan
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"sync"
+
+	"github.com/dolthub/go-mysql-server/sql/expression"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/hash"

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -18,9 +18,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/dolthub/go-mysql-server/sql/expression"
-
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/hash"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -127,7 +127,7 @@ func (n *HashLookup) GetHashKey(ctx *sql.Context, e sql.Expression, row sql.Row)
 		return nil, err
 	}
 	if s, ok := key.([]interface{}); ok {
-		return hash.HashOf(ctx, n.Schema(), s)
+		return hash.HashOf(ctx, nil, s)
 	}
 	// byte slices are not hashable
 	if k, ok := key.([]byte); ok {

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 
 	"github.com/dolthub/go-mysql-server/sql"
-		"github.com/dolthub/go-mysql-server/sql/hash"
+	"github.com/dolthub/go-mysql-server/sql/hash"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 

--- a/sql/plan/hash_lookup.go
+++ b/sql/plan/hash_lookup.go
@@ -143,4 +143,3 @@ func (n *HashLookup) GetHashKey(ctx *sql.Context, e sql.Expression, row sql.Row)
 func (n *HashLookup) Dispose() {
 	n.Lookup = nil
 }
-


### PR DESCRIPTION
The incorrect schema was used in the `hash.HashOf()` function.
`n.Schema()` is the schema of the entire JoinNode; we just needed the schema of the key.'

Test bump: https://github.com/dolthub/ld/pull/20634
