### PR TITLE
trim analyzer rules for simple selects

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -5382,6 +5382,14 @@ SELECT * FROM cte WHERE  d = 2;`,
 		},
 	},
 	{
+		Query: `SELECT CASE WHEN i > (select 1) THEN 'one' ELSE 'two' END FROM mytable`,
+		Expected: []sql.Row{
+			{"two"},
+			{"one"},
+			{"one"},
+		},
+	},
+	{
 		Query: `SELECT CASE i WHEN 1 THEN JSON_OBJECT("a", 1) WHEN 2 THEN JSON_OBJECT("b", 2) END FROM mytable`,
 		Expected: []sql.Row{
 			{types.MustJSON(`{"a": 1}`)},

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -537,7 +537,7 @@ func (a *Analyzer) analyzeWithSelector(ctx *sql.Context, n sql.Node, scope *plan
 	a.LogNode(n)
 
 	batches := a.Batches
-	if b, ok := getBatchesForNode(n); ok {
+	if b, ok := a.getBatchesForNode(scope, n); ok {
 		batches = b
 	}
 

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -537,7 +537,7 @@ func (a *Analyzer) analyzeWithSelector(ctx *sql.Context, n sql.Node, scope *plan
 	a.LogNode(n)
 
 	batches := a.Batches
-	if b, ok := getBatchesForNode(scope, n); ok {
+	if b, ok := getBatchesForNode(scope, n, qFlags); ok {
 		batches = b
 	}
 

--- a/sql/analyzer/analyzer.go
+++ b/sql/analyzer/analyzer.go
@@ -537,7 +537,7 @@ func (a *Analyzer) analyzeWithSelector(ctx *sql.Context, n sql.Node, scope *plan
 	a.LogNode(n)
 
 	batches := a.Batches
-	if b, ok := a.getBatchesForNode(scope, n); ok {
+	if b, ok := getBatchesForNode(scope, n); ok {
 		batches = b
 	}
 

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -21,7 +21,6 @@ func isSubqueryExpr(expr sql.Expression) bool {
 	case expression.BinaryExpression:
 		return isSubqueryExpr(e.Left()) || isSubqueryExpr(e.Right())
 	default:
-		// TODO: write test cases for subquery case
 		for _, child := range expr.Children() {
 			if isSubqueryExpr(child) {
 				return true

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -2,54 +2,15 @@ package analyzer
 
 import (
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
-
-func isSubqueryExpr(expr sql.Expression) bool {
-	switch e := expr.(type) {
-	case *plan.Subquery:
-		return true
-	case *plan.InSubquery:
-		return true
-	case *plan.ExistsSubquery:
-		return true
-	case *expression.Case:
-		if isSubqueryExpr(e.Expr) {
-			return true
-		}
-		if isSubqueryExpr(e.Else) {
-			return true
-		}
-		for _, branch := range e.Branches {
-			if isSubqueryExpr(branch.Value) || isSubqueryExpr(branch.Cond) {
-				return true
-			}
-		}
-		return false
-	case expression.UnaryExpression:
-		return isSubqueryExpr(e.UnaryChild())
-	case expression.BinaryExpression:
-		return isSubqueryExpr(e.Left()) || isSubqueryExpr(e.Right())
-	default:
-		return false
-	}
-}
 
 func isSimpleSelect(proj *plan.Project) bool {
 	child := proj.Child
 	switch c := child.(type) {
 	case *plan.Filter:
-		if isSubqueryExpr(c.Expression) {
-			return false
-		}
 		child = c.Child
 	default:
-	}
-	for _, expr := range proj.Projections {
-		if isSubqueryExpr(expr) {
-			return false
-		}
 	}
 	if _, isResTbl := child.(*plan.ResolvedTable); !isResTbl {
 		return false
@@ -59,7 +20,7 @@ func isSimpleSelect(proj *plan.Project) bool {
 
 // getBatchesForNode returns a partial analyzer ruleset for simple node
 // types that require little prior validation before execution.
-func getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
+func getBatchesForNode(scope *plan.Scope, node sql.Node, qFlags *sql.QueryFlags) ([]*Batch, bool) {
 	switch n := node.(type) {
 	case *plan.Commit:
 		return nil, true
@@ -190,7 +151,7 @@ func getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
 			return nil, false
 		}
 		// Scope checks to prevent this from applying to subqueries
-		if (scope == nil || scope.RecursionDepth() < 1) && isSimpleSelect(n) {
+		if (scope == nil || scope.RecursionDepth() < 1) && (qFlags == nil || !qFlags.SubqueryIsSet()) && isSimpleSelect(n) {
 			return []*Batch{
 				{
 					Desc:       "onceBeforeDefault",

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -48,7 +48,7 @@ func isSimpleSelect(proj *plan.Project) bool {
 
 // getBatchesForNode returns a partial analyzer ruleset for simple node
 // types that require little prior validation before execution.
-func (a *Analyzer) getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
+func getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
 	switch n := node.(type) {
 	case *plan.Commit:
 		return nil, true
@@ -174,7 +174,7 @@ func (a *Analyzer) getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch
 			}, true
 		}
 	case *plan.Project:
-		// TODO: avoid analyzer recursing on subqueries in project expressions
+		// Scope checks here are to prevent this from applying to subqueries
 		if (scope == nil || scope.RecursionDepth() < 1) && isSimpleSelect(n) {
 			return []*Batch{
 				{
@@ -191,8 +191,7 @@ func (a *Analyzer) getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch
 					Rules:      AlwaysBeforeDefault,
 				},
 				{
-					// TODO: hacky way to deal with subqueries?
-					Desc:       "default-rules",
+					Desc:       "defaultRules",
 					Iterations: 1,
 					Rules: []Rule{
 						{Id: validateStarExpressionsId, Apply: validateStarExpressions},
@@ -206,17 +205,19 @@ func (a *Analyzer) getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch
 						{Id: stripTableNameInDefaultsId, Apply: stripTableNamesFromColumnDefaults},
 						{Id: pushFiltersId, Apply: pushFilters},
 						{Id: optimizeJoinsId, Apply: optimizeJoins},
-						{Id: applyIndexesFromOuterScopeId, Apply: applyIndexesFromOuterScope}, // TODO: this shouldn't be necessary
 						{Id: eraseProjectionId, Apply: eraseProjection},
 						{Id: applyHashInId, Apply: applyHashIn},
 						{Id: assignRoutinesId, Apply: assignRoutines},
 					},
 				},
 				{
-					// TODO: can skip resolveInsertRows here probably
 					Desc:       "onceAfterAll",
 					Iterations: 1,
-					Rules:      OnceAfterAll,
+					Rules: []Rule{
+						{Id: assignExecIndexesId, Apply: assignExecIndexes},
+						{Id: QuoteDefaultColumnValueNamesId, Apply: quoteDefaultColumnValueNames},
+						{Id: TrackProcessId, Apply: trackProcess},
+					},
 				},
 				{
 					// TODO: can skip resolveInsertRows here probably

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
+// isSimpleSelect checks if an unanalyzed plan tree is SELECT query with a FILTER that doesn't need thorough analysis
 func isSimpleSelect(proj *plan.Project) bool {
 	child := proj.Child
 	switch c := child.(type) {
@@ -12,10 +13,8 @@ func isSimpleSelect(proj *plan.Project) bool {
 		child = c.Child
 	default:
 	}
-	if _, isResTbl := child.(*plan.ResolvedTable); !isResTbl {
-		return false
-	}
-	return true
+	_, isResTbl := child.(*plan.ResolvedTable)
+	return isResTbl
 }
 
 // getBatchesForNode returns a partial analyzer ruleset for simple node

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -186,7 +186,7 @@ func getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
 		}
 	case *plan.Project:
 		// TODO: hacky, but if using a custom rule set, do not apply this optimization
-		if len(AlwaysBeforeDefault) == 0 {
+		if len(AlwaysBeforeDefault) != 0 {
 			return nil, false
 		}
 		// Scope checks to prevent this from applying to subqueries

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -14,18 +14,24 @@ func isSubqueryExpr(expr sql.Expression) bool {
 		return true
 	case *plan.ExistsSubquery:
 		return true
-	case *expression.InTuple:
-		return true
+	case *expression.Case:
+		if isSubqueryExpr(e.Expr) {
+			return true
+		}
+		if isSubqueryExpr(e.Else) {
+			return true
+		}
+		for _, branch := range e.Branches {
+			if isSubqueryExpr(branch.Value) || isSubqueryExpr(branch.Cond) {
+				return true
+			}
+		}
+		return false
 	case expression.UnaryExpression:
 		return isSubqueryExpr(e.UnaryChild())
 	case expression.BinaryExpression:
 		return isSubqueryExpr(e.Left()) || isSubqueryExpr(e.Right())
 	default:
-		for _, child := range expr.Children() {
-			if isSubqueryExpr(child) {
-				return true
-			}
-		}
 		return false
 	}
 }

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
-func isSubqeryExpr(expr sql.Expression) bool {
+func isSubqueryExpr(expr sql.Expression) bool {
 	switch e := expr.(type) {
 	case *plan.Subquery:
 		return true
@@ -14,13 +14,19 @@ func isSubqeryExpr(expr sql.Expression) bool {
 		return true
 	case *plan.ExistsSubquery:
 		return true
-	//case *expression.Alias:
-	//	return isSubqeryExpr(e.Child)
+	case *expression.InTuple:
+		return true
 	case expression.UnaryExpression:
-		return isSubqeryExpr(e.UnaryChild())
+		return isSubqueryExpr(e.UnaryChild())
 	case expression.BinaryExpression:
-		return isSubqeryExpr(e.Left()) || isSubqeryExpr(e.Right())
+		return isSubqueryExpr(e.Left()) || isSubqueryExpr(e.Right())
 	default:
+		// TODO: write test cases for subquery case
+		for _, child := range expr.Children() {
+			if isSubqueryExpr(child) {
+				return true
+			}
+		}
 		return false
 	}
 }
@@ -29,14 +35,14 @@ func isSimpleSelect(proj *plan.Project) bool {
 	child := proj.Child
 	switch c := child.(type) {
 	case *plan.Filter:
-		if isSubqeryExpr(c.Expression) {
+		if isSubqueryExpr(c.Expression) {
 			return false
 		}
 		child = c.Child
 	default:
 	}
 	for _, expr := range proj.Projections {
-		if isSubqeryExpr(expr) {
+		if isSubqueryExpr(expr) {
 			return false
 		}
 	}
@@ -174,15 +180,25 @@ func getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
 			}, true
 		}
 	case *plan.Project:
-		// Scope checks here are to prevent this from applying to subqueries
+		// TODO: hacky, but if using a custom rule set, do not apply this optimization
+		if len(AlwaysBeforeDefault) == 0 {
+			return nil, false
+		}
+		// Scope checks to prevent this from applying to subqueries
 		if (scope == nil || scope.RecursionDepth() < 1) && isSimpleSelect(n) {
 			return []*Batch{
 				{
 					Desc:       "onceBeforeDefault",
 					Iterations: 1,
 					Rules: []Rule{
-						{Id: simplifyFiltersId, Apply: simplifyFilters},
-						{Id: pushNotFiltersId, Apply: pushNotFilters},
+						{
+							Id:    simplifyFiltersId,
+							Apply: simplifyFilters,
+						},
+						{
+							Id:    pushNotFiltersId,
+							Apply: pushNotFilters,
+						},
 					},
 				},
 				{
@@ -194,37 +210,72 @@ func getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
 					Desc:       "defaultRules",
 					Iterations: 1,
 					Rules: []Rule{
-						{Id: validateStarExpressionsId, Apply: validateStarExpressions},
-						{Id: pruneTablesId, Apply: pruneTables},
+						{
+							Id:    validateStarExpressionsId,
+							Apply: validateStarExpressions,
+						},
+						{
+							Id:    pruneTablesId,
+							Apply: pruneTables,
+						},
 					},
 				},
 				{
 					Desc:       "simpleSelect",
 					Iterations: 1,
 					Rules: []Rule{
-						{Id: stripTableNameInDefaultsId, Apply: stripTableNamesFromColumnDefaults},
-						{Id: pushFiltersId, Apply: pushFilters},
-						{Id: optimizeJoinsId, Apply: optimizeJoins},
-						{Id: eraseProjectionId, Apply: eraseProjection},
-						{Id: applyHashInId, Apply: applyHashIn},
-						{Id: assignRoutinesId, Apply: assignRoutines},
+						{
+							Id:    stripTableNameInDefaultsId,
+							Apply: stripTableNamesFromColumnDefaults,
+						},
+						{
+							Id:    pushFiltersId,
+							Apply: pushFilters,
+						},
+						{
+							Id:    optimizeJoinsId,
+							Apply: optimizeJoins,
+						},
+						{
+							Id:    eraseProjectionId,
+							Apply: eraseProjection,
+						},
+						{
+							Id:    applyHashInId,
+							Apply: applyHashIn,
+						},
+						{
+							Id:    assignRoutinesId,
+							Apply: assignRoutines,
+						},
 					},
 				},
 				{
 					Desc:       "onceAfterAll",
 					Iterations: 1,
 					Rules: []Rule{
-						{Id: assignExecIndexesId, Apply: assignExecIndexes},
-						{Id: QuoteDefaultColumnValueNamesId, Apply: quoteDefaultColumnValueNames},
-						{Id: TrackProcessId, Apply: trackProcess},
+						{
+							Id:    assignExecIndexesId,
+							Apply: assignExecIndexes,
+						},
+						{
+							Id:    QuoteDefaultColumnValueNamesId,
+							Apply: quoteDefaultColumnValueNames,
+						},
+						{
+							Id:    TrackProcessId,
+							Apply: trackProcess,
+						},
 					},
 				},
 				{
-					// TODO: can skip resolveInsertRows here probably
 					Desc:       "simpleSelectValidationRules",
 					Iterations: 1,
 					Rules: []Rule{
-						{Id: ValidateOperandsId, Apply: validateOperands},
+						{
+							Id:    ValidateOperandsId,
+							Apply: validateOperands,
+						},
 					},
 				},
 			}, true

--- a/sql/analyzer/node_batches.go
+++ b/sql/analyzer/node_batches.go
@@ -2,12 +2,53 @@ package analyzer
 
 import (
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
+func isSubqeryExpr(expr sql.Expression) bool {
+	switch e := expr.(type) {
+	case *plan.Subquery:
+		return true
+	case *plan.InSubquery:
+		return true
+	case *plan.ExistsSubquery:
+		return true
+	//case *expression.Alias:
+	//	return isSubqeryExpr(e.Child)
+	case expression.UnaryExpression:
+		return isSubqeryExpr(e.UnaryChild())
+	case expression.BinaryExpression:
+		return isSubqeryExpr(e.Left()) || isSubqeryExpr(e.Right())
+	default:
+		return false
+	}
+}
+
+func isSimpleSelect(proj *plan.Project) bool {
+	child := proj.Child
+	switch c := child.(type) {
+	case *plan.Filter:
+		if isSubqeryExpr(c.Expression) {
+			return false
+		}
+		child = c.Child
+	default:
+	}
+	for _, expr := range proj.Projections {
+		if isSubqeryExpr(expr) {
+			return false
+		}
+	}
+	if _, isResTbl := child.(*plan.ResolvedTable); !isResTbl {
+		return false
+	}
+	return true
+}
+
 // getBatchesForNode returns a partial analyzer ruleset for simple node
 // types that require little prior validation before execution.
-func getBatchesForNode(node sql.Node) ([]*Batch, bool) {
+func (a *Analyzer) getBatchesForNode(scope *plan.Scope, node sql.Node) ([]*Batch, bool) {
 	switch n := node.(type) {
 	case *plan.Commit:
 		return nil, true
@@ -129,6 +170,61 @@ func getBatchesForNode(node sql.Node) ([]*Batch, bool) {
 					Desc:       "onceAfterAll",
 					Iterations: 1,
 					Rules:      OnceAfterAll,
+				},
+			}, true
+		}
+	case *plan.Project:
+		// TODO: avoid analyzer recursing on subqueries in project expressions
+		if (scope == nil || scope.RecursionDepth() < 1) && isSimpleSelect(n) {
+			return []*Batch{
+				{
+					Desc:       "onceBeforeDefault",
+					Iterations: 1,
+					Rules: []Rule{
+						{Id: simplifyFiltersId, Apply: simplifyFilters},
+						{Id: pushNotFiltersId, Apply: pushNotFilters},
+					},
+				},
+				{
+					Desc:       "alwaysBeforeDefault",
+					Iterations: 1,
+					Rules:      AlwaysBeforeDefault,
+				},
+				{
+					// TODO: hacky way to deal with subqueries?
+					Desc:       "default-rules",
+					Iterations: 1,
+					Rules: []Rule{
+						{Id: validateStarExpressionsId, Apply: validateStarExpressions},
+						{Id: pruneTablesId, Apply: pruneTables},
+					},
+				},
+				{
+					Desc:       "simpleSelect",
+					Iterations: 1,
+					Rules: []Rule{
+						{Id: stripTableNameInDefaultsId, Apply: stripTableNamesFromColumnDefaults},
+						{Id: pushFiltersId, Apply: pushFilters},
+						{Id: optimizeJoinsId, Apply: optimizeJoins},
+						{Id: applyIndexesFromOuterScopeId, Apply: applyIndexesFromOuterScope}, // TODO: this shouldn't be necessary
+						{Id: eraseProjectionId, Apply: eraseProjection},
+						{Id: applyHashInId, Apply: applyHashIn},
+						{Id: assignRoutinesId, Apply: assignRoutines},
+					},
+				},
+				{
+					// TODO: can skip resolveInsertRows here probably
+					Desc:       "onceAfterAll",
+					Iterations: 1,
+					Rules:      OnceAfterAll,
+				},
+				{
+					// TODO: can skip resolveInsertRows here probably
+					Desc:       "simpleSelectValidationRules",
+					Iterations: 1,
+					Rules: []Rule{
+						{Id: ValidateOperandsId, Apply: validateOperands},
+					},
 				},
 			}, true
 		}

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -251,7 +251,7 @@ func resolveSubqueriesHelper(ctx *sql.Context, a *Analyzer, node sql.Node, scope
 		} else {
 			return transform.OneNodeExprsWithNode(n, func(node sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				if sq, ok := e.(*plan.Subquery); ok {
-					return analyzeSubqueryExpression(ctx, a, node, sq, scope, sel, finalize, qFlags)
+					return analyzeSubqueryExpression(ctx, a, n, sq, scope, sel, finalize, qFlags)
 				} else {
 					return e, transform.SameTree, nil
 				}

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -251,8 +251,7 @@ func resolveSubqueriesHelper(ctx *sql.Context, a *Analyzer, node sql.Node, scope
 		} else {
 			return transform.OneNodeExprsWithNode(n, func(node sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				if sq, ok := e.(*plan.Subquery); ok {
-					newExpr, same, err := analyzeSubqueryExpression(ctx, a, node, sq, scope, sel, finalize, qFlags)
-					return newExpr, same, err
+					return analyzeSubqueryExpression(ctx, a, node, sq, scope, sel, finalize, qFlags)
 				} else {
 					return e, transform.SameTree, nil
 				}

--- a/sql/analyzer/resolve_subqueries.go
+++ b/sql/analyzer/resolve_subqueries.go
@@ -251,7 +251,8 @@ func resolveSubqueriesHelper(ctx *sql.Context, a *Analyzer, node sql.Node, scope
 		} else {
 			return transform.OneNodeExprsWithNode(n, func(node sql.Node, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
 				if sq, ok := e.(*plan.Subquery); ok {
-					return analyzeSubqueryExpression(ctx, a, n, sq, scope, sel, finalize, qFlags)
+					newExpr, same, err := analyzeSubqueryExpression(ctx, a, node, sq, scope, sel, finalize, qFlags)
+					return newExpr, same, err
 				} else {
 					return e, transform.SameTree, nil
 				}

--- a/sql/plan/scope.go
+++ b/sql/plan/scope.go
@@ -90,6 +90,7 @@ func (s *Scope) NewScopeFromSubqueryExpression(node sql.Node, corr sql.ColSet) *
 	subScope := s.NewScope(node)
 	subScope.CurrentNodeIsFromSubqueryExpression = true
 	subScope.corr = corr
+	subScope.recursionDepth = s.RecursionDepth() + 1
 	if s != nil {
 		subScope.corr = s.corr.Union(corr)
 	}


### PR DESCRIPTION
This PR adds a fast analysis pass for queries of the form `SELECT ... FROM ... WHERE ...`.
The idea is that simple select queries (no subqueries) can avoid many (recursive) analyzer rules like applying triggers and foreign keys.

Benchmarks: https://github.com/dolthub/dolt/pull/10824#issuecomment-4202591072