### PR TITLE
Make `SHOW VARIABLES` display boolean values as ON/OFF to match MySQL

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5076,19 +5076,19 @@ SELECT * FROM cte WHERE  d = 2;`,
 	{
 		Query: `SHOW VARIABLES WHERE Variable_name = 'version' || variable_name = 'autocommit'`,
 		Expected: []sql.Row{
-			{"autocommit", 1}, {"version", "8.0.31"},
+			{"autocommit", "ON"}, {"version", "8.0.31"},
 		},
 	},
 	{
 		Query: `SHOW VARIABLES WHERE Variable_name > 'version' and variable_name like '%_%'`,
 		Expected: []sql.Row{
-			{"version_comment", "Dolt"}, {"version_compile_machine", ""}, {"version_compile_os", ""}, {"version_compile_zlib", ""}, {"wait_timeout", 28800}, {"windowing_use_high_precision", 1},
+			{"version_comment", "Dolt"}, {"version_compile_machine", ""}, {"version_compile_os", ""}, {"version_compile_zlib", ""}, {"wait_timeout", 28800}, {"windowing_use_high_precision", "ON"},
 		},
 	},
 	{
 		Query: `SHOW VARIABLES WHERE "1" and variable_name = 'autocommit'`,
 		Expected: []sql.Row{
-			{"autocommit", 1},
+			{"autocommit", "ON"},
 		},
 	},
 	{
@@ -5105,8 +5105,8 @@ SELECT * FROM cte WHERE  d = 2;`,
 			{"block_encryption_mode", "aes-128-ecb"},
 			{"gtid_mode", "OFF"},
 			{"innodb_autoinc_lock_mode", int64(2)},
-			{"offline_mode", int64(0)},
-			{"pseudo_slave_mode", int64(0)},
+			{"offline_mode", "OFF"},
+			{"pseudo_slave_mode", "OFF"},
 			{"rbr_exec_mode", "STRICT"},
 			{"sql_mode", "NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES"},
 			{"ssl_fips_mode", "OFF"},

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -557,7 +557,20 @@ func (b *BaseBuilder) buildShowVariables(ctx *sql.Context, n *plan.ShowVariables
 				continue
 			}
 		}
-		rows = append(rows, sql.NewRow(k, v))
+
+		// SHOW VARIABLES displays boolean values as "ON" or "OFF".
+		if boolVal, isBoolVal := v.(int8); isBoolVal {
+			switch boolVal {
+			case 0:
+				rows = append(rows, sql.NewRow(k, "OFF"))
+			case 1:
+				rows = append(rows, sql.NewRow(k, "ON"))
+			default:
+				rows = append(rows, sql.NewRow(k, v))
+			}
+		} else {
+			rows = append(rows, sql.NewRow(k, v))
+		}
 	}
 
 	sort.Slice(rows, func(i, j int) bool {

--- a/sql/rowexec/showvariables_test.go
+++ b/sql/rowexec/showvariables_test.go
@@ -44,7 +44,19 @@ func TestShowVariables(t *testing.T) {
 
 		t.Logf("key: %s\tval: %v\n", key, val)
 
-		require.Equal(vars[key], val)
+		// int8 values are interpreted as boolean values
+		if int8Val, isInt8 := vars[key].(int8); isInt8 {
+			if int8Val == 0 {
+				require.Equal("OFF", val)
+			} else if int8Val == 1 {
+				require.Equal("ON", val)
+			} else {
+				require.Failf("unexpected value for int8 system variable: %s: %v", key, val)
+			}
+		} else {
+			require.Equal(vars[key], val)
+		}
+
 		delete(vars, key)
 	}
 	if err != io.EOF {

--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -1286,6 +1286,24 @@ var systemVars = map[string]sql.SystemVariable{
 		//       Integrators who provide binary logging may change this default.
 		Default: int8(0),
 	},
+	"log_replica_updates": &sql.MysqlSystemVariable{
+		Name:              "log_replica_updates",
+		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Persist),
+		Dynamic:           true,
+		SetVarHintApplies: false,
+		Type:              types.NewSystemBoolType("log_replica_updates"),
+		Default:           int8(1),
+	},
+	"log_slave_updates": &sql.MysqlSystemVariable{
+		// TODO: This var should be an *alias* for log_replica_updates, but
+		//       we don't support system variable aliases yet.
+		Name:              "log_slave_updates",
+		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Persist),
+		Dynamic:           true,
+		SetVarHintApplies: false,
+		Type:              types.NewSystemBoolType("log_slave_updates"),
+		Default:           int8(1),
+	},
 	"log_error": &sql.MysqlSystemVariable{
 		Name:              "log_error",
 		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Global),
@@ -2041,7 +2059,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemUintType("query_cache_size", 0, 18446744073709551615),
-		Default:           int8(1),
+		Default:           1,
 	},
 	"query_cache_type": &sql.MysqlSystemVariable{
 		Name:              "query_cache_type",
@@ -2933,7 +2951,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemIntType("validate_password.length", 0, 2147483647, false),
-		Default:           int8(8),
+		Default:           8,
 	},
 	"validate_password.number_count": &sql.MysqlSystemVariable{
 		Name:              "validate_password.number_count",
@@ -2941,7 +2959,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemIntType("validate_password.number_count", 0, 2147483647, false),
-		Default:           int8(1),
+		Default:           1,
 	},
 	"validate_password.mixed_case_count": &sql.MysqlSystemVariable{
 		Name:              "validate_password.mixed_case_count",
@@ -2949,7 +2967,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemIntType("validate_password.mixed_case_count", 0, 2147483647, false),
-		Default:           int8(1),
+		Default:           1,
 	},
 	"validate_password.special_char_count": &sql.MysqlSystemVariable{
 		Name:              "validate_password.special_char_count",
@@ -2957,7 +2975,7 @@ var systemVars = map[string]sql.SystemVariable{
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemIntType("validate_password.special_char_count", 0, 2147483647, false),
-		Default:           int8(1),
+		Default:           1,
 	},
 	"validate_user_plugins": &sql.MysqlSystemVariable{
 		Name:              "validate_user_plugins",


### PR DESCRIPTION
Changes the output of `SHOW VARIABLES` to match MySQL's output, where boolean values are shown as `ON` or `OFF`. Also adds definitions for two replication related system variables. 