### PR TITLE
escape column names in check constraints

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -202,20 +202,20 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name:        "AS OF propagates to nested CALLs",
+			Name:        "asdf",
 			SetUpScript: []string{},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query: "create procedure create_proc() create table t (i int primary key, j int);",
+					Query: "create table t (`order` int, check (`order` > 0))",
 					Expected: []sql.Row{
 						{types.NewOkResult(0)},
 					},
 				},
 				{
-					Query: "call create_proc()",
+					Query: "insert into t values (1)",
 					Expected: []sql.Row{
 						{types.NewOkResult(0)},
 					},

--- a/sql/plan/alter_check.go
+++ b/sql/plan/alter_check.go
@@ -157,7 +157,9 @@ func NewCheckDefinition(ctx *sql.Context, check *sql.CheckConstraint) (*sql.Chec
 	unqualifiedCols, _, err := transform.Expr(check.Expr, func(e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 		gf, ok := e.(*expression.GetField)
 		if ok {
-			return expression.NewGetField(gf.Index(), gf.Type(), gf.Name(), gf.IsNullable()), transform.NewTree, nil
+			newGf := expression.NewGetField(gf.Index(), gf.Type(), gf.Name(), gf.IsNullable())
+			newGf = newGf.WithQuotedNames(sql.GlobalSchemaFormatter, true)
+			return newGf, transform.NewTree, nil
 		}
 		return e, transform.SameTree, nil
 	})
@@ -167,7 +169,7 @@ func NewCheckDefinition(ctx *sql.Context, check *sql.CheckConstraint) (*sql.Chec
 
 	return &sql.CheckDefinition{
 		Name:            check.Name,
-		CheckExpression: fmt.Sprintf("%s", unqualifiedCols),
+		CheckExpression: unqualifiedCols.String(),
 		Enforced:        check.Enforced,
 	}, nil
 }


### PR DESCRIPTION
MySQL escapes any column names within a check expression preventing any parser errors when round tripping tables, so we should do the same.

fixes: https://github.com/dolthub/dolt/issues/9343