### PR TITLE
Update for functional expression index parser changes

### DIFF
--- a/enginetest/evaluation.go
+++ b/enginetest/evaluation.go
@@ -63,17 +63,29 @@ func TestScript(t *testing.T, harness Harness, script queries.ScriptTest) {
 	TestScriptWithEngine(t, e, harness, script)
 }
 
+// ServerBackedEngine is implemented by QueryEngine types that run queries
+// through a real server (i.e. over the wire protocol). Plan-inspection checks
+// like evalIndexTest and evalJoinTypeTest are skipped for these engines.
+type ServerBackedEngine interface {
+	IsServerBacked() bool
+}
+
 func IsServerEngine(e QueryEngine) bool {
-	_, ok := e.(*ServerQueryEngine)
-	return ok
+	if _, ok := e.(*ServerQueryEngine); ok {
+		return true
+	}
+	if sb, ok := e.(ServerBackedEngine); ok {
+		return sb.IsServerBacked()
+	}
+	return false
 }
 
 // CreateNewConnectionForServerEngine creates a new connection in the server engine.
 // If there was an existing one, it gets closed before the new gets created.
 // This function should be called when needing to use new session for the server.
 func CreateNewConnectionForServerEngine(ctx *sql.Context, e QueryEngine) error {
-	if IsServerEngine(e) {
-		return e.(*ServerQueryEngine).NewConnection(ctx)
+	if sre, ok := e.(*ServerQueryEngine); ok {
+		return sre.NewConnection(ctx)
 	}
 	return nil
 }

--- a/enginetest/queries/indexed_expressions_queries.go
+++ b/enginetest/queries/indexed_expressions_queries.go
@@ -747,7 +747,9 @@ var IndexedExpressionsScriptTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "system hidden columns: omitted from SHOW CREATE TABLE",
+		// Doltgres and Dolt output for SHOW CREATE TABLE is different
+		Dialect: "mysql",
+		Name:    "system hidden columns: omitted from SHOW CREATE TABLE",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk INT PRIMARY KEY, c1 INT, c2 VARCHAR(100));",
 			"CREATE UNIQUE INDEX idx1 ON test ((c1*10));",
