### PR TITLE
Allow unparenthesized function expressions in column defaults.

### DIFF
--- a/enginetest/queries/column_default_queries.go
+++ b/enginetest/queries/column_default_queries.go
@@ -502,16 +502,6 @@ var ColumnDefaultTests = []ScriptTest{
 		},
 	},
 	{
-		Name: "Function expressions must be enclosed in parens",
-		Assertions: []ScriptTestAssertion{
-			{
-				Query:       "create table t0 (v0 varchar(100) default repeat(\"_\", 99));",
-				ExpectedErr: sql.ErrSyntaxError,
-			},
-		},
-	},
-
-	{
 		Name: "Column references must be enclosed in parens",
 		Assertions: []ScriptTestAssertion{
 			{
@@ -1053,6 +1043,26 @@ var ColumnDefaultTests = []ScriptTest{
 			{
 				Query:       "ALTER TABLE t ALTER COLUMN i SET DEFAULT (@@version);",
 				ExpectedErr: sql.ErrColumnDefaultUserVariable,
+			},
+		},
+	},
+	{
+		Name: "Unparenthesized function expression in DEFAULT clause",
+		SetUpScript: []string{
+			"CREATE TABLE t_unparens (id INT PRIMARY KEY, s LONGTEXT NOT NULL DEFAULT JSON_OBJECT())",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    "INSERT INTO t_unparens (id) VALUES (1)",
+				Expected: []sql.Row{{types.NewOkResult(1)}},
+			},
+			{
+				Query:    "SELECT * FROM t_unparens ORDER BY id",
+				Expected: []sql.Row{{1, "{}"}},
+			},
+			{
+				Query:    "SHOW CREATE TABLE t_unparens",
+				Expected: []sql.Row{{"t_unparens", "CREATE TABLE `t_unparens` (\n  `id` int NOT NULL,\n  `s` longtext NOT NULL DEFAULT (json_object()),\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin"}},
 			},
 		},
 	},

--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -10219,10 +10219,6 @@ var ErrorQueries = []QueryErrorTest{
 		ExpectedErr: types.ErrConvertingToTime,
 	},
 	{
-		Query:       "CREATE TABLE table_test (id int PRIMARY KEY, c float DEFAULT rand())",
-		ExpectedErr: sql.ErrSyntaxError,
-	},
-	{
 		Query:       "CREATE TABLE table_test (id int PRIMARY KEY, c float DEFAULT rand)",
 		ExpectedErr: sql.ErrSyntaxError,
 	},
@@ -10232,14 +10228,6 @@ var ErrorQueries = []QueryErrorTest{
 	},
 	{
 		Query:       "CREATE TABLE table_test (id int PRIMARY KEY, b int DEFAULT '2', c int DEFAULT `b`)",
-		ExpectedErr: sql.ErrSyntaxError,
-	},
-	{
-		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, v1 POINT DEFAULT POINT(1,2));",
-		ExpectedErr: sql.ErrSyntaxError,
-	},
-	{
-		Query:       "CREATE TABLE t0 (id INT PRIMARY KEY, v1 JSON DEFAULT JSON_ARRAY(1,2));",
 		ExpectedErr: sql.ErrSyntaxError,
 	},
 	{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
-	github.com/dolthub/vitess v0.0.0-20260521165014-2fdb4300ae8d
+	github.com/dolthub/vitess v0.0.0-20260528164423-e3f9fa81284c
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gocraft/dbr/v2 v2.7.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
 github.com/dolthub/vitess v0.0.0-20260521165014-2fdb4300ae8d h1:rN3SAE6dOwH3NmqkTR8TL46nT5B1U00koXmSjUDFpeo=
 github.com/dolthub/vitess v0.0.0-20260521165014-2fdb4300ae8d/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
+github.com/dolthub/vitess v0.0.0-20260528164423-e3f9fa81284c h1:DRmvqtt1OCIdtFAg8daaaIOGEe6gVWiSlhABDi+lNIg=
+github.com/dolthub/vitess v0.0.0-20260528164423-e3f9fa81284c/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -1887,15 +1887,16 @@ func (b *Builder) convertDefaultExpression(inScope *scope, defaultExpr ast.Expr,
 		}
 	} else if !isParenthesized {
 		if _, ok := resExpr.(sql.FunctionExpression); ok {
+			isLiteral = false
 			switch resExpr.(type) {
 			case *function.Now:
 				// Datetime and Timestamp columns allow now and current_timestamp to not be enclosed in parens,
 				// but they still need to be treated as function expressions
-				isLiteral = false
 			default:
-				// All other functions must *always* be enclosed in parens
-				err := sql.ErrSyntaxError.New("column default function expressions must be enclosed in parentheses")
-				b.handleErr(err)
+				// Other unparenthesized function expressions are allowed by MariaDB but rejected by MySQL.
+				// We accept them in order to match MariaDB, but we wrap the expression in parentheses
+				// so that dumps can be imported to MySQL.
+				isParenthesized = true
 			}
 		}
 	}

--- a/sql/session.go
+++ b/sql/session.go
@@ -24,12 +24,12 @@ import (
 	"time"
 
 	"github.com/dolthub/vitess/go/vt/sqlparser"
-
-	"github.com/dolthub/go-mysql-server/sql/sqlredact"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/go-mysql-server/sql/sqlredact"
 )
 
 type key uint


### PR DESCRIPTION
MariaDB allows the use of a function expression as a column default expressions without requiring it to be wrapped in parentheses. MySQL does not allow this.

In order to parse scripts created for MariaDB, we should also accept unwrapped function expressions as column defaults. However, in order to ensure that dumps created by Dolt are compatible with MySQL, we normalize these expressions by wrapping them in parentheses internally.