### PR TITLE
fix: panic in regexp functions over large text in group by

### DIFF
--- a/enginetest/engine_only_test.go
+++ b/enginetest/engine_only_test.go
@@ -837,6 +837,9 @@ func TestRegex(t *testing.T) {
 	} {
 		enginetest.TestScript(t, harness, test)
 	}
+	for _, test := range queries.RegexScriptTests {
+		enginetest.TestScript(t, harness, test)
+	}
 	// We force garbage collection twice as we have two levels of finalizers on our regex objects, and we want to make
 	// sure that neither of them panic.
 	runtime.GC()

--- a/enginetest/queries/regex_queries.go
+++ b/enginetest/queries/regex_queries.go
@@ -21,6 +21,8 @@
 package queries
 
 import (
+	"strings"
+
 	"gopkg.in/src-d/go-errors.v1"
 
 	"github.com/dolthub/go-mysql-server/internal/regex"
@@ -2158,4 +2160,47 @@ var RegexTests = []RegexTest{
 		Query:    "SELECT REGEXP_SUBSTR('abc def ghi', '[j-z]+');",
 		Expected: []sql.Row{{nil}},
 	},
+}
+
+// RegexScriptTests holds ScriptTests for the regexp functions.
+var RegexScriptTests = []ScriptTest{
+	{
+		Name: "regexp functions over a large text column in a group by grouping key",
+		SetUpScript: []string{
+			"CREATE TABLE writings (phelps TEXT, language TEXT, text LONGTEXT)",
+			"INSERT INTO writings VALUES " +
+				"('AB10000X','en',CONCAT('<p>',REPEAT('a',2000000)))," +
+				"('AB10000Y','en',CONCAT('<p>',REPEAT('a',2000000)))",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: regexpGroupByQuery("LEFT(REGEXP_REPLACE(text,'^<p>',''),70)"),
+				// REGEXP_REPLACE built a large native result whose buffer copy
+				// over-read past the end and crashed once the result left the heap.
+				// See https://github.com/dolthub/dolt/issues/11183
+				Expected: []sql.Row{{"AB10000", "en", strings.Repeat("a", 70), int64(2)}},
+			},
+			{
+				Query:    regexpGroupByQuery("LEFT(REGEXP_SUBSTR(text,'^<p>'),70)"),
+				Expected: []sql.Row{{"AB10000", "en", "<p>", int64(2)}},
+			},
+			{
+				Query:    regexpGroupByQuery("REGEXP_LIKE(text,'^<p>')"),
+				Expected: []sql.Row{{"AB10000", "en", int8(1), int64(2)}},
+			},
+			{
+				Query:    regexpGroupByQuery("REGEXP_INSTR(text,'^<p>')"),
+				Expected: []sql.Row{{"AB10000", "en", int32(1), int64(2)}},
+			},
+		},
+	},
+}
+
+// regexpGroupByQuery returns the issue's query with |head| as the grouping-key
+// expression, so each regexp function can run in the same context.
+func regexpGroupByQuery(head string) string {
+	return "SELECT SUBSTRING(phelps,1,7) AS base, language, " + head + " AS head, " +
+		"COUNT(DISTINCT phelps) FROM writings " +
+		"WHERE phelps REGEXP '^(BH|BB|AB)[0-9]{5}[A-Z]' " +
+		"GROUP BY base, language, head HAVING COUNT(DISTINCT phelps) > 1"
 }

--- a/enginetest/queries/regex_queries_race.go
+++ b/enginetest/queries/regex_queries_race.go
@@ -33,3 +33,5 @@ type RegexTest struct {
 }
 
 var RegexTests []RegexTest
+
+var RegexScriptTests []ScriptTest

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866
+	github.com/dolthub/go-icu-regex v0.0.0-20260609194726-5d94dca67656
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
 	github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2
