### PR TITLE
Add `IsExpr` case to `replaceVariablesInExpr`

### DIFF
--- a/enginetest/queries/procedure_queries.go
+++ b/enginetest/queries/procedure_queries.go
@@ -2407,6 +2407,23 @@ CREATE PROCEDURE test()
 			},
 		},
 	},
+	{
+		Name: "Resolve procedure variable in IS expression",
+		SetUpScript: []string{
+			`CREATE PROCEDURE p1(IN v TEXT)
+	BEGIN
+	DECLARE v_text TEXT;
+	SET v_text = v;
+	select v_text is null;
+	END`,
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "call p1('abc')",
+				Expected: []sql.Row{{false}},
+			},
+		},
+	},
 }
 
 var ProcedureCallTests = []ScriptTest{

--- a/sql/procedures/interpreter_logic.go
+++ b/sql/procedures/interpreter_logic.go
@@ -140,6 +140,12 @@ func replaceVariablesInExpr(ctx *sql.Context, stack *InterpreterStack, expr ast.
 			return nil, err
 		}
 		e.Expr = newExpr.(ast.Expr)
+	case *ast.IsExpr:
+		newExpr, err := replaceVariablesInExpr(ctx, stack, e.Expr, asOf)
+		if err != nil {
+			return nil, err
+		}
+		e.Expr = newExpr.(ast.Expr)
 	case *ast.ExistsExpr:
 		newSubquery, err := replaceVariablesInExpr(ctx, stack, e.Subquery, asOf)
 		if err != nil {


### PR DESCRIPTION
Stored procedures containing `IS` expressions that referenced a procedure variable were breaking.