### PR TITLE
dolthub/dolt#9481 - Move auto_increment validation to GMS

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1288,32 +1288,22 @@ var InsertScripts = []ScriptTest{
 	{
 		Name:    "auto increment on float",
 		Dialect: "mysql",
-		SetUpScript: []string{
-			"create table auto (pk float primary key auto_increment)",
-			"insert into auto values (NULL),(10),(0)",
-		},
+		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto order by 1",
-				Expected: []sql.Row{
-					{float64(1)}, {float64(10)}, {float64(11)},
-				},
+				Query:          "create table auto (pk float primary key auto_increment)",
+				ExpectedErrStr: "Incorrect column specifier for column 'pk'",
 			},
 		},
 	},
 	{
 		Name:    "auto increment on double",
 		Dialect: "mysql",
-		SetUpScript: []string{
-			"create table auto (pk double primary key auto_increment)",
-			"insert into auto values (NULL),(10),(0)",
-		},
+		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "select * from auto order by 1",
-				Expected: []sql.Row{
-					{float64(1)}, {float64(10)}, {float64(11)},
-				},
+				Query:          "create table auto (pk double primary key auto_increment)",
+				ExpectedErrStr: "Incorrect column specifier for column 'pk'",
 			},
 		},
 	},

--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1286,28 +1286,6 @@ var InsertScripts = []ScriptTest{
 		},
 	},
 	{
-		Name:    "auto increment on float",
-		Dialect: "mysql",
-		SetUpScript: []string{},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:          "create table auto (pk float primary key auto_increment)",
-				ExpectedErrStr: "Incorrect column specifier for column 'pk'",
-			},
-		},
-	},
-	{
-		Name:    "auto increment on double",
-		Dialect: "mysql",
-		SetUpScript: []string{},
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:          "create table auto (pk double primary key auto_increment)",
-				ExpectedErrStr: "Incorrect column specifier for column 'pk'",
-			},
-		},
-	},
-	{
 		Name:    "sql_mode=NO_auto_value_ON_ZERO",
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9606,7 +9606,6 @@ where
 		},
 	},
 	{
-		Skip:    true,
 		Name:    "set with auto increment",
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -8219,15 +8219,15 @@ where
 			},
 			{
 				Query:          "create table bad (tb tinyblob primary key auto_increment);",
-				ExpectedErrStr: "Incorrect column specifier for column 'b'",
+				ExpectedErrStr: "Incorrect column specifier for column 'tb'",
 			},
 			{
 				Query:          "create table bad (mb mediumblob primary key auto_increment);",
-				ExpectedErrStr: "Incorrect column specifier for column 'b'",
+				ExpectedErrStr: "Incorrect column specifier for column 'mb'",
 			},
 			{
 				Query:          "create table bad (lb longblob primary key auto_increment);",
-				ExpectedErrStr: "Incorrect column specifier for column 'b'",
+				ExpectedErrStr: "Incorrect column specifier for column 'lb'",
 			},
 		},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10060,28 +10060,34 @@ where
 
 	// Float Tests
 	{
-		Skip:        true,
 		Name:        "float with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:          "create table bad (f float primary key auto_increment);",
-				ExpectedErrStr: "Incorrect column specifier for column 'f'",
+				Query:    "create table float_tbl (f float primary key auto_increment);",
+				Expected: []sql.Row{{types.OkResult{}}},
+			},
+			{
+				Query:    "show create table float_tbl;",
+				Expected: []sql.Row{{"float_tbl", "CREATE TABLE `float_tbl` (\n  `f` float NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`f`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},
 
 	// Double Tests
 	{
-		Skip:        true,
 		Name:        "double with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:          "create table bad (d double primary key auto_increment);",
-				ExpectedErrStr: "Incorrect column specifier for column 'vc'",
+				Query:    "create table double_tbl (d double primary key auto_increment);",
+				Expected: []sql.Row{{types.OkResult{}}},
+			},
+			{
+				Query:    "show create table double_tbl;",
+				Expected: []sql.Row{{"double_tbl", "CREATE TABLE `double_tbl` (\n  `d` double NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`d`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10065,12 +10065,8 @@ where
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "create table float_tbl (f float primary key auto_increment);",
-				Expected: []sql.Row{{types.OkResult{}}},
-			},
-			{
-				Query:    "show create table float_tbl;",
-				Expected: []sql.Row{{"float_tbl", "CREATE TABLE `float_tbl` (\n  `f` float NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`f`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Query:          "create table float_tbl (f float primary key auto_increment);",
+				ExpectedErrStr: "Incorrect column specifier for column 'f'",
 			},
 		},
 	},
@@ -10082,12 +10078,8 @@ where
 		SetUpScript: []string{},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query:    "create table double_tbl (d double primary key auto_increment);",
-				Expected: []sql.Row{{types.OkResult{}}},
-			},
-			{
-				Query:    "show create table double_tbl;",
-				Expected: []sql.Row{{"double_tbl", "CREATE TABLE `double_tbl` (\n  `d` double NOT NULL AUTO_INCREMENT,\n  PRIMARY KEY (`d`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
+				Query:          "create table double_tbl (d double primary key auto_increment);",
+				ExpectedErrStr: "Incorrect column specifier for column 'd'",
 			},
 		},
 	},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -8157,7 +8157,6 @@ where
 
 	// Char tests
 	{
-		Skip:        true,
 		Name:        "char with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -8171,7 +8170,6 @@ where
 
 	// Varchar tests
 	{
-		Skip:        true,
 		Name:        "varchar with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -8185,7 +8183,6 @@ where
 
 	// Binary tests
 	{
-		Skip:        true,
 		Name:        "binary with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -8199,7 +8196,6 @@ where
 
 	// Varbinary tests
 	{
-		Skip:        true,
 		Name:        "varbinary with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -8213,7 +8209,6 @@ where
 
 	// Blob tests
 	{
-		Skip:        true,
 		Name:        "blob with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -8239,7 +8234,6 @@ where
 
 	// Text Tests
 	{
-		Skip:        true,
 		Name:        "text with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -9969,7 +9963,6 @@ where
 
 	// Bit Tests
 	{
-		Skip:        true,
 		Name:        "bit with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -10095,7 +10088,6 @@ where
 
 	// Decimal Tests
 	{
-		Skip:        true,
 		Name:        "decimal with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -10113,7 +10105,6 @@ where
 
 	// Date Tests
 	{
-		Skip:        true,
 		Name:        "date with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -10127,7 +10118,6 @@ where
 
 	// Datetime Tests
 	{
-		Skip:        true,
 		Name:        "datetime with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -10145,7 +10135,6 @@ where
 
 	// Timestamp Tests
 	{
-		Skip:        true,
 		Name:        "timestamp with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -10163,7 +10152,6 @@ where
 
 	// Time Tests
 	{
-		Skip:        true,
 		Name:        "time with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},
@@ -10181,7 +10169,6 @@ where
 
 	// Year Tests
 	{
-		Skip:        true,
 		Name:        "year with auto_increment",
 		Dialect:     "mysql",
 		SetUpScript: []string{},

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -794,17 +794,17 @@ func validateAutoIncrementType(t sql.Type) bool {
 	if types.IsEnum(t) || types.IsSet(t) || types.IsBit(t) {
 		return false
 	}
-	
+
 	// Check for text/string types - not allowed (includes TEXT, VARCHAR, CHAR, BLOB, BINARY, etc.)
 	if types.IsText(t) {
 		return false
 	}
-	
+
 	// Check for datetime/time types - not allowed
 	if types.IsTime(t) || types.IsDateType(t) || types.IsDatetimeType(t) || types.IsTimestampType(t) || types.IsYear(t) {
 		return false
 	}
-	
+
 	// Check for numeric types - only these are potentially allowed
 	if types.IsNumber(t) {
 		// DECIMAL is not allowed for auto_increment per MySQL behavior
@@ -813,7 +813,7 @@ func validateAutoIncrementType(t sql.Type) bool {
 		}
 		return true
 	}
-	
+
 	// Default to false for any other types (JSON, Geometry, etc.)
 	return false
 }

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -17,8 +17,6 @@ package analyzer
 import (
 	"strings"
 
-	"github.com/dolthub/vitess/go/vt/proto/query"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -792,44 +790,32 @@ func removeInSchema(sch sql.Schema, colName, tableName string) sql.Schema {
 
 // validateAutoIncrementType returns true if the given type can be used with AUTO_INCREMENT
 func validateAutoIncrementType(t sql.Type) bool {
-	if t == nil {
+	// Check for invalid types first
+	if types.IsEnum(t) || types.IsSet(t) || types.IsBit(t) {
 		return false
 	}
-
-	switch t.Type() {
-	// Integer types - allowed
-	case query.Type_INT8, query.Type_UINT8, query.Type_INT16, query.Type_UINT16,
-		query.Type_INT24, query.Type_UINT24, query.Type_INT32, query.Type_UINT32,
-		query.Type_INT64, query.Type_UINT64:
-		return true
-
-	// Floating point types - allowed
-	case query.Type_FLOAT32, query.Type_FLOAT64:
-		return true
-
-	// Text/string types - not allowed
-	case query.Type_CHAR, query.Type_VARCHAR, query.Type_TEXT,
-		query.Type_BLOB, query.Type_BINARY, query.Type_VARBINARY:
-		return false
-
-	// Decimal - not allowed per MySQL behavior
-	case query.Type_DECIMAL:
-		return false
-
-	// Date/time types - not allowed
-	case query.Type_DATE, query.Type_TIME, query.Type_DATETIME,
-		query.Type_TIMESTAMP, query.Type_YEAR:
-		return false
-
-	// Other types - not allowed
-	case query.Type_ENUM, query.Type_SET, query.Type_BIT,
-		query.Type_JSON, query.Type_GEOMETRY:
-		return false
-
-	// Default to false for any other types
-	default:
+	
+	// Check for text/string types - not allowed (includes TEXT, VARCHAR, CHAR, BLOB, BINARY, etc.)
+	if types.IsText(t) {
 		return false
 	}
+	
+	// Check for datetime/time types - not allowed
+	if types.IsTime(t) || types.IsDateType(t) || types.IsDatetimeType(t) || types.IsTimestampType(t) || types.IsYear(t) {
+		return false
+	}
+	
+	// Check for numeric types - only these are potentially allowed
+	if types.IsNumber(t) {
+		// DECIMAL is not allowed for auto_increment per MySQL behavior
+		if types.IsDecimal(t) {
+			return false
+		}
+		return true
+	}
+	
+	// Default to false for any other types (JSON, Geometry, etc.)
+	return false
 }
 
 func validateAutoIncrementModify(schema sql.Schema, keyedColumns map[string]bool) error {

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -790,31 +790,17 @@ func removeInSchema(sch sql.Schema, colName, tableName string) sql.Schema {
 
 // validateAutoIncrementType returns true if the given type can be used with AUTO_INCREMENT
 func validateAutoIncrementType(t sql.Type) bool {
-	// Check for invalid types first
-	if types.IsEnum(t) || types.IsSet(t) || types.IsBit(t) {
-		return false
-	}
-
-	// Check for text/string types - not allowed (includes TEXT, VARCHAR, CHAR, BLOB, BINARY, etc.)
-	if types.IsText(t) {
-		return false
-	}
-
-	// Check for datetime/time types - not allowed
-	if types.IsTime(t) || types.IsDateType(t) || types.IsDatetimeType(t) || types.IsTimestampType(t) || types.IsYear(t) {
-		return false
-	}
-
-	// Check for numeric types - only these are potentially allowed
+	// Only integer and floating point numeric types are allowed for auto_increment
+	// All other types are not allowed: TEXT, VARCHAR, CHAR, BLOB, BINARY, VARBINARY,
+	// DATE, TIME, DATETIME, TIMESTAMP, YEAR, ENUM, SET, BIT, DECIMAL, JSON, GEOMETRY, etc.
 	if types.IsNumber(t) {
-		// DECIMAL is not allowed for auto_increment per MySQL behavior
-		if types.IsDecimal(t) {
+		// DECIMAL, YEAR, and BIT are not allowed for auto_increment per MySQL behavior
+		if types.IsDecimal(t) || types.IsYear(t) || types.IsBit(t) {
 			return false
 		}
 		return true
 	}
-
-	// Default to false for any other types (JSON, Geometry, etc.)
+	
 	return false
 }
 

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -790,14 +790,10 @@ func removeInSchema(sch sql.Schema, colName, tableName string) sql.Schema {
 
 // validateAutoIncrementType returns true if the given type can be used with AUTO_INCREMENT
 func validateAutoIncrementType(t sql.Type) bool {
-	// Only integer and floating point numeric types are allowed for auto_increment
+	// Only integer types are allowed for auto_increment in MySQL 8.4+
 	// All other types are not allowed: TEXT, VARCHAR, CHAR, BLOB, BINARY, VARBINARY,
-	// DATE, TIME, DATETIME, TIMESTAMP, YEAR, ENUM, SET, BIT, DECIMAL, JSON, GEOMETRY, etc.
-	if types.IsNumber(t) {
-		// DECIMAL, YEAR, and BIT are not allowed for auto_increment per MySQL behavior
-		if types.IsDecimal(t) || types.IsYear(t) || types.IsBit(t) {
-			return false
-		}
+	// FLOAT, DOUBLE, DATE, TIME, DATETIME, TIMESTAMP, YEAR, ENUM, SET, BIT, DECIMAL, JSON, GEOMETRY, etc.
+	if types.IsInteger(t) {
 		return true
 	}
 

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -803,7 +803,7 @@ func validateAutoIncrementType(t sql.Type) bool {
 		query.Type_INT64, query.Type_UINT64:
 		return true
 
-	// Floating point types - allowed  
+	// Floating point types - allowed
 	case query.Type_FLOAT32, query.Type_FLOAT64:
 		return true
 
@@ -817,7 +817,7 @@ func validateAutoIncrementType(t sql.Type) bool {
 		return false
 
 	// Date/time types - not allowed
-	case query.Type_DATE, query.Type_TIME, query.Type_DATETIME, 
+	case query.Type_DATE, query.Type_TIME, query.Type_DATETIME,
 		query.Type_TIMESTAMP, query.Type_YEAR:
 		return false
 

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -800,7 +800,7 @@ func validateAutoIncrementType(t sql.Type) bool {
 		}
 		return true
 	}
-	
+
 	return false
 }
 


### PR DESCRIPTION
Move auto_increment constraint validation entirely from Dolt to go-mysql-server for better separation of concerns and MySQL compatibility.

Fixes dolthub/dolt#9481
Fixes dolthub/dolt#9470
- Add validateAutoIncrementType() function using existing type checking
- Fix validation order to prioritize auto_increment before index validation
- Unskip comprehensive test coverage for all invalid data types
- Fix bugs: YEAR and BIT types were incorrectly allowed