### PR TITLE
Add handling of TargetRowSize table attribute to GMS interfaces

### DIFF
--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -331,6 +331,18 @@ var CreateTableQueries = []WriteQueryTest{
 		SelectQuery:         `SHOW CREATE TABLE t1`,
 		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `id` bigint unsigned NOT NULL AUTO_INCREMENT,\n  UNIQUE KEY `id` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 	},
+	{
+		WriteQuery:          `CREATE TABLE t1 (pk int primary key) TARGET_ROW_SIZE=4096`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE t1",
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` int NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin TARGET_ROW_SIZE=4096"}},
+	},
+	{
+		WriteQuery:          `CREATE TABLE t1 (pk int primary key) TOAST_TUPLE_TARGET=1024`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE t1",
+		ExpectedSelect:      []sql.Row{{"t1", "CREATE TABLE `t1` (\n  `pk` int NOT NULL,\n  PRIMARY KEY (`pk`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin TARGET_ROW_SIZE=1024"}},
+	},
 }
 
 var CreateTableScriptTests = []ScriptTest{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
-	github.com/dolthub/vitess v0.0.0-20260430231310-7c57d88b21f6
+	github.com/dolthub/vitess v0.0.0-20260504232330-bcb1b9015c48
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gocraft/dbr/v2 v2.7.2
 	github.com/google/uuid v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
-	github.com/dolthub/vitess v0.0.0-20260424215137-ec6bd432b0be
+	github.com/dolthub/vitess v0.0.0-20260430231310-7c57d88b21f6
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gocraft/dbr/v2 v2.7.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/dolthub/vitess v0.0.0-20260424215137-ec6bd432b0be h1:m01DFtn4xQhLWni8
 github.com/dolthub/vitess v0.0.0-20260424215137-ec6bd432b0be/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/dolthub/vitess v0.0.0-20260430231310-7c57d88b21f6 h1:lhR+sY9D5JKbF7DqYtTVSgdMQAkei4KdOdGF0t5qZmA=
 github.com/dolthub/vitess v0.0.0-20260430231310-7c57d88b21f6/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
+github.com/dolthub/vitess v0.0.0-20260504232330-bcb1b9015c48 h1:znkwaIJnYUf9kL6hNctwWOaKDH0h1jWevwdmo0Otojo=
+github.com/dolthub/vitess v0.0.0-20260504232330-bcb1b9015c48/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/dolthub/vitess v0.0.0-20260422060906-f6f5b5573b7b h1:WMPhnYS/NlWK+HpI
 github.com/dolthub/vitess v0.0.0-20260422060906-f6f5b5573b7b/go.mod h1:eLLslh1CSPMf89pPcaMG4yM72PQbTN9OUYJeAy0fAis=
 github.com/dolthub/vitess v0.0.0-20260424215137-ec6bd432b0be h1:m01DFtn4xQhLWni8bCbRRjcjeiOZkAgaj2fOWGpPr6A=
 github.com/dolthub/vitess v0.0.0-20260424215137-ec6bd432b0be/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
+github.com/dolthub/vitess v0.0.0-20260430231310-7c57d88b21f6 h1:lhR+sY9D5JKbF7DqYtTVSgdMQAkei4KdOdGF0t5qZmA=
+github.com/dolthub/vitess v0.0.0-20260430231310-7c57d88b21f6/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/memory/table.go
+++ b/memory/table.go
@@ -80,6 +80,8 @@ var _ sql.PrimaryKeyTable = (*Table)(nil)
 var _ fulltext.IndexAlterableTable = (*Table)(nil)
 var _ sql.IndexBuildingTable = (*Table)(nil)
 var _ sql.Databaseable = (*Table)(nil)
+var _ sql.TargetRowSizeAlterableTable = (*Table)(nil)
+var _ sql.TargetRowSizeTable = (*Table)(nil)
 
 // NewTable creates a new Table with the given name and schema. Assigns the default collation, therefore if a different
 // collation is desired, please use NewTableWithCollation.
@@ -236,6 +238,22 @@ func (t *Table) Collation() sql.CollationID {
 // Comment implements the sql.CommentedTable interface.
 func (t *Table) Comment() string {
 	return t.data.comment
+}
+
+// ModifyTargetRowSize implements the sql.TargetRowSizeAlterableTable interface.
+func (t *Table) ModifyTargetRowSize(ctx *sql.Context, value uint64) error {
+	t.data.targetRowSize = value
+	return nil
+}
+
+// HasTargetRowSize implements the sql.TargetRowSizeTable interface.
+func (t *Table) HasTargetRowSize() bool {
+	return t.data.targetRowSize != 0
+}
+
+// GetTargetRowSize implements the sql.TargetRowSizeTable interface.
+func (t *Table) GetTargetRowSize() uint64 {
+	return t.data.targetRowSize
 }
 
 func (t *Table) IgnoreSessionData() bool {

--- a/memory/table.go
+++ b/memory/table.go
@@ -241,8 +241,8 @@ func (t *Table) Comment() string {
 }
 
 // ModifyTargetRowSize implements the sql.TargetRowSizeAlterableTable interface.
-func (t *Table) ModifyTargetRowSize(ctx *sql.Context, value uint64) error {
-	t.data.targetRowSize = value
+func (t *Table) ModifyTargetRowSize(ctx *sql.Context, sizeInBytes uint64) error {
+	t.data.targetRowSize = sizeInBytes
 	return nil
 }
 

--- a/memory/table_data.go
+++ b/memory/table_data.go
@@ -46,6 +46,7 @@ type TableData struct {
 	partitionKeys           [][]byte
 	autoColIdx              int
 	autoIncVal              uint64
+	targetRowSize           uint64
 	collation               sql.CollationID
 }
 

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -1378,6 +1378,13 @@ func (b *Builder) tableSpecToSchema(inScope, outScope *scope, db sql.Database, t
 				b.handleErr(err)
 			}
 			optVal = val
+		case "target_row_size", "toast_tuple_target":
+			optName = "target_row_size"
+			val, err := strconv.ParseUint(tblOpt.Value, 10, 64)
+			if err != nil {
+				b.handleErr(err)
+			}
+			optVal = val
 		default:
 			optVal = tblOpt.Value
 		}

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -1222,6 +1222,17 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 		}
 	}
 
+	if targetRowSize, hasTargetRowSize := n.TableOpts["target_row_size"]; hasTargetRowSize {
+		val := targetRowSize.(uint64)
+		alterable, ok := tableNode.(sql.TargetRowSizeAlterableTable)
+		if ok {
+			err = alterable.ModifyTargetRowSize(ctx, val)
+			if err != nil {
+				return sql.RowsToRowIter(), err
+			}
+		}
+	}
+
 	var nonPrimaryIdxes sql.IndexDefs
 	for _, def := range n.Indexes() {
 		if !def.IsPrimary() {

--- a/sql/rowexec/show_iters.go
+++ b/sql/rowexec/show_iters.go
@@ -566,7 +566,15 @@ func (i *showCreateTablesIter) produceCreateTableStatement(ctx *sql.Context, tab
 		temp = " TEMPORARY"
 	}
 
-	return i.formatter.GenerateCreateTableStatement(table.Name(), colStmts, temp, autoInc, table.Collation().CharacterSet().Name(), table.Collation().Name(), comment), nil
+	createStmt := i.formatter.GenerateCreateTableStatement(table.Name(), colStmts, temp, autoInc, table.Collation().CharacterSet().Name(), table.Collation().Name(), comment)
+
+	if targetRowSizeTable := getTargetRowSizeTable(table); targetRowSizeTable != nil {
+		if targetRowSizeTable.HasTargetRowSize() {
+			createStmt += fmt.Sprintf(" TARGET_ROW_SIZE=%d", targetRowSizeTable.GetTargetRowSize())
+		}
+	}
+
+	return createStmt, nil
 }
 
 func produceCreateViewStatement(view *plan.SubqueryAlias) string {
@@ -602,6 +610,19 @@ func getAutoIncrementTable(t sql.Table) sql.AutoIncrementGetter {
 		return getAutoIncrementTable(t.Underlying())
 	case *plan.ResolvedTable:
 		return getAutoIncrementTable(t.Table)
+	default:
+		return nil
+	}
+}
+
+func getTargetRowSizeTable(t sql.Table) sql.TargetRowSizeTable {
+	switch t := t.(type) {
+	case sql.TargetRowSizeTable:
+		return t
+	case sql.TableWrapper:
+		return getTargetRowSizeTable(t.Underlying())
+	case *plan.ResolvedTable:
+		return getTargetRowSizeTable(t.Table)
 	default:
 		return nil
 	}

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -256,6 +256,23 @@ type CommentAlterableTable interface {
 	ModifyComment(ctx *Context, comment string) error
 }
 
+// TargetRowSizeAlterableTable represents a table that supports altering its target row size.
+// The exact meaning of this value is implementation dependent.
+type TargetRowSizeAlterableTable interface {
+	Table
+	ModifyTargetRowSize(ctx *Context, value uint64) error
+}
+
+// TargetRowSizeTable represents a table that can report its adaptive encoding max row size.
+type TargetRowSizeTable interface {
+	Table
+	// HasTargetRowSize returns whether the table has a target row size that's different from the table's default.
+	// This is useful when determining whether to display the target row size in SHOW CREATE TABLE statements.
+	HasTargetRowSize() bool
+	// GetTargetRowSize returns the table's target row size.
+	GetTargetRowSize() uint64
+}
+
 // PrimaryKeyTable is a table with a primary key.
 type PrimaryKeyTable interface {
 	// PrimaryKeySchema returns this table's PrimaryKeySchema

--- a/sql/tables.go
+++ b/sql/tables.go
@@ -260,10 +260,12 @@ type CommentAlterableTable interface {
 // The exact meaning of this value is implementation dependent.
 type TargetRowSizeAlterableTable interface {
 	Table
-	ModifyTargetRowSize(ctx *Context, value uint64) error
+	// ModifyTargetRowSize sets that table's target row size.
+	ModifyTargetRowSize(ctx *Context, sizeInBytes uint64) error
 }
 
 // TargetRowSizeTable represents a table that can report its adaptive encoding max row size.
+// The exact meaning of this value is implementation dependent.
 type TargetRowSizeTable interface {
 	Table
 	// HasTargetRowSize returns whether the table has a target row size that's different from the table's default.


### PR DESCRIPTION
TARGET_ROW_SIZE is a custom table attribute whose exact meaning is implementation-defined by whatever storage backend implements it. It's used by Dolt to describe the threshold at which adaptive-encoded columns should be moved to out-of-band storage instead of being stored inline in the table.