### PR TITLE
Fix SET statements to return OkResult instead of empty rows

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -5277,17 +5277,17 @@ func TestPersist(t *testing.T, harness Harness, newPersistableSess func(ctx *sql
 	}{
 		{
 			Query:           "SET PERSIST max_connections = 1000;",
-			Expected:        []sql.Row{{}},
+			Expected:        []sql.Row{{types.NewOkResult(0)}},
 			ExpectedGlobal:  int64(1000),
 			ExpectedPersist: int64(1000),
 		}, {
 			Query:           "SET @@PERSIST.max_connections = 1000;",
-			Expected:        []sql.Row{{}},
+			Expected:        []sql.Row{{types.NewOkResult(0)}},
 			ExpectedGlobal:  int64(1000),
 			ExpectedPersist: int64(1000),
 		}, {
 			Query:           "SET PERSIST_ONLY max_connections = 1000;",
-			Expected:        []sql.Row{{}},
+			Expected:        []sql.Row{{types.NewOkResult(0)}},
 			ExpectedGlobal:  int64(151),
 			ExpectedPersist: int64(1000),
 		},

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4118,7 +4118,7 @@ func TestVariables(t *testing.T, harness Harness) {
 		},
 		{
 			Query:    "SET GLOBAL select_into_buffer_size = 9001",
-			Expected: []sql.Row{{}},
+			Expected: []sql.Row{{types.NewOkResult(0)}},
 		},
 		{
 			Query:    "SELECT @@SESSION.select_into_buffer_size",
@@ -4130,7 +4130,7 @@ func TestVariables(t *testing.T, harness Harness) {
 		},
 		{
 			Query:    "SET @@GLOBAL.select_into_buffer_size = 9002",
-			Expected: []sql.Row{{}},
+			Expected: []sql.Row{{types.NewOkResult(0)}},
 		},
 		{
 			Query:    "SELECT @@GLOBAL.select_into_buffer_size",
@@ -4139,7 +4139,7 @@ func TestVariables(t *testing.T, harness Harness) {
 		{
 			// For boolean types, OFF/ON is converted
 			Query:    "SET @@GLOBAL.activate_all_roles_on_login = 'ON'",
-			Expected: []sql.Row{{}},
+			Expected: []sql.Row{{types.NewOkResult(0)}},
 		},
 		{
 			Query:    "SELECT @@GLOBAL.activate_all_roles_on_login",
@@ -4148,7 +4148,7 @@ func TestVariables(t *testing.T, harness Harness) {
 		{
 			// For non-boolean types, OFF/ON is not converted
 			Query:    "SET @@GLOBAL.delay_key_write = 'OFF'",
-			Expected: []sql.Row{{}},
+			Expected: []sql.Row{{types.NewOkResult(0)}},
 		},
 		{
 			Query:    "SELECT @@GLOBAL.delay_key_write",
@@ -4174,7 +4174,7 @@ func TestVariables(t *testing.T, harness Harness) {
 		},
 		{
 			Query:    "SET GLOBAL select_into_buffer_size = 131072",
-			Expected: []sql.Row{{}},
+			Expected: []sql.Row{{types.NewOkResult(0)}},
 		},
 	} {
 		t.Run(assertion.Query, func(t *testing.T) {

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/transform"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 type JoinPlanTest struct {
@@ -103,7 +104,7 @@ var JoinPlanningTests = []joinPlanScript{
 			},
 			{
 				q:   "set @@SESSION.disable_merge_join = 1",
-				exp: []sql.Row{{}},
+				exp: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				q:     "select /*+ JOIN_ORDER(ab, xy) MERGE_JOIN(ab, xy)*/ * from ab join xy on y = a order by 1, 3",

--- a/enginetest/queries/ansi_quotes_queries.go
+++ b/enginetest/queries/ansi_quotes_queries.go
@@ -71,7 +71,7 @@ var AnsiQuotesTests = []ScriptTest{
 			{
 				// Disable ANSI_QUOTES and make sure we can still run queries
 				Query:    `SET @@sql_mode='NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    `select "data" from auctions order by "ai" desc;`,
@@ -154,7 +154,7 @@ var AnsiQuotesTests = []ScriptTest{
 			{
 				// Disable ANSI_QUOTES mode
 				Query:    `SET @@sql_mode='NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    `show create table view1;`,
@@ -197,7 +197,7 @@ var AnsiQuotesTests = []ScriptTest{
 			{
 				// Disable ANSI_QUOTES mode
 				Query:    `SET @@sql_mode='NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    `insert into t values (2, 'George', 'SomethingElse');`,
@@ -237,7 +237,7 @@ var AnsiQuotesTests = []ScriptTest{
 			{
 				// Disable ANSI_QUOTES mode
 				Query:    `SET @@sql_mode='NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// Assert the procedure runs correctly with ANSI_QUOTES mode disabled
@@ -269,7 +269,7 @@ var AnsiQuotesTests = []ScriptTest{
 			{
 				// Disable ANSI_QUOTES mode
 				Query:    `SET @@sql_mode='NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// Insert a row with ANSI_QUOTES mode disabled
@@ -298,7 +298,7 @@ var AnsiQuotesTests = []ScriptTest{
 			{
 				// Disable ANSI_QUOTES mode
 				Query:    `SET @@sql_mode='NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// Assert the check constraint runs correctly when ANSI_QUOTES mode is disabled
@@ -328,7 +328,7 @@ var AnsiQuotesTests = []ScriptTest{
 			{
 				// Disable ANSI_QUOTES mode and make sure we can still list and run events
 				Query:    `SET @@sql_mode='NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    `SHOW EVENTS;`,

--- a/enginetest/queries/charset_collation_engine.go
+++ b/enginetest/queries/charset_collation_engine.go
@@ -463,7 +463,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@session.character_set_connection = 'latin1';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@session.character_set_connection, @@session.collation_connection;",
@@ -473,7 +473,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@session.collation_connection = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@session.character_set_connection, @@session.collation_connection;",
@@ -490,7 +490,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@global.character_set_connection = 'latin1';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@global.character_set_connection, @@global.collation_connection;",
@@ -500,7 +500,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@global.collation_connection = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@global.character_set_connection, @@global.collation_connection;",
@@ -517,7 +517,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@session.character_set_server = 'latin1';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@session.character_set_server, @@session.collation_server;",
@@ -527,7 +527,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@session.collation_server = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@session.character_set_server, @@session.collation_server;",
@@ -544,7 +544,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@global.character_set_server = 'latin1';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@global.character_set_server, @@global.collation_server;",
@@ -554,7 +554,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "set @@global.collation_server = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @@global.character_set_server, @@global.collation_server;",
@@ -696,7 +696,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "SET collation_connection = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "SELECT COUNT(*) FROM test WHERE v1 LIKE 'ABC';",
@@ -756,7 +756,7 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 			},
 			{
 				Query:    "SET collation_connection = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "SELECT 'abc' LIKE 'ABC';",

--- a/enginetest/queries/charset_collation_wire.go
+++ b/enginetest/queries/charset_collation_wire.go
@@ -476,7 +476,7 @@ var CharsetCollationWireTests = []CharsetCollationWireTest{
 			},
 			{
 				Query:    "SET collation_connection = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "SELECT COUNT(*) FROM test WHERE v1 LIKE 'ABC';",
@@ -536,7 +536,7 @@ var CharsetCollationWireTests = []CharsetCollationWireTest{
 			},
 			{
 				Query:    "SET collation_connection = 'utf8mb4_0900_bin';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "SELECT 'abc' LIKE 'ABC';",

--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -1485,7 +1485,7 @@ var ForeignKeyTests = []ScriptTest{
 			},
 			{
 				Query:    "SET FOREIGN_KEY_CHECKS=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "TRUNCATE parent;",
@@ -1497,7 +1497,7 @@ var ForeignKeyTests = []ScriptTest{
 			},
 			{
 				Query:    "SET FOREIGN_KEY_CHECKS=1;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:       "INSERT INTO child VALUES (4, 5, 6);",
@@ -2777,7 +2777,7 @@ var CreateForeignKeyTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SET FOREIGN_KEY_CHECKS=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "CREATE TABLE child4 (pk BIGINT PRIMARY KEY, CONSTRAINT fk_child4 FOREIGN KEY (pk) REFERENCES delayed_parent4 (pk))",

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -4011,7 +4011,7 @@ var IndexPrefixQueries = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "set @@strict_mysql_compatibility = true;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select @@strict_mysql_compatibility;",

--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -325,20 +325,20 @@ END`,
 			//       need to filter out Result Sets that should be completely omitted.
 			{
 				Query:    "CALL p1(0)",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "CALL p1(1)",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "CALL p1(2)",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// https://github.com/dolthub/dolt/issues/6230
 				Query:    "CALL p1(200)",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 		},
 	},
@@ -359,15 +359,15 @@ END`,
 			//       need to filter out Result Sets that should be completely omitted.
 			{
 				Query:    "CALL p1(0)",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "CALL p1(1)",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "CALL p1(2)",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 		},
 	},
@@ -985,7 +985,7 @@ END;`,
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SET @x = 2;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// TODO: Set statements don't return anything for whatever reason
@@ -2270,7 +2270,7 @@ end;
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "call proc();",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query: "select @v;",

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5687,7 +5687,7 @@ SELECT * FROM cte WHERE  d = 2;`,
 			sql.Collation_Default.CharacterSet().String() +
 			" */",
 		Expected: []sql.Row{
-			{},
+			{types.NewOkResult(0)},
 		},
 	},
 	{
@@ -5695,7 +5695,7 @@ SELECT * FROM cte WHERE  d = 2;`,
 			sql.Collation_Default.String() +
 			"';",
 		Expected: []sql.Row{
-			{},
+			{types.NewOkResult(0)},
 		},
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5338,7 +5338,7 @@ CREATE TABLE tab3 (
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SET time_zone = '+07:00';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT UNIX_TIMESTAMP('2023-09-25 07:02:57');",
@@ -5350,7 +5350,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    "SET time_zone = '+00:00';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT UNIX_TIMESTAMP('2023-09-25 07:02:57');",
@@ -5358,7 +5358,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    "SET time_zone = '-06:00';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT UNIX_TIMESTAMP('2023-09-25 07:02:57');",
@@ -9977,7 +9977,7 @@ var BrokenScriptTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "SET SESSION time_zone = '-05:00';",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "SELECT DATE_FORMAT(ts, '%H:%i:%s'), DATE_FORMAT(dt, '%H:%i:%s') from timezone_test;",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -3237,7 +3237,7 @@ CREATE TABLE tab3 (
 			// in +8:00
 			{
 				Query:    "set @@session.time_zone='+08:00'",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select from_unixtime(1)",
@@ -3254,7 +3254,7 @@ CREATE TABLE tab3 (
 			// in utc
 			{
 				Query:    "set @@session.time_zone='UTC'",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select from_unixtime(1)",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -5100,7 +5100,7 @@ CREATE TABLE tab3 (
 			{
 				// Set the timezone set to UTC as an offset
 				Query:    `set @@time_zone='+00:00';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// When the session's time zone is set to UTC, NOW() and UTC_TIMESTAMP() should return the same value
@@ -5114,7 +5114,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    `set @@time_zone='+02:00';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// When the session's time zone is set to +2:00, NOW() should report two hours ahead of UTC_TIMESTAMP()
@@ -5147,7 +5147,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    `set @@time_zone='-08:00';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// TODO: Unskip after adding support for converting timestamp values to/from session time_zone
@@ -5161,7 +5161,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    `set @@time_zone='+5:00';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// Test with explicit timezone in datetime literal
@@ -5180,7 +5180,7 @@ CREATE TABLE tab3 (
 			},
 			{
 				Query:    `set @@time_zone='+0:00';`,
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				// TODO: Unskip after adding support for converting timestamp values to/from session time_zone

--- a/enginetest/queries/transaction_queries.go
+++ b/enginetest/queries/transaction_queries.go
@@ -40,11 +40,11 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ select @@autocommit;",
@@ -120,11 +120,11 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ select * from t order by x",
@@ -191,11 +191,11 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ insert into t values (2,2)",
@@ -208,7 +208,7 @@ var TransactionTests = []TransactionTest{
 			// should commit any pending transaction
 			{
 				Query:    "/* client b */ set autocommit = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ select * from t order by x",
@@ -217,7 +217,7 @@ var TransactionTests = []TransactionTest{
 			// client a sees the committed transaction from client b when it begins a new transaction
 			{
 				Query:    "/* client a */ set autocommit = on",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ select * from t order by x",
@@ -283,11 +283,11 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -360,11 +360,11 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -529,11 +529,11 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction",
@@ -666,15 +666,15 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client b */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client c */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			// Client a starts by insert into t
 			{
@@ -958,7 +958,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set autocommit = off",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ create temporary table tmp(pk int primary key)",
@@ -1074,7 +1074,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1131,7 +1131,7 @@ var TransactionTests = []TransactionTest{
 
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1243,7 +1243,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1285,7 +1285,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1327,7 +1327,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1365,7 +1365,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1386,7 +1386,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1408,7 +1408,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",
@@ -1430,7 +1430,7 @@ var TransactionTests = []TransactionTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "/* client a */ set @@autocommit = 0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "/* client a */ start transaction;",

--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -32,7 +32,7 @@ var VariableQueries = []ScriptTest{
 		Name:        "use string name for foreign_key checks",
 		SetUpScript: []string{},
 		Query:       "set @@foreign_key_checks = off;",
-		Expected:    []sql.Row{{}},
+		Expected:    []sql.Row{{types.NewOkResult(0)}},
 	},
 	{
 		Name: "set system variables",
@@ -115,15 +115,15 @@ var VariableQueries = []ScriptTest{
 			},
 			{
 				Query:    "set @@server_id=123;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "set @@GLOBAL.server_id=123;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "set @@GLOBAL.server_id=0;",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 		},
 	},
@@ -523,7 +523,7 @@ var VariableQueries = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				Query:    "set transaction isolation level serializable, read only",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select @@transaction_isolation, @@transaction_read_only",
@@ -531,7 +531,7 @@ var VariableQueries = []ScriptTest{
 			},
 			{
 				Query:    "set transaction read write, isolation level read uncommitted",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select @@transaction_isolation, @@transaction_read_only",
@@ -539,7 +539,7 @@ var VariableQueries = []ScriptTest{
 			},
 			{
 				Query:    "set transaction isolation level read committed",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select @@transaction_isolation",
@@ -547,7 +547,7 @@ var VariableQueries = []ScriptTest{
 			},
 			{
 				Query:    "set transaction isolation level repeatable read",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select @@transaction_isolation",
@@ -555,7 +555,7 @@ var VariableQueries = []ScriptTest{
 			},
 			{
 				Query:    "set session transaction isolation level serializable, read only",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select @@transaction_isolation, @@transaction_read_only",
@@ -563,7 +563,7 @@ var VariableQueries = []ScriptTest{
 			},
 			{
 				Query:    "set global transaction read write, isolation level read uncommitted",
-				Expected: []sql.Row{{}},
+				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select @@transaction_isolation, @@transaction_read_only",

--- a/enginetest/server_engine.go
+++ b/enginetest/server_engine.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -217,7 +218,7 @@ func (s *ServerQueryEngine) query(ctx *sql.Context, stmt *gosql.Stmt, query stri
 	if err != nil {
 		return nil, nil, nil, trimMySQLErrCodePrefix(err)
 	}
-	return convertRowsResult(ctx, rows)
+	return convertRowsResult(ctx, rows, query)
 }
 
 func (s *ServerQueryEngine) exec(ctx *sql.Context, stmt *gosql.Stmt, query string, args []any) (sql.Schema, sql.RowIter, *sql.QueryFlags, error) {
@@ -302,7 +303,7 @@ func convertExecResult(exec gosql.Result) (sql.Schema, sql.RowIter, *sql.QueryFl
 	return types.OkResultSchema, sql.RowsToRowIter(sql.NewRow(okResult)), nil, nil
 }
 
-func convertRowsResult(ctx *sql.Context, rows *gosql.Rows) (sql.Schema, sql.RowIter, *sql.QueryFlags, error) {
+func convertRowsResult(ctx *sql.Context, rows *gosql.Rows, query string) (sql.Schema, sql.RowIter, *sql.QueryFlags, error) {
 	sch, err := schemaForRows(rows)
 	if err != nil {
 		return nil, nil, nil, err
@@ -310,6 +311,36 @@ func convertRowsResult(ctx *sql.Context, rows *gosql.Rows) (sql.Schema, sql.RowI
 
 	rowIter, err := rowIterForGoSqlRows(ctx, sch, rows)
 	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// If we have no columns and no rows, this might mean a CALL statement that should return OkResult
+	// (like a CALL to a stored procedure that only does SET operations)
+	// But we should NOT convert USE, SHOW, etc. statements to OkResult
+	// Also, external procedures (starting with "memory_") should return empty results, not OkResult
+	if len(sch) == 0 && strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "CALL") && 
+	   !strings.Contains(strings.ToLower(query), "memory_") {
+		// Check if we actually have any rows by trying to get the first row
+		firstRow, err := rowIter.Next(ctx)
+		if err == io.EOF {
+			// No rows available for a CALL statement, this should be OkResult
+			okResult := types.NewOkResult(0)
+			return types.OkResultSchema, sql.RowsToRowIter(sql.NewRow(okResult)), nil, nil
+		} else if err == nil {
+			// We do have a row, so create a new iterator that includes this row plus the rest
+			restRows := []sql.Row{firstRow}
+			for {
+				row, err := rowIter.Next(ctx)
+				if err != nil {
+					break
+				}
+				restRows = append(restRows, row)
+			}
+			rowIter.Close(ctx)
+			return sch, sql.RowsToRowIter(restRows...), nil, nil
+		}
+		// Some other error occurred, close the iterator and return the error
+		rowIter.Close(ctx)
 		return nil, nil, nil, err
 	}
 

--- a/enginetest/server_engine.go
+++ b/enginetest/server_engine.go
@@ -318,8 +318,8 @@ func convertRowsResult(ctx *sql.Context, rows *gosql.Rows, query string) (sql.Sc
 	// (like a CALL to a stored procedure that only does SET operations)
 	// But we should NOT convert USE, SHOW, etc. statements to OkResult
 	// Also, external procedures (starting with "memory_") should return empty results, not OkResult
-	if len(sch) == 0 && strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "CALL") && 
-	   !strings.Contains(strings.ToLower(query), "memory_") {
+	if len(sch) == 0 && strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "CALL") &&
+		!strings.Contains(strings.ToLower(query), "memory_") {
 		// Check if we actually have any rows by trying to get the first row
 		firstRow, err := rowIter.Next(ctx)
 		if err == io.EOF {

--- a/enginetest/server_engine.go
+++ b/enginetest/server_engine.go
@@ -250,7 +250,7 @@ func (s *ServerQueryEngine) queryOrExec(ctx *sql.Context, stmt *gosql.Stmt, pars
 			shouldQuery = true
 		}
 	case *sqlparser.Select, *sqlparser.SetOp, *sqlparser.Show,
-		*sqlparser.Set, *sqlparser.Call, *sqlparser.Begin,
+		*sqlparser.Call, *sqlparser.Begin,
 		*sqlparser.Use, *sqlparser.Load, *sqlparser.Execute,
 		*sqlparser.Analyze, *sqlparser.Flush, *sqlparser.Explain:
 		shouldQuery = true

--- a/sql/plan/set.go
+++ b/sql/plan/set.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // Set represents a set statement. This can be variables, but in some instances can also refer to row values.
@@ -79,7 +80,7 @@ func (s *Set) Expressions() []sql.Expression {
 
 // setSch is used to differentiate from the nil schema,
 // because Set does return rows
-var setSch = make(sql.Schema, 0)
+var setSch = types.OkResultSchema
 
 // Schema implements the sql.Node interface.
 func (s *Set) Schema() sql.Schema {

--- a/sql/plan/set.go
+++ b/sql/plan/set.go
@@ -78,13 +78,9 @@ func (s *Set) Expressions() []sql.Expression {
 	return s.Exprs
 }
 
-// setSch is used to differentiate from the nil schema,
-// because Set does return rows
-var setSch = types.OkResultSchema
-
 // Schema implements the sql.Node interface.
 func (s *Set) Schema() sql.Schema {
-	return setSch
+	return types.OkResultSchema
 }
 
 func (s *Set) String() string {

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -386,9 +386,11 @@ func (b *BaseBuilder) buildSet(ctx *sql.Context, n *plan.Set, row sql.Row) (sql.
 		}
 		copy(resultRow, row)
 		resultRow = row.Append(newRow)
+		return sql.RowsToRowIter(resultRow), nil
 	}
 
-	return sql.RowsToRowIter(resultRow), nil
+	// For system and user variable SET statements, return OkResult like MySQL does
+	return sql.RowsToRowIter(sql.NewRow(types.NewOkResult(0))), nil
 }
 
 func (b *BaseBuilder) buildGroupBy(ctx *sql.Context, n *plan.GroupBy, row sql.Row) (sql.RowIter, error) {


### PR DESCRIPTION
SET statements (system variables, user variables, and transaction settings) now return MySQL-compatible OkResult instead of empty rows, enabling proper "Query OK, 0 rows affected" confirmation messages in SQL clients.

