### PR TITLE
Use key type for memory table index filter range

### DIFF
--- a/sql/expression/filter-range.go
+++ b/sql/expression/filter-range.go
@@ -40,62 +40,67 @@ func NewRangeFilterExpr(exprs []sql.Expression, ranges []sql.MySQLRange) (sql.Ex
 		var rangeExpr sql.Expression
 		for i, rce := range rang {
 			var rangeColumnExpr sql.Expression
+			typ := exprs[i].Type().Promote()
 			switch rce.Type() {
 			// Both Empty and All may seem like strange inclusions, but if only one range is given we need some
 			// expression to evaluate, otherwise our expression would be a nil expression which would panic.
 			case sql.RangeType_Empty:
-				rangeColumnExpr = NewEquals(NewLiteral(1, types.Int8), NewLiteral(2, types.Int8))
+				rangeColumnExpr = NewLiteral(false, types.Boolean)
 			case sql.RangeType_All:
-				rangeColumnExpr = NewEquals(NewLiteral(1, types.Int8), NewLiteral(1, types.Int8))
+				rangeColumnExpr = NewLiteral(true, types.Boolean)
 			case sql.RangeType_EqualNull:
 				rangeColumnExpr = DefaultExpressionFactory.NewIsNull(exprs[i])
 			case sql.RangeType_GreaterThan:
 				if sql.MySQLRangeCutIsBinding(rce.LowerBound) {
-					rangeColumnExpr = NewGreaterThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), rce.Typ.Promote()))
+					rangeColumnExpr = NewGreaterThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), typ))
 				} else {
 					rangeColumnExpr = DefaultExpressionFactory.NewIsNotNull(exprs[i])
 				}
 			case sql.RangeType_GreaterOrEqual:
-				rangeColumnExpr = NewGreaterThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), rce.Typ.Promote()))
+				rangeColumnExpr = NewGreaterThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), typ))
 			case sql.RangeType_LessThanOrNull:
 				rangeColumnExpr = JoinOr(
-					NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote())),
+					NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ)),
 					DefaultExpressionFactory.NewIsNull(exprs[i]),
 				)
 			case sql.RangeType_LessOrEqualOrNull:
 				rangeColumnExpr = JoinOr(
-					NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote())),
+					NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ)),
 					DefaultExpressionFactory.NewIsNull(exprs[i]),
 				)
 			case sql.RangeType_ClosedClosed:
-				rangeColumnExpr = JoinAnd(
-					NewGreaterThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), rce.Typ.Promote())),
-					NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote())),
-				)
+				if rce.LowerBound == rce.UpperBound {
+					rangeColumnExpr = NewEquals(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), typ))
+				} else {
+					rangeColumnExpr = JoinAnd(
+						NewGreaterThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), typ)),
+						NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ)),
+					)
+				}
 			case sql.RangeType_OpenOpen:
 				if sql.MySQLRangeCutIsBinding(rce.LowerBound) {
 					rangeColumnExpr = JoinAnd(
-						NewGreaterThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), rce.Typ.Promote())),
-						NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote())),
+						NewGreaterThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), typ)),
+						NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ)),
 					)
 				} else {
 					// Lower bound is (NULL, ...)
-					rangeColumnExpr = NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote()))
+					rangeColumnExpr = NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ))
 				}
 			case sql.RangeType_OpenClosed:
 				if sql.MySQLRangeCutIsBinding(rce.LowerBound) {
 					rangeColumnExpr = JoinAnd(
-						NewGreaterThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), rce.Typ.Promote())),
-						NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote())),
+						NewGreaterThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), typ)),
+						NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ)),
 					)
 				} else {
 					// Lower bound is (NULL, ...]
-					rangeColumnExpr = NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote()))
+					rangeColumnExpr = NewLessThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ))
 				}
 			case sql.RangeType_ClosedOpen:
 				rangeColumnExpr = JoinAnd(
-					NewGreaterThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), rce.Typ.Promote())),
-					NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), rce.Typ.Promote())),
+					NewGreaterThanOrEqual(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.LowerBound), typ)),
+					NewLessThan(exprs[i], NewLiteral(sql.GetMySQLRangeCutKey(rce.UpperBound), typ)),
 				)
 			}
 			rangeExpr = JoinAnd(rangeExpr, rangeColumnExpr)


### PR DESCRIPTION
part of dolthub/dolt#10311

This change allows avoiding unnecessary type conversions when filtering by index and also simplifies some range filter expressions. 

This causes foreign keys, particularly enums and sets, to be compared based on their internal values, instead of based on the generalized converted type.