### PR TITLE
[no-release-notes] Add default VarChar and VarBinary types to `types/strings.go`

### DIFF
--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -73,6 +73,9 @@ var (
 	MediumBlob = MustCreateBinary(sqltypes.Blob, MediumTextBlobMax)
 	LongBlob   = MustCreateBinary(sqltypes.Blob, LongTextBlobMax)
 
+	VarChar   = MustCreateStringWithDefaults(sqltypes.VarChar, varcharVarbinaryMax)
+	VarBinary = MustCreateBinary(sqltypes.VarBinary, varcharVarbinaryMax)
+
 	stringValueType = reflect.TypeOf(string(""))
 	byteValueType   = reflect.TypeOf(([]byte)(nil))
 )


### PR DESCRIPTION
These are useful for defining system table schemas.