### PR TITLE
add skipped tests for auto_increment and max integer

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10401,6 +10401,7 @@ where
 
 	// Int Tests
 	{
+		// https://github.com/dolthub/dolt/issues/9530
 		Name:    "int with auto_increment",
 		Dialect: "mysql",
 		SetUpScript: []string{
@@ -10543,6 +10544,7 @@ where
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/9530
 		Name:    "unsigned int with auto_increment",
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10404,38 +10404,78 @@ where
 		Name:    "int with auto_increment",
 		Dialect: "mysql",
 		SetUpScript: []string{
-			"create table int_tbl (i int primary key auto_increment);",
 			"create table tinyint_tbl (i tinyint primary key auto_increment);",
 			"create table smallint_tbl (i smallint primary key auto_increment);",
 			"create table mediumint_tbl (i mediumint primary key auto_increment);",
+			"create table int_tbl (i int primary key auto_increment);",
 			"create table bigint_tbl (i bigint primary key auto_increment);",
 		},
 		Assertions: []ScriptTestAssertion{
 			{
-				Query: "show create table int_tbl;",
+				Skip:        true,
+				Query:       "insert into tinyint_tbl values (999)",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into tinyint_tbl values (127)",
 				Expected: []sql.Row{
-					{"int_tbl", "CREATE TABLE `int_tbl` (\n" +
-						"  `i` int NOT NULL AUTO_INCREMENT,\n" +
-						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     127,
+					}},
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table tinyint_tbl;",
 				Expected: []sql.Row{
 					{"tinyint_tbl", "CREATE TABLE `tinyint_tbl` (\n" +
 						"  `i` tinyint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=127 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into smallint_tbl values (99999);",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into smallint_tbl values (32767);",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     32767,
+					}},
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table smallint_tbl;",
 				Expected: []sql.Row{
 					{"smallint_tbl", "CREATE TABLE `smallint_tbl` (\n" +
 						"  `i` smallint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=36727 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into mediumint_tbl values (9999999);",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into mediumint_tbl values (8388607);",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     8388607,
+					}},
 				},
 			},
 			{
@@ -10444,7 +10484,187 @@ where
 					{"mediumint_tbl", "CREATE TABLE `mediumint_tbl` (\n" +
 						"  `i` mediumint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
+						") ENGINE=InnoDB AUTO_INCREMENT=8388607 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into int_tbl values (99999999999)",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into int_tbl values (2147483647)",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     2147483647,
+					}},
+				},
+			},
+			{
+				Query: "show create table int_tbl;",
+				Expected: []sql.Row{
+					{"int_tbl", "CREATE TABLE `int_tbl` (\n" +
+						"  `i` int NOT NULL AUTO_INCREMENT,\n" +
+						"  PRIMARY KEY (`i`)\n" +
+						") ENGINE=InnoDB AUTO_INCREMENT=2147483647 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into bigint_tbl values (99999999999999999999);",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into bigint_tbl values (9223372036854775807);",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     9223372036854775807,
+					}},
+				},
+			},
+			{
+				Query: "show create table bigint_tbl;",
+				Expected: []sql.Row{
+					{"bigint_tbl", "CREATE TABLE `bigint_tbl` (\n" +
+						"  `i` bigint NOT NULL AUTO_INCREMENT,\n" +
+						"  PRIMARY KEY (`i`)\n" +
 						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+		},
+	},
+	{
+		Name:    "unsigned int with auto_increment",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"create table tinyint_tbl (i tinyint unsigned primary key auto_increment);",
+			"create table smallint_tbl (i smallint unsigned primary key auto_increment);",
+			"create table mediumint_tbl (i mediumint unsigned primary key auto_increment);",
+			"create table int_tbl (i int unsigned primary key auto_increment);",
+			"create table bigint_tbl (i bigint unsigned primary key auto_increment);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Skip:        true,
+				Query:       "insert into tinyint_tbl values (999)",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into tinyint_tbl values (127)",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     127,
+					}},
+				},
+			},
+			{
+				Skip:  true,
+				Query: "show create table tinyint_tbl;",
+				Expected: []sql.Row{
+					{"tinyint_tbl", "CREATE TABLE `tinyint_tbl` (\n" +
+						"  `i` tinyint NOT NULL AUTO_INCREMENT,\n" +
+						"  PRIMARY KEY (`i`)\n" +
+						") ENGINE=InnoDB AUTO_INCREMENT=127 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into smallint_tbl values (99999);",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into smallint_tbl values (32767);",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     32767,
+					}},
+				},
+			},
+			{
+				Skip:  true,
+				Query: "show create table smallint_tbl;",
+				Expected: []sql.Row{
+					{"smallint_tbl", "CREATE TABLE `smallint_tbl` (\n" +
+						"  `i` smallint NOT NULL AUTO_INCREMENT,\n" +
+						"  PRIMARY KEY (`i`)\n" +
+						") ENGINE=InnoDB AUTO_INCREMENT=36727 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into mediumint_tbl values (9999999);",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into mediumint_tbl values (8388607);",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     8388607,
+					}},
+				},
+			},
+			{
+				Query: "show create table mediumint_tbl;",
+				Expected: []sql.Row{
+					{"mediumint_tbl", "CREATE TABLE `mediumint_tbl` (\n" +
+						"  `i` mediumint NOT NULL AUTO_INCREMENT,\n" +
+						"  PRIMARY KEY (`i`)\n" +
+						") ENGINE=InnoDB AUTO_INCREMENT=8388607 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into int_tbl values (99999999999)",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into int_tbl values (2147483647)",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     2147483647,
+					}},
+				},
+			},
+			{
+				Query: "show create table int_tbl;",
+				Expected: []sql.Row{
+					{"int_tbl", "CREATE TABLE `int_tbl` (\n" +
+						"  `i` int NOT NULL AUTO_INCREMENT,\n" +
+						"  PRIMARY KEY (`i`)\n" +
+						") ENGINE=InnoDB AUTO_INCREMENT=2147483647 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+				},
+			},
+
+			{
+				Skip:        true,
+				Query:       "insert into bigint_tbl values (99999999999999999999);",
+				ExpectedErr: sql.ErrValueOutOfRange,
+			},
+			{
+				Skip:  true,
+				Query: "insert into bigint_tbl values (9223372036854775807);",
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 1,
+						InsertID:     9223372036854775807,
+					}},
 				},
 			},
 			{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10479,6 +10479,7 @@ where
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table mediumint_tbl;",
 				Expected: []sql.Row{
 					{"mediumint_tbl", "CREATE TABLE `mediumint_tbl` (\n" +
@@ -10504,6 +10505,7 @@ where
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table int_tbl;",
 				Expected: []sql.Row{
 					{"int_tbl", "CREATE TABLE `int_tbl` (\n" +
@@ -10529,6 +10531,7 @@ where
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table bigint_tbl;",
 				Expected: []sql.Row{
 					{"bigint_tbl", "CREATE TABLE `bigint_tbl` (\n" +
@@ -10618,6 +10621,7 @@ where
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table mediumint_tbl;",
 				Expected: []sql.Row{
 					{"mediumint_tbl", "CREATE TABLE `mediumint_tbl` (\n" +
@@ -10643,6 +10647,7 @@ where
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table int_tbl;",
 				Expected: []sql.Row{
 					{"int_tbl", "CREATE TABLE `int_tbl` (\n" +
@@ -10668,6 +10673,7 @@ where
 				},
 			},
 			{
+				Skip:  true,
 				Query: "show create table bigint_tbl;",
 				Expected: []sql.Row{
 					{"bigint_tbl", "CREATE TABLE `bigint_tbl` (\n" +

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10465,7 +10465,7 @@ where
 
 			{
 				Skip:        true,
-				Query:       "insert into mediumint_tbl values (9999999);",
+				Query:       "insert into mediumint_tbl values (99999999);",
 				ExpectedErr: sql.ErrValueOutOfRange,
 			},
 			{
@@ -10534,7 +10534,7 @@ where
 					{"bigint_tbl", "CREATE TABLE `bigint_tbl` (\n" +
 						"  `i` bigint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=9223372036854775807 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
 		},
@@ -10557,11 +10557,11 @@ where
 			},
 			{
 				Skip:  true,
-				Query: "insert into tinyint_tbl values (127)",
+				Query: "insert into tinyint_tbl values (255)",
 				Expected: []sql.Row{
 					{types.OkResult{
 						RowsAffected: 1,
-						InsertID:     127,
+						InsertID:     255,
 					}},
 				},
 			},
@@ -10572,7 +10572,7 @@ where
 					{"tinyint_tbl", "CREATE TABLE `tinyint_tbl` (\n" +
 						"  `i` tinyint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB AUTO_INCREMENT=127 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=255 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
 
@@ -10583,11 +10583,11 @@ where
 			},
 			{
 				Skip:  true,
-				Query: "insert into smallint_tbl values (32767);",
+				Query: "insert into smallint_tbl values (65535);",
 				Expected: []sql.Row{
 					{types.OkResult{
 						RowsAffected: 1,
-						InsertID:     32767,
+						InsertID:     65535,
 					}},
 				},
 			},
@@ -10598,22 +10598,22 @@ where
 					{"smallint_tbl", "CREATE TABLE `smallint_tbl` (\n" +
 						"  `i` smallint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB AUTO_INCREMENT=36727 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=65535 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
 
 			{
 				Skip:        true,
-				Query:       "insert into mediumint_tbl values (9999999);",
+				Query:       "insert into mediumint_tbl values (999999999);",
 				ExpectedErr: sql.ErrValueOutOfRange,
 			},
 			{
 				Skip:  true,
-				Query: "insert into mediumint_tbl values (8388607);",
+				Query: "insert into mediumint_tbl values (16777215);",
 				Expected: []sql.Row{
 					{types.OkResult{
 						RowsAffected: 1,
-						InsertID:     8388607,
+						InsertID:     16777215,
 					}},
 				},
 			},
@@ -10623,7 +10623,7 @@ where
 					{"mediumint_tbl", "CREATE TABLE `mediumint_tbl` (\n" +
 						"  `i` mediumint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB AUTO_INCREMENT=8388607 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=16777215 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
 
@@ -10634,11 +10634,11 @@ where
 			},
 			{
 				Skip:  true,
-				Query: "insert into int_tbl values (2147483647)",
+				Query: "insert into int_tbl values (4294967295)",
 				Expected: []sql.Row{
 					{types.OkResult{
 						RowsAffected: 1,
-						InsertID:     2147483647,
+						InsertID:     4294967295,
 					}},
 				},
 			},
@@ -10648,22 +10648,22 @@ where
 					{"int_tbl", "CREATE TABLE `int_tbl` (\n" +
 						"  `i` int NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB AUTO_INCREMENT=2147483647 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=4294967295 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
 
 			{
 				Skip:        true,
-				Query:       "insert into bigint_tbl values (99999999999999999999);",
+				Query:       "insert into bigint_tbl values (999999999999999999999);",
 				ExpectedErr: sql.ErrValueOutOfRange,
 			},
 			{
 				Skip:  true,
-				Query: "insert into bigint_tbl values (9223372036854775807);",
+				Query: "insert into bigint_tbl values (18446744073709551615);",
 				Expected: []sql.Row{
 					{types.OkResult{
 						RowsAffected: 1,
-						InsertID:     9223372036854775807,
+						InsertID:     18446744073709551615,
 					}},
 				},
 			},
@@ -10673,7 +10673,7 @@ where
 					{"bigint_tbl", "CREATE TABLE `bigint_tbl` (\n" +
 						"  `i` bigint NOT NULL AUTO_INCREMENT,\n" +
 						"  PRIMARY KEY (`i`)\n" +
-						") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
+						") ENGINE=InnoDB AUTO_INCREMENT=18446744073709551615 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"},
 				},
 			},
 		},


### PR DESCRIPTION
`auto_increment` breaks integer limits on dolt.

Instead of throwing an error when attempting to insert a value greater than the max of that type, a column with the auto_increment constraint just inserts the max value instead. Additionally, results in incorrect values in the `AUTO_INCREMENT=` table option when doing a `show create table ...`.