### PR TITLE
[no-release-notes] don't create new context in `expression.Alias.String()`

### DIFF
--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -146,6 +146,8 @@ func (e *Alias) Describe(ctx *sql.Context, options sql.DescribeOptions) string {
 func (e *Alias) String() string {
 	// To maintain compatibility with fmt.Stringer we have to use an empty context, but this will fail in any case that
 	// requires a context to determine a string (such as an integrator using the context to contain type information).
+	// TODO: Pass nil here for now to address performance issue, as this is unused.
+	//   Fix when we decide what to do with context threading.
 	return e.Describe(nil, sql.DescribeOptions{
 		Debug: false,
 	})

--- a/sql/expression/alias.go
+++ b/sql/expression/alias.go
@@ -146,8 +146,7 @@ func (e *Alias) Describe(ctx *sql.Context, options sql.DescribeOptions) string {
 func (e *Alias) String() string {
 	// To maintain compatibility with fmt.Stringer we have to use an empty context, but this will fail in any case that
 	// requires a context to determine a string (such as an integrator using the context to contain type information).
-	ctx := sql.NewEmptyContext()
-	return e.Describe(ctx, sql.DescribeOptions{
+	return e.Describe(nil, sql.DescribeOptions{
 		Debug: false,
 	})
 }


### PR DESCRIPTION
Alternatively, `String()` should take in a `sql.Context`