### PR TITLE
Fix `TimestampFuncExpr` and `SetOp` in stored procedures

### DIFF
--- a/sql/procedures/interpreter_logic.go
+++ b/sql/procedures/interpreter_logic.go
@@ -277,7 +277,7 @@ func replaceVariablesInExpr(ctx *sql.Context, stack *InterpreterStack, expr ast.
 		if err != nil {
 			return nil, err
 		}
-		e.Select = newExpr.(*ast.Select)
+		e.Select = newExpr.(ast.SelectStatement)
 	case *ast.SetOp:
 		newLeftExpr, err := replaceVariablesInExpr(ctx, stack, e.Left, asOf)
 		if err != nil {


### PR DESCRIPTION
Changes: 
 - add missing case for replacing variables for TimestampFuncExpr in the interpreter
 - fix incorrect interface cast when assigning to `ast.Subquery.Select`

Fixes:
 - https://github.com/dolthub/dolt/issues/10141
 - https://github.com/dolthub/dolt/issues/10142