### PR TITLE
Unwrap wrapped strings before casting to string during `RegexpReplace.Eval`

### DIFF
--- a/sql/expression/function/oct_test.go
+++ b/sql/expression/function/oct_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
-type test struct {
+type testCase struct {
 	name     string
 	nType    sql.Type
 	row      sql.Row
@@ -31,7 +31,7 @@ type test struct {
 }
 
 func TestOct(t *testing.T) {
-	tests := []test{
+	testCases := []testCase{
 		// NULL input
 		{"n is nil", types.Int32, sql.NewRow(nil), nil},
 
@@ -65,7 +65,7 @@ func TestOct(t *testing.T) {
 		{"negative decimal", types.Float64, sql.NewRow(-15.5), "1777777777777777777761"},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			f := NewOct(sql.NewEmptyContext(), expression.NewGetField(0, tt.nType, "n", true))
 			result, err := f.Eval(sql.NewEmptyContext(), tt.row)

--- a/sql/expression/function/regexp_replace.go
+++ b/sql/expression/function/regexp_replace.go
@@ -220,6 +220,10 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 	if err != nil {
 		return nil, err
 	}
+	text, err = sql.UnwrapAny(ctx, text)
+	if err != nil {
+		return nil, err
+	}
 
 	rText, err := r.RText.Eval(ctx, row)
 	if err != nil {
@@ -229,6 +233,10 @@ func (r *RegexpReplace) Eval(ctx *sql.Context, row sql.Row) (val interface{}, er
 		return nil, nil
 	}
 	rText, _, err = types.LongText.Convert(ctx, rText)
+	if err != nil {
+		return nil, err
+	}
+	rText, err = sql.UnwrapAny(ctx, rText)
 	if err != nil {
 		return nil, err
 	}

--- a/sql/expression/function/regexp_replace_test.go
+++ b/sql/expression/function/regexp_replace_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/go-mysql-server/test"
 )
 
 func TestRegexpReplaceInvalidArgNumber(t *testing.T) {
@@ -111,6 +112,15 @@ func TestRegexpReplace(t *testing.T) {
 		{
 			"valid case",
 			sql.NewRow("abc def ghi", `[a-z]`, "X"),
+			"XXX XXX XXX",
+			false,
+		},
+		{
+			"string wrapper input",
+			sql.NewRow(
+				test.NewMockStringWrapper("abc def ghi"),
+				test.NewMockStringWrapper(`[a-z]`),
+				test.NewMockStringWrapper("X")),
 			"XXX XXX XXX",
 			false,
 		},

--- a/sql/types/jsontests/json_test.go
+++ b/sql/types/jsontests/json_test.go
@@ -26,35 +26,8 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/types"
+	"github.com/dolthub/go-mysql-server/test"
 )
-
-type mockStringWrapper struct {
-	val string
-}
-
-func (m mockStringWrapper) Unwrap(ctx context.Context) (string, error) {
-	return m.val, nil
-}
-
-func (m mockStringWrapper) UnwrapAny(ctx context.Context) (interface{}, error) {
-	return m.val, nil
-}
-
-func (m mockStringWrapper) IsExactLength() bool {
-	return false
-}
-
-func (m mockStringWrapper) MaxByteLength() int64 {
-	return int64(len(m.val))
-}
-
-func (m mockStringWrapper) Compare(ctx context.Context, other interface{}) (int, bool, error) {
-	return 0, false, nil
-}
-
-func (m mockStringWrapper) Hash() interface{} {
-	return m.val
-}
 
 func TestJsonCompare(t *testing.T) {
 	RunJsonCompareTests(t, JsonCompareTests, func(t *testing.T, left, right interface{}) (interface{}, interface{}) {
@@ -86,7 +59,7 @@ func TestJsonConvert(t *testing.T) {
 		{types.MustJSON(`{"field":"test"}`), types.MustJSON(`{"field":"test"}`), false},
 		{[]string{}, types.MustJSON(`[]`), false},
 		{[]string{`555-555-5555`}, types.MustJSON(`["555-555-5555"]`), false},
-		{mockStringWrapper{val: `{"c": 1}`}, types.MustJSON(`{"c":1}`), false},
+		{test.NewMockStringWrapper(`{"c": 1}`), types.MustJSON(`{"c":1}`), false},
 	}
 
 	for _, test := range tests {

--- a/test/mock_types.go
+++ b/test/mock_types.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import "context"
+
+// MockStringWrapper is a StringWrapper used for testing purposes
+type MockStringWrapper struct {
+	val string
+}
+
+func NewMockStringWrapper(val string) *MockStringWrapper {
+	return &MockStringWrapper{val: val}
+}
+
+func (m MockStringWrapper) Unwrap(ctx context.Context) (string, error) {
+	return m.val, nil
+}
+
+func (m MockStringWrapper) UnwrapAny(ctx context.Context) (interface{}, error) {
+	return m.val, nil
+}
+
+func (m MockStringWrapper) IsExactLength() bool {
+	return false
+}
+
+func (m MockStringWrapper) MaxByteLength() int64 {
+	return int64(len(m.val))
+}
+
+func (m MockStringWrapper) Compare(ctx context.Context, other interface{}) (int, bool, error) {
+	return 0, false, nil
+}
+
+func (m MockStringWrapper) Hash() interface{} {
+	return m.val
+}


### PR DESCRIPTION
Fixes dolthub/dolt#11095

`REGEXP_REPLACE` queries on `LONGTEXT` type columns were panicking because we were casting values to strings without unwrapping them. Note that this doesn't happen with tables created in Dolt 2.0 due to the recent changes to adaptive encoding, but we still need to support tables before then. 

Also moved `mockStringWrapper` to a shared `test` util package so it can be used in various tests.