### PR TITLE
[no-release-notes] docs: mention MariaDB client compatibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for a reference implementation. Or, hop into the Dolt Discord server
 With the exception of specific limitations (see below),
 **go-mysql-server** is a drop-in replacement for MySQL. Any client
 library, tool, query, SQL syntax, SQL function, etc. that works with
-MySQL should also work with **go-mysql-server**. If you find a gap in
+MySQL (including the [MariaDB Java client](SUPPORTED_CLIENTS.md#mariadb-java-client)) should also work with **go-mysql-server**. If you find a gap in
 functionality, please file an issue.
 
 For full MySQL compatibility documentation, see the [Dolt


### PR DESCRIPTION
Links the MariaDB Java client from the README MySQL compatibility paragraph. Client support is already documented in `SUPPORTED_CLIENTS.md` (`mariadb-java-client` section); the README only mentioned MySQL clients.

Documentation only; no code or deployment changes.