### PR TITLE
Mark `innodb_lock_wait_timeout` as being in both global and session scopes

### DIFF
--- a/sql/variables/system_variables.go
+++ b/sql/variables/system_variables.go
@@ -1104,7 +1104,7 @@ var systemVars = map[string]sql.SystemVariable{
 	// Lowest value allowed by MySQL, which is 1. If you attempt to set this value to anything other than 1, errors ensue.
 	"innodb_lock_wait_timeout": &sql.MysqlSystemVariable{
 		Name:              "innodb_lock_wait_timeout",
-		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Global),
+		Scope:             sql.GetMysqlScope(sql.SystemVariableScope_Both),
 		Dynamic:           true,
 		SetVarHintApplies: false,
 		Type:              types.NewSystemIntType("innodb_lock_wait_timeout", 1, 1, false),


### PR DESCRIPTION
We had the `innodb_lock_wait_timeout` system variable marked only as being in global scope, but in MySQL, it is [in global and session scope](https://dev.mysql.com/doc/refman/8.4/en/innodb-parameters.html#sysvar_innodb_lock_wait_timeout). 