### PR TITLE
sql: opt-in SQL trace redaction

### DIFF
--- a/sql/planbuilder/parse.go
+++ b/sql/planbuilder/parse.go
@@ -49,7 +49,8 @@ func (b *Builder) Parse(query string, qFlags *sql.QueryFlags, multi bool) (ret s
 			}
 		}
 	}()
-	span, ctx := b.ctx.Span("parse", otel.WithAttributes(attribute.String("query", query)))
+	span, ctx := b.ctx.Span("parse",
+		otel.WithAttributes(attribute.String("query", b.ctx.RedactQueryForTrace(query))))
 	defer span.End()
 
 	if b.authQueryState != nil {

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -852,8 +852,8 @@ func createIndex(
 ) {
 	span, ctx := ctx.Span("plan.createIndex",
 		trace.WithAttributes(
-			attribute.String("index", index.ID()),
-			attribute.String("table", index.Table()),
+			attribute.String("index", ctx.RedactNameForTrace(index.ID())),
+			attribute.String("table", ctx.RedactNameForTrace(index.Table())),
 			attribute.String("driver", index.Driver()),
 		),
 	)

--- a/sql/rowexec/join_iters.go
+++ b/sql/rowexec/join_iters.go
@@ -189,8 +189,8 @@ func newJoinState(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinNode, par
 	}
 
 	span, ctx := ctx.Span(opName, trace.WithAttributes(
-		attribute.String("left", left),
-		attribute.String("right", right),
+		attribute.String("left", ctx.RedactNameForTrace(left)),
+		attribute.String("right", ctx.RedactNameForTrace(right)),
 	))
 
 	parentLen := len(parentRow)

--- a/sql/rowexec/range_heap_iter.go
+++ b/sql/rowexec/range_heap_iter.go
@@ -55,8 +55,8 @@ func newRangeHeapJoinIter(ctx *sql.Context, b sql.NodeExecBuilder, j *plan.JoinN
 	}
 
 	span, ctx := ctx.Span("plan.rangeHeapJoinIter", trace.WithAttributes(
-		attribute.String("left", leftName),
-		attribute.String("right", rightName),
+		attribute.String("left", ctx.RedactNameForTrace(leftName)),
+		attribute.String("right", ctx.RedactNameForTrace(rightName)),
 	))
 
 	l, err := b.Build(ctx, j.Left(), row)

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -128,7 +128,8 @@ func (b *BaseBuilder) buildWindow(ctx *sql.Context, n *plan.Window, row sql.Row)
 }
 
 func (b *BaseBuilder) buildOffset(ctx *sql.Context, n *plan.Offset, row sql.Row) (sql.RowIter, error) {
-	span, ctx := ctx.Span("plan.Offset", trace.WithAttributes(attribute.Stringer("offset", n.Offset)))
+	span, ctx := ctx.Span("plan.Offset",
+		trace.WithAttributes(attribute.String("offset", ctx.RedactStringerForTrace(n.Offset))))
 
 	offset, err := iters.GetInt64Value(ctx, n.Offset)
 	if err != nil {
@@ -261,7 +262,8 @@ func (b *BaseBuilder) buildTableAlias(ctx *sql.Context, n *plan.TableAlias, row 
 		table = reflect.TypeOf(n.Child).String()
 	}
 
-	span, ctx := ctx.Span("sql.TableAlias", trace.WithAttributes(attribute.String("table", table)))
+	span, ctx := ctx.Span("sql.TableAlias",
+		trace.WithAttributes(attribute.String("table", ctx.RedactNameForTrace(table))))
 
 	iter, err := b.Build(ctx, n.Child, row)
 	if err != nil {
@@ -474,7 +476,8 @@ func (b *BaseBuilder) buildRecursiveCte(ctx *sql.Context, n *plan.RecursiveCte, 
 }
 
 func (b *BaseBuilder) buildLimit(ctx *sql.Context, n *plan.Limit, row sql.Row) (sql.RowIter, error) {
-	span, ctx := ctx.Span("plan.Limit", trace.WithAttributes(attribute.Stringer("limit", n.Limit)))
+	span, ctx := ctx.Span("plan.Limit",
+		trace.WithAttributes(attribute.String("limit", ctx.RedactStringerForTrace(n.Limit))))
 
 	limit, err := iters.GetInt64Value(ctx, n.Limit)
 	if err != nil {

--- a/sql/session.go
+++ b/sql/session.go
@@ -25,12 +25,11 @@ import (
 
 	"github.com/dolthub/vitess/go/vt/sqlparser"
 
+	"github.com/dolthub/go-mysql-server/sql/sqlredact"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/dolthub/go-mysql-server/sql/sqlredact"
 )
 
 type key uint

--- a/sql/session.go
+++ b/sql/session.go
@@ -451,7 +451,7 @@ const redactedFragmentMarker = "<redacted>"
 //
 // Returns the original .String() output when redaction is disabled
 // (the default).
-func (c *Context) RedactStringerForTrace(v interface{ String() string }) string {
+func (c *Context) RedactStringerForTrace(v fmt.Stringer) string {
 	if c == nil || !c.traceRedactionEnabled {
 		return v.String()
 	}

--- a/sql/session.go
+++ b/sql/session.go
@@ -29,6 +29,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/go-mysql-server/sql/sqlredact"
 )
 
 type key uint
@@ -292,6 +294,19 @@ type Context struct {
 	pid         uint64
 	interpreted bool
 	Version     AnalyzerVersion
+	// traceRedactionEnabled, when true, opts the context into SQL
+	// trace redaction. The zero value (false) means redaction is
+	// disabled — opt-in to preserve backward compatibility with
+	// trace consumers that already read the parse-span "query"
+	// attribute and rowexec table-name attrs verbatim. Toggle with
+	// WithTraceRedaction.
+	traceRedactionEnabled bool
+	// redactionMapping is allocated by NewContext when redaction is
+	// enabled (eager — never lazy after construction). It captures
+	// the original → token substitution so resolved-name attributes
+	// (rowexec spans) can be redacted with the same tokens as the
+	// parsed query.
+	redactionMapping *sqlredact.Mapping
 }
 
 // ContextOption is a function to configure the context.
@@ -350,6 +365,98 @@ func WithServices(services Services) ContextOption {
 	return func(ctx *Context) {
 		ctx.services = services
 	}
+}
+
+// WithTraceRedaction toggles SQL redaction for trace span attributes
+// on this context. The default (no option) is DISABLED — opt-in so
+// existing consumers of the parse-span "query" attribute and
+// rowexec table-name attrs aren't surprised by a sudden token
+// substitution on a minor-version upgrade. Pass
+// WithTraceRedaction(true) to enable redaction at deployments where
+// trace data flows to multi-tenant or long-term storage.
+func WithTraceRedaction(enabled bool) ContextOption {
+	return func(ctx *Context) {
+		ctx.traceRedactionEnabled = enabled
+	}
+}
+
+// TraceRedactionEnabled reports whether SQL trace redaction is
+// active for this context. Returns false for nil contexts.
+func (c *Context) TraceRedactionEnabled() bool {
+	if c == nil {
+		return false
+	}
+	return c.traceRedactionEnabled
+}
+
+// RedactionMapping returns the per-query redaction mapping. It is
+// eagerly allocated by NewContext when redaction is enabled, so
+// concurrent rowexec spans never race on lazy initialization.
+// Returns nil when redaction is disabled or the context is nil.
+func (c *Context) RedactionMapping() *sqlredact.Mapping {
+	if c == nil || !c.traceRedactionEnabled {
+		return nil
+	}
+	return c.redactionMapping
+}
+
+// RedactQueryForTrace returns query in its trace-safe form. When
+// redaction is enabled, it parses the query and populates this
+// context's mapping (in place — the pointer is never replaced after
+// NewContext) with the substitutions, then returns the redacted
+// text. On parse failure it returns sqlredact.UnparseableMarker;
+// the parse error itself is intentionally swallowed so
+// trace-attribute callers don't need an error path.
+//
+// When redaction is disabled (the default), the input is returned
+// unchanged.
+func (c *Context) RedactQueryForTrace(query string) string {
+	if c == nil || !c.traceRedactionEnabled {
+		return query
+	}
+	// Populate THE EXISTING mapping (allocated eagerly in
+	// NewContext) rather than replacing it. The mapping pointer is
+	// already shared with in-flight rowexec spans; replacing it
+	// would race those reads. The Mapping's internal mutex covers
+	// the writes done here.
+	redacted, _ := sqlredact.RedactSQLForTraceInto(query, c.redactionMapping)
+	return redacted
+}
+
+// RedactNameForTrace returns name in its trace-safe form using this
+// context's identifier-namespace mapping. Tokens are minted on first
+// use, so a name appearing only in a rowexec span (never in the
+// parsed SQL) still gets a stable token. When redaction is disabled
+// (the default), returns the input unchanged.
+func (c *Context) RedactNameForTrace(name string) string {
+	if c == nil || !c.traceRedactionEnabled {
+		return name
+	}
+	return c.redactionMapping.RedactIdent(name)
+}
+
+// redactedFragmentMarker is what RedactStringerForTrace returns for a
+// SQL fragment when redaction is enabled. We can't safely re-tokenize
+// arbitrary expression text against the per-query mapping (the
+// expression may reference identifiers that were never in the parsed
+// SQL — e.g. internal pushdown rewrites), so we drop the value
+// entirely. The plan-level span itself still fires and preserves
+// timing — only the textual attribute disappears.
+const redactedFragmentMarker = "<redacted>"
+
+// RedactStringerForTrace renders v.String() into a span-attribute-
+// safe form. Used at sites that previously emitted attribute.Stringer
+// for SQL fragments (e.g. LIMIT/OFFSET expressions) — calling
+// .String() on a sql.Expression can return arbitrary user-supplied
+// SQL text, so under redaction we substitute a fixed marker.
+//
+// Returns the original .String() output when redaction is disabled
+// (the default).
+func (c *Context) RedactStringerForTrace(v interface{ String() string }) string {
+	if c == nil || !c.traceRedactionEnabled {
+		return v.String()
+	}
+	return redactedFragmentMarker
 }
 
 var ctxNowFunc = time.Now
@@ -420,6 +527,14 @@ func NewContext(
 	}
 	if c.Session == nil {
 		c.Session = NewBaseSession()
+	}
+	// Eager-allocate the redaction mapping so concurrent callers
+	// (parallel rowexec spans firing while RedactQueryForTrace is
+	// still running on another goroutine) never race on a nil-check
+	// followed by an allocation. The Mapping itself synchronizes
+	// concurrent mints internally.
+	if c.traceRedactionEnabled {
+		c.redactionMapping = sqlredact.NewMapping()
 	}
 
 	return c

--- a/sql/sqlredact/mapping.go
+++ b/sql/sqlredact/mapping.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlredact
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+// Mapping records a per-query substitution from an original identifier
+// or value to a stable, low-entropy token. Tokens are minted on first
+// lookup in lexer-emit order; subsequent lookups for the same original
+// return the same token. Two independent namespaces are kept so an
+// identifier and a literal sharing the same surface form get distinct
+// tokens, but tables/columns/aliases all share the identifier
+// namespace because the lexer cannot distinguish them.
+//
+// Tokens are intentionally short and repeating (n1, n2, ..., v1, v2,
+// ...) so trace storage compresses well across many queries with the
+// same shape. Hashes would be anti-compression.
+//
+// A Mapping is safe for concurrent use. The intended pattern is:
+// populate during the initial parse pass on one goroutine, then read
+// (with occasional mint-on-miss for synthetic names that never
+// appeared in the parsed SQL) from many goroutines as parallel
+// rowexec spans fire. Writes are guarded by a sync.RWMutex so a
+// fast-path read on an existing token only takes the read lock.
+type Mapping struct {
+	mu sync.RWMutex
+
+	idents map[string]string
+	values map[string]string
+
+	nCount int
+	vCount int
+}
+
+// NewMapping returns an empty mapping with the two namespaces
+// initialized.
+func NewMapping() *Mapping {
+	return &Mapping{
+		idents: map[string]string{},
+		values: map[string]string{},
+	}
+}
+
+// RedactIdent returns a stable token for orig in the identifier
+// namespace (table, column, alias, schema — the lexer does not
+// distinguish). The empty string passes through.
+func (m *Mapping) RedactIdent(orig string) string {
+	if m == nil || orig == "" {
+		return orig
+	}
+	m.mu.RLock()
+	if t, ok := m.idents[orig]; ok {
+		m.mu.RUnlock()
+		return t
+	}
+	m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Re-check after acquiring the write lock — another goroutine may
+	// have minted the same token between RUnlock and Lock.
+	if t, ok := m.idents[orig]; ok {
+		return t
+	}
+	m.nCount++
+	t := "n" + strconv.Itoa(m.nCount)
+	m.idents[orig] = t
+	return t
+}
+
+// RedactValue returns a stable token for orig in the literal-value
+// namespace (string, integer, float, hex, bit literal). The token is
+// a bare name; callers that want bind-arg syntax should prefix.
+func (m *Mapping) RedactValue(orig string) string {
+	if m == nil {
+		return orig
+	}
+	m.mu.RLock()
+	if t, ok := m.values[orig]; ok {
+		m.mu.RUnlock()
+		return t
+	}
+	m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if t, ok := m.values[orig]; ok {
+		return t
+	}
+	m.vCount++
+	t := "v" + strconv.Itoa(m.vCount)
+	m.values[orig] = t
+	return t
+}
+
+// Idents returns a snapshot copy of the original→token map for
+// identifiers. Safe to call from any goroutine.
+func (m *Mapping) Idents() map[string]string {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return copyMap(m.idents)
+}
+
+// Values returns a snapshot copy of the original→token map for
+// literal values. Safe to call from any goroutine.
+func (m *Mapping) Values() map[string]string {
+	if m == nil {
+		return nil
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return copyMap(m.values)
+}
+
+func copyMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// String returns a debug-friendly summary, used in trace error events
+// when redaction is partial.
+func (m *Mapping) String() string {
+	if m == nil {
+		return "<nil mapping>"
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return fmt.Sprintf("sqlredact.Mapping{idents:%d values:%d}",
+		m.nCount, m.vCount)
+}

--- a/sql/sqlredact/redactor.go
+++ b/sql/sqlredact/redactor.go
@@ -1,0 +1,260 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sqlredact rewrites SQL queries into a form safe to attach to
+// trace span attributes. Identifiers (table, column, schema, alias
+// names) and literal values are replaced with stable, low-entropy
+// tokens (n1, n2, ..., v1, v2, ...) that repeat across queries of the
+// same shape so storage compresses well.
+//
+// The implementation combines two passes over the same SQL:
+//
+//  1. Parse to AST, then walk the AST to collect every TableIdent
+//     and ColIdent string. The grammar is the authority on which
+//     lexemes are identifiers — this is necessary because vitess
+//     treats hundreds of words (e.g. NAME, USER, DATA, STATUS) as
+//     "non-reserved keywords" that the lexer emits with a keyword
+//     token type, even though they may appear in identifier
+//     positions in real queries.
+//
+//  2. Lex the SQL and emit each token. ID tokens redact as
+//     identifiers; literal tokens (STRING/INTEGRAL/FLOAT/HEX/HEXNUM/
+//     BIT_LITERAL) redact as values; COMMENT tokens drop;
+//     placeholder tokens (VALUE_ARG/LIST_ARG) pass through; any
+//     other token (keyword, punctuation, multi-character operator)
+//     emits structurally — UNLESS its val is in the identifier set
+//     from step (1), in which case it redacts as an identifier
+//     (catches the "non-reserved keyword used as a column name"
+//     case).
+//
+// Coverage is bounded by the grammar's notion of identifier rather
+// than by an evolving list of AST node fields: any future AST shape
+// that holds a TableIdent or ColIdent gets covered automatically as
+// long as it participates in Walk. Combined with the closed set of
+// lexer literal-token types, the redactor cannot silently leak
+// customer data through new grammar additions.
+//
+// On parse failure the redacted string is UnparseableMarker. We
+// could fall back to lex-only redaction in that case but it would
+// leak non-reserved keyword identifiers, so we prefer to publish
+// nothing rather than leak partial data.
+//
+// This is distinct from sqlparser.Normalize / RedactSQLQuery, which
+// is a query-plan-cache primitive that parameterizes literals only,
+// dedupes only inside SELECT, and skips long values for CPU. The
+// redactor here treats the trace surface as a privacy boundary:
+// every high-cardinality token is rewritten, always dedupes, drops
+// comments, and falls back to UnparseableMarker on parse errors.
+package sqlredact
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/dolthub/vitess/go/vt/sqlparser"
+)
+
+// UnparseableMarker is the value substituted when the input cannot be
+// parsed (or lexed). Callers should treat any returned redacted
+// string as opaque — never re-parse it or display it as a "fixed"
+// version of the user's SQL.
+const UnparseableMarker = "<unparseable>"
+
+// ErrLexFailed is returned when the lexer hits an irrecoverable error
+// before reaching EOF.
+var ErrLexFailed = errors.New("sqlredact: lex failed")
+
+// RedactSQLForTrace tokenizes sql and returns a copy in which every
+// high-cardinality token (identifiers and literals) has been replaced
+// by a stable token in the returned Mapping. Comments are dropped.
+// Keywords, punctuation, and multi-character operators pass through.
+//
+// The Mapping records the substitutions so callers can redact
+// related downstream attributes (resolved table names emitted from
+// rowexec spans, etc.) consistently.
+//
+// On parse or lex failure the redacted string is UnparseableMarker,
+// the Mapping is empty, and a non-nil error is returned. Callers
+// should always use the returned redacted string (never the input)
+// when publishing to traces, regardless of error.
+func RedactSQLForTrace(sql string) (string, *Mapping, error) {
+	m := NewMapping()
+	out, err := RedactSQLForTraceInto(sql, m)
+	return out, m, err
+}
+
+// RedactSQLForTraceInto is the same as RedactSQLForTrace but writes
+// substitutions into the caller-provided Mapping rather than
+// allocating a new one. Used by sql.Context's redact helpers so that
+// the same Mapping pointer is shared across all in-flight callers
+// (parent span, datasource.resolved events, GMS planbuilder spans,
+// rowexec spans) — the underlying maps' internal mutex covers the
+// concurrent reads.
+//
+// Pre-existing entries in m are preserved. Tokens already present
+// for a given original lexeme are reused; new lexemes mint fresh
+// tokens with counters continuing from m's current state.
+func RedactSQLForTraceInto(sql string, m *Mapping) (string, error) {
+	if m == nil {
+		m = NewMapping()
+	}
+	stmt, parseErr := sqlparser.Parse(sql)
+	if parseErr != nil {
+		return UnparseableMarker, parseErr
+	}
+	identSet := collectIdents(stmt)
+
+	var out strings.Builder
+	out.Grow(len(sql))
+
+	tk := sqlparser.NewStringTokenizer(sql)
+	first := true
+	for {
+		typ, val := tk.Scan()
+		if typ == 0 {
+			break
+		}
+		if typ == sqlparser.LEX_ERROR {
+			return UnparseableMarker, ErrLexFailed
+		}
+		if typ == sqlparser.COMMENT {
+			continue
+		}
+		if !first {
+			out.WriteByte(' ')
+		}
+		first = false
+		emitToken(&out, typ, val, m, identSet)
+	}
+	return out.String(), nil
+}
+
+// collectIdents walks the AST and collects every TableIdent and
+// ColIdent value. These are the only identifier types in the vitess
+// AST — every place the grammar accepts a user-supplied name (table,
+// column, alias, schema, CTE column rename, USING list, etc.) ends
+// up with one of these two types in the resulting AST.
+func collectIdents(stmt sqlparser.Statement) map[string]struct{} {
+	idents := map[string]struct{}{}
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		switch v := n.(type) {
+		case sqlparser.TableIdent:
+			if !v.IsEmpty() {
+				idents[v.String()] = struct{}{}
+			}
+		case sqlparser.ColIdent:
+			if !v.IsEmpty() {
+				idents[v.String()] = struct{}{}
+			}
+		}
+		return true, nil
+	}, stmt)
+	return idents
+}
+
+// emitToken writes a single redacted token to out. The branching
+// matches the categorization of token types into:
+//   - identifier (ID)
+//   - literal value (STRING, INTEGRAL, FLOAT, HEX, HEXNUM, BIT_LITERAL)
+//   - already-bound placeholder (VALUE_ARG, LIST_ARG)
+//   - structural (everything else: keyword, punctuation, multi-char op)
+//
+// Keywords whose val matches a name in identSet are treated as
+// identifiers — that's how non-reserved-keyword column names get
+// covered.
+func emitToken(out *strings.Builder, typ int, val []byte, m *Mapping, identSet map[string]struct{}) {
+	switch typ {
+	case sqlparser.ID:
+		emitIdent(out, val, m)
+	case sqlparser.STRING:
+		out.WriteByte('\'')
+		out.WriteString(m.RedactValue(string(val)))
+		out.WriteByte('\'')
+	case sqlparser.INTEGRAL, sqlparser.FLOAT, sqlparser.HEXNUM:
+		out.WriteByte(':')
+		out.WriteString(m.RedactValue(string(val)))
+	case sqlparser.HEX:
+		out.WriteString("X'")
+		out.WriteString(m.RedactValue(string(val)))
+		out.WriteByte('\'')
+	case sqlparser.BIT_LITERAL:
+		out.WriteString("B'")
+		out.WriteString(m.RedactValue(string(val)))
+		out.WriteByte('\'')
+	case sqlparser.VALUE_ARG, sqlparser.LIST_ARG:
+		out.Write(val)
+	default:
+		if len(val) > 0 {
+			if _, ok := identSet[string(val)]; ok {
+				// Non-reserved keyword used as an identifier.
+				emitIdent(out, val, m)
+				return
+			}
+		}
+		emitStructural(out, typ, val)
+	}
+}
+
+// emitIdent writes a backtick-quoted redacted identifier.
+func emitIdent(out *strings.Builder, val []byte, m *Mapping) {
+	out.WriteByte('`')
+	out.WriteString(m.RedactIdent(string(val)))
+	out.WriteByte('`')
+}
+
+// emitStructural writes a non-redacted token (keyword, punctuation,
+// or multi-character operator). These are bounded by the SQL grammar
+// and contain no customer data.
+func emitStructural(out *strings.Builder, typ int, val []byte) {
+	if len(val) > 0 {
+		// Keyword text from the lexer (e.g. "SELECT", "AND", "true").
+		out.Write(val)
+		return
+	}
+	if typ < 256 {
+		// Single-character operator (e.g. '=', '(', ',').
+		out.WriteByte(byte(typ))
+		return
+	}
+	// Multi-character symbol operator emitted with empty val.
+	if s, ok := symbolOps[typ]; ok {
+		out.WriteString(s)
+		return
+	}
+	// Unknown structural token — fall back to a separator. This
+	// branch is only reachable for typ ≥ 256 with empty val that we
+	// don't recognize; a leak is impossible because val is empty.
+	out.WriteByte(' ')
+}
+
+// symbolOps maps the multi-character symbol-operator token types
+// emitted by the vitess lexer with empty val back to their textual
+// representation. Sourced from token.go's Scan implementation.
+var symbolOps = map[int]string{
+	sqlparser.LE:                      "<=",
+	sqlparser.GE:                      ">=",
+	sqlparser.NE:                      "!=",
+	sqlparser.SHIFT_LEFT:              "<<",
+	sqlparser.SHIFT_RIGHT:             ">>",
+	sqlparser.NULL_SAFE_EQUAL:         "<=>",
+	sqlparser.JSON_EXTRACT_OP:         "->",
+	sqlparser.JSON_UNQUOTE_EXTRACT_OP: "->>",
+	// AND/OR also reach this branch when the input used the symbolic
+	// `&&` / `||` forms; when the input used the keyword spellings,
+	// val carries the keyword text and the symbolOps lookup is
+	// bypassed by emitStructural's len(val)>0 guard.
+	sqlparser.AND:    "&&",
+	sqlparser.OR:     "||",
+	sqlparser.CONCAT: "||",
+}

--- a/sql/sqlredact/redactor_test.go
+++ b/sql/sqlredact/redactor_test.go
@@ -1,0 +1,314 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlredact
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactSQLForTrace_BasicSelect(t *testing.T) {
+	sql := "SELECT a, b, c FROM t WHERE x = 1234 AND y = 1234 AND z = 'apple'"
+	got, m, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+
+	// Literal values must be replaced with v-tokens.
+	require.Containsf(t, got, ":v1", "expected literal token :v1 in: %q", got)
+	// Same value 1234 dedupes — token appears twice in the output.
+	require.Equalf(t, 2, strings.Count(got, ":v1"),
+		"expected the duplicated 1234 to dedupe to one token (twice in output), got: %q", got)
+	// 'apple' is a different value.
+	require.Containsf(t, got, "'v2'", "expected 'apple' to map to 'v2' string-literal, got: %q", got)
+	// Identifiers come back backtick-quoted.
+	require.Containsf(t, got, "`n1`", "expected first identifier as `n1`, got: %q", got)
+	require.Lenf(t, m.idents, 7, "expected 7 idents (a,b,c,t,x,y,z), got %v", m.idents)
+	require.Lenf(t, m.values, 2, "expected 2 values (1234, apple), got %v", m.values)
+}
+
+func TestRedactSQLForTrace_QualifiedNames(t *testing.T) {
+	sql := "SELECT u.name, u.email FROM users AS u WHERE u.id = 5"
+	got, m, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+
+	// Same lexeme "u" appears multiple times — must always map to the
+	// same token. Pick whichever token "u" got; assert it's repeated.
+	uTok := m.idents["u"]
+	require.NotEmptyf(t, uTok, "alias 'u' missing from idents map: %v", m.idents)
+	// Backtick-quoted form appears 4 times in the input (u.name, u.email,
+	// AS u, u.id).
+	require.GreaterOrEqualf(t, strings.Count(got, "`"+uTok+"`"), 4,
+		"expected `%s` at least 4 times for repeated 'u', got: %q", uTok, got)
+	for _, leaky := range []string{"users", "name", "email"} {
+		require.NotContainsf(t, got, leaky, "identifier %q leaked: %q", leaky, got)
+	}
+}
+
+func TestRedactSQLForTrace_DBQualifiedTable(t *testing.T) {
+	sql := "SELECT job FROM `prometheus::bfh6nkyxwj7cwf`.`up`"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+
+	require.NotContainsf(t, got, "bfh6nkyxwj7cwf", "UID leaked through redaction: %q", got)
+	require.NotContainsf(t, got, "prometheus", "datasource type leaked through redaction: %q", got)
+	// "up" is short and could appear inside a keyword — sanity check the
+	// quoted form specifically.
+	require.NotContainsf(t, got, "`up`", "table name leaked: %q", got)
+}
+
+func TestRedactSQLForTrace_INTuple(t *testing.T) {
+	sql := "SELECT a FROM t WHERE x IN (1, 2, 3)"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+
+	// None of the original integers should appear as raw digits (in
+	// either spaced or paren-adjacent form).
+	for _, lit := range []string{" 1 ", " 2 ", " 3 ", "(1", "(2", "(3"} {
+		require.NotContainsf(t, got, lit, "raw integer leaked %q: %q", lit, got)
+	}
+}
+
+func TestRedactSQLForTrace_LongValueDedupes(t *testing.T) {
+	long := strings.Repeat("x", 300)
+	sql := "SELECT a FROM t WHERE n = '" + long + "' AND m = '" + long + "'"
+	_, m, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	require.Lenf(t, m.values, 1, "expected long value to dedupe, got: %v", m.values)
+}
+
+func TestRedactSQLForTrace_ParseErrorFallsBack(t *testing.T) {
+	got, m, err := RedactSQLForTrace("SELECT secret_col FROM secret_tbl WHERE")
+	require.Error(t, err)
+	require.Equal(t, UnparseableMarker, got)
+	require.NotNil(t, m, "mapping must be non-nil even on error")
+	require.Empty(t, m.idents)
+	require.Empty(t, m.values)
+}
+
+func TestRedactSQLForTrace_NonReservedKeywordAsIdentifier(t *testing.T) {
+	// `name`, `data`, `user`, `time` are all non-reserved keywords in
+	// the vitess grammar — the lexer emits a keyword token type for
+	// them, but they are valid as bare column or table names. The
+	// redactor must catch them via the identifier set built from the
+	// AST.
+	cases := []string{
+		"SELECT name FROM users",
+		"SELECT u.name, u.data FROM users AS u",
+		"SELECT * FROM `time`",
+		"SELECT user FROM accounts",
+	}
+	for _, sql := range cases {
+		got, _, err := RedactSQLForTrace(sql)
+		require.NoErrorf(t, err, "error on %q", sql)
+		// None of the original identifiers should appear in the
+		// backtick-wrapped form — that would be the leak shape.
+		for _, leaky := range []string{"`name`", "`data`", "`user`", "`time`", "`users`", "`accounts`"} {
+			require.NotContainsf(t, got, leaky, "non-reserved keyword identifier %q leaked from %q: %q", leaky, sql, got)
+		}
+	}
+}
+
+func TestRedactSQLForTrace_Stability(t *testing.T) {
+	sql := "SELECT a, b FROM t WHERE x = 1 AND y = 1"
+	a, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	b, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	require.Equalf(t, a, b, "redaction not stable across calls")
+}
+
+func TestRedactSQLForTrace_MarginAndInlineCommentsDropped(t *testing.T) {
+	cases := []string{
+		"/* user_id='alice@example.com' */ SELECT 1 FROM t",
+		"SELECT 1 FROM t /* trailing alice */",
+		"SELECT /* inline alice */ 1 FROM t",
+		"SELECT 1 FROM t -- alice line comment",
+	}
+	for _, sql := range cases {
+		got, _, err := RedactSQLForTrace(sql)
+		require.NoErrorf(t, err, "error on %q", sql)
+		require.NotContainsf(t, got, "alice", "comment leaked from %q: %q", sql, got)
+	}
+}
+
+func TestRedactSQLForTrace_Insert(t *testing.T) {
+	sql := "INSERT INTO users (name, email) VALUES ('alice', 'a@x')"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+
+	for _, leaky := range []string{"alice", "a@x", "users", "email"} {
+		require.NotContainsf(t, got, leaky, "INSERT leaked %q: %q", leaky, got)
+	}
+	// `name` is also a non-reserved keyword; sanity check the
+	// backtick form specifically since unquoted "name" overlaps with
+	// keyword text.
+	require.NotContainsf(t, got, "`name`", "column 'name' leaked verbatim: %q", got)
+}
+
+func TestRedactSQLForTrace_SelectExprAlias(t *testing.T) {
+	sql := "SELECT email AS user_email_addr FROM users"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	for _, leaky := range []string{"user_email_addr", "email", "users"} {
+		require.NotContainsf(t, got, leaky, "identifier %q leaked: %q", leaky, got)
+	}
+}
+
+func TestRedactSQLForTrace_CTEColumnRename(t *testing.T) {
+	sql := "WITH x (sensitive_renamed_col) AS (SELECT a FROM t) SELECT * FROM x"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	require.NotContainsf(t, got, "sensitive_renamed_col", "CTE column rename leaked: %q", got)
+}
+
+func TestRedactSQLForTrace_JoinUsingColumns(t *testing.T) {
+	sql := "SELECT * FROM a JOIN b USING (sensitive_join_col)"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	require.NotContainsf(t, got, "sensitive_join_col", "USING column leaked: %q", got)
+}
+
+func TestRedactSQLForTrace_LikeAndRegexpPatterns(t *testing.T) {
+	cases := []string{
+		"SELECT * FROM t WHERE name LIKE '%alice@example.com%'",
+		"SELECT * FROM t WHERE name REGEXP '^alice@.*'",
+	}
+	for _, sql := range cases {
+		got, _, err := RedactSQLForTrace(sql)
+		require.NoErrorf(t, err, "error on %q", sql)
+		require.NotContainsf(t, got, "alice", "pattern literal leaked for %q: %q", sql, got)
+	}
+}
+
+func TestRedactSQLForTrace_TableFunctionLeakedNoMore(t *testing.T) {
+	// The earlier AST walker leaked the table-function NAME and
+	// alias because TableFuncExpr is a value-receiver SQLNode. The
+	// lexer-based redactor doesn't have that gap — both `my_func`
+	// and `sub` are ID tokens.
+	sql := "SELECT * FROM my_func('arg1', 'arg2') AS sub"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	for _, leaky := range []string{"my_func", "sub", "arg1", "arg2"} {
+		require.NotContainsf(t, got, leaky, "identifier or value %q leaked: %q", leaky, got)
+	}
+}
+
+func TestRedactSQLForTrace_OperatorsPassThrough(t *testing.T) {
+	// Multi-char operators (!=, <=, >=, <>, <<, >>, <=>, ->, ->>) come
+	// out of the lexer with empty val and a typ ≥ 256. emitStructural
+	// must restore them via the symbolOps map.
+	cases := map[string]string{
+		"SELECT 1 WHERE a != b":  "!=",
+		"SELECT 1 WHERE a <> b":  "!=", // <> shares NE token with !=
+		"SELECT 1 WHERE a <= b":  "<=",
+		"SELECT 1 WHERE a >= b":  ">=",
+		"SELECT 1 WHERE a << b":  "<<",
+		"SELECT 1 WHERE a >> b":  ">>",
+		"SELECT 1 WHERE a <=> b": "<=>",
+	}
+	for sql, op := range cases {
+		got, _, err := RedactSQLForTrace(sql)
+		require.NoErrorf(t, err, "error on %q", sql)
+		require.Containsf(t, got, op, "operator %q lost from %q -> %q", op, sql, got)
+	}
+}
+
+func TestRedactSQLForTrace_SubqueryRedacts(t *testing.T) {
+	sql := "SELECT * FROM t WHERE id IN (SELECT id FROM secret_table)"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	require.NotContainsf(t, got, "secret_table", "subquery table name leaked: %q", got)
+}
+
+func TestRedactSQLForTrace_UpdateSetClause(t *testing.T) {
+	sql := "UPDATE t SET secret_col = 'leaky_value' WHERE c = 1"
+	got, _, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	require.NotContainsf(t, got, "secret_col", "UPDATE column name leaked: %q", got)
+	require.NotContainsf(t, got, "leaky_value", "UPDATE value leaked: %q", got)
+}
+
+func TestRedactSQLForTrace_HexAndBitLiterals(t *testing.T) {
+	sql := "SELECT * FROM t WHERE a = 0xCAFE AND b = X'CAFE' AND c = B'10101'"
+	got, m, err := RedactSQLForTrace(sql)
+	require.NoError(t, err)
+	for _, leaky := range []string{"0xCAFE", "CAFE", "10101"} {
+		require.NotContainsf(t, got, leaky, "hex/bit literal %q leaked: %q", leaky, got)
+	}
+	require.GreaterOrEqualf(t, len(m.values), 2, "expected hex/bit literals in mapping, got: %v", m.values)
+}
+
+func TestMapping_ConcurrentRedactIsRaceFree(t *testing.T) {
+	// Models the pattern under which Mapping is actually used in
+	// production: a parent goroutine populated the mapping during
+	// parse, then many concurrent rowexec spans read tokens for
+	// names that appeared in the SQL plus a few synthetic names that
+	// only show up at exec time. Run under `go test -race` to
+	// validate the internal mutex.
+	m := NewMapping()
+	const goroutines = 32
+	const iterations = 500
+	parsedNames := []string{"users", "orders", "items", "products", "events"}
+	for _, n := range parsedNames {
+		m.RedactIdent(n)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				// Mostly hit pre-populated names (RLock fast path).
+				_ = m.RedactIdent(parsedNames[i%len(parsedNames)])
+				// Occasionally mint a synthetic name (Lock slow path).
+				if i%50 == 0 {
+					_ = m.RedactIdent(fmt.Sprintf("synthetic_g%d_i%d", g, i))
+				}
+				// And a value lookup.
+				_ = m.RedactValue("42")
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Pre-populated identifiers must still map to the same tokens
+	// they were assigned at the start (no clobbering by concurrent
+	// mints).
+	for i, n := range parsedNames {
+		want := "n" + strconv.Itoa(i+1)
+		require.Equalf(t, want, m.RedactIdent(n), "parsed name %q mint instability", n)
+	}
+}
+
+func TestMapping_TokensRepeat(t *testing.T) {
+	m := NewMapping()
+	require.Equal(t, "n1", m.RedactIdent("foo"))
+	require.Equal(t, "n1", m.RedactIdent("foo"), "repeat lookup must return same token")
+	require.Equal(t, "n2", m.RedactIdent("bar"))
+	// Same surface form in the value namespace doesn't collide with
+	// the identifier namespace.
+	require.Equal(t, "v1", m.RedactValue("foo"))
+}
+
+func TestMapping_NilSafe(t *testing.T) {
+	var m *Mapping
+	require.Equal(t, "foo", m.RedactIdent("foo"), "nil mapping should pass through")
+	require.Equal(t, "foo", m.RedactValue("foo"), "nil mapping should pass through value")
+}

--- a/sql/trace_redaction_test.go
+++ b/sql/trace_redaction_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraceRedaction_DefaultDisabled(t *testing.T) {
+	ctx := NewContext(context.Background())
+	require.False(t, ctx.TraceRedactionEnabled(), "redaction must be opt-in (default off)")
+}
+
+func TestTraceRedaction_WithTraceRedactionTrue_OptsIn(t *testing.T) {
+	ctx := NewContext(context.Background(), WithTraceRedaction(true))
+	require.True(t, ctx.TraceRedactionEnabled(), "WithTraceRedaction(true) should enable redaction")
+}
+
+func TestTraceRedaction_WithTraceRedactionFalse_StaysDisabled(t *testing.T) {
+	ctx := NewContext(context.Background(), WithTraceRedaction(false))
+	require.False(t, ctx.TraceRedactionEnabled(), "WithTraceRedaction(false) keeps the default-off state")
+}
+
+func TestTraceRedaction_NilContext(t *testing.T) {
+	var ctx *Context
+	require.False(t, ctx.TraceRedactionEnabled(), "nil context should report redaction disabled")
+	require.Equal(t, "foo", ctx.RedactNameForTrace("foo"), "nil context name redaction should pass through")
+	require.Equal(t, "SELECT 1", ctx.RedactQueryForTrace("SELECT 1"), "nil context query redaction should pass through")
+}
+
+func TestTraceRedaction_DefaultPassesThrough(t *testing.T) {
+	// With redaction off (the default), all helpers return their
+	// input unchanged and no mapping is allocated.
+	ctx := NewContext(context.Background())
+	const q = "SELECT a FROM t WHERE x = 1"
+	require.Equal(t, q, ctx.RedactQueryForTrace(q), "default-off RedactQueryForTrace must pass through")
+	require.Equal(t, "users", ctx.RedactNameForTrace("users"), "default-off RedactNameForTrace must pass through")
+	require.Nil(t, ctx.RedactionMapping(), "default-off context must not allocate a mapping")
+}
+
+func TestTraceRedaction_RedactQueryForTracePopulatesMapping(t *testing.T) {
+	ctx := NewContext(context.Background(), WithTraceRedaction(true))
+	got := ctx.RedactQueryForTrace("SELECT a FROM t WHERE x = 1")
+	require.NotContains(t, got, "FROM t", "table name not redacted")
+	require.NotContains(t, got, "from t ", "table name not redacted (lowercased form)")
+	require.NotNil(t, ctx.RedactionMapping(), "mapping must be populated when enabled")
+}
+
+func TestTraceRedaction_NameUsesParsedMapping(t *testing.T) {
+	ctx := NewContext(context.Background(), WithTraceRedaction(true))
+	_ = ctx.RedactQueryForTrace("SELECT a FROM users WHERE id = 1")
+	tok := ctx.RedactNameForTrace("users")
+	require.NotEqual(t, "users", tok, "expected redacted token for 'users', got original")
+	require.Equal(t, tok, ctx.RedactNameForTrace("users"), "name redaction must be stable")
+}
+
+func TestTraceRedaction_NameWithoutParsePhase(t *testing.T) {
+	// rowexec spans may fire on contexts where no SQL was parsed.
+	// Name redaction should still mint a stable token.
+	ctx := NewContext(context.Background(), WithTraceRedaction(true))
+	a := ctx.RedactNameForTrace("orphan_table")
+	require.NotEqual(t, "orphan_table", a, "expected a redacted token, got original")
+	require.Equal(t, a, ctx.RedactNameForTrace("orphan_table"), "token must be stable across calls")
+}
+
+type stubStringer string
+
+func (s stubStringer) String() string { return string(s) }
+
+func TestTraceRedaction_RedactStringerForTrace(t *testing.T) {
+	enabled := NewContext(context.Background(), WithTraceRedaction(true))
+	require.Containsf(t,
+		enabled.RedactStringerForTrace(stubStringer("user_col + 5")),
+		"redacted",
+		"enabled context should mask SQL fragment")
+
+	disabledByDefault := NewContext(context.Background())
+	const original = "user_col + 5"
+	require.Equal(t, original, disabledByDefault.RedactStringerForTrace(stubStringer(original)),
+		"default-off context should return original Stringer text")
+
+	var nilCtx *Context
+	require.Equal(t, original, nilCtx.RedactStringerForTrace(stubStringer(original)),
+		"nil context should return original Stringer text")
+}
+
+func TestTraceRedaction_UnparseableQuery(t *testing.T) {
+	ctx := NewContext(context.Background(), WithTraceRedaction(true))
+	require.Truef(t,
+		strings.Contains(ctx.RedactQueryForTrace("not even close to sql ;;"), "unparseable"),
+		"expected unparseable marker for invalid SQL")
+}


### PR DESCRIPTION
## Summary

Adds an opt-in redaction layer for the SQL text and identifiers that get attached to OpenTelemetry span attributes — the planbuilder parse-span `query` attribute and the rowexec `table`/`left`/`right`/`index` attributes. When enabled via a new `sql.Context` option, identifiers and literal values are rewritten into stable, low-entropy tokens (`n1`, `n2`, ..., `v1`, `v2`, ...) that repeat across queries of the same shape so trace storage compresses well.

Use case: multi-tenant SQL servers (Dolt is one, our own dsabstraction layer is another) where tracing data flows to shared long-term storage. Operators want privacy regulation compliance and tenant isolation without giving up trace visibility entirely.

**Default off** to preserve backward compatibility — existing trace consumers reading `query`, `table`, `left`, `right`, etc. verbatim see no change. Callers opt in with `sql.WithTraceRedaction(true)`.

## How it works

Two passes over the same SQL, deliberately combined:

1. **Parse to AST**, walk it to collect every `TableIdent` and `ColIdent` string. The grammar is the authority on which lexemes are identifiers — necessary because vitess treats hundreds of words (`NAME`, `USER`, `DATA`, `STATUS`, ...) as *non-reserved keywords*: the lexer emits a keyword token type for them, but real queries use them as bare column / table names.
2. **Lex** the SQL and emit token-by-token. Literal token types (`STRING`, `INTEGRAL`, `FLOAT`, `HEX`, `HEXNUM`, `BIT_LITERAL`) redact as values. `ID` tokens redact as identifiers. `COMMENT` tokens drop. `VALUE_ARG` / `LIST_ARG` pass through. Any other token (keyword, punctuation, multi-char operator) emits structurally — **unless** its `val` is in the identifier set from step 1, in which case it redacts as an identifier (this catches the non-reserved-keyword-as-column-name case).

Coverage is bounded by the *grammar's* notion of identifier (`TableIdent` + `ColIdent`) and the *lexer's* fixed set of literal token types — not by an evolving list of AST node fields. Future grammar / AST shape changes are covered automatically as long as they go through `Walk` and produce the same lexer token classes.

This is deliberately distinct from `sqlparser.Normalize` / `RedactSQLQuery`, which is a plan-cache primitive that parameterizes literals only, dedupes only inside SELECT, and skips long values for CPU. The redactor here treats traces as a privacy boundary: every high-cardinality token is rewritten, always dedupes, drops comments, and falls back to `<unparseable>` on parse failure rather than risk a partial redaction.

## Examples

```
Before: SELECT * FROM t WHERE c1 = 'could_be_sensitive'
After:  SELECT * FROM `n1` WHERE `n2` = 'v1'
```

```
Before: SELECT u.name, u.email FROM users AS u
After:  SELECT `n1` . `n2` , `n1` . `n3` FROM `n4` AS `n1`
```

`name` is a non-reserved keyword in the vitess grammar — lexed with a keyword token type, not `ID`. A pure lexer-driven redactor would leak it. The hybrid grammar+lex approach catches it.

```
Before: WITH x (renamed_col) AS (SELECT a FROM t) SELECT * FROM x JOIN y USING (sensitive_join_col)
After:  WITH `n1` ( `n2` ) AS ( SELECT `n3` FROM `n4` ) SELECT * FROM `n1` JOIN `n5` USING ( `n6` )
```

CTE column-rename list, USING column list — both are `[]ColIdent` slices on pointer parents. Picked up via the AST walk's identifier collection, redacted at lex time.

```
Before: /* PII: alice@example.com */ SELECT 1 FROM t /* inline */
After:  SELECT :v1 FROM `n1`
```

Both margin and inline comments are dropped (the lexer emits `COMMENT` for both — drop happens at the lex pass).

## Concurrency

The `Mapping` is eagerly allocated by `NewContext` when redaction is enabled (never lazy after construction), so concurrent rowexec spans firing while the parser populates the mapping never race on lazy initialization. The Mapping itself uses an internal `sync.RWMutex` — the fast path for already-minted tokens takes `RLock`, mints take `Lock` with a re-check after upgrade.

A new `TestMapping_ConcurrentRedactIsRaceFree` exercises the production usage pattern (parent populates during parse, many goroutines read with occasional mint-on-miss) under `-race` for 500 iterations × 32 goroutines.

## Public API

```go
// sql.Context option (default off)
sql.WithTraceRedaction(enabled bool) ContextOption

// Methods on *Context
(*Context).TraceRedactionEnabled() bool
(*Context).RedactionMapping() *sqlredact.Mapping
(*Context).RedactQueryForTrace(query string) string
(*Context).RedactNameForTrace(name string) string
(*Context).RedactStringerForTrace(v interface{ String() string }) string

// New subpackage
sqlredact.RedactSQLForTrace(sql string) (redacted string, m *Mapping, err error)
sqlredact.RedactSQLForTraceInto(sql string, m *Mapping) (string, error)
sqlredact.NewMapping() *Mapping
```

## Commits

1. `sqlredact: SQL trace redaction for span attributes (opt-in)` — new `sql/sqlredact` package (parse + lex hybrid, the `Mapping` with `sync.RWMutex`), new `sql.Context` option and helpers, tests including the concurrency stress.
2. `trace: redact SQL identifiers in span attributes` — wires `planbuilder/parse.go`, `rowexec/rel.go`, `rowexec/join_iters.go`, `rowexec/range_heap_iter.go`, and `rowexec/ddl_iters.go` through the new helpers.

## Test plan

- [x] `go build ./...` for `./sql` and `./sql/sqlredact` clean
- [x] `go test ./sql ./sql/sqlredact` all pass (incl. testify assertions and the concurrency test under `-race`)
- [x] `gofmt -l` clean on touched files
- [ ] `enginetest` end-to-end coverage — not yet added; per `CONTRIBUTING.md` this is expected. Happy to add a query+expected-redacted-trace fixture if there's an existing pattern for span-attribute assertions, or open to guidance on the right scaffolding.

## Open questions for review

- Token format `n1`/`v1`/`:v1`/`X'v1'` — chosen to be short and repeating for compression density. Happy to adopt a different convention (e.g. `_redacted_n1`) if the project prefers more obviously synthetic markers.
- The `<redacted>` placeholder for `LIMIT`/`OFFSET` Stringer attrs drops the value entirely under redaction (see commit message rationale). Open to alternative: re-tokenize the fragment text against the mapping, accepting that pushdown-generated synthetic identifiers won't have entries.
- Any existing convention for end-to-end tests of span attributes that I should hook into?

🤖 Generated with [Claude Code](https://claude.com/claude-code)