### PR TITLE
dolthub/dolt#9426 - Support enum string context in functions

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9137,6 +9137,33 @@ where
 		},
 	},
 	{
+		Name:    "enum conversion with system variables",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table t (e enum('ON', 'OFF', 'AUTO'));",
+			"set autocommit = 'ON';",
+			"insert into t values(@@autocommit), ('OFF'), ('AUTO');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select e, @@autocommit, e = @@autocommit from t order by e;",
+				Expected: []sql.Row{
+					{"ON", 1, true},
+					{"OFF", 1, false},
+					{"AUTO", 1, false},
+				},
+			},
+			{
+				Query: "select e, concat(e, @@version_comment) from t order by e;",
+				Expected: []sql.Row{
+					{"ON", "ONDolt"},
+					{"OFF", "OFFDolt"},
+					{"AUTO", "AUTODolt"},
+				},
+			},
+		},
+	},
+	{
 		Skip:    true,
 		Name:    "enums with foreign keys",
 		Dialect: "mysql",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9094,7 +9094,6 @@ where
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				// We incorrectly use the numeric values of the enum, resulting in length of 1
 				Query: "select e, length(e) from t order by e;",
 				Expected: []sql.Row{
 					{"abc", 3},
@@ -9103,12 +9102,37 @@ where
 				},
 			},
 			{
-				// We incorrectly use the numeric values of the enum, resulting in length of 1
 				Query: "select e, concat(e, 'test') from t order by e;",
 				Expected: []sql.Row{
 					{"abc", "abctest"},
 					{"defg", "defgtest"},
 					{"hjikl", "hjikltest"},
+				},
+			},
+			{
+				Query: "select e, e like 'a%', e like '%g' from t order by e;",
+				Expected: []sql.Row{
+					{"abc", true, false},
+					{"defg", false, true},
+					{"hjikl", false, false},
+				},
+			},
+			{
+				Query: "select group_concat(e order by e) as grouped from t;",
+				Expected: []sql.Row{
+					{"abc,defg,hjikl"},
+				},
+			},
+			{
+				Query: "select e from t where e = 'abc';",
+				Expected: []sql.Row{
+					{"abc"},
+				},
+			},
+			{
+				Query: "select count(*) from t where e = 'defg';",
+				Expected: []sql.Row{
+					{1},
 				},
 			},
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9085,7 +9085,6 @@ where
 		},
 	},
 	{
-		Skip:    false,
 		Name:    "enum conversion to strings",
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9085,7 +9085,7 @@ where
 		},
 	},
 	{
-		Skip:    true,
+		Skip:    false,
 		Name:    "enum conversion to strings",
 		Dialect: "mysql",
 		SetUpScript: []string{
@@ -9099,7 +9099,7 @@ where
 				Expected: []sql.Row{
 					{"abc", 3},
 					{"defg", 4},
-					{"hijkl", 5},
+					{"hjikl", 5},
 				},
 			},
 			{
@@ -9108,7 +9108,7 @@ where
 				Expected: []sql.Row{
 					{"abc", "abctest"},
 					{"defg", "defgtest"},
-					{"hijkl", "hijkltest"},
+					{"hjikl", "hjikltest"},
 				},
 			},
 		},

--- a/sql/expression/function/concat.go
+++ b/sql/expression/function/concat.go
@@ -123,17 +123,13 @@ func (c *Concat) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return nil, nil
 		}
 
-		val, _, err = types.LongText.Convert(ctx, val)
+		// Use type-aware conversion for enum types
+		content, _, err := types.ConvertToCollatedString(ctx, val, arg.Type())
 		if err != nil {
 			return nil, err
 		}
 
-		val, _, err = sql.Unwrap[string](ctx, val)
-		if err != nil {
-			return nil, err
-		}
-
-		parts = append(parts, val.(string))
+		parts = append(parts, content)
 	}
 
 	return strings.Join(parts, ""), nil

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -86,10 +86,12 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, err
 	}
 	if _, ok := left.(string); !ok {
-		left, _, err = types.LongText.Convert(ctx, left)
+		// Use type-aware conversion for enum types
+		leftStr, _, err := types.ConvertToCollatedString(ctx, left, l.Left().Type())
 		if err != nil {
 			return nil, err
 		}
+		left = leftStr
 	}
 
 	var lm LikeMatcher
@@ -138,10 +140,12 @@ func (l *Like) evalRight(ctx *sql.Context, row sql.Row) (right *string, escape r
 		return nil, 0, err
 	}
 	if _, ok := rightVal.(string); !ok {
-		rightVal, _, err = types.LongText.Convert(ctx, rightVal)
+		// Use type-aware conversion for enum types
+		rightStr, _, err := types.ConvertToCollatedString(ctx, rightVal, l.Right().Type())
 		if err != nil {
 			return nil, 0, err
 		}
+		rightVal = rightStr
 	}
 
 	var escapeVal interface{}

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -530,21 +530,33 @@ func ConvertToCollatedString(ctx context.Context, val interface{}, typ sql.Type)
 					if err != nil {
 						return "", sql.Collation_Unspecified, err
 					}
-					content = val.(string)
+					if val == nil {
+						content = ""
+					} else {
+						content = val.(string)
+					}
 				}
 			} else {
 				val, _, err = LongText.Convert(ctx, val)
 				if err != nil {
 					return "", sql.Collation_Unspecified, err
 				}
-				content = val.(string)
+				if val == nil {
+					content = ""
+				} else {
+					content = val.(string)
+				}
 			}
 		} else {
 			val, _, err = LongText.Convert(ctx, val)
 			if err != nil {
 				return "", sql.Collation_Unspecified, err
 			}
-			content = val.(string)
+			if val == nil {
+				content = ""
+			} else {
+				content = val.(string)
+			}
 		}
 	} else {
 		collation = sql.Collation_Default
@@ -563,7 +575,11 @@ func ConvertToCollatedString(ctx context.Context, val interface{}, typ sql.Type)
 		if err != nil {
 			return "", sql.Collation_Unspecified, err
 		}
-		content = val.(string)
+		if val == nil {
+			content = ""
+		} else {
+			content = val.(string)
+		}
 	}
 	return content, collation, nil
 }

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -554,14 +554,12 @@ func ConvertToCollatedString(ctx context.Context, val interface{}, typ sql.Type)
 	} else {
 		collation = sql.Collation_Default
 		// Handle enum types in string context even without collation
-		if IsEnum(typ) {
-			if enumType, ok := typ.(sql.EnumType); ok {
-				content, err = convertEnumToString(ctx, val, enumType)
-				if err != nil {
-					return "", sql.Collation_Unspecified, err
-				}
-				return content, collation, nil
+		if enumType, ok := typ.(sql.EnumType); ok {
+			content, err = convertEnumToString(ctx, val, enumType)
+			if err != nil {
+				return "", sql.Collation_Unspecified, err
 			}
+			return content, collation, nil
 		}
 		content, err = convertToLongTextString(ctx, val)
 		if err != nil {


### PR DESCRIPTION
Fixes dolthub/dolt#9426
- Modified ConvertToCollatedString in sql/types/strings.go to handle enum types
- Updated CONCAT function to use type-aware string conversion
- Enabled and fixed "enum conversion to strings" test

🤖 Generated with [Claude Code](https://claude.ai/code)