### PR TITLE
[DRAFT] Table as column draft

### DIFF
--- a/enginetest/memory_engine_test.go
+++ b/enginetest/memory_engine_test.go
@@ -200,23 +200,30 @@ func TestSingleQueryPrepared(t *testing.T) {
 
 // Convenience test for debugging a single query. Unskip and set to the desired query.
 func TestSingleScript(t *testing.T) {
-	t.Skip()
+	//t.Skip()
 	var scripts = []queries.ScriptTest{
 		{
-			Name:        "AS OF propagates to nested CALLs",
-			SetUpScript: []string{},
+			Name: "AS OF propagates to nested CALLs",
+			SetUpScript: []string{
+				`CREATE TABLE test (pk INT PRIMARY KEY, v1 VARCHAR(255));`,
+				`INSERT INTO test VALUES (1, 'a'), (2, 'b');`,
+			},
 			Assertions: []queries.ScriptTestAssertion{
 				{
-					Query: "create procedure create_proc() create table t (i int primary key, j int);",
-					Expected: []sql.Row{
-						{types.NewOkResult(0)},
-					},
+					Query:    "SELECT temporarytesting(t) FROM test AS t;",
+					Expected: []sql.Row{},
 				},
 				{
-					Query: "call create_proc()",
-					Expected: []sql.Row{
-						{types.NewOkResult(0)},
-					},
+					Query:    "SELECT temporarytesting(test) FROM test;",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "SELECT temporarytesting(pk, test) FROM test;",
+					Expected: []sql.Row{},
+				},
+				{
+					Query:    "SELECT temporarytesting(v1, test, pk) FROM test;",
+					Expected: []sql.Row{},
 				},
 			},
 		},

--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -165,3 +165,52 @@ func (e *Alias) WithChildren(children ...sql.Expression) (sql.Expression, error)
 
 // Name implements the Nameable interface.
 func (e *Alias) Name() string { return e.name }
+
+// TODO: DELETE EVERYTHING UNDER HERE -----------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+
+// This is an expression that will be returned from a Doltgres hook (GMS' hook will return a nil expression to indicate
+// incompatibility). This function is just a stand-in for testing purposes.
+type DoltgresHookExpression struct {
+	args []sql.Expression
+}
+
+var _ sql.Expression = (*DoltgresHookExpression)(nil)
+
+func NewDoltgresHookExpression(args ...sql.Expression) sql.Expression {
+	return &DoltgresHookExpression{args: args}
+}
+
+func (tt *DoltgresHookExpression) String() string { return "temporarytesting2" }
+
+// Type implements the Expression interface.
+func (tt *DoltgresHookExpression) Type() sql.Type { return types.Int32 }
+
+// Eval implements the Expression interface.
+func (tt *DoltgresHookExpression) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	rowLen := len(row)
+	return int32(-rowLen), nil
+}
+
+// Resolved implements the Expression interface.
+func (tt *DoltgresHookExpression) Resolved() bool {
+	return true
+}
+
+// Children implements the Expression interface.
+func (tt *DoltgresHookExpression) Children() []sql.Expression {
+	return tt.args
+}
+
+// IsNullable implements the Expression interface.
+func (tt *DoltgresHookExpression) IsNullable() bool {
+	return false
+}
+
+// WithChildren implements the Expression interface.
+func (*DoltgresHookExpression) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewDoltgresHookExpression(children...), nil
+}

--- a/sql/expression/function/registry.go
+++ b/sql/expression/function/registry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression/function/json"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/spatial"
 	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
+	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
 // ErrFunctionAlreadyRegistered is thrown when a function is already registered
@@ -342,6 +343,7 @@ var BuiltIns = []sql.Function{
 	sql.Function1{Name: "weekofyear", Fn: NewWeekOfYear},
 	sql.Function1{Name: "year", Fn: NewYear},
 	sql.FunctionN{Name: "yearweek", Fn: NewYearWeek},
+	sql.FunctionN{Name: "temporarytesting", Fn: NewTemporaryTesting}, // TODO: DELETE ME
 }
 
 func GetLockingFuncs(ls *sql.LockSubsystem) []sql.Function {
@@ -389,4 +391,66 @@ func (r Registry) mustRegister(fn ...sql.Function) {
 	if err := r.Register(fn...); err != nil {
 		panic(err)
 	}
+}
+
+// TODO: DELETE EVERYTHING UNDER HERE -----------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+//  ---------------------------------------------------------------------------------------------------------
+
+// This is an example Doltgres function. This exists solely for testing purposes, and will be deleted as noted by the
+// massive comment above this.
+type DoltgresFunction struct {
+	args []sql.Expression
+}
+
+var _ sql.FunctionExpression = (*DoltgresFunction)(nil)
+
+func NewTemporaryTesting(args ...sql.Expression) (sql.Expression, error) {
+	return &DoltgresFunction{args: args}, nil
+}
+
+// FunctionName implements sql.FunctionExpression
+func (tt *DoltgresFunction) FunctionName() string {
+	return "temporarytesting"
+}
+
+// Description implements sql.FunctionExpression
+func (tt *DoltgresFunction) Description() string {
+	return ""
+}
+
+func (tt *DoltgresFunction) String() string { return "temporarytesting()" }
+
+// Type implements the Expression interface.
+func (tt *DoltgresFunction) Type() sql.Type { return types.Int32 }
+
+// CollationCoercibility implements the interface sql.CollationCoercible.
+func (*DoltgresFunction) CollationCoercibility(ctx *sql.Context) (collation sql.CollationID, coercibility byte) {
+	return sql.Collation_binary, 5
+}
+
+// Eval implements the Expression interface.
+func (tt *DoltgresFunction) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
+	rowLen := len(row)
+	return int32(rowLen), nil
+}
+
+// Resolved implements the Expression interface.
+func (tt *DoltgresFunction) Resolved() bool {
+	return true
+}
+
+// Children implements the Expression interface.
+func (tt *DoltgresFunction) Children() []sql.Expression { return tt.args }
+
+// IsNullable implements the Expression interface.
+func (tt *DoltgresFunction) IsNullable() bool {
+	return false
+}
+
+// WithChildren implements the Expression interface.
+func (*DoltgresFunction) WithChildren(children ...sql.Expression) (sql.Expression, error) {
+	return NewTemporaryTesting(children...)
 }

--- a/sql/functions.go
+++ b/sql/functions.go
@@ -108,6 +108,7 @@ func NewFunction0(name string, fn func() Expression) Function0 {
 	}
 }
 
