### PR TITLE
server/handler: Add ConnectionAuthenticated callback which Vitess can call once the connection is authenticated.

### DIFF
--- a/server/handler.go
+++ b/server/handler.go
@@ -104,6 +104,19 @@ func (h *Handler) ConnectionAborted(_ *mysql.Conn, _ string) error {
 	return nil
 }
 
+// Called when a new connection successfully
+// authenticated. Responsible for creating the session associated with
+// the connection in the session manager and updating processlist with
+// the authenticated user and remote address.
+func (h *Handler) ConnectionAuthenticated(c *mysql.Conn) error {
+	err := h.sm.ConnReady(context.Background(), c)
+	if err != nil {
+		logrus.Errorf("unable to register new authenticated connection: %s", err.Error())
+		err = sql.CastSQLError(err)
+	}
+	return err
+}
+
 func (h *Handler) ComInitDB(c *mysql.Conn, schemaName string) error {
 	// SetDB itself handles session and processlist operation lifecycle callbacks.
 	err := h.sm.SetDB(context.Background(), c, schemaName)


### PR DESCRIPTION
Previously gms relied on the ComInitDB callback to update the processlist with the currently authenticated user. This resulted in the processlist showing "unauthenticated user" for connections which were already authenticated but which had not issued a ComInitDB. Those connections could issue queries which would also appear in the process list. Adding an explicit callback when the authentication is successful and allowing the processlist entry to be Command Sleep with an authenticated user even when no database is selected is more correct behavior here.