### PR TITLE
fix: strip backticks from join hint arguments

### DIFF
--- a/sql/memo/select_hints.go
+++ b/sql/memo/select_hints.go
@@ -145,7 +145,7 @@ func parseJoinHints(comment string) []Hint {
 		if c[3] != "" {
 			argsParsed := argsRegex.FindAllStringSubmatch(c[3], -1)
 			for _, arg := range argsParsed {
-				args = append(args, arg[1])
+				args = append(args, strings.Trim(arg[1], "`"))
 			}
 		}
 		hint := newHint(c[1], args)

--- a/sql/memo/select_hints_test.go
+++ b/sql/memo/select_hints_test.go
@@ -128,6 +128,22 @@ func TestHintParsing(t *testing.T) {
 				{Typ: HintTypeNoIndexConditionPushDown},
 			},
 		},
+		{
+			comment: "/*+ LOOKUP_JOIN(`a`, `b`) */",
+			hints:   []Hint{{Typ: HintTypeLookupJoin, Args: []string{"a", "b"}}},
+		},
+		{
+			comment: "/*+ HASH_JOIN(`a`,`b`) */",
+			hints:   []Hint{{Typ: HintTypeHashJoin, Args: []string{"a", "b"}}},
+		},
+		{
+			comment: "/*+ MERGE_JOIN(`a`, `b`) */",
+			hints:   []Hint{{Typ: HintTypeMergeJoin, Args: []string{"a", "b"}}},
+		},
+		{
+			comment: "/*+ JOIN_ORDER(`a`, `b`, `c`) */",
+			hints:   []Hint{{Typ: HintTypeJoinOrder, Args: []string{"a", "b", "c"}}},
+		},
 	}
 
 	for _, tt := range tests {

--- a/sql/memo/select_hints_test.go
+++ b/sql/memo/select_hints_test.go
@@ -144,6 +144,18 @@ func TestHintParsing(t *testing.T) {
 			comment: "/*+ JOIN_ORDER(`a`, `b`, `c`) */",
 			hints:   []Hint{{Typ: HintTypeJoinOrder, Args: []string{"a", "b", "c"}}},
 		},
+		{
+			comment: "/*+ LOOKUP_JOIN(t1, `t2.with.dot`) */",
+			hints:   []Hint{{Typ: HintTypeLookupJoin, Args: []string{"t1", "t2.with.dot"}}},
+		},
+		{
+			comment: "/*+ HASH_JOIN(`my-table`, `another-table`) */",
+			hints:   []Hint{{Typ: HintTypeHashJoin, Args: []string{"my-table", "another-table"}}},
+		},
+		{
+			comment: "/*+ JOIN_ORDER(`t1`, `t2.with.dot`, `my-table`) */",
+			hints:   []Hint{{Typ: HintTypeJoinOrder, Args: []string{"t1", "t2.with.dot", "my-table"}}},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes dolthub/dolt#10528

## Summary

When table names are backtick-quoted in join hints (e.g. `LOOKUP_JOIN(t1, `t2`)`), the `argsRegex` in `parseJoinHints()` captures backtick characters as part of the argument value. Later, `SetJoinOp()` compares this against `n.Name()` which returns the bare name (parser already stripped backticks from the AST). The comparison fails via `strings.EqualFold`, so the hint is silently ignored.

**Fix**: Strip surrounding backticks from each parsed hint argument using `strings.Trim(arg[1], "`")`.

## Test plan

- Added 4 unit test cases in `sql/memo/select_hints_test.go` for backtick-quoted args in `LOOKUP_JOIN`, `HASH_JOIN`, `MERGE_JOIN`, and `JOIN_ORDER`
- All existing tests continue to pass
- `go test -run TestHintParsing -v ./sql/memo/` passes (28/28)