### PR TITLE
Truncate invalid UTF-8 on `INSERT IGNORE` and warn on `LIKE` with bad charset pattern

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -16964,4 +16964,44 @@ var DropDatabaseScripts = []ScriptTest{
 			},
 		},
 	},
+	{
+		// See https://github.com/dolthub/dolt/issues/10924
+		Name:    "INSERT IGNORE truncates invalid UTF-8 at first bad byte",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// 0x85 is invalid UTF-8; the row is inserted with the value truncated to the valid prefix.
+				Query:                 "INSERT IGNORE INTO t VALUES (1, UNHEX('5353442031544220322E3585204E564D65'));",
+				Expected:              []sql.Row{{types.OkResult{RowsAffected: 1}}},
+				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
+				ExpectedWarningsCount: 1,
+			},
+			{
+				Query:    "SELECT name, HEX(name) FROM t WHERE id = 1;",
+				Expected: []sql.Row{{"SSD 1TB 2.5", "5353442031544220322E35"}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/10924
+		Name:    "LIKE with invalid UTF-8 pattern issues warning and returns no match",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255));",
+			"INSERT INTO t VALUES (1, 'hello');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// 0x85 is invalid UTF-8 in the pattern literal; LIKE issues warning 1300 and returns no match.
+				Query:                           "SELECT id FROM t WHERE name LIKE '%" + "\x85" + "%';",
+				Expected:                        []sql.Row{},
+				ExpectedWarning:                 mysql.ERInvalidCharacterString,
+				ExpectedWarningsCount:           1,
+				ExpectedWarningMessageSubstring: "invalid string for character set",
+			},
+		},
+	},
 }

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -14932,6 +14932,46 @@ select * from t1 except (
 			},
 		},
 	},
+	{
+		// See https://github.com/dolthub/dolt/issues/10924
+		Name:    "INSERT IGNORE truncates invalid UTF-8 at first bad byte",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255));",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// 0x85 is invalid UTF-8; the row is inserted with the value truncated to the valid prefix.
+				Query:                 "INSERT IGNORE INTO t VALUES (1, UNHEX('5353442031544220322E3585204E564D65'));",
+				Expected:              []sql.Row{{types.OkResult{RowsAffected: 1}}},
+				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
+				ExpectedWarningsCount: 1,
+			},
+			{
+				Query:    "SELECT name, HEX(name) FROM t WHERE id = 1;",
+				Expected: []sql.Row{{"SSD 1TB 2.5", "5353442031544220322E35"}},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/10924
+		Name:    "LIKE with invalid UTF-8 pattern issues warning and returns no match",
+		Dialect: "mysql",
+		SetUpScript: []string{
+			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255));",
+			"INSERT INTO t VALUES (1, 'hello');",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				// 0x85 is invalid UTF-8 in the pattern literal; LIKE issues warning 1300 and returns no match.
+				Query:                           "SELECT id FROM t WHERE name LIKE '%" + "\x85" + "%';",
+				Expected:                        []sql.Row{},
+				ExpectedWarning:                 mysql.ERInvalidCharacterString,
+				ExpectedWarningsCount:           1,
+				ExpectedWarningMessageSubstring: "invalid string for character set",
+			},
+		},
+	},
 }
 
 var SpatialScriptTests = []ScriptTest{
@@ -16961,46 +17001,6 @@ var DropDatabaseScripts = []ScriptTest{
 			{
 				Query:    "SHOW WARNINGS",
 				Expected: []sql.Row{{"Note", 1008, "Can't drop database testdb; database doesn't exist "}},
-			},
-		},
-	},
-	{
-		// See https://github.com/dolthub/dolt/issues/10924
-		Name:    "INSERT IGNORE truncates invalid UTF-8 at first bad byte",
-		Dialect: "mysql",
-		SetUpScript: []string{
-			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255));",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				// 0x85 is invalid UTF-8; the row is inserted with the value truncated to the valid prefix.
-				Query:                 "INSERT IGNORE INTO t VALUES (1, UNHEX('5353442031544220322E3585204E564D65'));",
-				Expected:              []sql.Row{{types.OkResult{RowsAffected: 1}}},
-				ExpectedWarning:       mysql.ERTruncatedWrongValueForField,
-				ExpectedWarningsCount: 1,
-			},
-			{
-				Query:    "SELECT name, HEX(name) FROM t WHERE id = 1;",
-				Expected: []sql.Row{{"SSD 1TB 2.5", "5353442031544220322E35"}},
-			},
-		},
-	},
-	{
-		// See https://github.com/dolthub/dolt/issues/10924
-		Name:    "LIKE with invalid UTF-8 pattern issues warning and returns no match",
-		Dialect: "mysql",
-		SetUpScript: []string{
-			"CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255));",
-			"INSERT INTO t VALUES (1, 'hello');",
-		},
-		Assertions: []ScriptTestAssertion{
-			{
-				// 0x85 is invalid UTF-8 in the pattern literal; LIKE issues warning 1300 and returns no match.
-				Query:                           "SELECT id FROM t WHERE name LIKE '%" + "\x85" + "%';",
-				Expected:                        []sql.Row{},
-				ExpectedWarning:                 mysql.ERInvalidCharacterString,
-				ExpectedWarningsCount:           1,
-				ExpectedWarningMessageSubstring: "invalid string for character set",
 			},
 		},
 	},

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -104,6 +104,7 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 	if right == nil {
 		return nil, nil
 	}
