### PR TITLE
dolthub/dolt#9519 - Fix SQL syntax error for mixed named columns and * in SELECT

### DIFF
--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -2969,6 +2969,24 @@ func TestPlanBuilderErr(t *testing.T) {
 			Query: "select 1 from xy group by 100;",
 			Err:   "column ordinal out of range: 100",
 		},
+		
+		// Test mixed named columns and star expressions
+		{
+			Query: "SELECT x, * FROM xy",
+			Err:   "Invalid syntax: cannot mix named columns with '*' in SELECT clause",
+		},
+		{
+			Query: "SELECT 'constant', * FROM xy",
+			Err:   "Invalid syntax: cannot mix named columns with '*' in SELECT clause",
+		},
+		{
+			Query: "SELECT 1, * FROM xy",
+			Err:   "Invalid syntax: cannot mix named columns with '*' in SELECT clause",
+		},
+		{
+			Query: "SELECT * FROM (SELECT 'parent' as db, * FROM xy) as combined",
+			Err:   "Invalid syntax: cannot mix named columns with '*' in SELECT clause",
+		},
 	}
 
 	db := memory.NewDatabase("mydb")


### PR DESCRIPTION
Fixes dolthub/dolt#9519
- Validates SELECT expressions in the existing processing loop
- Rejects named expressions before unqualified *
- Allows qualified table.* in any position
- Allows expressions after * (e.g., SELECT *, column)