### PR TITLE
dolthub/dolt#9984: Fix `nil` dereference by `Dispose()` in `GROUP BY` iterator when `Next()` is never called

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -132,7 +132,7 @@ var ScriptTests = []ScriptTest{
 		Assertions: []ScriptTestAssertion{
 			{
 				// LIMIT 0 causes the iterator to close without ever calling Next() on groupByIter
-				// This leaves all buffer elements as nil, causing panic in Dispose()
+				// This leaves all buffer elements as nil causing panic in Dispose(), or empty depending data struct
 				Query:    "SELECT category, SUM(value) FROM test_table GROUP BY category LIMIT 0",
 				Expected: []sql.Row{},
 			},

--- a/sql/rowexec/agg.go
+++ b/sql/rowexec/agg.go
@@ -236,9 +236,7 @@ func (i *groupByGroupingIter) Dispose() {
 		bs, _ := i.get(k)
 		if bs != nil {
 			for _, b := range bs {
-				if b != nil {
-					b.Dispose()
-				}
+				b.Dispose()
 			}
 		}
 	}


### PR DESCRIPTION
Fixes dolthub/dolt#9984