### PR TITLE
Use IsJoin flag to check if keyless tables are actually allowed

### DIFF
--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -847,6 +847,21 @@ var UpdateIgnoreScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "UPDATE with subquery in keyless tables",
+		// https://github.com/dolthub/dolt/issues/9334
+		SetUpScript: []string{
+			"create table t (i int)",
+			"insert into t values (1)",
+			"update t set i = 10 where i in (select 1)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from t",
+				Expected: []sql.Row{{10}},
+			},
+		},
+	},
 }
 
 var UpdateErrorTests = []QueryErrorTest{

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -122,8 +122,7 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 		if plan.IsEmptyTable(n.Child) {
 			return n, transform.SameTree, nil
 		}
-		if n.IsJoin {
-			uj := n.Child.(*plan.UpdateJoin)
+		if uj, ok := n.Child.(*plan.UpdateJoin); ok {
 			updateTargets := uj.UpdateTargets
 			fkHandlerMap := make(map[string]sql.Node, len(updateTargets))
 			for tableName, updateTarget := range updateTargets {

--- a/sql/analyzer/assign_update_join.go
+++ b/sql/analyzer/assign_update_join.go
@@ -34,8 +34,7 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 			return n, transform.SameTree, nil
 		}
 
-		n.IsJoin = true
-		updateTargets, err := getUpdateTargetsByTable(us, jn)
+		updateTargets, err := getUpdateTargetsByTable(us, jn, n.IsJoin)
 		if err != nil {
 			return nil, transform.SameTree, err
 		}
@@ -53,7 +52,7 @@ func modifyUpdateExprsForJoin(ctx *sql.Context, a *Analyzer, n sql.Node, scope *
 }
 
 // getUpdateTargetsByTable maps a set of table names and aliases to their corresponding update target Node
-func getUpdateTargetsByTable(node sql.Node, ij sql.Node) (map[string]sql.Node, error) {
+func getUpdateTargetsByTable(node sql.Node, ij sql.Node, isJoin bool) (map[string]sql.Node, error) {
 	namesOfTableToBeUpdated := getTablesToBeUpdated(node)
 	resolvedTables := getTablesByName(ij)
 
@@ -73,7 +72,7 @@ func getUpdateTargetsByTable(node sql.Node, ij sql.Node) (map[string]sql.Node, e
 		}
 
 		keyless := sql.IsKeyless(updatable.Schema())
-		if keyless {
+		if keyless && isJoin {
 			return nil, sql.ErrUnsupportedFeature.New("error: keyless tables unsupported for UPDATE JOIN")
 		}
 

--- a/sql/plan/update.go
+++ b/sql/plan/update.go
@@ -31,8 +31,10 @@ var ErrUpdateUnexpectedSetResult = errors.NewKind("attempted to set field but ex
 // Update is a node for updating rows on tables.
 type Update struct {
 	UnaryNode
-	checks       sql.CheckConstraints
-	Ignore       bool
+	checks sql.CheckConstraints
+	Ignore bool
+	// IsJoin is true only for explicit UPDATE JOIN queries. It's possible for Update.IsJoin to be false and
+	// Update.Child to be an UpdateJoin since subqueries are optimized as Joins
 	IsJoin       bool
 	HasSingleRel bool
 	IsProcNested bool


### PR DESCRIPTION
fixes dolthub/dolt#9334

Makes clear that IsJoin flag is only for explicit `UPDATE JOIN` statements. Update nodes with subqueries that have been optimized into an UpdateJoin node would have a false IsJoin.