### PR TITLE
Do not push down filters for Full Outer joins

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -2112,6 +2112,47 @@ WHERE
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/9793
+		name: "outer join on false",
+		setup: [][]string{
+			{
+				"create table t1(c0 int)",
+				"create table t2(c0 int)",
+				"insert into t1 values (1)",
+				"insert into t2 values (1)",
+			},
+		},
+		tests: []JoinOpTests{
+			{
+				Query: "select * from t1 full outer join t2 on false",
+				Expected: []sql.Row{
+					{1, nil},
+					{nil, 1},
+				},
+			},
+			{
+				Query:    "select * from t1 full outer join t2 on false where t2.c0 is not null and t1.c0 is not null",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from t1 left outer join t2 on false",
+				Expected: []sql.Row{{1, nil}},
+			},
+			{
+				Query:    "select * from t1 left outer join t2 on false where t2.c0 is not null",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select * from t1 right outer join t2 on false",
+				Expected: []sql.Row{{nil, 1}},
+			},
+			{
+				Query:    "select * from t1 right outer join t2 on false where t1.c0 is not null",
+				Expected: []sql.Row{},
+			},
+		},
+	},
 }
 
 var rangeJoinOpTests = []JoinOpTests{

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -157,11 +157,10 @@ func canDoPushdown(n sql.Node) bool {
 	return true
 }
 
-// Pushing down a filter is incompatible with the secondary table in a Left
-// or Right join. If we push a predicate on the secondary table below the
-// join, we end up not evaluating it in all cases (since the secondary table
-// result is sometimes null in these types of joins). It must be evaluated
-// only after the join result is computed.
+// Pushing down a filter is incompatible with the secondary table in a Left or Right join. If we push a predicate on the
+// secondary table below the join, we end up not evaluating it in all cases (since the secondary table result is
+// sometimes null in these types of joins). It must be evaluated only after the join result is computed. This is also
+// true with both tables in a Full Outer join, since either table result could be null.
 func filterPushdownChildSelector(c transform.Context) bool {
 	switch c.Node.(type) {
 	case *plan.Limit:
@@ -178,6 +177,8 @@ func filterPushdownChildSelector(c transform.Context) bool {
 		return false
 	case *plan.JoinNode:
 		switch {
+		case n.Op.IsFullOuter():
+			return false
 		case n.Op.IsMerge():
 			return false
 		case n.Op.IsLookup():


### PR DESCRIPTION
fixes dolthub/dolt#9793

Filters for Full Outer joins should not be evaluated until after tables have been joined.