### PR TITLE
Add required attribution for mascot image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,3 +249,6 @@ Martinez (@juanjux).
 ## License
 
 Apache License 2.0, see [LICENSE](/LICENSE)
+
+The Go gopher was designed by [Renee French](https://reneefrench.blogspot.com/), licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+The mascot image is based on work by [Takuya Ueda](https://twitter.com/tenntenn), licensed under [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/), with modifications.


### PR DESCRIPTION
This PR adds the required attribution for the mascot image used in the README.

The mascot image is based on the Go gopher and related derivative work,
and the README has been updated to include the appropriate credits.

Please let me know if any adjustments are needed.