### PR TITLE
Fix double counted time delta when converting time zones

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -6150,7 +6150,7 @@ func TestSQLLogicTests(t *testing.T, harness Harness) {
 func TestTimeQueryTests(t *testing.T, harness Harness) {
 	// "America/Phoenix" is a non-UTC time zone that does not observe daylight savings time
 	phoenixTimeZone, _ := time.LoadLocation("America/Phoenix")
-	mockNow := time.Date(2025, time.July, 23, 9, 43, 0, 0, phoenixTimeZone)
+	mockNow := time.Date(2025, time.July, 23, 9, 43, 21, 0, phoenixTimeZone)
 	for _, script := range queries.TimeQueryTests {
 		if sh, ok := harness.(SkippingHarness); ok {
 			if sh.SkipQueryTest(script.Name) {

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -6147,7 +6147,7 @@ func TestSQLLogicTests(t *testing.T, harness Harness) {
 	}
 }
 
-func TestTimeQueryTests(t *testing.T, harness Harness) {
+func TestTimeQueries(t *testing.T, harness Harness) {
 	// "America/Phoenix" is a non-UTC time zone that does not observe daylight savings time
 	phoenixTimeZone, _ := time.LoadLocation("America/Phoenix")
 	mockNow := time.Date(2025, time.July, 23, 9, 43, 21, 0, phoenixTimeZone)

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -6148,6 +6148,9 @@ func TestSQLLogicTests(t *testing.T, harness Harness) {
 }
 
 func TestTimeQueryTests(t *testing.T, harness Harness) {
+	// "America/Phoenix" is a non-UTC time zone that does not observe daylight savings time
+	phoenixTimeZone, _ := time.LoadLocation("America/Phoenix")
+	mockNow := time.Date(2025, time.July, 23, 9, 43, 0, 0, phoenixTimeZone)
 	for _, script := range queries.TimeQueryTests {
 		if sh, ok := harness.(SkippingHarness); ok {
 			if sh.SkipQueryTest(script.Name) {
@@ -6157,7 +6160,10 @@ func TestTimeQueryTests(t *testing.T, harness Harness) {
 				continue
 			}
 		}
-		TestScript(t, harness, script)
+		sql.RunWithNowFunc(func() time.Time { return mockNow }, func() error {
+			TestScript(t, harness, script)
+			return nil
+		})
 	}
 }
 

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -6147,6 +6147,20 @@ func TestSQLLogicTests(t *testing.T, harness Harness) {
 	}
 }
 
+func TestTimeQueryTests(t *testing.T, harness Harness) {
+	for _, script := range queries.TimeQueryTests {
+		if sh, ok := harness.(SkippingHarness); ok {
+			if sh.SkipQueryTest(script.Name) {
+				t.Run(script.Name, func(t *testing.T) {
+					t.Skip(script.Name)
+				})
+				continue
+			}
+		}
+		TestScript(t, harness, script)
+	}
+}
+
 // ExecuteNode builds an iterator and then drains it.
 // This is useful for populating actual row counts for `DESCRIBE ANALYZE`.
 func ExecuteNode(ctx *sql.Context, engine QueryEngine, node sql.Node) error {

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -1097,3 +1097,7 @@ func TestSQLLogicTestFiles(t *testing.T) {
 	}
 	logictest.RunTestFiles(h, paths...)
 }
+
+func TestTimeQueryTests(t *testing.T) {
+	enginetest.TestTimeQueryTests(t, enginetest.NewDefaultMemoryHarness())
+}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -1098,6 +1098,6 @@ func TestSQLLogicTestFiles(t *testing.T) {
 	logictest.RunTestFiles(h, paths...)
 }
 
-func TestTimeQueryTests(t *testing.T) {
-	enginetest.TestTimeQueryTests(t, enginetest.NewDefaultMemoryHarness())
+func TestTimeQueries(t *testing.T) {
+	enginetest.TestTimeQueries(t, enginetest.NewDefaultMemoryHarness())
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -22,7 +22,6 @@ import (
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 	"gopkg.in/src-d/go-errors.v1"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/analyzer/analyzererrors"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -4685,7 +4684,7 @@ CREATE TABLE tab3 (
 				// To match MySQL's behavior, this comes from the operating system's timezone setting
 				// TODO: the "global" shouldn't be necessary here, but GMS goes to session without it
 				Query:    `select @@global.system_time_zone;`,
-				Expected: []sql.Row{{gmstime.SystemTimezoneOffset()}},
+				Expected: []sql.Row{{sql.SystemTimezoneOffset()}},
 			},
 			{
 				// The default time_zone setting for MySQL is SYSTEM, which means timezone comes from @@system_time_zone

--- a/enginetest/queries/time_queries.go
+++ b/enginetest/queries/time_queries.go
@@ -1,9 +1,10 @@
 package queries
 
 import (
+	"time"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
-	"time"
 )
 
 var TimeQueryTests = []ScriptTest{

--- a/enginetest/queries/time_queries.go
+++ b/enginetest/queries/time_queries.go
@@ -1,3 +1,17 @@
+// Copyright 2020-2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package queries
 
 import (

--- a/enginetest/queries/time_queries.go
+++ b/enginetest/queries/time_queries.go
@@ -1,0 +1,49 @@
+package queries
+
+import (
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/types"
+)
+
+var TimeQueryTests = []ScriptTest{
+	{
+		// time zone tests the current time set as July 23, 2025 at 9:43am America/Phoenix (-7:00) (does not observe
+		// daylight savings time so time zone does not change)
+		Name:        "time zone tests",
+		SetUpScript: []string{},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "set time_zone='UTC'",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "select now()",
+				Expected: []sql.Row{{""}}, // july 23, 2025 16:43
+			},
+			{
+				Query:    "set time_zone='-5:00'",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "select now()",
+				Expected: []sql.Row{{""}}, // july 23, 2025 11:43
+			},
+			{
+				// doesn't observe daylight savings time so time zone does not change
+				Query:    "set time_zone='Pacific/Honolulu'",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "select now()",
+				Expected: []sql.Row{{""}}, // july 23, 2025 6:43am
+			},
+			{
+				// https://github.com/dolthub/dolt/issues/9559
+				Skip:  true,
+				Query: "set time_zone='invalid time zone",
+				// update to actual error or error string
+				ExpectedErrStr: "Unknown of incorrect time zone: 'invalid time zone'",
+			},
+		},
+	},
+}

--- a/enginetest/queries/time_queries.go
+++ b/enginetest/queries/time_queries.go
@@ -9,7 +9,7 @@ import (
 
 var TimeQueryTests = []ScriptTest{
 	{
-		// time zone tests the current time set as July 23, 2025 at 9:43am America/Phoenix (-7:00) (does not observe
+		// time zone tests the current time set as July 23, 2025 at 9:43:21am America/Phoenix (-7:00) (does not observe
 		// daylight savings time so time zone does not change)
 		Name:        "time zone tests",
 		SetUpScript: []string{},
@@ -20,7 +20,7 @@ var TimeQueryTests = []ScriptTest{
 			},
 			{
 				Query:    "select now()",
-				Expected: []sql.Row{{time.Date(2025, time.July, 23, 16, 43, 0, 0, time.UTC)}},
+				Expected: []sql.Row{{time.Date(2025, time.July, 23, 16, 43, 21, 0, time.UTC)}},
 			},
 			{
 				Query:    "set time_zone='-5:00'",
@@ -28,7 +28,7 @@ var TimeQueryTests = []ScriptTest{
 			},
 			{
 				Query:    "select now()",
-				Expected: []sql.Row{{time.Date(2025, time.July, 23, 11, 43, 0, 0, time.UTC)}},
+				Expected: []sql.Row{{time.Date(2025, time.July, 23, 11, 43, 21, 0, time.UTC)}},
 			},
 			{
 				// doesn't observe daylight savings time
@@ -37,7 +37,7 @@ var TimeQueryTests = []ScriptTest{
 			},
 			{
 				Query:    "select now()",
-				Expected: []sql.Row{{time.Date(2025, time.July, 23, 6, 43, 0, 0, time.UTC)}},
+				Expected: []sql.Row{{time.Date(2025, time.July, 23, 6, 43, 21, 0, time.UTC)}},
 			},
 			{
 				// https://github.com/dolthub/dolt/issues/9559

--- a/enginetest/queries/time_queries.go
+++ b/enginetest/queries/time_queries.go
@@ -3,6 +3,7 @@ package queries
 import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"time"
 )
 
 var TimeQueryTests = []ScriptTest{
@@ -18,7 +19,7 @@ var TimeQueryTests = []ScriptTest{
 			},
 			{
 				Query:    "select now()",
-				Expected: []sql.Row{{""}}, // july 23, 2025 16:43
+				Expected: []sql.Row{{time.Date(2025, time.July, 23, 16, 43, 0, 0, time.UTC)}},
 			},
 			{
 				Query:    "set time_zone='-5:00'",
@@ -26,16 +27,16 @@ var TimeQueryTests = []ScriptTest{
 			},
 			{
 				Query:    "select now()",
-				Expected: []sql.Row{{""}}, // july 23, 2025 11:43
+				Expected: []sql.Row{{time.Date(2025, time.July, 23, 11, 43, 0, 0, time.UTC)}},
 			},
 			{
-				// doesn't observe daylight savings time so time zone does not change
+				// doesn't observe daylight savings time
 				Query:    "set time_zone='Pacific/Honolulu'",
 				Expected: []sql.Row{{types.NewOkResult(0)}},
 			},
 			{
 				Query:    "select now()",
-				Expected: []sql.Row{{""}}, // july 23, 2025 6:43am
+				Expected: []sql.Row{{time.Date(2025, time.July, 23, 6, 43, 0, 0, time.UTC)}},
 			},
 			{
 				// https://github.com/dolthub/dolt/issues/9559

--- a/internal/time/time.go
+++ b/internal/time/time.go
@@ -24,7 +24,7 @@ import (
 )
 
 // offsetRegex is a regex for matching MySQL offsets (e.g. +01:00).
-var offsetRegex = regexp.MustCompile(`(?m)^([+\-])(\d{2}):(\d{2})$`)
+var offsetRegex = regexp.MustCompile(`(?m)^([+\-])(\d{1,2}):(\d{2})$`)
 
 // ConvertTimeZone converts |datetime| from one timezone to another. |fromLocation| and |toLocation| can be either
 // the name of a timezone (e.g. "UTC") or a MySQL-formatted timezone offset (e.g. "+01:00"). If the time was converted
@@ -107,7 +107,7 @@ func ConvertTimeToLocation(datetime time.Time, location string) (time.Time, erro
 	// If we can't parse a timezone location string, then try to parse a MySQL location offset
 	duration, err := MySQLOffsetToDuration(location)
 	if err == nil {
-		return datetime.Add(-1 * duration), nil
+		return getCopy(datetime, time.UTC).Add(-1 * duration), nil
 	}
 
 	return time.Time{}, errors.New(fmt.Sprintf("error: unable to parse timezone '%s'", location))

--- a/sql/events.go
+++ b/sql/events.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	"gopkg.in/src-d/go-errors.v1"
-
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 )
 
 const EventDateSpaceTimeFormat = "2006-01-02 15:04:05"
@@ -83,32 +81,32 @@ type EventDefinition struct {
 func (e *EventDefinition) ConvertTimesFromUTCToTz(tz string) *EventDefinition {
 	ne := *e
 	if ne.HasExecuteAt {
-		t, ok := gmstime.ConvertTimeZone(e.ExecuteAt, "+00:00", tz)
+		t, ok := ConvertTimeZone(e.ExecuteAt, "+00:00", tz)
 		if ok {
 			ne.ExecuteAt = t
 		}
 	} else {
-		t, ok := gmstime.ConvertTimeZone(e.Starts, "+00:00", tz)
+		t, ok := ConvertTimeZone(e.Starts, "+00:00", tz)
 		if ok {
 			ne.Starts = t
 		}
 		if ne.HasEnds {
-			t, ok = gmstime.ConvertTimeZone(e.Ends, "+00:00", tz)
+			t, ok = ConvertTimeZone(e.Ends, "+00:00", tz)
 			if ok {
 				ne.Ends = t
 			}
 		}
 	}
 
-	t, ok := gmstime.ConvertTimeZone(e.CreatedAt, "+00:00", tz)
+	t, ok := ConvertTimeZone(e.CreatedAt, "+00:00", tz)
 	if ok {
 		ne.CreatedAt = t
 	}
-	t, ok = gmstime.ConvertTimeZone(e.LastAltered, "+00:00", tz)
+	t, ok = ConvertTimeZone(e.LastAltered, "+00:00", tz)
 	if ok {
 		ne.LastAltered = t
 	}
-	t, ok = gmstime.ConvertTimeZone(e.LastExecuted, "+00:00", tz)
+	t, ok = ConvertTimeZone(e.LastExecuted, "+00:00", tz)
 	if ok {
 		ne.LastExecuted = t
 	}
@@ -363,7 +361,7 @@ var tzRegex = regexp.MustCompile(`(?m)^([+\-])(\d{2}):(\d{2})$`)
 // evaluating valid MySQL datetime and timestamp formats.
 func GetTimeValueFromStringInput(field, t string) (time.Time, error) {
 	// TODO: the time value should be in session timezone rather than system timezone.
-	sessTz := gmstime.SystemTimezoneOffset()
+	sessTz := SystemTimezoneOffset()
 
 	// For MySQL datetime format, it accepts any valid date format
 	// and tries parsing time part first and timezone part if time part is valid.
@@ -407,7 +405,7 @@ func GetTimeValueFromStringInput(field, t string) (time.Time, error) {
 		}
 
 		// convert the time value to the session timezone for display and storage
-		tVal, ok = gmstime.ConvertTimeZone(tVal, inputTz, sessTz)
+		tVal, ok = ConvertTimeZone(tVal, inputTz, sessTz)
 		if !ok {
 			return time.Time{}, fmt.Errorf("invalid time zone: %s", sessTz)
 		}

--- a/sql/expression/function/convert_tz.go
+++ b/sql/expression/function/convert_tz.go
@@ -17,7 +17,6 @@ package function
 import (
 	"fmt"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -104,7 +103,7 @@ func (c *ConvertTz) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	if fromStr == "SYSTEM" {
-		fromStr = gmstime.SystemTimezoneOffset()
+		fromStr = sql.SystemTimezoneOffset()
 	}
 
 	toStr, ok := to.(string)
@@ -113,10 +112,10 @@ func (c *ConvertTz) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	if toStr == "SYSTEM" {
-		toStr = gmstime.SystemTimezoneOffset()
+		toStr = sql.SystemTimezoneOffset()
 	}
 
-	converted, success := gmstime.ConvertTimeZone(datetime, fromStr, toStr)
+	converted, success := sql.ConvertTimeZone(datetime, fromStr, toStr)
 	if !success {
 		return nil, nil
 	}

--- a/sql/expression/function/date.go
+++ b/sql/expression/function/date.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/shopspring/decimal"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/transform"
@@ -314,7 +313,7 @@ func (ut *UnixTimestamp) Eval(ctx *sql.Context, row sql.Row) (interface{}, error
 		return nil, err
 	}
 
-	ctz, ok := gmstime.ConvertTimeZone(date.(time.Time), stz, "UTC")
+	ctz, ok := sql.ConvertTimeZone(date.(time.Time), stz, "UTC")
 	if ok {
 		date = ctz
 	}
@@ -408,7 +407,7 @@ func (r *FromUnixtime) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
-	t, _ = gmstime.ConvertTimeZone(t, "UTC", tz)
+	t, _ = sql.ConvertTimeZone(t, "UTC", tz)
 	if len(vals) == 1 {
 		return t, nil // If format is omitted, this function returns a DATETIME value.
 	}

--- a/sql/expression/function/time.go
+++ b/sql/expression/function/time.go
@@ -22,7 +22,6 @@ import (
 
 	"gopkg.in/src-d/go-errors.v1"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -1016,7 +1015,7 @@ func (n *Now) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	// If no arguments, just return with 0 precision
 	// The way the parser is implemented 0 should always be passed in; have this here just in case
 	if n.prec == nil {
-		t, ok := gmstime.ConvertTimeZone(currentTime, gmstime.SystemTimezoneOffset(), sessionTimeZone)
+		t, ok := sql.ConvertTimeZone(currentTime, sql.SystemTimezoneOffset(), sessionTimeZone)
 		if !ok {
 			return nil, fmt.Errorf("invalid time zone: %s", sessionTimeZone)
 		}
@@ -1056,7 +1055,7 @@ func (n *Now) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	// Get the timestamp
-	t, ok := gmstime.ConvertTimeZone(currentTime, gmstime.SystemTimezoneOffset(), sessionTimeZone)
+	t, ok := sql.ConvertTimeZone(currentTime, sql.SystemTimezoneOffset(), sessionTimeZone)
 	if !ok {
 		return nil, fmt.Errorf("invalid time zone: %s", sessionTimeZone)
 	}
@@ -1106,7 +1105,7 @@ func SessionTimeZone(ctx *sql.Context) (string, error) {
 	}
 
 	if sessionTimeZone == "SYSTEM" {
-		sessionTimeZone = gmstime.SystemTimezoneOffset()
+		sessionTimeZone = sql.SystemTimezoneOffset()
 	}
 	return sessionTimeZone, nil
 }

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -24,7 +24,6 @@ import (
 	"github.com/dolthub/vitess/go/sqltypes"
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	. "github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -965,7 +964,7 @@ func eventsRowIter(ctx *Context, c Catalog) (RowIter, error) {
 			}
 
 			for _, e := range eventDefs {
-				ed := e.ConvertTimesFromUTCToTz(gmstime.SystemTimezoneOffset())
+				ed := e.ConvertTimesFromUTCToTz(SystemTimezoneOffset())
 				var at, intervalVal, intervalField, starts, ends interface{}
 				var eventType, status string
 				if ed.HasExecuteAt {

--- a/sql/plan/alter_event.go
+++ b/sql/plan/alter_event.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/dolthub/vitess/go/mysql"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -241,7 +240,7 @@ func (a *AlterEvent) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error)
 	var err error
 	ed := a.Event
 	eventAlteredTime := ctx.QueryTime()
-	sysTz := gmstime.SystemTimezoneOffset()
+	sysTz := sql.SystemTimezoneOffset()
 	ed.LastAltered = eventAlteredTime
 	ed.Definer = a.Definer
 

--- a/sql/plan/ddl_event.go
+++ b/sql/plan/ddl_event.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/dolthub/vitess/go/mysql"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
@@ -231,7 +230,7 @@ func (c *CreateEvent) WithExpressions(e ...sql.Expression) (sql.Node, error) {
 func (c *CreateEvent) RowIter(ctx *sql.Context, _ sql.Row) (sql.RowIter, error) {
 	eventCreationTime := ctx.QueryTime()
 	// TODO: event time values are evaluated in 'SYSTEM' TZ for now (should be session TZ)
-	eventDefinition, err := c.GetEventDefinition(ctx, eventCreationTime, eventCreationTime, time.Time{}, gmstime.SystemTimezoneOffset())
+	eventDefinition, err := c.GetEventDefinition(ctx, eventCreationTime, eventCreationTime, time.Time{}, sql.SystemTimezoneOffset())
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +561,7 @@ func (ost *OnScheduleTimestamp) EvalTime(ctx *sql.Context, tz string) (time.Time
 	if err != nil {
 		return time.Time{}, err
 	}
-	return gmstime.ConvertTimeToLocation(truncatedVal, tz)
+	return sql.ConvertTimeToLocation(truncatedVal, tz)
 }
 
 var _ sql.Node = (*DropEvent)(nil)

--- a/sql/plan/show_events.go
+++ b/sql/plan/show_events.go
@@ -15,7 +15,6 @@
 package plan
 
 import (
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -100,7 +99,7 @@ func (s *ShowEvents) RowIter(ctx *sql.Context, row sql.Row) (sql.RowIter, error)
 	for _, event := range s.Events {
 		eventType := "RECURRING"
 		var executeAt, intervalVal, intervalField, starts, ends, status interface{}
-		e := event.ConvertTimesFromUTCToTz(gmstime.SystemTimezoneOffset())
+		e := event.ConvertTimesFromUTCToTz(sql.SystemTimezoneOffset())
 		if e.HasExecuteAt {
 			eventType = "ONE TIME"
 			executeAt = e.ExecuteAt.Format(sql.EventDateSpaceTimeFormat)

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -22,7 +22,6 @@ import (
 	"sort"
 	"strings"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/plan"
@@ -889,7 +888,7 @@ func (b *BaseBuilder) buildShowCreateEvent(ctx *sql.Context, n *plan.ShowCreateE
 	}
 
 	// Convert the Event's timestamps into the session's timezone (they are always stored in UTC)
-	newEvent := n.Event.ConvertTimesFromUTCToTz(gmstime.SystemTimezoneOffset())
+	newEvent := n.Event.ConvertTimesFromUTCToTz(sql.SystemTimezoneOffset())
 	n.Event = *newEvent
 
 	// TODO: fill time_zone with appropriate values

--- a/sql/time.go
+++ b/sql/time.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Contains low-level utility functions for working with time.Time values and timezones.
 package sql
 
 import (

--- a/sql/time.go
+++ b/sql/time.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package time contains low-level utility functions for working with time.Time values and timezones.
-package time
+package sql
 
 import (
 	"errors"
@@ -62,7 +62,7 @@ func MySQLOffsetToDuration(d string) (time.Duration, error) {
 
 // SystemTimezoneOffset returns the current system timezone offset as a MySQL timezone offset (e.g. "+01:00").
 func SystemTimezoneOffset() string {
-	t := time.Now()
+	t := Now()
 	_, offset := t.Zone()
 
 	return SecondsToMySQLOffset(offset)
@@ -70,7 +70,7 @@ func SystemTimezoneOffset() string {
 
 // SystemTimezoneName returns the current system timezone name.
 func SystemTimezoneName() string {
-	t := time.Now()
+	t := Now()
 	name, _ := t.Zone()
 
 	return name

--- a/sql/time.go
+++ b/sql/time.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package time contains low-level utility functions for working with time.Time values and timezones.
+// Contains low-level utility functions for working with time.Time values and timezones.
 package sql
 
 import (
@@ -29,6 +29,8 @@ var offsetRegex = regexp.MustCompile(`(?m)^([+\-])(\d{1,2}):(\d{2})$`)
 // ConvertTimeZone converts |datetime| from one timezone to another. |fromLocation| and |toLocation| can be either
 // the name of a timezone (e.g. "UTC") or a MySQL-formatted timezone offset (e.g. "+01:00"). If the time was converted
 // successfully, then the second return value will be true, otherwise the time was not able to be converted.
+// TODO: This function relies on ConvertTimeToLocation functioning incorrectly to get the correct result. The resulting
+// time is still the same location as the original time, just with time values shifted.
 func ConvertTimeZone(datetime time.Time, fromLocation string, toLocation string) (time.Time, bool) {
 	if fromLocation == toLocation {
 		return datetime, true
@@ -97,6 +99,8 @@ func SecondsToMySQLOffset(offset int) string {
 // ConvertTimeToLocation converts |datetime| to the given |location|. |location| can be either the name of a timezone
 // (e.g. "UTC") or a MySQL-formatted timezone offset (e.g. "+01:00"). If the time was converted successfully, then
 // the converted time is returned, otherwise an error is returned.
+// TODO: this function does not work as expected. it takes the current time and converts it to what UTC would be if the
+// datetime is in the given location. The converted time also assumes UTC as its location.
 func ConvertTimeToLocation(datetime time.Time, location string) (time.Time, error) {
 	// Try to load the timezone location string first
 	loc, err := time.LoadLocation(location)

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
-	gmstime "github.com/dolthub/go-mysql-server/internal/time"
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -2642,7 +2641,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           false,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemStringType("system_time_zone"),
-		Default:           gmstime.SystemTimezoneName(),
+		Default:           sql.SystemTimezoneName(),
 	},
 	"table_definition_cache": &sql.MysqlSystemVariable{
 		Name:              "table_definition_cache",


### PR DESCRIPTION
Fixes dolthub/dolt#9555

We were double counting timezone differences because we did not take the time object's location into account when calculating the time delta.

Time conversion util functions work how they're supposed to. This fix relies on the incorrect behavior to get the correct time.


TODO: redo how we do time conversions and use time. We often ignore the location a given time object is set in and we frequently arbitrarily set the location to UTC even when it's not.


Also moved `internal/time/time.go` to `sql/time.go` to avoid import cycle.