### PR TITLE
Fix 9280 escape ctrl z comment strs

### DIFF
--- a/enginetest/queries/alter_table_queries.go
+++ b/enginetest/queries/alter_table_queries.go
@@ -1033,16 +1033,17 @@ var AlterTableScripts = []ScriptTest{
 		Name: "alter table comments are escaped",
 		SetUpScript: []string{
 			"create table t (i int);",
-			`alter table t modify column i int comment "newline \n | return \r | backslash \\ | NUL \0 \x00"`,
-			`alter table t add column j int comment "newline \n | return \r | backslash \\ | NUL \0 \x00"`,
+			`alter table t modify column i int comment "newline \n | return \r | backslash \\ | NUL \0 \x00 | ctrlz \Z \x1A"`,
+			`alter table t add column j int comment "newline \n | return \r | backslash \\ | NUL \0 \x00 | ctrlz \Z \x1A"`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
 				Query: "show create table t",
 				Expected: []sql.Row{{
 					"t",
-					"CREATE TABLE `t` (\n  `i` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'," +
-						"\n  `j` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+					"CREATE TABLE `t` (\n  `i` int COMMENT 'newl ine \\n | return \\r | backslash \\\\ | NUL \\0 x00 | ctrlz \x1A x1A'," +
+						"\n  `j` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00 | ctrlz \x1A x1A'\n" +
+						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},

--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -53,10 +53,10 @@ var CreateTableQueries = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT=''''"}},
 	},
 	{
-		WriteQuery:          `create table tableWithComment (pk int) COMMENT "newline \n | return \r | backslash \\ | NUL \0 \x00"`,
+		WriteQuery:          `create table tableWithComment (pk int) COMMENT "newline \n | return \r | backslash \\ | NUL \0 \x00 | ctrlz \Z \x1A"`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
-		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT='newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'"}},
+		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT='newline \\n | return \\r | backslash \\\\ | NUL \\0 x00 | ctrlz \x1A x1A'"}},
 	},
 	{
 		WriteQuery:          `create table tableWithColumnComment (pk int COMMENT "'")`,
@@ -71,10 +71,10 @@ var CreateTableQueries = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{"tableWithColumnComment", "CREATE TABLE `tableWithColumnComment` (\n  `pk` int COMMENT ''''\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
-		WriteQuery:          `create table tableWithColumnComment (pk int COMMENT "newline \n | return \r | backslash \\ | NUL \0 \x00")`,
+		WriteQuery:          `create table tableWithColumnComment (pk int COMMENT "newline \n | return \r | backslash \\ | NUL \0 \x00 | ctrlz \Z \x1A")`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE tableWithColumnComment",
-		ExpectedSelect:      []sql.Row{{"tableWithColumnComment", "CREATE TABLE `tableWithColumnComment` (\n  `pk` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+		ExpectedSelect:      []sql.Row{{"tableWithColumnComment", "CREATE TABLE `tableWithColumnComment` (\n  `pk` int COMMENT 'newline \\n | return \\r | backslash \\\\ | NUL \\0 x00 | ctrlz \x1A x1A'\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
 	{
 		WriteQuery:          `create table floattypedefs (a float(10), b float(10, 2), c double(10, 2))`,

--- a/sql/parser.go
+++ b/sql/parser.go
@@ -133,10 +133,12 @@ func RemoveSpaceAndDelimiter(query string, d rune) string {
 	})
 }
 
+// EscapeSpecialCharactersInComment escapes special characters in a comment string.
 func EscapeSpecialCharactersInComment(comment string) string {
 	commentString := comment
 	commentString = strings.ReplaceAll(commentString, "'", "''")
 	commentString = strings.ReplaceAll(commentString, "\\", "\\\\")
+	commentString = strings.ReplaceAll(commentString, "\\Z", "\x1A") // MYSQL handles \\ first, then \Z
 	commentString = strings.ReplaceAll(commentString, "\"", "\\\"")
 	commentString = strings.ReplaceAll(commentString, "\n", "\\n")
 	commentString = strings.ReplaceAll(commentString, "\r", "\\r")


### PR DESCRIPTION
Fixes dolthub/dolt#9280
Add `\Z` as an escape character
Update query tests for escape characters