### PR TITLE
fix missed case for nullable enums

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -8083,6 +8083,27 @@ where
 		},
 	},
 	{
+		Name:    "ensure that special case does not apply for nullable enums",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table t (i int primary key, e enum('abc', 'def', 'ghi'));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "insert into t(i) values (1)",
+				Expected: []sql.Row{
+					{types.NewOkResult(1)},
+				},
+			},
+			{
+				Query: "select * from t;",
+				Expected: []sql.Row{
+					{1, nil},
+				},
+			},
+		},
+	},
+	{
 		Name:    "not expression optimization",
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -87,7 +87,7 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 			break
 		}
 		_, isColDefVal := i.insertExprs[idx].(*sql.ColumnDefaultValue)
-		if row[idx] == nil && types.IsEnum(col.Type) && isColDefVal {
+		if row[idx] == nil && !col.Nullable && types.IsEnum(col.Type) && isColDefVal {
 			row[idx] = 1
 		}
 	}


### PR DESCRIPTION
This PR adds a missed edge case from this: https://github.com/dolthub/go-mysql-server/pull/2985
We were incorrectly making nullable enum columns take the first value.