### PR TITLE
Initialize newChildren with node.Children to avoid nil child during replaceIdxSort

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -11757,6 +11757,29 @@ select * from t1 except (
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/9789
+		Name: "order by on empty set from joins",
+		SetUpScript: []string{
+			"create table t0(c0 int, primary key(c0))",
+			"create table t1(c0 int)",
+			"create table t2(c0 int)",
+			"create table t3(c0 int)",
+			"insert into t0 values (1)",
+			"insert into t1 values (1)",
+			"insert into t2 values (1)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "select * from t2, t3, t0, t1",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from t2, t3, t0, t1 order by t0.c0",
+				Expected: []sql.Row{},
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -145,8 +145,10 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 	}
 
 	allSame := transform.SameTree
-	newChildren := make([]sql.Node, len(node.Children()))
-	for i, child := range node.Children() {
+	children := node.Children()
+	newChildren := make([]sql.Node, len(children))
+	copy(newChildren, children)
+	for i, child := range children {
 		var err error
 		same := transform.SameTree
 		switch c := child.(type) {
@@ -213,14 +215,11 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 					c.IsReversed = true
 				}
 			}
-
 			newChildren[i], err = c.WithChildren(newLeft, newRight)
 			if err != nil {
 				return nil, transform.SameTree, err
 			}
 			allSame = false
-		default:
-			newChildren[i] = c
 		}
 		if err != nil {
 			return nil, transform.SameTree, err

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -146,8 +146,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 
 	allSame := transform.SameTree
 	children := node.Children()
-	newChildren := make([]sql.Node, len(children))
-	copy(newChildren, children)
+	newChildren := node.Children()
 	for i, child := range children {
 		var err error
 		same := transform.SameTree


### PR DESCRIPTION
fixes dolthub/dolt#9789

`continue` in JoinNode case was resulting in nil child in newChildren array. This would later cause a panic when child would be referenced.