### PR TITLE
dolthub/dolt#8893 - Fix graceful handling of invalid UTF-8 in existing data

### DIFF
--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -654,9 +654,9 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 		if !IsBinaryType(t) && !utf8.Valid(valueBytes) {
 			charset := t.CharacterSet()
 			if charset == sql.CharacterSet_utf8mb4 {
-				// For UTF8MB4, replace invalid UTF-8 sequences with replacement characters
-				// This provides more MySQL-compatible behavior for existing invalid data
-				valueBytes = []byte(strings2.ToValidUTF8(string(valueBytes), "�"))
+				// For UTF8MB4, return NULL for invalid UTF-8 sequences
+				// This matches MySQL's behavior exactly
+				return sqltypes.NULL, nil
 			} else {
 				var ok bool
 				if valueBytes, ok = t.CharacterSet().Encoder().Decode(valueBytes); !ok {

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -654,7 +654,9 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 		if !IsBinaryType(t) && !utf8.Valid(valueBytes) {
 			charset := t.CharacterSet()
 			if charset == sql.CharacterSet_utf8mb4 {
-				return sqltypes.Value{}, ErrBadCharsetString.New(charset.String(), valueBytes)
+				// For UTF8MB4, replace invalid UTF-8 sequences with replacement characters
+				// This provides more MySQL-compatible behavior for existing invalid data
+				valueBytes = []byte(strings2.ToValidUTF8(string(valueBytes), "�"))
 			} else {
 				var ok bool
 				if valueBytes, ok = t.CharacterSet().Encoder().Decode(valueBytes); !ok {


### PR DESCRIPTION
Fixes dolthub/dolt#8893
Replace invalid UTF-8 sequences with NULL values instead of throwing "invalid string for charset utf8mb4" errors. This provides MySQL-compatible behavior for reading existing invalid data while maintaining data integrity for new insertions.
