### PR TITLE
fix: use pure-Go regex on Windows to avoid ICU header dependency

### DIFF
--- a/internal/regex/regex_cgo.go
+++ b/internal/regex/regex_cgo.go
@@ -1,4 +1,4 @@
-//go:build cgo && !gms_pure_go
+//go:build cgo && !windows && !gms_pure_go
 
 package regex
 

--- a/internal/regex/regex_pure.go
+++ b/internal/regex/regex_pure.go
@@ -1,4 +1,4 @@
-//go:build gms_pure_go
+//go:build windows || gms_pure_go
 
 package regex
 


### PR DESCRIPTION
## Summary

On Windows with `CGO_ENABLED=1` (the default), building any module that depends
on `go-mysql-server` fails because `internal/regex/regex_cgo.go` is selected,
which imports `go-icu-regex`, which requires ICU C headers (`unicode/uregex.h`)
that are not available on Windows.

This PR adds `!windows` to the CGO regex build constraint and `windows` to the
pure-Go regex constraint, so Windows builds automatically use the pure-Go
`regexp` fallback — matching the behavior already available via `gms_pure_go`.

### Changes

- `internal/regex/regex_cgo.go`: `//go:build cgo && !gms_pure_go` → `//go:build cgo && !windows && !gms_pure_go`
- `internal/regex/regex_pure.go`: `//go:build gms_pure_go` → `//go:build windows || gms_pure_go`

### Why

The `gms_pure_go` build tag works for projects that control their build flags,
but users running `go install somepackage@latest` cannot pass build tags. This
means any downstream module depending on `go-mysql-server` is broken on Windows
out of the box when CGO is enabled.

### Testing

Verified with a downstream project (beads):
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=1 go list -deps ./cmd/bd` no longer
  includes `go-icu-regex`
- `go-mysql-server` packages remain in the dependency graph (embedded mode
  preserved)
- Linux/macOS CGO builds continue to use ICU regex as before

Ref: https://github.com/steveyegge/beads/issues/3013