### PR TITLE
avoid using `sql.Row.Append()`

### DIFF
--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -167,6 +167,8 @@ type JsonTableCol struct {
 	pos      int
 	finished bool // exhausted all rows in data
 	currSib  int
+
+	resultRow sql.Row
 }
 
 // IsSibling returns if the jsonTableCol contains multiple columns

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -754,7 +754,8 @@ func (u *updateSourceIter) Next(ctx *sql.Context) (sql.Row, error) {
 		newRow = newRow[len(newRow)-expectedSchemaLen:]
 	}
 
-	return oldRow.Append(newRow), nil
+	row := append(oldRow, newRow...)
+	return row, nil
 }
 
 func (u *updateSourceIter) Close(ctx *sql.Context) error {

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -221,7 +221,7 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 
 func (i *insertIter) handleOnDuplicateKeyUpdate(ctx *sql.Context, oldRow, newRow sql.Row) (returnRow sql.Row, returnErr error) {
 	var err error
-	updateAcc := append(oldRow, newRow...)
+	updateAcc := append(oldRow, newRow...) // TODO: how is this safe?
 	var evalRow sql.Row
 	for _, updateExpr := range i.updateExprs {
 		// this SET <val> indexes into LHS, but the <expr> can

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -103,7 +103,7 @@ func (b *BaseBuilder) buildValues(ctx *sql.Context, n *plan.Values, row sql.Row)
 			}
 		}
 
-		rows[i] = sql.NewRow(vals...)
+		rows[i] = vals
 	}
 
 	return sql.RowsToRowIter(rows...), nil

--- a/sql/rows.go
+++ b/sql/rows.go
@@ -29,7 +29,7 @@ type Row []interface{}
 
 // NewRow creates a row from the given values.
 func NewRow(values ...interface{}) Row {
-	row := make([]interface{}, len(values))
+	row := make(Row, len(values))
 	copy(row, values)
 	return row
 }


### PR DESCRIPTION
`sql.Row.Append()` will always make a deep copy of the row, so we should avoid it.
Instead we have copies to cached `sql.Rows` and have golang's runtime (sometimes) extend the backing array.