### PR TITLE
Support filtering by comment in `show table status`

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4550,8 +4550,8 @@ func TestPreparedStatements(t *testing.T, harness Harness) {
 	e := mustNewEngine(t, harness)
 	defer e.Close()
 
-	for _, query := range queries.PreparedScriptTests {
-		TestScript(t, harness, query)
+	for _, script := range queries.PreparedScriptTests {
+		TestScript(t, harness, script)
 	}
 }
 
@@ -4560,6 +4560,9 @@ func TestShowTableStatus(t *testing.T, harness Harness) {
 	harness.Setup(setup.MydbData, setup.MytableData, setup.OthertableData)
 	for _, tt := range queries.ShowTableStatusQueries {
 		TestQuery(t, harness, tt.Query, tt.Expected, nil, nil)
+	}
+	for _, script := range queries.ShowTableStatusScripts {
+		TestScript(t, harness, script)
 	}
 }
 

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10815,48 +10815,6 @@ var VersionedViewTests = []QueryTest{
 	},
 }
 
-var ShowTableStatusQueries = []QueryTest{
-	{
-		Query: `SHOW TABLE STATUS FROM mydb`,
-		Expected: []sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-		},
-	},
-	{
-		Query: `SHOW TABLE STATUS LIKE '%table'`,
-		Expected: []sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-		},
-	},
-	{
-		Query: `SHOW TABLE STATUS FROM mydb LIKE 'othertable'`,
-		Expected: []sql.Row{
-			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-		},
-	},
-	{
-		Query: `SHOW TABLE STATUS WHERE Name = 'mytable'`,
-		Expected: []sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-		},
-	},
-	{
-		Query: `SHOW TABLE STATUS`,
-		Expected: []sql.Row{
-			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-		},
-	},
-	{
-		Query: `SHOW TABLE STATUS FROM mydb LIKE 'othertable'`,
-		Expected: []sql.Row{
-			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, nil},
-		},
-	},
-}
-
 func MustParseTime(layout, value string) time.Time {
 	parsed, err := time.Parse(layout, value)
 	if err != nil {

--- a/enginetest/queries/show_table_status_queries.go
+++ b/enginetest/queries/show_table_status_queries.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queries
+
+import "github.com/dolthub/go-mysql-server/sql"
+
+var ShowTableStatusQueries = []QueryTest{
+	{
+		Query: `SHOW TABLE STATUS FROM mydb`,
+		Expected: []sql.Row{
+			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+		},
+	},
+	{
+		Query: `SHOW TABLE STATUS LIKE '%table'`,
+		Expected: []sql.Row{
+			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+		},
+	},
+	{
+		Query: `SHOW TABLE STATUS FROM mydb LIKE 'othertable'`,
+		Expected: []sql.Row{
+			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+		},
+	},
+	{
+		Query: `SHOW TABLE STATUS WHERE Name = 'mytable'`,
+		Expected: []sql.Row{
+			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+		},
+	},
+	{
+		Query: `SHOW TABLE STATUS`,
+		Expected: []sql.Row{
+			{"mytable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+		},
+	},
+	{
+		Query: `SHOW TABLE STATUS FROM mydb LIKE 'othertable'`,
+		Expected: []sql.Row{
+			{"othertable", "InnoDB", "10", "Fixed", uint64(3), uint64(88), uint64(264), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, ""},
+		},
+	},
+}
+
+var ShowTableStatusScripts = []ScriptTest{
+	{
+		Name: "filter table status by comment",
+		SetUpScript: []string{
+			"create table table_with_comment(pk int, c0 int) comment = 'table comment'",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `show table status where comment = 'table comment'`,
+				Expected: []sql.Row{
+					{"table_with_comment", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, "utf8mb4_0900_bin", nil, nil, "table comment"},
+				},
+			},
+		},
+	},
+}

--- a/sql/plan/showtablestatus.go
+++ b/sql/plan/showtablestatus.go
@@ -62,7 +62,7 @@ var showTableStatusSchema = sql.Schema{
 	{Name: "Collation", Type: types.LongText},
 	{Name: "Checksum", Type: types.LongText, Nullable: true},
 	{Name: "Create_options", Type: types.LongText, Nullable: true},
-	{Name: "Comments", Type: types.LongText, Nullable: true},
+	{Name: "Comment", Type: types.LongText, Nullable: true},
 }
 
 // Children implements the sql.Node interface.

--- a/sql/rowexec/show.go
+++ b/sql/rowexec/show.go
@@ -170,22 +170,10 @@ func (b *BaseBuilder) buildShowTableStatus(ctx *sql.Context, n *plan.ShowTableSt
 			return nil, err
 		}
 
-		var numRows uint64
-		var dataLength uint64
-
-		if st, ok := table.(sql.StatisticsTable); ok {
-			numRows, _, err = st.RowCount(ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			dataLength, err = st.DataLength(ctx)
-			if err != nil {
-				return nil, err
-			}
+		rows[i], err = tableToStatusRow(ctx, table)
+		if err != nil {
+			return nil, err
 		}
-
-		rows[i] = tableToStatusRow(tName, numRows, dataLength, table.Collation())
 	}
 
 	return sql.RowsToRowIter(rows...), nil

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -73,34 +73,54 @@ func (p process) toRow() sql.Row {
 }
 
 // cc here: https://dev.mysql.com/doc/refman/8.0/en/show-table-status.html
-func tableToStatusRow(table string, numRows uint64, dataLength uint64, collation sql.CollationID) sql.Row {
+func tableToStatusRow(ctx *sql.Context, table sql.Table) (sql.Row, error) {
+	var numRows uint64
+	var dataLength uint64
+	var err error
+	if st, ok := table.(sql.StatisticsTable); ok {
+		numRows, _, err = st.RowCount(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		dataLength, err = st.DataLength(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
 	var avgLength float64 = 0
 	if numRows > 0 {
 		avgLength = float64(dataLength) / float64(numRows)
 	}
+
+	var comment string
+	if ct, ok := table.(sql.CommentedTable); ok {
+		comment = ct.Comment()
+	}
+
 	return sql.NewRow(
-		table,    // Name
-		"InnoDB", // Engine
+		table.Name(), // Name
+		"InnoDB",     // Engine
 		// This column is unused. With the removal of .frm files in MySQL 8.0, this
 		// column now reports a hardcoded value of 10, which is the last .frm file
 		// version used in MySQL 5.7.
-		"10",               // Version
-		"Fixed",            // Row_format
-		numRows,            // Rows
-		uint64(avgLength),  // Avg_row_length
-		dataLength,         // Data_length
-		uint64(0),          // Max_data_length (Unused for InnoDB)
-		int64(0),           // Index_length
-		int64(0),           // Data_free
-		nil,                // Auto_increment (always null)
-		nil,                // Create_time
-		nil,                // Update_time
-		nil,                // Check_time
-		collation.String(), // Collation
-		nil,                // Checksum
-		nil,                // Create_options
-		nil,                // Comments
-	)
+		"10",                       // Version
+		"Fixed",                    // Row_format
+		numRows,                    // Rows
+		uint64(avgLength),          // Avg_row_length
+		dataLength,                 // Data_length
+		uint64(0),                  // Max_data_length (Unused for InnoDB)
+		int64(0),                   // Index_length
+		int64(0),                   // Data_free
+		nil,                        // Auto_increment (always null)
+		nil,                        // Create_time
+		nil,                        // Update_time
+		nil,                        // Check_time
+		table.Collation().String(), // Collation
+		nil,                        // Checksum
+		nil,                        // Create_options
+		comment,                    // Comment
+	), nil
 }
 
 // generatePrivStrings creates a formatted GRANT <privilege_list> on <global/database/table> to <user@host> string

--- a/sql/rowexec/showtablestatus_test.go
+++ b/sql/rowexec/showtablestatus_test.go
@@ -35,6 +35,7 @@ func TestShowTableStatus(t *testing.T) {
 	db2 := memory.NewDatabase("b")
 	db2.AddTable("t3", memory.NewTable(db2, "t3", sql.PrimaryKeySchema{}, db2.GetForeignKeyCollection()))
 	db2.AddTable("t4", memory.NewTable(db2, "t4", sql.PrimaryKeySchema{}, db2.GetForeignKeyCollection()))
+	db2.AddTable("t5", memory.NewPartitionedTableWithCollation(db2.Database(), "t5", sql.PrimaryKeySchema{}, db2.GetForeignKeyCollection(), 0, sql.Collation_Default, "table comment"))
 
 	catalog := test.NewCatalog(sql.NewDatabaseProvider(db1, db2))
 	pro := memory.NewDBProvider(db1, db2)
@@ -51,8 +52,8 @@ func TestShowTableStatus(t *testing.T) {
 	require.NoError(err)
 
 	expected := []sql.Row{
-		{"t1", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, nil},
-		{"t2", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, nil},
+		{"t1", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, ""},
+		{"t2", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, ""},
 	}
 
 	require.ElementsMatch(expected, rows)
@@ -66,8 +67,9 @@ func TestShowTableStatus(t *testing.T) {
 	require.NoError(err)
 
 	expected = []sql.Row{
-		{"t3", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, nil},
-		{"t4", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, nil},
+		{"t3", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, ""},
+		{"t4", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, ""},
+		{"t5", "InnoDB", "10", "Fixed", uint64(0), uint64(0), uint64(0), uint64(0), int64(0), int64(0), nil, nil, nil, nil, sql.Collation_Default.String(), nil, nil, "table comment"},
 	}
 
 	require.ElementsMatch(expected, rows)


### PR DESCRIPTION
fixes dolthub/dolt#6894
- update "Comments" to "Comment" in show table status schema
- include table comment in table status row