### PR TITLE
Changing how `NO_MERGE_JOIN` hint is applied to fix a panic

### DIFF
--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -158,6 +158,9 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *plan.Sco
 
 	qFlags.Set(sql.QFlagInnerJoin)
 
+	hints := m.SessionHints()
+	hints = append(hints, memo.ExtractJoinHint(n)...)
+
 	err = addIndexScans(ctx, m)
 	if err != nil {
 		return nil, err
@@ -180,9 +183,11 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *plan.Sco
 		return nil, err
 	}
 
-	err = addMergeJoins(ctx, m)
-	if err != nil {
-		return nil, err
+	if !mergeJoinsDisabled(hints) {
+		err = addMergeJoins(ctx, m)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	memo.CardMemoGroups(ctx, m.Root())
@@ -200,11 +205,9 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *plan.Sco
 		return nil, err
 	}
 
-	m.SetDefaultHints()
-	hints := memo.ExtractJoinHint(n)
+	// Once we've enumerated all expression groups, we can apply hints. This must be done after expression
+	// groups have been identified, so that the applied hints use the correct metadata.
 	for _, h := range hints {
-		// this should probably happen earlier, but the root is not
-		// populated before reordering
 		m.ApplyHint(h)
 	}
 
@@ -221,6 +224,16 @@ func replanJoin(ctx *sql.Context, n *plan.JoinNode, a *Analyzer, scope *plan.Sco
 	}
 
 	return m.BestRootPlan(ctx)
+}
+
+// mergeJoinsDisabled returns true if merge joins have been disabled in the specified |hints|.
+func mergeJoinsDisabled(hints []memo.Hint) bool {
+	for _, hint := range hints {
+		if hint.Typ == memo.HintTypeNoMergeJoin {
+			return true
+		}
+	}
+	return false
 }
 
 // addLookupJoins prefixes memo join group expressions with indexed join

--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -154,7 +154,7 @@ var ErrUnsupportedReorderNode = errors.New("unsupported join reorder node")
 
 // useFastReorder determines whether to skip the current brute force join planning and use an alternate
 // planning algorithm that analyzes the join tree to find a sequence that can be implemented purely as lookup joins.
-// Currently we only use it for large joins (20+ tables) with no join hints.
+// Currently, we only use it for large joins (15+ tables) with no join hints.
 func (j *joinOrderBuilder) useFastReorder() bool {
 	if j.forceFastDFSLookupForTest {
 		return true
@@ -180,7 +180,7 @@ func (j *joinOrderBuilder) ReorderJoin(n sql.Node) {
 	// from ensureClosure in buildSingleLookupPlan, but the equivalence sets could create multiple possible join orders
 	// for the single-lookup plan, which would complicate things.
 	j.ensureClosure(j.m.root)
-	j.dbSube()
+	j.dpEnumerateSubsets()
 	return
 }
 
@@ -627,10 +627,10 @@ func (j *joinOrderBuilder) checkSize() {
 	}
 }
 
-// dpSube iterates all disjoint combinations of table sets,
+// dpEnumerateSubsets iterates all disjoint combinations of table sets,
 // adding plans to the tree when we find two sets that can
 // be joined
-func (j *joinOrderBuilder) dbSube() {
+func (j *joinOrderBuilder) dpEnumerateSubsets() {
 	all := j.allVertices()
 	for subset := vertexSet(1); subset <= all; subset++ {
 		if subset.isSingleton() {

--- a/sql/memo/select_hints.go
+++ b/sql/memo/select_hints.go
@@ -372,25 +372,18 @@ func (o joinOpHint) typeMatches(n RelExpr) bool {
 	return true
 }
 
-type joinBlockHint struct {
-	cb func(n RelExpr) bool
-}
-
-func (o joinBlockHint) isOk(n RelExpr) bool {
-	return o.cb(n)
-}
-
 // joinHints wraps a collection of join hints. The memo
 // interfaces with this object during costing.
 type joinHints struct {
-	ops      []joinOpHint
-	order    *joinOrderHint
-	block    []joinBlockHint
-	leftDeep bool
+	ops              []joinOpHint
+	order            *joinOrderHint
+	leftDeep         bool
+	disableMergeJoin bool
 }
 
+// isEmpty returns true if no hints that affect join planning have been set.
 func (h joinHints) isEmpty() bool {
-	return len(h.ops) == 0 && h.order == nil && !h.leftDeep && len(h.block) == 0
+	return len(h.ops) == 0 && h.order == nil && !h.leftDeep && !h.disableMergeJoin
 }
 
 // satisfiedBy returns whether a RelExpr satisfies every join hint. This


### PR DESCRIPTION
The join planning hint system previously generated all join combinations, then relied on a set of "blocked" join ops to skip over plans with `MergeJoin` ops. This resulted in some plans panic'ing when this option was set, because the code generally assumes that each expression group will have a non-nil `Best` member set once the first expression in the group has been evaluated. However, for `MergeJoin`, this assignment would be skipped and `Best` would be nil, which causes a panic in some plans when the `NO_MERGE_JOIN` hint (or the @@disable_merge_join system variable) was enabled. 

This new logic skips ever adding the `MergeJoin` ops to the memo, which reduces time spent planning/costing the join, and also avoids breaking the assumption that `Best` will always be populated after the first expression in an expression group is costed. 

Also cleans up a few other small issues in the code, such as renaming `dbSube()` to `dpEnumerateSubsets()`.