### PR TITLE
fix for division on decimals

### DIFF
--- a/sql/expression/arithmetic_test.go
+++ b/sql/expression/arithmetic_test.go
@@ -610,3 +610,75 @@ func TestUnaryMinus(t *testing.T) {
 		})
 	}
 }
+
+// Results:
+// BenchmarkPlusHighScaleDecimals-16          3770235	       308.2 ns/op
+func BenchmarkPlusHighScaleDecimals(b *testing.B) {
+	require := require.New(b)
+	ctx := sql.NewEmptyContext()
+	p := NewPlus(
+		NewLiteral(types.DecimalFromFloat64(0.123456789), types.MustCreateDecimalType(types.DecimalTypeMaxPrecision, types.DecimalTypeMaxScale)),
+		NewLiteral(types.DecimalFromFloat64(0.987654321), types.MustCreateDecimalType(types.DecimalTypeMaxPrecision, types.DecimalTypeMaxScale)),
+	)
+	var res interface{}
+	var err error
+	for i := 0; i < b.N; i++ {
+		res, err = p.Eval(ctx, nil)
+		require.NoError(err)
+	}
+	if dec, ok := res.(*apd.Decimal); ok {
+		res = dec.Text('f')
+	}
+	exp := "1.111111110"
+	if res != exp {
+		b.Logf("Expected %v, got %v", exp, res)
+	}
+}
+
+// Results:
+// BenchmarkMinusHighScaleDecimals-16          3570638	       318.9 ns/op
+func BenchmarkMinusHighScaleDecimals(b *testing.B) {
+	require := require.New(b)
+	ctx := sql.NewEmptyContext()
+	m := NewMinus(
+		NewLiteral(types.DecimalFromFloat64(0.123456789), types.MustCreateDecimalType(types.DecimalTypeMaxPrecision, types.DecimalTypeMaxScale)),
+		NewLiteral(types.DecimalFromFloat64(0.987654321), types.MustCreateDecimalType(types.DecimalTypeMaxPrecision, types.DecimalTypeMaxScale)),
+	)
+	var res interface{}
+	var err error
+	for i := 0; i < b.N; i++ {
+		res, err = m.Eval(ctx, nil)
+		require.NoError(err)
+	}
+	if dec, ok := res.(*apd.Decimal); ok {
+		res = dec.Text('f')
+	}
+	exp := "-0.864197532"
+	if res != exp {
+		b.Logf("Expected %v, got %v", exp, res)
+	}
+}
+
+// Results:
+// BenchmarkMultHighScaleDecimals-16          3579982	       330.5 ns/op
+func BenchmarkMultHighScaleDecimals(b *testing.B) {
+	require := require.New(b)
+	ctx := sql.NewEmptyContext()
+	m := NewMult(
+		NewLiteral(types.DecimalFromFloat64(0.123456789), types.MustCreateDecimalType(types.DecimalTypeMaxPrecision, types.DecimalTypeMaxScale)),
+		NewLiteral(types.DecimalFromFloat64(0.987654321), types.MustCreateDecimalType(types.DecimalTypeMaxPrecision, types.DecimalTypeMaxScale)),
+	)
+	var res interface{}
+	var err error
+	for i := 0; i < b.N; i++ {
+		res, err = m.Eval(ctx, nil)
+		require.NoError(err)
+	}
+	if dec, ok := res.(*apd.Decimal); ok {
+		res = dec.Text('f')
+	}
+	exp := "0.121932631112635269"
+	if res != exp {
+		b.Logf("Expected %v, got %v", exp, res)
+	}
+}

--- a/sql/expression/div.go
+++ b/sql/expression/div.go
@@ -237,9 +237,7 @@ func (d *Div) div(ctx *sql.Context, lval, rval interface{}) (interface{}, error)
 			l = types.DecimalTruncate(l, scale)
 			r = types.DecimalTruncate(r, scale)
 
-			// give it buffer of 2 additional scale to avoid the result to be rounded
-			res := types.DecimalDivRound(l, r, scale+2)
-			res = types.DecimalTruncate(res, scale)
+			res := types.DecimalDiv(l, r, scale, true)
 			return res, nil
 		}
 	}
@@ -790,8 +788,7 @@ func intDiv(ctx *sql.Context, lval, rval interface{}) (interface{}, error) {
 
 			// intDiv operation gets the integer part of the divided value without rounding the result with 0 precision
 			// We get division result with non-zero precision and then truncate it to get integer part without it being rounded
-			divRes := types.DecimalDivRound(l, r, 2)
-			divRes = types.DecimalTruncate(divRes, 0)
+			divRes := types.DecimalDiv(l, r, 0, true)
 			// The fraction part should not be rounded, so truncate the result wih 0 precision.
 			i, err := divRes.Int64()
 			if err != nil {

--- a/sql/expression/function/aggregation/unary_agg_buffers.go
+++ b/sql/expression/function/aggregation/unary_agg_buffers.go
@@ -264,7 +264,7 @@ func (a *avgBuffer) Eval(ctx *sql.Context) (interface{}, error) {
 			return apd.New(0, 0), nil
 		}
 		scale := (s.Exponent * -1) + 4
-		return types.DecimalDivRound(s, types.DecimalFromInt64(a.rows), scale), nil
+		return types.DecimalDiv(s, types.DecimalFromInt64(a.rows), scale, false), nil
 	}
 	return nil, nil
 }

--- a/sql/session.go
+++ b/sql/session.go
@@ -24,12 +24,12 @@ import (
 	"time"
 
 	"github.com/dolthub/vitess/go/vt/sqlparser"
-
-	"github.com/dolthub/go-mysql-server/sql/sqlredact"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dolthub/go-mysql-server/sql/sqlredact"
 )
 
 type key uint

