### PR TITLE
[no-release-notes] Join cleanups

### DIFF
--- a/sql/analyzer/unnest_exists_subqueries.go
+++ b/sql/analyzer/unnest_exists_subqueries.go
@@ -132,7 +132,7 @@ func unnestExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, fil
 		case *expression.Not:
 			if esq, ok := e.Child.(*plan.ExistsSubquery); ok {
 				sq = esq.Query
-				joinType = plan.JoinTypeAnti
+				joinType = plan.JoinTypeAntiIncludeNulls
 			}
 		default:
 		}
@@ -176,7 +176,7 @@ func unnestExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, fil
 
 		if s.emptyScope {
 			switch joinType {
-			case plan.JoinTypeAnti:
+			case plan.JoinTypeAntiIncludeNulls:
 				// ret will be all rows
 			case plan.JoinTypeSemi:
 				ret = plan.NewEmptyTableWithSchema(ret.Schema())
@@ -188,7 +188,7 @@ func unnestExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, fil
 
 		if len(s.joinFilters) == 0 {
 			switch joinType {
-			case plan.JoinTypeAnti:
+			case plan.JoinTypeAntiIncludeNulls:
 				cond := expression.NewLiteral(true, types.Boolean)
 				ret = plan.NewAntiJoinIncludingNulls(ret, s.inner, cond).WithComment(comment)
 				qFlags.Set(sql.QFlagInnerJoin)
@@ -212,11 +212,8 @@ func unnestExistSubqueries(ctx *sql.Context, scope *plan.Scope, a *Analyzer, fil
 		}
 
 		switch joinType {
-		case plan.JoinTypeAnti:
-			ret = plan.NewAntiJoinIncludingNulls(ret, s.inner, expression.JoinAnd(outerFilters...)).WithComment(comment)
-			qFlags.Set(sql.QFlagInnerJoin)
-		case plan.JoinTypeSemi:
-			ret = plan.NewSemiJoin(ret, s.inner, expression.JoinAnd(outerFilters...)).WithComment(comment)
+		case plan.JoinTypeAntiIncludeNulls, plan.JoinTypeSemi:
+			ret = plan.NewJoin(ret, s.inner, joinType, expression.JoinAnd(outerFilters...)).WithComment(comment)
 			qFlags.Set(sql.QFlagInnerJoin)
 		default:
 			return filter, transform.SameTree, fmt.Errorf("hoistSelectExists failed on unexpected join type")

--- a/sql/plan/join.go
+++ b/sql/plan/join.go
@@ -327,16 +327,6 @@ func NewJoin(left, right sql.Node, op JoinType, cond sql.Expression) *JoinNode {
 	}
 }
 
-// NewUsingJoin creates a UsingJoin that joins on the specified columns with the same name.
-// This is a placeholder node, and should be transformed into the appropriate join during analysis.
-func NewUsingJoin(left, right sql.Node, op JoinType, cols []string) *JoinNode {
-	return &JoinNode{
-		Op:         op,
-		BinaryNode: BinaryNode{left: left, right: right},
-		UsingCols:  cols,
-	}
-}
-
 // Expressions implements sql.Expression
 func (j *JoinNode) Expressions() []sql.Expression {
 	if j.Op.IsDegenerate() || j.Filter == nil {
@@ -504,20 +494,8 @@ func NewInnerJoin(left, right sql.Node, cond sql.Expression) *JoinNode {
 	return NewJoin(left, right, JoinTypeInner, cond)
 }
 
-func NewHashJoin(left, right sql.Node, cond sql.Expression) *JoinNode {
-	return NewJoin(left, right, JoinTypeHash, cond)
-}
-
 func NewLeftOuterJoin(left, right sql.Node, cond sql.Expression) *JoinNode {
 	return NewJoin(left, right, JoinTypeLeftOuter, cond)
-}
-
-func NewLeftOuterHashJoin(left, right sql.Node, cond sql.Expression) *JoinNode {
-	return NewJoin(left, right, JoinTypeLeftOuterHash, cond)
-}
-
-func NewLeftOuterLookupJoin(left, right sql.Node, cond sql.Expression) *JoinNode {
-	return NewJoin(left, right, JoinTypeLeftOuterLookup, cond)
 }
 
 func NewRightOuterJoin(left, right sql.Node, cond sql.Expression) *JoinNode {
@@ -544,11 +522,8 @@ func NewNaturalJoin(left, right sql.Node) *JoinNode {
 	return NewJoin(left, right, JoinTypeUsing, nil)
 }
 
-// An LookupJoin is a join that uses index lookups for the secondary table.
-func NewLookupJoin(left, right sql.Node, cond sql.Expression) *JoinNode {
-	return NewJoin(left, right, JoinTypeLookup, cond)
-}
-
+// NewAntiJoinIncludingNulls creates a new antijoin that includes nulls, which is created from a NOT EXISTS query. This
+// is different from an antijoin excluding nulls (default antijoin) created from a NOT IN query.
 func NewAntiJoinIncludingNulls(left, right sql.Node, cond sql.Expression) *JoinNode {
 	return NewJoin(left, right, JoinTypeAntiIncludeNulls, cond)
 }


### PR DESCRIPTION
- remove unused join functions
- clarify that AntiJoinIncludingNulls is used for `NOT EXISTS` queries while AntiJoin (excluding nulls) is used for `NOT IN` queries