-	github.com/dolthub/go-icu-regex v0.0.0-20260609194726-5d94dca67656
+	github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83
 	github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71
 	github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216
 	github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/denisenkom/go-mssqldb v0.10.0 h1:QykgLZBorFE95+gO3u9esLd0BmbvpWp0/waN
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2/go.mod h1:mIEZOHnFx4ZMQeawhw9rhsj+0zwQj7adVsnBX7t+eKY=
-github.com/dolthub/go-icu-regex v0.0.0-20260609194726-5d94dca67656 h1:QkPZwbidx4VQ7IfKFR7y4T0nepv29yOqrGwcnZPdJiw=
-github.com/dolthub/go-icu-regex v0.0.0-20260609194726-5d94dca67656/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
+github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83 h1:FEMjCGEroDnY/BXyAffVZxUpXhP2GpoUJyyq5KaLn8c=
+github.com/dolthub/go-icu-regex v0.0.0-20260610153742-72563bc7ca83/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTEtT5tOBsCuCrlYnLRKpbJVJkDbrTRhwQ=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4EHUcEVQCMRBej8DYxjYjRz/9MdF/NNQh0o70=

--- a/go.sum
+++ b/go.sum
@@ -14,14 +14,12 @@ github.com/denisenkom/go-mssqldb v0.10.0 h1:QykgLZBorFE95+gO3u9esLd0BmbvpWp0/waN
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2 h1:u3PMzfF8RkKd3lB9pZ2bfn0qEG+1Gms9599cr0REMww=
 github.com/dolthub/flatbuffers/v23 v23.3.3-dh.2/go.mod h1:mIEZOHnFx4ZMQeawhw9rhsj+0zwQj7adVsnBX7t+eKY=
-github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866 h1:U6gSf5I0e6h6GP1/5Sa7D2lWW1CWfcVPtY5wkyHq6jY=
-github.com/dolthub/go-icu-regex v0.0.0-20260412212219-49724d547866/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
+github.com/dolthub/go-icu-regex v0.0.0-20260609194726-5d94dca67656 h1:QkPZwbidx4VQ7IfKFR7y4T0nepv29yOqrGwcnZPdJiw=
+github.com/dolthub/go-icu-regex v0.0.0-20260609194726-5d94dca67656/go.mod h1:F3cnm+vMRK1HaU6+rNqQrOCyR03HHhR1GWG2gnPOqaE=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71 h1:bMGS25NWAGTEtT5tOBsCuCrlYnLRKpbJVJkDbrTRhwQ=
 github.com/dolthub/jsonpath v0.0.2-0.20240227200619-19675ab05c71/go.mod h1:2/2zjLQ/JOOSbbSboojeg+cAwcRV0fDLzIiWch/lhqI=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216 h1:JWkKRE4EHUcEVQCMRBej8DYxjYjRz/9MdF/NNQh0o70=
 github.com/dolthub/sqllogictest/go v0.0.0-20240618184124-ca47f9354216/go.mod h1:e/FIZVvT2IR53HBCAo41NjqgtEnjMJGKca3Y/dAmZaA=
-github.com/dolthub/vitess v0.0.0-20260603183207-749c23081c82 h1:ymVmIacpdtsEVfl/e15doh+zq1ovCh1TxwBvZ+Fjqgc=
-github.com/dolthub/vitess v0.0.0-20260603183207-749c23081c82/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542 h1:0A5Y1IP9ribdYzzWDZwN/NM+oxCfmYh7NuM2xIIrEag=
 github.com/dolthub/vitess v0.0.0-20260604210335-0893abc80542/go.mod h1:dKAkzdfRkAudpc0g8JOQ0eiEjV83TYIFz/yNIEdcjXM=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=


### PR DESCRIPTION
`REGEXP_REPLACE` on a large `TEXT` column inside a `GROUP BY` panic with `SIGSEGV`.
- Add a `ScriptTest` and `RegexScriptTests` for similar regressions on `REGEXP_REPLACE`, `REGEXP_SUBSTR`, `REGEXP_LIKE`, and `REGEXP_INSTR`.
Depends on dolthub/go-icu-regex#13