### PR TITLE
Don't make string unless in Debug mode

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -702,7 +702,10 @@ func (h *Handler) resultForDefaultIter(ctx *sql.Context, c *mysql.Conn, schema s
 		defer wg.Done()
 		for {
 			if r == nil {
-				r = &sqltypes.Result{Fields: resultFields}
+				r = &sqltypes.Result{
+					Fields: resultFields,
+					Rows:   make([][]sqltypes.Value, 0, rowsBatch),
+				}
 			}
 			if r.RowsAffected == rowsBatch {
 				if err := resetCallback(r, more); err != nil {

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -141,9 +141,11 @@ func costedIndexLookup(ctx *sql.Context, n sql.Node, a *Analyzer, iat sql.IndexA
 		ret = plan.NewTableAlias(aliasName, ret)
 	}
 
-	a.Log("new indexed table: %s/%s/%s", ita.Index().Database(), ita.Index().Table(), ita.Index().ID())
-	a.Log("index stats cnt: %d", stats.RowCount())
-	a.Log("index stats histogram: %s", stats.Histogram().DebugString())
+	if a.Debug {
+		a.Log("new indexed table: %s/%s/%s", ita.Index().Database(), ita.Index().Table(), ita.Index().ID())
+		a.Log("index stats cnt: %d", stats.RowCount())
+		a.Log("index stats histogram: %s", stats.Histogram().DebugString())
+	}
 
 	// excluded from tree + not included in index scan => filter above scan
 	if len(filters) > 0 {


### PR DESCRIPTION
Even though this isn't getting logged anywhere, generating the DebugString for CostedIndexScans is costly enough to show in the profiler.
Also specify capacity for rows in Result.

benchmarks:
https://github.com/dolthub/dolt/pull/10039#issuecomment-3499431486