### PR TITLE
dolthub/dolt#9472 - Fix SET column foreign key constraintsfix specific errs

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -10131,8 +10131,8 @@ where
 				},
 			},
 			{
-				Query:       "insert into t2 values ('A,B,c');",
-				ExpectedErr: sql.ErrInvalidSetValue,
+				Query:          "insert into t2 values ('A,B,c');",
+				ExpectedErrStr: "Data truncated for column 's' at row 1",
 			},
 			{
 				Query:    "select * from t2",
@@ -10145,7 +10145,6 @@ where
 		},
 	},
 	{
-		Skip:    true,
 		Name:    "set with foreign keys",
 		Dialect: "mysql",
 		SetUpScript: []string{
@@ -10325,7 +10324,6 @@ where
 		},
 	},
 	{
-		Skip:    true,
 		Name:    "set with foreign keys and cascade",
 		Dialect: "mysql",
 		SetUpScript: []string{

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -663,6 +663,9 @@ func foreignKeyComparableTypes(ctx *sql.Context, type1 sql.Type, type2 sql.Type)
 				// MySQL allows decimal foreign keys with different precision/scale
 				// The foreign key constraint validation will handle the actual value comparison
 				return true
+			case sqltypes.Set:
+				// MySQL allows set foreign keys to match based on underlying numeric values.
+				return true
 			default:
 				return false
 			}

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -153,6 +153,10 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 						cErr = sql.ErrNotMatchingSRIDWithColName.New(col.Name, cErr)
 					} else if types.ErrConvertingToEnum.Is(cErr) {
 						cErr = types.ErrDataTruncatedForColumnAtRow.New(col.Name, i.rowNumber)
+					} else if sql.ErrInvalidSetValue.Is(cErr) {
+						cErr = types.ErrDataTruncatedForColumnAtRow.New(col.Name, i.rowNumber)
+					} else if sql.ErrConvertingToSet.Is(cErr) {
+						cErr = types.ErrDataTruncatedForColumnAtRow.New(col.Name, i.rowNumber)
 					}
 					return nil, sql.NewWrappedInsertError(origRow, cErr)
 				}


### PR DESCRIPTION
Fixes dolthub/dolt#9472
• Enabled previously skipped SET foreign key tests
• Fix SET type compatibility checking in foreign key validation
• Handle SET conversion errors appropriately during foreign key checks