+	var tpl likeMatcherErrTuple
 	if !l.cached {
 		// for non-cached regex every time create a new matcher
 		collation, _ := l.CollationCoercibility(ctx)
@@ -118,19 +119,16 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 				},
 			}
 		})
-		tpl := l.pool.Get().(likeMatcherErrTuple)
+		tpl = l.pool.Get().(likeMatcherErrTuple)
 		lm, err = tpl.matcher, tpl.err
 	}
 	if err != nil {
 		if sql.ErrCharSetInvalidString.Is(err) {
 			// MySQL returns no match and issues warning 1300 instead of an error.
-			if ctx.Session != nil {
-				ctx.Session.Warn(&sql.Warning{
-					Level:   "Warning",
-					Code:    mysql.ERInvalidCharacterString,
-					Message: err.Error(),
-				})
+			if l.cached {
+				l.pool.Put(tpl)
 			}
+			ctx.Warn(mysql.ERInvalidCharacterString, "%s", err.Error())
 			return nil, nil
 		}
 		return nil, err

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"unicode/utf8"
 
+	"github.com/dolthub/vitess/go/mysql"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -120,6 +122,17 @@ func (l *Like) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		lm, err = tpl.matcher, tpl.err
 	}
 	if err != nil {
+		if sql.ErrCharSetInvalidString.Is(err) {
+			// MySQL returns no match and issues warning 1300 instead of an error.
+			if ctx.Session != nil {
+				ctx.Session.Warn(&sql.Warning{
+					Level:   "Warning",
+					Code:    mysql.ERInvalidCharacterString,
+					Message: err.Error(),
+				})
+			}
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -383,7 +383,14 @@ func convertDataAndWarn(ctx *sql.Context, tableSchema sql.Schema, row sql.Row, c
 		maxLength := tableSchema[columnIdx].Type.(sql.StringType).MaxCharacterLength()
 		row[columnIdx] = row[columnIdx].(string)[:maxLength]
 	} else if types.ErrBadCharsetString.Is(err) {
-		row[columnIdx] = string(types.TruncateInvalidUTF8([]byte(row[columnIdx].(string))))
+		switch v := row[columnIdx].(type) {
+		case string:
+			row[columnIdx] = string(types.TruncateInvalidUTF8([]byte(v)))
+		case []byte:
+			row[columnIdx] = string(types.TruncateInvalidUTF8(v))
+		default:
+			row[columnIdx] = tableSchema[columnIdx].Type.Zero()
+		}
 		if ctx != nil && ctx.Session != nil {
 			ctx.Session.Warn(&sql.Warning{
 				Level:   "Warning",

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/dolthub/vitess/go/mysql"
 	"github.com/dolthub/vitess/go/vt/proto/query"
 	"gopkg.in/src-d/go-errors.v1"
 
@@ -380,14 +381,23 @@ func (i *insertIter) ignoreOrClose(ctx *sql.Context, row sql.Row, err error) err
 func convertDataAndWarn(ctx *sql.Context, tableSchema sql.Schema, row sql.Row, columnIdx int, err error) sql.Row {
 	if types.ErrLengthBeyondLimit.Is(err) {
 		maxLength := tableSchema[columnIdx].Type.(sql.StringType).MaxCharacterLength()
-		row[columnIdx] = row[columnIdx].(string)[:maxLength] // truncate string
+		row[columnIdx] = row[columnIdx].(string)[:maxLength]
+	} else if types.ErrBadCharsetString.Is(err) {
+		row[columnIdx] = string(types.TruncateInvalidUTF8([]byte(row[columnIdx].(string))))
+		if ctx != nil && ctx.Session != nil {
+			ctx.Session.Warn(&sql.Warning{
+				Level:   "Warning",
+				Code:    mysql.ERTruncatedWrongValueForField,
+				Message: err.Error(),
+			})
+		}
+		return row
 	} else {
 		row[columnIdx] = tableSchema[columnIdx].Type.Zero()
 	}
 
 	sqlerr := sql.CastSQLError(err)
 
-	// Add a warning instead
 	if ctx != nil && ctx.Session != nil {
 		ctx.Session.Warn(&sql.Warning{
 			Level:   "Note",

--- a/sql/rowexec/insert.go
+++ b/sql/rowexec/insert.go
@@ -381,7 +381,7 @@ func (i *insertIter) ignoreOrClose(ctx *sql.Context, row sql.Row, err error) err
 func convertDataAndWarn(ctx *sql.Context, tableSchema sql.Schema, row sql.Row, columnIdx int, err error) sql.Row {
 	if types.ErrLengthBeyondLimit.Is(err) {
 		maxLength := tableSchema[columnIdx].Type.(sql.StringType).MaxCharacterLength()
-		row[columnIdx] = row[columnIdx].(string)[:maxLength]
+		row[columnIdx] = row[columnIdx].(string)[:maxLength] // truncate string
 	} else if types.ErrBadCharsetString.Is(err) {
 		switch v := row[columnIdx].(type) {
 		case string:
@@ -391,13 +391,7 @@ func convertDataAndWarn(ctx *sql.Context, tableSchema sql.Schema, row sql.Row, c
 		default:
 			row[columnIdx] = tableSchema[columnIdx].Type.Zero()
 		}
-		if ctx != nil && ctx.Session != nil {
-			ctx.Session.Warn(&sql.Warning{
-				Level:   "Warning",
-				Code:    mysql.ERTruncatedWrongValueForField,
-				Message: err.Error(),
-			})
-		}
+		ctx.Warn(mysql.ERTruncatedWrongValueForField, "%s", err.Error())
 		return row
 	} else {
 		row[columnIdx] = tableSchema[columnIdx].Type.Zero()
@@ -405,6 +399,7 @@ func convertDataAndWarn(ctx *sql.Context, tableSchema sql.Schema, row sql.Row, c
 
 	sqlerr := sql.CastSQLError(err)
 
+	// Add a warning instead
 	if ctx != nil && ctx.Session != nil {
 		ctx.Session.Warn(&sql.Warning{
 			Level:   "Note",

--- a/sql/types/strings.go
+++ b/sql/types/strings.go
@@ -517,7 +517,7 @@ func ConvertToBytes(ctx context.Context, v interface{}, t sql.StringType, dest [
 				return nil, ErrBadCharsetString.New(invalidByte, colName, rowNum)
 			} else {
 				// Non-strict mode: truncate invalid bytes (MySQL behavior)
-				bytesVal = truncateInvalidUTF8(bytesVal)
+				bytesVal = TruncateInvalidUTF8(bytesVal)
 			}
 		} else {
 			var ok bool
@@ -547,12 +547,11 @@ func getColumnContext(ctx context.Context) (string, int64) {
 	return colName, rowNum
 }
 
-// truncateInvalidUTF8 truncates byte slice at first invalid UTF8 sequence (MySQL non-strict behavior)
-func truncateInvalidUTF8(data []byte) []byte {
+// TruncateInvalidUTF8 truncates data at the first invalid UTF-8 byte sequence.
+func TruncateInvalidUTF8(data []byte) []byte {
 	for i := 0; i < len(data); {
 		r, size := utf8.DecodeRune(data[i:])
 		if r == utf8.RuneError && size == 1 {
-			// Invalid UTF8 sequence found, truncate here
 			return data[:i]
 		}
 		i += size


### PR DESCRIPTION
- `INSERT IGNORE` with invalid UTF-8 in a utf8mb4 column now truncates at the first bad byte
- `LIKE` with an invalid UTF-8 pattern emits warning `1300` and return no match
- Exported `TruncateInvalidUTF8` from `sql/types`
Fix dolthub/dolt#10924
Blocks dolthub/dolt#10926
