### PR TITLE
fix: handle NULL vectors in ConvertToVector

### DIFF
--- a/sql/core.go
+++ b/sql/core.go
@@ -368,6 +368,9 @@ func ConvertToVector(ctx context.Context, v interface{}) ([]float32, error) {
 	if err != nil {
 		return nil, err
 	}
+	if v == nil {
+		return nil, nil
+	}
 	switch b := v.(type) {
 	case []float32:
 		return b, nil

--- a/sql/core_test.go
+++ b/sql/core_test.go
@@ -69,3 +69,39 @@ func TestEvaluateCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertToVectorNilHandling(t *testing.T) {
+	ctx := sql.NewEmptyContext()
+	tests := map[string]struct {
+		input    interface{}
+		expected []float32
+		wantErr  bool
+	}{
+		"nil input returns nil": {
+			input:    nil,
+			expected: nil,
+			wantErr:  false,
+		},
+		"valid float32 slice passes through": {
+			input:    []float32{1.0, 2.0, 3.0},
+			expected: []float32{1.0, 2.0, 3.0},
+			wantErr:  false,
+		},
+		"valid JSON string parses correctly": {
+			input:    "[1.0, 2.0, 3.0]",
+			expected: []float32{1.0, 2.0, 3.0},
+			wantErr:  false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := sql.ConvertToVector(ctx, tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a nil guard to `ConvertToVector` so that NULL vector values
return `(nil, nil)` instead of an error.

- Add nil check after `UnwrapAny` error handling, before the type switch
- Add regression tests: nil input, valid `[]float32`, valid JSON string

Fixes #3420

## Root Cause

When a table has a VECTOR INDEX and rows are inserted without providing
a vector value (NULL), the proximity map flush path calls
`ConvertToVector(ctx, nil)`. The nil value falls through to the `default`
switch case, producing `"unable to cast <nil> of type <nil> to vector"`.

## Before / After

**Before**: `ConvertToVector(ctx, nil)` → error
**After**: `ConvertToVector(ctx, nil)` → `(nil, nil)`

This is consistent with SQL NULL propagation — NULL in, NULL out.

## Test Plan

- `TestConvertToVectorNilHandling` covers nil, `[]float32`, and JSON string inputs
- `go test ./sql/... -count=1` passes
- No behavioral change for non-NULL vectors

## Notes

I think the Dolt side may also benefit from nil guards in the proximity
map flush path (`getConvertToVectorFunction` and `visitNode`), but those
would be in a separate PR on dolthub/dolt.