### PR TITLE
dolthub/dolt#9424 - Fix enum foreign key constraints to match MySQL behavior

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9164,7 +9164,7 @@ where
 		},
 	},
 	{
-		Skip:    true,
+		Skip:    false,
 		Name:    "enums with foreign keys",
 		Dialect: "mysql",
 		SetUpScript: []string{
@@ -9207,7 +9207,7 @@ where
 			},
 			{
 				Query:       "insert into child1 values (3);",
-				ExpectedErr: sql.ErrForeignKeyParentViolation,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query: "insert into child1 values ('x'), ('y');",
@@ -9217,7 +9217,7 @@ where
 			},
 			{
 				Query:       "insert into child1 values ('z');",
-				ExpectedErr: sql.ErrForeignKeyParentViolation,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query:          "insert into child1 values ('a');",
@@ -9247,7 +9247,7 @@ where
 			},
 			{
 				Query:       "insert into child2 values (3);",
-				ExpectedErr: sql.ErrForeignKeyParentViolation,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query: "insert into child2 values ('c');",
@@ -9257,7 +9257,7 @@ where
 			},
 			{
 				Query:       "insert into child2 values ('a');",
-				ExpectedErr: sql.ErrForeignKeyParentViolation,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query: "select * from child2 order by e;",
@@ -9282,7 +9282,7 @@ where
 			},
 			{
 				Query:       "insert into child3 values (3);",
-				ExpectedErr: sql.ErrForeignKeyParentViolation,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query: "insert into child3 values ('x'), ('y');",
@@ -9292,11 +9292,11 @@ where
 			},
 			{
 				Query:       "insert into child3 values ('z');",
-				ExpectedErr: sql.ErrForeignKeyParentViolation,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query:       "insert into child3 values ('a');",
-				ExpectedErr: sql.ErrForeignKeyParentViolation,
+				ExpectedErr: sql.ErrForeignKeyChildViolation,
 			},
 			{
 				Query: "select * from child3 order by e;",

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -655,6 +655,10 @@ func foreignKeyComparableTypes(ctx *sql.Context, type1 sql.Type, type2 sql.Type)
 				if type1String.Collation().CharacterSet() != type2String.Collation().CharacterSet() {
 					return false
 				}
+			case sqltypes.Enum:
+				// Enum types can reference each other in foreign keys regardless of their string values.
+				// MySQL allows enum foreign keys to match based on underlying numeric values.
+				return true
 			default:
 				return false
 			}


### PR DESCRIPTION
- Allow enum types to reference each other in foreign keys regardless of string values
- MySQL allows enum foreign keys to match based on underlying numeric values
- Modified foreignKeyComparableTypes to handle enum types specially
- Updated test expectations to use correct error types (ErrForeignKeyChildViolation)

🤖 Generated with [Claude Code](https://claude.ai/code)