### PR TITLE
Convert values to strings when evaluating `bit_length`

### DIFF
--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -573,6 +573,15 @@ var FunctionQueryTests = []QueryTest{
 		},
 	},
 	{
+		// https://github.com/dolthub/dolt/issues/9818
+		Query:    "select bit_length(10)",
+		Expected: []sql.Row{{16}},
+	},
+	{
+		Query:    "select bit_length(now())",
+		Expected: []sql.Row{{152}},
+	},
+	{
 		Query: "select date_format(datetime_col, '%D') from datetime_table order by 1",
 		Expected: []sql.Row{
 			{"1st"},

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -569,7 +569,7 @@ var FunctionQueryTests = []QueryTest{
 	{
 		Query: "SELECT BIT_LENGTH(i) from mytable order by i limit 1",
 		Expected: []sql.Row{
-			{64},
+			{8},
 		},
 	},
 	{

--- a/enginetest/queries/function_queries.go
+++ b/enginetest/queries/function_queries.go
@@ -582,6 +582,14 @@ var FunctionQueryTests = []QueryTest{
 		Expected: []sql.Row{{152}},
 	},
 	{
+		Query:    "select bit_length(-10)",
+		Expected: []sql.Row{{24}},
+	},
+	{
+		Query:    "select bit_length(true)",
+		Expected: []sql.Row{{8}},
+	},
+	{
 		Query: "select date_format(datetime_col, '%D') from datetime_table order by 1",
 		Expected: []sql.Row{
 			{"1st"},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -9467,6 +9467,14 @@ where
 				},
 			},
 			{
+				Query: "select e, bit_length(e) from t order by e;",
+				Expected: []sql.Row{
+					{"abc", 24},
+					{"defg", 32},
+					{"hijkl", 40},
+				},
+			},
+			{
 				Query: "select e, concat(e, 'test') from t order by e;",
 				Expected: []sql.Row{
 					{"abc", "abctest"},
@@ -10127,6 +10135,15 @@ where
 					{"defg", 4},
 					{"abc,defg", 8},
 					{"abc,defg,hijkl", 14},
+				},
+			},
+			{
+				Query: "select s, bit_length(s) from t order by s;",
+				Expected: []sql.Row{
+					{"abc", 24},
+					{"defg", 32},
+					{"abc,defg", 64},
+					{"abc,defg,hijkl", 112},
 				},
 			},
 			{

--- a/sql/expression/function/string_test.go
+++ b/sql/expression/function/string_test.go
@@ -143,24 +143,14 @@ func TestBinFunc(t *testing.T) {
 }
 
 func TestBitLength(t *testing.T) {
-	f := sql.Function1{Name: "bin", Fn: NewBitlength}
+	f := sql.Function1{Name: "bit_length", Fn: NewBitlength}
 	tf := NewTestFactory(f.Fn)
 	tf.AddSucceeding(nil, nil)
 	tf.AddSucceeding(32, "test")
 	tf.AddSucceeding(8, true)
-	tf.AddSucceeding(8, int8(0))
-	tf.AddSucceeding(8, uint8(0))
-	tf.AddSucceeding(16, int16(0))
-	tf.AddSucceeding(16, uint16(0))
-	tf.AddSucceeding(32, uint32(0))
-	tf.AddSucceeding(32, int32(0))
-	tf.AddSucceeding(32, uint(0))
-	tf.AddSucceeding(32, 0)
-	tf.AddSucceeding(64, uint64(0))
-	tf.AddSucceeding(64, int64(0))
-	tf.AddSucceeding(64, float64(0))
-	tf.AddSucceeding(32, float32(0))
-	tf.AddSucceeding(128, time.Now())
+	tf.AddSucceeding(8, 0)
+	tf.AddSucceeding(16, 10)
+	tf.AddSucceeding(24, -10)
 	tf.Test(t, nil, nil)
 }
 


### PR DESCRIPTION
Fixes dolthub/dolt#9818