### PR TITLE
fix(rowexec): dispose CachedResults child when closing hashLookupGeneratingIter (#3560)

### DIFF
--- a/sql/rowexec/other_iters.go
+++ b/sql/rowexec/other_iters.go
@@ -248,10 +248,6 @@ func (h *hashLookupGeneratingIter) Next(ctx *sql.Context) (sql.Row, error) {
 }
 
 func (h *hashLookupGeneratingIter) Close(c *sql.Context) error {
-	// Propagate Close down the child iter chain, and dispose the CachedResults
-	// child if present so its global Manager entry is released. Without the
-	// dispose, every executed hash join over a CachedResults subtree can leak
-	// an entry into plan.CachedResultsManager.cachedResultsCaches (issue #3560).
 	if cr, ok := h.n.Child.(*plan.CachedResults); ok {
 		cr.Dispose(c)
 	}

--- a/sql/rowexec/other_iters.go
+++ b/sql/rowexec/other_iters.go
@@ -248,7 +248,14 @@ func (h *hashLookupGeneratingIter) Next(ctx *sql.Context) (sql.Row, error) {
 }
 
 func (h *hashLookupGeneratingIter) Close(c *sql.Context) error {
-	return nil
+	// Propagate Close down the child iter chain, and dispose the CachedResults
+	// child if present so its global Manager entry is released. Without the
+	// dispose, every executed hash join over a CachedResults subtree can leak
+	// an entry into plan.CachedResultsManager.cachedResultsCaches (issue #3560).
+	if cr, ok := h.n.Child.(*plan.CachedResults); ok {
+		cr.Dispose(c)
+	}
+	return h.childIter.Close(c)
 }
 
 var _ sql.RowIter = (*hashLookupGeneratingIter)(nil)


### PR DESCRIPTION
## Summary
`hashLookupGeneratingIter.Close` returned `nil` without closing the child iter chain or disposing the wrapped `*plan.CachedResults` node. Every executed hash join over a `CachedResults` subtree could therefore leak one entry into `Analyzer.CachedResultsManager.cachedResultsCaches`, freed only by process restart.

This PR makes `Close`:
1. Dispose the `CachedResults` child if present (releases the global Manager entry).
2. Propagate `Close` down the rest of the child iter chain.

## Fix

```diff
 func (h *hashLookupGeneratingIter) Close(c *sql.Context) error {
-    return nil
+    if cr, ok := h.n.Child.(*plan.CachedResults); ok {
+        cr.Dispose(c)
+    }
+    return h.childIter.Close(c)
 }
```

## Why

Full RCA, reproducer, and pprof evidence are in #3560. Headline numbers from the 3-minute, ~30 req/sec workload reported there (Dolt 2.0.6 sql-server vendoring this commit):

| Metric | Vanilla Δ | **Patched Δ** | Improvement |
|---|---|---|---|
| RSS | +5069 MB | **+44 MB** | ~115× |
| HeapAlloc (live) | +4.3 GB | **+82 MB** | ~52× |
| HeapObjects (live) | +90 million | **+1.5 million** | ~60× |
| `Mallocs - Frees` (net live) | +204 million | **+4 million** | ~50× |

Allocation rate is unchanged (~1.1B mallocs in 3 min both runs); the patched build services the same workload but `Frees` keeps up with `Mallocs`.

## Tests

`go test ./sql/rowexec/...` passes locally with the patch applied.

I did not include a unit-level regression test in this PR. In a minimal `engine.Query` → `RowIterToRows` test, `TrackedRowIter.Close → done → disposeNode` already walks the plan tree and disposes the `CachedResults` via `sql.Dispose(ctx, node)`, so the leak doesn't reproduce that way; faithfully exercising the production path (Dolt sql-server, prepared statements via the MySQL wire protocol) needs significantly more harness scaffolding. Happy to add a test if maintainers can point me at the right entry point.

Closes #3560