### PR TITLE
Do not return EOF in existsIter when right iter is empty

### DIFF
--- a/enginetest/join_op_tests.go
+++ b/enginetest/join_op_tests.go
@@ -1977,12 +1977,14 @@ SELECT SUM(x) FROM xy WHERE x IN (
 		},
 	},
 	{
-		name: "where not exists",
+		name: "where exists and where not exists",
 		setup: [][]string{
 			setup.XyData[0],
 			{
 				"create table t(c varchar(500))",
 				"insert into t values ('a'),('a')",
+				"create table u(c0 int, c1 int, primary key(c0, c1))",
+				"insert into u values (1, 1),(2,2),(2,3)",
 			},
 		},
 		tests: []JoinOpTests{
@@ -1991,9 +1993,41 @@ SELECT SUM(x) FROM xy WHERE x IN (
 				Expected: []sql.Row{{1, 0}, {3, nil}},
 			},
 			{
+				Query:    "select x from xy where exists (select 1 from ab where ab.b = -1)",
+				Expected: []sql.Row{},
+			},
+			{
+				Query:    "select x from xy where exists (select 1 from ab where ab.b = xy.y)",
+				Expected: []sql.Row{{0}, {2}},
+			},
+			{
+				Query:    "select x from xy where not exists (select 1 from ab where ab.b = xy.y)",
+				Expected: []sql.Row{{1}, {3}},
+			},
+			{
+				Query:    "select x from xy_hasnull where not exists(select 1 from ab_hasnull where ab_hasnull.b <> xy_hasnull.y)",
+				Expected: []sql.Row{{3}},
+			},
+			{
+				// TODO: this fails as a merge join. it seems related to https://github.com/dolthub/dolt/issues/9797
+				Skip:     true,
+				Query:    "select x from xy_hasnull_idx where exists(select 1 from rs where rs.s = xy_hasnull_idx.y)",
+				Expected: []sql.Row{{1}},
+			},
+			{
+				Query:    "select x from xy_hasnull_idx where not exists(select 1 from rs where rs.s = xy_hasnull_idx.y)",
+				Expected: []sql.Row{{2}, {0}, {3}},
+			},
+			{
 				// https://github.com/dolthub/dolt/issues/9828
 				Query:    "with v as (select 'a' as c where false) select null from t where not exists (select 1 from v where v.c <> t.c);",
 				Expected: []sql.Row{{nil}, {nil}},
+			},
+			{
+				// https://github.com/dolthub/dolt/issues/9797
+				Skip:     true,
+				Query:    "select * from u where exists (select 1 from u as x where x.c0 = u.c0)",
+				Expected: []sql.Row{{1, 1}, {2, 2}, {2, 3}},
 			},
 		},
 	},

--- a/enginetest/join_planning_tests.go
+++ b/enginetest/join_planning_tests.go
@@ -1943,24 +1943,28 @@ func evalIndexTest(t *testing.T, harness Harness, e QueryEngine, q string, index
 	})
 }
 
-func evalJoinCorrectness(t *testing.T, harness Harness, e QueryEngine, name, q string, exp []sql.Row, skipOld bool) {
-	t.Run(name, func(t *testing.T) {
-		ctx := NewContext(harness)
-		ctx = ctx.WithQuery(q)
+func evalJoinCorrectness(t *testing.T, harness Harness, e QueryEngine, name, q string, exp []sql.Row, skip bool) {
+	if skip {
+		t.Skip()
+	} else {
+		t.Run(name, func(t *testing.T) {
+			ctx := NewContext(harness)
+			ctx = ctx.WithQuery(q)
 
-		sch, iter, _, err := e.QueryWithBindings(ctx, q, nil, nil, nil)
-		require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
+			sch, iter, _, err := e.QueryWithBindings(ctx, q, nil, nil, nil)
+			require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
 
-		rows, err := sql.RowIterToRows(ctx, iter)
-		require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
+			rows, err := sql.RowIterToRows(ctx, iter)
+			require.NoError(t, err, "Unexpected error for query %s: %s", q, err)
 
-		if exp != nil {
-			CheckResults(ctx, t, harness, exp, nil, sch, rows, q, e)
-		}
+			if exp != nil {
+				CheckResults(ctx, t, harness, exp, nil, sch, rows, q, e)
+			}
 
-		require.Equal(t, 0, ctx.Memory.NumCaches())
-		validateEngine(t, ctx, harness, e)
-	})
+			require.Equal(t, 0, ctx.Memory.NumCaches())
+			validateEngine(t, ctx, harness, e)
+		})
+	}
 }
 
 func collectJoinTypes(n sql.Node) []plan.JoinType {

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -311,10 +311,10 @@ func (i *existsIter) Next(ctx *sql.Context) (sql.Row, error) {
 					if i.nullRej {
 						// Filter is null-rejecting: need to run condition once with nil right so NULL can propagate
 						// and row may be excluded
-						nextState = esRet
+						nextState = esCompare
 					} else {
 						// Filter is not null-rejecting: no matches possible, row passes
-						nextState = esCompare
+						nextState = esRet
 					}
 				default:
 					nextState = esCompare


### PR DESCRIPTION
fixes dolthub/dolt#9828

Returning EOF was causing us to terminate the existsIter early

Added tests for dolthub/dolt#9797