### PR TITLE
Fix enum columns cannot have auto_increment

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9000,7 +9000,7 @@ where
 		},
 	},
 	{
-		Skip:        true,
+		Skip:        false,
 		Name:        "enums with auto increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9000,8 +9000,8 @@ where
 		},
 	},
 	{
-		Name:        "enums with auto increment",
-		Dialect:     "mysql",
+		Name:    "enums with auto increment",
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE t (e enum('a', 'b', 'c') PRIMARY KEY)",
 		},
@@ -9025,7 +9025,7 @@ where
 			{
 				Query:          "ALTER TABLE t CHANGE COLUMN e e enum('a', 'b', 'c') AUTO_INCREMENT",
 				ExpectedErrStr: "Incorrect column specifier for column 'e'",
-			}
+			},
 		},
 	},
 	{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9000,7 +9000,6 @@ where
 		},
 	},
 	{
-		Skip:        false,
 		Name:        "enums with auto increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9002,12 +9002,30 @@ where
 	{
 		Name:        "enums with auto increment",
 		Dialect:     "mysql",
-		SetUpScript: []string{},
+		SetUpScript: []string{
+			"CREATE TABLE t (e enum('a', 'b', 'c') PRIMARY KEY)",
+		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:          "create table t (e enum('a', 'b', 'c') primary key auto_increment);",
+				Query:          "CREATE TABLE t2 (e enum('a', 'b', 'c') PRIMARY KEY AUTO_INCREMENT)",
 				ExpectedErrStr: "Incorrect column specifier for column 'e'",
 			},
+			{
+				Query:          "ALTER TABLE t MODIFY e enum('a', 'b', 'c') AUTO_INCREMENT",
+				ExpectedErrStr: "Incorrect column specifier for column 'e'",
+			},
+			{
+				Query:          "ALTER TABLE t MODIFY COLUMN e enum('a', 'b', 'c') AUTO_INCREMENT",
+				ExpectedErrStr: "Incorrect column specifier for column 'e'",
+			},
+			{
+				Query:          "ALTER TABLE t CHANGE e e enum('a', 'b', 'c') AUTO_INCREMENT",
+				ExpectedErrStr: "Incorrect column specifier for column 'e'",
+			},
+			{
+				Query:          "ALTER TABLE t CHANGE COLUMN e e enum('a', 'b', 'c') AUTO_INCREMENT",
+				ExpectedErrStr: "Incorrect column specifier for column 'e'",
+			}
 		},
 	},
 	{

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -791,6 +791,10 @@ func validateAutoIncrementModify(schema sql.Schema, keyedColumns map[string]bool
 	seen := false
 	for _, col := range schema {
 		if col.AutoIncrement {
+			// Check if column type is valid for auto_increment
+			if types.IsEnum(col.Type) {
+				return sql.ErrInvalidColumnSpecifier.New(col.Name)
+			}
 			// keyedColumns == nil means they are trying to add auto_increment column
 			if !col.PrimaryKey && !keyedColumns[col.Name] {
 				// AUTO_INCREMENT col must be a key
@@ -815,6 +819,10 @@ func validateAutoIncrementAdd(schema sql.Schema, keyColumns map[string]bool) err
 	for _, col := range schema {
 		if col.AutoIncrement {
 			{
+				// Check if column type is valid for auto_increment
+				if types.IsEnum(col.Type) {
+					return sql.ErrInvalidColumnSpecifier.New(col.Name)
+				}
 				if !col.PrimaryKey && !keyColumns[col.Name] {
 					// AUTO_INCREMENT col must be a key
 					return sql.ErrInvalidAutoIncCols.New()

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -669,6 +669,9 @@ var (
 	// ErrInvalidAutoIncCols is returned when an auto_increment column cannot be applied
 	ErrInvalidAutoIncCols = errors.NewKind("there can be only one auto_increment column and it must be defined as a key")
 
+	// ErrInvalidColumnSpecifier is returned when an invalid column specifier is used
+	ErrInvalidColumnSpecifier = errors.NewKind("Incorrect column specifier for column '%s'")
+
 	// ErrUnknownConstraintDefinition is returned when an unknown constraint type is used
 	ErrUnknownConstraintDefinition = errors.NewKind("unknown constraint definition: %s, %T")
 


### PR DESCRIPTION
Fixes dolthub/dolt#9423
- Added ErrInvalidColumnSpecifier error message
- Added enum type validation in validateAutoIncrementModify and validateAutoIncrementAdd
- Enabled previously skipped test case for enum auto_increment validation

🤖 Generated with [Claude Code](https://claude.ai/code)