### PR TITLE
fix update join with conflicting aliases

### DIFF
--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -597,9 +597,9 @@ var UpdateScriptTests = []ScriptTest{
 		},
 	},
 	{
-		Dialect: "mysql",
 		// https://github.com/dolthub/dolt/issues/9403
-		Name: "UPDATE join – multiple tables with same column names with triggers",
+		Dialect: "mysql",
+		Name:    "UPDATE join – multiple tables with same column names with triggers",
 		SetUpScript: []string{
 			"create table customers (id int primary key, name text, tier text)",
 			"create table orders (id int primary key, customer_id int, status text)",
@@ -632,8 +632,54 @@ var UpdateScriptTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "UPDATE with subquery in keyless tables",
+		Dialect: "mysql",
+		Name:    "UPDATE join - conflicting alias in Subquery Alias",
+		SetUpScript: []string{
+			"create table parent (id int primary key);",
+			"insert into parent values (1), (2), (3);",
+			"create table child (id int primary key, pid int, foreign key (pid) references parent(id), oid int);",
+			"insert into child values (1, 1, 0), (2, 2, 0), (3, 3, 0);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `
+update child t1
+left join 
+(
+    select
+        t1.id
+    from
+        child t1
+    ) sqa
+    on
+        t1.id = sqa.id
+    join
+        child t2
+    set
+    t1.oid = t2.pid;`,
+				Expected: []sql.Row{
+					{types.OkResult{
+						RowsAffected: 3,
+						Info: plan.UpdateInfo{
+							Matched: 3,
+							Updated: 3,
+						},
+					}},
+				},
+			},
+			{
+				Query: "select * from child;",
+				Expected: []sql.Row{
+					{1, 1, 1},
+					{2, 2, 1},
+					{3, 3, 1},
+				},
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/9334
+		Name: "UPDATE with subquery in keyless tables",
 		SetUpScript: []string{
 			"create table t (i int)",
 			"insert into t values (1)",

--- a/enginetest/queries/update_queries.go
+++ b/enginetest/queries/update_queries.go
@@ -650,13 +650,13 @@ left join
         t1.id
     from
         child t1
-    ) sqa
-    on
-        t1.id = sqa.id
-    join
-        child t2
-    set
-    t1.oid = t2.pid;`,
+) sqa
+on
+    t1.id = sqa.id
+join
+    child t2
+set
+t1.oid = t2.pid;`,
 				Expected: []sql.Row{
 					{types.OkResult{
 						RowsAffected: 3,

--- a/sql/analyzer/apply_foreign_keys.go
+++ b/sql/analyzer/apply_foreign_keys.go
@@ -127,8 +127,7 @@ func applyForeignKeysToNodes(ctx *sql.Context, a *Analyzer, n sql.Node, cache *f
 			fkHandlerMap := make(map[string]sql.Node, len(updateTargets))
 			for tableName, updateTarget := range updateTargets {
 				fkHandlerMap[tableName] = updateTarget
-				fkHandler, err :=
-					getForeignKeyHandlerFromUpdateTarget(ctx, a, updateTarget, cache, fkChain)
+				fkHandler, err := getForeignKeyHandlerFromUpdateTarget(ctx, a, updateTarget, cache, fkChain)
 				if err != nil {
 					return nil, transform.SameTree, err
 				}

--- a/sql/analyzer/tables.go
+++ b/sql/analyzer/tables.go
@@ -100,8 +100,10 @@ func getResolvedTable(node sql.Node) *plan.ResolvedTable {
 // getTablesByName takes a node and returns all found resolved tables in a map.
 func getTablesByName(node sql.Node) map[string]*plan.ResolvedTable {
 	ret := make(map[string]*plan.ResolvedTable)
-
-	transform.Inspect(node, func(node sql.Node) bool {
+	// TODO: We should change transform.Inspect to not walk the children of sql.OpaqueNodes (like transform.Node)
+	//  and add a transform.InspectWithOpaque that does.
+	//  Using transform.Node here achieves the same result without a large refactor.
+	transform.Node(node, func(node sql.Node) (sql.Node, transform.TreeIdentity, error) {
 		switch n := node.(type) {
 		case *plan.ResolvedTable:
 			ret[strings.ToLower(n.Table.Name())] = n
@@ -109,17 +111,15 @@ func getTablesByName(node sql.Node) map[string]*plan.ResolvedTable {
 			rt, ok := n.TableNode.(*plan.ResolvedTable)
 			if ok {
 				ret[strings.ToLower(rt.Name())] = rt
-				return false
+				return nil, transform.SameTree, nil
 			}
 		case *plan.TableAlias:
 			rt := getResolvedTable(n)
 			if rt != nil {
 				ret[n.Name()] = rt
 			}
-		default:
 		}
-		return true
+		return nil, transform.SameTree, nil
 	})
-
 	return ret
 }

--- a/sql/analyzer/tables.go
+++ b/sql/analyzer/tables.go
@@ -98,6 +98,7 @@ func getResolvedTable(node sql.Node) *plan.ResolvedTable {
 }
 
 // getTablesByName takes a node and returns all found resolved tables in a map.
+// This function will not look inside sql.OpaqueNodes (like plan.SubqueryAlias).
 func getTablesByName(node sql.Node) map[string]*plan.ResolvedTable {
 	ret := make(map[string]*plan.ResolvedTable)
 	// TODO: We should change transform.Inspect to not walk the children of sql.OpaqueNodes (like transform.Node)
@@ -111,7 +112,6 @@ func getTablesByName(node sql.Node) map[string]*plan.ResolvedTable {
 			rt, ok := n.TableNode.(*plan.ResolvedTable)
 			if ok {
 				ret[strings.ToLower(rt.Name())] = rt
-				return nil, transform.SameTree, nil
 			}
 		case *plan.TableAlias:
 			rt := getResolvedTable(n)

--- a/sql/plan/common.go
+++ b/sql/plan/common.go
@@ -164,7 +164,7 @@ func getTableName(nodeToSearch sql.Node) string {
 	return ""
 }
 
-// GetTablesToBeUpdated takes a node and looks for the tables to modified by a SetField.
+// GetTablesToBeUpdated takes a node and looks for the tables modified by a SetField.
 func GetTablesToBeUpdated(node sql.Node) map[string]struct{} {
 	ret := make(map[string]struct{})
 

--- a/sql/plan/subqueryalias.go
+++ b/sql/plan/subqueryalias.go
@@ -44,6 +44,7 @@ type SubqueryAlias struct {
 var _ sql.Node = (*SubqueryAlias)(nil)
 var _ sql.CollationCoercible = (*SubqueryAlias)(nil)
 var _ sql.RenameableNode = (*SubqueryAlias)(nil)
+var _ sql.OpaqueNode = (*SubqueryAlias)(nil)
 
 // NewSubqueryAlias creates a new SubqueryAlias node.
 func NewSubqueryAlias(name, textDefinition string, node sql.Node) *SubqueryAlias {


### PR DESCRIPTION
Update joins with SubqueryAlias with TableAlias matching an outer TableAlias would result in the incorrect table getting picked when resolving Foreign Keys. Fix here is to not Inspect OpaqueNodes to avoid incorrectly overriding any aliases; they shouldn't be visible anyway.