### PR TITLE
Fix `CHAR_LENGTH` and `LIKE` failing on the replacement character

### DIFF
--- a/enginetest/queries/charset_collation_engine.go
+++ b/enginetest/queries/charset_collation_engine.go
@@ -880,6 +880,13 @@ var CharsetCollationEngineTests = []CharsetCollationEngineTest{
 					{int32(6)},
 				},
 			},
+			{
+				// See https://github.com/dolthub/dolt/issues/11088
+				Query: "SELECT CHAR_LENGTH(_utf8mb4'\xef\xbf\xbd' COLLATE utf8mb4_0900_bin);",
+				Expected: []sql.Row{
+					{int32(1)},
+				},
+			},
 		},
 	},
 	{

--- a/sql/expression/function/length.go
+++ b/sql/expression/function/length.go
@@ -138,7 +138,10 @@ func (l *Length) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		contentLen := int32(0)
 		for len(content) > 0 {
 			cr, cRead := charSetEncoder.NextRune(content)
-			if cRead == 0 || cr == utf8.RuneError {
+			// NextRune only pairs utf8.RuneError with an advance of one byte or fewer for a
+			// genuinely malformed sequence. The replacement character U+FFFD is valid and
+			// decodes to three bytes, so it must not be rejected here.
+			if cr == utf8.RuneError && cRead <= 1 {
 				return 0, sql.ErrCollationMalformedString.New("checking length")
 			}
 			content = content[cRead:]

--- a/sql/expression/function/length_test.go
+++ b/sql/expression/function/length_test.go
@@ -16,6 +16,7 @@ package function
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -101,6 +102,14 @@ func TestLength(t *testing.T) {
 			types.Blob,
 			NewCharLength,
 			nil,
+		},
+		{
+			// See https://github.com/dolthub/dolt/issues/11088
+			"char_length replacement character",
+			string(utf8.RuneError), // U+FFFD, 0xEFBFBD
+			types.LongText,
+			NewCharLength,
+			int32(1),
 		},
 	}
 

--- a/sql/expression/like.go
+++ b/sql/expression/like.go
@@ -303,7 +303,10 @@ func ConstructLikeMatcher(collation sql.CollationID, pattern string, escape rune
 	matcher := LikeMatcher{nil, collation, escape}
 	for i := 0; i < len(pattern); {
 		nextRune, advance := charsetEncoder.NextRune(pattern[i:])
-		if nextRune == utf8.RuneError {
+		// NextRune only pairs utf8.RuneError with an advance of one byte or fewer for a
+		// genuinely malformed sequence. The replacement character U+FFFD is valid and
+		// decodes to three bytes, so it must not be rejected here.
+		if nextRune == utf8.RuneError && advance <= 1 {
 			return LikeMatcher{}, sql.ErrCharSetInvalidString.New(collation.CharacterSet().Name(), pattern)
 		}
 		i += advance
@@ -315,7 +318,7 @@ func ConstructLikeMatcher(collation sql.CollationID, pattern string, escape rune
 			matcher.nodes = append(matcher.nodes, likeMatcherAny{})
 		case escape: // States that the next character should be taken literally
 			nextRune, advance = charsetEncoder.NextRune(pattern[i:])
-			if nextRune == utf8.RuneError {
+			if nextRune == utf8.RuneError && advance <= 1 {
 				return LikeMatcher{}, sql.ErrCharSetInvalidString.New(collation.CharacterSet().Name(), pattern)
 			}
 			i += advance
@@ -369,7 +372,7 @@ func (l LikeMatcher) Match(s string) bool {
 		}
 
 		nextRune, advance := charsetEncoder.NextRune(s[stringIndex:])
-		if nextRune == utf8.RuneError {
+		if nextRune == utf8.RuneError && advance <= 1 {
 			return false
 		}
 		matched, consumed := l.nodes[nodeIndex].Match(l.collation, nextRune)
@@ -429,7 +432,7 @@ func (l LikeMatcher) backtrack(s string, nodeIndex int, nodeNextIndex []int) (ma
 	for ; nodeIndex >= 0; nodeIndex-- {
 		stringIndex := nodeNextIndex[nodeIndex]
 		nextRune, advance := charsetEncoder.NextRune(s[stringIndex:])
-		if nextRune == utf8.RuneError {
+		if nextRune == utf8.RuneError && advance <= 1 {
 			return false, 0
 		}
 		if l.nodes[nodeIndex].MatchNext(l.collation, nextRune) {

--- a/sql/expression/like_test.go
+++ b/sql/expression/like_test.go
@@ -17,6 +17,7 @@ package expression
 import (
 	"fmt"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 
@@ -115,6 +116,10 @@ func TestLike(t *testing.T) {
 		{`a\\\b`, "a", "", false, sql.Collation_utf8mb4_0900_ai_ci},
 		{`A%%%%`, "abc", "", true, sql.Collation_utf8mb4_0900_ai_ci},
 		{`A%%%%bc`, "abc", "", true, sql.Collation_utf8mb4_0900_ai_ci},
+		// See https://github.com/dolthub/dolt/issues/11088
+		{string(utf8.RuneError), string(utf8.RuneError), "", true, sql.Collation_utf8mb4_0900_ai_ci}, // U+FFFD, 0xEFBFBD
+		{"%", string(utf8.RuneError), "", true, sql.Collation_utf8mb4_0900_ai_ci},
+		{"_", string(utf8.RuneError), "", true, sql.Collation_utf8mb4_0900_ai_ci},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
The replacement character (Unicode `U+FFFD`, shown when text gets garbled during encoding conversion) is a normal, valid character.  But `CHAR_LENGTH` would error on it instead of counting it. The fix adds that size check, so the valid character (3 bytes) is accepted while genuinely broken input (1 byte) is still rejected.
Fix dolthub/dolt#11088