### PR TITLE
fix equality check in `buildSingleLookupPlan()`

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -200,22 +200,30 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name:        "AS OF propagates to nested CALLs",
-			SetUpScript: []string{},
+			Name: "test",
+			SetUpScript: []string{
+				"create table t1 (i int primary key);",
+				"create table t2 (j int);",
+				"create table t3 (k int);",
+				"insert into t1 values (1), (2);",
+				"insert into t2 values (1), (2);",
+				"insert into t3 values (3);",
+			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query: "create procedure create_proc() create table t (i int primary key, j int);",
-					Expected: []sql.Row{
-						{types.NewOkResult(0)},
-					},
+					Query:    "select * from t1 cross join t2 join (select * from t3) v3 on v3.k = t2.j;",
+					Expected: []sql.Row{},
 				},
 				{
-					Query: "call create_proc()",
+					Query: "select * from t1 cross join t2 join (select * from t3) v3 on v3.k >= t2.j order by i, j, k;",
 					Expected: []sql.Row{
-						{types.NewOkResult(0)},
+						{1, 1, 3},
+						{1, 2, 3},
+						{2, 1, 3},
+						{2, 2, 3},
 					},
 				},
 			},
@@ -230,8 +238,8 @@ func TestSingleScript(t *testing.T) {
 			panic(err)
 		}
 
-		//engine.EngineAnalyzer().Debug = true
-		//engine.EngineAnalyzer().Verbose = true
+		engine.EngineAnalyzer().Debug = true
+		engine.EngineAnalyzer().Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -200,30 +200,22 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	//t.Skip()
+	t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name: "test",
-			SetUpScript: []string{
-				"create table t1 (i int primary key);",
-				"create table t2 (j int);",
-				"create table t3 (k int);",
-				"insert into t1 values (1), (2);",
-				"insert into t2 values (1), (2);",
-				"insert into t3 values (3);",
-			},
+			Name:        "AS OF propagates to nested CALLs",
+			SetUpScript: []string{},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query:    "select * from t1 cross join t2 join (select * from t3) v3 on v3.k = t2.j;",
-					Expected: []sql.Row{},
+					Query: "create procedure create_proc() create table t (i int primary key, j int);",
+					Expected: []sql.Row{
+						{types.NewOkResult(0)},
+					},
 				},
 				{
-					Query: "select * from t1 cross join t2 join (select * from t3) v3 on v3.k >= t2.j order by i, j, k;",
+					Query: "call create_proc()",
 					Expected: []sql.Row{
-						{1, 1, 3},
-						{1, 2, 3},
-						{2, 1, 3},
-						{2, 2, 3},
+						{types.NewOkResult(0)},
 					},
 				},
 			},
@@ -238,8 +230,8 @@ func TestSingleScript(t *testing.T) {
 			panic(err)
 		}
 
-		engine.EngineAnalyzer().Debug = true
-		engine.EngineAnalyzer().Verbose = true
+		//engine.EngineAnalyzer().Debug = true
+		//engine.EngineAnalyzer().Verbose = true
 
 		enginetest.TestScriptWithEngine(t, engine, harness, test)
 	}

--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -285,7 +285,7 @@ func (j *joinOrderBuilder) buildSingleLookupPlan() bool {
 			}
 			filter := edge.filters[0]
 			_, tables, _ := getExprScalarProps(filter)
-			if tables.Len() != 2 {
+			if tables.Len() != 2 || !isSimpleEquality(filter) {
 				// We have encountered a filter condition more complicated than a simple equality check.
 				// We probably can't optimize this, so bail out.
 				return false
@@ -319,7 +319,6 @@ func (j *joinOrderBuilder) buildSingleLookupPlan() bool {
 			for idx, ok := remainingVertexes.next(0); ok; idx, ok = remainingVertexes.next(idx + 1) {
 				nextVertex := newBitSet(idx)
 				j.addJoin(plan.JoinTypeCross, currentlyJoinedVertexes, nextVertex, nil, nil, false)
-
 				currentlyJoinedVertexes = currentlyJoinedVertexes.union(nextVertex)
 			}
 			return false

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -538,6 +538,18 @@ func getExprScalarProps(e sql.Expression) (sql.ColSet, sql.FastIntSet, bool) {
 	return cols, tables, nullRej
 }
 
+func isSimpleEquality(expr sql.Expression) bool {
+	hasOnlyEquals := true
+	transform.InspectExpr(expr, func(e sql.Expression) bool {
+		if _, isEq := e.(*expression.Equals); !isEq {
+			hasOnlyEquals = false
+			return true
+		}
+		return false
+	})
+	return hasOnlyEquals
+}
+
 // allTableCols returns the full schema of a table ignoring
 // declared projections.
 func allTableCols(rel SourceRel) sql.Schema {

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -543,7 +543,7 @@ func isSimpleEquality(expr sql.Expression) bool {
 	transform.InspectExpr(expr, func(e sql.Expression) bool {
 		switch e.(type) {
 		case *expression.GetField:
-		case *expression.Equals:
+		case *expression.Equals, *expression.NullSafeEquals:
 		default:
 			hasOnlyEquals = false
 			return true

--- a/sql/memo/rel_props.go
+++ b/sql/memo/rel_props.go
@@ -541,7 +541,10 @@ func getExprScalarProps(e sql.Expression) (sql.ColSet, sql.FastIntSet, bool) {
 func isSimpleEquality(expr sql.Expression) bool {
 	hasOnlyEquals := true
 	transform.InspectExpr(expr, func(e sql.Expression) bool {
-		if _, isEq := e.(*expression.Equals); !isEq {
+		switch e.(type) {
+		case *expression.GetField:
+		case *expression.Equals:
+		default:
 			hasOnlyEquals = false
 			return true
 		}


### PR DESCRIPTION
A join optimization to generate look up plans was incorrectly being applied to filters that were not simple equalities.
This resulted in filters getting dropped and incorrect results.

fixes: https://github.com/dolthub/dolt/issues/9803