### PR TITLE
fix panic in stats histogram union and intersect

### DIFF
--- a/sql/stats/filter.go
+++ b/sql/stats/filter.go
@@ -32,20 +32,22 @@ func Union(ctx *sql.Context, b1, b2 []sql.HistogramBucket, types []sql.Type) ([]
 			if err != nil {
 				return nil, err
 			}
-			switch cmp {
-			case 0:
-				if k == len(key1)-1 {
-					ret = append(ret, b1[i])
-					i++
-					j++
-				}
-				continue
-			case +1:
+			if cmp == +1 {
 				ret = append(ret, b2[j])
 				j++
-			case -1:
+				break
+			}
+			if cmp == -1 {
 				ret = append(ret, b1[i])
 				i++
+				break
+			}
+			// if keys are equal, merge buckets
+			if k == len(key1)-1 {
+				ret = append(ret, b1[i])
+				i++
+				j++
+				break
 			}
 		}
 	}
@@ -78,18 +80,19 @@ func Intersect(ctx *sql.Context, b1, b2 []sql.HistogramBucket, types []sql.Type)
 			if err != nil {
 				return nil, err
 			}
-			switch cmp {
-			case 0:
-				if k == len(key1)-1 {
-					ret = append(ret, b1[i])
-					i++
-					j++
-				}
-				continue
-			case +1:
+			if cmp == +1 {
 				j++
-			case -1:
+				break
+			}
+			if cmp == -1 {
 				i++
+				break
+			}
+			// if keys are equal, merge buckets
+			if k == len(key1) - 1 {
+				ret = append(ret, b1[i])
+				i++
+				j++
 			}
 		}
 	}

--- a/sql/stats/filter.go
+++ b/sql/stats/filter.go
@@ -88,7 +88,7 @@ func Intersect(ctx *sql.Context, b1, b2 []sql.HistogramBucket, types []sql.Type)
 				break
 			}
 			// if keys are equal, merge buckets
-			if k == len(key1) - 1 {
+			if k == len(key1)-1 {
 				ret = append(ret, b1[i])
 				i++
 				j++

--- a/sql/stats/filter.go
+++ b/sql/stats/filter.go
@@ -47,7 +47,6 @@ func Union(ctx *sql.Context, b1, b2 []sql.HistogramBucket, types []sql.Type) ([]
 				ret = append(ret, b1[i])
 				i++
 				j++
-				break
 			}
 		}
 	}

--- a/sql/stats/filter_test.go
+++ b/sql/stats/filter_test.go
@@ -986,31 +986,31 @@ func TestHistogramUnion(t *testing.T) {
 		{
 			types: []sql.Type{types.Int64, types.Int64},
 			h1: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{1,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{1, 9}},
 			},
 			h2: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 			exp: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{1,9}},
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{1, 9}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 		},
 		{
 			types: []sql.Type{types.Int64, types.Int64},
 			h1: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,9}},
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{1, 9}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 			h2: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
 			},
 			exp: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{1,9}},
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{1, 9}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 		},
 	}
@@ -1045,30 +1045,30 @@ func TestHistogramIntersect(t *testing.T) {
 		{
 			types: []sql.Type{types.Int64, types.Int64},
 			h1: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{1,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{1, 9}},
 			},
 			h2: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 			exp: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
 			},
 		},
 		{
 			types: []sql.Type{types.Int64, types.Int64},
 			h1: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 			h2: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 			exp: []sql.HistogramBucket{
-				&Bucket{BoundVal: []interface{}{1,1}},
-				&Bucket{BoundVal: []interface{}{9,9}},
+				&Bucket{BoundVal: []interface{}{1, 1}},
+				&Bucket{BoundVal: []interface{}{9, 9}},
 			},
 		},
 	}


### PR DESCRIPTION
I'm not 100% how to repro this, but there is definitely something up with the Union and Intersect logic in stats histograms.
Based on the stack trace, there's a panic when attempting to Union histogram buckets.

It seems like the logic assumes that the histogram keys are always shorter than the number of buckets.
This PR fixes the Union and Intersect logic to compare the keys without the assumption, and adds some unit tests.

fixes: https://github.com/dolthub/dolt/issues/9143