+// NewInstance implements the interface Function.
 func (fn Function0) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 0 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 0, len(args))
@@ -116,6 +117,7 @@ func (fn Function0) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn Function1) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 1 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 1, len(args))
@@ -124,6 +126,7 @@ func (fn Function1) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args[0]), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn Function2) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 2 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 2, len(args))
@@ -132,6 +135,7 @@ func (fn Function2) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args[0], args[1]), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn Function3) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 3 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 3, len(args))
@@ -140,6 +144,7 @@ func (fn Function3) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args[0], args[1], args[2]), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn Function4) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 4 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 4, len(args))
@@ -148,6 +153,7 @@ func (fn Function4) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args[0], args[1], args[2], args[3]), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn Function5) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 5 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 5, len(args))
@@ -156,6 +162,7 @@ func (fn Function5) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args[0], args[1], args[2], args[3], args[4]), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn Function6) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 6 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 6, len(args))
@@ -164,6 +171,7 @@ func (fn Function6) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args[0], args[1], args[2], args[3], args[4], args[5]), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn Function7) NewInstance(args []Expression) (Expression, error) {
 	if len(args) != 7 {
 		return nil, ErrInvalidArgumentNumber.New(fn.Name, 7, len(args))
@@ -172,6 +180,7 @@ func (fn Function7) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args[0], args[1], args[2], args[3], args[4], args[5], args[6]), nil
 }
 
+// NewInstance implements the interface Function.
 func (fn FunctionN) NewInstance(args []Expression) (Expression, error) {
 	return fn.Fn(args...)
 }

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -751,6 +751,7 @@ func (b *Builder) buildResolvedTable(inScope *scope, db, schema, name string, as
 		})
 		cols.Add(sql.ColumnId(id))
 	}
+	outScope.recordTableAsColumn(db, strings.ToLower(tab.Name()), tabId, rt)
 
 	rt = rt.WithId(tabId).WithColumns(cols).(*plan.ResolvedTable)
 	outScope.node = rt


### PR DESCRIPTION
As should be fairly obvious, this PR is to allow for using a table's name as though it were a column, which is required for:
* https://github.com/dolthub/doltgresql/pull/2009

This will be integrated with the following PR after comments are made here, but this is separate just to make it a little easier to look over. `DoltgresFunction` is a stand-in for a regular Doltgres function, and `DoltgresHookExpression` is a stand-in for an expression that will be returned by the hooks interface via Doltgres' integration.

* https://github.com/dolthub/go-mysql-server/pull/3303

I tried a few different methods of achieving this, but this seems to be the most straightforward (and most compatible) method I tried. There may be failure cases with this approach, but none seemed obvious from test cases. It's worth noting that this "fully works", in that debugging by stepping through shows that everything is where it needs to be for the hooks integration, so besides general cleanup and all the locations that I've marked can be removed, this can be treated with relatively high scrutiny.