### PR TITLE
sql/rowexec: Add a SessionCommandSafepoint session callback for long-running write commands. Call it in some rowexec implementations.

### DIFF
--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -570,7 +570,8 @@ func (i *modifyColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTabl
 		return false, err
 	}
 
-	rowIter := sql.NewTableRowIter(ctx, rwt, partitions)
+	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 	for {
 		r, err := rowIter.Next(ctx)
 		if err == io.EOF {
@@ -1117,7 +1118,8 @@ func (c *createPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) e
 		return err
 	}
 
-	rowIter := sql.NewTableRowIter(ctx, rwt, partitions)
+	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	for {
 		r, err := rowIter.Next(ctx)
@@ -1221,7 +1223,8 @@ func (d *dropPkIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) err
 		return err
 	}
 
-	rowIter := sql.NewTableRowIter(ctx, rwt, partitions)
+	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	for {
 		r, err := rowIter.Next(ctx)
@@ -1329,6 +1332,7 @@ func (i *addColumnIter) UpdateRowsWithDefaults(ctx *sql.Context, table sql.Table
 	if err != nil {
 		return err
 	}
+	tableIter = withSafepointPeriodicallyIter(tableIter)
 
 	schema := updatable.Schema()
 	idx := -1
@@ -1430,7 +1434,8 @@ func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) 
 		return false, err
 	}
 
-	rowIter := sql.NewTableRowIter(ctx, rwt, partitions)
+	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	var val uint64
 	var autoTbl sql.AutoIncrementTable
@@ -1740,7 +1745,8 @@ func (i *dropColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable)
 		return false, err
 	}
 
-	rowIter := sql.NewTableRowIter(ctx, rwt, partitions)
+	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	for {
 		r, err := rowIter.Next(ctx)
@@ -1849,6 +1855,7 @@ func (b *BaseBuilder) executeCreateCheck(ctx *sql.Context, c *plan.CreateCheck) 
 	if err != nil {
 		return err
 	}
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	for {
 		row, err := rowIter.Next(ctx)
@@ -2252,7 +2259,8 @@ func buildIndex(ctx *sql.Context, n *plan.AlterIndex, ibt sql.IndexBuildingTable
 		return err
 	}
 
-	rowIter := sql.NewTableRowIter(ctx, ibt, partitions)
+	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, ibt, partitions)
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	// Our table scan needs to include projections for virtual columns if there are any
 	isVirtual := ibt.Schema().HasVirtualColumns()
@@ -2339,7 +2347,8 @@ func rewriteTableForIndexCreate(ctx *sql.Context, n *plan.AlterIndex, table sql.
 		return err
 	}
 
-	rowIter := sql.NewTableRowIter(ctx, rwt, partitions)
+	var rowIter sql.RowIter = sql.NewTableRowIter(ctx, rwt, partitions)
+	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	isVirtual := table.Schema().HasVirtualColumns()
 	var projections []sql.Expression

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -1855,7 +1855,6 @@ func (b *BaseBuilder) executeCreateCheck(ctx *sql.Context, c *plan.CreateCheck) 
 	if err != nil {
 		return err
 	}
-	rowIter = withSafepointPeriodicallyIter(rowIter)
 
 	for {
 		row, err := rowIter.Next(ctx)

--- a/sql/rowexec/dml_iters.go
+++ b/sql/rowexec/dml_iters.go
@@ -638,6 +638,19 @@ func withSafepointPeriodicallyIter(child sql.RowIter) *safepointPeriodicallyIter
 	return &safepointPeriodicallyIter{child: child}
 }
 
+// A wrapper iterator which calls sql.SessionCommandSafepoint on the
+// ctx.Session periodically while returning rows through calls to
+// |Next|.
+//
+// Should be used to wrap any iterators which are involved in
+// long-running write operations and which are exhausted or iterated
+// by other iterators in the iterator tree, such as accumulatorIter.
+//
+// This iterator makes the assumption that a safepoint, from the
+// Engine's perspective, can be established at any moment we are
+// within a Next() call. This is generally true given the Engine's
+// lack of concurrency on a given Session, but if something like
+// Exchange node came back, this would not necessarily be true.
 type safepointPeriodicallyIter struct {
 	child sql.RowIter
 	n     int

--- a/sql/rowexec/proc.go
+++ b/sql/rowexec/proc.go
@@ -340,6 +340,7 @@ func (b *BaseBuilder) buildLoop(ctx *sql.Context, n *plan.Loop, row sql.Row) (sq
 				return nil, err
 			}
 		}
+		loopBodyIter = withSafepointPeriodicallyIter(loopBodyIter)
 
 		includeResultSet := false
 

--- a/sql/session.go
+++ b/sql/session.go
@@ -229,6 +229,15 @@ type LifecycleAwareSession interface {
 	SessionEnd()
 }
 
+// An optional Lifecycle callback which a session can receive. This can be
+// delivered periodically during a long running operation, between the
+// CommandBegin and CommandEnd calls. Across the call to this method, the
+// gms.Egnine is not accessing the session or any of its state, such as
+// table editors, database providers, etc.
+type SafepointAwareSession interface {
+	CommandSafepoint()
+}
+
 type (
 	// TypedValue is a value along with its type.
 	TypedValue struct {
@@ -760,6 +769,13 @@ func SessionCommandBegin(s Session) error {
 func SessionCommandEnd(s Session) {
 	if cur, ok := s.(LifecycleAwareSession); ok {
 		cur.CommandEnd()
+	}
+}
+
+// Helper function to call CommandSafepoint on a SafepointAwareSession, or do nothing.
+func SessionCommandSafepoint(s Session) {
+	if cur, ok := s.(SafepointAwareSession); ok {
+		cur.CommandSafepoint()
 	}
 }
 

--- a/sql/session.go
+++ b/sql/session.go
@@ -232,7 +232,7 @@ type LifecycleAwareSession interface {
 // An optional Lifecycle callback which a session can receive. This can be
 // delivered periodically during a long running operation, between the
 // CommandBegin and CommandEnd calls. Across the call to this method, the
-// gms.Egnine is not accessing the session or any of its state, such as
+// gms.Engine is not accessing the session or any of its state, such as
 // table editors, database providers, etc.
 type SafepointAwareSession interface {
 	CommandSafepoint()


### PR DESCRIPTION
This allows for integrators to see quiesced states on engine session utilization even on very long running write operations.