### PR TITLE
[no-release-notes] Fix plangen to correctly generate test files when explicitly skipping the row estimate

### DIFF
--- a/enginetest/plangen/cmd/plangen/main.go
+++ b/enginetest/plangen/cmd/plangen/main.go
@@ -208,30 +208,31 @@ func generatePlansForSuite(spec PlanSpec, w *bytes.Buffer) error {
 			writePlanString(w, planString)
 
 			if node.IsReadOnly() {
-				_, _ = w.WriteString(`ExpectedEstimates: `)
 				var planString string
 				if tt.ExpectedEstimates != "skip" {
+					_, _ = w.WriteString(`ExpectedEstimates: `)
 					planString = sql.Describe(enginetest.ExtractQueryNode(node), sql.DescribeOptions{
 						Estimates: true,
 					})
+					writePlanString(w, planString)
 				} else {
-					planString = "skip"
+					_, _ = w.WriteString("ExpectedEstimates: \"skip\",\n")
 				}
-				writePlanString(w, planString)
+
 				if tt.ExpectedAnalysis != "skip" {
+					_, _ = w.WriteString(`ExpectedAnalysis: `)
 					err = enginetest.ExecuteNode(ctx, engine, node)
 					if err != nil {
 						exit(fmt.Errorf("%w\nfailed to execute query: %s", err, tt.Query))
 					}
-					_, _ = w.WriteString(`ExpectedAnalysis: `)
 					planString = sql.Describe(enginetest.ExtractQueryNode(node), sql.DescribeOptions{
 						Analyze:   true,
 						Estimates: true,
 					})
+					writePlanString(w, planString)
 				} else {
-					planString = "skip"
+					_, _ = w.WriteString("ExpectedAnalysis: \"skip\",\n")
 				}
-				writePlanString(w, planString)
 			}
 		} else {
 			_, _ = w.WriteString(`Skip: true,\n`)


### PR DESCRIPTION
A follow up to https://github.com/dolthub/go-mysql-server/pull/3326, which contained mistake in the plangen code, causing it to generate invalid source files for plan tests.

Plangen doesn't contain any tests because its is implicitly tested whenever it's used to generate plan tests. I neglected to run plangen on the previous PR to verify that it generated correct tests. This fixes that.