### PR TITLE
Fix `SHOW CREATE VIEW` fail when underlying table is dropped

### DIFF
--- a/enginetest/queries/view_queries.go
+++ b/enginetest/queries/view_queries.go
@@ -541,6 +541,61 @@ CREATE TABLE tab1 (
 			},
 		},
 	},
+	{
+		// https://github.com/dolthub/dolt/issues/10902
+		Name: "SHOW CREATE VIEW returns stored definition regardless of underlying object state",
+		SetUpScript: []string{
+			"CREATE TABLE t (pk int PRIMARY KEY, c1 varchar(20));",
+			"CREATE VIEW v AS SELECT * FROM t;",
+			"DROP TABLE t;",
+			"CREATE TABLE t_chain (pk int PRIMARY KEY, c1 int);",
+			"CREATE VIEW v1 AS SELECT * FROM t_chain;",
+			"CREATE VIEW v2 AS SELECT pk FROM v1;",
+			"DROP VIEW v1;",
+			"CREATE TABLE t1 (pk int PRIMARY KEY, c1 int);",
+			"CREATE TABLE t2 (pk int PRIMARY KEY, c1 int);",
+			"CREATE VIEW v_union AS SELECT pk, c1 FROM t1 UNION SELECT pk, c1 FROM t2;",
+			"DROP TABLE t1;",
+			"DROP TABLE t2;",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "SHOW CREATE VIEW v;",
+				Expected: []sql.Row{{
+					"v",
+					"CREATE VIEW `v` AS SELECT * FROM t",
+					"utf8mb4",
+					"utf8mb4_0900_bin",
+				}},
+			},
+			{
+				Query: "SHOW CREATE VIEW v2;",
+				Expected: []sql.Row{{
+					"v2",
+					"CREATE VIEW `v2` AS SELECT pk FROM v1",
+					"utf8mb4",
+					"utf8mb4_0900_bin",
+				}},
+			},
+			{
+				Query: "SHOW CREATE VIEW v_union;",
+				Expected: []sql.Row{{
+					"v_union",
+					"CREATE VIEW `v_union` AS SELECT pk, c1 FROM t1 UNION SELECT pk, c1 FROM t2",
+					"utf8mb4",
+					"utf8mb4_0900_bin",
+				}},
+			},
+			{
+				Query:       "SHOW CREATE VIEW v1;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				Query:       "SHOW CREATE VIEW no_such_view;",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+		},
+	},
 }
 
 var ViewCreateInSubroutineTests = []ScriptTest{

--- a/sql/planbuilder/show.go
+++ b/sql/planbuilder/show.go
@@ -39,8 +39,10 @@ func (b *Builder) buildShow(inScope *scope, s *ast.Show) (outScope *scope) {
 	case "processlist":
 		outScope = inScope.push()
 		outScope.node = plan.NewShowProcessList()
-	case ast.CreateTableStr, "create view":
-		return b.buildShowTable(inScope, s, showType)
+	case ast.CreateTableStr:
+		return b.buildShowTable(inScope, s)
+	case ast.CreateViewStr:
+		return b.buildShowCreateView(inScope, s)
 	case "create database", "create schema":
 		return b.buildShowDatabase(inScope, s)
 	case ast.CreateTriggerStr:
@@ -118,24 +120,27 @@ func (b *Builder) buildShow(inScope *scope, s *ast.Show) (outScope *scope) {
 	return
 }
 
-func (b *Builder) buildShowTable(inScope *scope, s *ast.Show, showType string) (outScope *scope) {
-	outScope = inScope.push()
-	var asOf *ast.AsOf
-	var asOfExpr sql.Expression
+// showTargetInfo extracts the database name, table name, and AS OF info from |s|.
+func (b *Builder) showTargetInfo(inScope *scope, s *ast.Show) (db, tableName string, asOf *ast.AsOf, asOfExpr sql.Expression) {
 	if s.ShowTablesOpt != nil && s.ShowTablesOpt.AsOf != nil {
 		asOfExpr = b.buildAsOfExpr(inScope, s.ShowTablesOpt.AsOf)
 		asOf = &ast.AsOf{Time: s.ShowTablesOpt.AsOf}
 	}
-
-	db := s.Database
+	db = s.Database
 	if db == "" {
 		db = s.Table.DbQualifier.String()
 	}
 	if db == "" {
 		db = b.currentDb().Name()
 	}
+	tableName = strings.ToLower(s.Table.Name.String())
+	return
+}
 
-	tableName := strings.ToLower(s.Table.Name.String())
+func (b *Builder) buildShowTable(inScope *scope, s *ast.Show) (outScope *scope) {
+	outScope = inScope.push()
+	_, tableName, asOf, asOfExpr := b.showTargetInfo(inScope, s)
+
 	tableScope, ok := b.buildResolvedTableForTablename(inScope, s.Table, asOf)
 	if !ok {
 		err := sql.ErrTableNotFound.New(tableName)
@@ -152,7 +157,7 @@ func (b *Builder) buildShowTable(inScope *scope, s *ast.Show, showType string) (
 		})
 	}
 
-	showCreate := plan.NewShowCreateTableWithAsOf(tableScope.node, showType == "create view", asOfExpr)
+	showCreate := plan.NewShowCreateTableWithAsOf(tableScope.node, false, asOfExpr)
 	outScope.node = showCreate
 
 	if rt != nil {
@@ -178,6 +183,63 @@ func (b *Builder) buildShowTable(inScope *scope, s *ast.Show, showType string) (
 
 	}
 	return
+}
+
+func (b *Builder) buildShowCreateView(inScope *scope, s *ast.Show) (outScope *scope) {
+	outScope = inScope.push()
+	db, tableName, _, asOfExpr := b.showTargetInfo(inScope, s)
+	node, err := b.newShowCreateViewNode(db, tableName, asOfExpr)
+	if err != nil {
+		b.handleErr(err)
+	}
+	outScope.node = node
+	return
+}
+
+// newShowCreateViewNode returns a ShowCreateTable node for view |tableName| in |db|, reading
+// the stored definition directly without resolving the body.
+func (b *Builder) newShowCreateViewNode(db, tableName string, asOfExpr sql.Expression) (sql.Node, error) {
+	database, err := b.cat.Database(b.ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	viewDb, ok := database.(sql.ViewDatabase)
+	if !ok {
+		return nil, sql.ErrTableNotFound.New(tableName)
+	}
+	viewDef, found, err := viewDb.GetViewDefinition(b.ctx, tableName)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, sql.ErrTableNotFound.New(tableName)
+	}
+	textDef := viewDef.TextDefinition
+	if textDef == "" {
+		textDef = b.viewSelectBody(viewDef)
+		if textDef == "" {
+			return nil, sql.ErrTableNotFound.New(tableName)
+		}
+	}
+	subqueryAlias := plan.NewSubqueryAlias(tableName, textDef, plan.NewEmptyTableWithSchema(nil))
+	return plan.NewShowCreateTableWithAsOf(subqueryAlias, true, asOfExpr), nil
+}
+
+// viewSelectBody parses the CREATE VIEW statement in |viewDef| and returns the SELECT body text,
+// or an empty string if the statement cannot be parsed.
+func (b *Builder) viewSelectBody(viewDef sql.ViewDefinition) string {
+	oldOpts := b.parserOpts
+	defer func() { b.parserOpts = oldOpts }()
+	b.parserOpts = sql.NewSqlModeFromString(viewDef.SqlMode).ParserOptions()
+	stmt, _, _, err := b.parser.ParseWithOptions(b.ctx, viewDef.CreateViewStatement, ';', false, b.parserOpts)
+	if err != nil {
+		return ""
+	}
+	ddl, ok := stmt.(*ast.DDL)
+	if !ok {
+		return ""
+	}
+	return viewDef.CreateViewStatement[ddl.SubStatementPositionStart:ddl.SubStatementPositionEnd]
 }
 
 func (b *Builder) buildShowDatabase(inScope *scope, s *ast.Show) (outScope *scope) {


### PR DESCRIPTION
MySQL returns a view's stored definition regardless of whether its underlying table exists. GMS re-resolved the view body at query time, which failed if the referenced table had been dropped.
- Split `SHOW CREATE TABLE` and `SHOW CREATE VIEW` into separate build paths.
- `SHOW CREATE VIEW` now reads the stored definition directly via `ViewDatabase.GetViewDefinition`
- Extract `showTargetInfo` helper to deduplicate db/table/asOf extraction

Fix dolthub/dolt#10902
Blocked by dolthub/vitess#461
