### PR TITLE
Use child column id's for union when assigning exec indexes

### DIFF
--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -19981,7 +19981,7 @@ inner join pq on true
 			" │   ├─ tableId: 3\n" +
 			" │   └─ Filter\n" +
 			" │       ├─ GreaterThan\n" +
-			" │       │   ├─ a.x:0!null\n" +
+			" │       │   ├─ 1:0!null\n" +
 			" │       │   └─ 1 (tinyint)\n" +
 			" │       └─ Union distinct\n" +
 			" │           ├─ Project\n" +
@@ -20007,7 +20007,7 @@ inner join pq on true
 			"     ├─ tableId: 4\n" +
 			"     └─ Filter\n" +
 			"         ├─ GreaterThan\n" +
-			"         │   ├─ a.x:0!null\n" +
+			"         │   ├─ 1:0!null\n" +
 			"         │   └─ 1 (tinyint)\n" +
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
@@ -20032,7 +20032,7 @@ inner join pq on true
 			" │   ├─ isLateral: false\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   └─ Filter\n" +
-			" │       ├─ (a.x > 1)\n" +
+			" │       ├─ (1 > 1)\n" +
 			" │       └─ Union distinct\n" +
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [1]\n" +
@@ -20048,7 +20048,7 @@ inner join pq on true
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     └─ Filter\n" +
-			"         ├─ (a.x > 1)\n" +
+			"         ├─ (1 > 1)\n" +
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1]\n" +
@@ -20066,7 +20066,7 @@ inner join pq on true
 			" │   ├─ isLateral: false\n" +
 			" │   ├─ cacheable: true\n" +
 			" │   └─ Filter\n" +
-			" │       ├─ (a.x > 1)\n" +
+			" │       ├─ (1 > 1)\n" +
 			" │       └─ Union distinct\n" +
 			" │           ├─ Project\n" +
 			" │           │   ├─ columns: [1]\n" +
@@ -20082,7 +20082,7 @@ inner join pq on true
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     └─ Filter\n" +
-			"         ├─ (a.x > 1)\n" +
+			"         ├─ (1 > 1)\n" +
 			"         └─ Union distinct\n" +
 			"             ├─ Project\n" +
 			"             │   ├─ columns: [1]\n" +

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -11114,7 +11114,10 @@ where
 	},
 
 	{
-		Name: "correct union field index",
+		// TODO: This test currently fails in Doltgres because Doltgres does not allow `create table...as select...`
+		// even though it's a valid Postgres query. Remove Dialect tag once fixed in Doltgres
+		Dialect: "mysql",
+		Name:    "union field indexes",
 		SetUpScript: []string{
 			"create table t(id int primary key auto_increment, words varchar(100))",
 			"insert into t(words) values ('foo'),('bar'),('baz'),('zap')",

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -11116,6 +11116,7 @@ where
 	{
 		// TODO: This test currently fails in Doltgres because Doltgres does not allow `create table...as select...`
 		// even though it's a valid Postgres query. Remove Dialect tag once fixed in Doltgres
+		// https://github.com/dolthub/doltgresql/issues/1669
 		Dialect: "mysql",
 		Name:    "union field indexes",
 		SetUpScript: []string{

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -11133,8 +11133,8 @@ where
 			},
 			{
 				Query: "select * from " +
-					"(select 'parent' as db, id, words from t union " +
-					"select 'child' as db, id,words from t2) as combined where combined.id=1",
+					"(select 'parent' as tbl, id, words from t union " +
+					"select 'child' as tbl, id,words from t2) as combined where combined.id=1",
 				Expected: []sql.Row{
 					{"parent", 1, "foo"},
 					{"child", 1, "boo"},

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -692,6 +692,8 @@ func columnIdsForNode(n sql.Node) []sql.ColumnId {
 		default:
 			ret = append(ret, columnIdsForNode(n.Child)...)
 		}
+	case *plan.SetOp:
+		ret = append(ret, columnIdsForNode(n.Left())...)
 	case plan.TableIdNode:
 		if rt, ok := n.(*plan.ResolvedTable); ok && plan.IsDualTable(rt.Table) {
 			ret = append(ret, 0)

--- a/sql/analyzer/fix_exec_indexes.go
+++ b/sql/analyzer/fix_exec_indexes.go
@@ -712,6 +712,8 @@ func columnIdsForNode(n sql.Node) []sql.ColumnId {
 				break
 			}
 		}
+		// TODO: columns are appended in increasing order by ColumnId instead of how they are actually ordered. likely
+		// needs to be fixed
 		cols.ForEach(func(col sql.ColumnId) {
 			ret = append(ret, col)
 		})

--- a/sql/plan/set_op.go
+++ b/sql/plan/set_op.go
@@ -44,7 +44,8 @@ var _ sql.Node = (*SetOp)(nil)
 var _ sql.Expressioner = (*SetOp)(nil)
 var _ sql.CollationCoercible = (*SetOp)(nil)
 
-// var _ sql.NameableNode = (*SetOp)(nil)
+// TODO: This might not be necessary now that SetOp exec indexes are assigned based on its left child node, instead of
+// the cols in ColSet
 var _ TableIdNode = (*SetOp)(nil)
 
 // NewSetOp creates a new SetOp node with the given children.

--- a/sql/planbuilder/cte.go
+++ b/sql/planbuilder/cte.go
@@ -90,7 +90,7 @@ func (b *Builder) buildRecursiveCte(inScope *scope, union *ast.SetOp, name strin
 		// not recursive
 		sqScope := inScope.pushSubquery()
 		cteScope := b.buildSelectStmt(sqScope, union)
-		b.renameSource(cteScope, name, columns)
+
 		switch n := cteScope.node.(type) {
 		case *plan.SetOp:
 			sq := plan.NewSubqueryAlias(name, "", n)
@@ -107,9 +107,9 @@ func (b *Builder) buildRecursiveCte(inScope *scope, union *ast.SetOp, name strin
 				colset.Add(sql.ColumnId(c.id))
 				scopeMapping[sql.ColumnId(c.id)] = c.scalarGf()
 			}
-
 			cteScope.node = sq.WithScopeMapping(scopeMapping).WithId(tabId).WithColumns(colset)
 		}
+		b.renameSource(cteScope, name, columns)
 		return cteScope
 	}
 


### PR DESCRIPTION
Fixes dolthub/dolt#9516

SetOp is a TableIdNode so ColumnIds were assigned based off SetOp.cols, which is a ColSet. However, ColSet stores ColumnIds as a bitmap, not in the order they appear, and iterates over them in increasing numerical order. This causes a problem when the ColumnIds are not arranged in increasing order.

For example, in `(select 'parent' as tbl, id, words from t union select 'child' as tbl, id, words from t2) as combined`, the ColumnIds are `3, 1, 2` but ColSet iterates over them as `1, 2, 3`. As a result, `combined.id` gets wrongly assigned the field index of `0`, the wrong column is compared in the filter, and an empty result is returned.

This was fixed by adding a case for SetOp where ColumnIds are assigned based on the left child (a Project node for the above example). 

Added TODOs:
- It may not be necessary for SetOp to be a TableIdNode. It seems kinda hacky that it is.
- ColumnIds for TableIdNode probably shouldn't be assigned based on ColSet.ForEach (increasing order) since that might not reflect the actual order they are in.
- `create table as select...` currently failing in Doltgres (dolthub/doltgresql#1669)