### PR TITLE
dolthub/dolt#9554 - Fix varbinary display to show hex format with 0x prefix

### DIFF
--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -712,9 +712,14 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 			return sqltypes.Value{}, err
 		}
 
-		// Format binary data as hexadecimal with 0x prefix to match MySQL's display behavior
-		result := append([]byte("0x"), bytes.ToUpper([]byte(fmt.Sprintf("%x", binaryBytes)))...)
-		val = result
+		// Apply hex formatting only to VARBINARY and BINARY types, not BLOB types
+		// This ensures function results (which typically use BLOB types) display as raw bytes
+		if t.baseType == sqltypes.VarBinary || t.baseType == sqltypes.Binary {
+			result := append([]byte("0x"), bytes.ToUpper([]byte(fmt.Sprintf("%x", binaryBytes)))...)
+			val = result
+		} else {
+			val = binaryBytes
+		}
 	} else {
 		var valueBytes []byte
 		switch v := v.(type) {

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -711,7 +711,7 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 		if err != nil {
 			return sqltypes.Value{}, err
 		}
-		
+
 		// Format binary data in the MySQL CLI format, which is 0x followed by hex digits
 		result := append([]byte("0x"), bytes.ToUpper([]byte(fmt.Sprintf("%x", binaryBytes)))...)
 		val = result

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -712,7 +712,7 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 			return sqltypes.Value{}, err
 		}
 
-		// Format binary data in the MySQL CLI format, which is 0x followed by hex digits
+		// Format binary data as hexadecimal with 0x prefix to match MySQL's display behavior
 		result := append([]byte("0x"), bytes.ToUpper([]byte(fmt.Sprintf("%x", binaryBytes)))...)
 		val = result
 	} else {

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -707,10 +707,14 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 	start := len(dest)
 	var val []byte
 	if IsBinaryType(t) {
-		val, err = ConvertToBytes(ctx, v, t, dest)
+		binaryBytes, err := ConvertToBytes(ctx, v, t, dest)
 		if err != nil {
 			return sqltypes.Value{}, err
 		}
+		
+		// Format binary data in the MySQL CLI format, which is 0x followed by hex digits
+		result := append([]byte("0x"), bytes.ToUpper([]byte(fmt.Sprintf("%x", binaryBytes)))...)
+		val = result
 	} else {
 		var valueBytes []byte
 		switch v := v.(type) {

--- a/sql/types/strings_test.go
+++ b/sql/types/strings_test.go
@@ -379,6 +379,29 @@ func TestStringConvert(t *testing.T) {
 	}
 }
 
+func TestStringSQL(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	tests := []struct {
+		name        string
+		typ         sql.StringType
+		val         interface{}
+		expectedVal interface{}
+	}{
+		{"binary raw bytes", MustCreateBinary(sqltypes.Binary, 4), []byte{0x0A, 0x00, 0x00, 0x00}, []byte{0x0A, 0x00, 0x00, 0x00}},
+		{"varbinary raw bytes", MustCreateBinary(sqltypes.VarBinary, 4), []byte{0x0A, 0x00, 0x40, 0x00}, []byte{0x0A, 0x00, 0x40, 0x00}},
+		{"blob raw bytes", MustCreateBinary(sqltypes.Blob, 4), []byte{0x0A, 0x00, 0x80, 0x00}, []byte{0x0A, 0x00, 0x80, 0x00}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			val, err := test.typ.SQL(ctx, nil, test.val)
+			require.NoError(t, err)
+			actual := val.Raw()
+			assert.Equal(t, test.expectedVal, actual)
+		})
+	}
+}
+
 func TestStringString(t *testing.T) {
 	tests := []struct {
 		typ         sql.Type

--- a/sql/types/strings_test.go
+++ b/sql/types/strings_test.go
@@ -379,7 +379,6 @@ func TestStringConvert(t *testing.T) {
 	}
 }
 
-
 func TestStringString(t *testing.T) {
 	tests := []struct {
 		typ         sql.Type

--- a/sql/types/strings_test.go
+++ b/sql/types/strings_test.go
@@ -379,28 +379,6 @@ func TestStringConvert(t *testing.T) {
 	}
 }
 
-func TestBinaryDataSQLFormatting(t *testing.T) {
-	ctx := sql.NewEmptyContext()
-	tests := []struct {
-		name        string
-		typ         sql.StringType
-		val         interface{}
-		expectedVal interface{}
-	}{
-		{"binary hex", MustCreateBinary(sqltypes.Binary, 4), []byte{0x0A, 0x00, 0x00, 0x00}, []byte{'0', 'x', '0', 'A', '0', '0', '0', '0', '0', '0'}},
-		{"varbinary hex", MustCreateBinary(sqltypes.VarBinary, 4), []byte{0x0A, 0x00, 0x40, 0x00}, []byte{'0', 'x', '0', 'A', '0', '0', '4', '0', '0', '0'}},
-		{"blob hex", MustCreateBinary(sqltypes.Blob, 4), []byte{0x0A, 0x00, 0x80, 0x00}, []byte{'0', 'x', '0', 'A', '0', '0', '8', '0', '0', '0'}},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			val, err := test.typ.SQL(ctx, nil, test.val)
-			require.NoError(t, err)
-			actual := val.Raw()
-			assert.Equal(t, test.expectedVal, actual)
-		})
-	}
-}
 
 func TestStringString(t *testing.T) {
 	tests := []struct {

--- a/sql/types/strings_test.go
+++ b/sql/types/strings_test.go
@@ -387,9 +387,9 @@ func TestStringSQL(t *testing.T) {
 		val         interface{}
 		expectedVal interface{}
 	}{
-		{"binary raw bytes", MustCreateBinary(sqltypes.Binary, 4), []byte{0x0A, 0x00, 0x00, 0x00}, []byte{0x0A, 0x00, 0x00, 0x00}},
-		{"varbinary raw bytes", MustCreateBinary(sqltypes.VarBinary, 4), []byte{0x0A, 0x00, 0x40, 0x00}, []byte{0x0A, 0x00, 0x40, 0x00}},
-		{"blob raw bytes", MustCreateBinary(sqltypes.Blob, 4), []byte{0x0A, 0x00, 0x80, 0x00}, []byte{0x0A, 0x00, 0x80, 0x00}},
+		{"binary hex", MustCreateBinary(sqltypes.Binary, 4), []byte{0x0A, 0x00, 0x00, 0x00}, []byte{'0', 'x', '0', 'A', '0', '0', '0', '0', '0', '0'}},
+		{"varbinary hex", MustCreateBinary(sqltypes.VarBinary, 4), []byte{0x0A, 0x00, 0x40, 0x00}, []byte{'0', 'x', '0', 'A', '0', '0', '4', '0', '0', '0'}},
+		{"blob hex", MustCreateBinary(sqltypes.Blob, 4), []byte{0x0A, 0x00, 0x80, 0x00}, []byte{'0', 'x', '0', 'A', '0', '0', '8', '0', '0', '0'}},
 	}
 
 	for _, test := range tests {

--- a/sql/types/strings_test.go
+++ b/sql/types/strings_test.go
@@ -379,7 +379,7 @@ func TestStringConvert(t *testing.T) {
 	}
 }
 
-func TestStringSQL(t *testing.T) {
+func TestBinaryDataSQLFormatting(t *testing.T) {
 	ctx := sql.NewEmptyContext()
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Fixes dolthub/dolt#9554
Modified the StringType.SQL method to format binary data as hexadecimal with a 0x prefix. This change ensures that binary/varbinary data is displayed in a hex format.