### PR TITLE
Ignore unique key errors when inserting into fulltext position table

### DIFF
--- a/enginetest/queries/fulltext_queries.go
+++ b/enginetest/queries/fulltext_queries.go
@@ -1205,4 +1205,31 @@ var FulltextTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/10882
+		Name: "REPLACE INTO/INSERT...ON DUPLICATE KEY UPDATE when words are in the same position",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY, body LONGTEXT NOT NULL)",
+			"CREATE FULLTEXT INDEX ft ON t(body)",
+			"INSERT INTO t VALUES (1, 'hello world')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "REPLACE INTO t VALUES (1, 'hello earth')",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2}}},
+			},
+			{
+				Query:    "select * from t",
+				Expected: []sql.Row{{1, "hello earth"}},
+			},
+			{
+				Query:    "INSERT INTO t VALUES (1, 'hello world') ON DUPLICATE KEY UPDATE body = VALUES(body)",
+				Expected: []sql.Row{{types.OkResult{RowsAffected: 2}}},
+			},
+			{
+				Query:    "select * from t",
+				Expected: []sql.Row{{1, "hello world"}},
+			},
+		},
+	},
 }

--- a/sql/fulltext/fulltext_editor.go
+++ b/sql/fulltext/fulltext_editor.go
@@ -331,6 +331,10 @@ func (editor TableEditor) Insert(ctx *sql.Context, row sql.Row) error {
 			positionRow[0] = word
 			positionRow = append(positionRow, keyCols...)
 			positionRow = append(positionRow, position)
+			// TODO: In some places, for example `REPLACE INTO` and `INSERT...ON DUPLICATE UPDATE`, we use the information
+			//  inside UniqueKeyError to perform the replace/update. However, the information in the UniqueKeyError
+			//  generated from an Insert on index.Position.Editor does not match the primary table's schema.
+			//  https://github.com/dolthub/dolt/issues/10882#issuecomment-4255176383
 			if err = index.Position.Editor.Insert(ctx, positionRow); err != nil {
 				return err
 			}

--- a/sql/fulltext/fulltext_editor.go
+++ b/sql/fulltext/fulltext_editor.go
@@ -331,11 +331,8 @@ func (editor TableEditor) Insert(ctx *sql.Context, row sql.Row) error {
 			positionRow[0] = word
 			positionRow = append(positionRow, keyCols...)
 			positionRow = append(positionRow, position)
-			// TODO: In some places, for example `REPLACE INTO` and `INSERT...ON DUPLICATE UPDATE`, we use the information
-			//  inside UniqueKeyError to perform the replace/update. However, the information in the UniqueKeyError
-			//  generated from an Insert on index.Position.Editor does not match the primary table's schema.
-			//  https://github.com/dolthub/dolt/issues/10882#issuecomment-4255176383
-			if err = index.Position.Editor.Insert(ctx, positionRow); err != nil {
+			// TODO: write to this table only once, rather than ignoring duplicate errors
+			if err = index.Position.Editor.Insert(ctx, positionRow); err != nil && !sql.ErrPrimaryKeyViolation.Is(err) && !sql.ErrUniqueKeyViolation.Is(err) && !sql.ErrDuplicateEntry.Is(err) {
 				return err
 			}
 		}
@@ -358,7 +355,7 @@ func (editor TableEditor) Insert(ctx *sql.Context, row sql.Row) error {
 			docCountRow[0] = word
 			docCountRow = append(docCountRow, keyCols...)
 			docCountRow = append(docCountRow, wordDocCount)
-			//TODO: write to this table only once, rather than ignoring duplicate errors
+			// TODO: write to this table only once, rather than ignoring duplicate errors
 			if err = index.DocCount.Editor.Insert(ctx, docCountRow); err != nil && !sql.ErrPrimaryKeyViolation.Is(err) && !sql.ErrUniqueKeyViolation.Is(err) && !sql.ErrDuplicateEntry.Is(err) {
 				return err
 			}

--- a/sql/fulltext/multi_editor.go
+++ b/sql/fulltext/multi_editor.go
@@ -93,12 +93,21 @@ func (editor MultiTableEditor) StatementComplete(ctx *sql.Context) error {
 
 // Insert implements the interface sql.TableEditor.
 func (editor MultiTableEditor) Insert(ctx *sql.Context, row sql.Row) error {
+	// Any error generated from inserting on a primary table should take precedence over errors generated from
+	// inserting on a secondary table.
+	if err := editor.primary.Insert(ctx, row); err != nil {
+		return err
+	}
 	for _, secondary := range editor.secondaries {
+		// TODO: In some places, for example `REPLACE INTO` and `INSERT...ON DUPLICATE UPDATE`, we use the information
+		//  inside UniqueKeyError to perform the replace/update. However, the information in the UniqueKeyError
+		//  generated from an Insert on a secondary table does not match the primary table's schema.
+		//  https://github.com/dolthub/dolt/issues/10882#issuecomment-4255176383
 		if err := secondary.Insert(ctx, row); err != nil {
 			return err
 		}
 	}
-	return editor.primary.Insert(ctx, row)
+	return nil
 }
 
 // Update implements the interface sql.TableEditor.

--- a/sql/fulltext/multi_editor.go
+++ b/sql/fulltext/multi_editor.go
@@ -93,21 +93,16 @@ func (editor MultiTableEditor) StatementComplete(ctx *sql.Context) error {
 
 // Insert implements the interface sql.TableEditor.
 func (editor MultiTableEditor) Insert(ctx *sql.Context, row sql.Row) error {
-	// Any error generated from inserting on a primary table should take precedence over errors generated from
-	// inserting on a secondary table.
-	if err := editor.primary.Insert(ctx, row); err != nil {
-		return err
-	}
 	for _, secondary := range editor.secondaries {
 		// TODO: In some places, for example `REPLACE INTO` and `INSERT...ON DUPLICATE UPDATE`, we use the information
 		//  inside UniqueKeyError to perform the replace/update. However, the information in the UniqueKeyError
-		//  generated from an Insert on a secondary table does not match the primary table's schema.
+		//  generated from an Insert on a secondary table does always not match the primary table's schema.
 		//  https://github.com/dolthub/dolt/issues/10882#issuecomment-4255176383
 		if err := secondary.Insert(ctx, row); err != nil {
 			return err
 		}
 	}
-	return nil
+	return editor.primary.Insert(ctx, row)
 }
 
 // Update implements the interface sql.TableEditor.

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -189,6 +189,8 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 					return nil, sql.NewWrappedInsertError(row, err)
 				}
 
+				// TODO: For multitables, UniqueKeyError.Existing might not be the correct row if the error is coming
+				//  from a secondary table. https://github.com/dolthub/dolt/issues/10882#issuecomment-4255176383
 				ue := err.(*errors.Error).Cause().(sql.UniqueKeyError)
 				if err = i.replacer.Delete(ctx, ue.Existing); err != nil {
 					i.rowSource.Close(ctx)
@@ -206,6 +208,8 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 		if err := i.inserter.Insert(ctx, row); err != nil {
 			if (sql.ErrPrimaryKeyViolation.Is(err) || sql.ErrUniqueKeyViolation.Is(err)) &&
 				i.onDupKeyUpdateExprs.HasUpdates() {
+				// TODO: For multitables, UniqueKeyError.Existing might not be the correct row if the error is coming
+				//  from a secondary table. https://github.com/dolthub/dolt/issues/10882#issuecomment-4255176383
 				if uniqueKeyError, ok := err.(*errors.Error).Cause().(sql.UniqueKeyError); ok {
 					return i.handleOnDuplicateKeyUpdate(ctx, uniqueKeyError.Existing, row)
 				}


### PR DESCRIPTION
fixes dolthub/dolt#10882

Ignore unique key errors when inserting into fulltext `index.Position` table (similar to how [unique key errors are ignored for `index.DocCount`](https://github.com/dolthub/go-mysql-server/blob/c689a22b9f491118094fffe8a187e679de242864/sql/fulltext/fulltext_editor.go#L358)).

We should consider using a non-unique index for `index.Position` and `index.DocCount` or restructuring how we're writing to these tables if we're always going to be ignoring unique key errors.