### PR TITLE
Add support for `DELETE ... RETURNING`

### DIFF
--- a/sql/analyzer/process_truncate.go
+++ b/sql/analyzer/process_truncate.go
@@ -33,7 +33,9 @@ func processTruncate(ctx *sql.Context, a *Analyzer, node sql.Node, scope *plan.S
 
 	switch n := node.(type) {
 	case *plan.DeleteFrom:
-		if !n.Resolved() {
+		// If there are any returning expressions, then we can't convert to a Truncate operation,
+		// since we need to process all rows and return results.
+		if !n.Resolved() || len(n.Returning) > 0 {
 			return n, transform.SameTree, nil
 		}
 		return deleteToTruncate(ctx, a, n)

--- a/sql/planbuilder/dml.go
+++ b/sql/planbuilder/dml.go
@@ -492,6 +492,11 @@ func (b *Builder) buildDelete(inScope *scope, d *ast.Delete) (outScope *scope) {
 	del.RefsSingleRel = !outScope.refsSubquery
 	del.IsProcNested = b.ProcCtx().DbName != ""
 	outScope.node = del
+
+	if len(d.Returning) > 0 {
+		del.Returning = b.analyzeSelectList(outScope, outScope, d.Returning)
+	}
+
 	return
 }
 

--- a/sql/rowexec/dml.go
+++ b/sql/rowexec/dml.go
@@ -149,7 +149,7 @@ func (b *BaseBuilder) buildDeleteFrom(ctx *sql.Context, n *plan.DeleteFrom, row 
 		}
 		schemaPositionDeleters[i] = schemaPositionDeleter{deleter, int(start), int(end)}
 	}
-	return newDeleteIter(iter, schema, schemaPositionDeleters...), nil
+	return newDeleteIter(iter, schema, schemaPositionDeleters, n.Returning, n.Schema()), nil
 }
 
 func (b *BaseBuilder) buildForeignKeyHandler(ctx *sql.Context, n *plan.ForeignKeyHandler, row sql.Row) (sql.RowIter, error) {

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -619,6 +619,10 @@ func AddAccumulatorIter(ctx *sql.Context, iter sql.RowIter) (sql.RowIter, sql.Sc
 			if len(innerIter.returnExprs) > 0 {
 				return innerIter, innerIter.returnSchema
 			}
+		case *deleteIter:
+			if len(innerIter.returnExprs) > 0 {
+				return innerIter, innerIter.returnSchema
+			}
 		}
 
 		return defaultAccumulatorIter(ctx, iter)


### PR DESCRIPTION
Adds support for the `RETURNING` clause in `DELETE` statements. This syntax is supported in Postgres/Doltgres, but not in Dolt/GMS/MySQL. 

Tests for this functionality are in the associated Doltgres PR: https://github.com/dolthub/doltgresql/pull/1712