--- a/sql/type.go
+++ b/sql/type.go
@@ -17,7 +17,6 @@ package sql
 import (
 	"context"
 	"fmt"
-	"math"
 	"reflect"
 	"strings"
 	"time"
@@ -329,9 +328,14 @@ func DecimalRound(val *apd.Decimal, scale int32) (*apd.Decimal, error) {
 	newVal := new(apd.Decimal)
 	// Must use decimal context with precision set to non-zero to use .Quantize() method.
 	// Instead of using MaxExponent, find the big enough precision
-	p := val.NumDigits() + int64(math.Abs(float64(val.Exponent))) + int64(math.Abs(float64(scale))) + 1
-	c := DecimalCtx.WithPrecision(uint32(p))
-	_, err := c.Quantize(newVal, val, -scale)
+	p := val.NumDigits()
+	if val.Exponent > 0 {
+		p += int64(val.Exponent)
+	}
+	if scale > 0 {
+		p += int64(scale)
+	}
+	_, err := DecimalCtx.WithPrecision(uint32(p)).Quantize(newVal, val, -scale)
 	return newVal, err
 }
 

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -560,6 +560,9 @@ func DecimalDiv(a, b *apd.Decimal, scale int32, truncate bool) *apd.Decimal {
 	res := new(apd.Decimal)
 	// need to set precision for decimal context because it does division operation.
 	p := a.NumDigits()
+	if a.Exponent > 0 {
+		p += int64(a.Exponent)
+	}
 	if b.Exponent < 0 {
 		p += int64(-b.Exponent)
 	}

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -17,7 +17,6 @@ package types
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -556,18 +555,38 @@ func DecimalIntPartUint64(val *apd.Decimal) uint64 {
 	return v.Coeff.Uint64()
 }
 
-// DecimalDivRound divides and rounds to a given scale.
-func DecimalDivRound(a, b *apd.Decimal, scale int32) *apd.Decimal {
+// DecimalDiv divides and rounds to a given scale. If 'truncate' is false, it rounds.
+func DecimalDiv(a, b *apd.Decimal, scale int32, truncate bool) *apd.Decimal {
 	res := new(apd.Decimal)
 	// need to set precision for decimal context because it does division operation.
-	// TODO: can find precision for context based on the given values instead of using MaxExponent
-	_, err := sql.DecimalHighPrecisionCtx.Quo(res, a, b)
+	p := a.NumDigits()
+	if b.Exponent < 0 {
+		p += int64(-b.Exponent)
+	}
+	if scale > 0 {
+		p += int64(scale)
+	}
+	if truncate {
+		// give it buffer of 2 additional scale to avoid the result to be rounded
+		p += 2
+	}
+	c := sql.DecimalCtx.WithPrecision(uint32(p))
+	_, err := c.Quo(res, a, b)
 	if err != nil {
 		panic(err)
 	}
-	_, err = sql.DecimalHighPrecisionCtx.Quantize(res, res, -scale)
+
+	if truncate {
+		c.Rounding = apd.RoundDown
+	}
+	_, err = c.Quantize(res, res, -scale)
 	if err != nil {
 		panic(err)
+	}
+
+	if res.IsZero() {
+		res.Negative = false
+		res.Exponent = 0
 	}
 	return res
 }
@@ -575,9 +594,12 @@ func DecimalDivRound(a, b *apd.Decimal, scale int32) *apd.Decimal {
 // DecimalMod mods the given values.
 func DecimalMod(a, b *apd.Decimal) (*apd.Decimal, error) {
 	res := new(apd.Decimal)
-	m := math.Max(float64(a.NumDigits()), float64(b.NumDigits()))
+	p := a.NumDigits()
+	if bnd := b.NumDigits(); p < bnd {
+		p = bnd
+	}
 	// need to set precision for decimal context because it does division operation.
-	_, err := sql.DecimalCtx.WithPrecision(uint32(m)).Rem(res, a, b)
+	_, err := sql.DecimalCtx.WithPrecision(uint32(p)).Rem(res, a, b)
 	return res, err
 }
 
@@ -586,7 +608,11 @@ func DecimalMod(a, b *apd.Decimal) (*apd.Decimal, error) {
 // 545 truncated with scale of -1 = 540
 func DecimalTruncate(val *apd.Decimal, scale int32) *apd.Decimal {
 	if -scale > val.Exponent {
-		ctx := *sql.DecimalHighPrecisionCtx
+		p := val.NumDigits()
+		if scale > 0 {
+			p += int64(scale)
+		}
+		ctx := sql.DecimalCtx.WithPrecision(uint32(p))
 		ctx.Rounding = apd.RoundDown
 		newVal := new(*val)
 		_, err := ctx.Quantize(newVal, val, -scale)


### PR DESCRIPTION
BenchmarkPlusHighScaleDecimals:
```
before (decimal.Decimal)   2505679               460.8 ns/op
after (apd.Decimal)        3746318               304.5 ns/op
```

BenchmarkMinusHighScaleDecimals:
```
before (decimal.Decimal)   2619691               449.0 ns/op
after (apd.Decimal)        3723363               312.1 ns/op
```

BenchmarkMultHighScaleDecimals:
```
before (decimal.Decimal)   2537882               454.6 ns/op
after (apd.Decimal)        3608662               321.3 ns/op
```

BenchmarkDivHighScaleDecimals:
```
before (decimal.Decimal)   793515               1414 ns/op
before fix (apd.Decimal)   367                  3112350 ns/op
after fix (apd.Decimal)    946606               1246 ns/op
```

BenchmarkDivManyDecimals:
```
before (decimal.Decimal)   130582               7691 ns/op
before fix (apd.Decimal)   54                   21534736 ns/op
after fix (apd.Decimal)    110416               9347 ns/op
```
