### PR TITLE
fix exists subqueries in stored procedures

### DIFF
--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -2309,6 +2309,49 @@ end;
 			},
 		},
 	},
+	{
+		Name: "stored procedure with exists subquery",
+		SetUpScript: []string{
+			`
+create procedure exists_proc1(in x int)
+begin
+	select 1 where exists (select x);
+end;
+`,
+			`
+create procedure exists_proc2(in x int)
+begin
+	select exists (select x);
+end;
+`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "call exists_proc1(1);",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "call exists_proc1(0);",
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: "call exists_proc2(1);",
+				Expected: []sql.Row{
+					{true},
+				},
+			},
+			{
+				Query: "call exists_proc2(0);",
+				Expected: []sql.Row{
+					{true},
+				},
+			},
+		},
+	},
 }
 
 var ProcedureCallTests = []ScriptTest{

--- a/sql/procedures/interpreter_logic.go
+++ b/sql/procedures/interpreter_logic.go
@@ -140,6 +140,12 @@ func replaceVariablesInExpr(ctx *sql.Context, stack *InterpreterStack, expr ast.
 			return nil, err
 		}
 		e.Expr = newExpr.(ast.Expr)
+	case *ast.ExistsExpr:
+		newSubquery, err := replaceVariablesInExpr(ctx, stack, e.Subquery, asOf)
+		if err != nil {
+			return nil, err
+		}
+		e.Subquery = newSubquery.(*ast.Subquery)
 	case *ast.FuncExpr:
 		for i := range e.Exprs {
 			newExpr, err := replaceVariablesInExpr(ctx, stack, e.Exprs[i], asOf)


### PR DESCRIPTION
Missed a case for `ExistsSubquery` statements when replacing variables in Stored Procedures.

fixes: https://github.com/dolthub/dolt/issues/9409