### PR TITLE
improvements to time to wire format

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTE
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4EHUcEVQCMRBej8DYxjYjRz/9MdF/NNQh0o70=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
-github.com/dolthub/vitess v0.0.0-20260521165014-2fdb4300ae8d h1:rN3SAE6dOwH3NmqkTR8TL46nT5B1U00koXmSjUDFpeo=
-github.com/dolthub/vitess v0.0.0-20260521165014-2fdb4300ae8d/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/dolthub/vitess v0.0.0-20260528164423-e3f9fa81284c h1:DRmvqtt1OCIdtFAg8daaaIOGEe6gVWiSlhABDi+lNIg=
 github.com/dolthub/vitess v0.0.0-20260528164423-e3f9fa81284c/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=

--- a/sql/types/datetime.go
+++ b/sql/types/datetime.go
@@ -532,20 +532,16 @@ func appendDateFormat(dest []byte, t time.Time) []byte {
 	} else {
 		dest = strconv.AppendInt(dest, int64(year), 10)
 	}
-	dest = append(dest, '-')
-
 	month := int64(m)
-	if month < 10 {
-		dest = append(dest, '0')
-	}
-	dest = strconv.AppendInt(dest, month, 10)
-	dest = append(dest, '-')
-
 	day := int64(d)
-	if day < 10 {
-		dest = append(dest, '0')
-	}
-	dest = strconv.AppendInt(dest, day, 10)
+	dest = append(dest,
+		'-',
+		'0'+byte(month/10),
+		'0'+byte(month%10),
+		'-',
+		'0'+byte(day/10),
+		'0'+byte(day%10),
+	)
 	return dest
 }
 

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -28,7 +28,6 @@ import (
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/encodings"
 	"github.com/dolthub/go-mysql-server/sql/values"
 )
 

--- a/sql/types/decimal.go
+++ b/sql/types/decimal.go
@@ -343,8 +343,9 @@ func (t DecimalType_) SQL(ctx *sql.Context, dest []byte, v interface{}) (sqltype
 	if err != nil {
 		return sqltypes.Value{}, err
 	}
-	val := encodings.StringToBytes(t.DecimalValueStringFixed(value))
-	return sqltypes.MakeTrusted(sqltypes.Decimal, val), nil
+	// TODO: reslice?
+	dest = t.AppendStringFixedDecimal(dest, value)
+	return sqltypes.MakeTrusted(sqltypes.Decimal, dest), nil
 }
 
 func (t DecimalType_) SQLValue(ctx *sql.Context, v sql.Value, dest []byte) (sqltypes.Value, error) {
@@ -352,7 +353,9 @@ func (t DecimalType_) SQLValue(ctx *sql.Context, v sql.Value, dest []byte) (sqlt
 		return sqltypes.NULL, nil
 	}
 	d := values.ReadDecimal(v.Val)
-	return sqltypes.MakeTrusted(sqltypes.Decimal, encodings.StringToBytes(t.DecimalValueStringFixed(d))), nil
+	// TODO: reslice?
+	dest = t.AppendStringFixedDecimal(dest, d)
+	return sqltypes.MakeTrusted(sqltypes.Decimal, dest), nil
 }
 
 // String implements Type interface.
@@ -399,8 +402,9 @@ func (t DecimalType_) Scale() uint8 {
 	return t.scale
 }
 
-// DecimalValueStringFixed returns string value for the given decimal value. If decimal type value is for valid table column only,
-// it should use scale defined by the column. Otherwise, the result value should use its own precision and scale.
+// DecimalValueStringFixed returns the string for the given decimal value.
+// If the decimal type value is for the valid table column only, it should use scale defined by the column.
+// Otherwise, the result value should use its own precision and scale.
 func (t DecimalType_) DecimalValueStringFixed(v *apd.Decimal) string {
 	if t.definesColumn {
 		if int32(t.scale) != v.Exponent {
@@ -408,6 +412,18 @@ func (t DecimalType_) DecimalValueStringFixed(v *apd.Decimal) string {
 		}
 	}
 	return v.Text('f')
+}
+
+// AppendStringFixedDecimal appends the decimal value to the given []byte dest.
+// If the decimal type value is for the valid table column only, it should use scale defined by the column.
+// Otherwise, the result value should use its own precision and scale.
+func (t DecimalType_) AppendStringFixedDecimal(dest []byte, v *apd.Decimal) []byte {
+	if t.definesColumn {
+		if int32(t.scale) != v.Exponent {
+			v, _ = sql.DecimalRound(v, int32(t.scale))
+		}
+	}
+	return v.Append(dest, 'f')
 }
 
 func convertValueToDecimal(ctx *sql.Context, v sql.Value) (*apd.Decimal, error) {

--- a/sql/types/time.go
+++ b/sql/types/time.go
@@ -516,8 +516,12 @@ func (t Timespan) AppendBytes(dest []byte) []byte {
 }
 
 func appendTimeFormat(dest []byte, h, m, s, ms int64, msPrecision int) []byte {
+	if h < 10 {
+		dest = append(dest, '0')
+	}
+	dest = strconv.AppendInt(dest, h, 10)
 	dest = append(dest,
-		'0'+byte(h/10), '0'+byte(h%10), ':',
+		':',
 		'0'+byte(m/10), '0'+byte(m%10), ':',
 		'0'+byte(s/10), '0'+byte(s%10))
 

--- a/sql/types/time.go
+++ b/sql/types/time.go
@@ -517,9 +517,9 @@ func (t Timespan) AppendBytes(dest []byte) []byte {
 
 func appendTimeFormat(dest []byte, h, m, s, ms int64, msPrecision int) []byte {
 	dest = append(dest,
-		48+byte(h/10), 48+byte(h%10), ':',
-		48+byte(m/10), 48+byte(m%10), ':',
-		48+byte(s/10), 48+byte(s%10))
+		'0'+byte(h/10), '0'+byte(h%10), ':',
+		'0'+byte(m/10), '0'+byte(m%10), ':',
+		'0'+byte(s/10), '0'+byte(s%10))
 
 	if msPrecision > 0 {
 		dest = appendMicroseconds(dest, ms, msPrecision)

--- a/sql/types/time.go
+++ b/sql/types/time.go
@@ -516,22 +516,10 @@ func (t Timespan) AppendBytes(dest []byte) []byte {
 }
 
 func appendTimeFormat(dest []byte, h, m, s, ms int64, msPrecision int) []byte {
-	if h < 10 {
-		dest = append(dest, '0')
-	}
-	dest = strconv.AppendInt(dest, h, 10)
-	dest = append(dest, ':')
-
-	if m < 10 {
-		dest = append(dest, '0')
-	}
-	dest = strconv.AppendInt(dest, m, 10)
-	dest = append(dest, ':')
-
-	if s < 10 {
-		dest = append(dest, '0')
-	}
-	dest = strconv.AppendInt(dest, s, 10)
+	dest = append(dest,
+		48+byte(h/10), 48+byte(h%10), ':',
+		48+byte(m/10), 48+byte(m%10), ':',
+		48+byte(s/10), 48+byte(s%10))
 
 	if msPrecision > 0 {
 		dest = appendMicroseconds(dest, ms, msPrecision)


### PR DESCRIPTION
Should use `apd.Decimal.Append()` and faster way to append time strings.
Benchmarks: https://github.com/dolthub/dolt/pull/11130#issuecomment-4580541049
