### PR TITLE
[no-release-notes] Pass context to extended type deserialization

### DIFF
--- a/server/golden/proxy.go
+++ b/server/golden/proxy.go
@@ -403,7 +403,7 @@ func schemaToFields(ctx *sql.Context, cols []*dsql.ColumnType) ([]sql.Type, []*q
 			// default to the maximum width
 			typeStr = ts
 		}
-		types[i], err = planbuilder.ParseColumnTypeString(typeStr)
+		types[i], err = planbuilder.ParseColumnTypeString(ctx, typeStr)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/sql/planbuilder/ddl.go
+++ b/sql/planbuilder/ddl.go
@@ -15,6 +15,7 @@
 package planbuilder
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -2020,7 +2021,7 @@ func (b *Builder) buildDBDDL(inScope *scope, c *ast.DBDDL) (outScope *scope) {
 // ExtendedTypeTag is primarily used by ParseColumnTypeString when parsing strings representing extended types
 const ExtendedTypeTag = "extended_"
 
-func ParseColumnTypeString(columnType string) (sql.Type, error) {
+func ParseColumnTypeString(ctx context.Context, columnType string) (sql.Type, error) {
 	if strings.HasPrefix(columnType, ExtendedTypeTag) {
 		columnType = columnType[len(ExtendedTypeTag):]
 		// If the pipe character "|" is present, then we ignore all information after it (including the pipe), as it
@@ -2028,7 +2029,8 @@ func ParseColumnTypeString(columnType string) (sql.Type, error) {
 		if pipeIdx := strings.Index(columnType, "|"); pipeIdx != -1 {
 			columnType = columnType[:pipeIdx]
 		}
-		c, err := types.DeserializeTypeFromString(columnType)
+		sqlCtx, _ := ctx.(*sql.Context)
+		c, err := types.DeserializeTypeFromString(sqlCtx, columnType)
 		if err != nil {
 			return nil, err
 		}

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -2943,7 +2943,7 @@ func TestParseColumnTypeString(t *testing.T) {
 		ctx := sql.NewEmptyContext()
 		ctx.SetCurrentDatabase("mydb")
 		t.Run("parse "+test.columnType, func(t *testing.T) {
-			res, err := ParseColumnTypeString(test.columnType)
+			res, err := ParseColumnTypeString(ctx, test.columnType)
 			require.NoError(t, err)
 			if collatedType, ok := res.(sql.TypeWithCollation); ok {
 				if collatedType.Collation() == sql.Collation_Unspecified {
@@ -2955,7 +2955,7 @@ func TestParseColumnTypeString(t *testing.T) {
 		})
 		t.Run("round trip "+test.columnType, func(t *testing.T) {
 			str := test.expectedSqlType.String()
-			typ, err := ParseColumnTypeString(str)
+			typ, err := ParseColumnTypeString(ctx, str)
 			require.NoError(t, err)
 			if collatedType, ok := typ.(sql.TypeWithCollation); ok {
 				if collatedType.Collation() == sql.Collation_Unspecified {

--- a/sql/types/extended.go
+++ b/sql/types/extended.go
@@ -22,18 +22,18 @@ import (
 )
 
 // ExtendedTypeSerializer is the function signature for the extended type serializer.
-type ExtendedTypeSerializer func(extendedType sql.ExtendedType) ([]byte, error)
+type ExtendedTypeSerializer func(ctx *sql.Context, extendedType sql.ExtendedType) ([]byte, error)
 
 // ExtendedTypeDeserializer is the function signature for the extended type deserializer.
-type ExtendedTypeDeserializer func(serializedType []byte) (sql.ExtendedType, error)
+type ExtendedTypeDeserializer func(ctx *sql.Context, serializedType []byte) (sql.ExtendedType, error)
 
 // extendedTypeDeserializer refers to the function that will handle deserialization of extended types.
-var extendedTypeDeserializer ExtendedTypeDeserializer = func(serializedType []byte) (sql.ExtendedType, error) {
+var extendedTypeDeserializer ExtendedTypeDeserializer = func(ctx *sql.Context, serializedType []byte) (sql.ExtendedType, error) {
 	return nil, errors.New("placeholder extended type deserializer")
 }
 
 // extendedTypeSerializer refers to the function that will handle serialization of extended types.
-var extendedTypeSerializer ExtendedTypeSerializer = func(extendedType sql.ExtendedType) ([]byte, error) {
+var extendedTypeSerializer ExtendedTypeSerializer = func(ctx *sql.Context, extendedType sql.ExtendedType) ([]byte, error) {
 	return nil, errors.New("placeholder extended type serializer")
 }
 
@@ -45,13 +45,13 @@ func SetExtendedTypeSerializers(serializer ExtendedTypeSerializer, deserializer 
 }
 
 // SerializeType serializes the given extended type into a byte slice.
-func SerializeType(typ sql.ExtendedType) ([]byte, error) {
-	return extendedTypeSerializer(typ)
+func SerializeType(ctx *sql.Context, typ sql.ExtendedType) ([]byte, error) {
+	return extendedTypeSerializer(ctx, typ)
 }
 
 // SerializeTypeToString serializes the given extended type into a hex-encoded string.
-func SerializeTypeToString(typ sql.ExtendedType) (string, error) {
-	serializedType, err := extendedTypeSerializer(typ)
+func SerializeTypeToString(ctx *sql.Context, typ sql.ExtendedType) (string, error) {
+	serializedType, err := extendedTypeSerializer(ctx, typ)
 	if err != nil {
 		return "", err
 	}
@@ -59,17 +59,17 @@ func SerializeTypeToString(typ sql.ExtendedType) (string, error) {
 }
 
 // DeserializeType deserializes a byte slice representing a serialized extended type.
-func DeserializeType(typ []byte) (sql.ExtendedType, error) {
-	return extendedTypeDeserializer(typ)
+func DeserializeType(ctx *sql.Context, typ []byte) (sql.ExtendedType, error) {
+	return extendedTypeDeserializer(ctx, typ)
 }
 
 // DeserializeTypeFromString deserializes a hex-encoded string representing a serialized extended type.
-func DeserializeTypeFromString(typ string) (sql.ExtendedType, error) {
+func DeserializeTypeFromString(ctx *sql.Context, typ string) (sql.ExtendedType, error) {
 	serializedType, err := hex.DecodeString(typ)
 	if err != nil {
 		return nil, err
 	}
-	return extendedTypeDeserializer(serializedType)
+	return extendedTypeDeserializer(ctx, serializedType)
 }
 
 // IsExtendedType returns whether the given sql.Type is an ExtendedType.


### PR DESCRIPTION
This is needed for Doltgres. We now fully resolve types during deserialization, and therefore need the context so we can get the type collection from it.