### PR TITLE
Allow DROP TRIGGER when trigger is referenced by another trigger

### DIFF
--- a/sql/analyzer/load_triggers.go
+++ b/sql/analyzer/load_triggers.go
@@ -51,10 +51,7 @@ func loadTriggers(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, 
 			for _, trigger := range loadedTriggers {
 				if strings.EqualFold(node.TriggerName, trigger.TriggerName) {
 					node.TriggerName = trigger.TriggerName
-					continue
-				}
-				if trigger.TriggerOrder != nil && strings.EqualFold(node.TriggerName, trigger.TriggerOrder.OtherTriggerName) {
-					return nil, transform.SameTree, sql.ErrTriggerCannotBeDropped.New(node.TriggerName, trigger.TriggerName)
+					break
 				}
 			}
 			return node, transform.NewTree, nil


### PR DESCRIPTION
Previously, dropping a trigger that was referenced by another trigger's PRECEDES or FOLLOWS clause would fail with an error. This change allows such drops to succeed. When a referenced trigger is dropped, the referencing trigger stays in its current storage position and executes in the order it appears in the trigger list.

Changes:
- Remove the ErrTriggerCannotBeDropped check in load_triggers.go
- Update OrderTriggers to gracefully handle missing trigger references
- Update tests to reflect the new behavior