### PR TITLE
Allow hash functions to work on BINARY columns when the binary is not valid UTF8

### DIFF
--- a/sql/expression/function/hash.go
+++ b/sql/expression/function/hash.go
@@ -67,13 +67,13 @@ func (f *MD5) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	val, _, err := types.LongText.Convert(ctx, arg)
+	val, _, err := types.LongBlob.Convert(ctx, arg)
 	if err != nil {
 		return nil, err
 	}
 
 	h := md5.New()
-	_, err = io.WriteString(h, val.(string))
+	_, err = h.Write(val.([]byte))
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (f *SHA2) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	val, _, err := types.LongText.Convert(ctx, arg)
+	val, _, err := types.LongBlob.Convert(ctx, arg)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (f *SHA2) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, nil
 	}
 
-	_, err = io.WriteString(h, val.(string))
+	_, err = h.Write(val.([]byte))
 	if err != nil {
 		return nil, err
 	}

--- a/sql/expression/function/hash_test.go
+++ b/sql/expression/function/hash_test.go
@@ -37,6 +37,7 @@ func TestMD5(t *testing.T) {
 		{expression.NewLiteral("abcd", types.Text), "e2fc714c4727ee9395f324cd2e7f331f"},
 		{expression.NewLiteral(float32(2.5), types.Float32), "8221435bcce913b5c2dc22eaf6cb6590"},
 		{expression.NewLiteral("2.5", types.Text), "8221435bcce913b5c2dc22eaf6cb6590"},
+		{expression.NewLiteral([]byte{0x80}, types.LongBlob), "8d39dd7eef115ea6975446ef4082951f"},
 		{NewMD5(expression.NewLiteral(int8(10), types.Int8)), "8d8e353b98d5191d5ceea1aa3eb05d43"},
 	}
 
@@ -231,6 +232,11 @@ func TestSHA2(t *testing.T) {
 			expression.NewLiteral("2.5", types.Text),
 			expression.NewLiteral("512", types.Text),
 			"a4281cc49c2503bd0a0876db08ac6280583ebfcee6186c054792d877e7febe63251bfb82616504ed8ee36b146a7d5c6bfcdfcf9c27969a3874bab4544efed501",
+		},
+		{
+			expression.NewLiteral([]byte{0x80}, types.Blob),
+			expression.NewLiteral(256, types.Int64),
+			"76be8b528d0075f7aae98d6fa57a6d3c83ae480a8469e668d7b0af968995ac71",
 		},
 	}
 

--- a/sql/expression/function/tobase64_frombase64.go
+++ b/sql/expression/function/tobase64_frombase64.go
@@ -77,11 +77,11 @@ func (t *ToBase64) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		}
 		strBytes = encodedBytes
 	} else {
-		val, _, err = types.LongText.Convert(ctx, val)
+		val, _, err = types.LongBlob.Convert(ctx, val)
 		if err != nil {
 			return nil, sql.ErrInvalidType.New(reflect.TypeOf(val))
 		}
-		strBytes = []byte(val.(string))
+		strBytes = val.([]byte)
 	}
 
 	encoded := base64.StdEncoding.EncodeToString(strBytes)


### PR DESCRIPTION
Previous, as part of computing hashes for MySQL's hash functions (MD5, SHA1, etc), we could convert the input into a text type. But this would cause errors in strict mode of the input was a binary value that was not valid utf8.

By converting the input into a binary type, we keep all the same behavior, except that binary inputs now work correctly.