### PR TITLE
Do not allow `CASCADE` and `SET NULL` foreign keys on columns that are referenced by `STORED` generated column expressions

### DIFF
--- a/enginetest/queries/foreign_key_queries.go
+++ b/enginetest/queries/foreign_key_queries.go
@@ -2924,6 +2924,54 @@ var CreateForeignKeyTests = []ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "stored generated column foreign keys",
+		SetUpScript: []string{
+			"create table parent(id int primary key)",
+			"create table child(a int, b int as (a) stored)",
+			"create table child2(a int, b int as (a) virtual)",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:       "alter table child add constraint fk_child foreign key (a) references parent(id) on delete set null;",
+				ExpectedErr: sql.ErrStoredGeneratedColumnForeignKeyConflict,
+			},
+			{
+				// https://github.com/dolthub/dolt/issues/11083
+				Skip:        true,
+				Query:       "alter table child add constraint fk_child foreign key (b) references parent(id) on delete set null;",
+				ExpectedErr: sql.ErrStoredGeneratedColumnForeignKeyConflict,
+			},
+			{
+				Query: "alter table child2 add constraint fk_child foreign key (a) references parent(id) on delete set null;",
+				// This is allowed because the generated column is virtual.
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:       "create table child3(a int, b int as (a) stored, foreign key (a) references parent(id) on update cascade);",
+				ExpectedErr: sql.ErrStoredGeneratedColumnForeignKeyConflict,
+			},
+			{
+				// https://github.com/dolthub/dolt/issues/11083
+				Skip:        true,
+				Query:       "create table child3(a int, b int as (a) stored, foreign key (b) references parent(id) on update cascade);",
+				ExpectedErr: sql.ErrStoredGeneratedColumnForeignKeyConflict,
+			},
+			{
+				// https://github.com/dolthub/dolt/issues/11082
+				Skip:        true,
+				Query:       "select * from child3",
+				ExpectedErr: sql.ErrTableNotFound,
+			},
+			{
+				// This should be child3, but we have to use child4 here due to tables still being created despite
+				// erroring out https://github.com/dolthub/dolt/issues/11082
+				Query: "create table child4(a int, b int as (a) virtual, foreign key (a) references parent(id) on update cascade);",
+				// This is allowed because the generated column is virtual.
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+		},
+	},
 }
 
 var DropForeignKeyTests = []ScriptTest{

--- a/sql/constraints.go
+++ b/sql/constraints.go
@@ -44,7 +44,7 @@ func (f ForeignKeyReferentialAction) IsEquivalentToRestrict() bool {
 	}
 }
 
