### PR TITLE
Build index scans when tuples are compared for equality or used in set membership.

### DIFF
--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -2990,6 +2990,324 @@ var IndexPlanTests = []QueryPlanTest{
 			"",
 	},
 	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v1, v2) = (100, 200);`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ TUPLE(comp_index_t0.v1:1, comp_index_t0.v2:2)\n" +
+			" │   └─ TUPLE(100 (tinyint), 200 (tinyint unsigned))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ static: [{[100, 100], [200, 200]}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) = (100, 200))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) = (100, 200))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v1, v2) != (100, 200);`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ NOT\n" +
+			" │   └─ Eq\n" +
+			" │       ├─ TUPLE(comp_index_t0.v1:1, comp_index_t0.v2:2)\n" +
+			" │       └─ TUPLE(100 (tinyint), 200 (tinyint unsigned))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ static: [{[NULL, NULL], (NULL, 200)}, {[NULL, NULL], (200, ∞)}, {(NULL, 100), [NULL, ∞)}, {[100, 100], (NULL, 200)}, {[100, 100], (200, ∞)}, {(100, ∞), [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (NOT(((comp_index_t0.v1, comp_index_t0.v2) = (100, 200))))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[NULL, NULL], (NULL, 200)}, {[NULL, NULL], (200, ∞)}, {(NULL, 100), [NULL, ∞)}, {[100, 100], (NULL, 200)}, {[100, 100], (200, ∞)}, {(100, ∞), [NULL, ∞)}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (NOT(((comp_index_t0.v1, comp_index_t0.v2) = (100, 200))))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[NULL, NULL], (NULL, 200)}, {[NULL, NULL], (200, ∞)}, {(NULL, 100), [NULL, ∞)}, {[100, 100], (NULL, 200)}, {[100, 100], (200, ∞)}, {(100, ∞), [NULL, ∞)}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v2, v1) = (200, 100);`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ TUPLE(comp_index_t0.v2:2, comp_index_t0.v1:1)\n" +
+			" │   └─ TUPLE(200 (tinyint unsigned), 100 (tinyint))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ static: [{[100, 100], [200, 200]}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t0.v2, comp_index_t0.v1) = (200, 100))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t0.v2, comp_index_t0.v1) = (200, 100))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v1, v2) IN ((100, 200), (300, 400));`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ HashIn\n" +
+			" │   ├─ TUPLE(comp_index_t0.v1:1, comp_index_t0.v2:2)\n" +
+			" │   └─ TUPLE(TUPLE(100 (tinyint), 200 (tinyint unsigned)), TUPLE(300 (smallint), 400 (smallint)))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ static: [{[100, 100], [200, 200]}, {[300, 300], [400, 400]}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) HASH IN ((100, 200), (300, 400)))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}, {[300, 300], [400, 400]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) HASH IN ((100, 200), (300, 400)))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}, {[300, 300], [400, 400]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v1, v2, 300) = (100, 200, 300);`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ Eq\n" +
+			" │   ├─ TUPLE(comp_index_t0.v1:1, comp_index_t0.v2:2, 300 (tinyint unsigned))\n" +
+			" │   └─ TUPLE(100 (tinyint), 200 (tinyint unsigned), 300 (tinyint unsigned))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ static: [{[100, 100], [200, 200]}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) = (100, 200))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) = (100, 200))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v1, v2) <=> (100, 200);`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ (TUPLE(comp_index_t0.v1:1, comp_index_t0.v2:2) <=> TUPLE(100 (tinyint), 200 (tinyint unsigned)))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ static: [{[100, 100], [200, 200]}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) <=> (100, 200))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) <=> (100, 200))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [200, 200]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v1, v2) <=> (100, NULL);`,
+		ExpectedPlan: "Filter\n" +
+			" ├─ (TUPLE(comp_index_t0.v1:1, comp_index_t0.v2:2) <=> TUPLE(100 (tinyint), NULL (null)))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ static: [{[100, 100], [NULL, NULL]}]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) <=> (100, NULL))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [NULL, NULL]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t0.v1, comp_index_t0.v2) <=> (100, NULL))\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ filters: [{[100, 100], [NULL, NULL]}]\n" +
+			"     └─ columns: [pk v1 v2]\n" +
+			"",
+	},
+	{
+		Query: `SELECT /*+ LOOKUP_JOIN(one,two) */ * FROM comp_index_t0 one JOIN comp_index_t0 two ON (one.v1, one.v2) = (two.v1, two.v2);`,
+		ExpectedPlan: "Project\n" +
+			" ├─ columns: [one.pk:3!null, one.v1:4, one.v2:5, two.pk:0!null, two.v1:1, two.v2:2]\n" +
+			" └─ LookupJoin\n" +
+			"     ├─ TableAlias(two)\n" +
+			"     │   └─ ProcessTable\n" +
+			"     │       └─ Table\n" +
+			"     │           ├─ name: comp_index_t0\n" +
+			"     │           └─ columns: [pk v1 v2]\n" +
+			"     └─ TableAlias(one)\n" +
+			"         └─ IndexedTableAccess(comp_index_t0)\n" +
+			"             ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"             ├─ keys: [two.v1:1 two.v2:2]\n" +
+			"             ├─ colSet: (1-3)\n" +
+			"             ├─ tableId: 1\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: comp_index_t0\n" +
+			"                 └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Project\n" +
+			" ├─ columns: [one.pk, one.v1, one.v2, two.pk, two.v1, two.v2]\n" +
+			" └─ LookupJoin (estimated cost=404.600 rows=126)\n" +
+			"     ├─ TableAlias(two)\n" +
+			"     │   └─ Table\n" +
+			"     │       ├─ name: comp_index_t0\n" +
+			"     │       └─ columns: [pk v1 v2]\n" +
+			"     └─ TableAlias(one)\n" +
+			"         └─ IndexedTableAccess(comp_index_t0)\n" +
+			"             ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"             ├─ columns: [pk v1 v2]\n" +
+			"             └─ keys: two.v1, two.v2\n" +
+			"",
+		ExpectedAnalysis: "Project\n" +
+			" ├─ columns: [one.pk, one.v1, one.v2, two.pk, two.v1, two.v2]\n" +
+			" └─ LookupJoin (estimated cost=404.600 rows=126) (actual rows=1 loops=1)\n" +
+			"     ├─ TableAlias(two)\n" +
+			"     │   └─ Table\n" +
+			"     │       ├─ name: comp_index_t0\n" +
+			"     │       └─ columns: [pk v1 v2]\n" +
+			"     └─ TableAlias(one)\n" +
+			"         └─ IndexedTableAccess(comp_index_t0)\n" +
+			"             ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"             ├─ columns: [pk v1 v2]\n" +
+			"             └─ keys: two.v1, two.v2\n" +
+			"",
+	},
+	{
+		Query: `SELECT * FROM comp_index_t0 WHERE (v1, v2) IN (SELECT MAX(v1), MAX(v2) FROM comp_index_t1); `,
+		ExpectedPlan: "Filter\n" +
+			" ├─ InSubquery\n" +
+			" │   ├─ left: TUPLE(comp_index_t0.v1:1, comp_index_t0.v2:2)\n" +
+			" │   └─ right: Subquery\n" +
+			" │       ├─ cacheable: true\n" +
+			" │       ├─ alias-string: select MAX(v1), MAX(v2) from comp_index_t1\n" +
+			" │       └─ Project\n" +
+			" │           ├─ columns: [max(comp_index_t1.v1):3!null->MAX(v1):0, max(comp_index_t1.v2):4!null->MAX(v2):0]\n" +
+			" │           └─ GroupBy\n" +
+			" │               ├─ select: MAX(comp_index_t1.v1:3), MAX(comp_index_t1.v2:4)\n" +
+			" │               ├─ group: \n" +
+			" │               └─ Table\n" +
+			" │                   ├─ name: comp_index_t1\n" +
+			" │                   ├─ columns: [v1 v2]\n" +
+			" │                   ├─ colSet: (4-7)\n" +
+			" │                   └─ tableId: 2\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"     ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"     ├─ keys: [max(comp_index_t1.v1):3 max(comp_index_t1.v2):4]\n" +
+			"     ├─ colSet: (1-3)\n" +
+			"     ├─ tableId: 1\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ InSubquery\n" +
+			" │   ├─ left: (comp_index_t0.v1, comp_index_t0.v2)\n" +
+			" │   └─ right: Subquery\n" +
+			" │       ├─ cacheable: true\n" +
+			" │       └─ Project\n" +
+			" │           ├─ columns: [max(comp_index_t1.v1) as MAX(v1), max(comp_index_t1.v2) as MAX(v2)]\n" +
+			" │           └─ GroupBy\n" +
+			" │               ├─ select: MAX(comp_index_t1.v1), MAX(comp_index_t1.v2)\n" +
+			" │               ├─ group: \n" +
+			" │               └─ Table\n" +
+			" │                   ├─ name: comp_index_t1\n" +
+			" │                   └─ columns: [v1 v2]\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"    ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"    ├─ columns: [pk v1 v2]\n" +
+			"    └─ keys: max(comp_index_t1.v1), max(comp_index_t1.v2)\n" +
+			"",
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ InSubquery\n" +
+			" │   ├─ left: (comp_index_t0.v1, comp_index_t0.v2)\n" +
+			" │   └─ right: Subquery\n" +
+			" │       ├─ cacheable: true\n" +
+			" │       └─ Project\n" +
+			" │           ├─ columns: [max(comp_index_t1.v1) as MAX(v1), max(comp_index_t1.v2) as MAX(v2)]\n" +
+			" │           └─ GroupBy\n" +
+			" │               ├─ select: MAX(comp_index_t1.v1), MAX(comp_index_t1.v2)\n" +
+			" │               ├─ group: \n" +
+			" │               └─ Table\n" +
+			" │                   ├─ name: comp_index_t1\n" +
+			" │                   └─ columns: [v1 v2]\n" +
+			" └─ IndexedTableAccess(comp_index_t0)\n" +
+			"    ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"    ├─ columns: [pk v1 v2]\n" +
+			"    └─ keys: max(comp_index_t1.v1), max(comp_index_t1.v2)\n" +
+			"",
+	},
+	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>87 AND v2 BETWEEN 8 AND 33) OR (v1 BETWEEN 39 AND 69 AND v3<4));`,
 		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
 			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -1147,19 +1147,23 @@ func (b *indexScanRangeBuilder) rangeBuildFulltextLeaf(f *iScanLeaf, inScan bool
 }
 
 func (b *indexScanRangeBuilder) rangeBuildLeaf(f *iScanLeaf, inScan bool) (sql.MySQLRangeCollection, error) {
+
+	// I'm not sure when this is required.
+	b.markImprecise(f.id)
+
 	switch f.Op() {
 	case sql.IndexScanOpSpatialEq:
 		return b.rangeBuildSpatialLeaf(f, inScan)
 	case sql.IndexScanOpFulltextEq:
 		return b.rangeBuildFulltextLeaf(f, inScan)
 	case sql.IndexScanOpEq:
-		return b.rangeBuildEquals(f, false), nil
+		return b.rangeBuildEquals(f, false)
 	case sql.IndexScanOpNullSafeEq:
-		return b.rangeBuildEquals(f, true), nil
+		return b.rangeBuildEquals(f, true)
 	case sql.IndexScanOpNotEq:
-		return b.rangeBuildNotEquals(f), nil
+		return b.rangeBuildNotEquals(f)
 	case sql.IndexScanOpInSet:
-		return b.rangeBuildInSet(f), nil
+		return b.rangeBuildInSet(f)
 	default:
 		if len(f.columns) > 1 {
 			return nil, fmt.Errorf("unhandled op with multiple columns %v, this shouldn't happen", f)
@@ -1216,38 +1220,48 @@ func (b *indexScanRangeBuilder) rangeBuildDefaultLeaf(bb *sql.MySQLIndexBuilder,
 	}
 }
 
-func (b *indexScanRangeBuilder) rangeBuildEquals(f *iScanLeaf, nullSafe bool) sql.MySQLRangeCollection {
+func (b *indexScanRangeBuilder) rangeBuildEquals(f *iScanLeaf, nullSafe bool) (sql.MySQLRangeCollection, error) {
 	partBuilder := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
 	for i, column := range f.columns {
 		litType := column.litType
 		litValue := column.litValue
-		if f.litValue == nil {
+		if nullSafe && f.litValue == nil {
 			partBuilder.IsNull(b.ctx, f.normString(i))
+		} else {
+			partBuilder.Equals(b.ctx, f.normString(i), litType, litValue)
 		}
-		partBuilder.Equals(b.ctx, f.normString(i), litType, litValue)
 	}
-	return partBuilder.Ranges(b.ctx)
+	if _, err := partBuilder.Build(b.ctx); err != nil {
+		return nil, err
+	}
+	return partBuilder.Ranges(b.ctx), nil
 }
 
-func (b *indexScanRangeBuilder) rangeBuildNotEquals(f *iScanLeaf) sql.MySQLRangeCollection {
+func (b *indexScanRangeBuilder) rangeBuildNotEquals(f *iScanLeaf) (sql.MySQLRangeCollection, error) {
 	var ret sql.MySQLRangeCollection
 	for i, column := range f.columns {
 		litType := column.litType
 		litValue := column.litValue
 		partBuilder := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
 		partBuilder.NotEquals(b.ctx, f.normString(i), litType, litValue)
+		if _, err := partBuilder.Build(b.ctx); err != nil {
+			return nil, err
+		}
 		ret = append(ret, partBuilder.Ranges(b.ctx)...)
 	}
-	return ret
+	return ret, nil
 }
 
-func (b *indexScanRangeBuilder) rangeBuildInSet(f *iScanLeaf) sql.MySQLRangeCollection {
+func (b *indexScanRangeBuilder) rangeBuildInSet(f *iScanLeaf) (sql.MySQLRangeCollection, error) {
 	var ret sql.MySQLRangeCollection
 	_, isTuple := f.litType.(types.TupleType)
 	if !isTuple {
 		bb := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
-		bb.In(b.ctx, f.columns[0].name, f.setTypes, f.setValues)
-		return bb.Ranges(b.ctx)
+		bb.In(b.ctx, f.normString(0), f.setTypes, f.setValues)
+		if _, err := bb.Build(b.ctx); err != nil {
+			return nil, err
+		}
+		return bb.Ranges(b.ctx), nil
 	}
 
 	for i := range f.setValues {
@@ -1257,9 +1271,12 @@ func (b *indexScanRangeBuilder) rangeBuildInSet(f *iScanLeaf) sql.MySQLRangeColl
 		for j, setValue := range setValueTuple {
 			partBuilder.Equals(b.ctx, f.normString(j), setType[j], setValue)
 		}
+		if _, err := partBuilder.Build(b.ctx); err != nil {
+			return nil, err
+		}
 		ret = append(ret, partBuilder.Ranges(b.ctx)...)
 	}
-	return ret
+	return ret, nil
 }
 
 // markLeftover is used to check if leaf nodes and OR filters are left out
@@ -1714,6 +1731,17 @@ func indexHasContentHashedFieldForFilter(ctx *sql.Context, filter *iScanLeaf, id
 // by a statistic, returning the updated statistic, whether the filter was
 // applicable, and the maximum prefix key (0 or 1 for a leaf).
 func (c *indexCoster) costIndexScanLeaf(ctx *sql.Context, filter *iScanLeaf, s sql.Statistic, buckets []sql.HistogramBucket, ordinals map[string]int, idx sql.Index) ([]sql.HistogramBucket, *sql.FuncDepSet, bool, int, error) {
+	filterMatchesIndex := false
+	for _, column := range filter.columns {
+		if _, ok := ordinals[strings.ToLower(column.name)]; ok {
+			filterMatchesIndex = true
+			break
+		}
+	}
+	if !filterMatchesIndex {
+		return nil, nil, false, 0, nil
+	}
+
 	// indexes with content-hashed fields can be used to test equality or compare with NULL,
 	// but can't be used for other comparisons, such as less than or greater than.
 	if indexHasContentHashedFieldForFilter(ctx, filter, idx, ordinals) {
@@ -1742,6 +1770,7 @@ func (c *indexCoster) costIndexScanLeaf(ctx *sql.Context, filter *iScanLeaf, s s
 		stat, ok, err := c.costFulltext(filter, s, ord)
 		return buckets, stat.FuncDeps(), ok, 0, err
 	default:
+		// If none of the keys are in the index, then we won't
 		conj := newConjCollector(s, buckets, ordinals)
 		err := conj.add(ctx, filter)
 		if err != nil {
@@ -2185,7 +2214,7 @@ func (c *conjCollector) addEq(ctx *sql.Context, col string, val interface{}, nul
 	col = strings.ToLower(col)
 	ord, ok := c.ordinals[col]
 	if !ok {
-		return fmt.Errorf("unknown column '%s'", col)
+		return nil
 	}
 	if c.constant.Contains(ord + 1) {
 		if c.eqVals[ord] != val {
@@ -2223,7 +2252,7 @@ func (c *conjCollector) addIneq(ctx *sql.Context, op sql.IndexScanOp, col string
 	col = strings.ToLower(col)
 	ord, ok := c.ordinals[col]
 	if !ok {
-		return fmt.Errorf("unknown column '%s'", col)
+		return nil
 	}
 	c.ineqCols.Add(ord)
 	if ord > 0 {

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -769,7 +769,7 @@ func (c *indexCoster) buildRoot(ctx *sql.Context, e sql.Expression, walker sql.E
 		}
 		var imprecise sql.FastIntSet
 		if !expression.PreciseComparison(ctx, e) {
-			imprecise.Add(int(leaf.id))
+			imprecise.Add(int(leaf.Id()))
 		}
 		return leaf, nil, imprecise
 	}
@@ -810,7 +810,7 @@ func (c *indexCoster) buildAnd(ctx *sql.Context, e *expression.And, and *iScanAn
 			} else {
 				and.newLeaf(leaf)
 				if !expression.PreciseComparison(ctx, e) {
-					imprecise.Add(int(leaf.id))
+					imprecise.Add(int(leaf.Id()))
 				}
 			}
 			// keep a ref to the invalid |e|
@@ -1045,7 +1045,15 @@ func (b *indexScanRangeBuilder) rangeBuildAnd(f *iScanAnd, inScan bool) (sql.MyS
 				}
 			}
 		default:
-			b.rangeBuildDefaultLeaf(partBuilder, leaf, inScan)
+			if len(leaf.columns) == 1 {
+				b.rangeBuildDefaultLeaf(partBuilder, leaf, inScan)
+			} else {
+				ranges, err := b.rangeBuildLeaf(leaf, inScan)
+				if err != nil {
+					return nil, err
+				}
+				ret, err = ret.Intersect(b.ctx, ranges)
+			}
 		}
 	}
 
@@ -1066,13 +1074,13 @@ func (b *indexScanRangeBuilder) rangeBuildAnd(f *iScanAnd, inScan bool) (sql.MyS
 }
 
 func (b *indexScanRangeBuilder) rangeBuildOr(f *iScanOr, inScan bool) (sql.MySQLRangeCollection, error) {
-	inScan = !b.markLeftover(f, inScan)
+	inScan = !b.markLeftover(f.id, inScan)
 	if !inScan {
 		return nil, nil
 	}
 
 	// imprecise filters cannot be removed
-	b.markImprecise(f)
+	b.markImprecise(f.id)
 
 	// todo union the or ranges
 	var ret sql.MySQLRangeCollection
@@ -1096,7 +1104,7 @@ func (b *indexScanRangeBuilder) rangeBuildOr(f *iScanOr, inScan bool) (sql.MySQL
 }
 
 func (b *indexScanRangeBuilder) rangeBuildSpatialLeaf(f *iScanLeaf, inScan bool) (sql.MySQLRangeCollection, error) {
-	inScan = !b.markLeftover(f, inScan)
+	inScan = !b.markLeftover(f.id, inScan)
 	if inScan {
 		// always mark leftover
 		b.leftover = append(b.leftover, b.idToExpr[f.Id()])
@@ -1104,7 +1112,7 @@ func (b *indexScanRangeBuilder) rangeBuildSpatialLeaf(f *iScanLeaf, inScan bool)
 		return nil, nil
 	}
 
-	g, ok := f.litValue.(types.GeometryValue)
+	g, ok := f.columns[0].litValue.(types.GeometryValue)
 	if !ok {
 		return nil, sql.ErrInvalidGISData.New()
 	}
@@ -1112,7 +1120,7 @@ func (b *indexScanRangeBuilder) rangeBuildSpatialLeaf(f *iScanLeaf, inScan bool)
 	lower := types.Point{X: minX, Y: minY}
 	upper := types.Point{X: maxX, Y: maxY}
 
-	typ := f.typ
+	typ := f.columns[0].typ
 	return sql.MySQLRangeCollection{{{
 		LowerBound: sql.Below{
 			Key: lower,
@@ -1128,14 +1136,14 @@ func (b *indexScanRangeBuilder) rangeBuildSpatialLeaf(f *iScanLeaf, inScan bool)
 
 func (b *indexScanRangeBuilder) rangeBuildFulltextLeaf(f *iScanLeaf, inScan bool) (sql.MySQLRangeCollection, error) {
 	// fulltext leaf doesn't use ranges
-	inScan = !b.markLeftover(f, inScan)
+	inScan = !b.markLeftover(f.id, inScan)
 	if inScan {
 		// always mark leftover
 		b.leftover = append(b.leftover, b.idToExpr[f.Id()])
 	} else {
 		return nil, nil
 	}
-	return sql.MySQLRangeCollection{{sql.EmptyRangeColumnExpr(f.typ)}}, nil
+	return sql.MySQLRangeCollection{{sql.EmptyRangeColumnExpr(f.columns[0].typ)}}, nil
 }
 
 func (b *indexScanRangeBuilder) rangeBuildLeaf(f *iScanLeaf, inScan bool) (sql.MySQLRangeCollection, error) {
@@ -1144,7 +1152,18 @@ func (b *indexScanRangeBuilder) rangeBuildLeaf(f *iScanLeaf, inScan bool) (sql.M
 		return b.rangeBuildSpatialLeaf(f, inScan)
 	case sql.IndexScanOpFulltextEq:
 		return b.rangeBuildFulltextLeaf(f, inScan)
+	case sql.IndexScanOpEq:
+		return b.rangeBuildEquals(f, false), nil
+	case sql.IndexScanOpNullSafeEq:
+		return b.rangeBuildEquals(f, true), nil
+	case sql.IndexScanOpNotEq:
+		return b.rangeBuildNotEquals(f), nil
+	case sql.IndexScanOpInSet:
+		return b.rangeBuildInSet(f), nil
 	default:
+		if len(f.columns) > 1 {
+			return nil, fmt.Errorf("unhandled op with multiple columns %v, this shouldn't happen", f)
+		}
 		bb := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
 		b.rangeBuildDefaultLeaf(bb, f, inScan)
 		if _, err := bb.Build(b.ctx); err != nil {
@@ -1154,15 +1173,17 @@ func (b *indexScanRangeBuilder) rangeBuildLeaf(f *iScanLeaf, inScan bool) (sql.M
 	}
 }
 
+// rangeBuildDefaultLeaf populates a sql.MySQLIndexBuilder with information from a iScanLeaf.
+// It requires that the iScanLeaf only has a single column.
 func (b *indexScanRangeBuilder) rangeBuildDefaultLeaf(bb *sql.MySQLIndexBuilder, f *iScanLeaf, inScan bool) {
-	inScan = !b.markLeftover(f, inScan)
+	inScan = !b.markLeftover(f.id, inScan)
 	if !inScan {
 		return
 	}
 
-	b.markImprecise(f)
+	b.markImprecise(f.id)
 
-	name := f.normString()
+	name := f.normString(0)
 	switch f.Op() {
 	case sql.IndexScanOpEq:
 		bb.Equals(b.ctx, name, f.litType, f.litValue)
@@ -1195,20 +1216,66 @@ func (b *indexScanRangeBuilder) rangeBuildDefaultLeaf(bb *sql.MySQLIndexBuilder,
 	}
 }
 
+func (b *indexScanRangeBuilder) rangeBuildEquals(f *iScanLeaf, nullSafe bool) sql.MySQLRangeCollection {
+	partBuilder := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
+	for i, column := range f.columns {
+		litType := column.litType
+		litValue := column.litValue
+		if f.litValue == nil {
+			partBuilder.IsNull(b.ctx, f.normString(i))
+		}
+		partBuilder.Equals(b.ctx, f.normString(i), litType, litValue)
+	}
+	return partBuilder.Ranges(b.ctx)
+}
+
+func (b *indexScanRangeBuilder) rangeBuildNotEquals(f *iScanLeaf) sql.MySQLRangeCollection {
+	var ret sql.MySQLRangeCollection
+	for i, column := range f.columns {
+		litType := column.litType
+		litValue := column.litValue
+		partBuilder := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
+		partBuilder.NotEquals(b.ctx, f.normString(i), litType, litValue)
+		ret = append(ret, partBuilder.Ranges(b.ctx)...)
+	}
+	return ret
+}
+
+func (b *indexScanRangeBuilder) rangeBuildInSet(f *iScanLeaf) sql.MySQLRangeCollection {
+	var ret sql.MySQLRangeCollection
+	_, isTuple := f.litType.(types.TupleType)
+	if !isTuple {
+		bb := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
+		bb.In(b.ctx, f.columns[0].name, f.setTypes, f.setValues)
+		return bb.Ranges(b.ctx)
+	}
+
+	for i := range f.setValues {
+		setType := f.setTypes[i].(types.TupleType)
+		setValueTuple := f.setValues[i].([]interface{})
+		partBuilder := sql.NewMySQLIndexBuilder(b.ctx, b.idx)
+		for j, setValue := range setValueTuple {
+			partBuilder.Equals(b.ctx, f.normString(j), setType[j], setValue)
+		}
+		ret = append(ret, partBuilder.Ranges(b.ctx)...)
+	}
+	return ret
+}
+
 // markLeftover is used to check if leaf nodes and OR filters are left out
 // of the index lookup. We omit this check for AND filters because a portion
 // of their children can contribute to the scan.
-func (b *indexScanRangeBuilder) markLeftover(f indexFilter, inScan bool) bool {
-	if !inScan && !b.include.Contains(int(f.Id())) {
-		b.leftover = append(b.leftover, b.idToExpr[f.Id()])
+func (b *indexScanRangeBuilder) markLeftover(id indexScanId, inScan bool) bool {
+	if !inScan && !b.include.Contains(int(id)) {
+		b.leftover = append(b.leftover, b.idToExpr[id])
 		return true
 	}
 	return false
 }
 
-func (b *indexScanRangeBuilder) markImprecise(f indexFilter) {
-	if b.imprecise.Contains(int(f.Id())) {
-		b.leftover = append(b.leftover, b.idToExpr[f.Id()])
+func (b *indexScanRangeBuilder) markImprecise(id indexScanId) {
+	if b.imprecise.Contains(int(id)) {
+		b.leftover = append(b.leftover, b.idToExpr[id])
 	}
 }
 
@@ -1219,24 +1286,53 @@ type indexFilter interface {
 	Id() indexScanId
 }
 
-type iScanLeaf struct {
-	litValue      interface{}
-	litType       sql.Type
-	typ           sql.Type
-	name          string
-	underlying    string
-	fulltextIndex string
-	setValues     []interface{}
-	setTypes      []sql.Type
-	id            indexScanId
-	op            sql.IndexScanOp
+type iScanLeafColumn struct {
+	litValue interface{}
+	litType  sql.Type
+	typ      sql.Type
+	name     string
 }
 
-func (l *iScanLeaf) normString() string {
+type iScanLeaf struct {
+	columns       []iScanLeafColumn
+	setTypes      []sql.Type
+	setValues     []interface{}
+	underlying    string
+	fulltextIndex string
+	id            indexScanId
+	op            sql.IndexScanOp
+	typ           sql.Type
+	litValue      interface{}
+	litType       sql.Type
+}
+
+func (l *iScanLeaf) normString(index int) string {
 	if l.underlying != "" {
-		return strings.ToLower(l.underlying) + "." + strings.ToLower(l.name)
+		return strings.ToLower(l.underlying) + "." + strings.ToLower(l.columns[index].name)
 	}
-	return strings.ToLower(l.name)
+	return strings.ToLower(l.columns[index].name)
+}
+
+func (l *iScanLeaf) qualifiedNames() []string {
+	names := make([]string, len(l.columns))
+	for i := range l.columns {
+		names[i] = l.normString(i)
+	}
+	return names
+}
+
+func (l *iScanLeaf) formattedQualifiedNames() string {
+	result := ""
+	first := true
+	for i := range l.columns {
+		if first {
+			first = false
+		} else {
+			result += ", "
+		}
+		result += l.normString(i)
+	}
+	return result
 }
 
 func (l *iScanLeaf) Id() indexScanId {
@@ -1245,6 +1341,108 @@ func (l *iScanLeaf) Id() indexScanId {
 
 func (l *iScanLeaf) Op() sql.IndexScanOp {
 	return l.op
+}
+
+func supportedOpForTuples(op sql.IndexScanOp) bool {
+	switch op {
+	case sql.IndexScanOpEq, sql.IndexScanOpNullSafeEq, sql.IndexScanOpNotEq, sql.IndexScanOpInSet:
+		return true
+	default:
+		return false
+	}
+}
+
+func newLeafIndexFilter(id indexScanId, names []string, typ sql.Type, op sql.IndexScanOp, underlying string) (*iScanLeaf, bool) {
+	tupleType, isTuple := typ.(types.TupleType)
+	if !isTuple {
+		return &iScanLeaf{
+			columns: []iScanLeafColumn{{
+				name: names[0],
+				typ:  typ,
+			}},
+			underlying: underlying,
+			id:         id,
+			op:         op,
+			typ:        typ,
+		}, true
+	}
+	if len(tupleType) != len(names) {
+		return nil, false
+	}
+	columns := make([]iScanLeafColumn, len(names))
+	for i, columnType := range tupleType {
+		columns[i] = iScanLeafColumn{
+			name: names[i],
+			typ:  columnType,
+		}
+	}
+	return &iScanLeaf{
+		columns:    columns,
+		underlying: underlying,
+		id:         id,
+		op:         op,
+		typ:        typ,
+	}, true
+}
+
+func newLeafIndexFilterWithLiteral(id indexScanId, names []string, typ sql.Type, op sql.IndexScanOp, underlying string, literalValue interface{}, literalType sql.Type) (*iScanLeaf, bool) {
+	scanLeaf, ok := newLeafIndexFilter(id, names, typ, op, underlying)
+	if !ok {
+		return nil, false
+	}
+	scanLeaf.litValue = literalValue
+	scanLeaf.litType = literalType
+	tupleType, isTuple := typ.(types.TupleType)
+	if !isTuple {
+		scanLeaf.columns[0].litValue = literalValue
+		scanLeaf.columns[0].litType = literalType
+		return scanLeaf, true
+	}
+
+	literalTupleValue, ok := literalValue.([]interface{})
+	if !ok || len(literalTupleValue) != len(tupleType) {
+		return nil, false
+	}
+	literalTupleType, ok := literalType.(types.TupleType)
+	if !ok || len(literalTupleType) != len(tupleType) {
+		return nil, false
+	}
+
+	for i := range tupleType {
+		scanLeaf.columns[i].litValue = literalTupleValue[i]
+		scanLeaf.columns[i].litType = literalTupleType[i]
+	}
+
+	return scanLeaf, true
+}
+
+func newLeafIndexFilterWithSet(id indexScanId, names []string, typ sql.Type, op sql.IndexScanOp, underlying string, setValues []interface{}, setTypes []sql.Type, literalType sql.Type) (*iScanLeaf, bool) {
+	scanLeaf, ok := newLeafIndexFilter(id, names, typ, op, underlying)
+	if !ok {
+		return nil, false
+	}
+	scanLeaf.setValues = setValues
+	scanLeaf.setTypes = setTypes
+	scanLeaf.litType = literalType
+	tupleType, isTuple := typ.(types.TupleType)
+	if !isTuple {
+		scanLeaf.columns[0].litType = literalType
+		return scanLeaf, true
+	}
+
+	for i, setValue := range setValues {
+		var ok bool
+		setTupleValues, ok := setValue.([]interface{})
+		if !ok || len(setTupleValues) != len(tupleType) {
+			return nil, false
+		}
+		setTupleTypes, ok := setTypes[i].(types.TupleType)
+		if !ok || len(setTupleTypes) != len(tupleType) {
+			return nil, false
+		}
+	}
+
+	return scanLeaf, true
 }
 
 type iScanOr struct {
@@ -1285,13 +1483,28 @@ func (a *iScanAnd) newLeaf(l *iScanLeaf) {
 	if a.leafChildren == nil {
 		a.leafChildren = make(map[string][]*iScanLeaf)
 	}
-	key := strings.ToLower(l.name)
+	// Should we insert multiple times?
+	key := strings.ToLower(l.columns[0].name)
 	a.leafChildren[key] = append(a.leafChildren[key], l)
 	a.cnt++
 }
 
 // leaves returns a list of this nodes leaf filters, sorted by id
 func (a *iScanAnd) leaves() []*iScanLeaf {
+	var ret []*iScanLeaf
+	for _, colLeaves := range a.leafChildren {
+		for _, leaf := range colLeaves {
+			ret = append(ret, leaf)
+		}
+	}
+	sort.SliceStable(ret, func(i, j int) bool {
+		return ret[i].id < ret[j].id
+	})
+	return ret
+}
+
+// leaves returns a list of this nodes leaf filters, sorted by id
+func (a *iScanAnd) tupleLeaves() []*iScanLeaf {
 	var ret []*iScanLeaf
 	for _, colLeaves := range a.leafChildren {
 		for _, leaf := range colLeaves {
@@ -1353,15 +1566,15 @@ func formatIndexFilterRec(b *strings.Builder, nesting int, f indexFilter) {
 		}
 		switch f.Op() {
 		case sql.IndexScanOpIsNull, sql.IndexScanOpIsNotNull:
-			fmt.Fprintf(b, "(%d: %s %s)", f.Id(), f.normString(), f.Op())
+			fmt.Fprintf(b, "(%d: %s %s)", f.Id(), f.formattedQualifiedNames(), f.Op())
 		case sql.IndexScanOpInSet, sql.IndexScanOpNotInSet:
 			var valStrs []string
 			for _, v := range f.setValues {
 				valStrs = append(valStrs, fmt.Sprintf("%v", v))
 			}
-			fmt.Fprintf(b, "(%d: %s %s (%s))", f.Id(), f.normString(), f.Op(), strings.Join(valStrs, ", "))
+			fmt.Fprintf(b, "(%d: %s %s (%s))", f.Id(), f.formattedQualifiedNames(), f.Op(), strings.Join(valStrs, ", "))
 		default:
-			fmt.Fprintf(b, "(%d: %s %s %v)", f.Id(), f.normString(), f.Op(), f.litValue)
+			fmt.Fprintf(b, "(%d: %s %s %v)", f.Id(), f.formattedQualifiedNames(), f.Op(), f.litValue)
 		}
 
 	default:
@@ -1477,31 +1690,30 @@ func indexHasContentHashedFieldForFilter(ctx *sql.Context, filter *iScanLeaf, id
 		return false
 	}
 
-	i := ordinals[filter.name]
-	columnExpressionType := idx.ColumnExpressionTypes(ctx)[i]
+	for _, column := range filter.columns {
+		i := ordinals[column.name]
+		columnExpressionType := idx.ColumnExpressionTypes(ctx)[i]
 
-	// Only TEXT/BLOB types can currently use content-hashes in indexes
-	if !types.IsTextBlob(columnExpressionType.Type) {
-		return false
-	}
+		// Only TEXT/BLOB types can currently use content-hashes in indexes
+		if !types.IsTextBlob(columnExpressionType.Type) {
+			continue
+		}
 
-	prefixLength := uint16(0)
-	if len(idx.PrefixLengths()) > i {
-		prefixLength = idx.PrefixLengths()[i]
+		prefixLength := uint16(0)
+		if len(idx.PrefixLengths()) > i {
+			prefixLength = idx.PrefixLengths()[i]
+		}
+		if prefixLength == 0 {
+			return true
+		}
 	}
-	return prefixLength == 0
+	return false
 }
 
 // costIndexScanLeaf tries to apply a leaf filter to an index represented
 // by a statistic, returning the updated statistic, whether the filter was
 // applicable, and the maximum prefix key (0 or 1 for a leaf).
 func (c *indexCoster) costIndexScanLeaf(ctx *sql.Context, filter *iScanLeaf, s sql.Statistic, buckets []sql.HistogramBucket, ordinals map[string]int, idx sql.Index) ([]sql.HistogramBucket, *sql.FuncDepSet, bool, int, error) {
-	key := strings.ToLower(filter.name)
-	ord, ok := ordinals[key]
-	if !ok {
-		return nil, nil, false, 0, nil
-	}
-
 	// indexes with content-hashed fields can be used to test equality or compare with NULL,
 	// but can't be used for other comparisons, such as less than or greater than.
 	if indexHasContentHashedFieldForFilter(ctx, filter, idx, ordinals) {
@@ -1514,14 +1726,27 @@ func (c *indexCoster) costIndexScanLeaf(ctx *sql.Context, filter *iScanLeaf, s s
 
 	switch filter.op {
 	case sql.IndexScanOpSpatialEq:
+		key := strings.ToLower(filter.columns[0].name)
+		ord, ok := ordinals[key]
+		if !ok {
+			return nil, nil, false, 0, nil
+		}
 		stat, ok, err := c.costSpatial(filter, s, ord)
 		return buckets, stat.FuncDeps(), ok, 0, err
 	case sql.IndexScanOpFulltextEq:
+		key := strings.ToLower(filter.columns[0].name)
+		ord, ok := ordinals[key]
+		if !ok {
+			return nil, nil, false, 0, nil
+		}
 		stat, ok, err := c.costFulltext(filter, s, ord)
 		return buckets, stat.FuncDeps(), ok, 0, err
 	default:
 		conj := newConjCollector(s, buckets, ordinals)
-		conj.add(ctx, filter)
+		err := conj.add(ctx, filter)
+		if err != nil {
+			return nil, nil, false, 0, err
+		}
 		var conjFDs *sql.FuncDepSet
 		if idx.IsUnique() {
 			conjFDs = conj.getFds()
@@ -1557,40 +1782,54 @@ func (c *indexCoster) costFulltext(filter *iScanLeaf, s sql.Statistic, ordinal i
 //
 // ok is false when neither side of the comparison matches any indexed expression or GetField,
 // meaning this comparison cannot be served by an index scan.
-func (c *indexCoster) normalizeLeafSides(ctx *sql.Context, op sql.IndexScanOp, left, right sql.Expression) (name string, typ sql.Type, normalizedOp sql.IndexScanOp, litExpr sql.Expression, ok bool) {
+func (c *indexCoster) normalizeLeafSides(ctx *sql.Context, op sql.IndexScanOp, left, right sql.Expression) (names []string, typ sql.Type, normalizedOp sql.IndexScanOp, litExpr sql.Expression, ok bool) {
 	// Check the left side first: functional expression match, then plain GetField.
 	// If the index target is on the left, op is already in "indexTarget op litExpr" orientation.
 	if left != nil {
-		for _, entry := range c.indexedExprs {
-			if entry.matches(left) {
-				return entry.colName, left.Type(ctx), op, right, true
-			}
-		}
-		if gf, hit := left.(*expression.GetField); hit {
-			return gf.Name(), gf.Type(ctx), op, right, true
+		names, typ, normalizedOp, litExpr, ok = c.parseLeafExpression(ctx, op, left, right)
+		if ok {
+			return names, typ, normalizedOp, litExpr, ok
 		}
 	}
-	// Check the right side: functional expression match, then plain GetField.
-	// If the index target is on the right, swap op to normalize to "indexTarget op litExpr".
 	if right != nil {
-		for _, entry := range c.indexedExprs {
-			if entry.matches(right) {
-				return entry.colName, right.Type(ctx), op.Swap(), left, true
-			}
-		}
-		if gf, hit := right.(*expression.GetField); hit {
-			return gf.Name(), gf.Type(ctx), op.Swap(), left, true
+		// If the index target is on the right, swap op to normalize to "indexTarget op litExpr".
+		return c.parseLeafExpression(ctx, op.Swap(), right, left)
+	}
+	return nil, nil, 0, nil, false
+}
+
+func (c *indexCoster) parseLeafExpression(ctx *sql.Context, op sql.IndexScanOp, left sql.Expression, right sql.Expression) (names []string, typ sql.Type, normalizedOp sql.IndexScanOp, litExpr sql.Expression, ok bool) {
+	for _, entry := range c.indexedExprs {
+		if entry.matches(left) {
+			return []string{entry.colName}, left.Type(ctx), op, right, true
 		}
 	}
-	return "", nil, 0, nil, false
+	if gf, hit := left.(*expression.GetField); hit {
+		return []string{gf.Name()}, gf.Type(ctx), op, right, true
+	}
+	if tuple, hit := left.(expression.Tuple); hit && supportedOpForTuples(op) {
+		isTupleOfGetFields := true
+		for _, tupleExpr := range tuple.Children() {
+			if gf, hit := tupleExpr.(*expression.GetField); !hit {
+				isTupleOfGetFields = false
+				break
+			} else {
+				names = append(names, gf.Name())
+			}
+		}
+		if isTupleOfGetFields {
+			return names, left.Type(ctx), op, right, true
+		}
+	}
+	return nil, nil, 0, nil, false
 }
 
 // buildLeafFromParts constructs an iScanLeaf from a resolved index column name, its type,
 // the scan operation, and the literal expression on the other side of the comparison.
 // litExpr must be nil for unary operations (IsNull, IsNotNull) and non-nil otherwise.
-func (c *indexCoster) buildLeafFromParts(ctx *sql.Context, id indexScanId, name string, typ sql.Type, op sql.IndexScanOp, litExpr sql.Expression) (*iScanLeaf, bool) {
+func (c *indexCoster) buildLeafFromParts(ctx *sql.Context, id indexScanId, name []string, typ sql.Type, op sql.IndexScanOp, litExpr sql.Expression) (*iScanLeaf, bool) {
 	if op == sql.IndexScanOpIsNull || op == sql.IndexScanOpIsNotNull {
-		return &iScanLeaf{id: id, name: name, typ: typ, op: op, underlying: c.underlyingName}, true
+		return newLeafIndexFilter(id, name, typ, op, c.underlyingName)
 	}
 	if op == sql.IndexScanOpInSet || op == sql.IndexScanOpNotInSet {
 		tup := litExpr.(expression.Tuple)
@@ -1608,16 +1847,7 @@ func (c *indexCoster) buildLeafFromParts(ctx *sql.Context, id indexScanId, name 
 				litType = lit.Type(ctx)
 			}
 		}
-		return &iScanLeaf{
-			id:         id,
-			name:       name,
-			typ:        typ,
-			op:         op,
-			setValues:  litSet,
-			setTypes:   setTypes,
-			litType:    litType,
-			underlying: c.underlyingName,
-		}, true
+		return newLeafIndexFilterWithSet(id, name, typ, op, c.underlyingName, litSet, setTypes, litType)
 	}
 	if !isEvaluable(ctx, litExpr) {
 		return nil, false
@@ -1626,15 +1856,7 @@ func (c *indexCoster) buildLeafFromParts(ctx *sql.Context, id indexScanId, name 
 	if err != nil {
 		return nil, false
 	}
-	return &iScanLeaf{
-		id:         id,
-		name:       name,
-		typ:        typ,
-		op:         op,
-		litValue:   value,
-		litType:    litExpr.Type(ctx),
-		underlying: c.underlyingName,
-	}, true
+	return newLeafIndexFilterWithLiteral(id, name, typ, op, c.underlyingName, value, litExpr.Type(ctx))
 }
 
 // buildLeaf tries to convert an expression into the intermediate
@@ -1649,13 +1871,18 @@ func (c *indexCoster) buildLeaf(ctx *sql.Context, id indexScanId, e sql.Expressi
 	if op == sql.IndexScanOpFulltextEq {
 		e := e.(*expression.MatchAgainst)
 		gf := e.Columns[0].(*expression.GetField)
-		return &iScanLeaf{id: id, op: op, name: gf.Name(), typ: gf.Type(ctx), underlying: c.underlyingName, fulltextIndex: e.GetIndex().ID()}, true
+		scanLeaf, ok := newLeafIndexFilter(id, []string{gf.Name()}, gf.Type(ctx), op, c.underlyingName)
+		if !ok {
+			return nil, false
+		}
+		scanLeaf.fulltextIndex = e.GetIndex().ID()
+		return scanLeaf, true
 	}
-	name, typ, normalizedOp, litExpr, ok := c.normalizeLeafSides(ctx, op, left, right)
+	names, typ, normalizedOp, litExpr, ok := c.normalizeLeafSides(ctx, op, left, right)
 	if !ok {
 		return nil, false
 	}
-	return c.buildLeafFromParts(ctx, id, name, typ, normalizedOp, litExpr)
+	return c.buildLeafFromParts(ctx, id, names, typ, normalizedOp, litExpr)
 }
 
 // IndexLeafChildren handles the struct types that may be found on a leaf node while creating indexes.
@@ -1911,19 +2138,36 @@ type conjCollector struct {
 }
 
 func (c *conjCollector) add(ctx *sql.Context, f *iScanLeaf) error {
-	col := strings.ToLower(f.name)
 	c.applied.Add(int(f.Id()))
 	var err error
 	switch f.Op() {
 	case sql.IndexScanOpNullSafeEq:
-		err = c.addEq(ctx, col, f.litValue, true)
+		for _, column := range f.columns {
+			err = c.addEq(ctx, strings.ToLower(column.name), column.litValue, true)
+			if err != nil {
+				return err
+			}
+		}
 	case sql.IndexScanOpEq:
-		err = c.addEq(ctx, col, f.litValue, false)
+		for _, column := range f.columns {
+			err = c.addEq(ctx, strings.ToLower(column.name), column.litValue, false)
+			if err != nil {
+				return err
+			}
+		}
 	case sql.IndexScanOpInSet:
 		// TODO cost UNION of equals
-		err = c.addEq(ctx, col, f.setValues[0], false)
+		if len(f.columns) == 1 {
+			// TODO: This seems incorrect.
+			err = c.addEq(ctx, strings.ToLower(f.columns[0].name), f.setValues[0], false)
+		}
 	default:
-		err = c.addIneq(ctx, f.Op(), col, f.litValue)
+		// We can't currently express the implications of an inequality between tuples, so
+		// those don't inform the FDS. In the future, we can infer some information.
+		// For example, (x, y) > (A, B) implies that x >= A.
+		if len(f.columns) == 1 {
+			err = c.addIneq(ctx, f.Op(), strings.ToLower(f.columns[0].name), f.columns[0].litValue)
+		}
 	}
 	return err
 }

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -114,8 +114,7 @@ func (b *MySQLIndexBuilder) Equals(ctx *Context, colExpr string, keyType Type, k
 	}
 	colTyp, ok := b.colExprTypes[colExpr]
 	if !ok {
-		b.isInvalid = true
-		b.err = ErrInvalidColExpr.New(colExpr, b.idx.ID())
+		// A different column was included in a tuple. This is allowed.
 		return b
 	}
 	potentialRanges := make([]MySQLRangeColumnExpr, len(keys))


### PR DESCRIPTION
Fixes https://github.com/dolthub/dolt/issues/11003

Currently, Dolt will not optimize queries if index columns are used inside tuples. This can create problems for multi-column indexes, in situations where it is natural to represent the entire key as a tuple.

The most likely situation is one where the user wants to delete a specific set of records, and writes a query that looks like this:

```sql
delete from two_pk where (pk1, pk2) in (
  (a1, a2),
  (b1, b2),
  (c1, c2),
   ...
);
```

Currently, Dolt will never optimize this query to use an index. As written, the query will do a full table scan. Alternatively, the user can execute an individual delete statement for each row, but for a table with N rows, this will cause Dolt to write O(log N) garbage chunks for each row deleted. For large datasets, neither option is efficient.

Another workaround would be for the user to rewrite the query into an equivalent query that can be optimized. Such a query might look like this:

```sql
DELETE FROM two_pk WHERE (pk1 = a1 AND pk2 = a2) OR (pk1 = b1 AND pk2 = b2) OR (pk1 = c1 AND pk2 = c2)...
```

However, there's a compelling reason to not require the user to do this: prepared statements.

For example, the python SQL driver allows using a prepared statement like this:

```python
tuples_to_remove = [(a1, a2), (b1, b2), (c1, c2)]
cursor.execute("delete from two_pk where (pk1, pk2) in %s", tuples_to_remove)
```

No equivalent exists for the workaround query: the user would need to manually construct a different query string based on the number of rows to remove, and clients dynamically constructing SQL query strings is typically a bad practice. Thus, it makes sense to support optimizing the original query.

There are two different ways to address this: either improving the analyzer so that it can analyze tuple expressions, or rewriting the filter internally to match the workaround query's filter.

This PR is an attempt to implement the latter, by allowing a single node in the costed index scan tree (the iScanLeaf struct) to describe a filter on multiple index columns.

In hindsight, rewriting the filter might have been easier, and would also better handle cases where only some of the columns in the tuple match the index keys. But such an approach could have its own pitfalls.


