### PR TITLE
Introduce `SchemaObjectNameValidator` interface

### DIFF
--- a/enginetest/queries/insert_queries.go
+++ b/enginetest/queries/insert_queries.go
@@ -1885,7 +1885,7 @@ var InsertScripts = []ScriptTest{
 		Name: "Insert throws unique key violations",
 		SetUpScript: []string{
 			"CREATE TABLE t (pk int PRIMARY key, col1 int UNIQUE);",
-			"CREATE TABLE t2 (pk int PRIMARY key, col1 int, col2 int, UNIQUE KEY (col1, col2));",
+			"CREATE TABLE t2 (pk int PRIMARY key, col1 int, col2 int, CONSTRAINT col1_col2 UNIQUE KEY (col1, col2));",
 			"INSERT into t VALUES (1, 1);",
 			"INSERT into t2 VALUES (1, 1, 1);",
 		},
@@ -1936,7 +1936,7 @@ var InsertScripts = []ScriptTest{
 		Name: "Insert throws unique key violations for keyless tables",
 		SetUpScript: []string{
 			"CREATE TABLE t (not_pk int NOT NULL, col1 int UNIQUE);",
-			"CREATE TABLE t2 (not_pk int NOT NULL, col1 int, col2 int, UNIQUE KEY (col1, col2));",
+			"CREATE TABLE t2 (not_pk int NOT NULL, col1 int, col2 int, CONSTRAINT col1_col2 UNIQUE KEY (col1, col2));",
 			"INSERT into t VALUES (1, 1);",
 			"INSERT into t2 VALUES (1, 1, 1);",
 		},

--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -1919,7 +1919,8 @@ CREATE TABLE teams (
 	{
 		Name: "keyless reverse index",
 		SetUpScript: []string{
-			"create table x (x int, key(x));",
+			"create table x (x int);",
+			"CREATE INDEX idx_x_x ON x(x)",
 			"insert into x values (0),(1)",
 		},
 		Query: "select * from x order by x desc limit 1",
@@ -2078,11 +2079,13 @@ CREATE TABLE table2 (
 		SetUpScript: []string{
 			"CREATE TABLE pk (x varchar(10) primary key)",
 			"INSERT INTO pk values ('3'), ('30'), ('3#')",
-			"CREATE TABLE uniq (y int primary key, x varchar(10), unique key (x))",
+			"CREATE TABLE uniq (y int primary key, x varchar(10), constraint idx_uniq_x unique key (x))",
 			"INSERT INTO uniq values (1,'3'), (2,'30'), (3,'3#')",
-			"CREATE TABLE noncov (y int primary key, x varchar(10), z int, key (x))",
+			"CREATE TABLE noncov (y int primary key, x varchar(10), z int)",
+			"CREATE INDEX idx_noncov_x ON noncov(x);",
 			"INSERT INTO noncov values (1,'3',1), (2,'30',2), (3,'3#',3)",
-			"CREATE TABLE keyless (y int, x varchar(10),key (x))",
+			"CREATE TABLE keyless (y int, x varchar(10))",
+			"CREATE INDEX idx_keyless_x ON keyless(x);",
 			"INSERT INTO keyless values (1,'3'), (2,'30'), (3,'3#')",
 		},
 		Assertions: []ScriptTestAssertion{

--- a/sql/databases.go
+++ b/sql/databases.go
@@ -145,16 +145,43 @@ type TableCreator interface {
 	CreateTable(ctx *Context, name string, schema PrimaryKeySchema, collation CollationID, comment string) error
 }
 
-// RelationNameValidator is an optional interface a database can implement to enforce additional
-// validation or constraints on relation names beyond what GMS implements for MySQL compatibility.
-// This allows integrators to support relations that share a namespace.
-type RelationNameValidator interface {
+// SchemaObjectNameValidator is an optional interface a database can implement to enforce additional
+// validation or constraints on schema object names beyond what GMS implements for MySQL compatibility.
+// This allows integrators to support schema objects that share a namespace.
+type SchemaObjectNameValidator interface {
 	Database
 
-	// DoesRelationExist returns true if a relation of name |name| exists, along with the type
-	// of relation it is. This is used when handling "IF EXIST" and "IF NOT EXISTS" clauses for
-	// integrators where relation types share a namespace.
-	DoesRelationExist(ctx *Context, name string) (exists bool, relationType string, err error)
+	// ValidateNewIndexName checks if |newIndexName| is available to use as a new index name. If the name is available,
+	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
+	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
+	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
+	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
+	// |alreadyExists| and an error message in |err|.
+	ValidateNewIndexName(ctx *Context, newIndexName string) (alreadyExists bool, err error)
+
+	// ValidateNewSequenceName checks if |newSequenceName| is available to use as a new index name. If the name is available,
+	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
+	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
+	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
+	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
+	// |alreadyExists| and an error message in |err|.
+	ValidateNewSequenceName(ctx *Context, newSequenceName string) (alreadyExists bool, err error)
+
+	// ValidateNewViewName checks if |newViewName| is available to use as a new index name. If the name is available,
+	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
+	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
+	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
+	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
+	// |alreadyExists| and an error message in |err|.
+	ValidateNewViewName(ctx *Context, newViewName string) (alreadyExists bool, err error)
+
+	// ValidateNewTableName checks if |newTableName| is available to use as a new index name. If the name is available,
+	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
+	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
+	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
+	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
+	// |alreadyExists| and an error message in |err|.
+	ValidateNewTableName(ctx *Context, newTableName string) (alreadyExists bool, err error)
 }
 
 // IndexedTableCreator is a Database that can create new tables which have a Primary Key with columns that have

--- a/sql/databases.go
+++ b/sql/databases.go
@@ -147,41 +147,29 @@ type TableCreator interface {
 
 // SchemaObjectNameValidator is an optional interface a database can implement to enforce additional
 // validation or constraints on schema object names beyond what GMS implements for MySQL compatibility.
-// This allows integrators to support schema objects that share a namespace.
+// This allows integrators to support constraints such as schema objects that share a namespace.
 type SchemaObjectNameValidator interface {
 	Database
 
 	// ValidateNewIndexName checks if |newIndexName| is available to use as a new index name. If the name is available,
-	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
-	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
-	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
-	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
-	// |alreadyExists| and an error message in |err|.
-	ValidateNewIndexName(ctx *Context, newIndexName string) (alreadyExists bool, err error)
+	// then this method returns false for |nameAlreadyUsed| and nil for |err|. If |skipIfExists| is true, then this
+	// method will NOT return an error but will still return |nameAlreadyUsed| as true.
+	ValidateNewIndexName(ctx *Context, newIndexName string, skipIfExists bool) (nameAlreadyUsed bool, err error)
 
-	// ValidateNewSequenceName checks if |newSequenceName| is available to use as a new index name. If the name is available,
-	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
-	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
-	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
-	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
-	// |alreadyExists| and an error message in |err|.
-	ValidateNewSequenceName(ctx *Context, newSequenceName string) (alreadyExists bool, err error)
+	// ValidateNewSequenceName checks if |newSequenceName| is available to use as a new sequence name. If the name is
+	// available, then this method returns false for |nameAlreadyUsed| and nil for |err|. If |skipIfExists| is true,
+	// then this method will NOT return an error but will still return |nameAlreadyUsed| as true.
+	ValidateNewSequenceName(ctx *Context, newSequenceName string, skipIfExists bool) (nameAlreadyUsed bool, err error)
 
-	// ValidateNewViewName checks if |newViewName| is available to use as a new index name. If the name is available,
-	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
-	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
-	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
-	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
-	// |alreadyExists| and an error message in |err|.
-	ValidateNewViewName(ctx *Context, newViewName string) (alreadyExists bool, err error)
+	// ValidateNewViewName checks if |newViewName| is available to use as a new view name. If the name is available,
+	// then this method returns nil for |err|. If |replaceAllowed| is true, then this method will not return an
+	// error if a view already exists named |newViewName|.
+	ValidateNewViewName(ctx *Context, newViewName string, replaceAllowed bool) error
 
-	// ValidateNewTableName checks if |newTableName| is available to use as a new index name. If the name is available,
-	// then this method returns false for |alreadyExists| and nil for |err|. If an index with this name already exists,
-	// this method returns true for |alreadyExists| and an error message for the user in |err|. If an index with this
-	// name does NOT exist, but the name is not available, then this method returns false for |alreadyExists| and an
-	// error message for the user in |err|. If any other errors are encountered, then this method returns false for
-	// |alreadyExists| and an error message in |err|.
-	ValidateNewTableName(ctx *Context, newTableName string) (alreadyExists bool, err error)
+	// ValidateNewTableName checks if |newTableName| is available to use as a new table name. If the name is available,
+	// then this method returns false for |nameAlreadyUsed| and nil for |err|. If |skipIfExists| is true, then this
+	// method will NOT return an error but will still return |nameAlreadyUsed| as true.
+	ValidateNewTableName(ctx *Context, newTableName string, skipIfExists bool) (nameAlreadyUsed bool, err error)
 }
 
 // IndexedTableCreator is a Database that can create new tables which have a Primary Key with columns that have

--- a/sql/databases.go
+++ b/sql/databases.go
@@ -145,6 +145,18 @@ type TableCreator interface {
 	CreateTable(ctx *Context, name string, schema PrimaryKeySchema, collation CollationID, comment string) error
 }
 
+// RelationNameValidator is an optional interface a database can implement to enforce additional
+// validation or constraints on relation names beyond what GMS implements for MySQL compatibility.
+// This allows integrators to support relations that share a namespace.
+type RelationNameValidator interface {
+	Database
+
+	// DoesRelationExist returns true if a relation of name |name| exists, along with the type
+	// of relation it is. This is used when handling "IF EXIST" and "IF NOT EXISTS" clauses for
+	// integrators where relation types share a namespace.
+	DoesRelationExist(ctx *Context, name string) (exists bool, relationType string, err error)
+}
+
 // IndexedTableCreator is a Database that can create new tables which have a Primary Key with columns that have
 // prefix lengths.
 type IndexedTableCreator interface {

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -69,7 +69,7 @@ func (b *Builder) resolveDbForTable(table ast.TableName) (sql.Database, bool) {
 	if schema != "" {
 		scd, ok := database.(sql.SchemaDatabase)
 		if !ok {
-			b.handleErr(fmt.Errorf("database %T does not support schemas", database))
+			b.handleErr(sql.ErrDatabaseSchemasNotSupported.New(database))
 		}
 		database, ok, err = scd.GetSchema(b.ctx, schema)
 		if err != nil {

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -145,7 +145,7 @@ func (b *BaseBuilder) buildDropConstraint(ctx *sql.Context, n *plan.DropConstrai
 	return nil, fmt.Errorf("%T does not have an execution iterator, this is a bug", n)
 }
 
-func (b *BaseBuilder) buildCreateView(ctx *sql.Context, n *plan.CreateView, row sql.Row) (sql.RowIter, error) {
+func (b *BaseBuilder) buildCreateView(ctx *sql.Context, n *plan.CreateView, _ sql.Row) (sql.RowIter, error) {
 	registry := ctx.GetViewRegistry()
 	if n.IsReplace {
 		if dropper, ok := n.Database().(sql.ViewDatabase); ok {
@@ -160,6 +160,23 @@ func (b *BaseBuilder) buildCreateView(ctx *sql.Context, n *plan.CreateView, row 
 			}
 		}
 	}
+
+	if v, ok := n.Database().(sql.RelationNameValidator); ok {
+		exists, relationType, err := v.DoesRelationExist(ctx, n.Name)
+		if err != nil {
+			return nil, err
+		}
+		if n.IsReplace {
+			if exists && relationType != "view" {
+				return nil, fmt.Errorf("relation '%s' already exists and is not a view", n.Name)
+			}
+		} else {
+			if exists {
+				return nil, fmt.Errorf(`relation "%s" already exists`, n.Name)
+			}
+		}
+	}
+
 	names, err := n.Database().GetTableNames(ctx)
 	if err != nil {
 		return nil, err

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -162,15 +162,8 @@ func (b *BaseBuilder) buildCreateView(ctx *sql.Context, n *plan.CreateView, _ sq
 	}
 
 	if v, ok := n.Database().(sql.SchemaObjectNameValidator); ok {
-		alreadyExists, err := v.ValidateNewViewName(ctx, n.Name)
-		if err != nil {
-			if alreadyExists && n.IfNotExists {
-				return sql.RowsToRowIter(), nil
-			} else if alreadyExists && n.IsReplace {
-				// no-op, ignore the validation error and replace the view
-			} else {
-				return nil, err
-			}
+		if err := v.ValidateNewViewName(ctx, n.Name, n.IsReplace); err != nil {
+			return nil, err
 		}
 	}
 
@@ -1130,6 +1123,15 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 	maybePrivDb := n.Db
 	if privDb, ok := maybePrivDb.(mysql_db.PrivilegedDatabase); ok {
 		maybePrivDb = privDb.Unwrap()
+	}
+
+	if v, ok := maybePrivDb.(sql.SchemaObjectNameValidator); ok {
+		nameAlreadyUsed, err := v.ValidateNewTableName(ctx, n.Name(), n.IfNotExists())
+		if err != nil {
+			return nil, err
+		} else if nameAlreadyUsed && n.IfNotExists() {
+			return rowIterWithOkResultWithZeroRowsAffected(), nil
+		}
 	}
 
 	if n.Temporary() {

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -161,18 +161,15 @@ func (b *BaseBuilder) buildCreateView(ctx *sql.Context, n *plan.CreateView, _ sq
 		}
 	}
 
-	if v, ok := n.Database().(sql.RelationNameValidator); ok {
-		exists, relationType, err := v.DoesRelationExist(ctx, n.Name)
+	if v, ok := n.Database().(sql.SchemaObjectNameValidator); ok {
+		alreadyExists, err := v.ValidateNewViewName(ctx, n.Name)
 		if err != nil {
-			return nil, err
-		}
-		if n.IsReplace {
-			if exists && relationType != "view" {
-				return nil, fmt.Errorf("relation '%s' already exists and is not a view", n.Name)
-			}
-		} else {
-			if exists {
-				return nil, fmt.Errorf(`relation "%s" already exists`, n.Name)
+			if alreadyExists && n.IfNotExists {
+				return sql.RowsToRowIter(), nil
+			} else if alreadyExists && n.IsReplace {
+				// no-op, ignore the validation error and replace the view
+			} else {
+				return nil, err
 			}
 		}
 	}

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2213,23 +2213,13 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 			}
 		}
 
-		if v, ok := n.Db.(sql.RelationNameValidator); ok {
-			exists, relationType, err := v.DoesRelationExist(ctx, indexDef.Name)
+		if v, ok := n.Db.(sql.SchemaObjectNameValidator); ok {
+			alreadyExists, err := v.ValidateNewIndexName(ctx, indexDef.Name)
 			if err != nil {
-				return err
-			}
-
-			if n.IfNotExists {
-				// If the index already exists, this is a no-op
-				if exists && relationType == "index" {
+				if alreadyExists && n.IfNotExists {
 					return nil
-				} else if exists {
-					return fmt.Errorf(`relation "%s" already exists and is not an index`, indexDef.Name)
 				}
-			} else {
-				if exists {
-					return fmt.Errorf(`relation "%s" already exists`, indexDef.Name)
-				}
+				return err
 			}
 		}
 

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2213,6 +2213,26 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 			}
 		}
 
+		if v, ok := n.Db.(sql.RelationNameValidator); ok {
+			exists, relationType, err := v.DoesRelationExist(ctx, indexDef.Name)
+			if err != nil {
+				return err
+			}
+
+			if n.IfNotExists {
+				// If the index already exists, this is a no-op
+				if exists && relationType == "index" {
+					return nil
+				} else if exists {
+					return fmt.Errorf(`relation "%s" already exists and is not an index`, indexDef.Name)
+				}
+			} else {
+				if exists {
+					return fmt.Errorf(`relation "%s" already exists`, indexDef.Name)
+				}
+			}
+		}
+
 		err = idxAltTbl.CreateIndex(ctx, indexDef)
 		if err != nil {
 			if sql.ErrDuplicateKey.Is(err) && n.IfNotExists {

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2214,12 +2214,11 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 		}
 
 		if v, ok := n.Db.(sql.SchemaObjectNameValidator); ok {
-			alreadyExists, err := v.ValidateNewIndexName(ctx, indexDef.Name)
+			nameAlreadyUsed, err := v.ValidateNewIndexName(ctx, indexDef.Name, n.IfNotExists)
 			if err != nil {
-				if alreadyExists && n.IfNotExists {
-					return nil
-				}
 				return err
+			} else if nameAlreadyUsed && n.IfNotExists {
+				return nil
 			}
 		}
 


### PR DESCRIPTION
To support custom Postgresql logic for Doltgres, a new interface called `RelationNameValidator` is added. 