### PR TITLE
dolthub/go-mysql-server#3216: Fix `UNION ALL` with `NULL BLOB SELECT` returning `NULL` for all vals

### DIFF
--- a/sql/expression/convert.go
+++ b/sql/expression/convert.go
@@ -120,6 +120,10 @@ func GetConvertToType(l, r sql.Type) string {
 	}
 
 	if !types.IsNumber(l) || !types.IsNumber(r) {
+		// Special handling for BLOB types - preserve binary data
+		if types.IsBlobType(l) || types.IsBlobType(r) {
+			return ConvertToBinary
+		}
 		return ConvertToChar
 	}
 


### PR DESCRIPTION
Fixes #3216 