### PR TITLE
Validate trigger name length is not over 96 chars

### DIFF
--- a/enginetest/queries/trigger_queries.go
+++ b/enginetest/queries/trigger_queries.go
@@ -4839,4 +4839,15 @@ var TriggerErrorTests = []ScriptTest{
 		Query:       "create trigger trig before insert on v for each row set b = 1",
 		ExpectedErr: sql.ErrExpectedTableFoundView,
 	},
+	{
+		// NOTE: We limit trigger names to 96 chars. This is more than MySQL allows (64 chars).
+		Name: "trigger name length over limit",
+		SetUpScript: []string{
+			"CREATE TABLE example_table (id INT AUTO_INCREMENT PRIMARY KEY, value VARCHAR(50));",
+		},
+		Query: `CREATE TRIGGER this_is_a_very_long_trigger_name_that_is_purposefully_made_to_be_exactly_one_hundred_characters_long
+				BEFORE INSERT ON example_table
+				FOR EACH ROW BEGIN SET NEW.value = UPPER(NEW.value); END;`,
+		ExpectedErr: sql.ErrIdentifierIsTooLong,
+	},
 }

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -499,6 +499,9 @@ var (
 	// ErrInvalidIdentifier is returned when an identifier is invalid
 	ErrInvalidIdentifier = errors.NewKind("invalid identifier: `%s`")
 
+	// ErrIdentifierIsTooLong is returned when creating a resource, but the identifier is longer than a name limit
+	ErrIdentifierIsTooLong = errors.NewKind("Identifier name '%s' is too long")
+
 	// ErrInvalidArgument is returned when an argument to a function is invalid.
 	ErrInvalidArgument = errors.NewKind("Invalid argument to %s")
 

--- a/sql/information_schema/information_schema.go
+++ b/sql/information_schema/information_schema.go
@@ -698,7 +698,9 @@ var tablespacesExtensionsSchema = Schema{
 var triggersSchema = Schema{
 	{Name: "TRIGGER_CATALOG", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: TriggersTableName},
 	{Name: "TRIGGER_SCHEMA", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: TriggersTableName},
-	{Name: "TRIGGER_NAME", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: nil, Nullable: false, Source: TriggersTableName},
+	// NOTE: MySQL limits trigger names to 64 characters, but we limit them to 96 chars to avoid breaking existing customers who were
+	//       relying on us not enforcing the 64 character limit. This is a good candidate to change in a future major version bump.
+	{Name: "TRIGGER_NAME", Type: types.MustCreateString(sqltypes.VarChar, 96, Collation_Information_Schema_Default), Default: nil, Nullable: false, Source: TriggersTableName},
 	{Name: "EVENT_MANIPULATION", Type: types.MustCreateEnumType([]string{"INSERT", "UPDATE", "DELETE"}, Collation_Information_Schema_Default), Default: nil, Nullable: false, Source: TriggersTableName},
 	{Name: "EVENT_OBJECT_CATALOG", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: TriggersTableName},
 	{Name: "EVENT_OBJECT_SCHEMA", Type: types.MustCreateString(sqltypes.VarChar, 64, Collation_Information_Schema_Default), Default: nil, Nullable: true, Source: TriggersTableName},


### PR DESCRIPTION
We weren't enforcing any name length constraints on triggers, and when customers created triggers with very long names (i.e. over 64 characters, the MySQL limit), they could encounter problems with table schemas that don't support longer lengths. 

In this change, we apply a max trigger name length of 96 characters and reject `CREATE TRIGGER` statements that create triggers with names longer than that limit. We chose 96 characters for the limit, instead of copying MySQL's 64 character limit, so that this change would not break existing applications that are creating trigger names slightly longer than MySQL's 64 character limit. 