### PR TITLE
[no-release-notes] Remove uses of context.Background() by threading in context from callers.

### DIFF
--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -288,7 +288,7 @@ func getCostedIndexScan(
 	if len(ranges) == 0 {
 		emptyLookup = true
 	} else if len(ranges) == 1 {
-		emptyLookup, err = ranges[0].IsEmpty()
+		emptyLookup, err = ranges[0].IsEmpty(ctx)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -988,11 +988,11 @@ func (b *indexScanRangeBuilder) buildRangeCollection(f indexFilter) (sql.MySQLRa
 	if err != nil {
 		return nil, err
 	}
-	return sql.RemoveOverlappingRanges(ranges...)
+	return sql.RemoveOverlappingRanges(b.ctx, ranges...)
 }
 
 func (b *indexScanRangeBuilder) Ranges() (sql.MySQLRangeCollection, error) {
-	return sql.RemoveOverlappingRanges(b.allRanges...)
+	return sql.RemoveOverlappingRanges(b.ctx, b.allRanges...)
 }
 
 func (b *indexScanRangeBuilder) rangeBuildAnd(f *iScanAnd, inScan bool) (sql.MySQLRangeCollection, error) {
@@ -1013,7 +1013,7 @@ func (b *indexScanRangeBuilder) rangeBuildAnd(f *iScanAnd, inScan bool) (sql.MyS
 			ret = ranges
 			continue
 		}
-		ret, err = ret.Intersect(ranges)
+		ret, err = ret.Intersect(b.ctx, ranges)
 		if err != nil {
 			return nil, err
 		}
@@ -1028,7 +1028,7 @@ func (b *indexScanRangeBuilder) rangeBuildAnd(f *iScanAnd, inScan bool) (sql.MyS
 				return nil, err
 			}
 			if ranges != nil {
-				ret, err = ret.Intersect(partBuilder.Ranges(b.ctx))
+				ret, err = ret.Intersect(b.ctx, partBuilder.Ranges(b.ctx))
 				if err != nil {
 					return nil, err
 				}
@@ -1039,7 +1039,7 @@ func (b *indexScanRangeBuilder) rangeBuildAnd(f *iScanAnd, inScan bool) (sql.MyS
 				return nil, err
 			}
 			if ranges != nil {
-				ret, err = ret.Intersect(partBuilder.Ranges(b.ctx))
+				ret, err = ret.Intersect(b.ctx, partBuilder.Ranges(b.ctx))
 				if err != nil {
 					return nil, err
 				}
@@ -1057,7 +1057,7 @@ func (b *indexScanRangeBuilder) rangeBuildAnd(f *iScanAnd, inScan bool) (sql.MyS
 		return partBuilder.Ranges(b.ctx), nil
 	}
 
-	ret, err := ret.Intersect(partBuilder.Ranges(b.ctx))
+	ret, err := ret.Intersect(b.ctx, partBuilder.Ranges(b.ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/sql/analyzer/costed_index_scan_test.go
+++ b/sql/analyzer/costed_index_scan_test.go
@@ -587,15 +587,15 @@ func TestRangeBuilder(t *testing.T) {
 			if tt.cnt == 1 {
 				require.Equal(t, 0, len(b.leftover))
 			}
-			cmpRanges, err = sql.SortRanges(cmpRanges...)
+			cmpRanges, err = sql.SortRanges(ctx, cmpRanges...)
 			require.NoError(t, err)
 
-			expRanges, err := sql.RemoveOverlappingRanges(tt.exp...)
+			expRanges, err := sql.RemoveOverlappingRanges(ctx, tt.exp...)
 			require.NoError(t, err)
-			expRanges, err = sql.SortRanges(expRanges...)
+			expRanges, err = sql.SortRanges(ctx, expRanges...)
 			require.NoError(t, err)
 
-			ok, err := expRanges.Equals(cmpRanges)
+			ok, err := expRanges.Equals(ctx, cmpRanges)
 			require.NoError(t, err)
 			assert.True(t, ok)
 			if !ok {
@@ -670,16 +670,16 @@ func TestRangeBuilderInclude(t *testing.T) {
 			b := newIndexScanRangeBuilder(ctx, dummy1, tt.include, sql.FastIntSet{}, c.idToExpr)
 			cmpRanges, err := b.buildRangeCollection(root)
 			require.NoError(t, err)
-			cmpRanges, err = sql.SortRanges(cmpRanges...)
+			cmpRanges, err = sql.SortRanges(ctx, cmpRanges...)
 			require.NoError(t, err)
 
-			expRanges, err := sql.RemoveOverlappingRanges(tt.exp...)
+			expRanges, err := sql.RemoveOverlappingRanges(ctx, tt.exp...)
 			require.NoError(t, err)
-			expRanges, err = sql.SortRanges(expRanges...)
+			expRanges, err = sql.SortRanges(ctx, expRanges...)
 			require.NoError(t, err)
 
 			// TODO how to compare ranges, strings?
-			ok, err := expRanges.Equals(cmpRanges)
+			ok, err := expRanges.Equals(ctx, cmpRanges)
 			require.NoError(t, err)
 			assert.True(t, ok)
 			if !ok {

--- a/sql/analyzer/replace_sort.go
+++ b/sql/analyzer/replace_sort.go
@@ -54,7 +54,7 @@ func replaceIdxSortHelper(ctx *sql.Context, scope *plan.Scope, node sql.Node, so
 		}
 		// if the resulting ranges are overlapping, we cannot drop the sort node
 		// it is possible we end up with blocks of rows that intersect
-		if hasOverlapping(sfExprs, mysqlRanges) {
+		if hasOverlapping(ctx, sfExprs, mysqlRanges) {
 			return n, transform.SameTree, nil
 		}
 
@@ -454,11 +454,11 @@ func isValidSortFieldOrder(sfs sql.SortFields) bool {
 
 // hasOverlapping checks if the ranges in a RangeCollection that are part of the sortfield exprs are overlapping
 // This function assumes that the sort field exprs are a valid prefix of the index columns
-func hasOverlapping(sfExprs []sql.Expression, ranges sql.MySQLRangeCollection) bool {
+func hasOverlapping(ctx *sql.Context, sfExprs []sql.Expression, ranges sql.MySQLRangeCollection) bool {
 	for si := range sfExprs {
 		for ri := 0; ri < len(ranges)-1; ri++ {
 			for rj := ri + 1; rj < len(ranges); rj++ {
-				if _, overlaps, _ := ranges[ri][si].Overlaps(ranges[rj][si]); overlaps {
+				if _, overlaps, _ := ranges[ri][si].Overlaps(ctx, ranges[rj][si]); overlaps {
 					return true
 				}
 			}

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -280,7 +280,7 @@ func (b *MySQLIndexBuilder) NotEquals(ctx *Context, colExpr string, keyType Type
 		b.updateCol(ctx, colExpr, GreaterThanRangeColumnExpr(key, colTyp), LessThanRangeColumnExpr(key, colTyp))
 	}
 	if !b.isInvalid {
-		ranges, err := SimplifyRangeColumn(b.ranges[colExpr]...)
+		ranges, err := SimplifyRangeColumn(ctx, b.ranges[colExpr]...)
 		if err != nil {
 			b.isInvalid = true
 			b.err = err
@@ -569,7 +569,7 @@ func (b *MySQLIndexBuilder) Ranges(ctx *Context) MySQLRangeCollection {
 		for colIdx, exprIdx := range permutation {
 			currentRange[colIdx] = allColumns[colIdx][exprIdx]
 		}
-		isempty, err := currentRange.IsEmpty()
+		isempty, err := currentRange.IsEmpty(ctx)
 		if err != nil {
 			b.err = err
 			return nil
@@ -619,7 +619,7 @@ func (b *MySQLIndexBuilder) updateCol(ctx *Context, colExpr string, potentialRan
 	var newRanges []MySQLRangeColumnExpr
 	for _, currentRange := range currentRanges {
 		for _, potentialRange := range potentialRanges {
-			newRange, ok, err := currentRange.TryIntersect(potentialRange)
+			newRange, ok, err := currentRange.TryIntersect(ctx, potentialRange)
 			if err != nil {
 				b.isInvalid = true
 				if !ErrInvalidValue.Is(err) {
@@ -628,7 +628,7 @@ func (b *MySQLIndexBuilder) updateCol(ctx *Context, colExpr string, potentialRan
 				return
 			}
 			if ok {
-				isempty, err := newRange.IsEmpty()
+				isempty, err := newRange.IsEmpty(ctx)
 				if err != nil {
 					b.isInvalid = true
 					b.err = err

--- a/sql/index_builder_test.go
+++ b/sql/index_builder_test.go
@@ -15,6 +15,7 @@
 package sql_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -142,7 +143,7 @@ func TestIndexBuilderRanges(t *testing.T) {
 			all = append(all, clauses[perm[0]]...)
 			all = append(all, clauses[perm[1]]...)
 			all = append(all, clauses[perm[2]]...)
-			combined, err := sql.RemoveOverlappingRanges(all...)
+			combined, err := sql.RemoveOverlappingRanges(context.Background(), all...)
 			assert.NoError(t, err)
 			assert.NotNil(t, combined)
 			assert.Equal(t, sql.MySQLRangeCollection{

--- a/sql/range.go
+++ b/sql/range.go
@@ -14,13 +14,16 @@
 
 package sql
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // RangeCollection is a collection of ranges that represent different (non-overlapping) filter expressions.
 type RangeCollection interface {
 	DebugStringer
 	fmt.Stringer
-	Equals(otherCollection RangeCollection) (bool, error)
+	Equals(ctx context.Context, otherCollection RangeCollection) (bool, error)
 	Len() int
 	ToRanges() []Range
 }
@@ -30,5 +33,5 @@ type RangeCollection interface {
 type Range interface {
 	DebugStringer
 	fmt.Stringer
-	Equals(other Range) (bool, error)
+	Equals(ctx context.Context, other Range) (bool, error)
 }

--- a/sql/range_column_expr.go
+++ b/sql/range_column_expr.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -179,12 +180,12 @@ func NotNullRangeColumnExpr(typ Type) MySQLRangeColumnExpr {
 }
 
 // Equals checks for equality with the given MySQLRangeColumnExpr.
-func (r MySQLRangeColumnExpr) Equals(other MySQLRangeColumnExpr) (bool, error) {
-	cmpLower, err := r.LowerBound.Compare(other.LowerBound, r.Typ)
+func (r MySQLRangeColumnExpr) Equals(ctx context.Context, other MySQLRangeColumnExpr) (bool, error) {
+	cmpLower, err := r.LowerBound.Compare(ctx, other.LowerBound, r.Typ)
 	if err != nil {
 		return false, err
 	}
-	cmpUpper, err := r.UpperBound.Compare(other.UpperBound, r.Typ)
+	cmpUpper, err := r.UpperBound.Compare(ctx, other.UpperBound, r.Typ)
 	if err != nil {
 		return false, err
 	}
@@ -202,24 +203,24 @@ func (r MySQLRangeColumnExpr) HasUpperBound() bool {
 }
 
 // IsEmpty returns whether this MySQLRangeColumnExpr is empty.
-func (r MySQLRangeColumnExpr) IsEmpty() (bool, error) {
-	cmp, err := r.LowerBound.Compare(r.UpperBound, r.Typ)
+func (r MySQLRangeColumnExpr) IsEmpty(ctx context.Context) (bool, error) {
+	cmp, err := r.LowerBound.Compare(ctx, r.UpperBound, r.Typ)
 	return cmp >= 0, err
 }
 
 // IsConnected evaluates whether the given MySQLRangeColumnExpr overlaps or is adjacent to the calling MySQLRangeColumnExpr.
-func (r MySQLRangeColumnExpr) IsConnected(other MySQLRangeColumnExpr) (bool, error) {
+func (r MySQLRangeColumnExpr) IsConnected(ctx context.Context, other MySQLRangeColumnExpr) (bool, error) {
 	if r.Typ.String() != other.Typ.String() {
 		return false, nil
 	}
-	comp, err := r.LowerBound.Compare(other.UpperBound, r.Typ)
+	comp, err := r.LowerBound.Compare(ctx, other.UpperBound, r.Typ)
 	if err != nil {
 		return false, err
 	}
 	if comp > 0 {
 		return false, nil
 	}
-	comp, err = other.LowerBound.Compare(r.UpperBound, r.Typ)
+	comp, err = other.LowerBound.Compare(ctx, r.UpperBound, r.Typ)
 	if err != nil {
 		return false, err
 	}
@@ -228,23 +229,23 @@ func (r MySQLRangeColumnExpr) IsConnected(other MySQLRangeColumnExpr) (bool, err
 
 // Overlaps evaluates whether the given MySQLRangeColumnExpr overlaps the calling MySQLRangeColumnExpr. If they do, returns the
 // overlapping region as a MySQLRangeColumnExpr.
-func (r MySQLRangeColumnExpr) Overlaps(other MySQLRangeColumnExpr) (MySQLRangeColumnExpr, bool, error) {
+func (r MySQLRangeColumnExpr) Overlaps(ctx context.Context, other MySQLRangeColumnExpr) (MySQLRangeColumnExpr, bool, error) {
 	if r.Typ.String() != other.Typ.String() {
 		return EmptyRangeColumnExpr(r.Typ), false, nil
 	}
-	comp, err := r.LowerBound.Compare(other.UpperBound, r.Typ)
+	comp, err := r.LowerBound.Compare(ctx, other.UpperBound, r.Typ)
 	if err != nil || comp >= 0 {
 		return EmptyRangeColumnExpr(r.Typ), false, err
 	}
-	comp, err = other.LowerBound.Compare(r.UpperBound, r.Typ)
+	comp, err = other.LowerBound.Compare(ctx, r.UpperBound, r.Typ)
 	if err != nil || comp >= 0 {
 		return EmptyRangeColumnExpr(r.Typ), false, err
 	}
-	lowerbound, err := GetMySQLRangeCutMax(r.Typ, r.LowerBound, other.LowerBound)
+	lowerbound, err := GetMySQLRangeCutMax(ctx, r.Typ, r.LowerBound, other.LowerBound)
 	if err != nil {
 		return EmptyRangeColumnExpr(r.Typ), false, err
 	}
-	upperbound, err := GetMySQLRangeCutMin(r.Typ, r.UpperBound, other.UpperBound)
+	upperbound, err := GetMySQLRangeCutMin(ctx, r.Typ, r.UpperBound, other.UpperBound)
 	if err != nil {
 		return EmptyRangeColumnExpr(r.Typ), false, err
 	}
@@ -260,19 +261,19 @@ func (r MySQLRangeColumnExpr) Overlaps(other MySQLRangeColumnExpr) (MySQLRangeCo
 // given MySQLRangeColumnExpr does not overlap the calling MySQLRangeColumnExpr, then the calling MySQLRangeColumnExpr is returned.
 // If the calling MySQLRangeColumnExpr is a strict subset (or equivalent) of the given MySQLRangeColumnExpr, then an empty slice
 // is returned. In all other cases, a slice with a single MySQLRangeColumnExpr will be returned.
-func (r MySQLRangeColumnExpr) Subtract(other MySQLRangeColumnExpr) ([]MySQLRangeColumnExpr, error) {
-	_, overlaps, err := r.Overlaps(other)
+func (r MySQLRangeColumnExpr) Subtract(ctx context.Context, other MySQLRangeColumnExpr) ([]MySQLRangeColumnExpr, error) {
+	_, overlaps, err := r.Overlaps(ctx, other)
 	if err != nil {
 		return nil, err
 	}
 	if !overlaps {
 		return []MySQLRangeColumnExpr{r}, nil
 	}
-	lComp, err := r.LowerBound.Compare(other.LowerBound, r.Typ)
+	lComp, err := r.LowerBound.Compare(ctx, other.LowerBound, r.Typ)
 	if err != nil {
 		return nil, err
 	}
-	uComp, err := r.UpperBound.Compare(other.UpperBound, r.Typ)
+	uComp, err := r.UpperBound.Compare(ctx, other.UpperBound, r.Typ)
 	if err != nil {
 		return nil, err
 	}
@@ -308,15 +309,15 @@ func (r MySQLRangeColumnExpr) Subtract(other MySQLRangeColumnExpr) ([]MySQLRange
 }
 
 // IsSubsetOf evaluates whether the calling MySQLRangeColumnExpr is fully encompassed by the given MySQLRangeColumnExpr.
-func (r MySQLRangeColumnExpr) IsSubsetOf(other MySQLRangeColumnExpr) (bool, error) {
+func (r MySQLRangeColumnExpr) IsSubsetOf(ctx context.Context, other MySQLRangeColumnExpr) (bool, error) {
 	if r.Typ.String() != other.Typ.String() {
 		return false, nil
 	}
-	comp, err := r.LowerBound.Compare(other.LowerBound, r.Typ)
+	comp, err := r.LowerBound.Compare(ctx, other.LowerBound, r.Typ)
 	if err != nil || comp == -1 {
 		return false, err
 	}
-	comp, err = r.UpperBound.Compare(other.UpperBound, r.Typ)
+	comp, err = r.UpperBound.Compare(ctx, other.UpperBound, r.Typ)
 	if err != nil || comp == 1 {
 		return false, err
 	}
@@ -324,8 +325,8 @@ func (r MySQLRangeColumnExpr) IsSubsetOf(other MySQLRangeColumnExpr) (bool, erro
 }
 
 // IsSupersetOf evaluates whether the calling MySQLRangeColumnExpr fully encompasses the given MySQLRangeColumnExpr.
-func (r MySQLRangeColumnExpr) IsSupersetOf(other MySQLRangeColumnExpr) (bool, error) {
-	return other.IsSubsetOf(r)
+func (r MySQLRangeColumnExpr) IsSupersetOf(ctx context.Context, other MySQLRangeColumnExpr) (bool, error) {
+	return other.IsSubsetOf(ctx, r)
 }
 
 // String returns this MySQLRangeColumnExpr as a string for display purposes.
@@ -388,16 +389,16 @@ func (r MySQLRangeColumnExpr) DebugString(ctx *Context) string {
 // TryIntersect attempts to intersect the given MySQLRangeColumnExpr with the calling MySQLRangeColumnExpr. Returns true if the
 // intersection result is not the empty MySQLRangeColumnExpr, however a valid MySQLRangeColumnExpr is always returned if the error
 // is nil.
-func (r MySQLRangeColumnExpr) TryIntersect(other MySQLRangeColumnExpr) (MySQLRangeColumnExpr, bool, error) {
-	_, l, err := OrderedCuts(r.LowerBound, other.LowerBound, r.Typ)
+func (r MySQLRangeColumnExpr) TryIntersect(ctx context.Context, other MySQLRangeColumnExpr) (MySQLRangeColumnExpr, bool, error) {
+	_, l, err := OrderedCuts(ctx, r.LowerBound, other.LowerBound, r.Typ)
 	if err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	}
-	u, _, err := OrderedCuts(r.UpperBound, other.UpperBound, r.Typ)
+	u, _, err := OrderedCuts(ctx, r.UpperBound, other.UpperBound, r.Typ)
 	if err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	}
-	comp, err := l.Compare(u, r.Typ)
+	comp, err := l.Compare(ctx, u, r.Typ)
 	if err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	}
@@ -409,29 +410,29 @@ func (r MySQLRangeColumnExpr) TryIntersect(other MySQLRangeColumnExpr) (MySQLRan
 
 // TryUnion attempts to combine the given MySQLRangeColumnExpr with the calling MySQLRangeColumnExpr. Returns true if the union
 // was a success.
-func (r MySQLRangeColumnExpr) TryUnion(other MySQLRangeColumnExpr) (MySQLRangeColumnExpr, bool, error) {
-	if isEmpty, err := other.IsEmpty(); err != nil {
+func (r MySQLRangeColumnExpr) TryUnion(ctx context.Context, other MySQLRangeColumnExpr) (MySQLRangeColumnExpr, bool, error) {
+	if isEmpty, err := other.IsEmpty(ctx); err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	} else if isEmpty {
 		return r, true, nil
 	}
-	if isEmpty, err := r.IsEmpty(); err != nil {
+	if isEmpty, err := r.IsEmpty(ctx); err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	} else if isEmpty {
 		return other, true, nil
 	}
-	connected, err := r.IsConnected(other)
+	connected, err := r.IsConnected(ctx, other)
 	if err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	}
 	if !connected {
 		return MySQLRangeColumnExpr{}, false, nil
 	}
-	l, _, err := OrderedCuts(r.LowerBound, other.LowerBound, r.Typ)
+	l, _, err := OrderedCuts(ctx, r.LowerBound, other.LowerBound, r.Typ)
 	if err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	}
-	_, u, err := OrderedCuts(r.UpperBound, other.UpperBound, r.Typ)
+	_, u, err := OrderedCuts(ctx, r.UpperBound, other.UpperBound, r.Typ)
 	if err != nil {
 		return MySQLRangeColumnExpr{}, false, err
 	}
@@ -494,8 +495,8 @@ func (r MySQLRangeColumnExpr) Type() RangeType {
 }
 
 // OrderedCuts returns the given Cuts in order from lowest-touched values to highest-touched values.
-func OrderedCuts(l, r MySQLRangeCut, typ Type) (MySQLRangeCut, MySQLRangeCut, error) {
-	comp, err := l.Compare(r, typ)
+func OrderedCuts(ctx context.Context, l, r MySQLRangeCut, typ Type) (MySQLRangeCut, MySQLRangeCut, error) {
+	comp, err := l.Compare(ctx, r, typ)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -507,6 +508,7 @@ func OrderedCuts(l, r MySQLRangeCut, typ Type) (MySQLRangeCut, MySQLRangeCut, er
 
 // rangeColumnExprSlice is a sortable slice of RangeColumnExprs.
 type rangeColumnExprSlice struct {
+	ctx    context.Context
 	err    error
 	ranges []MySQLRangeColumnExpr
 }
@@ -514,7 +516,7 @@ type rangeColumnExprSlice struct {
 func (r *rangeColumnExprSlice) Len() int      { return len(r.ranges) }
 func (r *rangeColumnExprSlice) Swap(i, j int) { r.ranges[i], r.ranges[j] = r.ranges[j], r.ranges[i] }
 func (r *rangeColumnExprSlice) Less(i, j int) bool {
-	lc, err := r.ranges[i].LowerBound.Compare(r.ranges[j].LowerBound, r.ranges[i].Typ)
+	lc, err := r.ranges[i].LowerBound.Compare(r.ctx, r.ranges[j].LowerBound, r.ranges[i].Typ)
 	if err != nil {
 		r.err = err
 		return false
@@ -524,7 +526,7 @@ func (r *rangeColumnExprSlice) Less(i, j int) bool {
 	} else if lc > 0 {
 		return false
 	}
-	uc, err := r.ranges[i].UpperBound.Compare(r.ranges[j].UpperBound, r.ranges[i].Typ)
+	uc, err := r.ranges[i].UpperBound.Compare(r.ctx, r.ranges[j].UpperBound, r.ranges[i].Typ)
 	if err != nil {
 		r.err = err
 		return false
@@ -533,7 +535,7 @@ func (r *rangeColumnExprSlice) Less(i, j int) bool {
 }
 
 // SimplifyRangeColumn combines all RangeColumnExprs that are connected and returns a new slice.
-func SimplifyRangeColumn(rces ...MySQLRangeColumnExpr) ([]MySQLRangeColumnExpr, error) {
+func SimplifyRangeColumn(ctx context.Context, rces ...MySQLRangeColumnExpr) ([]MySQLRangeColumnExpr, error) {
 	if len(rces) == 0 {
 		return rces, nil
 	}
@@ -545,7 +547,7 @@ func SimplifyRangeColumn(rces ...MySQLRangeColumnExpr) ([]MySQLRangeColumnExpr, 
 	}
 	sorted := make([]MySQLRangeColumnExpr, len(rces))
 	copy(sorted, rces)
-	rSlice := &rangeColumnExprSlice{ranges: sorted}
+	rSlice := &rangeColumnExprSlice{ctx: ctx, ranges: sorted}
 	sort.Sort(rSlice)
 	if rSlice.err != nil {
 		return nil, rSlice.err
@@ -553,20 +555,20 @@ func SimplifyRangeColumn(rces ...MySQLRangeColumnExpr) ([]MySQLRangeColumnExpr, 
 	var res []MySQLRangeColumnExpr
 	cur := EmptyRangeColumnExpr(rces[0].Typ)
 	for _, r := range sorted {
-		merged, ok, err := cur.TryUnion(r)
+		merged, ok, err := cur.TryUnion(ctx, r)
 		if err != nil {
 			return nil, err
 		}
 		if ok {
 			cur = merged
-		} else if curIsEmpty, err := cur.IsEmpty(); err != nil {
+		} else if curIsEmpty, err := cur.IsEmpty(ctx); err != nil {
 			return nil, err
 		} else if !curIsEmpty {
 			res = append(res, cur)
 			cur = r
 		}
 	}
-	if curIsEmpty, err := cur.IsEmpty(); err != nil {
+	if curIsEmpty, err := cur.IsEmpty(ctx); err != nil {
 		return nil, err
 	} else if !curIsEmpty {
 		res = append(res, cur)

--- a/sql/range_column_expr_test.go
+++ b/sql/range_column_expr_test.go
@@ -15,6 +15,7 @@
 package sql_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,31 +25,33 @@ import (
 )
 
 func TestTryIntersect(t *testing.T) {
-	res, ok, err := sql.LessThanRangeColumnExpr(6, types.Int8).TryIntersect(sql.GreaterThanRangeColumnExpr(-1, types.Int8))
+	ctx := context.Background()
+	res, ok, err := sql.LessThanRangeColumnExpr(6, types.Int8).TryIntersect(ctx, sql.GreaterThanRangeColumnExpr(-1, types.Int8))
 	assert.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, sql.RangeType_OpenOpen, res.Type())
 
-	res, ok, err = sql.NotNullRangeColumnExpr(types.Int8).TryIntersect(sql.AllRangeColumnExpr(types.Int8))
+	res, ok, err = sql.NotNullRangeColumnExpr(types.Int8).TryIntersect(ctx, sql.AllRangeColumnExpr(types.Int8))
 	assert.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, sql.RangeType_GreaterThan, res.Type())
 	assert.False(t, sql.MySQLRangeCutIsBinding(res.LowerBound))
 
-	_, ok, err = sql.NotNullRangeColumnExpr(types.Int8).TryIntersect(sql.NullRangeColumnExpr(types.Int8))
+	_, ok, err = sql.NotNullRangeColumnExpr(types.Int8).TryIntersect(ctx, sql.NullRangeColumnExpr(types.Int8))
 	assert.NoError(t, err)
 	assert.False(t, ok)
-	_, ok, err = sql.NullRangeColumnExpr(types.Int8).TryIntersect(sql.NotNullRangeColumnExpr(types.Int8))
+	_, ok, err = sql.NullRangeColumnExpr(types.Int8).TryIntersect(ctx, sql.NotNullRangeColumnExpr(types.Int8))
 	assert.NoError(t, err)
 	assert.False(t, ok)
 }
 
 func TestTryUnion(t *testing.T) {
-	res, ok, err := sql.NotNullRangeColumnExpr(types.Int8).TryUnion(sql.NullRangeColumnExpr(types.Int8))
+	ctx := context.Background()
+	res, ok, err := sql.NotNullRangeColumnExpr(types.Int8).TryUnion(ctx, sql.NullRangeColumnExpr(types.Int8))
 	assert.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, sql.RangeType_All, res.Type())
-	res, ok, err = sql.NullRangeColumnExpr(types.Int8).TryUnion(sql.NotNullRangeColumnExpr(types.Int8))
+	res, ok, err = sql.NullRangeColumnExpr(types.Int8).TryUnion(ctx, sql.NotNullRangeColumnExpr(types.Int8))
 	assert.NoError(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, sql.RangeType_All, res.Type())

--- a/sql/range_cut.go
+++ b/sql/range_cut.go
@@ -22,7 +22,7 @@ import (
 // MySQLRangeCut represents a position on the line of all possible values.
 type MySQLRangeCut interface {
 	// Compare returns an integer stating the relative position of the calling MySQLRangeCut to the given MySQLRangeCut.
-	Compare(MySQLRangeCut, Type) (int, error)
+	Compare(context.Context, MySQLRangeCut, Type) (int, error)
 	// String returns the MySQLRangeCut as a string for display purposes.
 	String() string
 	// TypeAsLowerBound returns the bound type if the calling MySQLRangeCut is the lower bound of a range.
@@ -70,7 +70,7 @@ func MySQLRangeCutIsBinding(c MySQLRangeCut) bool {
 }
 
 // GetMySQLRangeCutMax returns the MySQLRangeCut with the highest value.
-func GetMySQLRangeCutMax(typ Type, cuts ...MySQLRangeCut) (MySQLRangeCut, error) {
+func GetMySQLRangeCutMax(ctx context.Context, typ Type, cuts ...MySQLRangeCut) (MySQLRangeCut, error) {
 	i := 0
 	var maxCut MySQLRangeCut
 	for ; i < len(cuts); i++ {
@@ -84,7 +84,7 @@ func GetMySQLRangeCutMax(typ Type, cuts ...MySQLRangeCut) (MySQLRangeCut, error)
 		if cuts[i] == nil {
 			continue
 		}
-		comp, err := maxCut.Compare(cuts[i], typ)
+		comp, err := maxCut.Compare(ctx, cuts[i], typ)
 		if err != nil {
 			return maxCut, err
 		}
@@ -96,7 +96,7 @@ func GetMySQLRangeCutMax(typ Type, cuts ...MySQLRangeCut) (MySQLRangeCut, error)
 }
 
 // GetMySQLRangeCutMin returns the MySQLRangeCut with the lowest value.
-func GetMySQLRangeCutMin(typ Type, cuts ...MySQLRangeCut) (MySQLRangeCut, error) {
+func GetMySQLRangeCutMin(ctx context.Context, typ Type, cuts ...MySQLRangeCut) (MySQLRangeCut, error) {
 	i := 0
 	var minCut MySQLRangeCut
 	for ; i < len(cuts); i++ {
@@ -110,7 +110,7 @@ func GetMySQLRangeCutMin(typ Type, cuts ...MySQLRangeCut) (MySQLRangeCut, error)
 		if cuts[i] == nil {
 			continue
 		}
-		comp, err := minCut.Compare(cuts[i], typ)
+		comp, err := minCut.Compare(ctx, cuts[i], typ)
 		if err != nil {
 			return minCut, err
 		}
@@ -130,9 +130,7 @@ type Above struct {
 var _ MySQLRangeCut = Above{}
 
 // Compare implements MySQLRangeCut.
-func (a Above) Compare(c MySQLRangeCut, typ Type) (int, error) {
-	// TODO: Add context parameter to MySQLRangeCut.Compare
-	ctx := context.Background()
+func (a Above) Compare(ctx context.Context, c MySQLRangeCut, typ Type) (int, error) {
 	switch c := c.(type) {
 	case AboveAll:
 		return -1, nil
@@ -177,7 +175,7 @@ type AboveAll struct{}
 var _ MySQLRangeCut = AboveAll{}
 
 // Compare implements MySQLRangeCut.
-func (AboveAll) Compare(c MySQLRangeCut, typ Type) (int, error) {
+func (AboveAll) Compare(_ context.Context, c MySQLRangeCut, typ Type) (int, error) {
 	if _, ok := c.(AboveAll); ok {
 		return 0, nil
 	}
@@ -208,9 +206,7 @@ type Below struct {
 var _ MySQLRangeCut = Below{}
 
 // Compare implements MySQLRangeCut.
-func (b Below) Compare(c MySQLRangeCut, typ Type) (int, error) {
-	// TODO: Add context parameter to MySQLRangeCut.Compare
-	ctx := context.Background()
+func (b Below) Compare(ctx context.Context, c MySQLRangeCut, typ Type) (int, error) {
 	switch c := c.(type) {
 	case AboveAll:
 		return -1, nil
@@ -286,7 +282,7 @@ type AboveNull struct{}
 var _ MySQLRangeCut = AboveNull{}
 
 // Compare implements MySQLRangeCut.
-func (AboveNull) Compare(c MySQLRangeCut, typ Type) (int, error) {
+func (AboveNull) Compare(_ context.Context, c MySQLRangeCut, typ Type) (int, error) {
 	if _, ok := c.(AboveNull); ok {
 		return 0, nil
 	}
@@ -318,7 +314,7 @@ type BelowNull struct{}
 var _ MySQLRangeCut = BelowNull{}
 
 // Compare implements MySQLRangeCut.
-func (BelowNull) Compare(c MySQLRangeCut, typ Type) (int, error) {
+func (BelowNull) Compare(_ context.Context, c MySQLRangeCut, typ Type) (int, error) {
 	// BelowNull overlaps with itself
 	if _, ok := c.(BelowNull); ok {
 		return 0, nil

--- a/sql/range_cut_test.go
+++ b/sql/range_cut_test.go
@@ -15,6 +15,7 @@
 package sql_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -52,11 +53,12 @@ func TestRangeCutCompare(t *testing.T) {
 		{sql.BelowNull{}, sql.BelowNull{}, 0},
 	} {
 		t.Run(fmt.Sprintf("%s/%s = %d", testcase.left.String(), testcase.right.String(), testcase.res), func(t *testing.T) {
-			res, err := testcase.left.Compare(testcase.right, types.Int8)
+			ctx := context.Background()
+			res, err := testcase.left.Compare(ctx, testcase.right, types.Int8)
 			assert.NoError(t, err)
 			assert.Equal(t, testcase.res, res, "forward Compare")
 
-			res, err = testcase.right.Compare(testcase.left, types.Int8)
+			res, err = testcase.right.Compare(ctx, testcase.left, types.Int8)
 			assert.NoError(t, err)
 			assert.Equal(t, -testcase.res, res, "reverse Compare")
 		})

--- a/sql/range_mysql.go
+++ b/sql/range_mysql.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -29,7 +30,7 @@ type MySQLRange []MySQLRangeColumnExpr
 
 // Equals returns whether the given RangeCollection matches the calling RangeCollection. The order of each Range is
 // important, therefore it is recommended to sort two collections beforehand.
-func (ranges MySQLRangeCollection) Equals(other RangeCollection) (bool, error) {
+func (ranges MySQLRangeCollection) Equals(ctx context.Context, other RangeCollection) (bool, error) {
 	otherCollection, ok := other.(MySQLRangeCollection)
 	if !ok {
 		return false, nil
@@ -38,7 +39,7 @@ func (ranges MySQLRangeCollection) Equals(other RangeCollection) (bool, error) {
 		return false, nil
 	}
 	for i := range ranges {
-		if ok, err := ranges[i].Equals(otherCollection[i]); err != nil || !ok {
+		if ok, err := ranges[i].Equals(ctx, otherCollection[i]); err != nil || !ok {
 			return ok, err
 		}
 	}
@@ -53,11 +54,11 @@ func (ranges MySQLRangeCollection) Len() int {
 // Intersect attempts to intersect the given MySQLRangeCollection with the calling MySQLRangeCollection. This ensures
 // that each MySQLRange belonging to the same collection is treated as a union with respect to that same collection,
 // rather than attempting to intersect ranges that are a part of the same collection.
-func (ranges MySQLRangeCollection) Intersect(otherRanges MySQLRangeCollection) (MySQLRangeCollection, error) {
+func (ranges MySQLRangeCollection) Intersect(ctx context.Context, otherRanges MySQLRangeCollection) (MySQLRangeCollection, error) {
 	var newRanges MySQLRangeCollection
 	for _, rang := range ranges {
 		for _, otherRange := range otherRanges {
-			newRange, err := rang.Intersect(otherRange)
+			newRange, err := rang.Intersect(ctx, otherRange)
 			if err != nil {
 				return nil, err
 			}
@@ -66,7 +67,7 @@ func (ranges MySQLRangeCollection) Intersect(otherRanges MySQLRangeCollection) (
 			}
 		}
 	}
-	newRanges, err := RemoveOverlappingRanges(newRanges...)
+	newRanges, err := RemoveOverlappingRanges(ctx, newRanges...)
 	if err != nil {
 		return nil, err
 	}
@@ -122,12 +123,12 @@ func (rang MySQLRange) AsEmpty() MySQLRange {
 	return emptyRange
 }
 
-func (rang MySQLRange) IsEmpty() (bool, error) {
+func (rang MySQLRange) IsEmpty(ctx context.Context) (bool, error) {
 	if len(rang) == 0 {
 		return true, nil
 	}
 	for i := range rang {
-		res, err := rang[i].IsEmpty()
+		res, err := rang[i].IsEmpty(ctx)
 		if err != nil {
 			return false, err
 		}
@@ -160,7 +161,7 @@ func (rang MySQLRange) ExpressionByColumnName(idx Index, colExpr string) (MySQLR
 }
 
 // Equals evaluates whether the calling Range is equivalent to the given Range.
-func (rang MySQLRange) Equals(other Range) (bool, error) {
+func (rang MySQLRange) Equals(ctx context.Context, other Range) (bool, error) {
 	otherRange, ok := other.(MySQLRange)
 	if !ok {
 		return false, nil
@@ -169,7 +170,7 @@ func (rang MySQLRange) Equals(other Range) (bool, error) {
 		return false, nil
 	}
 	for i := range rang {
-		if ok, err := rang[i].Equals(otherRange[i]); err != nil || !ok {
+		if ok, err := rang[i].Equals(ctx, otherRange[i]); err != nil || !ok {
 			return false, err
 		}
 	}
@@ -177,16 +178,16 @@ func (rang MySQLRange) Equals(other Range) (bool, error) {
 }
 
 // Compare returns an integer stating the relative position of the calling MySQLRange to the given MySQLRange.
-func (rang MySQLRange) Compare(otherRange MySQLRange) (int, error) {
+func (rang MySQLRange) Compare(ctx context.Context, otherRange MySQLRange) (int, error) {
 	if len(rang) != len(otherRange) {
 		return 0, fmt.Errorf("compared ranges must have matching lengths")
 	}
 	for i := range rang {
-		cmp, err := rang[i].LowerBound.Compare(otherRange[i].LowerBound, rang[i].Typ)
+		cmp, err := rang[i].LowerBound.Compare(ctx, otherRange[i].LowerBound, rang[i].Typ)
 		if err != nil || cmp != 0 {
 			return cmp, err
 		}
-		cmp, err = rang[i].UpperBound.Compare(otherRange[i].UpperBound, rang[i].Typ)
+		cmp, err = rang[i].UpperBound.Compare(ctx, otherRange[i].UpperBound, rang[i].Typ)
 		if err != nil || cmp != 0 {
 			return cmp, err
 		}
@@ -195,13 +196,13 @@ func (rang MySQLRange) Compare(otherRange MySQLRange) (int, error) {
 }
 
 // Intersect intersects the given MySQLRange with the calling MySQLRange.
-func (rang MySQLRange) Intersect(otherRange MySQLRange) (MySQLRange, error) {
+func (rang MySQLRange) Intersect(ctx context.Context, otherRange MySQLRange) (MySQLRange, error) {
 	if len(rang) != len(otherRange) {
 		return nil, nil
 	}
 	newRangeCollection := make(MySQLRange, len(rang))
 	for i := range rang {
-		intersectedRange, ok, err := rang[i].TryIntersect(otherRange[i])
+		intersectedRange, ok, err := rang[i].TryIntersect(ctx, otherRange[i])
 		if err != nil {
 			return nil, err
 		}
@@ -216,16 +217,16 @@ func (rang MySQLRange) Intersect(otherRange MySQLRange) (MySQLRange, error) {
 // TryMerge attempts to merge the given MySQLRange with the calling MySQLRange. This can only do a merge if one
 // MySQLRange is a subset of the other, or if all columns except for one are equivalent, upon which a union is attempted
 // on that column. Returns true if the merge was successful.
-func (rang MySQLRange) TryMerge(otherRange MySQLRange) (MySQLRange, bool, error) {
+func (rang MySQLRange) TryMerge(ctx context.Context, otherRange MySQLRange) (MySQLRange, bool, error) {
 	if len(rang) != len(otherRange) {
 		return nil, false, nil
 	}
-	if ok, err := rang.IsSupersetOf(otherRange); err != nil {
+	if ok, err := rang.IsSupersetOf(ctx, otherRange); err != nil {
 		return nil, false, err
 	} else if ok {
 		return rang, true, nil
 	}
-	if ok, err := otherRange.IsSupersetOf(rang); err != nil {
+	if ok, err := otherRange.IsSupersetOf(ctx, rang); err != nil {
 		return nil, false, err
 	} else if ok {
 		return otherRange, true, nil
@@ -234,7 +235,7 @@ func (rang MySQLRange) TryMerge(otherRange MySQLRange) (MySQLRange, bool, error)
 	indexToMerge := -1
 	// The superset checks will cover if every column expr is equivalent
 	for i := 0; i < len(rang); i++ {
-		if ok, err := rang[i].Equals(otherRange[i]); err != nil {
+		if ok, err := rang[i].Equals(ctx, otherRange[i]); err != nil {
 			return nil, false, err
 		} else if !ok {
 			// Only one column may not equal another
@@ -248,7 +249,7 @@ func (rang MySQLRange) TryMerge(otherRange MySQLRange) (MySQLRange, bool, error)
 	if indexToMerge == -1 {
 		return nil, false, fmt.Errorf("invalid index to merge")
 	}
-	mergedLastExpr, ok, err := rang[indexToMerge].TryUnion(otherRange[indexToMerge])
+	mergedLastExpr, ok, err := rang[indexToMerge].TryUnion(ctx, otherRange[indexToMerge])
 	if err != nil || !ok {
 		return nil, false, err
 	}
@@ -258,12 +259,12 @@ func (rang MySQLRange) TryMerge(otherRange MySQLRange) (MySQLRange, bool, error)
 }
 
 // IsSubsetOf evaluates whether the calling MySQLRange is fully encompassed by the given MySQLRange.
-func (rang MySQLRange) IsSubsetOf(otherRange MySQLRange) (bool, error) {
+func (rang MySQLRange) IsSubsetOf(ctx context.Context, otherRange MySQLRange) (bool, error) {
 	if len(rang) != len(otherRange) {
 		return false, nil
 	}
 	for i := range rang {
-		ok, err := rang[i].IsSubsetOf(otherRange[i])
+		ok, err := rang[i].IsSubsetOf(ctx, otherRange[i])
 		if err != nil || !ok {
 			return false, err
 		}
@@ -272,18 +273,18 @@ func (rang MySQLRange) IsSubsetOf(otherRange MySQLRange) (bool, error) {
 }
 
 // IsSupersetOf evaluates whether the calling MySQLRange fully encompasses the given MySQLRange.
-func (rang MySQLRange) IsSupersetOf(otherRange MySQLRange) (bool, error) {
-	return otherRange.IsSubsetOf(rang)
+func (rang MySQLRange) IsSupersetOf(ctx context.Context, otherRange MySQLRange) (bool, error) {
+	return otherRange.IsSubsetOf(ctx, rang)
 }
 
 // IsConnected returns whether the calling MySQLRange and given MySQLRange have overlapping values, which would result
 // in the same values being returned from some subset of both ranges.
-func (rang MySQLRange) IsConnected(otherRange MySQLRange) (bool, error) {
+func (rang MySQLRange) IsConnected(ctx context.Context, otherRange MySQLRange) (bool, error) {
 	if len(rang) != len(otherRange) {
 		return false, nil
 	}
 	for i := range rang {
-		_, ok, err := rang[i].Overlaps(otherRange[i])
+		_, ok, err := rang[i].Overlaps(ctx, otherRange[i])
 		if err != nil || !ok {
 			return false, err
 		}
@@ -293,12 +294,12 @@ func (rang MySQLRange) IsConnected(otherRange MySQLRange) (bool, error) {
 
 // Overlaps returns whether the calling MySQLRange and given MySQLRange have overlapping values, which would result in
 // the same values being returned from some subset of both ranges.
-func (rang MySQLRange) Overlaps(otherRange MySQLRange) (bool, error) {
+func (rang MySQLRange) Overlaps(ctx context.Context, otherRange MySQLRange) (bool, error) {
 	if len(rang) != len(otherRange) {
 		return false, nil
 	}
 	for i := range rang {
-		_, ok, err := rang[i].Overlaps(otherRange[i])
+		_, ok, err := rang[i].Overlaps(ctx, otherRange[i])
 		if err != nil || !ok {
 			return false, err
 		}
@@ -311,7 +312,7 @@ func (rang MySQLRange) Overlaps(otherRange MySQLRange) (bool, error) {
 // one MySQLRange is returned. Otherwise, this returns a collection of ranges that do not overlap with each other, and covers
 // the entirety of the original ranges (and nothing more). If the two ranges do not overlap and are not mergeable then
 // false is returned, otherwise returns true.
-func (rang MySQLRange) RemoveOverlap(otherRange MySQLRange) ([]MySQLRange, bool, error) {
+func (rang MySQLRange) RemoveOverlap(ctx context.Context, otherRange MySQLRange) ([]MySQLRange, bool, error) {
 	// An explanation on why overlapping ranges may return more than one range, and why they can't just be merged as-is.
 	// Let's start with a MySQLRange that has a single RangeColumnExpression (a one-dimensional range). Imagine this as a
 	// number line with contiguous sections defined as the range. If you have any two sections that overlap, then you
@@ -335,39 +336,39 @@ func (rang MySQLRange) RemoveOverlap(otherRange MySQLRange) ([]MySQLRange, bool,
 
 	// If the two ranges may be merged then we just do that and return.
 	// Also allows us to not have to worry about the case where every column is equivalent.
-	if mergedRange, ok, err := rang.TryMerge(otherRange); err != nil {
+	if mergedRange, ok, err := rang.TryMerge(ctx, otherRange); err != nil {
 		return nil, false, err
 	} else if ok {
 		return []MySQLRange{mergedRange}, true, nil
 	}
 	// We check for overlapping after checking for merge as two ranges may not overlap but may be mergeable.
 	// This would occur if all other columns are equivalent except for one column that is overlapping or adjacent.
-	if ok, err := rang.Overlaps(otherRange); err != nil || !ok {
+	if ok, err := rang.Overlaps(ctx, otherRange); err != nil || !ok {
 		return []MySQLRange{rang, otherRange}, false, err
 	}
 
 	var ranges []MySQLRange
 	for i := range rang {
-		if ok, err := rang[i].Equals(otherRange[i]); err != nil {
+		if ok, err := rang[i].Equals(ctx, otherRange[i]); err != nil {
 			return nil, false, err
 		} else if ok {
 			continue
 		}
 		// Get the MySQLRangeColumnExpr that overlaps both RangeColumnExprs
-		overlapExpr, _, err := rang[i].Overlaps(otherRange[i])
+		overlapExpr, _, err := rang[i].Overlaps(ctx, otherRange[i])
 		if err != nil {
 			return nil, false, err
 		}
 		// Subtract the overlapping range from each existing range.
 		// This will give us a collection of ranges that do not have any overlap.
-		range1Subtracted, err := rang[i].Subtract(overlapExpr)
+		range1Subtracted, err := rang[i].Subtract(ctx, overlapExpr)
 		if err != nil {
 			return nil, false, err
 		}
 		for _, newColExpr := range range1Subtracted {
 			ranges = append(ranges, rang.replace(i, newColExpr))
 		}
-		range2Subtracted, err := otherRange[i].Subtract(overlapExpr)
+		range2Subtracted, err := otherRange[i].Subtract(ctx, overlapExpr)
 		if err != nil {
 			return nil, false, err
 		}
@@ -377,7 +378,7 @@ func (rang MySQLRange) RemoveOverlap(otherRange MySQLRange) ([]MySQLRange, bool,
 		// Create two ranges that replace each respective MySQLRangeColumnExpr with the overlapping one, giving us two
 		// ranges that are guaranteed to overlap (and are a subset of the originals). We can then recursively call this
 		// function on the new overlapping ranges which will eventually return a set of non-overlapping ranges.
-		newRanges, _, err := rang.replace(i, overlapExpr).RemoveOverlap(otherRange.replace(i, overlapExpr))
+		newRanges, _, err := rang.replace(i, overlapExpr).RemoveOverlap(ctx, otherRange.replace(i, overlapExpr))
 		if err != nil {
 			return nil, false, err
 		}
@@ -427,7 +428,7 @@ func (rang MySQLRange) replace(i int, colExpr MySQLRangeColumnExpr) MySQLRange {
 
 // IntersectRanges intersects each MySQLRange for each column expression. If a MySQLRangeColumnExpr ends up with no valid ranges
 // then a nil is returned.
-func IntersectRanges(ranges ...MySQLRange) MySQLRange {
+func IntersectRanges(ctx context.Context, ranges ...MySQLRange) MySQLRange {
 	if len(ranges) == 0 {
 		return nil
 	}
@@ -451,7 +452,7 @@ func IntersectRanges(ranges ...MySQLRange) MySQLRange {
 		if len(rc) == 0 {
 			continue
 		}
-		newRange, err := rang.Intersect(rc)
+		newRange, err := rang.Intersect(ctx, rc)
 		if err != nil || len(newRange) == 0 {
 			return nil
 		}
@@ -463,7 +464,7 @@ func IntersectRanges(ranges ...MySQLRange) MySQLRange {
 }
 
 // RemoveOverlappingRanges removes all overlap between all ranges.
-func RemoveOverlappingRanges(ranges ...MySQLRange) (MySQLRangeCollection, error) {
+func RemoveOverlappingRanges(ctx context.Context, ranges ...MySQLRange) (MySQLRangeCollection, error) {
 	if len(ranges) == 0 {
 		return nil, nil
 	}
@@ -475,20 +476,20 @@ func RemoveOverlappingRanges(ranges ...MySQLRange) (MySQLRangeCollection, error)
 	}
 	for i := 1; i < len(ranges); i++ {
 		rang := ranges[i]
-		connectingRanges, err := rangeTree.FindConnections(rang, 0)
+		connectingRanges, err := rangeTree.FindConnections(ctx, rang, 0)
 		if err != nil {
 			return nil, err
 		}
 		foundOverlap := false
 		for _, connectingRange := range connectingRanges {
 			if connectingRange != nil {
-				newRanges, ok, err := connectingRange.RemoveOverlap(rang)
+				newRanges, ok, err := connectingRange.RemoveOverlap(ctx, rang)
 				if err != nil {
 					return nil, err
 				}
 				if ok {
 					foundOverlap = true
-					err = rangeTree.Remove(connectingRange)
+					err = rangeTree.Remove(ctx, connectingRange)
 					if err != nil {
 						return nil, err
 					}
@@ -499,19 +500,19 @@ func RemoveOverlappingRanges(ranges ...MySQLRange) (MySQLRangeCollection, error)
 			}
 		}
 		if !foundOverlap {
-			err = rangeTree.Insert(rang)
+			err = rangeTree.Insert(ctx, rang)
 			if err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	rangeColl, err := rangeTree.GetRangeCollection()
+	rangeColl, err := rangeTree.GetRangeCollection(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	if err = validateRangeCollection(rangeColl); err != nil {
+	if err = validateRangeCollection(ctx, rangeColl); err != nil {
 		return nil, err
 	}
 
@@ -519,12 +520,12 @@ func RemoveOverlappingRanges(ranges ...MySQLRange) (MySQLRangeCollection, error)
 }
 
 // SortRanges sorts the given ranges, returning a new slice of ranges.
-func SortRanges(ranges ...MySQLRange) ([]MySQLRange, error) {
+func SortRanges(ctx context.Context, ranges ...MySQLRange) ([]MySQLRange, error) {
 	sortedRanges := make([]MySQLRange, len(ranges))
 	copy(sortedRanges, ranges)
 	var err error
 	sort.Slice(sortedRanges, func(i, j int) bool {
-		cmp, cmpErr := sortedRanges[i].Compare(sortedRanges[j])
+		cmp, cmpErr := sortedRanges[i].Compare(ctx, sortedRanges[j])
 		if cmpErr != nil {
 			err = cmpErr
 		}
@@ -533,10 +534,10 @@ func SortRanges(ranges ...MySQLRange) ([]MySQLRange, error) {
 	return sortedRanges, err
 }
 
-func validateRangeCollection(rangeColl MySQLRangeCollection) error {
+func validateRangeCollection(ctx context.Context, rangeColl MySQLRangeCollection) error {
 	for i := 0; i < len(rangeColl)-1; i++ {
 		for j := i + 1; j < len(rangeColl); j++ {
-			if ok, err := rangeColl[i].Overlaps(rangeColl[j]); err != nil {
+			if ok, err := rangeColl[i].Overlaps(ctx, rangeColl[j]); err != nil {
 				return err
 			} else if ok {
 				return fmt.Errorf("overlapping ranges: %s and %s", rangeColl[i].String(), rangeColl[j].String())

--- a/sql/range_test.go
+++ b/sql/range_test.go
@@ -15,6 +15,7 @@
 package sql_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -180,21 +181,21 @@ func TestRangeOverlapTwoColumns(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Expr:  %s\nRange: %s", test.reference.String(), test.ranges.DebugString(ctx)), func(t *testing.T) {
-			discreteRanges, err := sql.RemoveOverlappingRanges(test.ranges...)
+			discreteRanges, err := sql.RemoveOverlappingRanges(ctx, test.ranges...)
 			require.NoError(t, err)
-			verificationRanges, err := removeOverlappingRangesVerification(test.ranges...)
+			verificationRanges, err := removeOverlappingRangesVerification(ctx, test.ranges...)
 			require.NoError(t, err)
 			for _, row := range values2 {
 				referenceBool, err := test.reference.Eval(ctx, row)
 				require.NoError(t, err)
-				rangeBool := evalRanges(t, discreteRanges, row)
+				rangeBool := evalRanges(t, ctx, discreteRanges, row)
 				assert.Equal(t, referenceBool, rangeBool, fmt.Sprintf("%v: DiscreteRanges: %s", row, discreteRanges.DebugString(ctx)))
 			}
-			discreteRanges, err = sql.SortRanges(discreteRanges...)
+			discreteRanges, err = sql.SortRanges(ctx, discreteRanges...)
 			require.NoError(t, err)
-			verificationRanges, err = sql.SortRanges(verificationRanges...)
+			verificationRanges, err = sql.SortRanges(ctx, verificationRanges...)
 			require.NoError(t, err)
-			ok, err := discreteRanges.Equals(verificationRanges)
+			ok, err := discreteRanges.Equals(ctx, verificationRanges)
 			require.NoError(t, err)
 			assert.True(t, ok)
 		})
@@ -295,21 +296,21 @@ func TestRangeOverlapThreeColumns(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Expr:  %s\nRange: %s", test.reference.String(), test.ranges.DebugString(ctx)), func(t *testing.T) {
-			discreteRanges, err := sql.RemoveOverlappingRanges(test.ranges...)
+			discreteRanges, err := sql.RemoveOverlappingRanges(ctx, test.ranges...)
 			require.NoError(t, err)
-			verificationRanges, err := removeOverlappingRangesVerification(test.ranges...)
+			verificationRanges, err := removeOverlappingRangesVerification(ctx, test.ranges...)
 			require.NoError(t, err)
 			for _, row := range values3 {
 				referenceBool, err := test.reference.Eval(ctx, row)
 				require.NoError(t, err)
-				rangeBool := evalRanges(t, discreteRanges, row)
+				rangeBool := evalRanges(t, ctx, discreteRanges, row)
 				assert.Equal(t, referenceBool, rangeBool, fmt.Sprintf("%v: DiscreteRanges: %s", row, discreteRanges.DebugString(ctx)))
 			}
-			discreteRanges, err = sql.SortRanges(discreteRanges...)
+			discreteRanges, err = sql.SortRanges(ctx, discreteRanges...)
 			require.NoError(t, err)
-			verificationRanges, err = sql.SortRanges(verificationRanges...)
+			verificationRanges, err = sql.SortRanges(ctx, verificationRanges...)
 			require.NoError(t, err)
-			ok, err := discreteRanges.Equals(verificationRanges)
+			ok, err := discreteRanges.Equals(ctx, verificationRanges)
 			require.NoError(t, err)
 			assert.True(t, ok)
 		})
@@ -384,21 +385,21 @@ func TestRangeOverlapNulls(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Expr:  %s\nRange: %s", test.reference.String(), test.ranges.DebugString(ctx)), func(t *testing.T) {
-			discreteRanges, err := sql.RemoveOverlappingRanges(test.ranges...)
+			discreteRanges, err := sql.RemoveOverlappingRanges(ctx, test.ranges...)
 			require.NoError(t, err)
-			verificationRanges, err := removeOverlappingRangesVerification(test.ranges...)
+			verificationRanges, err := removeOverlappingRangesVerification(ctx, test.ranges...)
 			require.NoError(t, err)
 			for _, row := range valuesNull {
 				referenceBool, err := test.reference.Eval(ctx, row)
 				require.NoError(t, err)
-				rangeBool := evalRanges(t, discreteRanges, row)
+				rangeBool := evalRanges(t, ctx, discreteRanges, row)
 				assert.Equal(t, referenceBool, rangeBool, fmt.Sprintf("%v: DiscreteRanges: %s", row, discreteRanges.DebugString(ctx)))
 			}
-			discreteRanges, err = sql.SortRanges(discreteRanges...)
+			discreteRanges, err = sql.SortRanges(ctx, discreteRanges...)
 			require.NoError(t, err)
-			verificationRanges, err = sql.SortRanges(verificationRanges...)
+			verificationRanges, err = sql.SortRanges(ctx, verificationRanges...)
 			require.NoError(t, err)
-			ok, err := discreteRanges.Equals(verificationRanges)
+			ok, err := discreteRanges.Equals(ctx, verificationRanges)
 			require.NoError(t, err)
 			assert.True(t, ok)
 		})
@@ -572,15 +573,15 @@ func TestComplexRange(t *testing.T) {
 			if test.skip {
 				t.Skip()
 			}
-			discreteRanges, err := sql.RemoveOverlappingRanges(test.ranges...)
+			discreteRanges, err := sql.RemoveOverlappingRanges(ctx, test.ranges...)
 			require.NoError(t, err)
-			verificationRanges, err := removeOverlappingRangesVerification(test.ranges...)
+			verificationRanges, err := removeOverlappingRangesVerification(ctx, test.ranges...)
 			require.NoError(t, err)
-			discreteRanges, err = sql.SortRanges(discreteRanges...)
+			discreteRanges, err = sql.SortRanges(ctx, discreteRanges...)
 			require.NoError(t, err)
-			verificationRanges, err = sql.SortRanges(verificationRanges...)
+			verificationRanges, err = sql.SortRanges(ctx, verificationRanges...)
 			require.NoError(t, err)
-			ok, err := discreteRanges.Equals(verificationRanges)
+			ok, err := discreteRanges.Equals(ctx, verificationRanges)
 			require.NoError(t, err)
 			assert.True(t, ok)
 			if !ok {
@@ -593,7 +594,7 @@ func TestComplexRange(t *testing.T) {
 				for j := i + 1; j < len(discreteRanges); j++ {
 					r1 := discreteRanges[i]
 					r2 := discreteRanges[j]
-					hasOverlap, err := r1.Overlaps(r2)
+					hasOverlap, err := r1.Overlaps(ctx, r2)
 					if hasOverlap {
 						t.Logf("Overlap: %s\n%s", r1.String(), r2.String())
 					}
@@ -627,10 +628,10 @@ func setup() (x, y, z sql.Expression, values2, values3, valuesNull [][]interface
 	return
 }
 
-func evalRanges(t *testing.T, ranges []sql.MySQLRange, row []interface{}) bool {
+func evalRanges(t *testing.T, ctx context.Context, ranges []sql.MySQLRange, row []interface{}) bool {
 	found := false
 	for _, rang := range ranges {
-		if evalRange(t, rang, row) {
+		if evalRange(t, ctx, rang, row) {
 			if !found {
 				found = true
 			} else {
@@ -641,7 +642,7 @@ func evalRanges(t *testing.T, ranges []sql.MySQLRange, row []interface{}) bool {
 	return found
 }
 
-func evalRange(t *testing.T, rang sql.MySQLRange, row []interface{}) bool {
+func evalRange(t *testing.T, ctx context.Context, rang sql.MySQLRange, row []interface{}) bool {
 	rowRange := make(sql.MySQLRange, len(rang))
 	for i, val := range row {
 		if val == nil {
@@ -650,12 +651,12 @@ func evalRange(t *testing.T, rang sql.MySQLRange, row []interface{}) bool {
 			rowRange[i] = sql.ClosedRangeColumnExpr(val, val, rangeType)
 		}
 	}
-	ok, err := rang.IsSupersetOf(rowRange)
+	ok, err := rang.IsSupersetOf(ctx, rowRange)
 	require.NoError(t, err)
 	return ok
 }
 
-func removeOverlappingRangesVerification(ranges ...sql.MySQLRange) (sql.MySQLRangeCollection, error) {
+func removeOverlappingRangesVerification(ctx context.Context, ranges ...sql.MySQLRange) (sql.MySQLRangeCollection, error) {
 	if len(ranges) == 0 {
 		return nil, nil
 	}
@@ -664,7 +665,7 @@ func removeOverlappingRangesVerification(ranges ...sql.MySQLRange) (sql.MySQLRan
 	for i := 0; i < len(ranges); i++ {
 		hadOverlap := false
 		for nri := 0; nri < len(newRanges); nri++ {
-			if resultingRanges, ok, err := ranges[i].RemoveOverlap(newRanges[nri]); err != nil {
+			if resultingRanges, ok, err := ranges[i].RemoveOverlap(ctx, newRanges[nri]); err != nil {
 				return nil, err
 			} else if ok {
 				hadOverlap = true
@@ -838,12 +839,13 @@ func and(expressions ...sql.Expression) sql.Expression {
 }
 
 func buildTestRangeTree(ranges []sql.MySQLRange) (*sql.MySQLRangeColumnExprTree, error) {
+	ctx := context.Background()
 	tree, err := sql.NewMySQLRangeColumnExprTree(ranges[0], []sql.Type{rangeType})
 	if err != nil {
 		return nil, err
 	}
 	for _, rng := range ranges[1:] {
-		err = tree.Insert(rng)
+		err = tree.Insert(ctx, rng)
 		if err != nil {
 			return nil, err
 		}
@@ -1013,7 +1015,7 @@ func TestRangeTreeInsert(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, test.setupExp, tree.String())
 
-			err = tree.Insert(test.rng)
+			err = tree.Insert(context.Background(), test.rng)
 			require.NoError(t, err)
 			assert.Equal(t, test.exp, tree.String())
 		})
@@ -1230,7 +1232,7 @@ func TestRangeTreeRemove(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, test.setupExp, tree.String())
 
-			err = tree.Remove(test.rng)
+			err = tree.Remove(context.Background(), test.rng)
 			require.NoError(t, err)
 			assert.Equal(t, test.exp, tree.String())
 		})

--- a/sql/range_tree.go
+++ b/sql/range_tree.go
@@ -18,6 +18,7 @@ package sql
 // Referenced https://en.wikipedia.org/wiki/Interval_tree#Augmented_tree
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -134,7 +135,7 @@ func NewMySQLRangeColumnExprTree(initialRange MySQLRange, columnExprTypes []Type
 }
 
 // FindConnections returns all connecting Ranges found in the tree. They may or may not be mergeable or overlap.
-func (tree *MySQLRangeColumnExprTree) FindConnections(rang MySQLRange, colExprIdx int) (MySQLRangeCollection, error) {
+func (tree *MySQLRangeColumnExprTree) FindConnections(ctx context.Context, rang MySQLRange, colExprIdx int) (MySQLRangeCollection, error) {
 	// Some potential optimizations that may significantly reduce the number of comparisons in a worst-case scenario:
 	// 1) Rewrite this function to return a single Range that is guaranteed to either merge or overlap, rather than
 	//    a slice of ranges that are all connected (either overlapping or adjacent) but may not be mergeable.
@@ -150,11 +151,11 @@ func (tree *MySQLRangeColumnExprTree) FindConnections(rang MySQLRange, colExprId
 	for len(stack) > 0 {
 		node := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		cmp1, err := colExpr.LowerBound.Compare(node.UpperBound, tree.typ)
+		cmp1, err := colExpr.LowerBound.Compare(ctx, node.UpperBound, tree.typ)
 		if err != nil {
 			return nil, err
 		}
-		cmp2, err := node.LowerBound.Compare(colExpr.UpperBound, tree.typ)
+		cmp2, err := node.LowerBound.Compare(ctx, colExpr.UpperBound, tree.typ)
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +172,7 @@ func (tree *MySQLRangeColumnExprTree) FindConnections(rang MySQLRange, colExprId
 			}
 			if node.Inner == nil {
 				rangeCollection = append(rangeCollection, MySQLRange{connectedColExpr})
-			} else if connectedRanges, err := node.Inner.FindConnections(rang, colExprIdx+1); err != nil {
+			} else if connectedRanges, err := node.Inner.FindConnections(ctx, rang, colExprIdx+1); err != nil {
 				return nil, err
 			} else if connectedRanges != nil {
 				for _, connectedRange := range connectedRanges {
@@ -186,7 +187,7 @@ func (tree *MySQLRangeColumnExprTree) FindConnections(rang MySQLRange, colExprId
 		}
 		// If the left child's max upperbound is greater than the search column's lowerbound, we need to search the left subtree
 		if node.Left != nil {
-			cmp, err := colExpr.LowerBound.Compare(node.Left.MaxUpperbound, tree.typ)
+			cmp, err := colExpr.LowerBound.Compare(ctx, node.Left.MaxUpperbound, tree.typ)
 			if err != nil {
 				return nil, err
 			}
@@ -199,12 +200,12 @@ func (tree *MySQLRangeColumnExprTree) FindConnections(rang MySQLRange, colExprId
 }
 
 // Insert adds the given Range into the tree.
-func (tree *MySQLRangeColumnExprTree) Insert(rang MySQLRange) error {
-	return tree.insert(rang, 0)
+func (tree *MySQLRangeColumnExprTree) Insert(ctx context.Context, rang MySQLRange) error {
+	return tree.insert(ctx, rang, 0)
 }
 
 // insert is the internal implementation of Insert.
-func (tree *MySQLRangeColumnExprTree) insert(rang MySQLRange, colExprIdx int) error {
+func (tree *MySQLRangeColumnExprTree) insert(ctx context.Context, rang MySQLRange, colExprIdx int) error {
 	colExpr := rang[colExprIdx]
 	var insertedNode *rangeColumnExprTreeNode
 	var inner *MySQLRangeColumnExprTree
@@ -231,18 +232,18 @@ func (tree *MySQLRangeColumnExprTree) insert(rang MySQLRange, colExprIdx int) er
 		node := tree.root
 		loop := true
 		for loop {
-			cmp, err := colExpr.LowerBound.Compare(node.LowerBound, tree.typ)
+			cmp, err := colExpr.LowerBound.Compare(ctx, node.LowerBound, tree.typ)
 			if err != nil {
 				return err
 			}
 			if cmp == 0 {
-				cmp, err = colExpr.UpperBound.Compare(node.UpperBound, tree.typ)
+				cmp, err = colExpr.UpperBound.Compare(ctx, node.UpperBound, tree.typ)
 				if err != nil {
 					return err
 				}
 			}
 			if cmp < 0 {
-				node.MaxUpperbound, err = GetMySQLRangeCutMax(colExpr.Typ, node.MaxUpperbound, colExpr.UpperBound)
+				node.MaxUpperbound, err = GetMySQLRangeCutMax(ctx, colExpr.Typ, node.MaxUpperbound, colExpr.UpperBound)
 				if err != nil {
 					return err
 				}
@@ -270,7 +271,7 @@ func (tree *MySQLRangeColumnExprTree) insert(rang MySQLRange, colExprIdx int) er
 					node = node.Left
 				}
 			} else if cmp > 0 {
-				node.MaxUpperbound, err = GetMySQLRangeCutMax(colExpr.Typ, node.MaxUpperbound, colExpr.UpperBound)
+				node.MaxUpperbound, err = GetMySQLRangeCutMax(ctx, colExpr.Typ, node.MaxUpperbound, colExpr.UpperBound)
 				if err != nil {
 					return err
 				}
@@ -302,7 +303,7 @@ func (tree *MySQLRangeColumnExprTree) insert(rang MySQLRange, colExprIdx int) er
 				}
 			} else /* cmp == 0 */ {
 				if node.Inner != nil {
-					return node.Inner.insert(rang, colExprIdx+1)
+					return node.Inner.insert(ctx, rang, colExprIdx+1)
 				}
 				return nil
 			}
@@ -315,20 +316,20 @@ func (tree *MySQLRangeColumnExprTree) insert(rang MySQLRange, colExprIdx int) er
 }
 
 // Remove removes the given Range from the tree (and subtrees if applicable).
-func (tree *MySQLRangeColumnExprTree) Remove(rang MySQLRange) error {
-	return tree.remove(rang, 0)
+func (tree *MySQLRangeColumnExprTree) Remove(ctx context.Context, rang MySQLRange) error {
+	return tree.remove(ctx, rang, 0)
 }
 
 // remove is the internal implementation of Remove.
-func (tree *MySQLRangeColumnExprTree) remove(rang MySQLRange, colExprIdx int) error {
+func (tree *MySQLRangeColumnExprTree) remove(ctx context.Context, rang MySQLRange, colExprIdx int) error {
 	colExpr := rang[colExprIdx]
 	var child *rangeColumnExprTreeNode
-	node, err := tree.getNode(colExpr)
+	node, err := tree.getNode(ctx, colExpr)
 	if err != nil || node == nil {
 		return err
 	}
 	if node.Inner != nil {
-		err = node.Inner.remove(rang, colExprIdx+1)
+		err = node.Inner.remove(ctx, rang, colExprIdx+1)
 		if err != nil {
 			return err
 		}
@@ -386,14 +387,14 @@ func (tree *MySQLRangeColumnExprTree) remove(rang MySQLRange, colExprIdx int) er
 }
 
 // GetRangeCollection returns every Range that this tree contains.
-func (tree *MySQLRangeColumnExprTree) GetRangeCollection() (MySQLRangeCollection, error) {
+func (tree *MySQLRangeColumnExprTree) GetRangeCollection(ctx context.Context) (MySQLRangeCollection, error) {
 	var rangeCollection MySQLRangeCollection
 	var emptyRange MySQLRange
 	iterStack := []*rangeTreeIter{tree.Iterator()}
 	rangeStack := MySQLRange{MySQLRangeColumnExpr{}}
 	for len(iterStack) > 0 {
 		iter := iterStack[len(iterStack)-1]
-		node, err := iter.Next()
+		node, err := iter.Next(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -409,13 +410,13 @@ func (tree *MySQLRangeColumnExprTree) GetRangeCollection() (MySQLRangeCollection
 			} else {
 				rang := make(MySQLRange, len(rangeStack))
 				copy(rang, rangeStack)
-				isempty, err := rang.IsEmpty()
+				isempty, err := rang.IsEmpty(ctx)
 				if err != nil {
 					return nil, err
 				}
 				if !isempty {
 					if len(rangeCollection) > 0 {
-						merged, ok, err := rangeCollection[len(rangeCollection)-1].TryMerge(rang)
+						merged, ok, err := rangeCollection[len(rangeCollection)-1].TryMerge(ctx, rang)
 						if err != nil {
 							return nil, err
 						}
@@ -502,15 +503,15 @@ func (node *rangeColumnExprTreeNode) string(ctx *Context, prefix string, isTail 
 }
 
 // getNode returns the node that matches the given column expression, if it exists. Returns nil otherwise.
-func (tree *MySQLRangeColumnExprTree) getNode(colExpr MySQLRangeColumnExpr) (*rangeColumnExprTreeNode, error) {
+func (tree *MySQLRangeColumnExprTree) getNode(ctx context.Context, colExpr MySQLRangeColumnExpr) (*rangeColumnExprTreeNode, error) {
 	node := tree.root
 	for node != nil {
-		cmp, err := colExpr.LowerBound.Compare(node.LowerBound, tree.typ)
+		cmp, err := colExpr.LowerBound.Compare(ctx, node.LowerBound, tree.typ)
 		if err != nil {
 			return nil, err
 		}
 		if cmp == 0 {
-			cmp, err = colExpr.UpperBound.Compare(node.UpperBound, tree.typ)
+			cmp, err = colExpr.UpperBound.Compare(ctx, node.UpperBound, tree.typ)
 			if err != nil {
 				return nil, err
 			}
@@ -757,7 +758,7 @@ func (tree *MySQLRangeColumnExprTree) Iterator() *rangeTreeIter {
 }
 
 // Next returns the next node, or nil if no more nodes are available.
-func (iterator *rangeTreeIter) Next() (*rangeColumnExprTreeNode, error) {
+func (iterator *rangeTreeIter) Next(ctx context.Context) (*rangeColumnExprTreeNode, error) {
 	if iterator.position == end {
 		return nil, nil
 	}
@@ -784,13 +785,13 @@ func (iterator *rangeTreeIter) Next() (*rangeColumnExprTreeNode, error) {
 		node := iterator.node
 		for iterator.node.Parent != nil {
 			iterator.node = iterator.node.Parent
-			if cmp, err := node.LowerBound.Compare(iterator.node.LowerBound, iterator.tree.typ); err != nil {
+			if cmp, err := node.LowerBound.Compare(ctx, iterator.node.LowerBound, iterator.tree.typ); err != nil {
 				return nil, err
 			} else if cmp < 0 {
 				iterator.position = between
 				return iterator.node, nil
 			} else if cmp == 0 {
-				cmp, err = node.UpperBound.Compare(iterator.node.UpperBound, iterator.tree.typ)
+				cmp, err = node.UpperBound.Compare(ctx, iterator.node.UpperBound, iterator.tree.typ)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
We've done a lot of work lately to make sure that all business logic has access to a proper context, but there's some lingering places that fell through the cracks. This cleans some of those up.