-func (f ForeignKeyReferentialAction) AllowGeneratedColumnReference() bool {
+func (f ForeignKeyReferentialAction) allowStoredGeneratedColumnReference() bool {
 	switch f {
 	case ForeignKeyReferentialAction_Cascade, ForeignKeyReferentialAction_SetNull:
 		return false
@@ -97,6 +97,10 @@ func (f *ForeignKeyConstraint) DebugString(ctx *Context) string {
 		f.ParentTable,
 		strings.Join(f.ParentColumns, ","),
 	)
+}
+
+func (f *ForeignKeyConstraint) AllowStoredGeneratedColumnReference() bool {
+	return f.OnDelete.allowStoredGeneratedColumnReference() && f.OnUpdate.allowStoredGeneratedColumnReference()
 }
 
 type ForeignKeyConstraints []*ForeignKeyConstraint

--- a/sql/constraints.go
+++ b/sql/constraints.go
@@ -20,7 +20,8 @@ import (
 )
 
 // ForeignKeyReferentialAction is the behavior for this foreign key with the relevant action is performed on the foreign
-// table.
+// table. It is equivalent to the reference_option in MySQL.
+// https://dev.mysql.com/doc/refman/8.4/en/create-table-foreign-keys.html#foreign-key-referential-actions
 type ForeignKeyReferentialAction string
 
 const (
@@ -37,6 +38,15 @@ const (
 func (f ForeignKeyReferentialAction) IsEquivalentToRestrict() bool {
 	switch f {
 	case ForeignKeyReferentialAction_Cascade, ForeignKeyReferentialAction_SetNull, ForeignKeyReferentialAction_SetDefault:
+		return false
+	default:
+		return true
+	}
+}
+
+func (f ForeignKeyReferentialAction) AllowGeneratedColumnReference() bool {
+	switch f {
+	case ForeignKeyReferentialAction_Cascade, ForeignKeyReferentialAction_SetNull:
 		return false
 	default:
 		return true

--- a/sql/constraints.go
+++ b/sql/constraints.go
@@ -44,8 +44,12 @@ func (f ForeignKeyReferentialAction) IsEquivalentToRestrict() bool {
 	}
 }
 
+// allowStoredGeneratedColumnReference returns whether the referential action is allowed when the foreign key is on a
+// column that is referenced by a stored generated column.
 func (f ForeignKeyReferentialAction) allowStoredGeneratedColumnReference() bool {
 	switch f {
+	// MySQL documentation includes SET DEFAULT, but actual MySQL behavior doesn't seem to follow the documentation.
+	// https://dev.mysql.com/doc/refman/8.4/en/create-table-foreign-keys.html#foreign-key-referential-actions
 	case ForeignKeyReferentialAction_Cascade, ForeignKeyReferentialAction_SetNull:
 		return false
 	default:

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -987,8 +987,9 @@ var (
 	// ErrWrongDBName is returned for illegal database names with the [mysql.ERWrongDbName] error code and [mysql.SSClientError] SQLSTATE.
 	ErrWrongDBName = newMySQLKind("Incorrect database name '%s'", mysql.ERWrongDbName, mysql.SSClientError)
 
-	// ErrInvalidForeignKeyConstraint is returned when a foreign key constraint cannot be added
-	ErrInvalidForeignKeyConstraint = errors.NewKind("Cannot add foreign key constraint")
+	// ErrStoredGeneratedColumnForeignKeyConflict is returned when a foreign key references a column also referenced by
+	// a stored generated column
+	ErrStoredGeneratedColumnForeignKeyConflict = errors.NewKind("Cannot add foreign key on the base column of a stored generated column.")
 )
 
 // CastSQLError returns a *mysql.SQLError with the error code and in some cases, also a SQL state, populated for the

--- a/sql/errors.go
+++ b/sql/errors.go
@@ -986,6 +986,9 @@ var (
 
 	// ErrWrongDBName is returned for illegal database names with the [mysql.ERWrongDbName] error code and [mysql.SSClientError] SQLSTATE.
 	ErrWrongDBName = newMySQLKind("Incorrect database name '%s'", mysql.ERWrongDbName, mysql.SSClientError)
+
+	// ErrInvalidForeignKeyConstraint is returned when a foreign key constraint cannot be added
+	ErrInvalidForeignKeyConstraint = errors.NewKind("Cannot add foreign key constraint")
 )
 
 // CastSQLError returns a *mysql.SQLError with the error code and in some cases, also a SQL state, populated for the

--- a/sql/plan/alter_foreign_key.go
+++ b/sql/plan/alter_foreign_key.go
@@ -112,6 +112,10 @@ var ValidateForeignKeyDefinition = validateForeignKeyDefinition
 // data as necessary.
 // fkChecks - whether to check the foreign key against the data in the table
 // checkRows - whether to check the existing rows in the table against the foreign key
+// TODO: This function is called in too many different places for different purposes, with varying flags such as
+// shouldAdd, fkChecks, and checkRows to indicate what parts of the function should and shouldn't be called. It would be
+// better to break this function up into parts and just call the parts that are necessary. Note that fkChecks is always
+// true when shouldAdd is false.
 func ResolveForeignKey(ctx *sql.Context, tbl sql.ForeignKeyTable, refTbl sql.ForeignKeyTable, fkDef sql.ForeignKeyConstraint, shouldAdd, fkChecks, checkRows bool) error {
 	if t, ok := tbl.(sql.TemporaryTable); ok && t.IsTemporary() {
 		return sql.ErrTemporaryTablesForeignKeySupport.New()

--- a/sql/plan/ddl.go
+++ b/sql/plan/ddl.go
@@ -352,48 +352,12 @@ func (*CreateTable) CollationCoercibility(_ *sql.Context) (collation sql.Collati
 	return sql.Collation_binary, 7
 }
 
-// CreateForeignKeys creates the foreign keys on the table.
-func (c *CreateTable) CreateForeignKeys(ctx *sql.Context, tableNode sql.Table) error {
-	fkTbl, ok := tableNode.(sql.ForeignKeyTable)
-	if !ok {
-		return sql.ErrNoForeignKeySupport.New(c.name)
-	}
-
-	fkChecks, err := ctx.GetSessionVariable(ctx, "foreign_key_checks")
-	if err != nil {
-		return err
-	}
-
-	for i, fkDef := range c.fkDefs {
-		if fkChecks.(int8) == 1 {
-			fkParentTbl := c.fkParentTbls[i]
-			// If a foreign key is self-referential then the analyzer uses a nil since the table does not yet exist
-			if fkParentTbl == nil {
-				fkParentTbl = fkTbl
-			}
-			// If foreign_key_checks are true, then the referenced tables will be populated
-			err = ResolveForeignKey(ctx, fkTbl, fkParentTbl, *fkDef, true, true, true)
-			if err != nil {
-				return err
-			}
-		} else {
-			// If foreign_key_checks are true, then the referenced tables will be populated
-			err = ResolveForeignKey(ctx, fkTbl, nil, *fkDef, true, false, false)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
 // ForeignKeys returns any foreign keys that will be declared on this table.
 func (c *CreateTable) ForeignKeys() []*sql.ForeignKeyConstraint {
 	return c.fkDefs
 }
 
-// WithParentForeignKeyTables adds the tables that are referenced in each foreign key. The table indices is assumed
+// WithParentForeignKeyTables adds the tables that are referenced in each foreign key. The table indices are assumed
 // to match the foreign key indices in their respective slices.
 func (c *CreateTable) WithParentForeignKeyTables(refTbls []sql.ForeignKeyTable) (*CreateTable, error) {
 	if len(c.fkDefs) != len(refTbls) {
@@ -403,6 +367,12 @@ func (c *CreateTable) WithParentForeignKeyTables(refTbls []sql.ForeignKeyTable) 
 	nc := *c
 	nc.fkParentTbls = refTbls
 	return &nc, nil
+}
+
+// ParentForeignKeyTables returns tables that are referenced in each foreign key. The table indices are assumed to match
+// the foreign key indices in their respective slices.
+func (c *CreateTable) ParentForeignKeyTables() sql.ForeignKeyTables {
+	return c.fkParentTbls
 }
 
 // CreateChecks creates the check constraints on the table.

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -17,6 +17,8 @@ package rowexec
 import (
 	"bufio"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"io"
 	"os"
 	"strings"
@@ -1248,7 +1250,7 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 	}
 
 	if len(n.ForeignKeys()) > 0 {
-		err = n.CreateForeignKeys(ctx, tableNode)
+		err = b.buildCreateTableForeignKeys(ctx, n, tableNode)
 		if err != nil {
 			return sql.RowsToRowIter(), err
 		}
@@ -1268,6 +1270,105 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 	}
 
 	return rowIterWithOkResultWithZeroRowsAffected(), nil
+}
+
+// buildCreateTableForeignKeys creates, validates, and resolves the foreign keys that are part of a CreateTable
+func (b *BaseBuilder) buildCreateTableForeignKeys(ctx *sql.Context, n *plan.CreateTable, tableNode sql.Table) error {
+	fkTbl, ok := tableNode.(sql.ForeignKeyTable)
+	if !ok {
+		return sql.ErrNoForeignKeySupport.New(n.Name())
+	}
+
+	fkChecks, err := ctx.GetSessionVariable(ctx, "foreign_key_checks")
+	if err != nil {
+		return err
+	}
+
+	// check fkTbl for generated columns
+	// if need to resolve generated column, resolve and flag base columns
+	// when iterating over foreign key definitions, check if fk column is ever used as base column (when appropriate)
+	generatedColumnRefs := b.generatedColumnReferences(ctx, fkTbl.Name(), fkTbl.Schema(ctx))
+	parentForeignKeyTables := n.ParentForeignKeyTables()
+	for i, fkDef := range n.ForeignKeys() {
+		err = validateForeignKeyGeneratedColumnRefs(fkDef, generatedColumnRefs)
+		if err != nil {
+			return err
+		}
+		if fkChecks.(int8) == 1 {
+			fkParentTbl := parentForeignKeyTables[i]
+			// If a foreign key is self-referential then the analyzer uses a nil since the table does not yet exist
+			if fkParentTbl == nil {
+				fkParentTbl = fkTbl
+			}
+			// If foreign_key_checks are true, then the referenced tables will be populated
+			err = plan.ResolveForeignKey(ctx, fkTbl, fkParentTbl, *fkDef, true, true, true)
+			if err != nil {
+				return err
+			}
+		} else {
+			// If foreign_key_checks are true, then the referenced tables will be populated
+			err = plan.ResolveForeignKey(ctx, fkTbl, nil, *fkDef, true, false, false)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateForeignKeyGeneratedColumnRefs(fkDef *sql.ForeignKeyConstraint, generatedColumnRefs map[string]bool) error {
+	if generatedColumnRefs == nil ||
+		(fkDef.OnDelete.AllowGeneratedColumnReference() && fkDef.OnUpdate.AllowGeneratedColumnReference()) {
+		return nil
+	}
+	for _, col := range fkDef.Columns {
+		if contains, ok := generatedColumnRefs[col]; contains && ok {
+			return sql.ErrInvalidForeignKeyConstraint.New()
+		}
+	}
+	return nil
+}
+
+// generatedColumnReferences resolves any generated columns, inspects them for references to other columns, and returns
+// whether a base column is referenced by a generated column
+func (b *BaseBuilder) generatedColumnReferences(ctx *sql.Context, tableName string, schema sql.Schema) map[string]bool {
+	resolvedSchema, hasGeneratedColumn := b.resolveGeneratedColumns(ctx, ctx.GetCurrentDatabase(), tableName, schema)
+	if hasGeneratedColumn {
+		refs := make(map[string]bool)
+		for _, col := range resolvedSchema {
+			if col.Generated != nil {
+				if !col.Generated.IsLiteral() {
+					sql.Inspect(ctx, col.Generated.Expr, func(ctx *sql.Context, e sql.Expression) bool {
+						if colRef, ok := e.(*expression.GetField); ok {
+							refs[colRef.Name()] = true
+							return false
+						}
+						return true
+					})
+				}
+			}
+		}
+		return refs
+	}
+	return nil
+}
+
+// resolveGeneratedColumns checks for any unresolved virtual/generated column expressions and resolves them if needed,
+// also returning a flag indicating if a generated column is present
+func (b *BaseBuilder) resolveGeneratedColumns(ctx *sql.Context, dbName, tableName string, schema sql.Schema) (sql.Schema, bool) {
+	hasGeneratedColumns := false
+	for _, col := range schema {
+		if col.Generated != nil {
+			hasGeneratedColumns = true
+			if !col.Generated.Resolved() {
+				// TODO: calling ResolveSchemaDefaults here might be doing too much since we likely only need the generated
+				//  columns to be resolved
+				return planbuilder.NewBuilderForColumnDefaultResolution(ctx, b.EngineOverrides).ResolveSchemaDefaults(dbName, tableName, schema), true
+			}
+		}
+	}
+	return schema, hasGeneratedColumns
 }
 
 func createIndexesForCreateTable(ctx *sql.Context, db sql.Database, tableNode sql.Table, idxes sql.IndexDefs) (err error) {

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -17,6 +17,8 @@ package rowexec
 import (
 	"bufio"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"io"
 	"os"
 	"strings"
@@ -26,11 +28,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/plan"
-	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -1284,13 +1284,10 @@ func (b *BaseBuilder) buildCreateTableForeignKeys(ctx *sql.Context, n *plan.Crea
 		return err
 	}
 
-	// check fkTbl for generated columns
-	// if need to resolve generated column, resolve and flag base columns
-	// when iterating over foreign key definitions, check if fk column is ever used as base column (when appropriate)
-	generatedColumnRefs := b.generatedColumnReferences(ctx, fkTbl.Name(), fkTbl.Schema(ctx))
+	storedGeneratedColumnRefs := b.storedGeneratedColumnReferences(ctx, fkTbl.Name(), fkTbl.Schema(ctx))
 	parentForeignKeyTables := n.ParentForeignKeyTables()
 	for i, fkDef := range n.ForeignKeys() {
-		err = validateForeignKeyGeneratedColumnRefs(fkDef, generatedColumnRefs)
+		err = validateForeignKeyStoredGeneratedColumnRefs(fkDef, storedGeneratedColumnRefs)
 		if err != nil {
 			return err
 		}
@@ -1317,58 +1314,54 @@ func (b *BaseBuilder) buildCreateTableForeignKeys(ctx *sql.Context, n *plan.Crea
 	return nil
 }
 
-func validateForeignKeyGeneratedColumnRefs(fkDef *sql.ForeignKeyConstraint, generatedColumnRefs map[string]bool) error {
-	if generatedColumnRefs == nil ||
+func validateForeignKeyStoredGeneratedColumnRefs(fkDef *sql.ForeignKeyConstraint, storedGeneratedColumnRefs map[string]bool) error {
+	if storedGeneratedColumnRefs == nil ||
 		(fkDef.OnDelete.AllowGeneratedColumnReference() && fkDef.OnUpdate.AllowGeneratedColumnReference()) {
 		return nil
 	}
 	for _, col := range fkDef.Columns {
-		if contains, ok := generatedColumnRefs[col]; contains && ok {
+		if contains, ok := storedGeneratedColumnRefs[col]; contains && ok {
 			return sql.ErrInvalidForeignKeyConstraint.New()
 		}
 	}
 	return nil
 }
 
-// generatedColumnReferences resolves any generated columns, inspects them for references to other columns, and returns
-// whether a base column is referenced by a generated column
-func (b *BaseBuilder) generatedColumnReferences(ctx *sql.Context, tableName string, schema sql.Schema) map[string]bool {
-	resolvedSchema, hasGeneratedColumn := b.resolveGeneratedColumns(ctx, ctx.GetCurrentDatabase(), tableName, schema)
-	if hasGeneratedColumn {
+// storedGeneratedColumnReferences resolves any stored generated columns, inspects them for references to other columns,
+// and returns a set of base columns referenced by any stored generated columns
+func (b *BaseBuilder) storedGeneratedColumnReferences(ctx *sql.Context, tableName string, schema sql.Schema) map[string]bool {
+	hasStoredGeneratedColumn := false
+	for _, col := range schema {
+		if !col.Virtual && col.Generated != nil {
+			hasStoredGeneratedColumn = true
+			if !col.Generated.Resolved() {
+				// TODO: calling ResolveSchemaDefaults here is doing too much since we only need the stored generated
+				//  columns to be resolved. We are currently not able to do so because planbuilder.scope and
+				//  planbuilder.resolveColumnDefaultExpression are both unexported.
+				schema = planbuilder.NewBuilderForColumnDefaultResolution(ctx, b.EngineOverrides).
+					ResolveSchemaDefaults(ctx.GetCurrentDatabase(), tableName, schema)
+				break
+			}
+		}
+	}
+	if hasStoredGeneratedColumn {
 		refs := make(map[string]bool)
-		for _, col := range resolvedSchema {
-			if col.Generated != nil {
-				if !col.Generated.IsLiteral() {
-					sql.Inspect(ctx, col.Generated.Expr, func(ctx *sql.Context, e sql.Expression) bool {
-						if colRef, ok := e.(*expression.GetField); ok {
-							refs[colRef.Name()] = true
-							return false
-						}
-						return true
-					})
-				}
+		// TODO: second pass through the schema would not be necessary if we're able to resolve individual column
+		//  expressions.
+		for _, col := range schema {
+			if !col.Virtual && col.Generated != nil {
+				sql.Inspect(ctx, col.Generated.Expr, func(ctx *sql.Context, e sql.Expression) bool {
+					if colRef, ok := e.(*expression.GetField); ok {
+						refs[colRef.Name()] = true
+						return false
+					}
+					return true
+				})
 			}
 		}
 		return refs
 	}
 	return nil
-}
-
-// resolveGeneratedColumns checks for any unresolved virtual/generated column expressions and resolves them if needed,
-// also returning a flag indicating if a generated column is present
-func (b *BaseBuilder) resolveGeneratedColumns(ctx *sql.Context, dbName, tableName string, schema sql.Schema) (sql.Schema, bool) {
-	hasGeneratedColumns := false
-	for _, col := range schema {
-		if col.Generated != nil {
-			hasGeneratedColumns = true
-			if !col.Generated.Resolved() {
-				// TODO: calling ResolveSchemaDefaults here might be doing too much since we likely only need the generated
-				//  columns to be resolved
-				return planbuilder.NewBuilderForColumnDefaultResolution(ctx, b.EngineOverrides).ResolveSchemaDefaults(dbName, tableName, schema), true
-			}
-		}
-	}
-	return schema, hasGeneratedColumns
 }
 
 func createIndexesForCreateTable(ctx *sql.Context, db sql.Database, tableNode sql.Table, idxes sql.IndexDefs) (err error) {

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -1315,8 +1315,7 @@ func (b *BaseBuilder) buildCreateTableForeignKeys(ctx *sql.Context, n *plan.Crea
 }
 
 func validateForeignKeyStoredGeneratedColumnRefs(fkDef *sql.ForeignKeyConstraint, storedGeneratedColumnRefs map[string]bool) error {
-	if storedGeneratedColumnRefs == nil ||
-		(fkDef.OnDelete.AllowGeneratedColumnReference() && fkDef.OnUpdate.AllowGeneratedColumnReference()) {
+	if storedGeneratedColumnRefs == nil || fkDef.AllowStoredGeneratedColumnReference() {
 		return nil
 	}
 	for _, col := range fkDef.Columns {

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -1284,7 +1284,7 @@ func (b *BaseBuilder) buildCreateTableForeignKeys(ctx *sql.Context, n *plan.Crea
 		return err
 	}
 
-	storedGeneratedColumnRefs := b.storedGeneratedColumnReferences(ctx, fkTbl.Name(), fkTbl.Schema(ctx))
+	storedGeneratedColumnRefs := b.storedGeneratedColumnReferences(ctx, fkTbl)
 	parentForeignKeyTables := n.ParentForeignKeyTables()
 	for i, fkDef := range n.ForeignKeys() {
 		err = validateForeignKeyStoredGeneratedColumnRefs(fkDef, storedGeneratedColumnRefs)
@@ -1320,7 +1320,7 @@ func validateForeignKeyStoredGeneratedColumnRefs(fkDef *sql.ForeignKeyConstraint
 	}
 	for _, col := range fkDef.Columns {
 		if contains, ok := storedGeneratedColumnRefs[col]; contains && ok {
-			return sql.ErrInvalidForeignKeyConstraint.New()
+			return sql.ErrStoredGeneratedColumnForeignKeyConflict.New()
 		}
 	}
 	return nil
@@ -1328,8 +1328,9 @@ func validateForeignKeyStoredGeneratedColumnRefs(fkDef *sql.ForeignKeyConstraint
 
 // storedGeneratedColumnReferences resolves any stored generated columns, inspects them for references to other columns,
 // and returns a set of base columns referenced by any stored generated columns
-func (b *BaseBuilder) storedGeneratedColumnReferences(ctx *sql.Context, tableName string, schema sql.Schema) map[string]bool {
+func (b *BaseBuilder) storedGeneratedColumnReferences(ctx *sql.Context, table sql.ForeignKeyTable) map[string]bool {
 	hasStoredGeneratedColumn := false
+	schema := table.Schema(ctx)
 	for _, col := range schema {
 		if !col.Virtual && col.Generated != nil {
 			hasStoredGeneratedColumn = true
@@ -1338,7 +1339,7 @@ func (b *BaseBuilder) storedGeneratedColumnReferences(ctx *sql.Context, tableNam
 				//  columns to be resolved. We are currently not able to do so because planbuilder.scope and
 				//  planbuilder.resolveColumnDefaultExpression are both unexported.
 				schema = planbuilder.NewBuilderForColumnDefaultResolution(ctx, b.EngineOverrides).
-					ResolveSchemaDefaults(ctx.GetCurrentDatabase(), tableName, schema)
+					ResolveSchemaDefaults(ctx.GetCurrentDatabase(), table.Name(), schema)
 				break
 			}
 		}
@@ -1567,11 +1568,14 @@ func (b *BaseBuilder) buildCreateForeignKey(ctx *sql.Context, n *plan.CreateFore
 		return nil, sql.ErrNoForeignKeySupport.New(n.FkDef.ParentTable)
 	}
 
+	err = validateForeignKeyStoredGeneratedColumnRefs(n.FkDef, b.storedGeneratedColumnReferences(ctx, fkTbl))
+	if err != nil {
+		return nil, err
+	}
 	fkChecks, err := ctx.GetSessionVariable(ctx, "foreign_key_checks")
 	if err != nil {
 		return nil, err
 	}
-
 	err = plan.ResolveForeignKey(ctx, fkTbl, refFkTbl, *n.FkDef, true, fkChecks.(int8) == 1, true)
 	if err != nil {
 		return nil, err

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -1186,8 +1186,9 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 		}
 	}
 
-	// TODO: in the event that foreign keys or indexes aren't supported, you'll be left with a created table and no foreign keys/indexes
-	// this also means that if a foreign key or index fails, you'll only have what was declared up to the failure
+	// TODO: in the event that foreign keys or indexes aren't supported, you'll be left with a created table and no
+	//  foreign keys/indexes This also means that if a foreign key or index fails, the table will still have been
+	//  created anyways, just without the foreign key or index https://github.com/dolthub/dolt/issues/11082
 	tableNode, ok, err := n.Db.GetTableInsensitive(ctx, n.Name())
 	if err != nil {
 		return sql.RowsToRowIter(), err
@@ -1314,6 +1315,8 @@ func (b *BaseBuilder) buildCreateTableForeignKeys(ctx *sql.Context, n *plan.Crea
 	return nil
 }
 
+// validateForeignKeyStoredGeneratedColumnRefs checks if there are any conflicts between foreign key referential actions
+// and stored generated columns
 func validateForeignKeyStoredGeneratedColumnRefs(fkDef *sql.ForeignKeyConstraint, storedGeneratedColumnRefs map[string]bool) error {
 	if storedGeneratedColumnRefs == nil || fkDef.AllowStoredGeneratedColumnReference() {
 		return nil

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -17,8 +17,6 @@ package rowexec
 import (
 	"bufio"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/expression"
-	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"io"
 	"os"
 	"strings"
@@ -28,9 +26,11 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -17,7 +17,6 @@ package rowexec
 import (
 	"bufio"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"io"
 	"strings"
 	"sync"
@@ -34,6 +33,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/plan"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -33,7 +33,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/mysql_db"
 	"github.com/dolthub/go-mysql-server/sql/plan"
-	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
@@ -1524,16 +1523,7 @@ func (i addColumnIter) Close(context *sql.Context) error {
 
 // rewriteTable rewrites the table given if required or requested, and returns whether it was rewritten
 func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) (bool, error) {
-	targetSch := i.a.TargetSchema()
-	for _, col := range targetSch {
-		// To correctly update secondary indexes that store values from virtual
-		// generated columns, the generated expression must be resolved.
-		if col.Virtual && col.Generated != nil && !col.Generated.Resolved() {
-			b := planbuilder.NewBuilderForColumnDefaultResolution(ctx, i.b.EngineOverrides)
-			targetSch = b.ResolveSchemaDefaults(i.a.Db.Name(), rwt.Name(), targetSch)
-			break
-		}
-	}
+	targetSch, _ := i.b.resolveGeneratedColumns(ctx, i.a.Db.Name(), rwt.Name(), i.a.TargetSchema())
 	newSch, projections, err := addColumnToSchema(ctx, targetSch, i.a.Column(), i.a.Order(ctx))
 	if err != nil {
 		return false, err

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -17,6 +17,7 @@ package rowexec
 import (
 	"bufio"
 	"fmt"
+	"github.com/dolthub/go-mysql-server/sql/planbuilder"
 	"io"
 	"strings"
 	"sync"
@@ -1523,7 +1524,16 @@ func (i addColumnIter) Close(context *sql.Context) error {
 
 // rewriteTable rewrites the table given if required or requested, and returns whether it was rewritten
 func (i *addColumnIter) rewriteTable(ctx *sql.Context, rwt sql.RewritableTable) (bool, error) {
-	targetSch, _ := i.b.resolveGeneratedColumns(ctx, i.a.Db.Name(), rwt.Name(), i.a.TargetSchema())
+	targetSch := i.a.TargetSchema()
+	for _, col := range targetSch {
+		// To correctly update secondary indexes that store values from virtual
+		// generated columns, the generated expression must be resolved.
+		if col.Virtual && col.Generated != nil && !col.Generated.Resolved() {
+			b := planbuilder.NewBuilderForColumnDefaultResolution(ctx, i.b.EngineOverrides)
+			targetSch = b.ResolveSchemaDefaults(i.a.Db.Name(), rwt.Name(), targetSch)
+			break
+		}
+	}
 	newSch, projections, err := addColumnToSchema(ctx, targetSch, i.a.Column(), i.a.Order(ctx))
 	if err != nil {
 		return false, err


### PR DESCRIPTION
fixes dolthub/dolt#11065

According to the [MySQL docs](https://dev.mysql.com/doc/refman/8.4/en/create-table-foreign-keys.html#foreign-key-referential-actions):
> A foreign key constraint on the base column of a stored generated column cannot use `CASCADE`, `SET NULL`, or `SET DEFAULT` as `ON UPDATE` or `ON DELETE` referential actions.

(This is actually not totally true because I was able to create a such foreign key constraint with a `SET DEFAULT` referential action in MySQL)

This PR prevents adding such foreign key constraints (with the exception of `SET DEFAULT`) during `CREATE TABLE` and `ALTER TABLE`. Note that in MySQL, the error messages for creating a new table with an invalid foreign key and adding an invalid foreign key to an existing table are different (`Cannot add foreign key constraint` vs `Cannot add foreign key on the base column of stored column.`), but I've decided to use the same error message for both cases (`Cannot add foreign key on the base column of a stored generated column.`).

`CreateTable.CreateForeignKeys` was removed and replaced with `BaseBuilder.buildCreateTableForeignKeys` to avoid a cyclical import.