### PR TITLE
new signal error to skip modifying rows during DML operation

### DIFF
--- a/sql/errors.go
+++ b/sql/errors.go
@@ -136,7 +136,7 @@ var (
 
 	// ErrMisusedAlias is returned when a alias is defined and used in the same projection.
 	ErrMisusedAlias = errors.NewKind("column %q does not exist in scope, but there is an alias defined in" +
-			" this projection with that name. Aliases cannot be used in the same projection they're defined in")
+		" this projection with that name. Aliases cannot be used in the same projection they're defined in")
 
 	// ErrInvalidAsOfExpression is returned when an expression for AS OF cannot be used
 	ErrInvalidAsOfExpression = errors.NewKind("expression %s cannot be used in AS OF")
@@ -420,7 +420,7 @@ var (
 	// prefix length specified, and the collation is case-insensitive or accent-insensitive, meaning we can't
 	// reliably use a content-hashed field to detect uniqueness.
 	ErrCollationNotSupportedOnUniqueTextIndex = errors.NewKind("unable to create a unique index on TEXT columns without " +
-			"a prefix length specified when using a case-insensitive or accent-insensitive collation")
+		"a prefix length specified when using a case-insensitive or accent-insensitive collation")
 
 	// ErrPartitionNotFound is thrown when a partition key on a table is not found
 	ErrPartitionNotFound = errors.NewKind("partition not found %q")
@@ -576,7 +576,7 @@ var (
 	// grouping and another projected expression contains a non-aggregated column.
 	// MySQL error code: 1140, SQL state: 42000
 	ErrNonAggregatedColumnWithoutGroupBy = errors.NewKind("in aggregated query without GROUP BY, expression #%d of SELECT list contains nonaggregated column '%s'; " +
-			"this is incompatible with sql_mode=only_full_group_by")
+		"this is incompatible with sql_mode=only_full_group_by")
 
 	// ErrInvalidArgumentNumber is returned when the number of arguments to call a
 	// function is different from the function arity.
