### PR TITLE
Allow aggregate/window functions with match expressions

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -11688,7 +11688,8 @@ select * from t1 except (
 		},
 	},
 	{
-		Name: "aggregate function with match",
+		Name:    "aggregate function with match",
+		Dialect: "mysql",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk INT PRIMARY KEY, doc TEXT, FULLTEXT idx (doc));",
 			"INSERT INTO test VALUES (2, 'g hhhh aaaab ooooo aaaa'), (1, 'bbbb ff cccc ddd eee'), (4, 'AAAA aaaa aaaac aaaa Aaaa aaaa'), (3, 'aaaA ff j kkkk llllllll');",

--- a/sql/planbuilder/scalar.go
+++ b/sql/planbuilder/scalar.go
@@ -1015,10 +1015,6 @@ func (b *Builder) ConvertVal(v *ast.SQLVal) sql.Expression {
 // filter, since we only need to load the tables once. All steps after this
 // one can assume that the expression has been fully resolved and is valid.
 func (b *Builder) buildMatchAgainst(inScope *scope, v *ast.MatchExpr) *expression.MatchAgainst {
-	// TODO: implement proper scope support and remove this check
-	if (inScope.groupBy != nil && inScope.groupBy.hasAggs()) || inScope.windowFuncs != nil {
-		b.handleErr(fmt.Errorf("aggregate and window functions are not yet supported alongside MATCH expressions"))
-	}
 	rts := getTablesByName(inScope.node)
 	var rt *plan.ResolvedTable
 	var matchTable string


### PR DESCRIPTION
fixes dolthub/dolt#6556

Seems like the scoping issue has already been fixed.