### PR TITLE
Do not materialize any output for WindowPartitionIter if input is empty

### DIFF
--- a/enginetest/queries/logic_test_scripts.go
+++ b/enginetest/queries/logic_test_scripts.go
@@ -951,7 +951,6 @@ var SQLLogicSubqueryTests = []ScriptTest{
 				},
 			},
 			{
-				Skip:  true,
 				Query: "SELECT * FROM (SELECT c_id AS c_c_id, bill FROM c) sq1, LATERAL (SELECT row_number() OVER () AS rownum FROM o WHERE c_id = c_c_id) sq2 ORDER BY c_c_id, bill, rownum;",
 				Expected: []sql.Row{
 					{1, "CA", 1},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -11644,6 +11644,8 @@ select * from t1 except (
 				Expected: []sql.Row{},
 			},
 			{
+				// TODO: valid query in Postgres. https://github.com/dolthub/doltgresql/issues/1796
+				Dialect:  "mysql",
 				Query:    "select row_number() over () as rn from o where c_id=1",
 				Expected: []sql.Row{{1}, {2}, {3}},
 			},
@@ -11652,7 +11654,9 @@ select * from t1 except (
 				Expected: []sql.Row{},
 			},
 			{
-				Query: "select o_id, c_id, rank() over(order by o_id) as rnk from o where c_id=1",
+				// TODO: valid query in Postgres. https://github.com/dolthub/doltgresql/issues/1796
+				Dialect: "mysql",
+				Query:   "select o_id, c_id, rank() over(order by o_id) as rnk from o where c_id=1",
 				Expected: []sql.Row{
 					{10, 1, uint64(1)},
 					{20, 1, uint64(2)},
@@ -11664,7 +11668,10 @@ select * from t1 except (
 				Expected: []sql.Row{},
 			},
 			{
-				Query: "select ship, dense_rank() over (order by ship) as drnk from o where c_id in (1, 2) order by ship",
+				// TODO: valid query in Postgres. But Postgres orders nil at the end. Maybe rewrite query to filter out
+				//  ship=null https://github.com/dolthub/doltgresql/issues/1796
+				Dialect: "mysql",
+				Query:   "select ship, dense_rank() over (order by ship) as drnk from o where c_id in (1, 2) order by ship",
 				Expected: []sql.Row{
 					{nil, uint64(1)},
 					{"CA", uint64(2)},
@@ -11680,6 +11687,8 @@ select * from t1 except (
 			},
 			{
 				Query: "SELECT * FROM (SELECT c_id AS c_c_id, bill FROM c) sq1, LATERAL (SELECT row_number() OVER () AS rownum FROM o WHERE c_id = c_c_id) sq2 ORDER BY c_c_id, bill, rownum;",
+				// TODO: valid query in Postgres. https://github.com/dolthub/doltgresql/issues/1796
+				Dialect: "mysql",
 				Expected: []sql.Row{
 					{1, "CA", 1},
 					{1, "CA", 2},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -11685,22 +11685,6 @@ select * from t1 except (
 				Query:    "select count(*) from o where c_id=-999",
 				Expected: []sql.Row{{0}},
 			},
-			{
-				Query: "SELECT * FROM (SELECT c_id AS c_c_id, bill FROM c) sq1, LATERAL (SELECT row_number() OVER () AS rownum FROM o WHERE c_id = c_c_id) sq2 ORDER BY c_c_id, bill, rownum;",
-				// TODO: valid query in Postgres. https://github.com/dolthub/doltgresql/issues/1796
-				Dialect: "mysql",
-				Expected: []sql.Row{
-					{1, "CA", 1},
-					{1, "CA", 2},
-					{1, "CA", 3},
-					{2, "TX", 1},
-					{2, "TX", 2},
-					{2, "TX", 3},
-					{4, "TX", 1},
-					{4, "TX", 2},
-					{6, "FL", 1},
-				},
-			},
 		},
 	},
 }

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -16,11 +16,9 @@ package aggregation
 
 import (
 	"errors"
-	"io"
-	"reflect"
-
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 	sqlerr "gopkg.in/src-d/go-errors.v1"
+	"io"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
@@ -599,7 +597,11 @@ func isNewOrderByValue(ctx *sql.Context, orderByExprs []sql.Expression, last sql
 	}
 
 	for i := range lastExp {
-		if !reflect.DeepEqual(lastExp[i], thisExp[i]) {
+		compare, err := orderByExprs[i].Type().Compare(ctx, lastExp[i], thisExp[i])
+		if err != nil {
+			return false, err
+		}
+		if compare != 0 {
 			return true, nil
 		}
 	}

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -16,9 +16,10 @@ package aggregation
 
 import (
 	"errors"
+	"io"
+
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 	sqlerr "gopkg.in/src-d/go-errors.v1"
-	"io"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"

--- a/sql/expression/function/aggregation/window_framer.go
+++ b/sql/expression/function/aggregation/window_framer.go
@@ -17,6 +17,7 @@ package aggregation
 import (
 	"errors"
 	"io"
+	"reflect"
 
 	ast "github.com/dolthub/vitess/go/vt/sqlparser"
 	sqlerr "gopkg.in/src-d/go-errors.v1"
@@ -598,7 +599,7 @@ func isNewOrderByValue(ctx *sql.Context, orderByExprs []sql.Expression, last sql
 	}
 
 	for i := range lastExp {
-		if lastExp[i] != thisExp[i] {
+		if !reflect.DeepEqual(lastExp[i], thisExp[i]) {
 			return true, nil
 		}
 	}

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -233,9 +233,7 @@ func (i *WindowPartitionIter) initializePartitions(ctx *sql.Context) ([]sql.Wind
 // At this stage, result rows are appended with the original row index for resorting. The size of
 // [i.output] will be smaller than [i.input] if the outer sql.Node is a plan.GroupBy with fewer partitions than rows.
 func (i *WindowPartitionIter) materializeOutput(ctx *sql.Context) (sql.WindowBuffer, error) {
-	// handle nil input specially if no partition clause
-	// ex: COUNT(*) on nil rows returns 0, not nil
-	if len(i.input) == 0 && len(i.w.PartitionBy) > 0 {
+	if len(i.input) == 0 {
 		return nil, io.EOF
 	}
 

--- a/sql/expression/function/aggregation/window_partition_test.go
+++ b/sql/expression/function/aggregation/window_partition_test.go
@@ -233,7 +233,7 @@ func TestWindowPartition_MaterializeOutput(t *testing.T) {
 		require.ElementsMatch(t, nil, output)
 	})
 
-	t.Run("nil input no partition by", func(t *testing.T) {
+	t.Skip("nil input no partition by", func(t *testing.T) {
 		ctx := sql.NewEmptyContext()
 		i := NewWindowPartitionIter(
 			&WindowPartition{

--- a/sql/expression/function/aggregation/window_partition_test.go
+++ b/sql/expression/function/aggregation/window_partition_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/dolthub/go-mysql-server/memory"
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -233,23 +232,23 @@ func TestWindowPartition_MaterializeOutput(t *testing.T) {
 		require.ElementsMatch(t, nil, output)
 	})
 
-	t.Skip("nil input no partition by", func(t *testing.T) {
-		ctx := sql.NewEmptyContext()
-		i := NewWindowPartitionIter(
-			&WindowPartition{
-				PartitionBy: nil,
-				Aggs: []*Aggregation{
-					NewAggregation(NewCountAgg(expression.NewGetField(0, types.Int64, "z", true)), NewGroupByFramer()),
-				},
-			})
-		i.input = []sql.Row{}
-		i.partitions = []sql.WindowInterval{{0, 0}}
-		i.outputOrdering = nil
-		output, err := i.materializeOutput(ctx)
-		require.NoError(t, err)
-		expOutput := []sql.Row{{int64(0), nil}}
-		require.ElementsMatch(t, expOutput, output)
-	})
+	//t.Run("nil input no partition by", func(t *testing.T) {
+	//	ctx := sql.NewEmptyContext()
+	//	i := NewWindowPartitionIter(
+	//		&WindowPartition{
+	//			PartitionBy: nil,
+	//			Aggs: []*Aggregation{
+	//				NewAggregation(NewCountAgg(expression.NewGetField(0, types.Int64, "z", true)), NewGroupByFramer()),
+	//			},
+	//		})
+	//	i.input = []sql.Row{}
+	//	i.partitions = []sql.WindowInterval{{0, 0}}
+	//	i.outputOrdering = nil
+	//	output, err := i.materializeOutput(ctx)
+	//	require.NoError(t, err)
+	//	expOutput := []sql.Row{{int64(0), nil}}
+	//	require.ElementsMatch(t, expOutput, output)
+	//})
 }
 
 func TestWindowPartition_SortAndFilterOutput(t *testing.T) {

--- a/sql/expression/function/aggregation/window_partition_test.go
+++ b/sql/expression/function/aggregation/window_partition_test.go
@@ -215,7 +215,7 @@ func TestWindowPartition_MaterializeOutput(t *testing.T) {
 		require.ElementsMatch(t, expOutput, output)
 	})
 
-	t.Run("nil input with partition by", func(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
 		ctx := sql.NewEmptyContext()
 		i := NewWindowPartitionIter(
 			&WindowPartition{
@@ -231,24 +231,6 @@ func TestWindowPartition_MaterializeOutput(t *testing.T) {
 		require.Equal(t, io.EOF, err)
 		require.ElementsMatch(t, nil, output)
 	})
-
-	//t.Run("nil input no partition by", func(t *testing.T) {
-	//	ctx := sql.NewEmptyContext()
-	//	i := NewWindowPartitionIter(
-	//		&WindowPartition{
-	//			PartitionBy: nil,
-	//			Aggs: []*Aggregation{
-	//				NewAggregation(NewCountAgg(expression.NewGetField(0, types.Int64, "z", true)), NewGroupByFramer()),
-	//			},
-	//		})
-	//	i.input = []sql.Row{}
-	//	i.partitions = []sql.WindowInterval{{0, 0}}
-	//	i.outputOrdering = nil
-	//	output, err := i.materializeOutput(ctx)
-	//	require.NoError(t, err)
-	//	expOutput := []sql.Row{{int64(0), nil}}
-	//	require.ElementsMatch(t, expOutput, output)
-	//})
 }
 
 func TestWindowPartition_SortAndFilterOutput(t *testing.T) {


### PR DESCRIPTION
Fixes dolthub/dolt#6899
The comment about `count` doesn't seem to apply since `count` is an aggregation and not a window function.

Also fixes bug in Dolt where `dense_rank` was not working because text storage objects were not being compared properly.