### PR TITLE
[no-release-notes] Tweak ComparableJSON interface to take context parameter and have mor…

### DIFF
--- a/sql/expression/function/json/json_type.go
+++ b/sql/expression/function/json/json_type.go
@@ -106,7 +106,7 @@ func (j JSONType) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	}
 
 	if comparableDoc, ok := doc.(types.ComparableJSON); ok {
-		return comparableDoc.Type(ctx)
+		return comparableDoc.JsonType(ctx)
 	}
 
 	val, err := doc.ToInterface(ctx)

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -95,8 +95,8 @@ type SearchableJSON interface {
 
 type ComparableJSON interface {
 	sql.JSONWrapper
-	Compare(other interface{}) (int, error)
-	Type(ctx context.Context) (string, error)
+	Compare(ctx context.Context, other interface{}) (int, error)
+	JsonType(ctx context.Context) (string, error)
 }
 
 // MutableJSON is a JSON value that can be efficiently modified. These modifications return the new value, but they
@@ -510,11 +510,11 @@ func CompareJSON(ctx context.Context, a, b interface{}) (int, error) {
 	}
 
 	if comparableA, ok := a.(ComparableJSON); ok {
-		return comparableA.Compare(b)
+		return comparableA.Compare(ctx, b)
 	}
 
 	if comparableB, ok := b.(ComparableJSON); ok {
-		result, err := comparableB.Compare(a)
+		result, err := comparableB.Compare(ctx, a)
 		return -result, err
 	}
 


### PR DESCRIPTION
Tweak ComparableJSON interface to take context parameter and have more clear method names.

ComparableJSON is an interface for JSON values that can be compared with each other without needing to full deserialize the document. The only implementations are in Dolt, so this has no effect on GMS.