### PR TITLE
[no-release-notes] sql/types: fix dropped errors

### DIFF
--- a/sql/types/geometry.go
+++ b/sql/types/geometry.go
@@ -263,6 +263,9 @@ func DeserializeMLine(buf []byte, isBig bool, srid uint32) (MultiLineString, int
 	var c int
 	for i := range lines {
 		isBig, typ, err := DeserializeWKBHeader(buf)
+		if err != nil {
+			return MultiLineString{}, 0, err
+		}
 		if typ != WKBLineID {
 			return MultiLineString{}, 0, sql.ErrInvalidGISData.New("DeserializeMLine")
 		}
@@ -294,6 +297,9 @@ func DeserializeMPoly(buf []byte, isBig bool, srid uint32) (MultiPolygon, int, e
 	var c int
 	for i := range polys {
 		isBig, typ, err := DeserializeWKBHeader(buf)
+		if err != nil {
+			return MultiPolygon{}, 0, err
+		}
 		if typ != WKBPolyID {
 			return MultiPolygon{}, 0, sql.ErrInvalidGISData.New("DeserializeMPoly")
 		}

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -767,6 +767,9 @@ func (t StringType) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltypes.
 			}
 		default:
 			valueBytes, err = ConvertToBytes(ctx, v, t, dest)
+			if err != nil {
+				return sqltypes.Value{}, err
+			}
 		}
 		if t.baseType == sqltypes.Binary {
 			val = append(val, make([]byte, int(t.maxCharLength)-len(val))...)


### PR DESCRIPTION
This fixes dropped `err` variables in the `sql/types` package. Unit tests are passing both before and after changes.