@@ -839,7 +839,7 @@ var (
 	// ErrCollationNotYetImplementedTemp is returned when the collation is valid but has not yet been implemented.
 	// This error is temporary, and will be removed once all collations have been added.
 	ErrCollationNotYetImplementedTemp = errors.NewKind("The collation `%s` has not yet been implemented, " +
-			"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
+		"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
 
 	// ErrCollationIllegalMix is returned when two different collations are used in a scenario where they are not compatible.
 	ErrCollationIllegalMix = errors.NewKind("Illegal mix of collations (%v) and (%v)")
@@ -859,7 +859,7 @@ var (
 	// ErrCharSetNotYetImplementedTemp is returned when the character set is valid but has not yet been implemented.
 	// This error is temporary, and will be removed once all character sets have been added.
 	ErrCharSetNotYetImplementedTemp = errors.NewKind("The character set `%s` has not yet been implemented, " +
-			"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
+		"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
 
 	// ErrNoTablesUsed is returned when there is no table provided or dual table is defined with column access.
 	ErrNoTablesUsed = errors.NewKind("No tables used")

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -119,6 +119,10 @@ var (
 	// ErrDeleteRowNotFound is returned when row being deleted was not found
 	ErrDeleteRowNotFound = errors.NewKind("row was not found when attempting to delete")
 
+	// ErrRowEditCanceled is returned when an INSERT, UPDATE, or DELETE operation is canceled due to a trigger
+	// or other circumstances. It is only used as a signal error.
+	ErrRowEditCanceled = errors.NewKind("row edit was canceled")
+
 	// ErrDuplicateAliasOrTable should be returned when a query contains a duplicate alias / table name.
 	ErrDuplicateAliasOrTable = errors.NewKind("Not unique table/alias: %s")
 
@@ -132,7 +136,7 @@ var (
 
 	// ErrMisusedAlias is returned when a alias is defined and used in the same projection.
 	ErrMisusedAlias = errors.NewKind("column %q does not exist in scope, but there is an alias defined in" +
-		" this projection with that name. Aliases cannot be used in the same projection they're defined in")
+			" this projection with that name. Aliases cannot be used in the same projection they're defined in")
 
 	// ErrInvalidAsOfExpression is returned when an expression for AS OF cannot be used
 	ErrInvalidAsOfExpression = errors.NewKind("expression %s cannot be used in AS OF")
@@ -416,7 +420,7 @@ var (
 	// prefix length specified, and the collation is case-insensitive or accent-insensitive, meaning we can't
 	// reliably use a content-hashed field to detect uniqueness.
 	ErrCollationNotSupportedOnUniqueTextIndex = errors.NewKind("unable to create a unique index on TEXT columns without " +
-		"a prefix length specified when using a case-insensitive or accent-insensitive collation")
+			"a prefix length specified when using a case-insensitive or accent-insensitive collation")
 
 	// ErrPartitionNotFound is thrown when a partition key on a table is not found
 	ErrPartitionNotFound = errors.NewKind("partition not found %q")
@@ -572,7 +576,7 @@ var (
 	// grouping and another projected expression contains a non-aggregated column.
 	// MySQL error code: 1140, SQL state: 42000
 	ErrNonAggregatedColumnWithoutGroupBy = errors.NewKind("in aggregated query without GROUP BY, expression #%d of SELECT list contains nonaggregated column '%s'; " +
-		"this is incompatible with sql_mode=only_full_group_by")
+			"this is incompatible with sql_mode=only_full_group_by")
 
 	// ErrInvalidArgumentNumber is returned when the number of arguments to call a
 	// function is different from the function arity.
@@ -835,7 +839,7 @@ var (
 	// ErrCollationNotYetImplementedTemp is returned when the collation is valid but has not yet been implemented.
 	// This error is temporary, and will be removed once all collations have been added.
 	ErrCollationNotYetImplementedTemp = errors.NewKind("The collation `%s` has not yet been implemented, " +
-		"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
+			"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
 
 	// ErrCollationIllegalMix is returned when two different collations are used in a scenario where they are not compatible.
 	ErrCollationIllegalMix = errors.NewKind("Illegal mix of collations (%v) and (%v)")
@@ -855,7 +859,7 @@ var (
 	// ErrCharSetNotYetImplementedTemp is returned when the character set is valid but has not yet been implemented.
 	// This error is temporary, and will be removed once all character sets have been added.
 	ErrCharSetNotYetImplementedTemp = errors.NewKind("The character set `%s` has not yet been implemented, " +
-		"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
+			"please create an issue at https://github.com/dolthub/go-mysql-server/issues/new and the DoltHub developers will implement it")
 
 	// ErrNoTablesUsed is returned when there is no table provided or dual table is defined with column access.
 	ErrNoTablesUsed = errors.NewKind("No tables used")

--- a/sql/rowexec/delete.go
+++ b/sql/rowexec/delete.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"
+	"gopkg.in/src-d/go-errors.v1"
 )
 
 // schemaPositionDeleter contains a sql.RowDeleter and the start (inclusive) and end (exclusive) position
@@ -74,7 +75,11 @@ type deleteIter struct {
 
 func (d *deleteIter) Next(ctx *sql.Context) (sql.Row, error) {
 	row, err := d.childIter.Next(ctx)
+
 	if err != nil {
+		if errors.Is(err, sql.ErrRowEditCanceled) {
+			return d.Next(ctx)
+		}
 		return nil, err
 	}
 	select {

--- a/sql/rowexec/delete.go
+++ b/sql/rowexec/delete.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"strings"
 
+	"gopkg.in/src-d/go-errors.v1"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/plan"
-	"gopkg.in/src-d/go-errors.v1"
 )
 
 // schemaPositionDeleter contains a sql.RowDeleter and the start (inclusive) and end (exclusive) position

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -73,6 +73,9 @@ func (i *insertIter) Next(ctx *sql.Context) (returnRow sql.Row, returnErr error)
 	}
 
 	if err != nil {
+		if errors.Is(err, sql.ErrRowEditCanceled) {
+			return i.Next(ctx)
+		}
 		return nil, i.ignoreOrClose(ctx, row, err)
 	}
 

--- a/sql/rowexec/update.go
+++ b/sql/rowexec/update.go
@@ -19,10 +19,11 @@ import (
 	"fmt"
 	"strings"
 
+	go_errors "gopkg.in/src-d/go-errors.v1"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/hash"
 	"github.com/dolthub/go-mysql-server/sql/plan"
-	go_errors "gopkg.in/src-d/go-errors.v1"
 )
 
 type updateIter struct {

--- a/sql/rowexec/update.go
+++ b/sql/rowexec/update.go
@@ -22,6 +22,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/hash"
 	"github.com/dolthub/go-mysql-server/sql/plan"
+	go_errors "gopkg.in/src-d/go-errors.v1"
 )
 
 type updateIter struct {
@@ -38,6 +39,9 @@ type updateIter struct {
 func (u *updateIter) Next(ctx *sql.Context) (sql.Row, error) {
 	oldAndNewRow, err := u.childIter.Next(ctx)
 	if err != nil {
+		if go_errors.Is(err, sql.ErrRowEditCanceled) {
+			return u.Next(ctx)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
This behavior is supported by postgres but not MySQL. This is a cleaner way to express that a row edit should be ignored and the rest of the operation continued.