### PR TITLE
fix: change INFORMATION_SCHEMA default collation from utf8mb3 to utf8mb4

### DIFF
--- a/sql/collations.go
+++ b/sql/collations.go
@@ -380,7 +380,7 @@ const (
 	Collation_utf8_general_mysql500_ci = Collation_utf8mb3_general_mysql500_ci
 
 	Collation_Default                    = Collation_utf8mb4_0900_bin
-	Collation_Information_Schema_Default = Collation_utf8mb3_general_ci
+	Collation_Information_Schema_Default = Collation_utf8mb4_general_ci
 	// Collation_Unspecified is used when a collation has not been specified, either explicitly or implicitly. This is
 	// usually used as an intermediate collation to be later replaced by an analyzer pass or a plan, although it is
 	// valid to use it directly. When used, behaves identically to the default collation, although it will NOT match


### PR DESCRIPTION
## Problem

Popular MySQL clients like **Tableau Desktop** send metadata discovery queries that explicitly apply `utf8mb4` collations to `INFORMATION_SCHEMA` columns:

```sql
SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
WHERE IS_NULLABLE COLLATE utf8mb4_0900_bin = 'NO'
```

This is standard client behavior, **the client chooses the collation**, not the server application. Tableau (and potentially other modern MySQL clients) assumes `INFORMATION_SCHEMA` columns are `utf8mb4`-compatible, which is true for real MySQL 8.0+ servers.

However, `go-mysql-server` currently defaults `INFORMATION_SCHEMA` columns to `utf8mb3_general_ci`. This causes `CollatedExpression.Eval()` ([`sql/expression/collatedexpr.go:87`](https://github.com/dolthub/go-mysql-server/blob/main/sql/expression/collatedexpr.go#L87)) to reject the query with:

```
COLLATION 'utf8mb4_0900_bin' is not valid for CHARACTER SET 'utf8mb3'
```

The charset comparison (`utf8mb4 != utf8mb3`) fails, even though the data is fully compatible. This makes `go-mysql-server` incompatible with any client that uses `utf8mb4` collations on metadata columns.

## Fix

One-line change in [`sql/collations.go`](https://github.com/dolthub/go-mysql-server/blob/main/sql/collations.go):

```diff
- Collation_Information_Schema_Default = Collation_utf8mb3_general_ci
+ Collation_Information_Schema_Default = Collation_utf8mb4_general_ci
```

## Why this is safe

1. **`utf8mb4` is a strict superset of `utf8mb3`** — identical encoding for all BMP characters. From the [MySQL docs](https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8mb4.html):

   > *For a BMP character, utf8mb4 and utf8mb3 have identical storage characteristics: same code values, same encoding, same length.*

2. **`INFORMATION_SCHEMA` columns only contain ASCII values** (`YES`, `NO`, `varchar`, `int`, column names, etc.), all BMP characters. Storage and encoding remain identical.

3. **`utf8mb3` is deprecated as of MySQL 8.0**. From the [MySQL docs](https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8.html):

   > *The recommended character set for MySQL is utf8mb4. All new applications should use utf8mb4.*

4. **Real MySQL 8.0+ servers already use `utf8mb4` for `INFORMATION_SCHEMA`**. This change aligns `go-mysql-server` with actual MySQL behavior, improving client compatibility.

## Impact

Without this fix, any MySQL client that applies a `utf8mb4` collation to `INFORMATION_SCHEMA` queries will fail. This is not an edge case, it affects **Tableau Desktop** (one of the most widely used BI tools) and will likely affect more clients as `utf8mb3` continues to be phased out.

## References

- [MySQL 8.4: The utf8mb4 Character Set](https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8mb4.html)
- [MySQL 8.4: The utf8mb3 Character Set (Deprecated)](https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8.html)
