### PR TITLE
rowexec: add debug logs for iterator build and merge join nils

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -446,21 +446,21 @@ func (e *Engine) QueryWithBindings(ctx *sql.Context, query string, parsed sqlpar
 		return nil, nil, nil, err
 	}
 
-    ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", analyzed)).Debug("building exec iterator")
-    iter, err := e.Analyzer.ExecBuilder.Build(ctx, analyzed, nil)
+	ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", analyzed)).Debug("building exec iterator")
+	iter, err := e.Analyzer.ExecBuilder.Build(ctx, analyzed, nil)
 	if err != nil {
-        ctx.GetLogger().WithError(err).Debug("exec builder returned error")
+		ctx.GetLogger().WithError(err).Debug("exec builder returned error")
 		err2 := clearAutocommitTransaction(ctx)
 		if err2 != nil {
 			return nil, nil, nil, errors.Wrap(err, "unable to clear autocommit transaction: "+err2.Error())
 		}
 		return nil, nil, nil, err
 	}
-    if iter == nil {
-        ctx.GetLogger().Debug("exec builder returned nil iterator")
-    } else {
-        ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
-    }
+	if iter == nil {
+		ctx.GetLogger().Debug("exec builder returned nil iterator")
+	} else {
+		ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
+	}
 
 	var schema sql.Schema
 	iter, schema, err = rowexec.FinalizeIters(ctx, analyzed, qFlags, iter)
@@ -499,21 +499,21 @@ func (e *Engine) PrepQueryPlanForExecution(ctx *sql.Context, _ string, plan sql.
 		return nil, nil, nil, err
 	}
 
-    ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", plan)).Debug("building exec iterator")
-    iter, err := e.Analyzer.ExecBuilder.Build(ctx, plan, nil)
+	ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", plan)).Debug("building exec iterator")
+	iter, err := e.Analyzer.ExecBuilder.Build(ctx, plan, nil)
 	if err != nil {
-        ctx.GetLogger().WithError(err).Debug("exec builder returned error")
+		ctx.GetLogger().WithError(err).Debug("exec builder returned error")
 		err2 := clearAutocommitTransaction(ctx)
 		if err2 != nil {
 			return nil, nil, nil, errors.Wrap(err, "unable to clear autocommit transaction: "+err2.Error())
 		}
 		return nil, nil, nil, err
 	}
-    if iter == nil {
-        ctx.GetLogger().Debug("exec builder returned nil iterator")
-    } else {
-        ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
-    }
+	if iter == nil {
+		ctx.GetLogger().Debug("exec builder returned nil iterator")
+	} else {
+		ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
+	}
 
 	var schema sql.Schema
 	iter, schema, err = rowexec.FinalizeIters(ctx, plan, qFlags, iter)
