### PR TITLE
fix: retain table comment when primary key is a separate clause

### DIFF
--- a/enginetest/queries/create_table_queries.go
+++ b/enginetest/queries/create_table_queries.go
@@ -35,6 +35,27 @@ var CreateTableQueries = []WriteQueryTest{
 		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `pk` int\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT='Table Comments=Still Work'"}},
 	},
 	{
+		// See https://github.com/dolthub/dolt/issues/11163
+		WriteQuery:          `create table tableWithComment (id int not null, r varchar(8) not null, primary key (r, id)) COMMENT='c'`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
+		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `id` int NOT NULL,\n  `r` varchar(8) NOT NULL,\n  PRIMARY KEY (`r`,`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT='c'"}},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11163
+		WriteQuery:          `create table tableWithComment (id int not null, v int, primary key (id), key k (v)) COMMENT='c'`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
+		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `id` int NOT NULL,\n  `v` int,\n  PRIMARY KEY (`id`),\n  KEY `k` (`v`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_bin COMMENT='c'"}},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11163
+		WriteQuery:          `create table tableWithComment (id int not null, primary key (id)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='c'`,
+		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
+		SelectQuery:         "SHOW CREATE TABLE tableWithComment",
+		ExpectedSelect:      []sql.Row{{"tableWithComment", "CREATE TABLE `tableWithComment` (\n  `id` int NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='c'"}},
+	},
+	{
 		WriteQuery:          `create table tableWithComment (pk int) COMMENT "~!@ #$ %^ &* ()"`,
 		ExpectedWriteResult: []sql.Row{{types.NewOkResult(0)}},
 		SelectQuery:         "SHOW CREATE TABLE tableWithComment",

--- a/memory/database.go
+++ b/memory/database.go
@@ -279,7 +279,7 @@ func (d *BaseDatabase) CreateTable(ctx *sql.Context, name string, schema sql.Pri
 }
 
 // CreateIndexedTable creates a table with the given name and schema
-func (d *BaseDatabase) CreateIndexedTable(ctx *sql.Context, name string, sch sql.PrimaryKeySchema, idxDef sql.IndexDef, collation sql.CollationID) error {
+func (d *BaseDatabase) CreateIndexedTable(ctx *sql.Context, name string, sch sql.PrimaryKeySchema, idxDef sql.IndexDef, collation sql.CollationID, comment string) error {
 	d.tablesMu.RLock()
 	_, ok := d.tables[name]
 	d.tablesMu.RUnlock()
@@ -289,6 +289,7 @@ func (d *BaseDatabase) CreateIndexedTable(ctx *sql.Context, name string, sch sql
 
 	table := NewTableWithCollation(ctx, d, name, sch, d.fkColl, collation)
 	table.db = d
+	table.data.comment = comment
 
 	for _, idxCol := range idxDef.Columns {
 		idx := sch.Schema.IndexOfColName(idxCol.Name)

--- a/sql/databases.go
+++ b/sql/databases.go
@@ -177,8 +177,10 @@ type SchemaObjectNameValidator interface {
 type IndexedTableCreator interface {
 	Database
 	// CreateIndexedTable creates the table with the given name and schema using the index definition provided for its
-	// primary key index.
-	CreateIndexedTable(ctx *Context, name string, schema PrimaryKeySchema, idxDef IndexDef, collation CollationID) error
+	// primary key index. Integrators are responsible for persisting all provided table metadata. Comment may be
+	// optionally persisted, and if so, sql.Table implementations should also implement sql.CommentedTable so that the
+	// comment may be retrieved.
+	CreateIndexedTable(ctx *Context, name string, schema PrimaryKeySchema, idxDef IndexDef, collation CollationID, comment string) error
 }
 
 // TemporaryTableCreator is a database that can create temporary tables that persist only as long as the session.

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -1147,6 +1147,7 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 		}
 	}
 
+	comment, _ := n.TableOpts["comment"].(string)
 	if n.Temporary() {
 		creatable, ok := maybePrivDb.(sql.TemporaryTableCreator)
 		if !ok {
@@ -1170,7 +1171,7 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 				}
 			}
 			if pkIdxDef != nil {
-				err = creatable.CreateIndexedTable(ctx, n.Name(), n.PkSchema(), *pkIdxDef, n.Collation)
+				err = creatable.CreateIndexedTable(ctx, n.Name(), n.PkSchema(), *pkIdxDef, n.Collation, comment)
 				if sql.ErrUnsupportedIndexPrefix.Is(err) {
 					return sql.RowsToRowIter(), err
 				}
@@ -1179,17 +1180,9 @@ func (b *BaseBuilder) buildCreateTable(ctx *sql.Context, n *plan.CreateTable, ro
 				if !ok {
 					return sql.RowsToRowIter(), sql.ErrCreateTableNotSupported.New(n.Db.Name())
 				}
-				comment := ""
-				if n.TableOpts != nil && n.TableOpts["comment"] != nil {
-					comment = n.TableOpts["comment"].(string)
-				}
 				err = creatable.CreateTable(ctx, n.Name(), n.PkSchema(), n.Collation, comment)
 			}
 		case sql.TableCreator:
-			comment := ""
-			if n.TableOpts != nil && n.TableOpts["comment"] != nil {
-				comment = n.TableOpts["comment"].(string)
-			}
 			err = creatable.CreateTable(ctx, n.Name(), n.PkSchema(), n.Collation, comment)
 		default:
 			return sql.RowsToRowIter(), sql.ErrCreateTableNotSupported.New(n.Db.Name())


### PR DESCRIPTION
`CREATE TABLE ... COMMENT='c'` dropped the comment when `PRIMARY KEY` was given as a separate clause.
- Add a `comment` parameter to `IndexedTableCreator.CreateIndexedTable` and thread it through the executor.
Block dolthub/dolt#11170