### PR TITLE
 dolthub/dolt#9427 - Prevent user and system variables in column defaults and generated values

### DIFF
--- a/enginetest/queries/column_default_queries.go
+++ b/enginetest/queries/column_default_queries.go
@@ -940,4 +940,120 @@ var ColumnDefaultTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "User variables in column defaults are not allowed",
+		SetUpScript: []string{
+			"set @a = 1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CREATE TABLE t(i int DEFAULT (@a));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+			{
+				Query:       "CREATE TABLE t(i int DEFAULT ((@a)));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+			{
+				Query:       "CREATE TABLE t(i int DEFAULT (@a + 1));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "System variables in column defaults are not allowed",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CREATE TABLE t(i int DEFAULT (@@version));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+			{
+				Query:       "CREATE TABLE t(i int DEFAULT (@@session.sql_mode));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+			{
+				Query:       "CREATE TABLE t(i int DEFAULT (@@global.max_connections));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "User variables in generated columns are not allowed",
+		SetUpScript: []string{
+			"set @a = 1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CREATE TABLE t(i int GENERATED ALWAYS AS (@a));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+			{
+				Query:       "CREATE TABLE t(i int GENERATED ALWAYS AS (@a + 1));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "System variables in generated columns are not allowed",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "CREATE TABLE t(i int GENERATED ALWAYS AS (@@version));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+			{
+				Query:       "CREATE TABLE t(i int GENERATED ALWAYS AS (@@session.sql_mode));",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "User variables in ALTER TABLE ADD COLUMN defaults are not allowed",
+		SetUpScript: []string{
+			"CREATE TABLE t(pk int PRIMARY KEY);",
+			"set @a = 1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "ALTER TABLE t ADD COLUMN i int DEFAULT (@a);",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "System variables in ALTER TABLE ADD COLUMN defaults are not allowed",
+		SetUpScript: []string{
+			"CREATE TABLE t(pk int PRIMARY KEY);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "ALTER TABLE t ADD COLUMN i int DEFAULT (@@version);",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "User variables in ALTER TABLE ALTER COLUMN defaults are not allowed",
+		SetUpScript: []string{
+			"CREATE TABLE t(pk int PRIMARY KEY, i int);",
+			"set @a = 1;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "ALTER TABLE t ALTER COLUMN i SET DEFAULT (@a);",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "System variables in ALTER TABLE ALTER COLUMN defaults are not allowed",
+		SetUpScript: []string{
+			"CREATE TABLE t(pk int PRIMARY KEY, i int);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "ALTER TABLE t ALTER COLUMN i SET DEFAULT (@@version);",
+				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
 }

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -233,6 +233,9 @@ func validateColumnDefault(ctx *sql.Context, col *sql.Column, colDefault *sql.Co
 	var err error
 	sql.Inspect(colDefault.Expr, func(e sql.Expression) bool {
 		switch e.(type) {
+		case *expression.UserVar, *expression.SystemVar:
+			err = sql.ErrColumnDefaultUserVariable.New(col.Name)
+			return false
 		case sql.FunctionExpression, *expression.UnresolvedFunction:
 			var funcName string
 			switch expr := e.(type) {

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -147,6 +147,9 @@ var (
 	// ErrInvalidColumnDefaultValue is returned when column default function value is not wrapped in parentheses for column types excluding datetime and timestamp
 	ErrInvalidColumnDefaultValue = errors.NewKind("Invalid default value for '%s'")
 
+	// ErrColumnDefaultUserVariable is returned when a column default expression contains user or system variables
+	ErrColumnDefaultUserVariable = errors.NewKind("Default value expression of column '%s' cannot refer user or system variables.")
+
 	// ErrInvalidDefaultValueOrder is returned when a default value references a column that comes after it and contains a default expression.
 	ErrInvalidDefaultValueOrder = errors.NewKind(`default value of column "%s" cannot refer to a column defined after it if those columns have an expression default value`)
 


### PR DESCRIPTION
 Fixes dolthub/dolt#9427

Adds validation to prevent user variables (@variable) and system variables (@@variable) from being used in column default value expressions and generated column expressions.
Modified validateColumnDefault function in sql/analyzer/resolve_column_defaults.go to detect UserVar and SystemVar expressions and return ErrColumnDefaultUserVariable error.
Added ErrColumnDefaultUserVariable error definition to sql/errors.go to match MySQL's error message format.
🤖 Generated with [Claude Code](https://claude.ai/code)