@@ -856,21 +856,21 @@ func (e *Engine) executeEvent(ctx *sql.Context, dbName, createEventStatement, us
 	definitionNode := createEventNode.DefinitionNode
 
 	// Build an iterator to execute the event body
-    ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", definitionNode)).Debug("building exec iterator")
-    iter, err := e.Analyzer.ExecBuilder.Build(ctx, definitionNode, nil)
+	ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", definitionNode)).Debug("building exec iterator")
+	iter, err := e.Analyzer.ExecBuilder.Build(ctx, definitionNode, nil)
 	if err != nil {
-        ctx.GetLogger().WithError(err).Debug("exec builder returned error")
+		ctx.GetLogger().WithError(err).Debug("exec builder returned error")
 		clearAutocommitErr := clearAutocommitTransaction(ctx)
 		if clearAutocommitErr != nil {
 			return clearAutocommitErr
 		}
 		return err
 	}
-    if iter == nil {
-        ctx.GetLogger().Debug("exec builder returned nil iterator")
-    } else {
-        ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
-    }
+	if iter == nil {
+		ctx.GetLogger().Debug("exec builder returned nil iterator")
+	} else {
+		ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
+	}
 
 	iter, _, err = rowexec.FinalizeIters(ctx, definitionNode, nil, iter)
 	if err != nil {

--- a/engine.go
+++ b/engine.go
@@ -446,14 +446,21 @@ func (e *Engine) QueryWithBindings(ctx *sql.Context, query string, parsed sqlpar
 		return nil, nil, nil, err
 	}
 
-	iter, err := e.Analyzer.ExecBuilder.Build(ctx, analyzed, nil)
+    ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", analyzed)).Debug("building exec iterator")
+    iter, err := e.Analyzer.ExecBuilder.Build(ctx, analyzed, nil)
 	if err != nil {
+        ctx.GetLogger().WithError(err).Debug("exec builder returned error")
 		err2 := clearAutocommitTransaction(ctx)
 		if err2 != nil {
 			return nil, nil, nil, errors.Wrap(err, "unable to clear autocommit transaction: "+err2.Error())
 		}
 		return nil, nil, nil, err
 	}
+    if iter == nil {
+        ctx.GetLogger().Debug("exec builder returned nil iterator")
+    } else {
+        ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
+    }
 
 	var schema sql.Schema
 	iter, schema, err = rowexec.FinalizeIters(ctx, analyzed, qFlags, iter)
@@ -492,14 +499,21 @@ func (e *Engine) PrepQueryPlanForExecution(ctx *sql.Context, _ string, plan sql.
 		return nil, nil, nil, err
 	}
 
-	iter, err := e.Analyzer.ExecBuilder.Build(ctx, plan, nil)
+    ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", plan)).Debug("building exec iterator")
+    iter, err := e.Analyzer.ExecBuilder.Build(ctx, plan, nil)
 	if err != nil {
+        ctx.GetLogger().WithError(err).Debug("exec builder returned error")
 		err2 := clearAutocommitTransaction(ctx)
 		if err2 != nil {
 			return nil, nil, nil, errors.Wrap(err, "unable to clear autocommit transaction: "+err2.Error())
 		}
 		return nil, nil, nil, err
 	}
+    if iter == nil {
+        ctx.GetLogger().Debug("exec builder returned nil iterator")
+    } else {
+        ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
+    }
 
 	var schema sql.Schema
 	iter, schema, err = rowexec.FinalizeIters(ctx, plan, qFlags, iter)
@@ -842,14 +856,21 @@ func (e *Engine) executeEvent(ctx *sql.Context, dbName, createEventStatement, us
 	definitionNode := createEventNode.DefinitionNode
 
 	// Build an iterator to execute the event body
-	iter, err := e.Analyzer.ExecBuilder.Build(ctx, definitionNode, nil)
+    ctx.GetLogger().WithField("planNodeType", fmt.Sprintf("%T", definitionNode)).Debug("building exec iterator")
+    iter, err := e.Analyzer.ExecBuilder.Build(ctx, definitionNode, nil)
 	if err != nil {
+        ctx.GetLogger().WithError(err).Debug("exec builder returned error")
 		clearAutocommitErr := clearAutocommitTransaction(ctx)
 		if clearAutocommitErr != nil {
 			return clearAutocommitErr
 		}
 		return err
 	}
+    if iter == nil {
+        ctx.GetLogger().Debug("exec builder returned nil iterator")
+    } else {
+        ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built exec iterator")
+    }
 
 	iter, _, err = rowexec.FinalizeIters(ctx, definitionNode, nil, iter)
 	if err != nil {

--- a/sql/rowexec/builder.go
+++ b/sql/rowexec/builder.go
@@ -15,11 +15,11 @@
 package rowexec
 
 import (
-    "fmt"
-    "runtime/trace"
+	"fmt"
+	"runtime/trace"
 
-    "github.com/dolthub/go-mysql-server/sql"
-    "github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
 var DefaultBuilder = &BaseBuilder{}
@@ -38,25 +38,25 @@ type BaseBuilder struct {
 
 func (b *BaseBuilder) Build(ctx *sql.Context, n sql.Node, r sql.Row) (sql.RowIter, error) {
 	defer trace.StartRegion(ctx, "ExecBuilder.Build").End()
-    logger := ctx.GetLogger().WithField("nodeType", fmt.Sprintf("%T", n))
-    if b.override != nil {
-        logger = logger.WithField("override", true)
-    } else {
-        logger = logger.WithField("override", false)
-    }
-    logger.Debug("building RowIter for node")
+	logger := ctx.GetLogger().WithField("nodeType", fmt.Sprintf("%T", n))
+	if b.override != nil {
+		logger = logger.WithField("override", true)
+	} else {
+		logger = logger.WithField("override", false)
+	}
+	logger.Debug("building RowIter for node")
 
-    iter, err := b.buildNodeExec(ctx, n, r)
-    if err != nil {
-        logger.WithError(err).Debug("buildNodeExec returned error")
-        return nil, err
-    }
-    if iter == nil {
-        logger.Debug("buildNodeExec returned nil iterator")
-        return nil, nil
-    }
-    logger.WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built iterator for node")
-    return iter, nil
+	iter, err := b.buildNodeExec(ctx, n, r)
+	if err != nil {
+		logger.WithError(err).Debug("buildNodeExec returned error")
+		return nil, err
+	}
+	if iter == nil {
+		logger.Debug("buildNodeExec returned nil iterator")
+		return nil, nil
+	}
+	logger.WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built iterator for node")
+	return iter, nil
 }
 
 func NewOverrideBuilder(override sql.NodeExecBuilder) sql.NodeExecBuilder {

--- a/sql/rowexec/builder.go
+++ b/sql/rowexec/builder.go
@@ -15,10 +15,11 @@
 package rowexec
 
 import (
-	"runtime/trace"
+    "fmt"
+    "runtime/trace"
 
-	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/plan"
+    "github.com/dolthub/go-mysql-server/sql"
+    "github.com/dolthub/go-mysql-server/sql/plan"
 )
 
 var DefaultBuilder = &BaseBuilder{}
@@ -37,7 +38,25 @@ type BaseBuilder struct {
 
 func (b *BaseBuilder) Build(ctx *sql.Context, n sql.Node, r sql.Row) (sql.RowIter, error) {
 	defer trace.StartRegion(ctx, "ExecBuilder.Build").End()
-	return b.buildNodeExec(ctx, n, r)
+    logger := ctx.GetLogger().WithField("nodeType", fmt.Sprintf("%T", n))
+    if b.override != nil {
+        logger = logger.WithField("override", true)
+    } else {
+        logger = logger.WithField("override", false)
+    }
+    logger.Debug("building RowIter for node")
+
+    iter, err := b.buildNodeExec(ctx, n, r)
+    if err != nil {
+        logger.WithError(err).Debug("buildNodeExec returned error")
+        return nil, err
+    }
+    if iter == nil {
+        logger.Debug("buildNodeExec returned nil iterator")
+        return nil, nil
+    }
+    logger.WithField("iterType", fmt.Sprintf("%T", iter)).Debug("built iterator for node")
+    return iter, nil
 }
 
 func NewOverrideBuilder(override sql.NodeExecBuilder) sql.NodeExecBuilder {

--- a/sql/rowexec/merge_join.go
+++ b/sql/rowexec/merge_join.go
@@ -15,14 +15,14 @@
 package rowexec
 
 import (
-    "errors"
-    "fmt"
-    "io"
+	"errors"
+	"fmt"
+	"io"
 
-    "github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/plan"
 
-    "github.com/dolthub/go-mysql-server/sql"
-    "github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 )
 
 // NewMergeJoin returns a node that performs a presorted merge join on
@@ -47,16 +47,16 @@ func newMergeJoinIter(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinNode,
 		return nil, err
 	}
 
-    ctx.GetLogger().WithFields(map[string]any{
-        "joinOp":         fmt.Sprintf("%v", j.Op),
-        "isReversed":     j.IsReversed,
-        "scopeLen":       j.ScopeLen,
-        "leftSchemaLen":  len(j.Left().Schema()),
-        "rightSchemaLen": len(j.Right().Schema()),
-        "filterIsNil":    j.Filter == nil,
-        "leftIterType":   fmt.Sprintf("%T", l),
-        "rightIterType":  fmt.Sprintf("%T", r),
-    }).Debug("constructed merge join child iterators")
+	ctx.GetLogger().WithFields(map[string]any{
+		"joinOp":         fmt.Sprintf("%v", j.Op),
+		"isReversed":     j.IsReversed,
+		"scopeLen":       j.ScopeLen,
+		"leftSchemaLen":  len(j.Left().Schema()),
+		"rightSchemaLen": len(j.Right().Schema()),
+		"filterIsNil":    j.Filter == nil,
+		"leftIterType":   fmt.Sprintf("%T", l),
+		"rightIterType":  fmt.Sprintf("%T", r),
+	}).Debug("constructed merge join child iterators")
 
 	fullRow := make(sql.Row, len(row)+len(j.Left().Schema())+len(j.Right().Schema()))
 	fullRow[0] = row
@@ -67,7 +67,7 @@ func newMergeJoinIter(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinNode,
 	// a merge join's first filter provides direction information
 	// for which iter to update next
 	filters := expression.SplitConjunction(j.Filter)
-    cmp, ok := filters[0].(expression.Comparer)
+	cmp, ok := filters[0].(expression.Comparer)
 	if !ok {
 		if equality, ok := filters[0].(expression.Equality); ok {
 			cmp, err = equality.ToComparer()
@@ -75,15 +75,15 @@ func newMergeJoinIter(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinNode,
 				return nil, err
 			}
 		} else {
-            ctx.GetLogger().WithField("firstFilterType", fmt.Sprintf("%T", filters[0])).Debug("merge join expected comparer filter")
-            return nil, sql.ErrMergeJoinExpectsComparerFilters.New(filters[0])
+			ctx.GetLogger().WithField("firstFilterType", fmt.Sprintf("%T", filters[0])).Debug("merge join expected comparer filter")
+			return nil, sql.ErrMergeJoinExpectsComparerFilters.New(filters[0])
 		}
 	}
 
-    if len(filters) == 0 {
-        ctx.GetLogger().Debug("merge join constructed with zero filters")
-        return nil, sql.ErrNoJoinFilters.New()
-    }
+	if len(filters) == 0 {
+		ctx.GetLogger().Debug("merge join constructed with zero filters")
+		return nil, sql.ErrNoJoinFilters.New()
+	}
 
 	var iter sql.RowIter = &mergeJoinIter{
 		left:        l,
@@ -98,7 +98,7 @@ func newMergeJoinIter(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinNode,
 		rightRowLen: len(j.Right().Schema()),
 		isReversed:  j.IsReversed,
 	}
-    ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("created merge join iter")
+	ctx.GetLogger().WithField("iterType", fmt.Sprintf("%T", iter)).Debug("created merge join iter")
 	return iter, nil
 }
 
@@ -223,10 +223,10 @@ func (i *mergeJoinIter) Next(ctx *sql.Context) (sql.Row, error) {
 			} else {
 				nextState = msCompare
 			}
-        case msCompare:
-            res, err = i.cmp.Compare(ctx, i.fullRow)
-            if expression.ErrNilOperand.Is(err) {
-                ctx.GetLogger().Debug("merge join comparer produced nil operand; rejecting null")
+		case msCompare:
+			res, err = i.cmp.Compare(ctx, i.fullRow)
+			if expression.ErrNilOperand.Is(err) {
+				ctx.GetLogger().Debug("merge join comparer produced nil operand; rejecting null")
 				nextState = msRejectNull
 				break
 			} else if err != nil {
@@ -450,7 +450,7 @@ func (i *mergeJoinIter) initIters(ctx *sql.Context) error {
 	}
 	i.init = true
 	i.resetMatchState()
-    ctx.GetLogger().Debug("merge join iters initialized")
+	ctx.GetLogger().Debug("merge join iters initialized")
 	return nil
 }
 
@@ -526,14 +526,14 @@ func (i *mergeJoinIter) incLeft(ctx *sql.Context) error {
 	i.leftMatched = false
 	var row sql.Row
 	var err error
-    if i.leftPeek != nil {
+	if i.leftPeek != nil {
 		row = i.leftPeek
 		i.leftPeek = nil
 	} else {
 		row, err = i.left.Next(ctx)
 		if errors.Is(err, io.EOF) {
 			i.leftExhausted = true
-            ctx.GetLogger().Trace("merge join left iterator exhausted")
+			ctx.GetLogger().Trace("merge join left iterator exhausted")
 			return nil
 		} else if err != nil {
 			return err
@@ -544,7 +544,7 @@ func (i *mergeJoinIter) incLeft(ctx *sql.Context) error {
 	for j, v := range row {
 		i.fullRow[off+j] = v
 	}
-    ctx.GetLogger().Trace("merge join advanced left iterator")
+	ctx.GetLogger().Trace("merge join advanced left iterator")
 	return nil
 }
 
@@ -552,14 +552,14 @@ func (i *mergeJoinIter) incLeft(ctx *sql.Context) error {
 func (i *mergeJoinIter) incRight(ctx *sql.Context) error {
 	var row sql.Row
 	var err error
-    if i.rightPeek != nil {
+	if i.rightPeek != nil {
 		row = i.rightPeek
 		i.rightPeek = nil
 	} else {
 		row, err = i.right.Next(ctx)
 		if errors.Is(err, io.EOF) {
 			i.rightExhausted = true
-            ctx.GetLogger().Trace("merge join right iterator exhausted")
+			ctx.GetLogger().Trace("merge join right iterator exhausted")
 			return nil
 		} else if err != nil {
 			return err
@@ -570,7 +570,7 @@ func (i *mergeJoinIter) incRight(ctx *sql.Context) error {
 	for j, v := range row {
 		i.fullRow[off+j] = v
 	}
-    ctx.GetLogger().Trace("merge join advanced right iterator")
+	ctx.GetLogger().Trace("merge join advanced right iterator")
 	return nil
 }
 

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -15,26 +15,26 @@
 package rowexec
 
 import (
-    "errors"
-    "fmt"
-    "io"
-    "os"
-    "path/filepath"
-    "reflect"
-    "strings"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
 
-    "github.com/dolthub/jsonpath"
-    "github.com/shopspring/decimal"
-    "go.opentelemetry.io/otel/attribute"
-    "go.opentelemetry.io/otel/trace"
+	"github.com/dolthub/jsonpath"
+	"github.com/shopspring/decimal"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
-    "github.com/dolthub/go-mysql-server/sql"
-    "github.com/dolthub/go-mysql-server/sql/expression"
-    "github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
-    "github.com/dolthub/go-mysql-server/sql/expression/function/json"
-    "github.com/dolthub/go-mysql-server/sql/iters"
-    "github.com/dolthub/go-mysql-server/sql/plan"
-    "github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/aggregation"
+	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
+	"github.com/dolthub/go-mysql-server/sql/iters"
+	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 func (b *BaseBuilder) buildTopN(ctx *sql.Context, n *plan.TopN, row sql.Row) (sql.RowIter, error) {
@@ -307,15 +307,15 @@ func (b *BaseBuilder) buildProject(ctx *sql.Context, n *plan.Project, row sql.Ro
 		attribute.Int("projections", len(n.Projections)),
 	))
 
-    i, err := b.buildNodeExec(ctx, n.Child, row)
+	i, err := b.buildNodeExec(ctx, n.Child, row)
 	if err != nil {
 		span.End()
 		return nil, err
 	}
 
-    if i == nil {
-        ctx.GetLogger().WithField("nodeType", "Project").Debug("child iterator is nil")
-    }
+	if i == nil {
+		ctx.GetLogger().WithField("nodeType", "Project").Debug("child iterator is nil")
+	}
 
 	return sql.NewSpanIter(span, &ProjectIter{
 		projs:          n.Projections,
@@ -479,14 +479,14 @@ func (b *BaseBuilder) buildLimit(ctx *sql.Context, n *plan.Limit, row sql.Row) (
 		return nil, err
 	}
 
-    childIter, err := b.buildNodeExec(ctx, n.Child, row)
+	childIter, err := b.buildNodeExec(ctx, n.Child, row)
 	if err != nil {
 		span.End()
 		return nil, err
 	}
-    if childIter == nil {
-        ctx.GetLogger().WithField("nodeType", "Limit").Debug("child iterator is nil")
-    }
+	if childIter == nil {
+		ctx.GetLogger().WithField("nodeType", "Limit").Debug("child iterator is nil")
+	}
 	return sql.NewSpanIter(span, &iters.LimitIter{
 		CalcFoundRows: n.CalcFoundRows,
 		Limit:         limit,


### PR DESCRIPTION
Add debug-level logs in ExecBuilder.Build and Engine to trace iterator construction and types. Add targeted merge join logs to capture child iter types, filter/comparer assumptions, and nil-operand cases, improving panic diagnostics surfaced by Dolt when running at debug level.