### PR TITLE
Add `IndexNameGenerator` interface

### DIFF
--- a/memory/database.go
+++ b/memory/database.go
@@ -52,6 +52,7 @@ var _ sql.ViewDatabase = (*Database)(nil)
 var _ sql.CollatedDatabase = (*Database)(nil)
 var _ fulltext.Database = (*Database)(nil)
 var _ sql.SchemaValidator = (*BaseDatabase)(nil)
+var _ sql.IndexNameGenerator = (*BaseDatabase)(nil)
 
 // BaseDatabase is an in-memory database that can't store views, only for testing the engine
 type BaseDatabase struct {
@@ -157,6 +158,11 @@ func (d *BaseDatabase) GetTableNames(ctx *sql.Context) ([]string, error) {
 	}
 
 	return tblNames, nil
+}
+
+// GenerateIndexName implements the sql.IndexNameGenerator interface.
+func (d *BaseDatabase) GenerateIndexName(ctx *sql.Context, _ string, idxDef sql.IndexDef, tbl sql.Table) (string, error) {
+	return sql.GenerateMySqlIndexName(ctx, idxDef, tbl)
 }
 
 func (d *BaseDatabase) CreateFulltextTableNames(ctx *sql.Context, parentTableName string, parentIndexName string) (fulltext.IndexTableNames, error) {

--- a/sql/index.go
+++ b/sql/index.go
@@ -64,6 +64,57 @@ func (i *IndexDef) ColumnNames() []string {
 
 type IndexDefs []*IndexDef
 
+// IndexNameGenerator is an optional interface that a Database can implement to customize how unnamed indexes
+// are named. When GMS needs to generate a name for an index that has no explicit name, it checks whether the
+// current database implements this interface and delegates to it. Implementations are responsible for both
+// choosing the base name and ensuring it does not collide with existing names, querying whatever scope is
+// appropriate (e.g. table-level for MySQL, schema-level for PostgreSQL).
+// If the database does not implement this interface, GMS falls back to MySQL-compatible naming.
+type IndexNameGenerator interface {
+	// GenerateIndexName returns a unique name for the given unnamed index. tableName is the target table,
+	// idxDef describes the index being created (columns, constraint type, etc.), and tbl is the table itself
+	// for implementations that need to inspect existing indexes (e.g. via a type assertion to IndexAddressable).
+	// Implementations that perform their own collision detection (e.g. via a schema-level catalog query) may ignore tbl.
+	GenerateIndexName(ctx *Context, tableName string, idxDef IndexDef, tbl Table) (string, error)
+}
+
+// MySQLIndexNameGenerator is the default IndexNameGenerator, implementing MySQL-compatible naming:
+// the first column name is the base, with _2, _3, … appended on collision.
+type MySQLIndexNameGenerator struct{}
+
+var _ IndexNameGenerator = MySQLIndexNameGenerator{}
+
+// GenerateIndexName implements the IndexNameGenerator interface.
+func (MySQLIndexNameGenerator) GenerateIndexName(ctx *Context, _ string, idxDef IndexDef, tbl Table) (string, error) {
+	return GenerateMySqlIndexName(ctx, idxDef, tbl)
+}
+
+// GenerateMySqlIndexName implements MySQL-compatible index auto-naming: the first column name is used as the
+// base, with _2, _3, … appended on collision against existing indexes on the table. Databases that follow
+// MySQL naming conventions can call this from their GenerateIndexName implementation.
+func GenerateMySqlIndexName(ctx *Context, idxDef IndexDef, tbl Table) (string, error) {
+	indexMap := make(map[string]struct{})
+	if indexedTable, ok := tbl.(IndexAddressable); ok {
+		indexes, err := indexedTable.GetIndexes(ctx)
+		if err != nil {
+			return "", err
+		}
+		for _, index := range indexes {
+			indexMap[strings.ToLower(index.ID())] = struct{}{}
+		}
+	}
+	base := idxDef.ColumnNames()[0]
+	if _, ok := indexMap[strings.ToLower(base)]; !ok {
+		return base, nil
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%d", base, i)
+		if _, ok := indexMap[strings.ToLower(candidate)]; !ok {
+			return candidate, nil
+		}
+	}
+}
+
 // IndexColumn is the column by which to add to an index.
 type IndexColumn struct {
 	Name string

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -1393,7 +1393,7 @@ func createIndexesForCreateTable(ctx *sql.Context, db sql.Database, tableNode sq
 	fulltextIndexes := make(sql.IndexDefs, 0)
 	for _, idxDef := range idxes {
 		if len(idxDef.Name) == 0 {
-			idxDef.Name, err = generateIndexName(ctx, idxAltTbl, idxDef.ColumnNames())
+			idxDef.Name, err = getIndexNameGenerator(db).GenerateIndexName(ctx, tableNode.Name(), *idxDef, idxAltTbl)
 			if err != nil {
 				return err
 			}

--- a/sql/rowexec/ddl_iters.go
+++ b/sql/rowexec/ddl_iters.go
@@ -2075,32 +2075,19 @@ func getCheckAlterableTable(t sql.Table) (sql.CheckAlterableTable, error) {
 	}
 }
 
-// generateIndexName generates a unique index name based on the columns in the index, and any existing indexes on the table.
-func generateIndexName(ctx *sql.Context, idxAltable sql.IndexAlterableTable, idxColNames []string) (string, error) {
-	indexMap := make(map[string]struct{})
-	if indexedTable, ok := idxAltable.(sql.IndexAddressable); ok {
-		indexes, err := indexedTable.GetIndexes(ctx)
-		if err != nil {
-			return "", err
-		}
-		for _, index := range indexes {
-			indexMap[strings.ToLower(index.ID())] = struct{}{}
-		}
+// getIndexNameGenerator returns the IndexNameGenerator for the given database. It checks whether the database
+// (or its inner database when wrapped by a PrivilegedDatabase) implements sql.IndexNameGenerator, and falls
+// back to sql.MySQLIndexNameGenerator if not.
+func getIndexNameGenerator(db sql.Database) sql.IndexNameGenerator {
+	if gen, ok := db.(sql.IndexNameGenerator); ok {
+		return gen
 	}
-	// MySQL names the index by the first column in the definition
-	indexName := idxColNames[0]
-	if _, ok := indexMap[strings.ToLower(indexName)]; !ok {
-		return indexName, nil
-	}
-	// MySQL starts at 2 for generating duplicate indexes
-	for i := 2; true; i++ {
-		newIndexName := fmt.Sprintf("%s_%d", indexName, i)
-		if _, ok := indexMap[strings.ToLower(newIndexName)]; !ok {
-			return newIndexName, nil
+	if pdb, ok := db.(mysql_db.PrivilegedDatabase); ok {
+		if gen, ok := pdb.Unwrap().(sql.IndexNameGenerator); ok {
+			return gen
 		}
 	}
-	// Should never reach here
-	return indexName, nil
+	return sql.MySQLIndexNameGenerator{}
 }
 
 // getFulltextDatabase returns the fulltext.Database from the given sql.Database, or an error if it is not supported.
@@ -2164,13 +2151,6 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 		}
 
 		indexName := n.IndexName
-		if len(indexName) == 0 {
-			indexName, err = generateIndexName(ctx, idxAltTbl, n.ColumnNames())
-			if err != nil {
-				return err
-			}
-		}
-
 		// TODO: this should really be a pointer, but there are too many interfaces that expect a value
 		indexDef := sql.IndexDef{
 			Name:       indexName,
@@ -2179,6 +2159,12 @@ func (b *BaseBuilder) executeAlterIndex(ctx *sql.Context, n *plan.AlterIndex) er
 			Storage:    n.Using,
 			Comment:    n.Comment,
 			Predicate:  n.Predicate,
+		}
+		if len(indexName) == 0 {
+			indexDef.Name, err = getIndexNameGenerator(n.Db).GenerateIndexName(ctx, n.Table.Name(), indexDef, idxAltTbl)
+			if err != nil {
+				return err
+			}
 		}
 
 		if indexDef.IsFullText() {


### PR DESCRIPTION
New `IndexNameGenerator` interface allows databases to customize the logic that generates index names when they aren't explicitly specified. 