@@ -781,7 +783,9 @@ var IndexedExpressionsScriptTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "system hidden columns: omitted from SHOW CREATE TABLE after ALTER TABLE ADD COLUMN",
+		// Doltgres and Dolt output for SHOW CREATE TABLE is different
+		Dialect: "mysql",
+		Name:    "system hidden columns: omitted from SHOW CREATE TABLE after ALTER TABLE ADD COLUMN",
 		SetUpScript: []string{
 			"CREATE TABLE test (pk INT PRIMARY KEY, c1 INT);",
 			"CREATE UNIQUE INDEX idx1 ON test ((c1*10));",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
-	github.com/dolthub/vitess v0.0.0-20260422060906-f6f5b5573b7b
+	github.com/dolthub/vitess v0.0.0-20260424213754-9df76f31c1b8
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gocraft/dbr/v2 v2.7.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
 github.com/dolthub/vitess v0.0.0-20260422060906-f6f5b5573b7b h1:WMPhnYS/NlWK+HpI4DqKWZxFJrNlyjOdJ2JtZRU0Vb8=
 github.com/dolthub/vitess v0.0.0-20260422060906-f6f5b5573b7b/go.mod h1:eLLslh1CSPMf89pPcaMG4yM72PQbTN9OUYJeAy0fAis=
+github.com/dolthub/vitess v0.0.0-20260424213754-9df76f31c1b8 h1:6dWL4Bt8TefB0LXyYAaWLz2z2/kkOuQnkoPoa7bIwks=
+github.com/dolthub/vitess v0.0.0-20260424213754-9df76f31c1b8/go.mod h1:eLLslh1CSPMf89pPcaMG4yM72PQbTN9OUYJeAy0fAis=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -397,7 +397,8 @@ func addLookupJoins(ctx *sql.Context, m *memo.Memo, cat sql.Catalog) error {
 // key into the given index. The key fields will either be equality filters
 // (from ON conditions) or constants.
 func keyExprsForIndex(
-	ctx *sql.Context, tableId sql.TableId,
+	ctx *sql.Context,
+	tableId sql.TableId,
 	idxExprs []sql.ColumnId,
 	filters []sql.Expression,
 	columnIdToIndexedExprMap map[sql.ColumnId]indexedExprEntry) (keyExprs, matchedFilters []sql.Expression, nullmask []bool) {
@@ -419,7 +420,8 @@ func keyExprsForIndex(
 // keyForExpr returns an equivalence or constant value to satisfy the
 // lookup index expression.
 func keyForExpr(
-	ctx *sql.Context, targetCol sql.ColumnId,
+	ctx *sql.Context,
+	targetCol sql.ColumnId,
 	tableId sql.TableId,
 	filters []sql.Expression,
 	columnIdToIndexedExprMap map[sql.ColumnId]indexedExprEntry) (key sql.Expression, filter sql.Expression, nullable bool) {

--- a/sql/analyzer/resolve_column_defaults.go
+++ b/sql/analyzer/resolve_column_defaults.go
@@ -145,23 +145,32 @@ func stripTableNamesFromColumnDefaults(ctx *sql.Context, _ *Analyzer, n sql.Node
 			// it explicitly so the expression is stored without a table name (e.g. "lower(email)"
 			// instead of "lower(users.email)"), matching what stripTableNamesFromDefault does for
 			// regular generated column defaults.
-			if node.Expression == nil {
-				return node, transform.SameTree, nil
-			}
-			newExpr, same, err := transform.Expr(ctx, node.Expression, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
-				if gf, ok := e.(*expression.GetField); ok {
-					return gf.WithTable(""), transform.NewTree, nil
-				}
-				return e, transform.SameTree, nil
-			})
-			if err != nil {
-				return node, transform.SameTree, err
-			}
-			if same {
-				return node, transform.SameTree, nil
-			}
 			np := *node
-			np.Expression = newExpr
+			allSame := transform.SameTree
+			for i, idxCol := range node.Columns {
+				if idxCol.Expression == nil {
+					continue
+				}
+
+				newExpr, same, err := transform.Expr(ctx, idxCol.Expression, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {
+					if gf, ok := e.(*expression.GetField); ok {
+						return gf.WithTable(""), transform.NewTree, nil
+					}
+					return e, transform.SameTree, nil
+				})
+				if err != nil {
+					return node, transform.SameTree, err
+				}
+
+				allSame = allSame && same
+				if !same {
+					np.Columns[i].Expression = newExpr
+				}
+			}
+
+			if allSame {
+				return node, transform.SameTree, nil
+			}
 			return &np, transform.NewTree, nil
 		case sql.SchemaTarget:
 			return transform.NodeExprs(ctx, n, func(ctx *sql.Context, e sql.Expression) (sql.Expression, transform.TreeIdentity, error) {

--- a/sql/analyzer/validate_create_table.go
+++ b/sql/analyzer/validate_create_table.go
@@ -883,6 +883,10 @@ func validateIndexes(ctx *sql.Context, sch sql.Schema, idxDefs sql.IndexDefs, st
 func validateIndex(ctx *sql.Context, colMap map[string]*sql.Column, idxDef *sql.IndexDef, strictMySQLCompat bool) error {
 	seenCols := make(map[string]struct{})
 	for _, idxCol := range idxDef.Columns {
+		if idxCol.Expression != nil {
+			continue
+		}
+
 		schCol, exists := colMap[strings.ToLower(idxCol.Name)]
 		if !exists {
 			return sql.ErrKeyColumnDoesNotExist.New(idxCol.Name)

--- a/sql/index.go
+++ b/sql/index.go
@@ -67,6 +67,9 @@ type IndexColumn struct {
 	Name string
 	// Length represents the index prefix length. If zero, then no length was specified.
 	Length int64
+	// Expression is an indexed functional expression. When this field is set, the Name
+	// field is empty.
+	Expression Expression
 }
 
 // IndexConstraint represents any constraints that should be applied to the index.

--- a/sql/plan/alter_index.go
+++ b/sql/plan/alter_index.go
@@ -58,9 +58,6 @@ type AlterIndex struct {
 	targetSchema sql.Schema
 	// Columns contains the column names (and possibly lengths) when creating an index
 	Columns []sql.IndexColumn
-	// Expression holds the expression when creating an index
-	// TODO: Not currently implemented. Returns a no-op & warning if used
-	Expression sql.Expression
 	// TODO: This should just use sql.IndexDef
 	// Using states whether you're using BTREE, HASH, or non
 	Using sql.IndexUsing
@@ -83,7 +80,7 @@ var _ sql.Node = (*AlterIndex)(nil)
 var _ sql.CollationCoercible = (*AlterIndex)(nil)
 var _ sql.Databaser = (*AlterIndex)(nil)
 
-func NewAlterCreateIndex(db sql.Database, table sql.TableNode, ifNotExists bool, indexName string, using sql.IndexUsing, constraint sql.IndexConstraint, columns []sql.IndexColumn, expression sql.Expression, comment string) *AlterIndex {
+func NewAlterCreateIndex(db sql.Database, table sql.TableNode, ifNotExists bool, indexName string, using sql.IndexUsing, constraint sql.IndexConstraint, columns []sql.IndexColumn, comment string) *AlterIndex {
 	return &AlterIndex{
 		Action:      IndexAction_Create,
 		Db:          db,
@@ -93,7 +90,6 @@ func NewAlterCreateIndex(db sql.Database, table sql.TableNode, ifNotExists bool,
 		Using:       using,
 		Constraint:  constraint,
 		Columns:     columns,
-		Expression:  expression,
 		Comment:     comment,
 	}
 }

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -845,7 +845,7 @@ func (b *Builder) buildIndexDefs(inScope *scope, spec *ast.TableSpec) (idxDefs s
 			constraint = sql.IndexConstraint_Vector
 		}
 
-		columns := b.gatherIndexColumns(inScope, idxDef.Columns)
+		columns := b.gatherIndexColumns(inScope, idxDef.Fields)
 
 		var comment string
 		for _, option := range idxDef.Options {
@@ -986,7 +986,7 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 			constraint = sql.IndexConstraint_None
 		}
 
-		columns := b.gatherIndexColumns(inScope, ddl.IndexSpec.Columns)
+		columns := b.gatherIndexColumns(inScope, ddl.IndexSpec.Fields)
 
 		var comment string
 		for _, option := range ddl.IndexSpec.Options {
@@ -1047,9 +1047,9 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 // scalar expression using inScope for name resolution. Plain column references
 // carry only a name and an optional length; expression columns carry only the
 // built sql.Expression.
-func (b *Builder) gatherIndexColumns(inScope *scope, cols []*ast.IndexColumn) []sql.IndexColumn {
-	out := make([]sql.IndexColumn, len(cols))
-	for i, col := range cols {
+func (b *Builder) gatherIndexColumns(inScope *scope, idxFields []*ast.IndexField) []sql.IndexColumn {
+	out := make([]sql.IndexColumn, len(idxFields))
+	for i, col := range idxFields {
 		var length int64
 		var err error
 		if col.Length != nil && col.Length.Type == ast.IntVal {
@@ -1276,20 +1276,20 @@ func (b *Builder) buildExternalCreateIndex(inScope *scope, ddl *ast.DDL) (outSco
 	}
 
 	tableId := outScope.tables[tblName]
-	cols := make([]sql.Expression, len(ddl.IndexSpec.Columns))
-	for i, col := range ddl.IndexSpec.Columns {
+	idxFields := make([]sql.Expression, len(ddl.IndexSpec.Fields))
+	for i, col := range ddl.IndexSpec.Fields {
 		colName := strings.ToLower(col.Column.String())
 		c, ok := inScope.resolveColumn(dbName, tblName, colName, true, false)
 		if !ok {
 			b.handleErr(sql.ErrColumnNotFound.New(colName))
 		}
-		cols[i] = expression.NewGetFieldWithTable(int(c.id), int(tableId), c.typ, c.db, c.table, c.col, c.nullable)
+		idxFields[i] = expression.NewGetFieldWithTable(int(c.id), int(tableId), c.typ, c.db, c.table, c.col, c.nullable)
 	}
 
 	createIndex := plan.NewCreateIndex(
 		ddl.IndexSpec.ToName.String(),
 		table,
-		cols,
+		idxFields,
 		ddl.IndexSpec.Using.Lowered(),
 		config,
 	)
@@ -1539,7 +1539,7 @@ func getPkOrdinals(ts *ast.TableSpec) []int {
 				colIdx[ts.Columns[i].Name.Lowered()] = i
 			}
 
-			for _, i := range idxDef.Columns {
+			for _, i := range idxDef.Fields {
 				pkOrdinals = append(pkOrdinals, colIdx[i.Column.Lowered()])
 			}
 
@@ -1573,7 +1573,7 @@ func (b *Builder) columnDefinitionToColumn(inScope *scope, cd *ast.ColumnDefinit
 	OuterLoop:
 		for _, index := range indexes {
 			if index.Info.Primary {
-				for _, indexCol := range index.Columns {
+				for _, indexCol := range index.Fields {
 					if indexCol.Column.Equal(cd.Name) {
 						isPkey = true
 						break OuterLoop

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -624,7 +624,6 @@ func (b *Builder) buildAlterTableClause(inScope *scope, ddl *ast.DDL) []*scope {
 						sql.IndexUsing_BTree,
 						sql.IndexConstraint_Unique,
 						[]sql.IndexColumn{{Name: column.Name.String()}},
-						nil,
 						"",
 					)
 
@@ -830,7 +829,7 @@ func columnOrderToColumnOrder(order *ast.ColumnOrder) *sql.ColumnOrder {
 	}
 }
 
-func (b *Builder) buildIndexDefs(_ *scope, spec *ast.TableSpec) (idxDefs sql.IndexDefs) {
+func (b *Builder) buildIndexDefs(inScope *scope, spec *ast.TableSpec) (idxDefs sql.IndexDefs) {
 	for _, idxDef := range spec.Indexes {
 		constraint := sql.IndexConstraint_None
 		if idxDef.Info.Primary {
@@ -846,7 +845,7 @@ func (b *Builder) buildIndexDefs(_ *scope, spec *ast.TableSpec) (idxDefs sql.Ind
 			constraint = sql.IndexConstraint_Vector
 		}
 
-		columns := b.gatherIndexColumns(idxDef.Columns)
+		columns := b.gatherIndexColumns(inScope, idxDef.Columns)
 
 		var comment string
 		for _, option := range idxDef.Options {
@@ -987,12 +986,7 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 			constraint = sql.IndexConstraint_None
 		}
 
-		columns := b.gatherIndexColumns(ddl.IndexSpec.Columns)
-
-		var indexExpr sql.Expression
-		if ddl.IndexSpec.Expression != nil {
-			indexExpr = b.buildScalar(inScope, ddl.IndexSpec.Expression)
-		}
+		columns := b.gatherIndexColumns(inScope, ddl.IndexSpec.Columns)
 
 		var comment string
 		for _, option := range ddl.IndexSpec.Options {
@@ -1020,7 +1014,6 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 			using,
 			constraint,
 			columns,
-			indexExpr,
 			comment,
 		)
 		outScope.node = b.modifySchemaTarget(inScope, createIndex, table.Schema(b.ctx))
@@ -1048,7 +1041,13 @@ func (b *Builder) buildAlterIndex(inScope *scope, ddl *ast.DDL, table *plan.Reso
 	return
 }
 
-func (b *Builder) gatherIndexColumns(cols []*ast.IndexColumn) []sql.IndexColumn {
+// gatherIndexColumns converts a slice of AST index column definitions into
+// []sql.IndexColumn. For each column, it parses the optional key length prefix
+// (rejecting lengths less than 1) and, for functional index columns, builds the
+// scalar expression using inScope for name resolution. Plain column references
+// carry only a name and an optional length; expression columns carry only the
+// built sql.Expression.
+func (b *Builder) gatherIndexColumns(inScope *scope, cols []*ast.IndexColumn) []sql.IndexColumn {
 	out := make([]sql.IndexColumn, len(cols))
 	for i, col := range cols {
 		var length int64
@@ -1063,9 +1062,16 @@ func (b *Builder) gatherIndexColumns(cols []*ast.IndexColumn) []sql.IndexColumn 
 				b.handleErr(err)
 			}
 		}
+
+		var expr sql.Expression
+		if col.Expression != nil {
+			expr = b.buildScalar(inScope, col.Expression)
+		}
+
 		out[i] = sql.IndexColumn{
-			Name:   col.Column.String(),
-			Length: length,
+			Name:       col.Column.String(),
+			Expression: expr,
+			Length:     length,
 		}
 	}
 	return out

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2135,27 +2135,28 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 
 	switch n.Action {
 	case plan.IndexAction_Create:
-		if n.Expression != nil {
-			// NOTE: For now, if n.Expression is set, then we know the index has a single functional expression,
-			//       and does not contain any columns as other index fields. This logic will need to change when
-			//       we start allowing multiple functional expressions and allow mixing functional expressions with
-			//       column names as multiple fields in the index.
-			newColumn, err := b.createHiddenSystemColumn(ctx, n)
-			if err != nil {
-				return err
-			}
+		if err = validateSingleFunctionalExpression(n.Columns); err != nil {
+			return err
+		}
 
-			// After creating the system hidden, generated column, update the plan node so we can create the index next
-			n.Expression = nil
-			n.Columns = []sql.IndexColumn{{
-				Name: newColumn.Name,
-			}}
-			newSchema := append(n.Table.Schema(ctx).Copy(), newColumn)
-			newNode, err := n.WithTargetSchema(newSchema)
-			if err != nil {
-				return err
+		for i, idxCol := range n.Columns {
+			if idxCol.Expression != nil {
+				newColumn, err := b.createHiddenSystemColumn(ctx, n, idxCol.Expression)
+				if err != nil {
+					return err
+				}
+
+				// After creating the system hidden, generated column,
+				// update the plan node so we can create the index next
+				n.Columns[i].Expression = nil
+				n.Columns[i].Name = newColumn.Name
+				newSchema := append(n.Table.Schema(ctx).Copy(), newColumn)
+				newNode, err := n.WithTargetSchema(newSchema)
+				if err != nil {
+					return err
+				}
+				n = newNode.(*plan.AlterIndex)
 			}
-			n = newNode.(*plan.AlterIndex)
 		}
 
 		if len(n.Columns) == 0 {
@@ -2405,15 +2406,16 @@ func (b *BaseBuilder) dropHiddenSystemColumnsForIndex(ctx *sql.Context, table *p
 	return nil
 }
 
-// createHiddenSystemColumn created a virtual, hidden system column, used to generate an expression that
-// is used in a secondary index. The new column is returned, along with any encountered error.
-func (b *BaseBuilder) createHiddenSystemColumn(ctx *sql.Context, n *plan.AlterIndex) (*sql.Column, error) {
+// createHiddenSystemColumn created a virtual, hidden system column for the specifeid |expr|, used
+// to generate an expression that is used in a secondary index. The new column is returned, along
+// with any encountered error.
+func (b *BaseBuilder) createHiddenSystemColumn(ctx *sql.Context, n *plan.AlterIndex, expr sql.Expression) (*sql.Column, error) {
 	resolvedTable, ok := n.Table.(*plan.ResolvedTable)
 	if !ok {
 		return nil, fmt.Errorf("alter index: table is not a resolved table: %T", n.Table)
 	}
 
-	columnDefaultValue, err := sql.NewColumnDefaultValue(n.Expression, n.Expression.Type(ctx), false, true, true)
+	columnDefaultValue, err := sql.NewColumnDefaultValue(expr, expr.Type(ctx), false, true, true)
 	if err != nil {
 		return nil, err
 	}
@@ -2425,7 +2427,7 @@ func (b *BaseBuilder) createHiddenSystemColumn(ctx *sql.Context, n *plan.AlterIn
 	hiddenColumnName := sql.HiddenSystemColumnPrefix + strings.ToLower(n.IndexName) + "!0!0"
 
 	newColumn := sql.Column{
-		Type:           n.Expression.Type(ctx),
+		Type:           expr.Type(ctx),
 		Generated:      columnDefaultValue,
 		Name:           hiddenColumnName,
 		Source:         n.Table.Name(),
@@ -2457,6 +2459,24 @@ func (b *BaseBuilder) createHiddenSystemColumn(ctx *sql.Context, n *plan.AlterIn
 	}
 
 	return &newColumn, nil
+}
+
+// validateSingleFunctionalExpression validates that the specified |idxCols| contain at
+// most one functional expression, and that no other indexed columns are included if a
+// functional expression is included.
+//
+// TODO: This is a temporary limitation that will be removed in a follow up PR.
+func validateSingleFunctionalExpression(idxCols []sql.IndexColumn) error {
+	functionalExpressionCount := 0
+	for _, idxCol := range idxCols {
+		if idxCol.Expression != nil {
+			functionalExpressionCount += 1
+		}
+	}
+	if functionalExpressionCount > 1 || functionalExpressionCount == 1 && len(idxCols) > 1 {
+		return fmt.Errorf("functional indexes with multiple expressions are not supported")
+	}
+	return nil
 }
 
 // warnOnDuplicateSecondaryIndex emits a session warning if the newly created index |newIndexName| duplicates


### PR DESCRIPTION
Parser changes support multiple functional expressions, or a mix of columns and functional expressions in an index. GMS still restricts functional indexes to a single functional expression, but that restriction will be removed in the next PR. 

Also includes a new test interface that Doltgres will use when integrating with functional indexes. 

Depends on: https://github.com/dolthub/vitess/pull/466