### PR TITLE
allow AllRange prefix for composite indexes

### DIFF
--- a/enginetest/queries/imdb_plans.go
+++ b/enginetest/queries/imdb_plans.go
@@ -15287,16 +15287,16 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   ├─ HashJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ it1.id:18!null\n" +
-			"         │   │   │   │   └─ mi.info_type_id:14!null\n" +
+			"         │   │   │   │   └─ mi.info_type_id:12!null\n" +
 			"         │   │   │   ├─ HashJoin\n" +
 			"         │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   ├─ ct.id:17!null\n" +
 			"         │   │   │   │   │   └─ mc.company_type_id:10!null\n" +
 			"         │   │   │   │   ├─ LookupJoin\n" +
-			"         │   │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   │   ├─ t.id:2!null\n" +
-			"         │   │   │   │   │   │   └─ mi.movie_id:13!null\n" +
 			"         │   │   │   │   │   ├─ LookupJoin\n" +
+			"         │   │   │   │   │   │   ├─ Eq\n" +
+			"         │   │   │   │   │   │   │   ├─ t.id:2!null\n" +
+			"         │   │   │   │   │   │   │   └─ mi.movie_id:11!null\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   │   │   │   ├─ t.id:2!null\n" +
@@ -15346,36 +15346,36 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │   │   │   │               ├─ name: movie_companies\n" +
 			"         │   │   │   │   │   │   │               └─ columns: [movie_id company_id company_type_id]\n" +
 			"         │   │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │   │       ├─ Eq\n" +
-			"         │   │   │   │   │   │       │   ├─ cn.country_code:1\n" +
-			"         │   │   │   │   │   │       │   └─ [us] (longtext)\n" +
-			"         │   │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │   │               ├─ keys: [mc.company_id:9!null]\n" +
-			"         │   │   │   │   │   │               ├─ colSet: (7-13)\n" +
-			"         │   │   │   │   │   │               ├─ tableId: 3\n" +
+			"         │   │   │   │   │   │       ├─ AND\n" +
+			"         │   │   │   │   │   │       │   ├─ AND\n" +
+			"         │   │   │   │   │   │       │   │   ├─ mi.note LIKE '%internet%'\n" +
+			"         │   │   │   │   │   │       │   │   └─ NOT\n" +
+			"         │   │   │   │   │   │       │   │       └─ mi.info:2!null IS NULL\n" +
+			"         │   │   │   │   │   │       │   └─ Or\n" +
+			"         │   │   │   │   │   │       │       ├─ mi.info LIKE 'USA:% 199%'\n" +
+			"         │   │   │   │   │   │       │       └─ mi.info LIKE 'USA:% 200%'\n" +
+			"         │   │   │   │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │   │   │   │               ├─ keys: [mc.movie_id:8!null]\n" +
+			"         │   │   │   │   │   │               ├─ colSet: (28-32)\n" +
+			"         │   │   │   │   │   │               ├─ tableId: 9\n" +
 			"         │   │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │   │                   ├─ name: company_name\n" +
-			"         │   │   │   │   │   │                   └─ columns: [id country_code]\n" +
+			"         │   │   │   │   │   │                   ├─ name: movie_info\n" +
+			"         │   │   │   │   │   │                   └─ columns: [movie_id info_type_id info note]\n" +
 			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ AND\n" +
-			"         │   │   │   │   │       │   ├─ AND\n" +
-			"         │   │   │   │   │       │   │   ├─ mi.note LIKE '%internet%'\n" +
-			"         │   │   │   │   │       │   │   └─ NOT\n" +
-			"         │   │   │   │   │       │   │       └─ mi.info:2!null IS NULL\n" +
-			"         │   │   │   │   │       │   └─ Or\n" +
-			"         │   │   │   │   │       │       ├─ mi.info LIKE 'USA:% 199%'\n" +
-			"         │   │   │   │   │       │       └─ mi.info LIKE 'USA:% 200%'\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ keys: [mc.movie_id:8!null]\n" +
-			"         │   │   │   │   │               ├─ colSet: (28-32)\n" +
-			"         │   │   │   │   │               ├─ tableId: 9\n" +
+			"         │   │   │   │   │       ├─ Eq\n" +
+			"         │   │   │   │   │       │   ├─ cn.country_code:1\n" +
+			"         │   │   │   │   │       │   └─ [us] (longtext)\n" +
+			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │               ├─ keys: [mc.company_id:9!null]\n" +
+			"         │   │   │   │   │               ├─ colSet: (7-13)\n" +
+			"         │   │   │   │   │               ├─ tableId: 3\n" +
 			"         │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │                   ├─ name: movie_info\n" +
-			"         │   │   │   │   │                   └─ columns: [movie_id info_type_id info note]\n" +
+			"         │   │   │   │   │                   ├─ name: company_name\n" +
+			"         │   │   │   │   │                   └─ columns: [id country_code]\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: TUPLE(mc.company_type_id:10!null)\n" +
 			"         │   │   │   │       ├─ right-key: TUPLE(ct.id:0!null)\n" +
@@ -15385,7 +15385,7 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │                   ├─ name: company_type\n" +
 			"         │   │   │   │                   └─ columns: [id]\n" +
 			"         │   │   │   └─ HashLookup\n" +
-			"         │   │   │       ├─ left-key: TUPLE(mi.info_type_id:14!null)\n" +
+			"         │   │   │       ├─ left-key: TUPLE(mi.info_type_id:12!null)\n" +
 			"         │   │   │       ├─ right-key: TUPLE(it1.id:0!null)\n" +
 			"         │   │   │       └─ Filter\n" +
 			"         │   │   │           ├─ Eq\n" +
@@ -15411,7 +15411,7 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   └─ TableAlias(mk)\n" +
 			"         │       └─ IndexedTableAccess(movie_keyword)\n" +
 			"         │           ├─ index: [movie_keyword.movie_id]\n" +
-			"         │           ├─ keys: [mi.movie_id:13!null]\n" +
+			"         │           ├─ keys: [mi.movie_id:11!null]\n" +
 			"         │           ├─ colSet: (33-35)\n" +
 			"         │           ├─ tableId: 10\n" +
 			"         │           └─ Table\n" +
@@ -15441,9 +15441,9 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   ├─ (it1.id = mi.info_type_id)\n" +
 			"         │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857)\n" +
 			"         │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
-			"         │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
-			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857)\n" +
+			"         │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857)\n" +
+			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
+			"         │   │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=137796.720 rows=135086)\n" +
@@ -15475,19 +15475,19 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │   │   │   │           ├─ columns: [movie_id company_id company_type_id]\n" +
 			"         │   │   │   │   │   │   │           └─ keys: cc.movie_id\n" +
 			"         │   │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
-			"         │   │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │   │               ├─ columns: [id country_code]\n" +
-			"         │   │   │   │   │   │               └─ keys: mc.company_id\n" +
+			"         │   │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
+			"         │   │   │   │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
+			"         │   │   │   │   │   │               └─ keys: mc.movie_id\n" +
 			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
-			"         │   │   │   │   │               └─ keys: mc.movie_id\n" +
+			"         │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
+			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │               ├─ columns: [id country_code]\n" +
+			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
 			"         │   │   │   │       ├─ right-key: (ct.id)\n" +
@@ -15538,9 +15538,9 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   ├─ (it1.id = mi.info_type_id)\n" +
 			"         │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
-			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=137796.720 rows=135086) (actual rows=0 loops=1)\n" +
@@ -15572,19 +15572,19 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │   │   │   │           ├─ columns: [movie_id company_id company_type_id]\n" +
 			"         │   │   │   │   │   │   │           └─ keys: cc.movie_id\n" +
 			"         │   │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
-			"         │   │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │   │               ├─ columns: [id country_code]\n" +
-			"         │   │   │   │   │   │               └─ keys: mc.company_id\n" +
+			"         │   │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
+			"         │   │   │   │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
+			"         │   │   │   │   │   │               └─ keys: mc.movie_id\n" +
 			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
-			"         │   │   │   │   │               └─ keys: mc.movie_id\n" +
+			"         │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
+			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │               ├─ columns: [id country_code]\n" +
+			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
 			"         │   │   │   │       ├─ right-key: (ct.id)\n" +
@@ -15734,16 +15734,16 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   ├─ HashJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ it1.id:18!null\n" +
-			"         │   │   │   │   └─ mi.info_type_id:14!null\n" +
+			"         │   │   │   │   └─ mi.info_type_id:12!null\n" +
 			"         │   │   │   ├─ HashJoin\n" +
 			"         │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   ├─ ct.id:17!null\n" +
 			"         │   │   │   │   │   └─ mc.company_type_id:10!null\n" +
 			"         │   │   │   │   ├─ LookupJoin\n" +
-			"         │   │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   │   ├─ t.id:2!null\n" +
-			"         │   │   │   │   │   │   └─ mi.movie_id:13!null\n" +
 			"         │   │   │   │   │   ├─ LookupJoin\n" +
+			"         │   │   │   │   │   │   ├─ Eq\n" +
+			"         │   │   │   │   │   │   │   ├─ t.id:2!null\n" +
+			"         │   │   │   │   │   │   │   └─ mi.movie_id:11!null\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   │   │   │   ├─ t.id:2!null\n" +
@@ -15793,36 +15793,36 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │   │   │   │               ├─ name: movie_companies\n" +
 			"         │   │   │   │   │   │   │               └─ columns: [movie_id company_id company_type_id]\n" +
 			"         │   │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │   │       ├─ Eq\n" +
-			"         │   │   │   │   │   │       │   ├─ cn.country_code:1\n" +
-			"         │   │   │   │   │   │       │   └─ [us] (longtext)\n" +
-			"         │   │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │   │               ├─ keys: [mc.company_id:9!null]\n" +
-			"         │   │   │   │   │   │               ├─ colSet: (7-13)\n" +
-			"         │   │   │   │   │   │               ├─ tableId: 3\n" +
+			"         │   │   │   │   │   │       ├─ AND\n" +
+			"         │   │   │   │   │   │       │   ├─ AND\n" +
+			"         │   │   │   │   │   │       │   │   ├─ mi.note LIKE '%internet%'\n" +
+			"         │   │   │   │   │   │       │   │   └─ NOT\n" +
+			"         │   │   │   │   │   │       │   │       └─ mi.info:2!null IS NULL\n" +
+			"         │   │   │   │   │   │       │   └─ Or\n" +
+			"         │   │   │   │   │   │       │       ├─ mi.info LIKE 'USA:% 199%'\n" +
+			"         │   │   │   │   │   │       │       └─ mi.info LIKE 'USA:% 200%'\n" +
+			"         │   │   │   │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │   │   │   │               ├─ keys: [mc.movie_id:8!null]\n" +
+			"         │   │   │   │   │   │               ├─ colSet: (28-32)\n" +
+			"         │   │   │   │   │   │               ├─ tableId: 9\n" +
 			"         │   │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │   │                   ├─ name: company_name\n" +
-			"         │   │   │   │   │   │                   └─ columns: [id country_code]\n" +
+			"         │   │   │   │   │   │                   ├─ name: movie_info\n" +
+			"         │   │   │   │   │   │                   └─ columns: [movie_id info_type_id info note]\n" +
 			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ AND\n" +
-			"         │   │   │   │   │       │   ├─ AND\n" +
-			"         │   │   │   │   │       │   │   ├─ mi.note LIKE '%internet%'\n" +
-			"         │   │   │   │   │       │   │   └─ NOT\n" +
-			"         │   │   │   │   │       │   │       └─ mi.info:2!null IS NULL\n" +
-			"         │   │   │   │   │       │   └─ Or\n" +
-			"         │   │   │   │   │       │       ├─ mi.info LIKE 'USA:% 199%'\n" +
-			"         │   │   │   │   │       │       └─ mi.info LIKE 'USA:% 200%'\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ keys: [mc.movie_id:8!null]\n" +
-			"         │   │   │   │   │               ├─ colSet: (28-32)\n" +
-			"         │   │   │   │   │               ├─ tableId: 9\n" +
+			"         │   │   │   │   │       ├─ Eq\n" +
+			"         │   │   │   │   │       │   ├─ cn.country_code:1\n" +
+			"         │   │   │   │   │       │   └─ [us] (longtext)\n" +
+			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │               ├─ keys: [mc.company_id:9!null]\n" +
+			"         │   │   │   │   │               ├─ colSet: (7-13)\n" +
+			"         │   │   │   │   │               ├─ tableId: 3\n" +
 			"         │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │                   ├─ name: movie_info\n" +
-			"         │   │   │   │   │                   └─ columns: [movie_id info_type_id info note]\n" +
+			"         │   │   │   │   │                   ├─ name: company_name\n" +
+			"         │   │   │   │   │                   └─ columns: [id country_code]\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: TUPLE(mc.company_type_id:10!null)\n" +
 			"         │   │   │   │       ├─ right-key: TUPLE(ct.id:0!null)\n" +
@@ -15832,7 +15832,7 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │                   ├─ name: company_type\n" +
 			"         │   │   │   │                   └─ columns: [id]\n" +
 			"         │   │   │   └─ HashLookup\n" +
-			"         │   │   │       ├─ left-key: TUPLE(mi.info_type_id:14!null)\n" +
+			"         │   │   │       ├─ left-key: TUPLE(mi.info_type_id:12!null)\n" +
 			"         │   │   │       ├─ right-key: TUPLE(it1.id:0!null)\n" +
 			"         │   │   │       └─ Filter\n" +
 			"         │   │   │           ├─ Eq\n" +
@@ -15858,7 +15858,7 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   └─ TableAlias(mk)\n" +
 			"         │       └─ IndexedTableAccess(movie_keyword)\n" +
 			"         │           ├─ index: [movie_keyword.movie_id]\n" +
-			"         │           ├─ keys: [mi.movie_id:13!null]\n" +
+			"         │           ├─ keys: [mi.movie_id:11!null]\n" +
 			"         │           ├─ colSet: (33-35)\n" +
 			"         │           ├─ tableId: 10\n" +
 			"         │           └─ Table\n" +
@@ -15888,9 +15888,9 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   ├─ (it1.id = mi.info_type_id)\n" +
 			"         │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857)\n" +
 			"         │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
-			"         │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
-			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857)\n" +
+			"         │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857)\n" +
+			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
+			"         │   │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=137796.720 rows=135086)\n" +
@@ -15922,19 +15922,19 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │   │   │   │           ├─ columns: [movie_id company_id company_type_id]\n" +
 			"         │   │   │   │   │   │   │           └─ keys: cc.movie_id\n" +
 			"         │   │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
-			"         │   │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │   │               ├─ columns: [id country_code]\n" +
-			"         │   │   │   │   │   │               └─ keys: mc.company_id\n" +
+			"         │   │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
+			"         │   │   │   │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
+			"         │   │   │   │   │   │               └─ keys: mc.movie_id\n" +
 			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
-			"         │   │   │   │   │               └─ keys: mc.movie_id\n" +
+			"         │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
+			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │               ├─ columns: [id country_code]\n" +
+			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
 			"         │   │   │   │       ├─ right-key: (ct.id)\n" +
@@ -15985,9 +15985,9 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   ├─ (it1.id = mi.info_type_id)\n" +
 			"         │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
-			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   │   │   ├─ (t.id = mi.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=137796.720 rows=135086) (actual rows=0 loops=1)\n" +
@@ -16019,19 +16019,19 @@ WHERE cct1.kind = 'complete+verified'
 			"         │   │   │   │   │   │   │           ├─ columns: [movie_id company_id company_type_id]\n" +
 			"         │   │   │   │   │   │   │           └─ keys: cc.movie_id\n" +
 			"         │   │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
-			"         │   │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │   │               ├─ columns: [id country_code]\n" +
-			"         │   │   │   │   │   │               └─ keys: mc.company_id\n" +
+			"         │   │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
+			"         │   │   │   │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
+			"         │   │   │   │   │   │               └─ keys: mc.movie_id\n" +
 			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ ((mi.note LIKE '%internet%' AND (NOT(mi.info IS NULL))) AND (mi.info LIKE 'USA:% 199%' OR mi.info LIKE 'USA:% 200%'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ columns: [movie_id info_type_id info note]\n" +
-			"         │   │   │   │   │               └─ keys: mc.movie_id\n" +
+			"         │   │   │   │   │       ├─ (cn.country_code = '[us]')\n" +
+			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │               ├─ columns: [id country_code]\n" +
+			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
 			"         │   │   │   │       ├─ right-key: (ct.id)\n" +
@@ -18568,11 +18568,14 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ k.id:21!null\n" +
 			"         │   │   │   │   └─ mk.keyword_id:12!null\n" +
-			"         │   │   │   ├─ LookupJoin\n" +
-			"         │   │   │   │   ├─ HashJoin\n" +
+			"         │   │   │   ├─ HashJoin\n" +
+			"         │   │   │   │   ├─ Eq\n" +
+			"         │   │   │   │   │   ├─ it2.id:19!null\n" +
+			"         │   │   │   │   │   └─ mi_idx.info_type_id:14!null\n" +
+			"         │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   │   ├─ it2.id:16!null\n" +
-			"         │   │   │   │   │   │   └─ mi_idx.info_type_id:14!null\n" +
+			"         │   │   │   │   │   │   ├─ ci.movie_id:17!null\n" +
+			"         │   │   │   │   │   │   └─ mi_idx.movie_id:13!null\n" +
 			"         │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   │   │   ├─ mk.movie_id:11!null\n" +
@@ -18649,27 +18652,27 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │           └─ Table\n" +
 			"         │   │   │   │   │   │               ├─ name: movie_info_idx\n" +
 			"         │   │   │   │   │   │               └─ columns: [movie_id info_type_id info]\n" +
-			"         │   │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │   │       ├─ left-key: TUPLE(mi_idx.info_type_id:14!null)\n" +
-			"         │   │   │   │   │       ├─ right-key: TUPLE(it2.id:0!null)\n" +
-			"         │   │   │   │   │       └─ Filter\n" +
-			"         │   │   │   │   │           ├─ Eq\n" +
-			"         │   │   │   │   │           │   ├─ it2.info:1!null\n" +
-			"         │   │   │   │   │           │   └─ rating (longtext)\n" +
-			"         │   │   │   │   │           └─ TableAlias(it2)\n" +
-			"         │   │   │   │   │               └─ ProcessTable\n" +
-			"         │   │   │   │   │                   └─ Table\n" +
-			"         │   │   │   │   │                       ├─ name: info_type\n" +
-			"         │   │   │   │   │                       └─ columns: [id info]\n" +
-			"         │   │   │   │   └─ TableAlias(ci)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess(cast_info)\n" +
-			"         │   │   │   │           ├─ index: [cast_info.movie_id]\n" +
-			"         │   │   │   │           ├─ keys: [cc.movie_id:0]\n" +
-			"         │   │   │   │           ├─ colSet: (16-22)\n" +
-			"         │   │   │   │           ├─ tableId: 5\n" +
-			"         │   │   │   │           └─ Table\n" +
-			"         │   │   │   │               ├─ name: cast_info\n" +
-			"         │   │   │   │               └─ columns: [person_id movie_id person_role_id]\n" +
+			"         │   │   │   │   │   └─ TableAlias(ci)\n" +
+			"         │   │   │   │   │       └─ IndexedTableAccess(cast_info)\n" +
+			"         │   │   │   │   │           ├─ index: [cast_info.movie_id]\n" +
+			"         │   │   │   │   │           ├─ keys: [cc.movie_id:0]\n" +
+			"         │   │   │   │   │           ├─ colSet: (16-22)\n" +
+			"         │   │   │   │   │           ├─ tableId: 5\n" +
+			"         │   │   │   │   │           └─ Table\n" +
+			"         │   │   │   │   │               ├─ name: cast_info\n" +
+			"         │   │   │   │   │               └─ columns: [person_id movie_id person_role_id]\n" +
+			"         │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │       ├─ left-key: TUPLE(mi_idx.info_type_id:14!null)\n" +
+			"         │   │   │   │       ├─ right-key: TUPLE(it2.id:0!null)\n" +
+			"         │   │   │   │       └─ Filter\n" +
+			"         │   │   │   │           ├─ Eq\n" +
+			"         │   │   │   │           │   ├─ it2.info:1!null\n" +
+			"         │   │   │   │           │   └─ rating (longtext)\n" +
+			"         │   │   │   │           └─ TableAlias(it2)\n" +
+			"         │   │   │   │               └─ ProcessTable\n" +
+			"         │   │   │   │                   └─ Table\n" +
+			"         │   │   │   │                       ├─ name: info_type\n" +
+			"         │   │   │   │                       └─ columns: [id info]\n" +
 			"         │   │   │   └─ HashLookup\n" +
 			"         │   │   │       ├─ left-key: TUPLE(mk.keyword_id:12!null)\n" +
 			"         │   │   │       ├─ right-key: TUPLE(k.id:0!null)\n" +
@@ -18704,7 +18707,7 @@ WHERE cct1.kind = 'cast'
 			"         │       └─ TableAlias(chn)\n" +
 			"         │           └─ IndexedTableAccess(char_name)\n" +
 			"         │               ├─ index: [char_name.id]\n" +
-			"         │               ├─ keys: [ci.person_role_id:20]\n" +
+			"         │               ├─ keys: [ci.person_role_id:18]\n" +
 			"         │               ├─ colSet: (9-15)\n" +
 			"         │               ├─ tableId: 4\n" +
 			"         │               └─ Table\n" +
@@ -18713,7 +18716,7 @@ WHERE cct1.kind = 'cast'
 			"         └─ TableAlias(n)\n" +
 			"             └─ IndexedTableAccess(name)\n" +
 			"                 ├─ index: [name.id]\n" +
-			"                 ├─ keys: [ci.person_id:18!null]\n" +
+			"                 ├─ keys: [ci.person_id:16!null]\n" +
 			"                 ├─ colSet: (38-46)\n" +
 			"                 ├─ tableId: 11\n" +
 			"                 └─ Table\n" +
@@ -18731,9 +18734,10 @@ WHERE cct1.kind = 'cast'
 			"         │   │   ├─ (kt.id = t.kind_id)\n" +
 			"         │   │   ├─ HashJoin (estimated cost=514213.140 rows=168857)\n" +
 			"         │   │   │   ├─ (k.id = mk.keyword_id)\n" +
-			"         │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
-			"         │   │   │   │   ├─ HashJoin (estimated cost=172522.140 rows=168857)\n" +
-			"         │   │   │   │   │   ├─ (it2.id = mi_idx.info_type_id)\n" +
+			"         │   │   │   ├─ HashJoin (estimated cost=172522.140 rows=168857)\n" +
+			"         │   │   │   │   ├─ (it2.id = mi_idx.info_type_id)\n" +
+			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
+			"         │   │   │   │   │   ├─ (ci.movie_id = mi_idx.movie_id)\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
 			"         │   │   │   │   │   │   ├─ (mk.movie_id = mi_idx.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857)\n" +
@@ -18782,20 +18786,20 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
 			"         │   │   │   │   │   │           ├─ columns: [movie_id info_type_id info]\n" +
 			"         │   │   │   │   │   │           └─ keys: cc.movie_id\n" +
-			"         │   │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │   │       ├─ left-key: (mi_idx.info_type_id)\n" +
-			"         │   │   │   │   │       ├─ right-key: (it2.id)\n" +
-			"         │   │   │   │   │       └─ Filter\n" +
-			"         │   │   │   │   │           ├─ (it2.info = 'rating')\n" +
-			"         │   │   │   │   │           └─ TableAlias(it2)\n" +
-			"         │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │                   ├─ name: info_type\n" +
-			"         │   │   │   │   │                   └─ columns: [id info]\n" +
-			"         │   │   │   │   └─ TableAlias(ci)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess(cast_info)\n" +
-			"         │   │   │   │           ├─ index: [cast_info.movie_id]\n" +
-			"         │   │   │   │           ├─ columns: [person_id movie_id person_role_id]\n" +
-			"         │   │   │   │           └─ keys: cc.movie_id\n" +
+			"         │   │   │   │   │   └─ TableAlias(ci)\n" +
+			"         │   │   │   │   │       └─ IndexedTableAccess(cast_info)\n" +
+			"         │   │   │   │   │           ├─ index: [cast_info.movie_id]\n" +
+			"         │   │   │   │   │           ├─ columns: [person_id movie_id person_role_id]\n" +
+			"         │   │   │   │   │           └─ keys: cc.movie_id\n" +
+			"         │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │       ├─ left-key: (mi_idx.info_type_id)\n" +
+			"         │   │   │   │       ├─ right-key: (it2.id)\n" +
+			"         │   │   │   │       └─ Filter\n" +
+			"         │   │   │   │           ├─ (it2.info = 'rating')\n" +
+			"         │   │   │   │           └─ TableAlias(it2)\n" +
+			"         │   │   │   │               └─ Table\n" +
+			"         │   │   │   │                   ├─ name: info_type\n" +
+			"         │   │   │   │                   └─ columns: [id info]\n" +
 			"         │   │   │   └─ HashLookup\n" +
 			"         │   │   │       ├─ left-key: (mk.keyword_id)\n" +
 			"         │   │   │       ├─ right-key: (k.id)\n" +
@@ -18838,9 +18842,10 @@ WHERE cct1.kind = 'cast'
 			"         │   │   ├─ (kt.id = t.kind_id)\n" +
 			"         │   │   ├─ HashJoin (estimated cost=514213.140 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   ├─ (k.id = mk.keyword_id)\n" +
-			"         │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   ├─ HashJoin (estimated cost=172522.140 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   │   ├─ (it2.id = mi_idx.info_type_id)\n" +
+			"         │   │   │   ├─ HashJoin (estimated cost=172522.140 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   ├─ (it2.id = mi_idx.info_type_id)\n" +
+			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   │   ├─ (ci.movie_id = mi_idx.movie_id)\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   ├─ (mk.movie_id = mi_idx.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857) (actual rows=0 loops=1)\n" +
@@ -18889,20 +18894,20 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
 			"         │   │   │   │   │   │           ├─ columns: [movie_id info_type_id info]\n" +
 			"         │   │   │   │   │   │           └─ keys: cc.movie_id\n" +
-			"         │   │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │   │       ├─ left-key: (mi_idx.info_type_id)\n" +
-			"         │   │   │   │   │       ├─ right-key: (it2.id)\n" +
-			"         │   │   │   │   │       └─ Filter\n" +
-			"         │   │   │   │   │           ├─ (it2.info = 'rating')\n" +
-			"         │   │   │   │   │           └─ TableAlias(it2)\n" +
-			"         │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │                   ├─ name: info_type\n" +
-			"         │   │   │   │   │                   └─ columns: [id info]\n" +
-			"         │   │   │   │   └─ TableAlias(ci)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess(cast_info)\n" +
-			"         │   │   │   │           ├─ index: [cast_info.movie_id]\n" +
-			"         │   │   │   │           ├─ columns: [person_id movie_id person_role_id]\n" +
-			"         │   │   │   │           └─ keys: cc.movie_id\n" +
+			"         │   │   │   │   │   └─ TableAlias(ci)\n" +
+			"         │   │   │   │   │       └─ IndexedTableAccess(cast_info)\n" +
+			"         │   │   │   │   │           ├─ index: [cast_info.movie_id]\n" +
+			"         │   │   │   │   │           ├─ columns: [person_id movie_id person_role_id]\n" +
+			"         │   │   │   │   │           └─ keys: cc.movie_id\n" +
+			"         │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │       ├─ left-key: (mi_idx.info_type_id)\n" +
+			"         │   │   │   │       ├─ right-key: (it2.id)\n" +
+			"         │   │   │   │       └─ Filter\n" +
+			"         │   │   │   │           ├─ (it2.info = 'rating')\n" +
+			"         │   │   │   │           └─ TableAlias(it2)\n" +
+			"         │   │   │   │               └─ Table\n" +
+			"         │   │   │   │                   ├─ name: info_type\n" +
+			"         │   │   │   │                   └─ columns: [id info]\n" +
 			"         │   │   │   └─ HashLookup\n" +
 			"         │   │   │       ├─ left-key: (mk.keyword_id)\n" +
 			"         │   │   │       ├─ right-key: (k.id)\n" +
@@ -19050,7 +19055,7 @@ WHERE cct1.kind IN ('cast',
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [min(cn.name):0!null->producing_company:0, min(lt.link):1!null->link_type:0, min(t.title):2!null->complete_western_sequel:0]\n" +
 			" └─ GroupBy\n" +
-			"     ├─ select: MIN(cn.name:17!null), MIN(lt.link:28!null), MIN(t.title:3!null)\n" +
+			"     ├─ select: MIN(cn.name:19!null), MIN(lt.link:28!null), MIN(t.title:3!null)\n" +
 			"     ├─ group: \n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
@@ -19077,11 +19082,11 @@ WHERE cct1.kind IN ('cast',
 			"         │   │   │   │   └─ Eq\n" +
 			"         │   │   │   │       ├─ ml.movie_id:0!null\n" +
 			"         │   │   │   │       └─ mk.movie_id:21!null\n" +
-			"         │   │   │   ├─ HashJoin\n" +
-			"         │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   ├─ mc.company_type_id:14!null\n" +
-			"         │   │   │   │   │   └─ ct.id:19!null\n" +
-			"         │   │   │   │   ├─ LookupJoin\n" +
+			"         │   │   │   ├─ LookupJoin\n" +
+			"         │   │   │   │   ├─ HashJoin\n" +
+			"         │   │   │   │   │   ├─ Eq\n" +
+			"         │   │   │   │   │   │   ├─ mc.company_type_id:14!null\n" +
+			"         │   │   │   │   │   │   └─ ct.id:16!null\n" +
 			"         │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   │   │   ├─ ml.movie_id:0!null\n" +
@@ -19159,36 +19164,36 @@ WHERE cct1.kind IN ('cast',
 			"         │   │   │   │   │   │               └─ Table\n" +
 			"         │   │   │   │   │   │                   ├─ name: movie_companies\n" +
 			"         │   │   │   │   │   │                   └─ columns: [movie_id company_id company_type_id note]\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ AND\n" +
-			"         │   │   │   │   │       │   ├─ NOT\n" +
-			"         │   │   │   │   │       │   │   └─ Eq\n" +
-			"         │   │   │   │   │       │   │       ├─ cn.country_code:2\n" +
-			"         │   │   │   │   │       │   │       └─ [pl] (longtext)\n" +
-			"         │   │   │   │   │       │   └─ Or\n" +
-			"         │   │   │   │   │       │       ├─ cn.name LIKE '%Film%'\n" +
-			"         │   │   │   │   │       │       └─ cn.name LIKE '%Warner%'\n" +
-			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │               ├─ keys: [mc.company_id:13!null]\n" +
-			"         │   │   │   │   │               ├─ colSet: (9-15)\n" +
-			"         │   │   │   │   │               ├─ tableId: 4\n" +
-			"         │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │                   ├─ name: company_name\n" +
-			"         │   │   │   │   │                   └─ columns: [id name country_code]\n" +
-			"         │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │       ├─ left-key: TUPLE(mc.company_type_id:14!null)\n" +
-			"         │   │   │   │       ├─ right-key: TUPLE(ct.id:0!null)\n" +
-			"         │   │   │   │       └─ Filter\n" +
-			"         │   │   │   │           ├─ Eq\n" +
-			"         │   │   │   │           │   ├─ ct.kind:1!null\n" +
-			"         │   │   │   │           │   └─ production companies (longtext)\n" +
-			"         │   │   │   │           └─ TableAlias(ct)\n" +
-			"         │   │   │   │               └─ ProcessTable\n" +
-			"         │   │   │   │                   └─ Table\n" +
-			"         │   │   │   │                       ├─ name: company_type\n" +
-			"         │   │   │   │                       └─ columns: [id kind]\n" +
+			"         │   │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │   │       ├─ left-key: TUPLE(mc.company_type_id:14!null)\n" +
+			"         │   │   │   │   │       ├─ right-key: TUPLE(ct.id:0!null)\n" +
+			"         │   │   │   │   │       └─ Filter\n" +
+			"         │   │   │   │   │           ├─ Eq\n" +
+			"         │   │   │   │   │           │   ├─ ct.kind:1!null\n" +
+			"         │   │   │   │   │           │   └─ production companies (longtext)\n" +
+			"         │   │   │   │   │           └─ TableAlias(ct)\n" +
+			"         │   │   │   │   │               └─ ProcessTable\n" +
+			"         │   │   │   │   │                   └─ Table\n" +
+			"         │   │   │   │   │                       ├─ name: company_type\n" +
+			"         │   │   │   │   │                       └─ columns: [id kind]\n" +
+			"         │   │   │   │   └─ Filter\n" +
+			"         │   │   │   │       ├─ AND\n" +
+			"         │   │   │   │       │   ├─ NOT\n" +
+			"         │   │   │   │       │   │   └─ Eq\n" +
+			"         │   │   │   │       │   │       ├─ cn.country_code:2\n" +
+			"         │   │   │   │       │   │       └─ [pl] (longtext)\n" +
+			"         │   │   │   │       │   └─ Or\n" +
+			"         │   │   │   │       │       ├─ cn.name LIKE '%Film%'\n" +
+			"         │   │   │   │       │       └─ cn.name LIKE '%Warner%'\n" +
+			"         │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │               ├─ keys: [mc.company_id:13!null]\n" +
+			"         │   │   │   │               ├─ colSet: (9-15)\n" +
+			"         │   │   │   │               ├─ tableId: 4\n" +
+			"         │   │   │   │               └─ Table\n" +
+			"         │   │   │   │                   ├─ name: company_name\n" +
+			"         │   │   │   │                   └─ columns: [id name country_code]\n" +
 			"         │   │   │   └─ TableAlias(mk)\n" +
 			"         │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
 			"         │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
@@ -19247,9 +19252,9 @@ WHERE cct1.kind IN ('cast',
 			"         │   ├─ LookupJoin (estimated cost=144826.800 rows=37496)\n" +
 			"         │   │   ├─ LookupJoin (estimated cost=181638.500 rows=58586)\n" +
 			"         │   │   │   ├─ ((mk.movie_id = cc.movie_id) AND (ml.movie_id = mk.movie_id))\n" +
-			"         │   │   │   ├─ HashJoin (estimated cost=47816.400 rows=46870)\n" +
-			"         │   │   │   │   ├─ (mc.company_type_id = ct.id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=154671.000 rows=46870)\n" +
+			"         │   │   │   ├─ LookupJoin (estimated cost=154671.000 rows=46870)\n" +
+			"         │   │   │   │   ├─ HashJoin (estimated cost=47816.400 rows=46870)\n" +
+			"         │   │   │   │   │   ├─ (mc.company_type_id = ct.id)\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=145317.700 rows=46870)\n" +
 			"         │   │   │   │   │   │   ├─ (ml.movie_id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ HashJoin (estimated cost=38254.920 rows=37496)\n" +
@@ -19299,22 +19304,22 @@ WHERE cct1.kind IN ('cast',
 			"         │   │   │   │   │   │               ├─ index: [movie_companies.movie_id]\n" +
 			"         │   │   │   │   │   │               ├─ columns: [movie_id company_id company_type_id note]\n" +
 			"         │   │   │   │   │   │               └─ keys: cc.movie_id\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ ((NOT((cn.country_code = '[pl]'))) AND (cn.name LIKE '%Film%' OR cn.name LIKE '%Warner%'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │               ├─ columns: [id name country_code]\n" +
-			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
-			"         │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
-			"         │   │   │   │       ├─ right-key: (ct.id)\n" +
-			"         │   │   │   │       └─ Filter\n" +
-			"         │   │   │   │           ├─ (ct.kind = 'production companies')\n" +
-			"         │   │   │   │           └─ TableAlias(ct)\n" +
-			"         │   │   │   │               └─ Table\n" +
-			"         │   │   │   │                   ├─ name: company_type\n" +
-			"         │   │   │   │                   └─ columns: [id kind]\n" +
+			"         │   │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
+			"         │   │   │   │   │       ├─ right-key: (ct.id)\n" +
+			"         │   │   │   │   │       └─ Filter\n" +
+			"         │   │   │   │   │           ├─ (ct.kind = 'production companies')\n" +
+			"         │   │   │   │   │           └─ TableAlias(ct)\n" +
+			"         │   │   │   │   │               └─ Table\n" +
+			"         │   │   │   │   │                   ├─ name: company_type\n" +
+			"         │   │   │   │   │                   └─ columns: [id kind]\n" +
+			"         │   │   │   │   └─ Filter\n" +
+			"         │   │   │   │       ├─ ((NOT((cn.country_code = '[pl]'))) AND (cn.name LIKE '%Film%' OR cn.name LIKE '%Warner%'))\n" +
+			"         │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │               ├─ columns: [id name country_code]\n" +
+			"         │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   └─ TableAlias(mk)\n" +
 			"         │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
 			"         │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
@@ -19356,9 +19361,9 @@ WHERE cct1.kind IN ('cast',
 			"         │   ├─ LookupJoin (estimated cost=144826.800 rows=37496) (actual rows=0 loops=1)\n" +
 			"         │   │   ├─ LookupJoin (estimated cost=181638.500 rows=58586) (actual rows=0 loops=1)\n" +
 			"         │   │   │   ├─ ((mk.movie_id = cc.movie_id) AND (ml.movie_id = mk.movie_id))\n" +
-			"         │   │   │   ├─ HashJoin (estimated cost=47816.400 rows=46870) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   ├─ (mc.company_type_id = ct.id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=154671.000 rows=46870) (actual rows=0 loops=1)\n" +
+			"         │   │   │   ├─ LookupJoin (estimated cost=154671.000 rows=46870) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   ├─ HashJoin (estimated cost=47816.400 rows=46870) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   │   ├─ (mc.company_type_id = ct.id)\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=145317.700 rows=46870) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   ├─ (ml.movie_id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ HashJoin (estimated cost=38254.920 rows=37496) (actual rows=0 loops=1)\n" +
@@ -19408,22 +19413,22 @@ WHERE cct1.kind IN ('cast',
 			"         │   │   │   │   │   │               ├─ index: [movie_companies.movie_id]\n" +
 			"         │   │   │   │   │   │               ├─ columns: [movie_id company_id company_type_id note]\n" +
 			"         │   │   │   │   │   │               └─ keys: cc.movie_id\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ ((NOT((cn.country_code = '[pl]'))) AND (cn.name LIKE '%Film%' OR cn.name LIKE '%Warner%'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │               ├─ columns: [id name country_code]\n" +
-			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
-			"         │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
-			"         │   │   │   │       ├─ right-key: (ct.id)\n" +
-			"         │   │   │   │       └─ Filter\n" +
-			"         │   │   │   │           ├─ (ct.kind = 'production companies')\n" +
-			"         │   │   │   │           └─ TableAlias(ct)\n" +
-			"         │   │   │   │               └─ Table\n" +
-			"         │   │   │   │                   ├─ name: company_type\n" +
-			"         │   │   │   │                   └─ columns: [id kind]\n" +
+			"         │   │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
+			"         │   │   │   │   │       ├─ right-key: (ct.id)\n" +
+			"         │   │   │   │   │       └─ Filter\n" +
+			"         │   │   │   │   │           ├─ (ct.kind = 'production companies')\n" +
+			"         │   │   │   │   │           └─ TableAlias(ct)\n" +
+			"         │   │   │   │   │               └─ Table\n" +
+			"         │   │   │   │   │                   ├─ name: company_type\n" +
+			"         │   │   │   │   │                   └─ columns: [id kind]\n" +
+			"         │   │   │   │   └─ Filter\n" +
+			"         │   │   │   │       ├─ ((NOT((cn.country_code = '[pl]'))) AND (cn.name LIKE '%Film%' OR cn.name LIKE '%Warner%'))\n" +
+			"         │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │               ├─ columns: [id name country_code]\n" +
+			"         │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   └─ TableAlias(mk)\n" +
 			"         │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
 			"         │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
@@ -19723,7 +19728,7 @@ WHERE cct1.kind = 'cast'
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [min(cn.name):0!null->movie_company:0, min(mi_idx.info):1!null->rating:0, min(t.title):2!null->complete_euro_dark_movie:0]\n" +
 			" └─ GroupBy\n" +
-			"     ├─ select: MIN(cn.name:23!null), MIN(mi_idx.info:18!null), MIN(t.title:4!null)\n" +
+			"     ├─ select: MIN(cn.name:16!null), MIN(mi_idx.info:20!null), MIN(t.title:4!null)\n" +
 			"     ├─ group: \n" +
 			"     └─ LookupJoin\n" +
 			"         ├─ LookupJoin\n" +
@@ -19731,7 +19736,7 @@ WHERE cct1.kind = 'cast'
 			"         │   │   ├─ AND\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ mk.movie_id:31!null\n" +
-			"         │   │   │   │   └─ mi_idx.movie_id:16!null\n" +
+			"         │   │   │   │   └─ mi_idx.movie_id:18!null\n" +
 			"         │   │   │   └─ Eq\n" +
 			"         │   │   │       ├─ mk.movie_id:31!null\n" +
 			"         │   │   │       └─ mc.movie_id:11!null\n" +
@@ -19745,24 +19750,24 @@ WHERE cct1.kind = 'cast'
 			"         │   │   ├─ HashJoin\n" +
 			"         │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   ├─ it2.id:27!null\n" +
-			"         │   │   │   │   └─ mi_idx.info_type_id:17!null\n" +
+			"         │   │   │   │   └─ mi_idx.info_type_id:19!null\n" +
 			"         │   │   │   ├─ HashJoin\n" +
 			"         │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   ├─ it1.id:25!null\n" +
-			"         │   │   │   │   │   └─ mi.info_type_id:20!null\n" +
-			"         │   │   │   │   ├─ LookupJoin\n" +
+			"         │   │   │   │   │   └─ mi.info_type_id:22!null\n" +
+			"         │   │   │   │   ├─ HashJoin\n" +
+			"         │   │   │   │   │   ├─ Eq\n" +
+			"         │   │   │   │   │   │   ├─ ct.id:24!null\n" +
+			"         │   │   │   │   │   │   └─ mc.company_type_id:13!null\n" +
 			"         │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   │   │   ├─ mi.movie_id:19!null\n" +
-			"         │   │   │   │   │   │   │   └─ mi_idx.movie_id:16!null\n" +
+			"         │   │   │   │   │   │   │   ├─ mi.movie_id:21!null\n" +
+			"         │   │   │   │   │   │   │   └─ mi_idx.movie_id:18!null\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   │   │   │   ├─ t.id:3!null\n" +
-			"         │   │   │   │   │   │   │   │   └─ mi_idx.movie_id:16!null\n" +
-			"         │   │   │   │   │   │   │   ├─ HashJoin\n" +
-			"         │   │   │   │   │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   │   │   │   │   ├─ ct.id:15!null\n" +
-			"         │   │   │   │   │   │   │   │   │   └─ mc.company_type_id:13!null\n" +
+			"         │   │   │   │   │   │   │   │   └─ mi_idx.movie_id:18!null\n" +
+			"         │   │   │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   │   │   │   ├─ Eq\n" +
 			"         │   │   │   │   │   │   │   │   │   │   ├─ t.id:3!null\n" +
@@ -19833,14 +19838,20 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │   │   │   │               └─ Table\n" +
 			"         │   │   │   │   │   │   │   │   │                   ├─ name: movie_companies\n" +
 			"         │   │   │   │   │   │   │   │   │                   └─ columns: [movie_id company_id company_type_id note]\n" +
-			"         │   │   │   │   │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │   │   │   │   │       ├─ left-key: TUPLE(mc.company_type_id:13!null)\n" +
-			"         │   │   │   │   │   │   │   │       ├─ right-key: TUPLE(ct.id:0!null)\n" +
-			"         │   │   │   │   │   │   │   │       └─ TableAlias(ct)\n" +
-			"         │   │   │   │   │   │   │   │           └─ ProcessTable\n" +
+			"         │   │   │   │   │   │   │   │   └─ Filter\n" +
+			"         │   │   │   │   │   │   │   │       ├─ NOT\n" +
+			"         │   │   │   │   │   │   │   │       │   └─ Eq\n" +
+			"         │   │   │   │   │   │   │   │       │       ├─ cn.country_code:2\n" +
+			"         │   │   │   │   │   │   │   │       │       └─ [us] (longtext)\n" +
+			"         │   │   │   │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │   │   │   │               ├─ keys: [mc.company_id:12!null]\n" +
+			"         │   │   │   │   │   │   │   │               ├─ colSet: (9-15)\n" +
+			"         │   │   │   │   │   │   │   │               ├─ tableId: 4\n" +
 			"         │   │   │   │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │   │   │   │                   ├─ name: company_type\n" +
-			"         │   │   │   │   │   │   │   │                   └─ columns: [id]\n" +
+			"         │   │   │   │   │   │   │   │                   ├─ name: company_name\n" +
+			"         │   │   │   │   │   │   │   │                   └─ columns: [id name country_code]\n" +
 			"         │   │   │   │   │   │   │   └─ Filter\n" +
 			"         │   │   │   │   │   │   │       ├─ LessThan\n" +
 			"         │   │   │   │   │   │   │       │   ├─ mi_idx.info:2!null\n" +
@@ -19867,22 +19878,16 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │               └─ Table\n" +
 			"         │   │   │   │   │   │                   ├─ name: movie_info\n" +
 			"         │   │   │   │   │   │                   └─ columns: [movie_id info_type_id info]\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ NOT\n" +
-			"         │   │   │   │   │       │   └─ Eq\n" +
-			"         │   │   │   │   │       │       ├─ cn.country_code:2\n" +
-			"         │   │   │   │   │       │       └─ [us] (longtext)\n" +
-			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │               ├─ keys: [mc.company_id:12!null]\n" +
-			"         │   │   │   │   │               ├─ colSet: (9-15)\n" +
-			"         │   │   │   │   │               ├─ tableId: 4\n" +
+			"         │   │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │   │       ├─ left-key: TUPLE(mc.company_type_id:13!null)\n" +
+			"         │   │   │   │   │       ├─ right-key: TUPLE(ct.id:0!null)\n" +
+			"         │   │   │   │   │       └─ TableAlias(ct)\n" +
+			"         │   │   │   │   │           └─ ProcessTable\n" +
 			"         │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │                   ├─ name: company_name\n" +
-			"         │   │   │   │   │                   └─ columns: [id name country_code]\n" +
+			"         │   │   │   │   │                   ├─ name: company_type\n" +
+			"         │   │   │   │   │                   └─ columns: [id]\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │       ├─ left-key: TUPLE(mi.info_type_id:20!null)\n" +
+			"         │   │   │   │       ├─ left-key: TUPLE(mi.info_type_id:22!null)\n" +
 			"         │   │   │   │       ├─ right-key: TUPLE(it1.id:0!null)\n" +
 			"         │   │   │   │       └─ Filter\n" +
 			"         │   │   │   │           ├─ Eq\n" +
@@ -19894,7 +19899,7 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │                       ├─ name: info_type\n" +
 			"         │   │   │   │                       └─ columns: [id info]\n" +
 			"         │   │   │   └─ HashLookup\n" +
-			"         │   │   │       ├─ left-key: TUPLE(mi_idx.info_type_id:17!null)\n" +
+			"         │   │   │       ├─ left-key: TUPLE(mi_idx.info_type_id:19!null)\n" +
 			"         │   │   │       ├─ right-key: TUPLE(it2.id:0!null)\n" +
 			"         │   │   │       └─ Filter\n" +
 			"         │   │   │           ├─ Eq\n" +
@@ -19921,7 +19926,7 @@ WHERE cct1.kind = 'cast'
 			"         │   └─ TableAlias(mk)\n" +
 			"         │       └─ IndexedTableAccess(movie_keyword)\n" +
 			"         │           ├─ index: [movie_keyword.movie_id]\n" +
-			"         │           ├─ keys: [mi.movie_id:19!null]\n" +
+			"         │           ├─ keys: [mi.movie_id:21!null]\n" +
 			"         │           ├─ colSet: (42-44)\n" +
 			"         │           ├─ tableId: 13\n" +
 			"         │           └─ Table\n" +
@@ -19955,13 +19960,13 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   ├─ (it2.id = mi_idx.info_type_id)\n" +
 			"         │   │   │   ├─ HashJoin (estimated cost=172522.140 rows=168857)\n" +
 			"         │   │   │   │   ├─ (it1.id = mi.info_type_id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857)\n" +
+			"         │   │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857)\n" +
+			"         │   │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
 			"         │   │   │   │   │   │   ├─ (mi.movie_id = mi_idx.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = mi_idx.movie_id)\n" +
-			"         │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857)\n" +
-			"         │   │   │   │   │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
+			"         │   │   │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857)\n" +
 			"         │   │   │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857)\n" +
 			"         │   │   │   │   │   │   │   │   │   ├─ (t.id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=137796.720 rows=135086)\n" +
@@ -20005,13 +20010,13 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │   │   │   │               ├─ index: [movie_companies.movie_id]\n" +
 			"         │   │   │   │   │   │   │   │   │               ├─ columns: [movie_id company_id company_type_id note]\n" +
 			"         │   │   │   │   │   │   │   │   │               └─ keys: cc.movie_id\n" +
-			"         │   │   │   │   │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │   │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
-			"         │   │   │   │   │   │   │   │       ├─ right-key: (ct.id)\n" +
-			"         │   │   │   │   │   │   │   │       └─ TableAlias(ct)\n" +
-			"         │   │   │   │   │   │   │   │           └─ Table\n" +
-			"         │   │   │   │   │   │   │   │               ├─ name: company_type\n" +
-			"         │   │   │   │   │   │   │   │               └─ columns: [id]\n" +
+			"         │   │   │   │   │   │   │   │   └─ Filter\n" +
+			"         │   │   │   │   │   │   │   │       ├─ (NOT((cn.country_code = '[us]')))\n" +
+			"         │   │   │   │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │   │   │   │               ├─ columns: [id name country_code]\n" +
+			"         │   │   │   │   │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   │   │   │   │   └─ Filter\n" +
 			"         │   │   │   │   │   │   │       ├─ (mi_idx.info < '8.5')\n" +
 			"         │   │   │   │   │   │   │       └─ TableAlias(mi_idx)\n" +
@@ -20026,13 +20031,13 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
 			"         │   │   │   │   │   │               ├─ columns: [movie_id info_type_id info]\n" +
 			"         │   │   │   │   │   │               └─ keys: mc.movie_id\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ (NOT((cn.country_code = '[us]')))\n" +
-			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │               ├─ columns: [id name country_code]\n" +
-			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
+			"         │   │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
+			"         │   │   │   │   │       ├─ right-key: (ct.id)\n" +
+			"         │   │   │   │   │       └─ TableAlias(ct)\n" +
+			"         │   │   │   │   │           └─ Table\n" +
+			"         │   │   │   │   │               ├─ name: company_type\n" +
+			"         │   │   │   │   │               └─ columns: [id]\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: (mi.info_type_id)\n" +
 			"         │   │   │   │       ├─ right-key: (it1.id)\n" +
@@ -20087,13 +20092,13 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   ├─ (it2.id = mi_idx.info_type_id)\n" +
 			"         │   │   │   ├─ HashJoin (estimated cost=172522.140 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   ├─ (it1.id = mi.info_type_id)\n" +
-			"         │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857) (actual rows=0 loops=1)\n" +
+			"         │   │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   ├─ (mi.movie_id = mi_idx.movie_id)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = mi_idx.movie_id)\n" +
-			"         │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=172246.140 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   │   │   │   │   ├─ (ct.id = mc.company_type_id)\n" +
+			"         │   │   │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   │   │   │   ├─ (t.id = mc.movie_id)\n" +
 			"         │   │   │   │   │   │   │   │   │   ├─ HashJoin (estimated cost=137796.720 rows=135086) (actual rows=0 loops=1)\n" +
@@ -20137,13 +20142,13 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │   │   │   │               ├─ index: [movie_companies.movie_id]\n" +
 			"         │   │   │   │   │   │   │   │   │               ├─ columns: [movie_id company_id company_type_id note]\n" +
 			"         │   │   │   │   │   │   │   │   │               └─ keys: cc.movie_id\n" +
-			"         │   │   │   │   │   │   │   │   └─ HashLookup\n" +
-			"         │   │   │   │   │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
-			"         │   │   │   │   │   │   │   │       ├─ right-key: (ct.id)\n" +
-			"         │   │   │   │   │   │   │   │       └─ TableAlias(ct)\n" +
-			"         │   │   │   │   │   │   │   │           └─ Table\n" +
-			"         │   │   │   │   │   │   │   │               ├─ name: company_type\n" +
-			"         │   │   │   │   │   │   │   │               └─ columns: [id]\n" +
+			"         │   │   │   │   │   │   │   │   └─ Filter\n" +
+			"         │   │   │   │   │   │   │   │       ├─ (NOT((cn.country_code = '[us]')))\n" +
+			"         │   │   │   │   │   │   │   │       └─ TableAlias(cn)\n" +
+			"         │   │   │   │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
+			"         │   │   │   │   │   │   │   │               ├─ index: [company_name.id]\n" +
+			"         │   │   │   │   │   │   │   │               ├─ columns: [id name country_code]\n" +
+			"         │   │   │   │   │   │   │   │               └─ keys: mc.company_id\n" +
 			"         │   │   │   │   │   │   │   └─ Filter\n" +
 			"         │   │   │   │   │   │   │       ├─ (mi_idx.info < '8.5')\n" +
 			"         │   │   │   │   │   │   │       └─ TableAlias(mi_idx)\n" +
@@ -20158,13 +20163,13 @@ WHERE cct1.kind = 'cast'
 			"         │   │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
 			"         │   │   │   │   │   │               ├─ columns: [movie_id info_type_id info]\n" +
 			"         │   │   │   │   │   │               └─ keys: mc.movie_id\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ (NOT((cn.country_code = '[us]')))\n" +
-			"         │   │   │   │   │       └─ TableAlias(cn)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(company_name)\n" +
-			"         │   │   │   │   │               ├─ index: [company_name.id]\n" +
-			"         │   │   │   │   │               ├─ columns: [id name country_code]\n" +
-			"         │   │   │   │   │               └─ keys: mc.company_id\n" +
+			"         │   │   │   │   │   └─ HashLookup\n" +
+			"         │   │   │   │   │       ├─ left-key: (mc.company_type_id)\n" +
+			"         │   │   │   │   │       ├─ right-key: (ct.id)\n" +
+			"         │   │   │   │   │       └─ TableAlias(ct)\n" +
+			"         │   │   │   │   │           └─ Table\n" +
+			"         │   │   │   │   │               ├─ name: company_type\n" +
+			"         │   │   │   │   │               └─ columns: [id]\n" +
 			"         │   │   │   │   └─ HashLookup\n" +
 			"         │   │   │   │       ├─ left-key: (mi.info_type_id)\n" +
 			"         │   │   │   │       ├─ right-key: (it1.id)\n" +
@@ -22927,36 +22932,44 @@ WHERE cct1.kind IN ('cast',
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [min(mi.info):0!null->movie_budget:0, min(mi_idx.info):1!null->movie_votes:0, min(n.name):2!null->writer:0, min(t.title):3!null->complete_gore_movie:0]\n" +
 			" └─ GroupBy\n" +
-			"     ├─ select: MIN(mi.info:18!null), MIN(mi_idx.info:23!null), MIN(n.name:14!null), MIN(t.title:4!null)\n" +
+			"     ├─ select: MIN(mi.info:23!null), MIN(mi_idx.info:20!null), MIN(n.name:14!null), MIN(t.title:4!null)\n" +
 			"     ├─ group: \n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
 			"         │   ├─ k.id:28!null\n" +
-			"         │   └─ mk.keyword_id:20!null\n" +
+			"         │   └─ mk.keyword_id:17!null\n" +
 			"         ├─ HashJoin\n" +
 			"         │   ├─ Eq\n" +
 			"         │   │   ├─ it2.id:26!null\n" +
-			"         │   │   └─ mi_idx.info_type_id:22!null\n" +
+			"         │   │   └─ mi_idx.info_type_id:19!null\n" +
 			"         │   ├─ HashJoin\n" +
 			"         │   │   ├─ Eq\n" +
 			"         │   │   │   ├─ it1.id:24!null\n" +
-			"         │   │   │   └─ mi.info_type_id:17!null\n" +
+			"         │   │   │   └─ mi.info_type_id:22!null\n" +
 			"         │   │   ├─ LookupJoin\n" +
-			"         │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   ├─ mi_idx.movie_id:21!null\n" +
-			"         │   │   │   │   └─ mk.movie_id:19!null\n" +
-			"         │   │   │   ├─ LookupJoin\n" +
+			"         │   │   │   ├─ AND\n" +
 			"         │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   ├─ t.id:3!null\n" +
-			"         │   │   │   │   │   └─ mk.movie_id:19!null\n" +
+			"         │   │   │   │   │   ├─ mi.movie_id:21!null\n" +
+			"         │   │   │   │   │   └─ cc.movie_id:0\n" +
+			"         │   │   │   │   └─ Eq\n" +
+			"         │   │   │   │       ├─ mi.movie_id:21!null\n" +
+			"         │   │   │   │       └─ mi_idx.movie_id:18!null\n" +
+			"         │   │   │   ├─ LookupJoin\n" +
+			"         │   │   │   │   ├─ AND\n" +
+			"         │   │   │   │   │   ├─ Eq\n" +
+			"         │   │   │   │   │   │   ├─ mi_idx.movie_id:18!null\n" +
+			"         │   │   │   │   │   │   └─ cc.movie_id:0\n" +
+			"         │   │   │   │   │   └─ Eq\n" +
+			"         │   │   │   │   │       ├─ mi_idx.movie_id:18!null\n" +
+			"         │   │   │   │   │       └─ mk.movie_id:16!null\n" +
 			"         │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   ├─ AND\n" +
 			"         │   │   │   │   │   │   ├─ Eq\n" +
-			"         │   │   │   │   │   │   │   ├─ mi.movie_id:16!null\n" +
+			"         │   │   │   │   │   │   │   ├─ mk.movie_id:16!null\n" +
 			"         │   │   │   │   │   │   │   └─ cc.movie_id:0\n" +
 			"         │   │   │   │   │   │   └─ Eq\n" +
 			"         │   │   │   │   │   │       ├─ t.id:3!null\n" +
-			"         │   │   │   │   │   │       └─ mi.movie_id:16!null\n" +
+			"         │   │   │   │   │   │       └─ mk.movie_id:16!null\n" +
 			"         │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin\n" +
 			"         │   │   │   │   │   │   │   ├─ Eq\n" +
@@ -23052,39 +23065,39 @@ WHERE cct1.kind IN ('cast',
 			"         │   │   │   │   │   │               └─ Table\n" +
 			"         │   │   │   │   │   │                   ├─ name: name\n" +
 			"         │   │   │   │   │   │                   └─ columns: [id name gender]\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ HashIn\n" +
-			"         │   │   │   │   │       │   ├─ mi.info:2!null\n" +
-			"         │   │   │   │   │       │   └─ TUPLE(Horror (longtext), Thriller (longtext))\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ keys: [ci.movie_id:11!null]\n" +
-			"         │   │   │   │   │               ├─ colSet: (23-27)\n" +
-			"         │   │   │   │   │               ├─ tableId: 8\n" +
-			"         │   │   │   │   │               └─ Table\n" +
-			"         │   │   │   │   │                   ├─ name: movie_info\n" +
-			"         │   │   │   │   │                   └─ columns: [movie_id info_type_id info]\n" +
-			"         │   │   │   │   └─ TableAlias(mk)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
-			"         │   │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
-			"         │   │   │   │           ├─ keys: [mi.movie_id:16!null]\n" +
-			"         │   │   │   │           ├─ colSet: (33-35)\n" +
-			"         │   │   │   │           ├─ tableId: 10\n" +
+			"         │   │   │   │   │   └─ TableAlias(mk)\n" +
+			"         │   │   │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
+			"         │   │   │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
+			"         │   │   │   │   │           ├─ keys: [ci.movie_id:11!null]\n" +
+			"         │   │   │   │   │           ├─ colSet: (33-35)\n" +
+			"         │   │   │   │   │           ├─ tableId: 10\n" +
+			"         │   │   │   │   │           └─ Table\n" +
+			"         │   │   │   │   │               ├─ name: movie_keyword\n" +
+			"         │   │   │   │   │               └─ columns: [movie_id keyword_id]\n" +
+			"         │   │   │   │   └─ TableAlias(mi_idx)\n" +
+			"         │   │   │   │       └─ IndexedTableAccess(movie_info_idx)\n" +
+			"         │   │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
+			"         │   │   │   │           ├─ keys: [ci.movie_id:11!null]\n" +
+			"         │   │   │   │           ├─ colSet: (28-32)\n" +
+			"         │   │   │   │           ├─ tableId: 9\n" +
 			"         │   │   │   │           └─ Table\n" +
-			"         │   │   │   │               ├─ name: movie_keyword\n" +
-			"         │   │   │   │               └─ columns: [movie_id keyword_id]\n" +
-			"         │   │   │   └─ TableAlias(mi_idx)\n" +
-			"         │   │   │       └─ IndexedTableAccess(movie_info_idx)\n" +
-			"         │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
-			"         │   │   │           ├─ keys: [mi.movie_id:16!null]\n" +
-			"         │   │   │           ├─ colSet: (28-32)\n" +
-			"         │   │   │           ├─ tableId: 9\n" +
-			"         │   │   │           └─ Table\n" +
-			"         │   │   │               ├─ name: movie_info_idx\n" +
-			"         │   │   │               └─ columns: [movie_id info_type_id info]\n" +
+			"         │   │   │   │               ├─ name: movie_info_idx\n" +
+			"         │   │   │   │               └─ columns: [movie_id info_type_id info]\n" +
+			"         │   │   │   └─ Filter\n" +
+			"         │   │   │       ├─ HashIn\n" +
+			"         │   │   │       │   ├─ mi.info:2!null\n" +
+			"         │   │   │       │   └─ TUPLE(Horror (longtext), Thriller (longtext))\n" +
+			"         │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │               ├─ keys: [ci.movie_id:11!null]\n" +
+			"         │   │   │               ├─ colSet: (23-27)\n" +
+			"         │   │   │               ├─ tableId: 8\n" +
+			"         │   │   │               └─ Table\n" +
+			"         │   │   │                   ├─ name: movie_info\n" +
+			"         │   │   │                   └─ columns: [movie_id info_type_id info]\n" +
 			"         │   │   └─ HashLookup\n" +
-			"         │   │       ├─ left-key: TUPLE(mi.info_type_id:17!null)\n" +
+			"         │   │       ├─ left-key: TUPLE(mi.info_type_id:22!null)\n" +
 			"         │   │       ├─ right-key: TUPLE(it1.id:0!null)\n" +
 			"         │   │       └─ Filter\n" +
 			"         │   │           ├─ Eq\n" +
@@ -23096,7 +23109,7 @@ WHERE cct1.kind IN ('cast',
 			"         │   │                       ├─ name: info_type\n" +
 			"         │   │                       └─ columns: [id info]\n" +
 			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: TUPLE(mi_idx.info_type_id:22!null)\n" +
+			"         │       ├─ left-key: TUPLE(mi_idx.info_type_id:19!null)\n" +
 			"         │       ├─ right-key: TUPLE(it2.id:0!null)\n" +
 			"         │       └─ Filter\n" +
 			"         │           ├─ Eq\n" +
@@ -23109,7 +23122,7 @@ WHERE cct1.kind IN ('cast',
 			"         │                   ├─ colSet: (18,19)\n" +
 			"         │                   └─ tableId: 6\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(mk.keyword_id:20!null)\n" +
+			"             ├─ left-key: TUPLE(mk.keyword_id:17!null)\n" +
 			"             ├─ right-key: TUPLE(k.id:0!null)\n" +
 			"             └─ Filter\n" +
 			"                 ├─ HashIn\n" +
@@ -23133,11 +23146,11 @@ WHERE cct1.kind IN ('cast',
 			"         │   ├─ HashJoin (estimated cost=172522.140 rows=168857)\n" +
 			"         │   │   ├─ (it1.id = mi.info_type_id)\n" +
 			"         │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
-			"         │   │   │   ├─ (mi_idx.movie_id = mk.movie_id)\n" +
+			"         │   │   │   ├─ ((mi.movie_id = cc.movie_id) AND (mi.movie_id = mi_idx.movie_id))\n" +
 			"         │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
-			"         │   │   │   │   ├─ (t.id = mk.movie_id)\n" +
+			"         │   │   │   │   ├─ ((mi_idx.movie_id = cc.movie_id) AND (mi_idx.movie_id = mk.movie_id))\n" +
 			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857)\n" +
-			"         │   │   │   │   │   ├─ ((mi.movie_id = cc.movie_id) AND (t.id = mi.movie_id))\n" +
+			"         │   │   │   │   │   ├─ ((mk.movie_id = cc.movie_id) AND (t.id = mk.movie_id))\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = ci.movie_id)\n" +
@@ -23189,23 +23202,23 @@ WHERE cct1.kind IN ('cast',
 			"         │   │   │   │   │   │               ├─ index: [name.id]\n" +
 			"         │   │   │   │   │   │               ├─ columns: [id name gender]\n" +
 			"         │   │   │   │   │   │               └─ keys: ci.person_id\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ (mi.info HASH IN ('Horror', 'Thriller'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ columns: [movie_id info_type_id info]\n" +
-			"         │   │   │   │   │               └─ keys: ci.movie_id\n" +
-			"         │   │   │   │   └─ TableAlias(mk)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
-			"         │   │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
-			"         │   │   │   │           ├─ columns: [movie_id keyword_id]\n" +
-			"         │   │   │   │           └─ keys: mi.movie_id\n" +
-			"         │   │   │   └─ TableAlias(mi_idx)\n" +
-			"         │   │   │       └─ IndexedTableAccess(movie_info_idx)\n" +
-			"         │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
-			"         │   │   │           ├─ columns: [movie_id info_type_id info]\n" +
-			"         │   │   │           └─ keys: mi.movie_id\n" +
+			"         │   │   │   │   │   └─ TableAlias(mk)\n" +
+			"         │   │   │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
+			"         │   │   │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
+			"         │   │   │   │   │           ├─ columns: [movie_id keyword_id]\n" +
+			"         │   │   │   │   │           └─ keys: ci.movie_id\n" +
+			"         │   │   │   │   └─ TableAlias(mi_idx)\n" +
+			"         │   │   │   │       └─ IndexedTableAccess(movie_info_idx)\n" +
+			"         │   │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
+			"         │   │   │   │           ├─ columns: [movie_id info_type_id info]\n" +
+			"         │   │   │   │           └─ keys: ci.movie_id\n" +
+			"         │   │   │   └─ Filter\n" +
+			"         │   │   │       ├─ (mi.info HASH IN ('Horror', 'Thriller'))\n" +
+			"         │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │               ├─ columns: [movie_id info_type_id info]\n" +
+			"         │   │   │               └─ keys: ci.movie_id\n" +
 			"         │   │   └─ HashLookup\n" +
 			"         │   │       ├─ left-key: (mi.info_type_id)\n" +
 			"         │   │       ├─ right-key: (it1.id)\n" +
@@ -23246,11 +23259,11 @@ WHERE cct1.kind IN ('cast',
 			"         │   ├─ HashJoin (estimated cost=172522.140 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   ├─ (it1.id = mi.info_type_id)\n" +
 			"         │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   ├─ (mi_idx.movie_id = mk.movie_id)\n" +
+			"         │   │   │   ├─ ((mi.movie_id = cc.movie_id) AND (mi.movie_id = mi_idx.movie_id))\n" +
 			"         │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   ├─ (t.id = mk.movie_id)\n" +
+			"         │   │   │   │   ├─ ((mi_idx.movie_id = cc.movie_id) AND (mi_idx.movie_id = mk.movie_id))\n" +
 			"         │   │   │   │   ├─ LookupJoin (estimated cost=557248.800 rows=168857) (actual rows=0 loops=1)\n" +
-			"         │   │   │   │   │   ├─ ((mi.movie_id = cc.movie_id) AND (t.id = mi.movie_id))\n" +
+			"         │   │   │   │   │   ├─ ((mk.movie_id = cc.movie_id) AND (t.id = mk.movie_id))\n" +
 			"         │   │   │   │   │   ├─ LookupJoin (estimated cost=557228.100 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   ├─ LookupJoin (estimated cost=523477.800 rows=168857) (actual rows=0 loops=1)\n" +
 			"         │   │   │   │   │   │   │   ├─ (t.id = ci.movie_id)\n" +
@@ -23302,23 +23315,23 @@ WHERE cct1.kind IN ('cast',
 			"         │   │   │   │   │   │               ├─ index: [name.id]\n" +
 			"         │   │   │   │   │   │               ├─ columns: [id name gender]\n" +
 			"         │   │   │   │   │   │               └─ keys: ci.person_id\n" +
-			"         │   │   │   │   │   └─ Filter\n" +
-			"         │   │   │   │   │       ├─ (mi.info HASH IN ('Horror', 'Thriller'))\n" +
-			"         │   │   │   │   │       └─ TableAlias(mi)\n" +
-			"         │   │   │   │   │           └─ IndexedTableAccess(movie_info)\n" +
-			"         │   │   │   │   │               ├─ index: [movie_info.movie_id]\n" +
-			"         │   │   │   │   │               ├─ columns: [movie_id info_type_id info]\n" +
-			"         │   │   │   │   │               └─ keys: ci.movie_id\n" +
-			"         │   │   │   │   └─ TableAlias(mk)\n" +
-			"         │   │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
-			"         │   │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
-			"         │   │   │   │           ├─ columns: [movie_id keyword_id]\n" +
-			"         │   │   │   │           └─ keys: mi.movie_id\n" +
-			"         │   │   │   └─ TableAlias(mi_idx)\n" +
-			"         │   │   │       └─ IndexedTableAccess(movie_info_idx)\n" +
-			"         │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
-			"         │   │   │           ├─ columns: [movie_id info_type_id info]\n" +
-			"         │   │   │           └─ keys: mi.movie_id\n" +
+			"         │   │   │   │   │   └─ TableAlias(mk)\n" +
+			"         │   │   │   │   │       └─ IndexedTableAccess(movie_keyword)\n" +
+			"         │   │   │   │   │           ├─ index: [movie_keyword.movie_id]\n" +
+			"         │   │   │   │   │           ├─ columns: [movie_id keyword_id]\n" +
+			"         │   │   │   │   │           └─ keys: ci.movie_id\n" +
+			"         │   │   │   │   └─ TableAlias(mi_idx)\n" +
+			"         │   │   │   │       └─ IndexedTableAccess(movie_info_idx)\n" +
+			"         │   │   │   │           ├─ index: [movie_info_idx.movie_id]\n" +
+			"         │   │   │   │           ├─ columns: [movie_id info_type_id info]\n" +
+			"         │   │   │   │           └─ keys: ci.movie_id\n" +
+			"         │   │   │   └─ Filter\n" +
+			"         │   │   │       ├─ (mi.info HASH IN ('Horror', 'Thriller'))\n" +
+			"         │   │   │       └─ TableAlias(mi)\n" +
+			"         │   │   │           └─ IndexedTableAccess(movie_info)\n" +
+			"         │   │   │               ├─ index: [movie_info.movie_id]\n" +
+			"         │   │   │               ├─ columns: [movie_id info_type_id info]\n" +
+			"         │   │   │               └─ keys: ci.movie_id\n" +
 			"         │   │   └─ HashLookup\n" +
 			"         │   │       ├─ left-key: (mi.info_type_id)\n" +
 			"         │   │       ├─ right-key: (it1.id)\n" +

--- a/enginetest/queries/index_queries.go
+++ b/enginetest/queries/index_queries.go
@@ -3952,9 +3952,10 @@ var IndexPrefixQueries = []ScriptTest{
 			},
 			{
 				// Indexes with content-hashed fields are not eligible for use with range scans
-				Query:           "select * from t where col2 >= 'one';",
-				ExpectedIndexes: []string{},
-				Expected:        []sql.Row{{1, "one", "one___"}, {2, "two", "two___"}},
+				Query:              "select * from t where col2 >= 'one';",
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk1"},
+				Expected:           []sql.Row{{1, "one", "one___"}, {2, "two", "two___"}},
 			},
 			{
 				// Indexes with a content-hashed BLOB/TEXT field cannot be used in range scans
@@ -3964,9 +3965,10 @@ var IndexPrefixQueries = []ScriptTest{
 			},
 			{
 				// Indexes with a content-hashed BLOB/TEXT field cannot be used in range scans
-				Query:           "select count(*) from t where col2 >= ' ';",
-				ExpectedIndexes: []string{},
-				Expected:        []sql.Row{{2}},
+				Query:              "select count(*) from t where col2 >= ' ';",
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk1"},
+				Expected:           []sql.Row{{2}},
 			},
 			{
 				// Indexes with a content-hashed BLOB/TEXT field cannot be used in ordered range scans
@@ -3976,9 +3978,10 @@ var IndexPrefixQueries = []ScriptTest{
 			},
 			{
 				// Indexes with a content-hashed BLOB/TEXT field cannot be used in ordered range scans
-				Query:           "select * from t where col2 >= ' ' order by pk;",
-				ExpectedIndexes: []string{"primary"},
-				Expected:        []sql.Row{{1, "one", "one___"}, {2, "two", "two___"}},
+				Query:              "select * from t where col2 >= ' ' order by pk;",
+				CheckIndexedAccess: true,
+				ExpectedIndexes:    []string{"uk1"},
+				Expected:           []sql.Row{{1, "one", "one___"}, {2, "two", "two___"}},
 			},
 		},
 	},

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -791,24 +791,30 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<25) OR (v1>24));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ LessThan\n" +
+			" │   │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   └─ 25 (bigint)\n" +
+			" │   └─ GreaterThan\n" +
+			" │       ├─ comp_index_t0.v1:1\n" +
+			" │       └─ 24 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t0.v1 < 25) OR (comp_index_t0.v1 > 24))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t0.v1 < 25) OR (comp_index_t0.v1 > 24))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1011,24 +1017,40 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>22 AND v2>18) OR (v1<>12)) OR (v1<=34));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ AND\n" +
+			" │   │   │   ├─ NOT\n" +
+			" │   │   │   │   └─ Eq\n" +
+			" │   │   │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   │       └─ 22 (bigint)\n" +
+			" │   │   │   └─ GreaterThan\n" +
+			" │   │   │       ├─ comp_index_t0.v2:2\n" +
+			" │   │   │       └─ 18 (bigint)\n" +
+			" │   │   └─ NOT\n" +
+			" │   │       └─ Eq\n" +
+			" │   │           ├─ comp_index_t0.v1:1\n" +
+			" │   │           └─ 12 (bigint)\n" +
+			" │   └─ LessThanOrEqual\n" +
+			" │       ├─ comp_index_t0.v1:1\n" +
+			" │       └─ 34 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((((NOT((comp_index_t0.v1 = 22))) AND (comp_index_t0.v2 > 18)) OR (NOT((comp_index_t0.v1 = 12)))) OR (comp_index_t0.v1 <= 34))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((((NOT((comp_index_t0.v1 = 22))) AND (comp_index_t0.v2 > 18)) OR (NOT((comp_index_t0.v1 = 12)))) OR (comp_index_t0.v1 <= 34))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1495,24 +1517,39 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1>35) OR (v1 BETWEEN 11 AND 21)) OR (v1<>98));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ GreaterThan\n" +
+			" │   │   │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   └─ 35 (bigint)\n" +
+			" │   │   └─ AND\n" +
+			" │   │       ├─ GreaterThanOrEqual\n" +
+			" │   │       │   ├─ comp_index_t0.v1:1\n" +
+			" │   │       │   └─ 11 (tinyint)\n" +
+			" │   │       └─ LessThanOrEqual\n" +
+			" │   │           ├─ comp_index_t0.v1:1\n" +
+			" │   │           └─ 21 (tinyint)\n" +
+			" │   └─ NOT\n" +
+			" │       └─ Eq\n" +
+			" │           ├─ comp_index_t0.v1:1\n" +
+			" │           └─ 98 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((comp_index_t0.v1 > 35) OR ((comp_index_t0.v1 >= 11) AND (comp_index_t0.v1 <= 21))) OR (NOT((comp_index_t0.v1 = 98))))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((comp_index_t0.v1 > 35) OR ((comp_index_t0.v1 >= 11) AND (comp_index_t0.v1 <= 21))) OR (NOT((comp_index_t0.v1 = 98))))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1561,24 +1598,56 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((((v1<>30) OR (v1>=6 AND v2 BETWEEN 62 AND 65)) OR (v1<>89)) OR (v1<=40 AND v2>=73)) OR (v1<99));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ Or\n" +
+			" │   │   │   ├─ Or\n" +
+			" │   │   │   │   ├─ NOT\n" +
+			" │   │   │   │   │   └─ Eq\n" +
+			" │   │   │   │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   │   │       └─ 30 (bigint)\n" +
+			" │   │   │   │   └─ AND\n" +
+			" │   │   │   │       ├─ GreaterThanOrEqual\n" +
+			" │   │   │   │       │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   │       │   └─ 6 (bigint)\n" +
+			" │   │   │   │       └─ AND\n" +
+			" │   │   │   │           ├─ GreaterThanOrEqual\n" +
+			" │   │   │   │           │   ├─ comp_index_t0.v2:2\n" +
+			" │   │   │   │           │   └─ 62 (tinyint)\n" +
+			" │   │   │   │           └─ LessThanOrEqual\n" +
+			" │   │   │   │               ├─ comp_index_t0.v2:2\n" +
+			" │   │   │   │               └─ 65 (tinyint)\n" +
+			" │   │   │   └─ NOT\n" +
+			" │   │   │       └─ Eq\n" +
+			" │   │   │           ├─ comp_index_t0.v1:1\n" +
+			" │   │   │           └─ 89 (bigint)\n" +
+			" │   │   └─ AND\n" +
+			" │   │       ├─ LessThanOrEqual\n" +
+			" │   │       │   ├─ comp_index_t0.v1:1\n" +
+			" │   │       │   └─ 40 (bigint)\n" +
+			" │   │       └─ GreaterThanOrEqual\n" +
+			" │   │           ├─ comp_index_t0.v2:2\n" +
+			" │   │           └─ 73 (bigint)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ comp_index_t0.v1:1\n" +
+			" │       └─ 99 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((((NOT((comp_index_t0.v1 = 30))) OR ((comp_index_t0.v1 >= 6) AND ((comp_index_t0.v2 >= 62) AND (comp_index_t0.v2 <= 65)))) OR (NOT((comp_index_t0.v1 = 89)))) OR ((comp_index_t0.v1 <= 40) AND (comp_index_t0.v2 >= 73))) OR (comp_index_t0.v1 < 99))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((((NOT((comp_index_t0.v1 = 30))) OR ((comp_index_t0.v1 >= 6) AND ((comp_index_t0.v2 >= 62) AND (comp_index_t0.v2 <= 65)))) OR (NOT((comp_index_t0.v1 = 89)))) OR ((comp_index_t0.v1 <= 40) AND (comp_index_t0.v2 >= 73))) OR (comp_index_t0.v1 < 99))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1891,24 +1960,46 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>28) OR (v1<=30 AND v2=30)) OR (v1<29)) OR (v1 BETWEEN 54 AND 74));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ Or\n" +
+			" │   │   │   ├─ GreaterThan\n" +
+			" │   │   │   │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   │   └─ 28 (bigint)\n" +
+			" │   │   │   └─ AND\n" +
+			" │   │   │       ├─ LessThanOrEqual\n" +
+			" │   │   │       │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   │       │   └─ 30 (bigint)\n" +
+			" │   │   │       └─ Eq\n" +
+			" │   │   │           ├─ comp_index_t0.v2:2\n" +
+			" │   │   │           └─ 30 (bigint)\n" +
+			" │   │   └─ LessThan\n" +
+			" │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │       └─ 29 (bigint)\n" +
+			" │   └─ AND\n" +
+			" │       ├─ GreaterThanOrEqual\n" +
+			" │       │   ├─ comp_index_t0.v1:1\n" +
+			" │       │   └─ 54 (tinyint)\n" +
+			" │       └─ LessThanOrEqual\n" +
+			" │           ├─ comp_index_t0.v1:1\n" +
+			" │           └─ 74 (tinyint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((((comp_index_t0.v1 > 28) OR ((comp_index_t0.v1 <= 30) AND (comp_index_t0.v2 = 30))) OR (comp_index_t0.v1 < 29)) OR ((comp_index_t0.v1 >= 54) AND (comp_index_t0.v1 <= 74)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((((comp_index_t0.v1 > 28) OR ((comp_index_t0.v1 <= 30) AND (comp_index_t0.v2 = 30))) OR (comp_index_t0.v1 < 29)) OR ((comp_index_t0.v1 >= 54) AND (comp_index_t0.v1 <= 74)))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2045,68 +2136,102 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>31) OR (v1<>43)) OR (v1>37 AND v2>5));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ NOT\n" +
+			" │   │   │   └─ Eq\n" +
+			" │   │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │   │       └─ 31 (bigint)\n" +
+			" │   │   └─ NOT\n" +
+			" │   │       └─ Eq\n" +
+			" │   │           ├─ comp_index_t0.v1:1\n" +
+			" │   │           └─ 43 (bigint)\n" +
+			" │   └─ AND\n" +
+			" │       ├─ GreaterThan\n" +
+			" │       │   ├─ comp_index_t0.v1:1\n" +
+			" │       │   └─ 37 (bigint)\n" +
+			" │       └─ GreaterThan\n" +
+			" │           ├─ comp_index_t0.v2:2\n" +
+			" │           └─ 5 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((NOT((comp_index_t0.v1 = 31))) OR (NOT((comp_index_t0.v1 = 43)))) OR ((comp_index_t0.v1 > 37) AND (comp_index_t0.v2 > 5)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((NOT((comp_index_t0.v1 = 31))) OR (NOT((comp_index_t0.v1 = 43)))) OR ((comp_index_t0.v1 > 37) AND (comp_index_t0.v2 > 5)))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=91) OR (v1<>79)) OR (v1<64));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ LessThanOrEqual\n" +
+			" │   │   │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   └─ 91 (bigint)\n" +
+			" │   │   └─ NOT\n" +
+			" │   │       └─ Eq\n" +
+			" │   │           ├─ comp_index_t0.v1:1\n" +
+			" │   │           └─ 79 (bigint)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ comp_index_t0.v1:1\n" +
+			" │       └─ 64 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((comp_index_t0.v1 <= 91) OR (NOT((comp_index_t0.v1 = 79)))) OR (comp_index_t0.v1 < 64))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((comp_index_t0.v1 <= 91) OR (NOT((comp_index_t0.v1 = 79)))) OR (comp_index_t0.v1 < 64))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>48) OR (v1>11));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ NOT\n" +
+			" │   │   └─ Eq\n" +
+			" │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │       └─ 48 (bigint)\n" +
+			" │   └─ GreaterThan\n" +
+			" │       ├─ comp_index_t0.v1:1\n" +
+			" │       └─ 11 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((NOT((comp_index_t0.v1 = 48))) OR (comp_index_t0.v1 > 11))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((NOT((comp_index_t0.v1 = 48))) OR (comp_index_t0.v1 > 11))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2177,24 +2302,43 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 27 AND 84) OR (v1<98 AND v2>38)) OR (v1<>30));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ AND\n" +
+			" │   │   │   ├─ GreaterThanOrEqual\n" +
+			" │   │   │   │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   │   └─ 27 (tinyint)\n" +
+			" │   │   │   └─ LessThanOrEqual\n" +
+			" │   │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │   │       └─ 84 (tinyint)\n" +
+			" │   │   └─ AND\n" +
+			" │   │       ├─ LessThan\n" +
+			" │   │       │   ├─ comp_index_t0.v1:1\n" +
+			" │   │       │   └─ 98 (bigint)\n" +
+			" │   │       └─ GreaterThan\n" +
+			" │   │           ├─ comp_index_t0.v2:2\n" +
+			" │   │           └─ 38 (bigint)\n" +
+			" │   └─ NOT\n" +
+			" │       └─ Eq\n" +
+			" │           ├─ comp_index_t0.v1:1\n" +
+			" │           └─ 30 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((((comp_index_t0.v1 >= 27) AND (comp_index_t0.v1 <= 84)) OR ((comp_index_t0.v1 < 98) AND (comp_index_t0.v2 > 38))) OR (NOT((comp_index_t0.v1 = 30))))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((((comp_index_t0.v1 >= 27) AND (comp_index_t0.v1 <= 84)) OR ((comp_index_t0.v1 < 98) AND (comp_index_t0.v2 > 38))) OR (NOT((comp_index_t0.v1 = 30))))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2573,24 +2717,43 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>50) OR (v1<=88)) OR (v1>=28 AND v2 BETWEEN 30 AND 85));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ NOT\n" +
+			" │   │   │   └─ Eq\n" +
+			" │   │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │   │       └─ 50 (bigint)\n" +
+			" │   │   └─ LessThanOrEqual\n" +
+			" │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │       └─ 88 (bigint)\n" +
+			" │   └─ AND\n" +
+			" │       ├─ GreaterThanOrEqual\n" +
+			" │       │   ├─ comp_index_t0.v1:1\n" +
+			" │       │   └─ 28 (bigint)\n" +
+			" │       └─ AND\n" +
+			" │           ├─ GreaterThanOrEqual\n" +
+			" │           │   ├─ comp_index_t0.v2:2\n" +
+			" │           │   └─ 30 (tinyint)\n" +
+			" │           └─ LessThanOrEqual\n" +
+			" │               ├─ comp_index_t0.v2:2\n" +
+			" │               └─ 85 (tinyint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((NOT((comp_index_t0.v1 = 50))) OR (comp_index_t0.v1 <= 88)) OR ((comp_index_t0.v1 >= 28) AND ((comp_index_t0.v2 >= 30) AND (comp_index_t0.v2 <= 85))))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((NOT((comp_index_t0.v1 = 50))) OR (comp_index_t0.v1 <= 88)) OR ((comp_index_t0.v1 >= 28) AND ((comp_index_t0.v2 >= 30) AND (comp_index_t0.v2 <= 85))))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2859,24 +3022,46 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<32 AND v2>=79) OR (v1<=28)) OR (v1 BETWEEN 46 AND 72)) OR (v1>16));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-3)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ Or\n" +
+			" │   │   │   ├─ AND\n" +
+			" │   │   │   │   ├─ LessThan\n" +
+			" │   │   │   │   │   ├─ comp_index_t0.v1:1\n" +
+			" │   │   │   │   │   └─ 32 (bigint)\n" +
+			" │   │   │   │   └─ GreaterThanOrEqual\n" +
+			" │   │   │   │       ├─ comp_index_t0.v2:2\n" +
+			" │   │   │   │       └─ 79 (bigint)\n" +
+			" │   │   │   └─ LessThanOrEqual\n" +
+			" │   │   │       ├─ comp_index_t0.v1:1\n" +
+			" │   │   │       └─ 28 (bigint)\n" +
+			" │   │   └─ AND\n" +
+			" │   │       ├─ GreaterThanOrEqual\n" +
+			" │   │       │   ├─ comp_index_t0.v1:1\n" +
+			" │   │       │   └─ 46 (tinyint)\n" +
+			" │   │       └─ LessThanOrEqual\n" +
+			" │   │           ├─ comp_index_t0.v1:1\n" +
+			" │   │           └─ 72 (tinyint)\n" +
+			" │   └─ GreaterThan\n" +
+			" │       ├─ comp_index_t0.v1:1\n" +
+			" │       └─ 16 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t0\n" +
+			"         └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((((comp_index_t0.v1 < 32) AND (comp_index_t0.v2 >= 79)) OR (comp_index_t0.v1 <= 28)) OR ((comp_index_t0.v1 >= 46) AND (comp_index_t0.v1 <= 72))) OR (comp_index_t0.v1 > 16))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
-			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((((comp_index_t0.v1 < 32) AND (comp_index_t0.v2 >= 79)) OR (comp_index_t0.v1 <= 28)) OR ((comp_index_t0.v1 >= 46) AND (comp_index_t0.v1 <= 72))) OR (comp_index_t0.v1 > 16))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t0\n" +
+			"     └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -3035,24 +3220,46 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<93 AND v2<39 AND v3 BETWEEN 30 AND 97) OR (v1>54)) OR (v1<66));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ AND\n" +
+			" │   │   │   ├─ AND\n" +
+			" │   │   │   │   ├─ LessThan\n" +
+			" │   │   │   │   │   ├─ comp_index_t1.v1:1\n" +
+			" │   │   │   │   │   └─ 93 (bigint)\n" +
+			" │   │   │   │   └─ LessThan\n" +
+			" │   │   │   │       ├─ comp_index_t1.v2:2\n" +
+			" │   │   │   │       └─ 39 (bigint)\n" +
+			" │   │   │   └─ AND\n" +
+			" │   │   │       ├─ GreaterThanOrEqual\n" +
+			" │   │   │       │   ├─ comp_index_t1.v3:3\n" +
+			" │   │   │       │   └─ 30 (tinyint)\n" +
+			" │   │   │       └─ LessThanOrEqual\n" +
+			" │   │   │           ├─ comp_index_t1.v3:3\n" +
+			" │   │   │           └─ 97 (tinyint)\n" +
+			" │   │   └─ GreaterThan\n" +
+			" │   │       ├─ comp_index_t1.v1:1\n" +
+			" │   │       └─ 54 (bigint)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ comp_index_t1.v1:1\n" +
+			" │       └─ 66 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((((comp_index_t1.v1 < 93) AND (comp_index_t1.v2 < 39)) AND ((comp_index_t1.v3 >= 30) AND (comp_index_t1.v3 <= 97))) OR (comp_index_t1.v1 > 54)) OR (comp_index_t1.v1 < 66))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((((comp_index_t1.v1 < 93) AND (comp_index_t1.v2 < 39)) AND ((comp_index_t1.v3 >= 30) AND (comp_index_t1.v3 <= 97))) OR (comp_index_t1.v1 > 54)) OR (comp_index_t1.v1 < 66))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -4861,46 +5068,77 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>2) OR (v1<=30)) OR (v1<>35 AND v2 BETWEEN 6 AND 61 AND v3>=16));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ GreaterThan\n" +
+			" │   │   │   ├─ comp_index_t1.v1:1\n" +
+			" │   │   │   └─ 2 (bigint)\n" +
+			" │   │   └─ LessThanOrEqual\n" +
+			" │   │       ├─ comp_index_t1.v1:1\n" +
+			" │   │       └─ 30 (bigint)\n" +
+			" │   └─ AND\n" +
+			" │       ├─ AND\n" +
+			" │       │   ├─ NOT\n" +
+			" │       │   │   └─ Eq\n" +
+			" │       │   │       ├─ comp_index_t1.v1:1\n" +
+			" │       │   │       └─ 35 (bigint)\n" +
+			" │       │   └─ AND\n" +
+			" │       │       ├─ GreaterThanOrEqual\n" +
+			" │       │       │   ├─ comp_index_t1.v2:2\n" +
+			" │       │       │   └─ 6 (tinyint)\n" +
+			" │       │       └─ LessThanOrEqual\n" +
+			" │       │           ├─ comp_index_t1.v2:2\n" +
+			" │       │           └─ 61 (tinyint)\n" +
+			" │       └─ GreaterThanOrEqual\n" +
+			" │           ├─ comp_index_t1.v3:3\n" +
+			" │           └─ 16 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((comp_index_t1.v1 > 2) OR (comp_index_t1.v1 <= 30)) OR (((NOT((comp_index_t1.v1 = 35))) AND ((comp_index_t1.v2 >= 6) AND (comp_index_t1.v2 <= 61))) AND (comp_index_t1.v3 >= 16)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((comp_index_t1.v1 > 2) OR (comp_index_t1.v1 <= 30)) OR (((NOT((comp_index_t1.v1 = 35))) AND ((comp_index_t1.v2 >= 6) AND (comp_index_t1.v2 <= 61))) AND (comp_index_t1.v3 >= 16)))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>19) OR (v1<>48));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ NOT\n" +
+			" │   │   └─ Eq\n" +
+			" │   │       ├─ comp_index_t1.v1:1\n" +
+			" │   │       └─ 19 (bigint)\n" +
+			" │   └─ NOT\n" +
+			" │       └─ Eq\n" +
+			" │           ├─ comp_index_t1.v1:1\n" +
+			" │           └─ 48 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((NOT((comp_index_t1.v1 = 19))) OR (NOT((comp_index_t1.v1 = 48))))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((NOT((comp_index_t1.v1 = 19))) OR (NOT((comp_index_t1.v1 = 48))))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5499,24 +5737,31 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>50) OR (v1<=71));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ NOT\n" +
+			" │   │   └─ Eq\n" +
+			" │   │       ├─ comp_index_t1.v1:1\n" +
+			" │   │       └─ 50 (bigint)\n" +
+			" │   └─ LessThanOrEqual\n" +
+			" │       ├─ comp_index_t1.v1:1\n" +
+			" │       └─ 71 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((NOT((comp_index_t1.v1 = 50))) OR (comp_index_t1.v1 <= 71))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((NOT((comp_index_t1.v1 = 50))) OR (comp_index_t1.v1 <= 71))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5829,24 +6074,30 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25) OR (v1<53));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ GreaterThan\n" +
+			" │   │   ├─ comp_index_t1.v1:1\n" +
+			" │   │   └─ 25 (bigint)\n" +
+			" │   └─ LessThan\n" +
+			" │       ├─ comp_index_t1.v1:1\n" +
+			" │       └─ 53 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((comp_index_t1.v1 > 25) OR (comp_index_t1.v1 < 53))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((comp_index_t1.v1 > 25) OR (comp_index_t1.v1 < 53))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6027,24 +6278,46 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>12) OR (v1>=26 AND v2 BETWEEN 77 AND 87 AND v3<19)) OR (v1<=89));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ GreaterThan\n" +
+			" │   │   │   ├─ comp_index_t1.v1:1\n" +
+			" │   │   │   └─ 12 (bigint)\n" +
+			" │   │   └─ AND\n" +
+			" │   │       ├─ AND\n" +
+			" │   │       │   ├─ GreaterThanOrEqual\n" +
+			" │   │       │   │   ├─ comp_index_t1.v1:1\n" +
+			" │   │       │   │   └─ 26 (bigint)\n" +
+			" │   │       │   └─ AND\n" +
+			" │   │       │       ├─ GreaterThanOrEqual\n" +
+			" │   │       │       │   ├─ comp_index_t1.v2:2\n" +
+			" │   │       │       │   └─ 77 (tinyint)\n" +
+			" │   │       │       └─ LessThanOrEqual\n" +
+			" │   │       │           ├─ comp_index_t1.v2:2\n" +
+			" │   │       │           └─ 87 (tinyint)\n" +
+			" │   │       └─ LessThan\n" +
+			" │   │           ├─ comp_index_t1.v3:3\n" +
+			" │   │           └─ 19 (bigint)\n" +
+			" │   └─ LessThanOrEqual\n" +
+			" │       ├─ comp_index_t1.v1:1\n" +
+			" │       └─ 89 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((comp_index_t1.v1 > 12) OR (((comp_index_t1.v1 >= 26) AND ((comp_index_t1.v2 >= 77) AND (comp_index_t1.v2 <= 87))) AND (comp_index_t1.v3 < 19))) OR (comp_index_t1.v1 <= 89))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((comp_index_t1.v1 > 12) OR (((comp_index_t1.v1 >= 26) AND ((comp_index_t1.v2 >= 77) AND (comp_index_t1.v2 <= 87))) AND (comp_index_t1.v3 < 19))) OR (comp_index_t1.v1 <= 89))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6621,46 +6894,77 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=8 AND v2<=97 AND v3>=77) OR (v1<>4)) OR (v1<=41));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ AND\n" +
+			" │   │   │   ├─ AND\n" +
+			" │   │   │   │   ├─ GreaterThanOrEqual\n" +
+			" │   │   │   │   │   ├─ comp_index_t1.v1:1\n" +
+			" │   │   │   │   │   └─ 8 (bigint)\n" +
+			" │   │   │   │   └─ LessThanOrEqual\n" +
+			" │   │   │   │       ├─ comp_index_t1.v2:2\n" +
+			" │   │   │   │       └─ 97 (bigint)\n" +
+			" │   │   │   └─ GreaterThanOrEqual\n" +
+			" │   │   │       ├─ comp_index_t1.v3:3\n" +
+			" │   │   │       └─ 77 (bigint)\n" +
+			" │   │   └─ NOT\n" +
+			" │   │       └─ Eq\n" +
+			" │   │           ├─ comp_index_t1.v1:1\n" +
+			" │   │           └─ 4 (bigint)\n" +
+			" │   └─ LessThanOrEqual\n" +
+			" │       ├─ comp_index_t1.v1:1\n" +
+			" │       └─ 41 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((((comp_index_t1.v1 >= 8) AND (comp_index_t1.v2 <= 97)) AND (comp_index_t1.v3 >= 77)) OR (NOT((comp_index_t1.v1 = 4)))) OR (comp_index_t1.v1 <= 41))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((((comp_index_t1.v1 >= 8) AND (comp_index_t1.v2 <= 97)) AND (comp_index_t1.v3 >= 77)) OR (NOT((comp_index_t1.v1 = 4)))) OR (comp_index_t1.v1 <= 41))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>33) OR (v1<=28)) OR (v1<>68));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-4)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ NOT\n" +
+			" │   │   │   └─ Eq\n" +
+			" │   │   │       ├─ comp_index_t1.v1:1\n" +
+			" │   │   │       └─ 33 (bigint)\n" +
+			" │   │   └─ LessThanOrEqual\n" +
+			" │   │       ├─ comp_index_t1.v1:1\n" +
+			" │   │       └─ 28 (bigint)\n" +
+			" │   └─ NOT\n" +
+			" │       └─ Eq\n" +
+			" │           ├─ comp_index_t1.v1:1\n" +
+			" │           └─ 68 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t1\n" +
+			"         └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((NOT((comp_index_t1.v1 = 33))) OR (comp_index_t1.v1 <= 28)) OR (NOT((comp_index_t1.v1 = 68))))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
-			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((NOT((comp_index_t1.v1 = 33))) OR (comp_index_t1.v1 <= 28)) OR (NOT((comp_index_t1.v1 = 68))))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t1\n" +
+			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -8557,24 +8861,53 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<31 AND v2<>14 AND v3 BETWEEN 0 AND 10 AND v4>=95) OR (v1<>91)) OR (v1<>35));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-5)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ AND\n" +
+			" │   │   │   ├─ AND\n" +
+			" │   │   │   │   ├─ AND\n" +
+			" │   │   │   │   │   ├─ LessThan\n" +
+			" │   │   │   │   │   │   ├─ comp_index_t2.v1:1\n" +
+			" │   │   │   │   │   │   └─ 31 (bigint)\n" +
+			" │   │   │   │   │   └─ NOT\n" +
+			" │   │   │   │   │       └─ Eq\n" +
+			" │   │   │   │   │           ├─ comp_index_t2.v2:2\n" +
+			" │   │   │   │   │           └─ 14 (bigint)\n" +
+			" │   │   │   │   └─ AND\n" +
+			" │   │   │   │       ├─ GreaterThanOrEqual\n" +
+			" │   │   │   │       │   ├─ comp_index_t2.v3:3\n" +
+			" │   │   │   │       │   └─ 0 (tinyint)\n" +
+			" │   │   │   │       └─ LessThanOrEqual\n" +
+			" │   │   │   │           ├─ comp_index_t2.v3:3\n" +
+			" │   │   │   │           └─ 10 (tinyint)\n" +
+			" │   │   │   └─ GreaterThanOrEqual\n" +
+			" │   │   │       ├─ comp_index_t2.v4:4\n" +
+			" │   │   │       └─ 95 (bigint)\n" +
+			" │   │   └─ NOT\n" +
+			" │   │       └─ Eq\n" +
+			" │   │           ├─ comp_index_t2.v1:1\n" +
+			" │   │           └─ 91 (bigint)\n" +
+			" │   └─ NOT\n" +
+			" │       └─ Eq\n" +
+			" │           ├─ comp_index_t2.v1:1\n" +
+			" │           └─ 35 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t2\n" +
+			"         └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((((((comp_index_t2.v1 < 31) AND (NOT((comp_index_t2.v2 = 14)))) AND ((comp_index_t2.v3 >= 0) AND (comp_index_t2.v3 <= 10))) AND (comp_index_t2.v4 >= 95)) OR (NOT((comp_index_t2.v1 = 91)))) OR (NOT((comp_index_t2.v1 = 35))))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((((((comp_index_t2.v1 < 31) AND (NOT((comp_index_t2.v2 = 14)))) AND ((comp_index_t2.v3 >= 0) AND (comp_index_t2.v3 <= 10))) AND (comp_index_t2.v4 >= 95)) OR (NOT((comp_index_t2.v1 = 91)))) OR (NOT((comp_index_t2.v1 = 35))))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t2\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -9833,24 +10166,31 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>69) OR (v1>=43));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-5)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ NOT\n" +
+			" │   │   └─ Eq\n" +
+			" │   │       ├─ comp_index_t2.v1:1\n" +
+			" │   │       └─ 69 (bigint)\n" +
+			" │   └─ GreaterThanOrEqual\n" +
+			" │       ├─ comp_index_t2.v1:1\n" +
+			" │       └─ 43 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t2\n" +
+			"         └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((NOT((comp_index_t2.v1 = 69))) OR (comp_index_t2.v1 >= 43))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((NOT((comp_index_t2.v1 = 69))) OR (comp_index_t2.v1 >= 43))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t2\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11395,24 +11735,44 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>79 AND v2<=85) OR (v1<>13)) OR (v1 BETWEEN 4 AND 67));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-5)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ AND\n" +
+			" │   │   │   ├─ NOT\n" +
+			" │   │   │   │   └─ Eq\n" +
+			" │   │   │   │       ├─ comp_index_t2.v1:1\n" +
+			" │   │   │   │       └─ 79 (bigint)\n" +
+			" │   │   │   └─ LessThanOrEqual\n" +
+			" │   │   │       ├─ comp_index_t2.v2:2\n" +
+			" │   │   │       └─ 85 (bigint)\n" +
+			" │   │   └─ NOT\n" +
+			" │   │       └─ Eq\n" +
+			" │   │           ├─ comp_index_t2.v1:1\n" +
+			" │   │           └─ 13 (bigint)\n" +
+			" │   └─ AND\n" +
+			" │       ├─ GreaterThanOrEqual\n" +
+			" │       │   ├─ comp_index_t2.v1:1\n" +
+			" │       │   └─ 4 (tinyint)\n" +
+			" │       └─ LessThanOrEqual\n" +
+			" │           ├─ comp_index_t2.v1:1\n" +
+			" │           └─ 67 (tinyint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t2\n" +
+			"         └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ ((((NOT((comp_index_t2.v1 = 79))) AND (comp_index_t2.v2 <= 85)) OR (NOT((comp_index_t2.v1 = 13)))) OR ((comp_index_t2.v1 >= 4) AND (comp_index_t2.v1 <= 67)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ ((((NOT((comp_index_t2.v1 = 79))) AND (comp_index_t2.v2 <= 85)) OR (NOT((comp_index_t2.v1 = 13)))) OR ((comp_index_t2.v1 >= 4) AND (comp_index_t2.v1 <= 67)))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t2\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11439,24 +11799,60 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((((v1<65) OR (v1<>44)) OR (v1<=39 AND v3>=14)) OR (v1<=33 AND v2<>11)) OR (v1=75 AND v2=0 AND v3<28));`,
-		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" ├─ colSet: (1-5)\n" +
-			" ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ Or\n" +
+			" │   ├─ Or\n" +
+			" │   │   ├─ Or\n" +
+			" │   │   │   ├─ Or\n" +
+			" │   │   │   │   ├─ LessThan\n" +
+			" │   │   │   │   │   ├─ comp_index_t2.v1:1\n" +
+			" │   │   │   │   │   └─ 65 (bigint)\n" +
+			" │   │   │   │   └─ NOT\n" +
+			" │   │   │   │       └─ Eq\n" +
+			" │   │   │   │           ├─ comp_index_t2.v1:1\n" +
+			" │   │   │   │           └─ 44 (bigint)\n" +
+			" │   │   │   └─ AND\n" +
+			" │   │   │       ├─ LessThanOrEqual\n" +
+			" │   │   │       │   ├─ comp_index_t2.v1:1\n" +
+			" │   │   │       │   └─ 39 (bigint)\n" +
+			" │   │   │       └─ GreaterThanOrEqual\n" +
+			" │   │   │           ├─ comp_index_t2.v3:3\n" +
+			" │   │   │           └─ 14 (bigint)\n" +
+			" │   │   └─ AND\n" +
+			" │   │       ├─ LessThanOrEqual\n" +
+			" │   │       │   ├─ comp_index_t2.v1:1\n" +
+			" │   │       │   └─ 33 (bigint)\n" +
+			" │   │       └─ NOT\n" +
+			" │   │           └─ Eq\n" +
+			" │   │               ├─ comp_index_t2.v2:2\n" +
+			" │   │               └─ 11 (bigint)\n" +
+			" │   └─ AND\n" +
+			" │       ├─ AND\n" +
+			" │       │   ├─ Eq\n" +
+			" │       │   │   ├─ comp_index_t2.v1:1\n" +
+			" │       │   │   └─ 75 (bigint)\n" +
+			" │       │   └─ Eq\n" +
+			" │       │       ├─ comp_index_t2.v2:2\n" +
+			" │       │       └─ 0 (bigint)\n" +
+			" │       └─ LessThan\n" +
+			" │           ├─ comp_index_t2.v3:3\n" +
+			" │           └─ 28 (bigint)\n" +
+			" └─ ProcessTable\n" +
+			"     └─ Table\n" +
+			"         ├─ name: comp_index_t2\n" +
+			"         └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (((((comp_index_t2.v1 < 65) OR (NOT((comp_index_t2.v1 = 44)))) OR ((comp_index_t2.v1 <= 39) AND (comp_index_t2.v3 >= 14))) OR ((comp_index_t2.v1 <= 33) AND (NOT((comp_index_t2.v2 = 11))))) OR (((comp_index_t2.v1 = 75) AND (comp_index_t2.v2 = 0)) AND (comp_index_t2.v3 < 28)))\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
-			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
-			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
-			" └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (((((comp_index_t2.v1 < 65) OR (NOT((comp_index_t2.v1 = 44)))) OR ((comp_index_t2.v1 <= 39) AND (comp_index_t2.v3 >= 14))) OR ((comp_index_t2.v1 <= 33) AND (NOT((comp_index_t2.v2 = 11))))) OR (((comp_index_t2.v1 = 75) AND (comp_index_t2.v2 = 0)) AND (comp_index_t2.v3 < 28)))\n" +
+			" └─ Table\n" +
+			"     ├─ name: comp_index_t2\n" +
+			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -16502,7 +16898,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ tableId: 3\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"     ├─ static: [{[1, 1], [1, 1], (NULL, ∞)}]\n" +
+			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-3)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -16518,7 +16914,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ tableId: 3\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2 pk3]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -16530,7 +16926,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ tableId: 3\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2 pk3]\n" +
 			"",
 	},
@@ -16695,7 +17091,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ TableAlias(r)\n" +
 			"         │   └─ IndexedTableAccess(three_pk)\n" +
 			"         │       ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"         │       ├─ static: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │       ├─ static: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │       ├─ colSet: (9-16)\n" +
 			"         │       ├─ tableId: 2\n" +
 			"         │       └─ Table\n" +
@@ -16704,7 +17100,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         └─ TableAlias(l)\n" +
 			"             └─ IndexedTableAccess(three_pk)\n" +
 			"                 ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"                 ├─ static: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                 ├─ static: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                 ├─ colSet: (1-8)\n" +
 			"                 ├─ tableId: 1\n" +
 			"                 └─ Table\n" +
@@ -16724,12 +17120,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ TableAlias(r)\n" +
 			"         │   └─ IndexedTableAccess(three_pk)\n" +
 			"         │       ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"         │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │       └─ columns: [pk1]\n" +
 			"         └─ TableAlias(l)\n" +
 			"             └─ IndexedTableAccess(three_pk)\n" +
 			"                 ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"                 ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                 ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                 └─ columns: [pk1]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -16745,12 +17141,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ TableAlias(r)\n" +
 			"         │   └─ IndexedTableAccess(three_pk)\n" +
 			"         │       ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"         │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │       └─ columns: [pk1]\n" +
 			"         └─ TableAlias(l)\n" +
 			"             └─ IndexedTableAccess(three_pk)\n" +
 			"                 ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"                 ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                 ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                 └─ columns: [pk1]\n" +
 			"",
 	},
@@ -16782,7 +17178,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           ├─ TableAlias(r)\n" +
 			"         │           │   └─ IndexedTableAccess(three_pks)\n" +
 			"         │           │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │           │       ├─ static: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │           │       ├─ static: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │           │       ├─ colSet: (4-6)\n" +
 			"         │           │       ├─ tableId: 2\n" +
 			"         │           │       └─ Table\n" +
@@ -16791,7 +17187,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           └─ TableAlias(l)\n" +
 			"         │               └─ IndexedTableAccess(three_pks)\n" +
 			"         │                   ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │                   ├─ static: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │                   ├─ static: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │                   ├─ colSet: (1-3)\n" +
 			"         │                   ├─ tableId: 1\n" +
 			"         │                   └─ Table\n" +
@@ -16817,7 +17213,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             ├─ TableAlias(r)\n" +
 			"                             │   └─ IndexedTableAccess(three_pks)\n" +
 			"                             │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                             │       ├─ static: [{[4, 4], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                             │       ├─ static: [{[4, 4], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                             │       ├─ colSet: (14-16)\n" +
 			"                             │       ├─ tableId: 6\n" +
 			"                             │       └─ Table\n" +
@@ -16826,7 +17222,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             └─ TableAlias(l)\n" +
 			"                                 └─ IndexedTableAccess(three_pks)\n" +
 			"                                     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                                     ├─ static: [{[3, 3], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                                     ├─ static: [{[3, 3], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                                     ├─ colSet: (11-13)\n" +
 			"                                     ├─ tableId: 5\n" +
 			"                                     └─ Table\n" +
@@ -16857,12 +17253,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           ├─ TableAlias(r)\n" +
 			"         │           │   └─ IndexedTableAccess(three_pks)\n" +
 			"         │           │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │           │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │           │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │           │       └─ columns: [pk1 pk2]\n" +
 			"         │           └─ TableAlias(l)\n" +
 			"         │               └─ IndexedTableAccess(three_pks)\n" +
 			"         │                   ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │                   ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │                   ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │                   └─ columns: [pk1 pk2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: ()\n" +
@@ -16880,12 +17276,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             ├─ TableAlias(r)\n" +
 			"                             │   └─ IndexedTableAccess(three_pks)\n" +
 			"                             │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                             │       ├─ filters: [{[4, 4], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                             │       ├─ filters: [{[4, 4], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                             │       └─ columns: [pk1 pk2]\n" +
 			"                             └─ TableAlias(l)\n" +
 			"                                 └─ IndexedTableAccess(three_pks)\n" +
 			"                                     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                                     ├─ filters: [{[3, 3], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                                     ├─ filters: [{[3, 3], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                                     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -16912,12 +17308,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           ├─ TableAlias(r)\n" +
 			"         │           │   └─ IndexedTableAccess(three_pks)\n" +
 			"         │           │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │           │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │           │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │           │       └─ columns: [pk1 pk2]\n" +
 			"         │           └─ TableAlias(l)\n" +
 			"         │               └─ IndexedTableAccess(three_pks)\n" +
 			"         │                   ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │                   ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
+			"         │                   ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
 			"         │                   └─ columns: [pk1 pk2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: ()\n" +
@@ -16935,12 +17331,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             ├─ TableAlias(r)\n" +
 			"                             │   └─ IndexedTableAccess(three_pks)\n" +
 			"                             │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                             │       ├─ filters: [{[4, 4], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                             │       ├─ filters: [{[4, 4], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                             │       └─ columns: [pk1 pk2]\n" +
 			"                             └─ TableAlias(l)\n" +
 			"                                 └─ IndexedTableAccess(three_pks)\n" +
 			"                                     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                                     ├─ filters: [{[3, 3], (NULL, ∞), (NULL, ∞)}]\n" +
+			"                                     ├─ filters: [{[3, 3], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                                     └─ columns: [pk1 pk2]\n" +
 			"",
 	},

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -791,30 +791,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<25) OR (v1>24));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ LessThan\n" +
-			" │   │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   └─ 25 (bigint)\n" +
-			" │   └─ GreaterThan\n" +
-			" │       ├─ comp_index_t0.v1:1\n" +
-			" │       └─ 24 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((comp_index_t0.v1 < 25) OR (comp_index_t0.v1 > 24))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((comp_index_t0.v1 < 25) OR (comp_index_t0.v1 > 24))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1017,40 +1011,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>22 AND v2>18) OR (v1<>12)) OR (v1<=34));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ AND\n" +
-			" │   │   │   ├─ NOT\n" +
-			" │   │   │   │   └─ Eq\n" +
-			" │   │   │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   │       └─ 22 (bigint)\n" +
-			" │   │   │   └─ GreaterThan\n" +
-			" │   │   │       ├─ comp_index_t0.v2:2\n" +
-			" │   │   │       └─ 18 (bigint)\n" +
-			" │   │   └─ NOT\n" +
-			" │   │       └─ Eq\n" +
-			" │   │           ├─ comp_index_t0.v1:1\n" +
-			" │   │           └─ 12 (bigint)\n" +
-			" │   └─ LessThanOrEqual\n" +
-			" │       ├─ comp_index_t0.v1:1\n" +
-			" │       └─ 34 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((((NOT((comp_index_t0.v1 = 22))) AND (comp_index_t0.v2 > 18)) OR (NOT((comp_index_t0.v1 = 12)))) OR (comp_index_t0.v1 <= 34))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((((NOT((comp_index_t0.v1 = 22))) AND (comp_index_t0.v2 > 18)) OR (NOT((comp_index_t0.v1 = 12)))) OR (comp_index_t0.v1 <= 34))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1517,39 +1495,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1>35) OR (v1 BETWEEN 11 AND 21)) OR (v1<>98));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ GreaterThan\n" +
-			" │   │   │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   └─ 35 (bigint)\n" +
-			" │   │   └─ AND\n" +
-			" │   │       ├─ GreaterThanOrEqual\n" +
-			" │   │       │   ├─ comp_index_t0.v1:1\n" +
-			" │   │       │   └─ 11 (tinyint)\n" +
-			" │   │       └─ LessThanOrEqual\n" +
-			" │   │           ├─ comp_index_t0.v1:1\n" +
-			" │   │           └─ 21 (tinyint)\n" +
-			" │   └─ NOT\n" +
-			" │       └─ Eq\n" +
-			" │           ├─ comp_index_t0.v1:1\n" +
-			" │           └─ 98 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((comp_index_t0.v1 > 35) OR ((comp_index_t0.v1 >= 11) AND (comp_index_t0.v1 <= 21))) OR (NOT((comp_index_t0.v1 = 98))))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((comp_index_t0.v1 > 35) OR ((comp_index_t0.v1 >= 11) AND (comp_index_t0.v1 <= 21))) OR (NOT((comp_index_t0.v1 = 98))))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1598,56 +1561,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((((v1<>30) OR (v1>=6 AND v2 BETWEEN 62 AND 65)) OR (v1<>89)) OR (v1<=40 AND v2>=73)) OR (v1<99));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ Or\n" +
-			" │   │   │   ├─ Or\n" +
-			" │   │   │   │   ├─ NOT\n" +
-			" │   │   │   │   │   └─ Eq\n" +
-			" │   │   │   │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   │   │       └─ 30 (bigint)\n" +
-			" │   │   │   │   └─ AND\n" +
-			" │   │   │   │       ├─ GreaterThanOrEqual\n" +
-			" │   │   │   │       │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   │       │   └─ 6 (bigint)\n" +
-			" │   │   │   │       └─ AND\n" +
-			" │   │   │   │           ├─ GreaterThanOrEqual\n" +
-			" │   │   │   │           │   ├─ comp_index_t0.v2:2\n" +
-			" │   │   │   │           │   └─ 62 (tinyint)\n" +
-			" │   │   │   │           └─ LessThanOrEqual\n" +
-			" │   │   │   │               ├─ comp_index_t0.v2:2\n" +
-			" │   │   │   │               └─ 65 (tinyint)\n" +
-			" │   │   │   └─ NOT\n" +
-			" │   │   │       └─ Eq\n" +
-			" │   │   │           ├─ comp_index_t0.v1:1\n" +
-			" │   │   │           └─ 89 (bigint)\n" +
-			" │   │   └─ AND\n" +
-			" │   │       ├─ LessThanOrEqual\n" +
-			" │   │       │   ├─ comp_index_t0.v1:1\n" +
-			" │   │       │   └─ 40 (bigint)\n" +
-			" │   │       └─ GreaterThanOrEqual\n" +
-			" │   │           ├─ comp_index_t0.v2:2\n" +
-			" │   │           └─ 73 (bigint)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ comp_index_t0.v1:1\n" +
-			" │       └─ 99 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((((NOT((comp_index_t0.v1 = 30))) OR ((comp_index_t0.v1 >= 6) AND ((comp_index_t0.v2 >= 62) AND (comp_index_t0.v2 <= 65)))) OR (NOT((comp_index_t0.v1 = 89)))) OR ((comp_index_t0.v1 <= 40) AND (comp_index_t0.v2 >= 73))) OR (comp_index_t0.v1 < 99))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((((NOT((comp_index_t0.v1 = 30))) OR ((comp_index_t0.v1 >= 6) AND ((comp_index_t0.v2 >= 62) AND (comp_index_t0.v2 <= 65)))) OR (NOT((comp_index_t0.v1 = 89)))) OR ((comp_index_t0.v1 <= 40) AND (comp_index_t0.v2 >= 73))) OR (comp_index_t0.v1 < 99))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -1960,46 +1891,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1>28) OR (v1<=30 AND v2=30)) OR (v1<29)) OR (v1 BETWEEN 54 AND 74));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ Or\n" +
-			" │   │   │   ├─ GreaterThan\n" +
-			" │   │   │   │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   │   └─ 28 (bigint)\n" +
-			" │   │   │   └─ AND\n" +
-			" │   │   │       ├─ LessThanOrEqual\n" +
-			" │   │   │       │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   │       │   └─ 30 (bigint)\n" +
-			" │   │   │       └─ Eq\n" +
-			" │   │   │           ├─ comp_index_t0.v2:2\n" +
-			" │   │   │           └─ 30 (bigint)\n" +
-			" │   │   └─ LessThan\n" +
-			" │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │       └─ 29 (bigint)\n" +
-			" │   └─ AND\n" +
-			" │       ├─ GreaterThanOrEqual\n" +
-			" │       │   ├─ comp_index_t0.v1:1\n" +
-			" │       │   └─ 54 (tinyint)\n" +
-			" │       └─ LessThanOrEqual\n" +
-			" │           ├─ comp_index_t0.v1:1\n" +
-			" │           └─ 74 (tinyint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((((comp_index_t0.v1 > 28) OR ((comp_index_t0.v1 <= 30) AND (comp_index_t0.v2 = 30))) OR (comp_index_t0.v1 < 29)) OR ((comp_index_t0.v1 >= 54) AND (comp_index_t0.v1 <= 74)))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((((comp_index_t0.v1 > 28) OR ((comp_index_t0.v1 <= 30) AND (comp_index_t0.v2 = 30))) OR (comp_index_t0.v1 < 29)) OR ((comp_index_t0.v1 >= 54) AND (comp_index_t0.v1 <= 74)))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2136,102 +2045,68 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>31) OR (v1<>43)) OR (v1>37 AND v2>5));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ NOT\n" +
-			" │   │   │   └─ Eq\n" +
-			" │   │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │   │       └─ 31 (bigint)\n" +
-			" │   │   └─ NOT\n" +
-			" │   │       └─ Eq\n" +
-			" │   │           ├─ comp_index_t0.v1:1\n" +
-			" │   │           └─ 43 (bigint)\n" +
-			" │   └─ AND\n" +
-			" │       ├─ GreaterThan\n" +
-			" │       │   ├─ comp_index_t0.v1:1\n" +
-			" │       │   └─ 37 (bigint)\n" +
-			" │       └─ GreaterThan\n" +
-			" │           ├─ comp_index_t0.v2:2\n" +
-			" │           └─ 5 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((NOT((comp_index_t0.v1 = 31))) OR (NOT((comp_index_t0.v1 = 43)))) OR ((comp_index_t0.v1 > 37) AND (comp_index_t0.v2 > 5)))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((NOT((comp_index_t0.v1 = 31))) OR (NOT((comp_index_t0.v1 = 43)))) OR ((comp_index_t0.v1 > 37) AND (comp_index_t0.v2 > 5)))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<=91) OR (v1<>79)) OR (v1<64));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ LessThanOrEqual\n" +
-			" │   │   │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   └─ 91 (bigint)\n" +
-			" │   │   └─ NOT\n" +
-			" │   │       └─ Eq\n" +
-			" │   │           ├─ comp_index_t0.v1:1\n" +
-			" │   │           └─ 79 (bigint)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ comp_index_t0.v1:1\n" +
-			" │       └─ 64 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((comp_index_t0.v1 <= 91) OR (NOT((comp_index_t0.v1 = 79)))) OR (comp_index_t0.v1 < 64))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((comp_index_t0.v1 <= 91) OR (NOT((comp_index_t0.v1 = 79)))) OR (comp_index_t0.v1 < 64))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((v1<>48) OR (v1>11));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ NOT\n" +
-			" │   │   └─ Eq\n" +
-			" │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │       └─ 48 (bigint)\n" +
-			" │   └─ GreaterThan\n" +
-			" │       ├─ comp_index_t0.v1:1\n" +
-			" │       └─ 11 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((NOT((comp_index_t0.v1 = 48))) OR (comp_index_t0.v1 > 11))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((NOT((comp_index_t0.v1 = 48))) OR (comp_index_t0.v1 > 11))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2302,43 +2177,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1 BETWEEN 27 AND 84) OR (v1<98 AND v2>38)) OR (v1<>30));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ AND\n" +
-			" │   │   │   ├─ GreaterThanOrEqual\n" +
-			" │   │   │   │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   │   └─ 27 (tinyint)\n" +
-			" │   │   │   └─ LessThanOrEqual\n" +
-			" │   │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │   │       └─ 84 (tinyint)\n" +
-			" │   │   └─ AND\n" +
-			" │   │       ├─ LessThan\n" +
-			" │   │       │   ├─ comp_index_t0.v1:1\n" +
-			" │   │       │   └─ 98 (bigint)\n" +
-			" │   │       └─ GreaterThan\n" +
-			" │   │           ├─ comp_index_t0.v2:2\n" +
-			" │   │           └─ 38 (bigint)\n" +
-			" │   └─ NOT\n" +
-			" │       └─ Eq\n" +
-			" │           ├─ comp_index_t0.v1:1\n" +
-			" │           └─ 30 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((((comp_index_t0.v1 >= 27) AND (comp_index_t0.v1 <= 84)) OR ((comp_index_t0.v1 < 98) AND (comp_index_t0.v2 > 38))) OR (NOT((comp_index_t0.v1 = 30))))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((((comp_index_t0.v1 >= 27) AND (comp_index_t0.v1 <= 84)) OR ((comp_index_t0.v1 < 98) AND (comp_index_t0.v2 > 38))) OR (NOT((comp_index_t0.v1 = 30))))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -2717,43 +2573,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE (((v1<>50) OR (v1<=88)) OR (v1>=28 AND v2 BETWEEN 30 AND 85));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ NOT\n" +
-			" │   │   │   └─ Eq\n" +
-			" │   │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │   │       └─ 50 (bigint)\n" +
-			" │   │   └─ LessThanOrEqual\n" +
-			" │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │       └─ 88 (bigint)\n" +
-			" │   └─ AND\n" +
-			" │       ├─ GreaterThanOrEqual\n" +
-			" │       │   ├─ comp_index_t0.v1:1\n" +
-			" │       │   └─ 28 (bigint)\n" +
-			" │       └─ AND\n" +
-			" │           ├─ GreaterThanOrEqual\n" +
-			" │           │   ├─ comp_index_t0.v2:2\n" +
-			" │           │   └─ 30 (tinyint)\n" +
-			" │           └─ LessThanOrEqual\n" +
-			" │               ├─ comp_index_t0.v2:2\n" +
-			" │               └─ 85 (tinyint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((NOT((comp_index_t0.v1 = 50))) OR (comp_index_t0.v1 <= 88)) OR ((comp_index_t0.v1 >= 28) AND ((comp_index_t0.v2 >= 30) AND (comp_index_t0.v2 <= 85))))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((NOT((comp_index_t0.v1 = 50))) OR (comp_index_t0.v1 <= 88)) OR ((comp_index_t0.v1 >= 28) AND ((comp_index_t0.v2 >= 30) AND (comp_index_t0.v2 <= 85))))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -3022,46 +2859,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t0 WHERE ((((v1<32 AND v2>=79) OR (v1<=28)) OR (v1 BETWEEN 46 AND 72)) OR (v1>16));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ Or\n" +
-			" │   │   │   ├─ AND\n" +
-			" │   │   │   │   ├─ LessThan\n" +
-			" │   │   │   │   │   ├─ comp_index_t0.v1:1\n" +
-			" │   │   │   │   │   └─ 32 (bigint)\n" +
-			" │   │   │   │   └─ GreaterThanOrEqual\n" +
-			" │   │   │   │       ├─ comp_index_t0.v2:2\n" +
-			" │   │   │   │       └─ 79 (bigint)\n" +
-			" │   │   │   └─ LessThanOrEqual\n" +
-			" │   │   │       ├─ comp_index_t0.v1:1\n" +
-			" │   │   │       └─ 28 (bigint)\n" +
-			" │   │   └─ AND\n" +
-			" │   │       ├─ GreaterThanOrEqual\n" +
-			" │   │       │   ├─ comp_index_t0.v1:1\n" +
-			" │   │       │   └─ 46 (tinyint)\n" +
-			" │   │       └─ LessThanOrEqual\n" +
-			" │   │           ├─ comp_index_t0.v1:1\n" +
-			" │   │           └─ 72 (tinyint)\n" +
-			" │   └─ GreaterThan\n" +
-			" │       ├─ comp_index_t0.v1:1\n" +
-			" │       └─ 16 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t0\n" +
-			"         └─ columns: [pk v1 v2]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((((comp_index_t0.v1 < 32) AND (comp_index_t0.v2 >= 79)) OR (comp_index_t0.v1 <= 28)) OR ((comp_index_t0.v1 >= 46) AND (comp_index_t0.v1 <= 72))) OR (comp_index_t0.v1 > 16))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-3)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t0\n" +
 			"     └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((((comp_index_t0.v1 < 32) AND (comp_index_t0.v2 >= 79)) OR (comp_index_t0.v1 <= 28)) OR ((comp_index_t0.v1 >= 46) AND (comp_index_t0.v1 <= 72))) OR (comp_index_t0.v1 > 16))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t0\n" +
-			"     └─ columns: [pk v1 v2]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t0)\n" +
+			" ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
@@ -3220,46 +3035,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<93 AND v2<39 AND v3 BETWEEN 30 AND 97) OR (v1>54)) OR (v1<66));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ AND\n" +
-			" │   │   │   ├─ AND\n" +
-			" │   │   │   │   ├─ LessThan\n" +
-			" │   │   │   │   │   ├─ comp_index_t1.v1:1\n" +
-			" │   │   │   │   │   └─ 93 (bigint)\n" +
-			" │   │   │   │   └─ LessThan\n" +
-			" │   │   │   │       ├─ comp_index_t1.v2:2\n" +
-			" │   │   │   │       └─ 39 (bigint)\n" +
-			" │   │   │   └─ AND\n" +
-			" │   │   │       ├─ GreaterThanOrEqual\n" +
-			" │   │   │       │   ├─ comp_index_t1.v3:3\n" +
-			" │   │   │       │   └─ 30 (tinyint)\n" +
-			" │   │   │       └─ LessThanOrEqual\n" +
-			" │   │   │           ├─ comp_index_t1.v3:3\n" +
-			" │   │   │           └─ 97 (tinyint)\n" +
-			" │   │   └─ GreaterThan\n" +
-			" │   │       ├─ comp_index_t1.v1:1\n" +
-			" │   │       └─ 54 (bigint)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ comp_index_t1.v1:1\n" +
-			" │       └─ 66 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((((comp_index_t1.v1 < 93) AND (comp_index_t1.v2 < 39)) AND ((comp_index_t1.v3 >= 30) AND (comp_index_t1.v3 <= 97))) OR (comp_index_t1.v1 > 54)) OR (comp_index_t1.v1 < 66))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((((comp_index_t1.v1 < 93) AND (comp_index_t1.v2 < 39)) AND ((comp_index_t1.v3 >= 30) AND (comp_index_t1.v3 <= 97))) OR (comp_index_t1.v1 > 54)) OR (comp_index_t1.v1 < 66))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5068,77 +4861,46 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>2) OR (v1<=30)) OR (v1<>35 AND v2 BETWEEN 6 AND 61 AND v3>=16));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ GreaterThan\n" +
-			" │   │   │   ├─ comp_index_t1.v1:1\n" +
-			" │   │   │   └─ 2 (bigint)\n" +
-			" │   │   └─ LessThanOrEqual\n" +
-			" │   │       ├─ comp_index_t1.v1:1\n" +
-			" │   │       └─ 30 (bigint)\n" +
-			" │   └─ AND\n" +
-			" │       ├─ AND\n" +
-			" │       │   ├─ NOT\n" +
-			" │       │   │   └─ Eq\n" +
-			" │       │   │       ├─ comp_index_t1.v1:1\n" +
-			" │       │   │       └─ 35 (bigint)\n" +
-			" │       │   └─ AND\n" +
-			" │       │       ├─ GreaterThanOrEqual\n" +
-			" │       │       │   ├─ comp_index_t1.v2:2\n" +
-			" │       │       │   └─ 6 (tinyint)\n" +
-			" │       │       └─ LessThanOrEqual\n" +
-			" │       │           ├─ comp_index_t1.v2:2\n" +
-			" │       │           └─ 61 (tinyint)\n" +
-			" │       └─ GreaterThanOrEqual\n" +
-			" │           ├─ comp_index_t1.v3:3\n" +
-			" │           └─ 16 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((comp_index_t1.v1 > 2) OR (comp_index_t1.v1 <= 30)) OR (((NOT((comp_index_t1.v1 = 35))) AND ((comp_index_t1.v2 >= 6) AND (comp_index_t1.v2 <= 61))) AND (comp_index_t1.v3 >= 16)))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((comp_index_t1.v1 > 2) OR (comp_index_t1.v1 <= 30)) OR (((NOT((comp_index_t1.v1 = 35))) AND ((comp_index_t1.v2 >= 6) AND (comp_index_t1.v2 <= 61))) AND (comp_index_t1.v3 >= 16)))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>19) OR (v1<>48));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ NOT\n" +
-			" │   │   └─ Eq\n" +
-			" │   │       ├─ comp_index_t1.v1:1\n" +
-			" │   │       └─ 19 (bigint)\n" +
-			" │   └─ NOT\n" +
-			" │       └─ Eq\n" +
-			" │           ├─ comp_index_t1.v1:1\n" +
-			" │           └─ 48 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((NOT((comp_index_t1.v1 = 19))) OR (NOT((comp_index_t1.v1 = 48))))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((NOT((comp_index_t1.v1 = 19))) OR (NOT((comp_index_t1.v1 = 48))))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -5737,31 +5499,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1<>50) OR (v1<=71));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ NOT\n" +
-			" │   │   └─ Eq\n" +
-			" │   │       ├─ comp_index_t1.v1:1\n" +
-			" │   │       └─ 50 (bigint)\n" +
-			" │   └─ LessThanOrEqual\n" +
-			" │       ├─ comp_index_t1.v1:1\n" +
-			" │       └─ 71 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((NOT((comp_index_t1.v1 = 50))) OR (comp_index_t1.v1 <= 71))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((NOT((comp_index_t1.v1 = 50))) OR (comp_index_t1.v1 <= 71))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6074,30 +5829,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE ((v1>25) OR (v1<53));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ GreaterThan\n" +
-			" │   │   ├─ comp_index_t1.v1:1\n" +
-			" │   │   └─ 25 (bigint)\n" +
-			" │   └─ LessThan\n" +
-			" │       ├─ comp_index_t1.v1:1\n" +
-			" │       └─ 53 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((comp_index_t1.v1 > 25) OR (comp_index_t1.v1 < 53))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((comp_index_t1.v1 > 25) OR (comp_index_t1.v1 < 53))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6278,46 +6027,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>12) OR (v1>=26 AND v2 BETWEEN 77 AND 87 AND v3<19)) OR (v1<=89));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ GreaterThan\n" +
-			" │   │   │   ├─ comp_index_t1.v1:1\n" +
-			" │   │   │   └─ 12 (bigint)\n" +
-			" │   │   └─ AND\n" +
-			" │   │       ├─ AND\n" +
-			" │   │       │   ├─ GreaterThanOrEqual\n" +
-			" │   │       │   │   ├─ comp_index_t1.v1:1\n" +
-			" │   │       │   │   └─ 26 (bigint)\n" +
-			" │   │       │   └─ AND\n" +
-			" │   │       │       ├─ GreaterThanOrEqual\n" +
-			" │   │       │       │   ├─ comp_index_t1.v2:2\n" +
-			" │   │       │       │   └─ 77 (tinyint)\n" +
-			" │   │       │       └─ LessThanOrEqual\n" +
-			" │   │       │           ├─ comp_index_t1.v2:2\n" +
-			" │   │       │           └─ 87 (tinyint)\n" +
-			" │   │       └─ LessThan\n" +
-			" │   │           ├─ comp_index_t1.v3:3\n" +
-			" │   │           └─ 19 (bigint)\n" +
-			" │   └─ LessThanOrEqual\n" +
-			" │       ├─ comp_index_t1.v1:1\n" +
-			" │       └─ 89 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((comp_index_t1.v1 > 12) OR (((comp_index_t1.v1 >= 26) AND ((comp_index_t1.v2 >= 77) AND (comp_index_t1.v2 <= 87))) AND (comp_index_t1.v3 < 19))) OR (comp_index_t1.v1 <= 89))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((comp_index_t1.v1 > 12) OR (((comp_index_t1.v1 >= 26) AND ((comp_index_t1.v2 >= 77) AND (comp_index_t1.v2 <= 87))) AND (comp_index_t1.v3 < 19))) OR (comp_index_t1.v1 <= 89))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -6894,77 +6621,46 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1>=8 AND v2<=97 AND v3>=77) OR (v1<>4)) OR (v1<=41));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ AND\n" +
-			" │   │   │   ├─ AND\n" +
-			" │   │   │   │   ├─ GreaterThanOrEqual\n" +
-			" │   │   │   │   │   ├─ comp_index_t1.v1:1\n" +
-			" │   │   │   │   │   └─ 8 (bigint)\n" +
-			" │   │   │   │   └─ LessThanOrEqual\n" +
-			" │   │   │   │       ├─ comp_index_t1.v2:2\n" +
-			" │   │   │   │       └─ 97 (bigint)\n" +
-			" │   │   │   └─ GreaterThanOrEqual\n" +
-			" │   │   │       ├─ comp_index_t1.v3:3\n" +
-			" │   │   │       └─ 77 (bigint)\n" +
-			" │   │   └─ NOT\n" +
-			" │   │       └─ Eq\n" +
-			" │   │           ├─ comp_index_t1.v1:1\n" +
-			" │   │           └─ 4 (bigint)\n" +
-			" │   └─ LessThanOrEqual\n" +
-			" │       ├─ comp_index_t1.v1:1\n" +
-			" │       └─ 41 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((((comp_index_t1.v1 >= 8) AND (comp_index_t1.v2 <= 97)) AND (comp_index_t1.v3 >= 77)) OR (NOT((comp_index_t1.v1 = 4)))) OR (comp_index_t1.v1 <= 41))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((((comp_index_t1.v1 >= 8) AND (comp_index_t1.v2 <= 97)) AND (comp_index_t1.v3 >= 77)) OR (NOT((comp_index_t1.v1 = 4)))) OR (comp_index_t1.v1 <= 41))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM comp_index_t1 WHERE (((v1<>33) OR (v1<=28)) OR (v1<>68));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ NOT\n" +
-			" │   │   │   └─ Eq\n" +
-			" │   │   │       ├─ comp_index_t1.v1:1\n" +
-			" │   │   │       └─ 33 (bigint)\n" +
-			" │   │   └─ LessThanOrEqual\n" +
-			" │   │       ├─ comp_index_t1.v1:1\n" +
-			" │   │       └─ 28 (bigint)\n" +
-			" │   └─ NOT\n" +
-			" │       └─ Eq\n" +
-			" │           ├─ comp_index_t1.v1:1\n" +
-			" │           └─ 68 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t1\n" +
-			"         └─ columns: [pk v1 v2 v3]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((NOT((comp_index_t1.v1 = 33))) OR (comp_index_t1.v1 <= 28)) OR (NOT((comp_index_t1.v1 = 68))))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-4)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t1\n" +
 			"     └─ columns: [pk v1 v2 v3]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((NOT((comp_index_t1.v1 = 33))) OR (comp_index_t1.v1 <= 28)) OR (NOT((comp_index_t1.v1 = 68))))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t1\n" +
-			"     └─ columns: [pk v1 v2 v3]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t1)\n" +
+			" ├─ index: [comp_index_t1.v1,comp_index_t1.v2,comp_index_t1.v3]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3]\n" +
 			"",
 	},
 	{
@@ -8861,53 +8557,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<31 AND v2<>14 AND v3 BETWEEN 0 AND 10 AND v4>=95) OR (v1<>91)) OR (v1<>35));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ AND\n" +
-			" │   │   │   ├─ AND\n" +
-			" │   │   │   │   ├─ AND\n" +
-			" │   │   │   │   │   ├─ LessThan\n" +
-			" │   │   │   │   │   │   ├─ comp_index_t2.v1:1\n" +
-			" │   │   │   │   │   │   └─ 31 (bigint)\n" +
-			" │   │   │   │   │   └─ NOT\n" +
-			" │   │   │   │   │       └─ Eq\n" +
-			" │   │   │   │   │           ├─ comp_index_t2.v2:2\n" +
-			" │   │   │   │   │           └─ 14 (bigint)\n" +
-			" │   │   │   │   └─ AND\n" +
-			" │   │   │   │       ├─ GreaterThanOrEqual\n" +
-			" │   │   │   │       │   ├─ comp_index_t2.v3:3\n" +
-			" │   │   │   │       │   └─ 0 (tinyint)\n" +
-			" │   │   │   │       └─ LessThanOrEqual\n" +
-			" │   │   │   │           ├─ comp_index_t2.v3:3\n" +
-			" │   │   │   │           └─ 10 (tinyint)\n" +
-			" │   │   │   └─ GreaterThanOrEqual\n" +
-			" │   │   │       ├─ comp_index_t2.v4:4\n" +
-			" │   │   │       └─ 95 (bigint)\n" +
-			" │   │   └─ NOT\n" +
-			" │   │       └─ Eq\n" +
-			" │   │           ├─ comp_index_t2.v1:1\n" +
-			" │   │           └─ 91 (bigint)\n" +
-			" │   └─ NOT\n" +
-			" │       └─ Eq\n" +
-			" │           ├─ comp_index_t2.v1:1\n" +
-			" │           └─ 35 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((((((comp_index_t2.v1 < 31) AND (NOT((comp_index_t2.v2 = 14)))) AND ((comp_index_t2.v3 >= 0) AND (comp_index_t2.v3 <= 10))) AND (comp_index_t2.v4 >= 95)) OR (NOT((comp_index_t2.v1 = 91)))) OR (NOT((comp_index_t2.v1 = 35))))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-5)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((((((comp_index_t2.v1 < 31) AND (NOT((comp_index_t2.v2 = 14)))) AND ((comp_index_t2.v3 >= 0) AND (comp_index_t2.v3 <= 10))) AND (comp_index_t2.v4 >= 95)) OR (NOT((comp_index_t2.v1 = 91)))) OR (NOT((comp_index_t2.v1 = 35))))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -10166,31 +9833,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE ((v1<>69) OR (v1>=43));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ NOT\n" +
-			" │   │   └─ Eq\n" +
-			" │   │       ├─ comp_index_t2.v1:1\n" +
-			" │   │       └─ 69 (bigint)\n" +
-			" │   └─ GreaterThanOrEqual\n" +
-			" │       ├─ comp_index_t2.v1:1\n" +
-			" │       └─ 43 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((NOT((comp_index_t2.v1 = 69))) OR (comp_index_t2.v1 >= 43))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-5)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((NOT((comp_index_t2.v1 = 69))) OR (comp_index_t2.v1 >= 43))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11735,44 +11395,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((v1<>79 AND v2<=85) OR (v1<>13)) OR (v1 BETWEEN 4 AND 67));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ AND\n" +
-			" │   │   │   ├─ NOT\n" +
-			" │   │   │   │   └─ Eq\n" +
-			" │   │   │   │       ├─ comp_index_t2.v1:1\n" +
-			" │   │   │   │       └─ 79 (bigint)\n" +
-			" │   │   │   └─ LessThanOrEqual\n" +
-			" │   │   │       ├─ comp_index_t2.v2:2\n" +
-			" │   │   │       └─ 85 (bigint)\n" +
-			" │   │   └─ NOT\n" +
-			" │   │       └─ Eq\n" +
-			" │   │           ├─ comp_index_t2.v1:1\n" +
-			" │   │           └─ 13 (bigint)\n" +
-			" │   └─ AND\n" +
-			" │       ├─ GreaterThanOrEqual\n" +
-			" │       │   ├─ comp_index_t2.v1:1\n" +
-			" │       │   └─ 4 (tinyint)\n" +
-			" │       └─ LessThanOrEqual\n" +
-			" │           ├─ comp_index_t2.v1:1\n" +
-			" │           └─ 67 (tinyint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ ((((NOT((comp_index_t2.v1 = 79))) AND (comp_index_t2.v2 <= 85)) OR (NOT((comp_index_t2.v1 = 13)))) OR ((comp_index_t2.v1 >= 4) AND (comp_index_t2.v1 <= 67)))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-5)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ ((((NOT((comp_index_t2.v1 = 79))) AND (comp_index_t2.v2 <= 85)) OR (NOT((comp_index_t2.v1 = 13)))) OR ((comp_index_t2.v1 >= 4) AND (comp_index_t2.v1 <= 67)))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{
@@ -11799,60 +11439,24 @@ var IndexPlanTests = []QueryPlanTest{
 	},
 	{
 		Query: `SELECT * FROM comp_index_t2 WHERE (((((v1<65) OR (v1<>44)) OR (v1<=39 AND v3>=14)) OR (v1<=33 AND v2<>11)) OR (v1=75 AND v2=0 AND v3<28));`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ Or\n" +
-			" │   ├─ Or\n" +
-			" │   │   ├─ Or\n" +
-			" │   │   │   ├─ Or\n" +
-			" │   │   │   │   ├─ LessThan\n" +
-			" │   │   │   │   │   ├─ comp_index_t2.v1:1\n" +
-			" │   │   │   │   │   └─ 65 (bigint)\n" +
-			" │   │   │   │   └─ NOT\n" +
-			" │   │   │   │       └─ Eq\n" +
-			" │   │   │   │           ├─ comp_index_t2.v1:1\n" +
-			" │   │   │   │           └─ 44 (bigint)\n" +
-			" │   │   │   └─ AND\n" +
-			" │   │   │       ├─ LessThanOrEqual\n" +
-			" │   │   │       │   ├─ comp_index_t2.v1:1\n" +
-			" │   │   │       │   └─ 39 (bigint)\n" +
-			" │   │   │       └─ GreaterThanOrEqual\n" +
-			" │   │   │           ├─ comp_index_t2.v3:3\n" +
-			" │   │   │           └─ 14 (bigint)\n" +
-			" │   │   └─ AND\n" +
-			" │   │       ├─ LessThanOrEqual\n" +
-			" │   │       │   ├─ comp_index_t2.v1:1\n" +
-			" │   │       │   └─ 33 (bigint)\n" +
-			" │   │       └─ NOT\n" +
-			" │   │           └─ Eq\n" +
-			" │   │               ├─ comp_index_t2.v2:2\n" +
-			" │   │               └─ 11 (bigint)\n" +
-			" │   └─ AND\n" +
-			" │       ├─ AND\n" +
-			" │       │   ├─ Eq\n" +
-			" │       │   │   ├─ comp_index_t2.v1:1\n" +
-			" │       │   │   └─ 75 (bigint)\n" +
-			" │       │   └─ Eq\n" +
-			" │       │       ├─ comp_index_t2.v2:2\n" +
-			" │       │       └─ 0 (bigint)\n" +
-			" │       └─ LessThan\n" +
-			" │           ├─ comp_index_t2.v3:3\n" +
-			" │           └─ 28 (bigint)\n" +
-			" └─ ProcessTable\n" +
-			"     └─ Table\n" +
-			"         ├─ name: comp_index_t2\n" +
-			"         └─ columns: [pk v1 v2 v3 v4]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (((((comp_index_t2.v1 < 65) OR (NOT((comp_index_t2.v1 = 44)))) OR ((comp_index_t2.v1 <= 39) AND (comp_index_t2.v3 >= 14))) OR ((comp_index_t2.v1 <= 33) AND (NOT((comp_index_t2.v2 = 11))))) OR (((comp_index_t2.v1 = 75) AND (comp_index_t2.v2 = 0)) AND (comp_index_t2.v3 < 28)))\n" +
+		ExpectedPlan: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ static: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ colSet: (1-5)\n" +
+			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
 			"     ├─ name: comp_index_t2\n" +
 			"     └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (((((comp_index_t2.v1 < 65) OR (NOT((comp_index_t2.v1 = 44)))) OR ((comp_index_t2.v1 <= 39) AND (comp_index_t2.v3 >= 14))) OR ((comp_index_t2.v1 <= 33) AND (NOT((comp_index_t2.v2 = 11))))) OR (((comp_index_t2.v1 = 75) AND (comp_index_t2.v2 = 0)) AND (comp_index_t2.v3 < 28)))\n" +
-			" └─ Table\n" +
-			"     ├─ name: comp_index_t2\n" +
-			"     └─ columns: [pk v1 v2 v3 v4]\n" +
+		ExpectedEstimates: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
+			"",
+		ExpectedAnalysis: "IndexedTableAccess(comp_index_t2)\n" +
+			" ├─ index: [comp_index_t2.v1,comp_index_t2.v2,comp_index_t2.v3,comp_index_t2.v4]\n" +
+			" ├─ filters: [{(NULL, ∞), [NULL, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" └─ columns: [pk v1 v2 v3 v4]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -16502,7 +16502,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ tableId: 3\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     ├─ static: [{[1, 1], [1, 1], (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-3)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -16518,7 +16518,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ tableId: 3\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2 pk3]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -16530,7 +16530,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ tableId: 3\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2 pk3]\n" +
 			"",
 	},
@@ -16695,7 +16695,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ TableAlias(r)\n" +
 			"         │   └─ IndexedTableAccess(three_pk)\n" +
 			"         │       ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"         │       ├─ static: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │       ├─ static: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │       ├─ colSet: (9-16)\n" +
 			"         │       ├─ tableId: 2\n" +
 			"         │       └─ Table\n" +
@@ -16704,7 +16704,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         └─ TableAlias(l)\n" +
 			"             └─ IndexedTableAccess(three_pk)\n" +
 			"                 ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"                 ├─ static: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ static: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                 ├─ colSet: (1-8)\n" +
 			"                 ├─ tableId: 1\n" +
 			"                 └─ Table\n" +
@@ -16724,12 +16724,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ TableAlias(r)\n" +
 			"         │   └─ IndexedTableAccess(three_pk)\n" +
 			"         │       ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"         │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │       └─ columns: [pk1]\n" +
 			"         └─ TableAlias(l)\n" +
 			"             └─ IndexedTableAccess(three_pk)\n" +
 			"                 ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"                 ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                 └─ columns: [pk1]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -16745,12 +16745,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         ├─ TableAlias(r)\n" +
 			"         │   └─ IndexedTableAccess(three_pk)\n" +
 			"         │       ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"         │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │       └─ columns: [pk1]\n" +
 			"         └─ TableAlias(l)\n" +
 			"             └─ IndexedTableAccess(three_pk)\n" +
 			"                 ├─ index: [three_pk.pk1,three_pk.pk2,three_pk.pk3]\n" +
-			"                 ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                 ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                 └─ columns: [pk1]\n" +
 			"",
 	},
@@ -16782,7 +16782,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           ├─ TableAlias(r)\n" +
 			"         │           │   └─ IndexedTableAccess(three_pks)\n" +
 			"         │           │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │           │       ├─ static: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │           │       ├─ static: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │           │       ├─ colSet: (4-6)\n" +
 			"         │           │       ├─ tableId: 2\n" +
 			"         │           │       └─ Table\n" +
@@ -16791,7 +16791,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           └─ TableAlias(l)\n" +
 			"         │               └─ IndexedTableAccess(three_pks)\n" +
 			"         │                   ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │                   ├─ static: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │                   ├─ static: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │                   ├─ colSet: (1-3)\n" +
 			"         │                   ├─ tableId: 1\n" +
 			"         │                   └─ Table\n" +
@@ -16817,7 +16817,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             ├─ TableAlias(r)\n" +
 			"                             │   └─ IndexedTableAccess(three_pks)\n" +
 			"                             │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                             │       ├─ static: [{[4, 4], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                             │       ├─ static: [{[4, 4], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                             │       ├─ colSet: (14-16)\n" +
 			"                             │       ├─ tableId: 6\n" +
 			"                             │       └─ Table\n" +
@@ -16826,7 +16826,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             └─ TableAlias(l)\n" +
 			"                                 └─ IndexedTableAccess(three_pks)\n" +
 			"                                     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                                     ├─ static: [{[3, 3], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                                     ├─ static: [{[3, 3], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                                     ├─ colSet: (11-13)\n" +
 			"                                     ├─ tableId: 5\n" +
 			"                                     └─ Table\n" +
@@ -16857,12 +16857,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           ├─ TableAlias(r)\n" +
 			"         │           │   └─ IndexedTableAccess(three_pks)\n" +
 			"         │           │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │           │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │           │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │           │       └─ columns: [pk1 pk2]\n" +
 			"         │           └─ TableAlias(l)\n" +
 			"         │               └─ IndexedTableAccess(three_pks)\n" +
 			"         │                   ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │                   ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │                   ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │                   └─ columns: [pk1 pk2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: ()\n" +
@@ -16880,12 +16880,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             ├─ TableAlias(r)\n" +
 			"                             │   └─ IndexedTableAccess(three_pks)\n" +
 			"                             │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                             │       ├─ filters: [{[4, 4], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                             │       ├─ filters: [{[4, 4], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                             │       └─ columns: [pk1 pk2]\n" +
 			"                             └─ TableAlias(l)\n" +
 			"                                 └─ IndexedTableAccess(three_pks)\n" +
 			"                                     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                                     ├─ filters: [{[3, 3], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                                     ├─ filters: [{[3, 3], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                                     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -16912,12 +16912,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │           ├─ TableAlias(r)\n" +
 			"         │           │   └─ IndexedTableAccess(three_pks)\n" +
 			"         │           │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │           │       ├─ filters: [{[2, 2], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │           │       ├─ filters: [{[2, 2], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │           │       └─ columns: [pk1 pk2]\n" +
 			"         │           └─ TableAlias(l)\n" +
 			"         │               └─ IndexedTableAccess(three_pks)\n" +
 			"         │                   ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"         │                   ├─ filters: [{[1, 1], [NULL, ∞), [NULL, ∞)}]\n" +
+			"         │                   ├─ filters: [{[1, 1], (NULL, ∞), (NULL, ∞)}]\n" +
 			"         │                   └─ columns: [pk1 pk2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: ()\n" +
@@ -16935,12 +16935,12 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             ├─ TableAlias(r)\n" +
 			"                             │   └─ IndexedTableAccess(three_pks)\n" +
 			"                             │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                             │       ├─ filters: [{[4, 4], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                             │       ├─ filters: [{[4, 4], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                             │       └─ columns: [pk1 pk2]\n" +
 			"                             └─ TableAlias(l)\n" +
 			"                                 └─ IndexedTableAccess(three_pks)\n" +
 			"                                     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
-			"                                     ├─ filters: [{[3, 3], [NULL, ∞), [NULL, ∞)}]\n" +
+			"                                     ├─ filters: [{[3, 3], (NULL, ∞), (NULL, ∞)}]\n" +
 			"                                     └─ columns: [pk1 pk2]\n" +
 			"",
 	},

--- a/enginetest/queries/indexed_expressions_queries.go
+++ b/enginetest/queries/indexed_expressions_queries.go
@@ -1116,10 +1116,10 @@ var IndexedExpressionsScriptTests = []ScriptTest{
 				ExpectedIndexes: []string{"secondary"},
 			},
 			{
-				// No index
+				// Empty prefix should still use primary key
 				Query:           "SELECT pk1, pk2, pk3 FROM t WHERE (pk2, pk3) IN ((1, 20))",
 				Expected:        []sql.Row{{0, 1, 20}},
-				ExpectedIndexes: []string{},
+				ExpectedIndexes: []string{"primary"},
 			},
 			{
 				// Correct behavior around nulls

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -215,15 +215,15 @@ WHERE
 			"     │                                   │                       ├─ name: HDDVB\n" +
 			"     │                                   │                       └─ columns: [uj6xy]\n" +
 			"     │                                   │  ->WGBRL:0]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           ├─ colSet: (1-17)\n" +
-			"     │                                           ├─ tableId: 1\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ NOT\n" +
+			"     │                                       │   └─ nd.ZH72S:7 IS NULL\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               ├─ name: E2I7U\n" +
-			"     │                                               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     │                                               ├─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     │                                               ├─ colSet: (1-17)\n" +
+			"     │                                               └─ tableId: 1\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -292,10 +292,11 @@ WHERE
 			"     │                                   │                   ├─ columns: [uj6xy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as WGBRL]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                           └─ Table\n" +
+			"     │                                               └─ name: E2I7U\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -360,10 +361,11 @@ WHERE
 			"     │                                   │                   ├─ columns: [uj6xy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as WGBRL]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                           └─ Table\n" +
+			"     │                                               └─ name: E2I7U\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -545,58 +547,55 @@ WHERE
 			" │               ├─ alias-string: select TIZHK.id as FWATE from WGSDC as NHMXW join WRZVO as TIZHK on TIZHK.TVNW2 = NHMXW.NOHHR and TIZHK.ZHITY = NHMXW.AVPYF and TIZHK.SYPKF = NHMXW.SYPKF and TIZHK.IDUT2 = NHMXW.IDUT2 where NHMXW.SWCQV = 0 and NHMXW.id not in (select PRUV2 from HDDVB where PRUV2 is not null)\n" +
 			" │               └─ Project\n" +
 			" │                   ├─ columns: [tizhk.id:19!null->FWATE:0]\n" +
-			" │                   └─ Project\n" +
-			" │                       ├─ columns: [WGSDC.id:9!null, WGSDC.NOHHR:10!null, WGSDC.AVPYF:11!null, WGSDC.SYPKF:12!null, WGSDC.IDUT2:13!null, WGSDC.FZXV5:14, WGSDC.DQYGV:15, WGSDC.SWCQV:16!null, WGSDC.YKSSU:17, WGSDC.FHCYT:18, WRZVO.id:19!null, WRZVO.TVNW2:20, WRZVO.ZHITY:21, WRZVO.SYPKF:22, WRZVO.IDUT2:23, WRZVO.O6QJ3:24, WRZVO.NO2JA:25, WRZVO.YKSSU:26, WRZVO.FHCYT:27, WRZVO.QZ6VT:28]\n" +
-			" │                       └─ Filter\n" +
-			" │                           ├─ 1:30 IS NULL\n" +
-			" │                           └─ LeftOuterHashJoinExcludingNulls\n" +
-			" │                               ├─ Eq\n" +
-			" │                               │   ├─ nhmxw.id:9!null\n" +
-			" │                               │   └─ hddvb.PRUV2:29\n" +
-			" │                               ├─ LookupJoin\n" +
-			" │                               │   ├─ AND\n" +
-			" │                               │   │   ├─ AND\n" +
-			" │                               │   │   │   ├─ Eq\n" +
-			" │                               │   │   │   │   ├─ tizhk.TVNW2:20\n" +
-			" │                               │   │   │   │   └─ nhmxw.NOHHR:10!null\n" +
-			" │                               │   │   │   └─ Eq\n" +
-			" │                               │   │   │       ├─ tizhk.ZHITY:21\n" +
-			" │                               │   │   │       └─ nhmxw.AVPYF:11!null\n" +
-			" │                               │   │   └─ Eq\n" +
-			" │                               │   │       ├─ tizhk.IDUT2:23\n" +
-			" │                               │   │       └─ nhmxw.IDUT2:13!null\n" +
-			" │                               │   ├─ Filter\n" +
-			" │                               │   │   ├─ Eq\n" +
-			" │                               │   │   │   ├─ nhmxw.SWCQV:16!null\n" +
-			" │                               │   │   │   └─ 0 (int)\n" +
-			" │                               │   │   └─ TableAlias(nhmxw)\n" +
-			" │                               │   │       └─ Table\n" +
-			" │                               │   │           ├─ name: WGSDC\n" +
-			" │                               │   │           ├─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
-			" │                               │   │           ├─ colSet: (74-83)\n" +
-			" │                               │   │           └─ tableId: 7\n" +
-			" │                               │   └─ TableAlias(tizhk)\n" +
-			" │                               │       └─ IndexedTableAccess(WRZVO)\n" +
-			" │                               │           ├─ index: [WRZVO.SYPKF]\n" +
-			" │                               │           ├─ keys: [nhmxw.SYPKF:12!null]\n" +
-			" │                               │           ├─ colSet: (84-93)\n" +
-			" │                               │           ├─ tableId: 8\n" +
-			" │                               │           └─ Table\n" +
-			" │                               │               ├─ name: WRZVO\n" +
-			" │                               │               └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
-			" │                               └─ HashLookup\n" +
-			" │                                   ├─ left-key: TUPLE(nhmxw.id:9!null)\n" +
-			" │                                   ├─ right-key: TUPLE(hddvb.PRUV2:9)\n" +
-			" │                                   └─ Project\n" +
-			" │                                       ├─ columns: [hddvb.PRUV2:9, 1 (bigint)]\n" +
-			" │                                       └─ IndexedTableAccess(HDDVB)\n" +
-			" │                                           ├─ index: [HDDVB.PRUV2]\n" +
-			" │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			" │                                           ├─ colSet: (94-102)\n" +
-			" │                                           ├─ tableId: 9\n" +
-			" │                                           └─ Table\n" +
-			" │                                               ├─ name: HDDVB\n" +
-			" │                                               └─ columns: [pruv2]\n" +
+			" │                   └─ LookupJoin\n" +
+			" │                       ├─ AND\n" +
+			" │                       │   ├─ AND\n" +
+			" │                       │   │   ├─ Eq\n" +
+			" │                       │   │   │   ├─ tizhk.TVNW2:20\n" +
+			" │                       │   │   │   └─ nhmxw.NOHHR:10!null\n" +
+			" │                       │   │   └─ Eq\n" +
+			" │                       │   │       ├─ tizhk.ZHITY:21\n" +
+			" │                       │   │       └─ nhmxw.AVPYF:11!null\n" +
+			" │                       │   └─ Eq\n" +
+			" │                       │       ├─ tizhk.IDUT2:23\n" +
+			" │                       │       └─ nhmxw.IDUT2:13!null\n" +
+			" │                       ├─ Project\n" +
+			" │                       │   ├─ columns: [WGSDC.id:9!null, WGSDC.NOHHR:10!null, WGSDC.AVPYF:11!null, WGSDC.SYPKF:12!null, WGSDC.IDUT2:13!null, WGSDC.FZXV5:14, WGSDC.DQYGV:15, WGSDC.SWCQV:16!null, WGSDC.YKSSU:17, WGSDC.FHCYT:18]\n" +
+			" │                       │   └─ Filter\n" +
+			" │                       │       ├─ 1:20 IS NULL\n" +
+			" │                       │       └─ LeftOuterLookupJoin\n" +
+			" │                       │           ├─ Filter\n" +
+			" │                       │           │   ├─ Eq\n" +
+			" │                       │           │   │   ├─ nhmxw.SWCQV:16!null\n" +
+			" │                       │           │   │   └─ 0 (int)\n" +
+			" │                       │           │   └─ TableAlias(nhmxw)\n" +
+			" │                       │           │       └─ Table\n" +
+			" │                       │           │           ├─ name: WGSDC\n" +
+			" │                       │           │           ├─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
+			" │                       │           │           ├─ colSet: (74-83)\n" +
+			" │                       │           │           └─ tableId: 7\n" +
+			" │                       │           └─ Project\n" +
+			" │                       │               ├─ columns: [hddvb.PRUV2:9, 1 (bigint)]\n" +
+			" │                       │               └─ Filter\n" +
+			" │                       │                   ├─ NOT\n" +
+			" │                       │                   │   └─ hddvb.PRUV2:9 IS NULL\n" +
+			" │                       │                   └─ IndexedTableAccess(HDDVB)\n" +
+			" │                       │                       ├─ index: [HDDVB.PRUV2]\n" +
+			" │                       │                       ├─ keys: [nhmxw.id:9!null]\n" +
+			" │                       │                       ├─ colSet: (94-102)\n" +
+			" │                       │                       ├─ tableId: 9\n" +
+			" │                       │                       └─ Table\n" +
+			" │                       │                           ├─ name: HDDVB\n" +
+			" │                       │                           └─ columns: [pruv2]\n" +
+			" │                       └─ TableAlias(tizhk)\n" +
+			" │                           └─ IndexedTableAccess(WRZVO)\n" +
+			" │                               ├─ index: [WRZVO.SYPKF]\n" +
+			" │                               ├─ keys: [nhmxw.SYPKF:12!null]\n" +
+			" │                               ├─ colSet: (84-93)\n" +
+			" │                               ├─ tableId: 8\n" +
+			" │                               └─ Table\n" +
+			" │                                   ├─ name: WRZVO\n" +
+			" │                                   └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ ProcessTable\n" +
 			"         └─ Table\n" +
@@ -610,32 +609,30 @@ WHERE
 			" │       ├─ cacheable: true\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [tizhk.id as FWATE]\n" +
-			" │           └─ Project\n" +
-			" │               ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT, WRZVO.id, WRZVO.TVNW2, WRZVO.ZHITY, WRZVO.SYPKF, WRZVO.IDUT2, WRZVO.O6QJ3, WRZVO.NO2JA, WRZVO.YKSSU, WRZVO.FHCYT, WRZVO.QZ6VT]\n" +
-			" │               └─ Filter\n" +
-			" │                   ├─ 1 IS NULL\n" +
-			" │                   └─ LeftOuterHashJoinExcludingNulls\n" +
-			" │                       ├─ (nhmxw.id = hddvb.PRUV2)\n" +
-			" │                       ├─ LookupJoin\n" +
-			" │                       │   ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
-			" │                       │   ├─ Filter\n" +
-			" │                       │   │   ├─ (nhmxw.SWCQV = 0)\n" +
-			" │                       │   │   └─ TableAlias(nhmxw)\n" +
-			" │                       │   │       └─ Table\n" +
-			" │                       │   │           └─ name: WGSDC\n" +
-			" │                       │   └─ TableAlias(tizhk)\n" +
-			" │                       │       └─ IndexedTableAccess(WRZVO)\n" +
-			" │                       │           ├─ index: [WRZVO.SYPKF]\n" +
-			" │                       │           └─ keys: nhmxw.SYPKF\n" +
-			" │                       └─ HashLookup\n" +
-			" │                           ├─ left-key: (nhmxw.id)\n" +
-			" │                           ├─ right-key: (hddvb.PRUV2)\n" +
-			" │                           └─ Project\n" +
-			" │                               ├─ columns: [hddvb.PRUV2, 1]\n" +
-			" │                               └─ IndexedTableAccess(HDDVB)\n" +
-			" │                                   ├─ index: [HDDVB.PRUV2]\n" +
-			" │                                   ├─ filters: [{(NULL, ∞)}]\n" +
-			" │                                   └─ columns: [pruv2]\n" +
+			" │           └─ LookupJoin\n" +
+			" │               ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
+			" │               ├─ Project\n" +
+			" │               │   ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT]\n" +
+			" │               │   └─ Filter\n" +
+			" │               │       ├─ 1 IS NULL\n" +
+			" │               │       └─ LeftOuterLookupJoin\n" +
+			" │               │           ├─ Filter\n" +
+			" │               │           │   ├─ (nhmxw.SWCQV = 0)\n" +
+			" │               │           │   └─ TableAlias(nhmxw)\n" +
+			" │               │           │       └─ Table\n" +
+			" │               │           │           └─ name: WGSDC\n" +
+			" │               │           └─ Project\n" +
+			" │               │               ├─ columns: [hddvb.PRUV2, 1]\n" +
+			" │               │               └─ Filter\n" +
+			" │               │                   ├─ (NOT(hddvb.PRUV2 IS NULL))\n" +
+			" │               │                   └─ IndexedTableAccess(HDDVB)\n" +
+			" │               │                       ├─ index: [HDDVB.PRUV2]\n" +
+			" │               │                       ├─ columns: [pruv2]\n" +
+			" │               │                       └─ keys: nhmxw.id\n" +
+			" │               └─ TableAlias(tizhk)\n" +
+			" │                   └─ IndexedTableAccess(WRZVO)\n" +
+			" │                       ├─ index: [WRZVO.SYPKF]\n" +
+			" │                       └─ keys: nhmxw.SYPKF\n" +
 			" │  ))\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ Table\n" +
@@ -648,32 +645,30 @@ WHERE
 			" │       ├─ cacheable: true\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [tizhk.id as FWATE]\n" +
-			" │           └─ Project\n" +
-			" │               ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT, WRZVO.id, WRZVO.TVNW2, WRZVO.ZHITY, WRZVO.SYPKF, WRZVO.IDUT2, WRZVO.O6QJ3, WRZVO.NO2JA, WRZVO.YKSSU, WRZVO.FHCYT, WRZVO.QZ6VT]\n" +
-			" │               └─ Filter\n" +
-			" │                   ├─ 1 IS NULL\n" +
-			" │                   └─ LeftOuterHashJoinExcludingNulls\n" +
-			" │                       ├─ (nhmxw.id = hddvb.PRUV2)\n" +
-			" │                       ├─ LookupJoin\n" +
-			" │                       │   ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
-			" │                       │   ├─ Filter\n" +
-			" │                       │   │   ├─ (nhmxw.SWCQV = 0)\n" +
-			" │                       │   │   └─ TableAlias(nhmxw)\n" +
-			" │                       │   │       └─ Table\n" +
-			" │                       │   │           └─ name: WGSDC\n" +
-			" │                       │   └─ TableAlias(tizhk)\n" +
-			" │                       │       └─ IndexedTableAccess(WRZVO)\n" +
-			" │                       │           ├─ index: [WRZVO.SYPKF]\n" +
-			" │                       │           └─ keys: nhmxw.SYPKF\n" +
-			" │                       └─ HashLookup\n" +
-			" │                           ├─ left-key: (nhmxw.id)\n" +
-			" │                           ├─ right-key: (hddvb.PRUV2)\n" +
-			" │                           └─ Project\n" +
-			" │                               ├─ columns: [hddvb.PRUV2, 1]\n" +
-			" │                               └─ IndexedTableAccess(HDDVB)\n" +
-			" │                                   ├─ index: [HDDVB.PRUV2]\n" +
-			" │                                   ├─ filters: [{(NULL, ∞)}]\n" +
-			" │                                   └─ columns: [pruv2]\n" +
+			" │           └─ LookupJoin\n" +
+			" │               ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
+			" │               ├─ Project\n" +
+			" │               │   ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT]\n" +
+			" │               │   └─ Filter\n" +
+			" │               │       ├─ 1 IS NULL\n" +
+			" │               │       └─ LeftOuterLookupJoin\n" +
+			" │               │           ├─ Filter\n" +
+			" │               │           │   ├─ (nhmxw.SWCQV = 0)\n" +
+			" │               │           │   └─ TableAlias(nhmxw)\n" +
+			" │               │           │       └─ Table\n" +
+			" │               │           │           └─ name: WGSDC\n" +
+			" │               │           └─ Project\n" +
+			" │               │               ├─ columns: [hddvb.PRUV2, 1]\n" +
+			" │               │               └─ Filter\n" +
+			" │               │                   ├─ (NOT(hddvb.PRUV2 IS NULL))\n" +
+			" │               │                   └─ IndexedTableAccess(HDDVB)\n" +
+			" │               │                       ├─ index: [HDDVB.PRUV2]\n" +
+			" │               │                       ├─ columns: [pruv2]\n" +
+			" │               │                       └─ keys: nhmxw.id\n" +
+			" │               └─ TableAlias(tizhk)\n" +
+			" │                   └─ IndexedTableAccess(WRZVO)\n" +
+			" │                       ├─ index: [WRZVO.SYPKF]\n" +
+			" │                       └─ keys: nhmxw.SYPKF\n" +
 			" │  ))\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ Table\n" +
@@ -1237,15 +1232,15 @@ WHERE
 			"     │                                   │                       ├─ name: FLQLP\n" +
 			"     │                                   │                       └─ columns: [luevy]\n" +
 			"     │                                   │  ->LEA4J:0]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           ├─ colSet: (1-17)\n" +
-			"     │                                           ├─ tableId: 1\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ NOT\n" +
+			"     │                                       │   └─ nd.ZH72S:7 IS NULL\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               ├─ name: E2I7U\n" +
-			"     │                                               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     │                                               ├─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     │                                               ├─ colSet: (1-17)\n" +
+			"     │                                               └─ tableId: 1\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -1314,10 +1309,11 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as LEA4J]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                           └─ Table\n" +
+			"     │                                               └─ name: E2I7U\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -1382,10 +1378,11 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as LEA4J]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                           └─ Table\n" +
+			"     │                                               └─ name: E2I7U\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -1532,54 +1529,51 @@ WHERE
 			"     │   │               ├─ alias-string: select uct.id as FDL23 from EPZU6 as I7HCR join OUBDL as uct on uct.FTQLQ = I7HCR.TOFPN and uct.ZH72S = I7HCR.SJYN2 and uct.LJLUM = I7HCR.BTXC5 where I7HCR.SWCQV = 0 and I7HCR.id not in (select OCA7E from FLQLP where OCA7E is not null)\n" +
 			"     │   │               └─ Project\n" +
 			"     │   │                   ├─ columns: [uct.id:40!null->FDL23:0]\n" +
-			"     │   │                   └─ Project\n" +
-			"     │   │                       ├─ columns: [EPZU6.id:32!null, EPZU6.TOFPN:33!null, EPZU6.SJYN2:34!null, EPZU6.BTXC5:35!null, EPZU6.FVUCX:36!null, EPZU6.SWCQV:37!null, EPZU6.YKSSU:38, EPZU6.FHCYT:39, OUBDL.id:40!null, OUBDL.FTQLQ:41, OUBDL.ZH72S:42, OUBDL.SFJ6L:43, OUBDL.V5DPX:44, OUBDL.LJLUM:45, OUBDL.IDPK7:46, OUBDL.NO52D:47, OUBDL.ZRV3B:48, OUBDL.VYO5E:49, OUBDL.YKSSU:50, OUBDL.FHCYT:51, OUBDL.QZ6VT:52]\n" +
-			"     │   │                       └─ Filter\n" +
-			"     │   │                           ├─ 1:54 IS NULL\n" +
-			"     │   │                           └─ LeftOuterHashJoinExcludingNulls\n" +
-			"     │   │                               ├─ Eq\n" +
-			"     │   │                               │   ├─ i7hcr.id:32!null\n" +
-			"     │   │                               │   └─ flqlp.OCA7E:53\n" +
-			"     │   │                               ├─ LookupJoin\n" +
-			"     │   │                               │   ├─ AND\n" +
-			"     │   │                               │   │   ├─ Eq\n" +
-			"     │   │                               │   │   │   ├─ uct.ZH72S:42\n" +
-			"     │   │                               │   │   │   └─ i7hcr.SJYN2:34!null\n" +
-			"     │   │                               │   │   └─ Eq\n" +
-			"     │   │                               │   │       ├─ uct.LJLUM:45\n" +
-			"     │   │                               │   │       └─ i7hcr.BTXC5:35!null\n" +
-			"     │   │                               │   ├─ Filter\n" +
-			"     │   │                               │   │   ├─ Eq\n" +
-			"     │   │                               │   │   │   ├─ i7hcr.SWCQV:37!null\n" +
-			"     │   │                               │   │   │   └─ 0 (int)\n" +
-			"     │   │                               │   │   └─ TableAlias(i7hcr)\n" +
-			"     │   │                               │   │       └─ Table\n" +
-			"     │   │                               │   │           ├─ name: EPZU6\n" +
-			"     │   │                               │   │           ├─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
-			"     │   │                               │   │           ├─ colSet: (71-78)\n" +
-			"     │   │                               │   │           └─ tableId: 8\n" +
-			"     │   │                               │   └─ TableAlias(uct)\n" +
-			"     │   │                               │       └─ IndexedTableAccess(OUBDL)\n" +
-			"     │   │                               │           ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │   │                               │           ├─ keys: [i7hcr.TOFPN:33!null]\n" +
-			"     │   │                               │           ├─ colSet: (79-91)\n" +
-			"     │   │                               │           ├─ tableId: 9\n" +
-			"     │   │                               │           └─ Table\n" +
-			"     │   │                               │               ├─ name: OUBDL\n" +
-			"     │   │                               │               └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
-			"     │   │                               └─ HashLookup\n" +
-			"     │   │                                   ├─ left-key: TUPLE(i7hcr.id:32!null)\n" +
-			"     │   │                                   ├─ right-key: TUPLE(flqlp.OCA7E:32)\n" +
-			"     │   │                                   └─ Project\n" +
-			"     │   │                                       ├─ columns: [flqlp.OCA7E:32, 1 (bigint)]\n" +
-			"     │   │                                       └─ IndexedTableAccess(FLQLP)\n" +
-			"     │   │                                           ├─ index: [FLQLP.OCA7E]\n" +
-			"     │   │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │   │                                           ├─ colSet: (92-103)\n" +
-			"     │   │                                           ├─ tableId: 10\n" +
-			"     │   │                                           └─ Table\n" +
-			"     │   │                                               ├─ name: FLQLP\n" +
-			"     │   │                                               └─ columns: [oca7e]\n" +
+			"     │   │                   └─ LookupJoin\n" +
+			"     │   │                       ├─ AND\n" +
+			"     │   │                       │   ├─ Eq\n" +
+			"     │   │                       │   │   ├─ uct.ZH72S:42\n" +
+			"     │   │                       │   │   └─ i7hcr.SJYN2:34!null\n" +
+			"     │   │                       │   └─ Eq\n" +
+			"     │   │                       │       ├─ uct.LJLUM:45\n" +
+			"     │   │                       │       └─ i7hcr.BTXC5:35!null\n" +
+			"     │   │                       ├─ Project\n" +
+			"     │   │                       │   ├─ columns: [EPZU6.id:32!null, EPZU6.TOFPN:33!null, EPZU6.SJYN2:34!null, EPZU6.BTXC5:35!null, EPZU6.FVUCX:36!null, EPZU6.SWCQV:37!null, EPZU6.YKSSU:38, EPZU6.FHCYT:39]\n" +
+			"     │   │                       │   └─ Filter\n" +
+			"     │   │                       │       ├─ 1:41 IS NULL\n" +
+			"     │   │                       │       └─ LeftOuterLookupJoin\n" +
+			"     │   │                       │           ├─ Filter\n" +
+			"     │   │                       │           │   ├─ Eq\n" +
+			"     │   │                       │           │   │   ├─ i7hcr.SWCQV:37!null\n" +
+			"     │   │                       │           │   │   └─ 0 (int)\n" +
+			"     │   │                       │           │   └─ TableAlias(i7hcr)\n" +
+			"     │   │                       │           │       └─ Table\n" +
+			"     │   │                       │           │           ├─ name: EPZU6\n" +
+			"     │   │                       │           │           ├─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
+			"     │   │                       │           │           ├─ colSet: (71-78)\n" +
+			"     │   │                       │           │           └─ tableId: 8\n" +
+			"     │   │                       │           └─ Project\n" +
+			"     │   │                       │               ├─ columns: [flqlp.OCA7E:32, 1 (bigint)]\n" +
+			"     │   │                       │               └─ Filter\n" +
+			"     │   │                       │                   ├─ NOT\n" +
+			"     │   │                       │                   │   └─ flqlp.OCA7E:32 IS NULL\n" +
+			"     │   │                       │                   └─ IndexedTableAccess(FLQLP)\n" +
+			"     │   │                       │                       ├─ index: [FLQLP.OCA7E]\n" +
+			"     │   │                       │                       ├─ keys: [i7hcr.id:32!null]\n" +
+			"     │   │                       │                       ├─ colSet: (92-103)\n" +
+			"     │   │                       │                       ├─ tableId: 10\n" +
+			"     │   │                       │                       └─ Table\n" +
+			"     │   │                       │                           ├─ name: FLQLP\n" +
+			"     │   │                       │                           └─ columns: [oca7e]\n" +
+			"     │   │                       └─ TableAlias(uct)\n" +
+			"     │   │                           └─ IndexedTableAccess(OUBDL)\n" +
+			"     │   │                               ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │   │                               ├─ keys: [i7hcr.TOFPN:33!null]\n" +
+			"     │   │                               ├─ colSet: (79-91)\n" +
+			"     │   │                               ├─ tableId: 9\n" +
+			"     │   │                               └─ Table\n" +
+			"     │   │                                   ├─ name: OUBDL\n" +
+			"     │   │                                   └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
 			"     │   ├─ MergeJoin\n" +
 			"     │   │   ├─ cmp: Eq\n" +
 			"     │   │   │   ├─ ct.LUEVY:2!null\n" +
@@ -1631,32 +1625,30 @@ WHERE
 			"     │   │       ├─ cacheable: true\n" +
 			"     │   │       └─ Project\n" +
 			"     │   │           ├─ columns: [uct.id as FDL23]\n" +
-			"     │   │           └─ Project\n" +
-			"     │   │               ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT, OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.SFJ6L, OUBDL.V5DPX, OUBDL.LJLUM, OUBDL.IDPK7, OUBDL.NO52D, OUBDL.ZRV3B, OUBDL.VYO5E, OUBDL.YKSSU, OUBDL.FHCYT, OUBDL.QZ6VT]\n" +
-			"     │   │               └─ Filter\n" +
-			"     │   │                   ├─ 1 IS NULL\n" +
-			"     │   │                   └─ LeftOuterHashJoinExcludingNulls\n" +
-			"     │   │                       ├─ (i7hcr.id = flqlp.OCA7E)\n" +
-			"     │   │                       ├─ LookupJoin\n" +
-			"     │   │                       │   ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
-			"     │   │                       │   ├─ Filter\n" +
-			"     │   │                       │   │   ├─ (i7hcr.SWCQV = 0)\n" +
-			"     │   │                       │   │   └─ TableAlias(i7hcr)\n" +
-			"     │   │                       │   │       └─ Table\n" +
-			"     │   │                       │   │           └─ name: EPZU6\n" +
-			"     │   │                       │   └─ TableAlias(uct)\n" +
-			"     │   │                       │       └─ IndexedTableAccess(OUBDL)\n" +
-			"     │   │                       │           ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │   │                       │           └─ keys: i7hcr.TOFPN\n" +
-			"     │   │                       └─ HashLookup\n" +
-			"     │   │                           ├─ left-key: (i7hcr.id)\n" +
-			"     │   │                           ├─ right-key: (flqlp.OCA7E)\n" +
-			"     │   │                           └─ Project\n" +
-			"     │   │                               ├─ columns: [flqlp.OCA7E, 1]\n" +
-			"     │   │                               └─ IndexedTableAccess(FLQLP)\n" +
-			"     │   │                                   ├─ index: [FLQLP.OCA7E]\n" +
-			"     │   │                                   ├─ filters: [{(NULL, ∞)}]\n" +
-			"     │   │                                   └─ columns: [oca7e]\n" +
+			"     │   │           └─ LookupJoin\n" +
+			"     │   │               ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
+			"     │   │               ├─ Project\n" +
+			"     │   │               │   ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT]\n" +
+			"     │   │               │   └─ Filter\n" +
+			"     │   │               │       ├─ 1 IS NULL\n" +
+			"     │   │               │       └─ LeftOuterLookupJoin\n" +
+			"     │   │               │           ├─ Filter\n" +
+			"     │   │               │           │   ├─ (i7hcr.SWCQV = 0)\n" +
+			"     │   │               │           │   └─ TableAlias(i7hcr)\n" +
+			"     │   │               │           │       └─ Table\n" +
+			"     │   │               │           │           └─ name: EPZU6\n" +
+			"     │   │               │           └─ Project\n" +
+			"     │   │               │               ├─ columns: [flqlp.OCA7E, 1]\n" +
+			"     │   │               │               └─ Filter\n" +
+			"     │   │               │                   ├─ (NOT(flqlp.OCA7E IS NULL))\n" +
+			"     │   │               │                   └─ IndexedTableAccess(FLQLP)\n" +
+			"     │   │               │                       ├─ index: [FLQLP.OCA7E]\n" +
+			"     │   │               │                       ├─ columns: [oca7e]\n" +
+			"     │   │               │                       └─ keys: i7hcr.id\n" +
+			"     │   │               └─ TableAlias(uct)\n" +
+			"     │   │                   └─ IndexedTableAccess(OUBDL)\n" +
+			"     │   │                       ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │   │                       └─ keys: i7hcr.TOFPN\n" +
 			"     │   │  ))\n" +
 			"     │   ├─ MergeJoin (estimated cost=18957.040 rows=14781)\n" +
 			"     │   │   ├─ cmp: (ct.LUEVY = nd.id)\n" +
@@ -1690,32 +1682,30 @@ WHERE
 			"     │   │       ├─ cacheable: true\n" +
 			"     │   │       └─ Project\n" +
 			"     │   │           ├─ columns: [uct.id as FDL23]\n" +
-			"     │   │           └─ Project\n" +
-			"     │   │               ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT, OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.SFJ6L, OUBDL.V5DPX, OUBDL.LJLUM, OUBDL.IDPK7, OUBDL.NO52D, OUBDL.ZRV3B, OUBDL.VYO5E, OUBDL.YKSSU, OUBDL.FHCYT, OUBDL.QZ6VT]\n" +
-			"     │   │               └─ Filter\n" +
-			"     │   │                   ├─ 1 IS NULL\n" +
-			"     │   │                   └─ LeftOuterHashJoinExcludingNulls\n" +
-			"     │   │                       ├─ (i7hcr.id = flqlp.OCA7E)\n" +
-			"     │   │                       ├─ LookupJoin\n" +
-			"     │   │                       │   ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
-			"     │   │                       │   ├─ Filter\n" +
-			"     │   │                       │   │   ├─ (i7hcr.SWCQV = 0)\n" +
-			"     │   │                       │   │   └─ TableAlias(i7hcr)\n" +
-			"     │   │                       │   │       └─ Table\n" +
-			"     │   │                       │   │           └─ name: EPZU6\n" +
-			"     │   │                       │   └─ TableAlias(uct)\n" +
-			"     │   │                       │       └─ IndexedTableAccess(OUBDL)\n" +
-			"     │   │                       │           ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │   │                       │           └─ keys: i7hcr.TOFPN\n" +
-			"     │   │                       └─ HashLookup\n" +
-			"     │   │                           ├─ left-key: (i7hcr.id)\n" +
-			"     │   │                           ├─ right-key: (flqlp.OCA7E)\n" +
-			"     │   │                           └─ Project\n" +
-			"     │   │                               ├─ columns: [flqlp.OCA7E, 1]\n" +
-			"     │   │                               └─ IndexedTableAccess(FLQLP)\n" +
-			"     │   │                                   ├─ index: [FLQLP.OCA7E]\n" +
-			"     │   │                                   ├─ filters: [{(NULL, ∞)}]\n" +
-			"     │   │                                   └─ columns: [oca7e]\n" +
+			"     │   │           └─ LookupJoin\n" +
+			"     │   │               ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
+			"     │   │               ├─ Project\n" +
+			"     │   │               │   ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT]\n" +
+			"     │   │               │   └─ Filter\n" +
+			"     │   │               │       ├─ 1 IS NULL\n" +
+			"     │   │               │       └─ LeftOuterLookupJoin\n" +
+			"     │   │               │           ├─ Filter\n" +
+			"     │   │               │           │   ├─ (i7hcr.SWCQV = 0)\n" +
+			"     │   │               │           │   └─ TableAlias(i7hcr)\n" +
+			"     │   │               │           │       └─ Table\n" +
+			"     │   │               │           │           └─ name: EPZU6\n" +
+			"     │   │               │           └─ Project\n" +
+			"     │   │               │               ├─ columns: [flqlp.OCA7E, 1]\n" +
+			"     │   │               │               └─ Filter\n" +
+			"     │   │               │                   ├─ (NOT(flqlp.OCA7E IS NULL))\n" +
+			"     │   │               │                   └─ IndexedTableAccess(FLQLP)\n" +
+			"     │   │               │                       ├─ index: [FLQLP.OCA7E]\n" +
+			"     │   │               │                       ├─ columns: [oca7e]\n" +
+			"     │   │               │                       └─ keys: i7hcr.id\n" +
+			"     │   │               └─ TableAlias(uct)\n" +
+			"     │   │                   └─ IndexedTableAccess(OUBDL)\n" +
+			"     │   │                       ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │   │                       └─ keys: i7hcr.TOFPN\n" +
 			"     │   │  ))\n" +
 			"     │   ├─ MergeJoin (estimated cost=18957.040 rows=14781) (actual rows=0 loops=1)\n" +
 			"     │   │   ├─ cmp: (ct.LUEVY = nd.id)\n" +
@@ -1793,10 +1783,7 @@ WHERE
 			"     │               │   │   ├─ columns: [OUBDL.id:1!null, OUBDL.FTQLQ:2, OUBDL.ZH72S:3, OUBDL.LJLUM:4, E2I7U.ZH72S:0]\n" +
 			"     │               │   │   └─ Filter\n" +
 			"     │               │   │       ├─ 1:6 IS NULL\n" +
-			"     │               │   │       └─ LeftOuterHashJoinExcludingNulls\n" +
-			"     │               │   │           ├─ Eq\n" +
-			"     │               │   │           │   ├─ ylksy.id:1!null\n" +
-			"     │               │   │           │   └─ flqlp.NRURT:5\n" +
+			"     │               │   │       └─ LeftOuterLookupJoin\n" +
 			"     │               │   │           ├─ LookupJoin\n" +
 			"     │               │   │           │   ├─ TableAlias(nd)\n" +
 			"     │               │   │           │   │   └─ Table\n" +
@@ -1816,14 +1803,14 @@ WHERE
 			"     │               │   │           │               └─ Table\n" +
 			"     │               │   │           │                   ├─ name: OUBDL\n" +
 			"     │               │   │           │                   └─ columns: [id ftqlq zh72s ljlum]\n" +
-			"     │               │   │           └─ HashLookup\n" +
-			"     │               │   │               ├─ left-key: TUPLE(ylksy.id:1!null)\n" +
-			"     │               │   │               ├─ right-key: TUPLE(flqlp.NRURT:0)\n" +
-			"     │               │   │               └─ Project\n" +
-			"     │               │   │                   ├─ columns: [flqlp.NRURT:0, 1 (bigint)]\n" +
+			"     │               │   │           └─ Project\n" +
+			"     │               │   │               ├─ columns: [flqlp.NRURT:0, 1 (bigint)]\n" +
+			"     │               │   │               └─ Filter\n" +
+			"     │               │   │                   ├─ NOT\n" +
+			"     │               │   │                   │   └─ flqlp.NRURT:0 IS NULL\n" +
 			"     │               │   │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │   │                       ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │   │                       ├─ static: [{(NULL, ∞)}]\n" +
+			"     │               │   │                       ├─ keys: [ylksy.id:1!null]\n" +
 			"     │               │   │                       ├─ colSet: (39-50)\n" +
 			"     │               │   │                       ├─ tableId: 5\n" +
 			"     │               │   │                       └─ Table\n" +
@@ -1877,8 +1864,7 @@ WHERE
 			"     │               │   │   ├─ columns: [OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.LJLUM, E2I7U.ZH72S]\n" +
 			"     │               │   │   └─ Filter\n" +
 			"     │               │   │       ├─ 1 IS NULL\n" +
-			"     │               │   │       └─ LeftOuterHashJoinExcludingNulls (estimated cost=381887.820 rows=35486780)\n" +
-			"     │               │   │           ├─ (ylksy.id = flqlp.NRURT)\n" +
+			"     │               │   │       └─ LeftOuterLookupJoin (estimated cost=18627.300 rows=6002)\n" +
 			"     │               │   │           ├─ LookupJoin (estimated cost=14907.300 rows=4802)\n" +
 			"     │               │   │           │   ├─ TableAlias(nd)\n" +
 			"     │               │   │           │   │   └─ Table\n" +
@@ -1891,15 +1877,14 @@ WHERE
 			"     │               │   │           │               ├─ index: [OUBDL.ZH72S]\n" +
 			"     │               │   │           │               ├─ columns: [id ftqlq zh72s ljlum]\n" +
 			"     │               │   │           │               └─ keys: nd.ZH72S\n" +
-			"     │               │   │           └─ HashLookup\n" +
-			"     │               │   │               ├─ left-key: (ylksy.id)\n" +
-			"     │               │   │               ├─ right-key: (flqlp.NRURT)\n" +
-			"     │               │   │               └─ Project\n" +
-			"     │               │   │                   ├─ columns: [flqlp.NRURT, 1]\n" +
+			"     │               │   │           └─ Project\n" +
+			"     │               │   │               ├─ columns: [flqlp.NRURT, 1]\n" +
+			"     │               │   │               └─ Filter\n" +
+			"     │               │   │                   ├─ (NOT(flqlp.NRURT IS NULL))\n" +
 			"     │               │   │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │   │                       ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │   │                       ├─ filters: [{(NULL, ∞)}]\n" +
-			"     │               │   │                       └─ columns: [nrurt]\n" +
+			"     │               │   │                       ├─ columns: [nrurt]\n" +
+			"     │               │   │                       └─ keys: ylksy.id\n" +
 			"     │               │   └─ TableAlias(aac)\n" +
 			"     │               │       └─ IndexedTableAccess(TPXBU)\n" +
 			"     │               │           ├─ index: [TPXBU.BTXC5]\n" +
@@ -1938,8 +1923,7 @@ WHERE
 			"     │               │   │   ├─ columns: [OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.LJLUM, E2I7U.ZH72S]\n" +
 			"     │               │   │   └─ Filter\n" +
 			"     │               │   │       ├─ 1 IS NULL\n" +
-			"     │               │   │       └─ LeftOuterHashJoinExcludingNulls (estimated cost=381887.820 rows=35486780) (actual rows=0 loops=1)\n" +
-			"     │               │   │           ├─ (ylksy.id = flqlp.NRURT)\n" +
+			"     │               │   │       └─ LeftOuterLookupJoin (estimated cost=18627.300 rows=6002) (actual rows=0 loops=1)\n" +
 			"     │               │   │           ├─ LookupJoin (estimated cost=14907.300 rows=4802) (actual rows=0 loops=1)\n" +
 			"     │               │   │           │   ├─ TableAlias(nd)\n" +
 			"     │               │   │           │   │   └─ Table\n" +
@@ -1952,15 +1936,14 @@ WHERE
 			"     │               │   │           │               ├─ index: [OUBDL.ZH72S]\n" +
 			"     │               │   │           │               ├─ columns: [id ftqlq zh72s ljlum]\n" +
 			"     │               │   │           │               └─ keys: nd.ZH72S\n" +
-			"     │               │   │           └─ HashLookup\n" +
-			"     │               │   │               ├─ left-key: (ylksy.id)\n" +
-			"     │               │   │               ├─ right-key: (flqlp.NRURT)\n" +
-			"     │               │   │               └─ Project\n" +
-			"     │               │   │                   ├─ columns: [flqlp.NRURT, 1]\n" +
+			"     │               │   │           └─ Project\n" +
+			"     │               │   │               ├─ columns: [flqlp.NRURT, 1]\n" +
+			"     │               │   │               └─ Filter\n" +
+			"     │               │   │                   ├─ (NOT(flqlp.NRURT IS NULL))\n" +
 			"     │               │   │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │   │                       ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │   │                       ├─ filters: [{(NULL, ∞)}]\n" +
-			"     │               │   │                       └─ columns: [nrurt]\n" +
+			"     │               │   │                       ├─ columns: [nrurt]\n" +
+			"     │               │   │                       └─ keys: ylksy.id\n" +
 			"     │               │   └─ TableAlias(aac)\n" +
 			"     │               │       └─ IndexedTableAccess(TPXBU)\n" +
 			"     │               │           ├─ index: [TPXBU.BTXC5]\n" +
@@ -2179,19 +2162,12 @@ WHERE
 			" ├─ columns: [HU5A5.id:0!null, HU5A5.TOFPN:1!null, HU5A5.I3VTA:2!null, HU5A5.SFJ6L:3, HU5A5.V5DPX:4!null, HU5A5.LJLUM:5!null, HU5A5.IDPK7:6!null, HU5A5.NO52D:7!null, HU5A5.ZRV3B:8!null, HU5A5.VYO5E:9, HU5A5.SWCQV:10!null, HU5A5.YKSSU:11, HU5A5.FHCYT:12]\n" +
 			" └─ Filter\n" +
 			"     ├─ 1:14 IS NULL\n" +
-			"     └─ LeftOuterMergeJoin\n" +
-			"         ├─ cmp: Eq\n" +
-			"         │   ├─ hu5a5.id:0!null\n" +
-			"         │   └─ flqlp.XMM6Q:13\n" +
+			"     └─ LeftOuterLookupJoin\n" +
 			"         ├─ Filter\n" +
 			"         │   ├─ Eq\n" +
 			"         │   │   ├─ hu5a5.SWCQV:10!null\n" +
 			"         │   │   └─ 0 (int)\n" +
-			"         │   └─ IndexedTableAccess(HU5A5)\n" +
-			"         │       ├─ index: [HU5A5.id]\n" +
-			"         │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │       ├─ colSet: (1-13)\n" +
-			"         │       ├─ tableId: 1\n" +
+			"         │   └─ ProcessTable\n" +
 			"         │       └─ Table\n" +
 			"         │           ├─ name: HU5A5\n" +
 			"         │           └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
@@ -2204,7 +2180,7 @@ WHERE
 			"                     │   └─ flqlp.XMM6Q:7 IS NULL\n" +
 			"                     └─ IndexedTableAccess(FLQLP)\n" +
 			"                         ├─ index: [FLQLP.XMM6Q]\n" +
-			"                         ├─ static: [{[NULL, ∞)}]\n" +
+			"                         ├─ keys: [hu5a5.id:0!null]\n" +
 			"                         ├─ colSet: (14-25)\n" +
 			"                         ├─ tableId: 2\n" +
 			"                         └─ Table\n" +
@@ -2215,13 +2191,11 @@ WHERE
 			" ├─ columns: [HU5A5.id, HU5A5.TOFPN, HU5A5.I3VTA, HU5A5.SFJ6L, HU5A5.V5DPX, HU5A5.LJLUM, HU5A5.IDPK7, HU5A5.NO52D, HU5A5.ZRV3B, HU5A5.VYO5E, HU5A5.SWCQV, HU5A5.YKSSU, HU5A5.FHCYT]\n" +
 			" └─ Filter\n" +
 			"     ├─ 1 IS NULL\n" +
-			"     └─ LeftOuterMergeJoin (estimated cost=9561.410 rows=206920)\n" +
-			"         ├─ cmp: (hu5a5.id = flqlp.XMM6Q)\n" +
+			"     └─ LeftOuterLookupJoin (estimated cost=126.900 rows=34)\n" +
 			"         ├─ Filter\n" +
 			"         │   ├─ (hu5a5.SWCQV = 0)\n" +
-			"         │   └─ IndexedTableAccess(HU5A5)\n" +
-			"         │       ├─ index: [HU5A5.id]\n" +
-			"         │       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   └─ Table\n" +
+			"         │       └─ name: HU5A5\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [flqlp.XMM6Q, 1]\n" +
 			"             └─ Project\n" +
@@ -2230,19 +2204,17 @@ WHERE
 			"                     ├─ (NOT(flqlp.XMM6Q IS NULL))\n" +
 			"                     └─ IndexedTableAccess(FLQLP)\n" +
 			"                         ├─ index: [FLQLP.XMM6Q]\n" +
-			"                         └─ filters: [{[NULL, ∞)}]\n" +
+			"                         └─ keys: hu5a5.id\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [HU5A5.id, HU5A5.TOFPN, HU5A5.I3VTA, HU5A5.SFJ6L, HU5A5.V5DPX, HU5A5.LJLUM, HU5A5.IDPK7, HU5A5.NO52D, HU5A5.ZRV3B, HU5A5.VYO5E, HU5A5.SWCQV, HU5A5.YKSSU, HU5A5.FHCYT]\n" +
 			" └─ Filter\n" +
 			"     ├─ 1 IS NULL\n" +
-			"     └─ LeftOuterMergeJoin (estimated cost=9561.410 rows=206920) (actual rows=0 loops=1)\n" +
-			"         ├─ cmp: (hu5a5.id = flqlp.XMM6Q)\n" +
+			"     └─ LeftOuterLookupJoin (estimated cost=126.900 rows=34) (actual rows=0 loops=1)\n" +
 			"         ├─ Filter\n" +
 			"         │   ├─ (hu5a5.SWCQV = 0)\n" +
-			"         │   └─ IndexedTableAccess(HU5A5)\n" +
-			"         │       ├─ index: [HU5A5.id]\n" +
-			"         │       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   └─ Table\n" +
+			"         │       └─ name: HU5A5\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [flqlp.XMM6Q, 1]\n" +
 			"             └─ Project\n" +
@@ -2251,7 +2223,7 @@ WHERE
 			"                     ├─ (NOT(flqlp.XMM6Q IS NULL))\n" +
 			"                     └─ IndexedTableAccess(FLQLP)\n" +
 			"                         ├─ index: [FLQLP.XMM6Q]\n" +
-			"                         └─ filters: [{[NULL, ∞)}]\n" +
+			"                         └─ keys: hu5a5.id\n" +
 			"",
 	},
 	{
@@ -3146,15 +3118,15 @@ WHERE
 			"     │                                   │                       ├─ name: AMYXQ\n" +
 			"     │                                   │                       └─ columns: [luevy]\n" +
 			"     │                                   │  ->TJ66D:0]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                                           ├─ colSet: (1-17)\n" +
-			"     │                                           ├─ tableId: 1\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ NOT\n" +
+			"     │                                       │   └─ nd.ZH72S:7 IS NULL\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               ├─ name: E2I7U\n" +
-			"     │                                               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     │                                               ├─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"     │                                               ├─ colSet: (1-17)\n" +
+			"     │                                               └─ tableId: 1\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -3223,10 +3195,11 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as TJ66D]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                           └─ Table\n" +
+			"     │                                               └─ name: E2I7U\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -3291,10 +3264,11 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as TJ66D]\n" +
-			"     │                                   └─ TableAlias(nd)\n" +
-			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
-			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
-			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
+			"     │                                   └─ Filter\n" +
+			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                           └─ Table\n" +
+			"     │                                               └─ name: E2I7U\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -3326,137 +3300,119 @@ WHERE
 			"     ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ nd.ZH72S:48\n" +
-			"         │   └─ ufc.ZH72S:2\n" +
-			"         ├─ HashJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ cla.FTQLQ:12!null\n" +
-			"         │   │   └─ ufc.T4IBQ:1\n" +
-			"         │   ├─ Project\n" +
-			"         │   │   ├─ columns: [SISUT.id:0!null, SISUT.T4IBQ:1, SISUT.ZH72S:2, SISUT.AMYXQ:3, SISUT.KTNZ2:4, SISUT.HIID2:5, SISUT.DN3OQ:6, SISUT.VVKNB:7, SISUT.SH7TP:8, SISUT.SRZZO:9, SISUT.QZ6VT:10]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ 1:12 IS NULL\n" +
-			"         │   │       └─ LeftOuterMergeJoin\n" +
-			"         │   │           ├─ cmp: Eq\n" +
-			"         │   │           │   ├─ ufc.id:0!null\n" +
-			"         │   │           │   └─ amyxq.KKGN5:11\n" +
-			"         │   │           ├─ TableAlias(ufc)\n" +
-			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           │       ├─ index: [SISUT.id]\n" +
-			"         │   │           │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │           │       ├─ colSet: (1-11)\n" +
-			"         │   │           │       ├─ tableId: 1\n" +
-			"         │   │           │       └─ Table\n" +
-			"         │   │           │           ├─ name: SISUT\n" +
-			"         │   │           │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
-			"         │   │           └─ Project\n" +
-			"         │   │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [amyxq.KKGN5:7]\n" +
-			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │   │                       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │                       ├─ colSet: (59-66)\n" +
-			"         │   │                       ├─ tableId: 4\n" +
-			"         │   │                       └─ Table\n" +
-			"         │   │                           ├─ name: AMYXQ\n" +
-			"         │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
-			"         │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
-			"         │       └─ TableAlias(cla)\n" +
-			"         │           └─ ProcessTable\n" +
-			"         │               └─ Table\n" +
-			"         │                   ├─ name: YK2GW\n" +
-			"         │                   └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"         │   ├─ cla.FTQLQ:29!null\n" +
+			"         │   └─ ufc.T4IBQ:1\n" +
+			"         ├─ Project\n" +
+			"         │   ├─ columns: [SISUT.id:17!null, SISUT.T4IBQ:18, SISUT.ZH72S:19, SISUT.AMYXQ:20, SISUT.KTNZ2:21, SISUT.HIID2:22, SISUT.DN3OQ:23, SISUT.VVKNB:24, SISUT.SH7TP:25, SISUT.SRZZO:26, SISUT.QZ6VT:27, E2I7U.id:0!null, E2I7U.DKCAJ:1!null, E2I7U.KNG7T:2, E2I7U.TW55N:3!null, E2I7U.QRQXW:4!null, E2I7U.ECXAJ:5!null, E2I7U.FGG57:6, E2I7U.ZH72S:7, E2I7U.FSK67:8!null, E2I7U.XQDYT:9!null, E2I7U.TCE7A:10, E2I7U.IWV2H:11, E2I7U.HPCMS:12!null, E2I7U.N5CC2:13, E2I7U.FHCYT:14, E2I7U.ETAQ7:15, E2I7U.A75X7:16]\n" +
+			"         │   └─ Filter\n" +
+			"         │       ├─ 1:29 IS NULL\n" +
+			"         │       └─ LeftOuterLookupJoin\n" +
+			"         │           ├─ LookupJoin\n" +
+			"         │           │   ├─ Filter\n" +
+			"         │           │   │   ├─ NOT\n" +
+			"         │           │   │   │   └─ nd.ZH72S:7 IS NULL\n" +
+			"         │           │   │   └─ TableAlias(nd)\n" +
+			"         │           │   │       └─ ProcessTable\n" +
+			"         │           │   │           └─ Table\n" +
+			"         │           │   │               ├─ name: E2I7U\n" +
+			"         │           │   │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"         │           │   └─ TableAlias(ufc)\n" +
+			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │           │           ├─ keys: [nd.ZH72S:7]\n" +
+			"         │           │           ├─ colSet: (1-11)\n" +
+			"         │           │           ├─ tableId: 1\n" +
+			"         │           │           └─ Table\n" +
+			"         │           │               ├─ name: SISUT\n" +
+			"         │           │               └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
+			"         │           └─ Project\n" +
+			"         │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
+			"         │               └─ Project\n" +
+			"         │                   ├─ columns: [amyxq.KKGN5:7]\n" +
+			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │                       ├─ keys: [ufc.id:17!null]\n" +
+			"         │                       ├─ colSet: (59-66)\n" +
+			"         │                       ├─ tableId: 4\n" +
+			"         │                       └─ Table\n" +
+			"         │                           ├─ name: AMYXQ\n" +
+			"         │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
-			"             ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.ZH72S]\n" +
-			"                     ├─ static: [{(NULL, ∞)}]\n" +
-			"                     ├─ colSet: (12-28)\n" +
-			"                     ├─ tableId: 2\n" +
+			"             ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
+			"             ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
+			"             └─ TableAlias(cla)\n" +
+			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
-			"                         ├─ name: E2I7U\n" +
-			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"                         ├─ name: YK2GW\n" +
+			"                         └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"",
 		ExpectedEstimates: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260)\n" +
-			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
-			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060)\n" +
-			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         │   ├─ Project\n" +
-			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ 1 IS NULL\n" +
-			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130)\n" +
-			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
-			"         │   │           ├─ TableAlias(ufc)\n" +
-			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           │       ├─ index: [SISUT.id]\n" +
-			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │           └─ Project\n" +
-			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
-			"         │       ├─ right-key: (cla.FTQLQ)\n" +
-			"         │       └─ TableAlias(cla)\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"     └─ HashJoin (estimated cost=11656.620 rows=4081)\n" +
+			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         ├─ Project\n" +
+			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
+			"         │   └─ Filter\n" +
+			"         │       ├─ 1 IS NULL\n" +
+			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101)\n" +
+			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081)\n" +
+			"         │           │   ├─ Filter\n" +
+			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"         │           │   │   └─ TableAlias(nd)\n" +
+			"         │           │   │       └─ Table\n" +
+			"         │           │   │           └─ name: E2I7U\n" +
+			"         │           │   └─ TableAlias(ufc)\n" +
+			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │           │           └─ keys: nd.ZH72S\n" +
+			"         │           └─ Project\n" +
+			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │               └─ Project\n" +
+			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │                       └─ keys: ufc.id\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.ZH72S)\n" +
-			"             ├─ right-key: (nd.ZH72S)\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.ZH72S]\n" +
-			"                     └─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ left-key: (ufc.T4IBQ)\n" +
+			"             ├─ right-key: (cla.FTQLQ)\n" +
+			"             └─ TableAlias(cla)\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: YK2GW\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260) (actual rows=0 loops=1)\n" +
-			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
-			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060) (actual rows=0 loops=1)\n" +
-			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         │   ├─ Project\n" +
-			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ 1 IS NULL\n" +
-			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130) (actual rows=0 loops=1)\n" +
-			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
-			"         │   │           ├─ TableAlias(ufc)\n" +
-			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           │       ├─ index: [SISUT.id]\n" +
-			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │           └─ Project\n" +
-			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
-			"         │       ├─ right-key: (cla.FTQLQ)\n" +
-			"         │       └─ TableAlias(cla)\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"     └─ HashJoin (estimated cost=11656.620 rows=4081) (actual rows=0 loops=1)\n" +
+			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         ├─ Project\n" +
+			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
+			"         │   └─ Filter\n" +
+			"         │       ├─ 1 IS NULL\n" +
+			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101) (actual rows=0 loops=1)\n" +
+			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081) (actual rows=0 loops=1)\n" +
+			"         │           │   ├─ Filter\n" +
+			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"         │           │   │   └─ TableAlias(nd)\n" +
+			"         │           │   │       └─ Table\n" +
+			"         │           │   │           └─ name: E2I7U\n" +
+			"         │           │   └─ TableAlias(ufc)\n" +
+			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │           │           └─ keys: nd.ZH72S\n" +
+			"         │           └─ Project\n" +
+			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │               └─ Project\n" +
+			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │                       └─ keys: ufc.id\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.ZH72S)\n" +
-			"             ├─ right-key: (nd.ZH72S)\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.ZH72S]\n" +
-			"                     └─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ left-key: (ufc.T4IBQ)\n" +
+			"             ├─ right-key: (cla.FTQLQ)\n" +
+			"             └─ TableAlias(cla)\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: YK2GW\n" +
 			"",
 	},
 	{
@@ -3483,137 +3439,119 @@ WHERE
 			"     ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ nd.ZH72S:48\n" +
-			"         │   └─ ufc.ZH72S:2\n" +
-			"         ├─ HashJoin\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ cla.FTQLQ:12!null\n" +
-			"         │   │   └─ ufc.T4IBQ:1\n" +
-			"         │   ├─ Project\n" +
-			"         │   │   ├─ columns: [SISUT.id:0!null, SISUT.T4IBQ:1, SISUT.ZH72S:2, SISUT.AMYXQ:3, SISUT.KTNZ2:4, SISUT.HIID2:5, SISUT.DN3OQ:6, SISUT.VVKNB:7, SISUT.SH7TP:8, SISUT.SRZZO:9, SISUT.QZ6VT:10]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ 1:12 IS NULL\n" +
-			"         │   │       └─ LeftOuterMergeJoin\n" +
-			"         │   │           ├─ cmp: Eq\n" +
-			"         │   │           │   ├─ ufc.id:0!null\n" +
-			"         │   │           │   └─ amyxq.KKGN5:11\n" +
-			"         │   │           ├─ TableAlias(ufc)\n" +
-			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           │       ├─ index: [SISUT.id]\n" +
-			"         │   │           │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │           │       ├─ colSet: (1-11)\n" +
-			"         │   │           │       ├─ tableId: 1\n" +
-			"         │   │           │       └─ Table\n" +
-			"         │   │           │           ├─ name: SISUT\n" +
-			"         │   │           │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
-			"         │   │           └─ Project\n" +
-			"         │   │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [amyxq.KKGN5:7]\n" +
-			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │   │                       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │                       ├─ colSet: (59-66)\n" +
-			"         │   │                       ├─ tableId: 4\n" +
-			"         │   │                       └─ Table\n" +
-			"         │   │                           ├─ name: AMYXQ\n" +
-			"         │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
-			"         │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
-			"         │       └─ TableAlias(cla)\n" +
-			"         │           └─ ProcessTable\n" +
-			"         │               └─ Table\n" +
-			"         │                   ├─ name: YK2GW\n" +
-			"         │                   └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"         │   ├─ cla.FTQLQ:29!null\n" +
+			"         │   └─ ufc.T4IBQ:1\n" +
+			"         ├─ Project\n" +
+			"         │   ├─ columns: [SISUT.id:17!null, SISUT.T4IBQ:18, SISUT.ZH72S:19, SISUT.AMYXQ:20, SISUT.KTNZ2:21, SISUT.HIID2:22, SISUT.DN3OQ:23, SISUT.VVKNB:24, SISUT.SH7TP:25, SISUT.SRZZO:26, SISUT.QZ6VT:27, E2I7U.id:0!null, E2I7U.DKCAJ:1!null, E2I7U.KNG7T:2, E2I7U.TW55N:3!null, E2I7U.QRQXW:4!null, E2I7U.ECXAJ:5!null, E2I7U.FGG57:6, E2I7U.ZH72S:7, E2I7U.FSK67:8!null, E2I7U.XQDYT:9!null, E2I7U.TCE7A:10, E2I7U.IWV2H:11, E2I7U.HPCMS:12!null, E2I7U.N5CC2:13, E2I7U.FHCYT:14, E2I7U.ETAQ7:15, E2I7U.A75X7:16]\n" +
+			"         │   └─ Filter\n" +
+			"         │       ├─ 1:29 IS NULL\n" +
+			"         │       └─ LeftOuterLookupJoin\n" +
+			"         │           ├─ LookupJoin\n" +
+			"         │           │   ├─ Filter\n" +
+			"         │           │   │   ├─ NOT\n" +
+			"         │           │   │   │   └─ nd.ZH72S:7 IS NULL\n" +
+			"         │           │   │   └─ TableAlias(nd)\n" +
+			"         │           │   │       └─ ProcessTable\n" +
+			"         │           │   │           └─ Table\n" +
+			"         │           │   │               ├─ name: E2I7U\n" +
+			"         │           │   │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"         │           │   └─ TableAlias(ufc)\n" +
+			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │           │           ├─ keys: [nd.ZH72S:7]\n" +
+			"         │           │           ├─ colSet: (1-11)\n" +
+			"         │           │           ├─ tableId: 1\n" +
+			"         │           │           └─ Table\n" +
+			"         │           │               ├─ name: SISUT\n" +
+			"         │           │               └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
+			"         │           └─ Project\n" +
+			"         │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
+			"         │               └─ Project\n" +
+			"         │                   ├─ columns: [amyxq.KKGN5:7]\n" +
+			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │                       ├─ keys: [ufc.id:17!null]\n" +
+			"         │                       ├─ colSet: (59-66)\n" +
+			"         │                       ├─ tableId: 4\n" +
+			"         │                       └─ Table\n" +
+			"         │                           ├─ name: AMYXQ\n" +
+			"         │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
-			"             ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.ZH72S]\n" +
-			"                     ├─ static: [{(NULL, ∞)}]\n" +
-			"                     ├─ colSet: (12-28)\n" +
-			"                     ├─ tableId: 2\n" +
+			"             ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
+			"             ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
+			"             └─ TableAlias(cla)\n" +
+			"                 └─ ProcessTable\n" +
 			"                     └─ Table\n" +
-			"                         ├─ name: E2I7U\n" +
-			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"                         ├─ name: YK2GW\n" +
+			"                         └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"",
 		ExpectedEstimates: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260)\n" +
-			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
-			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060)\n" +
-			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         │   ├─ Project\n" +
-			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ 1 IS NULL\n" +
-			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130)\n" +
-			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
-			"         │   │           ├─ TableAlias(ufc)\n" +
-			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           │       ├─ index: [SISUT.id]\n" +
-			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │           └─ Project\n" +
-			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
-			"         │       ├─ right-key: (cla.FTQLQ)\n" +
-			"         │       └─ TableAlias(cla)\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"     └─ HashJoin (estimated cost=11656.620 rows=4081)\n" +
+			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         ├─ Project\n" +
+			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
+			"         │   └─ Filter\n" +
+			"         │       ├─ 1 IS NULL\n" +
+			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101)\n" +
+			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081)\n" +
+			"         │           │   ├─ Filter\n" +
+			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"         │           │   │   └─ TableAlias(nd)\n" +
+			"         │           │   │       └─ Table\n" +
+			"         │           │   │           └─ name: E2I7U\n" +
+			"         │           │   └─ TableAlias(ufc)\n" +
+			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │           │           └─ keys: nd.ZH72S\n" +
+			"         │           └─ Project\n" +
+			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │               └─ Project\n" +
+			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │                       └─ keys: ufc.id\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.ZH72S)\n" +
-			"             ├─ right-key: (nd.ZH72S)\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.ZH72S]\n" +
-			"                     └─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ left-key: (ufc.T4IBQ)\n" +
+			"             ├─ right-key: (cla.FTQLQ)\n" +
+			"             └─ TableAlias(cla)\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: YK2GW\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260) (actual rows=0 loops=1)\n" +
-			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
-			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060) (actual rows=0 loops=1)\n" +
-			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         │   ├─ Project\n" +
-			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
-			"         │   │   └─ Filter\n" +
-			"         │   │       ├─ 1 IS NULL\n" +
-			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130) (actual rows=0 loops=1)\n" +
-			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
-			"         │   │           ├─ TableAlias(ufc)\n" +
-			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
-			"         │   │           │       ├─ index: [SISUT.id]\n" +
-			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │           └─ Project\n" +
-			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
-			"         │   └─ HashLookup\n" +
-			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
-			"         │       ├─ right-key: (cla.FTQLQ)\n" +
-			"         │       └─ TableAlias(cla)\n" +
-			"         │           └─ Table\n" +
-			"         │               └─ name: YK2GW\n" +
+			"     └─ HashJoin (estimated cost=11656.620 rows=4081) (actual rows=0 loops=1)\n" +
+			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         ├─ Project\n" +
+			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
+			"         │   └─ Filter\n" +
+			"         │       ├─ 1 IS NULL\n" +
+			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101) (actual rows=0 loops=1)\n" +
+			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081) (actual rows=0 loops=1)\n" +
+			"         │           │   ├─ Filter\n" +
+			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
+			"         │           │   │   └─ TableAlias(nd)\n" +
+			"         │           │   │       └─ Table\n" +
+			"         │           │   │           └─ name: E2I7U\n" +
+			"         │           │   └─ TableAlias(ufc)\n" +
+			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
+			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
+			"         │           │           └─ keys: nd.ZH72S\n" +
+			"         │           └─ Project\n" +
+			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │               └─ Project\n" +
+			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │                       └─ keys: ufc.id\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.ZH72S)\n" +
-			"             ├─ right-key: (nd.ZH72S)\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ IndexedTableAccess(E2I7U)\n" +
-			"                     ├─ index: [E2I7U.ZH72S]\n" +
-			"                     └─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ left-key: (ufc.T4IBQ)\n" +
+			"             ├─ right-key: (cla.FTQLQ)\n" +
+			"             └─ TableAlias(cla)\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: YK2GW\n" +
 			"",
 	},
 	{
@@ -4167,19 +4105,18 @@ WHERE
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: TUPLE(umf.FGG57:2)\n" +
 			"         ├─ right-key: TUPLE(nd.FGG57:6)\n" +
-			"         └─ TableAlias(nd)\n" +
-			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 ├─ index: [E2I7U.FGG57]\n" +
-			"                 ├─ static: [{(NULL, ∞)}]\n" +
-			"                 ├─ colSet: (26-42)\n" +
-			"                 ├─ tableId: 2\n" +
-			"                 └─ Table\n" +
-			"                     ├─ name: E2I7U\n" +
-			"                     └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"         └─ Filter\n" +
+			"             ├─ NOT\n" +
+			"             │   └─ nd.FGG57:6 IS NULL\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ ProcessTable\n" +
+			"                     └─ Table\n" +
+			"                         ├─ name: E2I7U\n" +
+			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [umf.id, umf.T4IBQ, umf.FGG57, umf.SSHPJ, umf.NLA6O, umf.SFJ6L, umf.TJPT7, umf.ARN5P, umf.SYPKF, umf.IVFMK, umf.IDE43, umf.AZ6SP, umf.FSDY2, umf.XOSD4, umf.HMW4H, umf.S76OM, umf.vaf, umf.ZROH6, umf.QCGTS, umf.LNFM6, umf.TVAWL, umf.HDLCL, umf.BHHW6, umf.FHCYT, umf.QZ6VT]\n" +
-			" └─ HashJoin (estimated cost=13845473.880 rows=13568344)\n" +
+			" └─ HashJoin (estimated cost=13849505.880 rows=13568344)\n" +
 			"     ├─ (nd.FGG57 = umf.FGG57)\n" +
 			"     ├─ HashJoin (estimated cost=13847204.880 rows=13568344)\n" +
 			"     │   ├─ (cla.FTQLQ = umf.T4IBQ)\n" +
@@ -4211,14 +4148,15 @@ WHERE
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: (umf.FGG57)\n" +
 			"         ├─ right-key: (nd.FGG57)\n" +
-			"         └─ TableAlias(nd)\n" +
-			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 ├─ index: [E2I7U.FGG57]\n" +
-			"                 └─ filters: [{(NULL, ∞)}]\n" +
+			"         └─ Filter\n" +
+			"             ├─ (NOT(nd.FGG57 IS NULL))\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: E2I7U\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [umf.id, umf.T4IBQ, umf.FGG57, umf.SSHPJ, umf.NLA6O, umf.SFJ6L, umf.TJPT7, umf.ARN5P, umf.SYPKF, umf.IVFMK, umf.IDE43, umf.AZ6SP, umf.FSDY2, umf.XOSD4, umf.HMW4H, umf.S76OM, umf.vaf, umf.ZROH6, umf.QCGTS, umf.LNFM6, umf.TVAWL, umf.HDLCL, umf.BHHW6, umf.FHCYT, umf.QZ6VT]\n" +
-			" └─ HashJoin (estimated cost=13845473.880 rows=13568344) (actual rows=0 loops=1)\n" +
+			" └─ HashJoin (estimated cost=13849505.880 rows=13568344) (actual rows=0 loops=1)\n" +
 			"     ├─ (nd.FGG57 = umf.FGG57)\n" +
 			"     ├─ HashJoin (estimated cost=13847204.880 rows=13568344) (actual rows=0 loops=1)\n" +
 			"     │   ├─ (cla.FTQLQ = umf.T4IBQ)\n" +
@@ -4250,10 +4188,11 @@ WHERE
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: (umf.FGG57)\n" +
 			"         ├─ right-key: (nd.FGG57)\n" +
-			"         └─ TableAlias(nd)\n" +
-			"             └─ IndexedTableAccess(E2I7U)\n" +
-			"                 ├─ index: [E2I7U.FGG57]\n" +
-			"                 └─ filters: [{(NULL, ∞)}]\n" +
+			"         └─ Filter\n" +
+			"             ├─ (NOT(nd.FGG57 IS NULL))\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ Table\n" +
+			"                     └─ name: E2I7U\n" +
 			"",
 	},
 	{
@@ -4266,7 +4205,7 @@ WHERE
 			" ├─ columns: [qywqd.HVHRZ:1!null]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-6)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -4277,14 +4216,14 @@ WHERE
 			" ├─ columns: [qywqd.HVHRZ]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id hvhrz]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [qywqd.HVHRZ]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id hvhrz]\n" +
 			"",
 	},
@@ -8886,7 +8825,7 @@ WHERE
 			" ├─ columns: [e2i7u.ECXAJ:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -8897,14 +8836,14 @@ WHERE
 			" ├─ columns: [e2i7u.ECXAJ]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id ecxaj]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.ECXAJ]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id ecxaj]\n" +
 			"",
 	},
@@ -9163,7 +9102,7 @@ WHERE
 			"     │   THEN 0 (tinyint) ELSE 3 (tinyint) END->SZ6KK:0]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-17)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -9210,7 +9149,7 @@ WHERE
 			"     │   THEN 1 WHEN (e2i7u.FSK67 = 'z') THEN 2 WHEN (e2i7u.FSK67 = 'CRZ2X') THEN 0 ELSE 3 END as SZ6KK]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         └─ filters: [{(NULL, ∞)}]\n" +
+			"         └─ filters: [{[NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [CASE  WHEN e2i7u.FGG57 IS NULL THEN 0 WHEN InSubquery\n" +
@@ -9252,7 +9191,7 @@ WHERE
 			"     │   THEN 1 WHEN (e2i7u.FSK67 = 'z') THEN 2 WHEN (e2i7u.FSK67 = 'CRZ2X') THEN 0 ELSE 3 END as SZ6KK]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         └─ filters: [{(NULL, ∞)}]\n" +
+			"         └─ filters: [{[NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -15967,7 +15906,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -15978,14 +15917,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.TW55N]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n]\n" +
 			"",
 	},
@@ -16000,7 +15939,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N:1!null, e2i7u.FGG57:2]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -16011,14 +15950,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N, e2i7u.FGG57]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.TW55N, e2i7u.FGG57]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 	},
@@ -16257,7 +16196,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id:0!null->XLFIA:0, noxn3.BRQP2:1!null]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ static: [{(NULL, ∞)}]\n" +
+			"         │           ├─ static: [{[NULL, ∞)}]\n" +
 			"         │           ├─ colSet: (1-10)\n" +
 			"         │           ├─ tableId: 1\n" +
 			"         │           └─ Table\n" +
@@ -16332,7 +16271,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ filters: [{(NULL, ∞)}]\n" +
+			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
 			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
@@ -16390,7 +16329,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ filters: [{(NULL, ∞)}]\n" +
+			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
 			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
@@ -17459,7 +17398,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.KBO7R:1!null]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17470,14 +17409,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.KBO7R]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id kbo7r]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [noxn3.KBO7R]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id kbo7r]\n" +
 			"",
 	},
@@ -17720,7 +17659,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.QRQXW:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17731,14 +17670,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.QRQXW]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id qrqxw]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.QRQXW]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id qrqxw]\n" +
 			"",
 	},
@@ -17832,7 +17771,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.id:0!null, noxn3.NUMK2:2!null, noxn3.ECDKM:1]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17843,14 +17782,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.id, noxn3.NUMK2, noxn3.ECDKM]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [noxn3.id, noxn3.NUMK2, noxn3.ECDKM]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
@@ -17870,7 +17809,7 @@ SELECT
 			" │   THEN noxn3.ECDKM:1 ELSE 0 (tinyint) END->RGXLL:0]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17881,14 +17820,14 @@ SELECT
 			" ├─ columns: [CASE  WHEN (noxn3.NUMK2 = 2) THEN noxn3.ECDKM ELSE 0 END as RGXLL]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [CASE  WHEN (noxn3.NUMK2 = 2) THEN noxn3.ECDKM ELSE 0 END as RGXLL]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
@@ -19710,14 +19649,14 @@ WHERE
 			"     │                       │   │   │       └─ right: Subquery\n" +
 			"     │                       │   │   │           ├─ cacheable: true\n" +
 			"     │                       │   │   │           ├─ alias-string: select BTXC5 from TPXBU where BTXC5 is not null\n" +
-			"     │                       │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
-			"     │                       │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
-			"     │                       │   │   │               ├─ static: [{(NULL, ∞)}]\n" +
-			"     │                       │   │   │               ├─ colSet: (29-31)\n" +
-			"     │                       │   │   │               ├─ tableId: 3\n" +
+			"     │                       │   │   │           └─ Filter\n" +
+			"     │                       │   │   │               ├─ NOT\n" +
+			"     │                       │   │   │               │   └─ tpxbu.BTXC5:25 IS NULL\n" +
 			"     │                       │   │   │               └─ Table\n" +
 			"     │                       │   │   │                   ├─ name: TPXBU\n" +
-			"     │                       │   │   │                   └─ columns: [btxc5]\n" +
+			"     │                       │   │   │                   ├─ columns: [btxc5]\n" +
+			"     │                       │   │   │                   ├─ colSet: (29-31)\n" +
+			"     │                       │   │   │                   └─ tableId: 3\n" +
 			"     │                       │   │   └─ NOT\n" +
 			"     │                       │   │       └─ umf.SYPKF:8 IS NULL\n" +
 			"     │                       │   └─ NOT\n" +
@@ -19892,13 +19831,16 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │       │   └─ Project\n" +
 			"     │       │       ├─ columns: [nd_for_id.id:84!null]\n" +
 			"     │       │       └─ Filter\n" +
-			"     │       │           ├─ Eq\n" +
-			"     │       │           │   ├─ nd_for_id.FGG57:85\n" +
-			"     │       │           │   └─ umf.FGG57:2\n" +
+			"     │       │           ├─ AND\n" +
+			"     │       │           │   ├─ NOT\n" +
+			"     │       │           │   │   └─ nd_for_id.FGG57:85 IS NULL\n" +
+			"     │       │           │   └─ Eq\n" +
+			"     │       │           │       ├─ nd_for_id.FGG57:85\n" +
+			"     │       │           │       └─ umf.FGG57:2\n" +
 			"     │       │           └─ TableAlias(nd_for_id)\n" +
 			"     │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"     │       │                   ├─ index: [E2I7U.FGG57]\n" +
-			"     │       │                   ├─ static: [{(NULL, ∞)}]\n" +
+			"     │       │                   ├─ keys: [umf.FGG57:2]\n" +
 			"     │       │                   ├─ colSet: (176-192)\n" +
 			"     │       │                   ├─ tableId: 10\n" +
 			"     │       │                   └─ Table\n" +
@@ -19990,13 +19932,16 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │           │   └─ Project\n" +
 			"     │           │       ├─ columns: [nd_for_id.id:67!null]\n" +
 			"     │           │       └─ Filter\n" +
-			"     │           │           ├─ Eq\n" +
-			"     │           │           │   ├─ nd_for_id.FGG57:68\n" +
-			"     │           │           │   └─ umf.FGG57:2\n" +
+			"     │           │           ├─ AND\n" +
+			"     │           │           │   ├─ NOT\n" +
+			"     │           │           │   │   └─ nd_for_id.FGG57:68 IS NULL\n" +
+			"     │           │           │   └─ Eq\n" +
+			"     │           │           │       ├─ nd_for_id.FGG57:68\n" +
+			"     │           │           │       └─ umf.FGG57:2\n" +
 			"     │           │           └─ TableAlias(nd_for_id)\n" +
 			"     │           │               └─ IndexedTableAccess(E2I7U)\n" +
 			"     │           │                   ├─ index: [E2I7U.FGG57]\n" +
-			"     │           │                   ├─ static: [{(NULL, ∞)}]\n" +
+			"     │           │                   ├─ keys: [umf.FGG57:2]\n" +
 			"     │           │                   ├─ colSet: (176-192)\n" +
 			"     │           │                   ├─ tableId: 10\n" +
 			"     │           │                   └─ Table\n" +
@@ -20104,14 +20049,14 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │               │   │   │       │   │       └─ right: Subquery\n" +
 			"     │               │   │   │       │   │           ├─ cacheable: true\n" +
 			"     │               │   │   │       │   │           ├─ alias-string: select FGG57 from E2I7U where FGG57 is not null\n" +
-			"     │               │   │   │       │   │           └─ IndexedTableAccess(E2I7U)\n" +
-			"     │               │   │   │       │   │               ├─ index: [E2I7U.FGG57]\n" +
-			"     │               │   │   │       │   │               ├─ static: [{(NULL, ∞)}]\n" +
-			"     │               │   │   │       │   │               ├─ colSet: (73-89)\n" +
-			"     │               │   │   │       │   │               ├─ tableId: 4\n" +
+			"     │               │   │   │       │   │           └─ Filter\n" +
+			"     │               │   │   │       │   │               ├─ NOT\n" +
+			"     │               │   │   │       │   │               │   └─ e2i7u.FGG57:25 IS NULL\n" +
 			"     │               │   │   │       │   │               └─ Table\n" +
 			"     │               │   │   │       │   │                   ├─ name: E2I7U\n" +
-			"     │               │   │   │       │   │                   └─ columns: [fgg57]\n" +
+			"     │               │   │   │       │   │                   ├─ columns: [fgg57]\n" +
+			"     │               │   │   │       │   │                   ├─ colSet: (73-89)\n" +
+			"     │               │   │   │       │   │                   └─ tableId: 4\n" +
 			"     │               │   │   │       │   └─ NOT\n" +
 			"     │               │   │   │       │       └─ Eq\n" +
 			"     │               │   │   │       │           ├─ nzkpm.ARN5P:7\n" +
@@ -20938,14 +20883,14 @@ WHERE
 			"     │           │   │               ├─ cacheable: true\n" +
 			"     │           │   │               ├─ alias-string: select distinct NO52D, VYO5E, DKCAJ from SFEGG where VYO5E is not null\n" +
 			"     │           │   │               └─ Distinct\n" +
-			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
-			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │   │                       ├─ static: [{(NULL, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
-			"     │           │   │                       ├─ colSet: (60-65)\n" +
-			"     │           │   │                       ├─ tableId: 8\n" +
+			"     │           │   │                   └─ Filter\n" +
+			"     │           │   │                       ├─ NOT\n" +
+			"     │           │   │                       │   └─ sfegg.VYO5E:5 IS NULL\n" +
 			"     │           │   │                       └─ Table\n" +
 			"     │           │   │                           ├─ name: SFEGG\n" +
-			"     │           │   │                           └─ columns: [no52d vyo5e dkcaj]\n" +
+			"     │           │   │                           ├─ columns: [no52d vyo5e dkcaj]\n" +
+			"     │           │   │                           ├─ colSet: (60-65)\n" +
+			"     │           │   │                           └─ tableId: 8\n" +
 			"     │           │   └─ AND\n" +
 			"     │           │       ├─ rs.VYO5E:1 IS NULL\n" +
 			"     │           │       └─ NOT\n" +
@@ -20959,7 +20904,7 @@ WHERE
 			"     │           │                           ├─ columns: [sfegg.NO52D:4!null, sfegg.DKCAJ:6!null]\n" +
 			"     │           │                           └─ IndexedTableAccess(SFEGG)\n" +
 			"     │           │                               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │                               ├─ static: [{(NULL, ∞), [NULL, NULL], (NULL, ∞)}]\n" +
+			"     │           │                               ├─ static: [{[NULL, ∞), [NULL, NULL], [NULL, ∞)}]\n" +
 			"     │           │                               ├─ colSet: (66-71)\n" +
 			"     │           │                               ├─ tableId: 9\n" +
 			"     │           │                               └─ Table\n" +
@@ -21692,14 +21637,14 @@ WHERE
 			"     │           │   │               ├─ cacheable: true\n" +
 			"     │           │   │               ├─ alias-string: select distinct NO52D, VYO5E, DKCAJ from SFEGG where VYO5E is not null\n" +
 			"     │           │   │               └─ Distinct\n" +
-			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
-			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │   │                       ├─ static: [{(NULL, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
-			"     │           │   │                       ├─ colSet: (48-53)\n" +
-			"     │           │   │                       ├─ tableId: 6\n" +
+			"     │           │   │                   └─ Filter\n" +
+			"     │           │   │                       ├─ NOT\n" +
+			"     │           │   │                       │   └─ sfegg.VYO5E:5 IS NULL\n" +
 			"     │           │   │                       └─ Table\n" +
 			"     │           │   │                           ├─ name: SFEGG\n" +
-			"     │           │   │                           └─ columns: [no52d vyo5e dkcaj]\n" +
+			"     │           │   │                           ├─ columns: [no52d vyo5e dkcaj]\n" +
+			"     │           │   │                           ├─ colSet: (48-53)\n" +
+			"     │           │   │                           └─ tableId: 6\n" +
 			"     │           │   └─ AND\n" +
 			"     │           │       ├─ rs.VYO5E:1 IS NULL\n" +
 			"     │           │       └─ NOT\n" +
@@ -21713,7 +21658,7 @@ WHERE
 			"     │           │                           ├─ columns: [sfegg.NO52D:4!null, sfegg.DKCAJ:6!null]\n" +
 			"     │           │                           └─ IndexedTableAccess(SFEGG)\n" +
 			"     │           │                               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │                               ├─ static: [{(NULL, ∞), [NULL, NULL], (NULL, ∞)}]\n" +
+			"     │           │                               ├─ static: [{[NULL, ∞), [NULL, NULL], [NULL, ∞)}]\n" +
 			"     │           │                               ├─ colSet: (54-59)\n" +
 			"     │           │                               ├─ tableId: 7\n" +
 			"     │           │                               └─ Table\n" +

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -215,15 +215,15 @@ WHERE
 			"     │                                   │                       ├─ name: HDDVB\n" +
 			"     │                                   │                       └─ columns: [uj6xy]\n" +
 			"     │                                   │  ->WGBRL:0]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ NOT\n" +
-			"     │                                       │   └─ nd.ZH72S:7 IS NULL\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           ├─ colSet: (1-17)\n" +
+			"     │                                           ├─ tableId: 1\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               ├─ name: E2I7U\n" +
-			"     │                                               ├─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"     │                                               ├─ colSet: (1-17)\n" +
-			"     │                                               └─ tableId: 1\n" +
+			"     │                                               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -292,11 +292,10 @@ WHERE
 			"     │                                   │                   ├─ columns: [uj6xy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as WGBRL]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -361,11 +360,10 @@ WHERE
 			"     │                                   │                   ├─ columns: [uj6xy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as WGBRL]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -547,55 +545,58 @@ WHERE
 			" │               ├─ alias-string: select TIZHK.id as FWATE from WGSDC as NHMXW join WRZVO as TIZHK on TIZHK.TVNW2 = NHMXW.NOHHR and TIZHK.ZHITY = NHMXW.AVPYF and TIZHK.SYPKF = NHMXW.SYPKF and TIZHK.IDUT2 = NHMXW.IDUT2 where NHMXW.SWCQV = 0 and NHMXW.id not in (select PRUV2 from HDDVB where PRUV2 is not null)\n" +
 			" │               └─ Project\n" +
 			" │                   ├─ columns: [tizhk.id:19!null->FWATE:0]\n" +
-			" │                   └─ LookupJoin\n" +
-			" │                       ├─ AND\n" +
-			" │                       │   ├─ AND\n" +
-			" │                       │   │   ├─ Eq\n" +
-			" │                       │   │   │   ├─ tizhk.TVNW2:20\n" +
-			" │                       │   │   │   └─ nhmxw.NOHHR:10!null\n" +
-			" │                       │   │   └─ Eq\n" +
-			" │                       │   │       ├─ tizhk.ZHITY:21\n" +
-			" │                       │   │       └─ nhmxw.AVPYF:11!null\n" +
-			" │                       │   └─ Eq\n" +
-			" │                       │       ├─ tizhk.IDUT2:23\n" +
-			" │                       │       └─ nhmxw.IDUT2:13!null\n" +
-			" │                       ├─ Project\n" +
-			" │                       │   ├─ columns: [WGSDC.id:9!null, WGSDC.NOHHR:10!null, WGSDC.AVPYF:11!null, WGSDC.SYPKF:12!null, WGSDC.IDUT2:13!null, WGSDC.FZXV5:14, WGSDC.DQYGV:15, WGSDC.SWCQV:16!null, WGSDC.YKSSU:17, WGSDC.FHCYT:18]\n" +
-			" │                       │   └─ Filter\n" +
-			" │                       │       ├─ 1:20 IS NULL\n" +
-			" │                       │       └─ LeftOuterLookupJoin\n" +
-			" │                       │           ├─ Filter\n" +
-			" │                       │           │   ├─ Eq\n" +
-			" │                       │           │   │   ├─ nhmxw.SWCQV:16!null\n" +
-			" │                       │           │   │   └─ 0 (int)\n" +
-			" │                       │           │   └─ TableAlias(nhmxw)\n" +
-			" │                       │           │       └─ Table\n" +
-			" │                       │           │           ├─ name: WGSDC\n" +
-			" │                       │           │           ├─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
-			" │                       │           │           ├─ colSet: (74-83)\n" +
-			" │                       │           │           └─ tableId: 7\n" +
-			" │                       │           └─ Project\n" +
-			" │                       │               ├─ columns: [hddvb.PRUV2:9, 1 (bigint)]\n" +
-			" │                       │               └─ Filter\n" +
-			" │                       │                   ├─ NOT\n" +
-			" │                       │                   │   └─ hddvb.PRUV2:9 IS NULL\n" +
-			" │                       │                   └─ IndexedTableAccess(HDDVB)\n" +
-			" │                       │                       ├─ index: [HDDVB.PRUV2]\n" +
-			" │                       │                       ├─ keys: [nhmxw.id:9!null]\n" +
-			" │                       │                       ├─ colSet: (94-102)\n" +
-			" │                       │                       ├─ tableId: 9\n" +
-			" │                       │                       └─ Table\n" +
-			" │                       │                           ├─ name: HDDVB\n" +
-			" │                       │                           └─ columns: [pruv2]\n" +
-			" │                       └─ TableAlias(tizhk)\n" +
-			" │                           └─ IndexedTableAccess(WRZVO)\n" +
-			" │                               ├─ index: [WRZVO.SYPKF]\n" +
-			" │                               ├─ keys: [nhmxw.SYPKF:12!null]\n" +
-			" │                               ├─ colSet: (84-93)\n" +
-			" │                               ├─ tableId: 8\n" +
-			" │                               └─ Table\n" +
-			" │                                   ├─ name: WRZVO\n" +
-			" │                                   └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
+			" │                   └─ Project\n" +
+			" │                       ├─ columns: [WGSDC.id:9!null, WGSDC.NOHHR:10!null, WGSDC.AVPYF:11!null, WGSDC.SYPKF:12!null, WGSDC.IDUT2:13!null, WGSDC.FZXV5:14, WGSDC.DQYGV:15, WGSDC.SWCQV:16!null, WGSDC.YKSSU:17, WGSDC.FHCYT:18, WRZVO.id:19!null, WRZVO.TVNW2:20, WRZVO.ZHITY:21, WRZVO.SYPKF:22, WRZVO.IDUT2:23, WRZVO.O6QJ3:24, WRZVO.NO2JA:25, WRZVO.YKSSU:26, WRZVO.FHCYT:27, WRZVO.QZ6VT:28]\n" +
+			" │                       └─ Filter\n" +
+			" │                           ├─ 1:30 IS NULL\n" +
+			" │                           └─ LeftOuterHashJoinExcludingNulls\n" +
+			" │                               ├─ Eq\n" +
+			" │                               │   ├─ nhmxw.id:9!null\n" +
+			" │                               │   └─ hddvb.PRUV2:29\n" +
+			" │                               ├─ LookupJoin\n" +
+			" │                               │   ├─ AND\n" +
+			" │                               │   │   ├─ AND\n" +
+			" │                               │   │   │   ├─ Eq\n" +
+			" │                               │   │   │   │   ├─ tizhk.TVNW2:20\n" +
+			" │                               │   │   │   │   └─ nhmxw.NOHHR:10!null\n" +
+			" │                               │   │   │   └─ Eq\n" +
+			" │                               │   │   │       ├─ tizhk.ZHITY:21\n" +
+			" │                               │   │   │       └─ nhmxw.AVPYF:11!null\n" +
+			" │                               │   │   └─ Eq\n" +
+			" │                               │   │       ├─ tizhk.IDUT2:23\n" +
+			" │                               │   │       └─ nhmxw.IDUT2:13!null\n" +
+			" │                               │   ├─ Filter\n" +
+			" │                               │   │   ├─ Eq\n" +
+			" │                               │   │   │   ├─ nhmxw.SWCQV:16!null\n" +
+			" │                               │   │   │   └─ 0 (int)\n" +
+			" │                               │   │   └─ TableAlias(nhmxw)\n" +
+			" │                               │   │       └─ Table\n" +
+			" │                               │   │           ├─ name: WGSDC\n" +
+			" │                               │   │           ├─ columns: [id nohhr avpyf sypkf idut2 fzxv5 dqygv swcqv ykssu fhcyt]\n" +
+			" │                               │   │           ├─ colSet: (74-83)\n" +
+			" │                               │   │           └─ tableId: 7\n" +
+			" │                               │   └─ TableAlias(tizhk)\n" +
+			" │                               │       └─ IndexedTableAccess(WRZVO)\n" +
+			" │                               │           ├─ index: [WRZVO.SYPKF]\n" +
+			" │                               │           ├─ keys: [nhmxw.SYPKF:12!null]\n" +
+			" │                               │           ├─ colSet: (84-93)\n" +
+			" │                               │           ├─ tableId: 8\n" +
+			" │                               │           └─ Table\n" +
+			" │                               │               ├─ name: WRZVO\n" +
+			" │                               │               └─ columns: [id tvnw2 zhity sypkf idut2 o6qj3 no2ja ykssu fhcyt qz6vt]\n" +
+			" │                               └─ HashLookup\n" +
+			" │                                   ├─ left-key: TUPLE(nhmxw.id:9!null)\n" +
+			" │                                   ├─ right-key: TUPLE(hddvb.PRUV2:9)\n" +
+			" │                                   └─ Project\n" +
+			" │                                       ├─ columns: [hddvb.PRUV2:9, 1 (bigint)]\n" +
+			" │                                       └─ IndexedTableAccess(HDDVB)\n" +
+			" │                                           ├─ index: [HDDVB.PRUV2]\n" +
+			" │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			" │                                           ├─ colSet: (94-102)\n" +
+			" │                                           ├─ tableId: 9\n" +
+			" │                                           └─ Table\n" +
+			" │                                               ├─ name: HDDVB\n" +
+			" │                                               └─ columns: [pruv2]\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ ProcessTable\n" +
 			"         └─ Table\n" +
@@ -609,30 +610,32 @@ WHERE
 			" │       ├─ cacheable: true\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [tizhk.id as FWATE]\n" +
-			" │           └─ LookupJoin\n" +
-			" │               ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
-			" │               ├─ Project\n" +
-			" │               │   ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT]\n" +
-			" │               │   └─ Filter\n" +
-			" │               │       ├─ 1 IS NULL\n" +
-			" │               │       └─ LeftOuterLookupJoin\n" +
-			" │               │           ├─ Filter\n" +
-			" │               │           │   ├─ (nhmxw.SWCQV = 0)\n" +
-			" │               │           │   └─ TableAlias(nhmxw)\n" +
-			" │               │           │       └─ Table\n" +
-			" │               │           │           └─ name: WGSDC\n" +
-			" │               │           └─ Project\n" +
-			" │               │               ├─ columns: [hddvb.PRUV2, 1]\n" +
-			" │               │               └─ Filter\n" +
-			" │               │                   ├─ (NOT(hddvb.PRUV2 IS NULL))\n" +
-			" │               │                   └─ IndexedTableAccess(HDDVB)\n" +
-			" │               │                       ├─ index: [HDDVB.PRUV2]\n" +
-			" │               │                       ├─ columns: [pruv2]\n" +
-			" │               │                       └─ keys: nhmxw.id\n" +
-			" │               └─ TableAlias(tizhk)\n" +
-			" │                   └─ IndexedTableAccess(WRZVO)\n" +
-			" │                       ├─ index: [WRZVO.SYPKF]\n" +
-			" │                       └─ keys: nhmxw.SYPKF\n" +
+			" │           └─ Project\n" +
+			" │               ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT, WRZVO.id, WRZVO.TVNW2, WRZVO.ZHITY, WRZVO.SYPKF, WRZVO.IDUT2, WRZVO.O6QJ3, WRZVO.NO2JA, WRZVO.YKSSU, WRZVO.FHCYT, WRZVO.QZ6VT]\n" +
+			" │               └─ Filter\n" +
+			" │                   ├─ 1 IS NULL\n" +
+			" │                   └─ LeftOuterHashJoinExcludingNulls\n" +
+			" │                       ├─ (nhmxw.id = hddvb.PRUV2)\n" +
+			" │                       ├─ LookupJoin\n" +
+			" │                       │   ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
+			" │                       │   ├─ Filter\n" +
+			" │                       │   │   ├─ (nhmxw.SWCQV = 0)\n" +
+			" │                       │   │   └─ TableAlias(nhmxw)\n" +
+			" │                       │   │       └─ Table\n" +
+			" │                       │   │           └─ name: WGSDC\n" +
+			" │                       │   └─ TableAlias(tizhk)\n" +
+			" │                       │       └─ IndexedTableAccess(WRZVO)\n" +
+			" │                       │           ├─ index: [WRZVO.SYPKF]\n" +
+			" │                       │           └─ keys: nhmxw.SYPKF\n" +
+			" │                       └─ HashLookup\n" +
+			" │                           ├─ left-key: (nhmxw.id)\n" +
+			" │                           ├─ right-key: (hddvb.PRUV2)\n" +
+			" │                           └─ Project\n" +
+			" │                               ├─ columns: [hddvb.PRUV2, 1]\n" +
+			" │                               └─ IndexedTableAccess(HDDVB)\n" +
+			" │                                   ├─ index: [HDDVB.PRUV2]\n" +
+			" │                                   ├─ filters: [{(NULL, ∞)}]\n" +
+			" │                                   └─ columns: [pruv2]\n" +
 			" │  ))\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ Table\n" +
@@ -645,30 +648,32 @@ WHERE
 			" │       ├─ cacheable: true\n" +
 			" │       └─ Project\n" +
 			" │           ├─ columns: [tizhk.id as FWATE]\n" +
-			" │           └─ LookupJoin\n" +
-			" │               ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
-			" │               ├─ Project\n" +
-			" │               │   ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT]\n" +
-			" │               │   └─ Filter\n" +
-			" │               │       ├─ 1 IS NULL\n" +
-			" │               │       └─ LeftOuterLookupJoin\n" +
-			" │               │           ├─ Filter\n" +
-			" │               │           │   ├─ (nhmxw.SWCQV = 0)\n" +
-			" │               │           │   └─ TableAlias(nhmxw)\n" +
-			" │               │           │       └─ Table\n" +
-			" │               │           │           └─ name: WGSDC\n" +
-			" │               │           └─ Project\n" +
-			" │               │               ├─ columns: [hddvb.PRUV2, 1]\n" +
-			" │               │               └─ Filter\n" +
-			" │               │                   ├─ (NOT(hddvb.PRUV2 IS NULL))\n" +
-			" │               │                   └─ IndexedTableAccess(HDDVB)\n" +
-			" │               │                       ├─ index: [HDDVB.PRUV2]\n" +
-			" │               │                       ├─ columns: [pruv2]\n" +
-			" │               │                       └─ keys: nhmxw.id\n" +
-			" │               └─ TableAlias(tizhk)\n" +
-			" │                   └─ IndexedTableAccess(WRZVO)\n" +
-			" │                       ├─ index: [WRZVO.SYPKF]\n" +
-			" │                       └─ keys: nhmxw.SYPKF\n" +
+			" │           └─ Project\n" +
+			" │               ├─ columns: [WGSDC.id, WGSDC.NOHHR, WGSDC.AVPYF, WGSDC.SYPKF, WGSDC.IDUT2, WGSDC.FZXV5, WGSDC.DQYGV, WGSDC.SWCQV, WGSDC.YKSSU, WGSDC.FHCYT, WRZVO.id, WRZVO.TVNW2, WRZVO.ZHITY, WRZVO.SYPKF, WRZVO.IDUT2, WRZVO.O6QJ3, WRZVO.NO2JA, WRZVO.YKSSU, WRZVO.FHCYT, WRZVO.QZ6VT]\n" +
+			" │               └─ Filter\n" +
+			" │                   ├─ 1 IS NULL\n" +
+			" │                   └─ LeftOuterHashJoinExcludingNulls\n" +
+			" │                       ├─ (nhmxw.id = hddvb.PRUV2)\n" +
+			" │                       ├─ LookupJoin\n" +
+			" │                       │   ├─ (((tizhk.TVNW2 = nhmxw.NOHHR) AND (tizhk.ZHITY = nhmxw.AVPYF)) AND (tizhk.IDUT2 = nhmxw.IDUT2))\n" +
+			" │                       │   ├─ Filter\n" +
+			" │                       │   │   ├─ (nhmxw.SWCQV = 0)\n" +
+			" │                       │   │   └─ TableAlias(nhmxw)\n" +
+			" │                       │   │       └─ Table\n" +
+			" │                       │   │           └─ name: WGSDC\n" +
+			" │                       │   └─ TableAlias(tizhk)\n" +
+			" │                       │       └─ IndexedTableAccess(WRZVO)\n" +
+			" │                       │           ├─ index: [WRZVO.SYPKF]\n" +
+			" │                       │           └─ keys: nhmxw.SYPKF\n" +
+			" │                       └─ HashLookup\n" +
+			" │                           ├─ left-key: (nhmxw.id)\n" +
+			" │                           ├─ right-key: (hddvb.PRUV2)\n" +
+			" │                           └─ Project\n" +
+			" │                               ├─ columns: [hddvb.PRUV2, 1]\n" +
+			" │                               └─ IndexedTableAccess(HDDVB)\n" +
+			" │                                   ├─ index: [HDDVB.PRUV2]\n" +
+			" │                                   ├─ filters: [{(NULL, ∞)}]\n" +
+			" │                                   └─ columns: [pruv2]\n" +
 			" │  ))\n" +
 			" └─ TableAlias(ism)\n" +
 			"     └─ Table\n" +
@@ -1232,15 +1237,15 @@ WHERE
 			"     │                                   │                       ├─ name: FLQLP\n" +
 			"     │                                   │                       └─ columns: [luevy]\n" +
 			"     │                                   │  ->LEA4J:0]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ NOT\n" +
-			"     │                                       │   └─ nd.ZH72S:7 IS NULL\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           ├─ colSet: (1-17)\n" +
+			"     │                                           ├─ tableId: 1\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               ├─ name: E2I7U\n" +
-			"     │                                               ├─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"     │                                               ├─ colSet: (1-17)\n" +
-			"     │                                               └─ tableId: 1\n" +
+			"     │                                               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -1309,11 +1314,10 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as LEA4J]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -1378,11 +1382,10 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as LEA4J]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -1529,51 +1532,54 @@ WHERE
 			"     │   │               ├─ alias-string: select uct.id as FDL23 from EPZU6 as I7HCR join OUBDL as uct on uct.FTQLQ = I7HCR.TOFPN and uct.ZH72S = I7HCR.SJYN2 and uct.LJLUM = I7HCR.BTXC5 where I7HCR.SWCQV = 0 and I7HCR.id not in (select OCA7E from FLQLP where OCA7E is not null)\n" +
 			"     │   │               └─ Project\n" +
 			"     │   │                   ├─ columns: [uct.id:40!null->FDL23:0]\n" +
-			"     │   │                   └─ LookupJoin\n" +
-			"     │   │                       ├─ AND\n" +
-			"     │   │                       │   ├─ Eq\n" +
-			"     │   │                       │   │   ├─ uct.ZH72S:42\n" +
-			"     │   │                       │   │   └─ i7hcr.SJYN2:34!null\n" +
-			"     │   │                       │   └─ Eq\n" +
-			"     │   │                       │       ├─ uct.LJLUM:45\n" +
-			"     │   │                       │       └─ i7hcr.BTXC5:35!null\n" +
-			"     │   │                       ├─ Project\n" +
-			"     │   │                       │   ├─ columns: [EPZU6.id:32!null, EPZU6.TOFPN:33!null, EPZU6.SJYN2:34!null, EPZU6.BTXC5:35!null, EPZU6.FVUCX:36!null, EPZU6.SWCQV:37!null, EPZU6.YKSSU:38, EPZU6.FHCYT:39]\n" +
-			"     │   │                       │   └─ Filter\n" +
-			"     │   │                       │       ├─ 1:41 IS NULL\n" +
-			"     │   │                       │       └─ LeftOuterLookupJoin\n" +
-			"     │   │                       │           ├─ Filter\n" +
-			"     │   │                       │           │   ├─ Eq\n" +
-			"     │   │                       │           │   │   ├─ i7hcr.SWCQV:37!null\n" +
-			"     │   │                       │           │   │   └─ 0 (int)\n" +
-			"     │   │                       │           │   └─ TableAlias(i7hcr)\n" +
-			"     │   │                       │           │       └─ Table\n" +
-			"     │   │                       │           │           ├─ name: EPZU6\n" +
-			"     │   │                       │           │           ├─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
-			"     │   │                       │           │           ├─ colSet: (71-78)\n" +
-			"     │   │                       │           │           └─ tableId: 8\n" +
-			"     │   │                       │           └─ Project\n" +
-			"     │   │                       │               ├─ columns: [flqlp.OCA7E:32, 1 (bigint)]\n" +
-			"     │   │                       │               └─ Filter\n" +
-			"     │   │                       │                   ├─ NOT\n" +
-			"     │   │                       │                   │   └─ flqlp.OCA7E:32 IS NULL\n" +
-			"     │   │                       │                   └─ IndexedTableAccess(FLQLP)\n" +
-			"     │   │                       │                       ├─ index: [FLQLP.OCA7E]\n" +
-			"     │   │                       │                       ├─ keys: [i7hcr.id:32!null]\n" +
-			"     │   │                       │                       ├─ colSet: (92-103)\n" +
-			"     │   │                       │                       ├─ tableId: 10\n" +
-			"     │   │                       │                       └─ Table\n" +
-			"     │   │                       │                           ├─ name: FLQLP\n" +
-			"     │   │                       │                           └─ columns: [oca7e]\n" +
-			"     │   │                       └─ TableAlias(uct)\n" +
-			"     │   │                           └─ IndexedTableAccess(OUBDL)\n" +
-			"     │   │                               ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │   │                               ├─ keys: [i7hcr.TOFPN:33!null]\n" +
-			"     │   │                               ├─ colSet: (79-91)\n" +
-			"     │   │                               ├─ tableId: 9\n" +
-			"     │   │                               └─ Table\n" +
-			"     │   │                                   ├─ name: OUBDL\n" +
-			"     │   │                                   └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
+			"     │   │                   └─ Project\n" +
+			"     │   │                       ├─ columns: [EPZU6.id:32!null, EPZU6.TOFPN:33!null, EPZU6.SJYN2:34!null, EPZU6.BTXC5:35!null, EPZU6.FVUCX:36!null, EPZU6.SWCQV:37!null, EPZU6.YKSSU:38, EPZU6.FHCYT:39, OUBDL.id:40!null, OUBDL.FTQLQ:41, OUBDL.ZH72S:42, OUBDL.SFJ6L:43, OUBDL.V5DPX:44, OUBDL.LJLUM:45, OUBDL.IDPK7:46, OUBDL.NO52D:47, OUBDL.ZRV3B:48, OUBDL.VYO5E:49, OUBDL.YKSSU:50, OUBDL.FHCYT:51, OUBDL.QZ6VT:52]\n" +
+			"     │   │                       └─ Filter\n" +
+			"     │   │                           ├─ 1:54 IS NULL\n" +
+			"     │   │                           └─ LeftOuterHashJoinExcludingNulls\n" +
+			"     │   │                               ├─ Eq\n" +
+			"     │   │                               │   ├─ i7hcr.id:32!null\n" +
+			"     │   │                               │   └─ flqlp.OCA7E:53\n" +
+			"     │   │                               ├─ LookupJoin\n" +
+			"     │   │                               │   ├─ AND\n" +
+			"     │   │                               │   │   ├─ Eq\n" +
+			"     │   │                               │   │   │   ├─ uct.ZH72S:42\n" +
+			"     │   │                               │   │   │   └─ i7hcr.SJYN2:34!null\n" +
+			"     │   │                               │   │   └─ Eq\n" +
+			"     │   │                               │   │       ├─ uct.LJLUM:45\n" +
+			"     │   │                               │   │       └─ i7hcr.BTXC5:35!null\n" +
+			"     │   │                               │   ├─ Filter\n" +
+			"     │   │                               │   │   ├─ Eq\n" +
+			"     │   │                               │   │   │   ├─ i7hcr.SWCQV:37!null\n" +
+			"     │   │                               │   │   │   └─ 0 (int)\n" +
+			"     │   │                               │   │   └─ TableAlias(i7hcr)\n" +
+			"     │   │                               │   │       └─ Table\n" +
+			"     │   │                               │   │           ├─ name: EPZU6\n" +
+			"     │   │                               │   │           ├─ columns: [id tofpn sjyn2 btxc5 fvucx swcqv ykssu fhcyt]\n" +
+			"     │   │                               │   │           ├─ colSet: (71-78)\n" +
+			"     │   │                               │   │           └─ tableId: 8\n" +
+			"     │   │                               │   └─ TableAlias(uct)\n" +
+			"     │   │                               │       └─ IndexedTableAccess(OUBDL)\n" +
+			"     │   │                               │           ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │   │                               │           ├─ keys: [i7hcr.TOFPN:33!null]\n" +
+			"     │   │                               │           ├─ colSet: (79-91)\n" +
+			"     │   │                               │           ├─ tableId: 9\n" +
+			"     │   │                               │           └─ Table\n" +
+			"     │   │                               │               ├─ name: OUBDL\n" +
+			"     │   │                               │               └─ columns: [id ftqlq zh72s sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e ykssu fhcyt qz6vt]\n" +
+			"     │   │                               └─ HashLookup\n" +
+			"     │   │                                   ├─ left-key: TUPLE(i7hcr.id:32!null)\n" +
+			"     │   │                                   ├─ right-key: TUPLE(flqlp.OCA7E:32)\n" +
+			"     │   │                                   └─ Project\n" +
+			"     │   │                                       ├─ columns: [flqlp.OCA7E:32, 1 (bigint)]\n" +
+			"     │   │                                       └─ IndexedTableAccess(FLQLP)\n" +
+			"     │   │                                           ├─ index: [FLQLP.OCA7E]\n" +
+			"     │   │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			"     │   │                                           ├─ colSet: (92-103)\n" +
+			"     │   │                                           ├─ tableId: 10\n" +
+			"     │   │                                           └─ Table\n" +
+			"     │   │                                               ├─ name: FLQLP\n" +
+			"     │   │                                               └─ columns: [oca7e]\n" +
 			"     │   ├─ MergeJoin\n" +
 			"     │   │   ├─ cmp: Eq\n" +
 			"     │   │   │   ├─ ct.LUEVY:2!null\n" +
@@ -1625,30 +1631,32 @@ WHERE
 			"     │   │       ├─ cacheable: true\n" +
 			"     │   │       └─ Project\n" +
 			"     │   │           ├─ columns: [uct.id as FDL23]\n" +
-			"     │   │           └─ LookupJoin\n" +
-			"     │   │               ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
-			"     │   │               ├─ Project\n" +
-			"     │   │               │   ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT]\n" +
-			"     │   │               │   └─ Filter\n" +
-			"     │   │               │       ├─ 1 IS NULL\n" +
-			"     │   │               │       └─ LeftOuterLookupJoin\n" +
-			"     │   │               │           ├─ Filter\n" +
-			"     │   │               │           │   ├─ (i7hcr.SWCQV = 0)\n" +
-			"     │   │               │           │   └─ TableAlias(i7hcr)\n" +
-			"     │   │               │           │       └─ Table\n" +
-			"     │   │               │           │           └─ name: EPZU6\n" +
-			"     │   │               │           └─ Project\n" +
-			"     │   │               │               ├─ columns: [flqlp.OCA7E, 1]\n" +
-			"     │   │               │               └─ Filter\n" +
-			"     │   │               │                   ├─ (NOT(flqlp.OCA7E IS NULL))\n" +
-			"     │   │               │                   └─ IndexedTableAccess(FLQLP)\n" +
-			"     │   │               │                       ├─ index: [FLQLP.OCA7E]\n" +
-			"     │   │               │                       ├─ columns: [oca7e]\n" +
-			"     │   │               │                       └─ keys: i7hcr.id\n" +
-			"     │   │               └─ TableAlias(uct)\n" +
-			"     │   │                   └─ IndexedTableAccess(OUBDL)\n" +
-			"     │   │                       ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │   │                       └─ keys: i7hcr.TOFPN\n" +
+			"     │   │           └─ Project\n" +
+			"     │   │               ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT, OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.SFJ6L, OUBDL.V5DPX, OUBDL.LJLUM, OUBDL.IDPK7, OUBDL.NO52D, OUBDL.ZRV3B, OUBDL.VYO5E, OUBDL.YKSSU, OUBDL.FHCYT, OUBDL.QZ6VT]\n" +
+			"     │   │               └─ Filter\n" +
+			"     │   │                   ├─ 1 IS NULL\n" +
+			"     │   │                   └─ LeftOuterHashJoinExcludingNulls\n" +
+			"     │   │                       ├─ (i7hcr.id = flqlp.OCA7E)\n" +
+			"     │   │                       ├─ LookupJoin\n" +
+			"     │   │                       │   ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
+			"     │   │                       │   ├─ Filter\n" +
+			"     │   │                       │   │   ├─ (i7hcr.SWCQV = 0)\n" +
+			"     │   │                       │   │   └─ TableAlias(i7hcr)\n" +
+			"     │   │                       │   │       └─ Table\n" +
+			"     │   │                       │   │           └─ name: EPZU6\n" +
+			"     │   │                       │   └─ TableAlias(uct)\n" +
+			"     │   │                       │       └─ IndexedTableAccess(OUBDL)\n" +
+			"     │   │                       │           ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │   │                       │           └─ keys: i7hcr.TOFPN\n" +
+			"     │   │                       └─ HashLookup\n" +
+			"     │   │                           ├─ left-key: (i7hcr.id)\n" +
+			"     │   │                           ├─ right-key: (flqlp.OCA7E)\n" +
+			"     │   │                           └─ Project\n" +
+			"     │   │                               ├─ columns: [flqlp.OCA7E, 1]\n" +
+			"     │   │                               └─ IndexedTableAccess(FLQLP)\n" +
+			"     │   │                                   ├─ index: [FLQLP.OCA7E]\n" +
+			"     │   │                                   ├─ filters: [{(NULL, ∞)}]\n" +
+			"     │   │                                   └─ columns: [oca7e]\n" +
 			"     │   │  ))\n" +
 			"     │   ├─ MergeJoin (estimated cost=18957.040 rows=14781)\n" +
 			"     │   │   ├─ cmp: (ct.LUEVY = nd.id)\n" +
@@ -1682,30 +1690,32 @@ WHERE
 			"     │   │       ├─ cacheable: true\n" +
 			"     │   │       └─ Project\n" +
 			"     │   │           ├─ columns: [uct.id as FDL23]\n" +
-			"     │   │           └─ LookupJoin\n" +
-			"     │   │               ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
-			"     │   │               ├─ Project\n" +
-			"     │   │               │   ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT]\n" +
-			"     │   │               │   └─ Filter\n" +
-			"     │   │               │       ├─ 1 IS NULL\n" +
-			"     │   │               │       └─ LeftOuterLookupJoin\n" +
-			"     │   │               │           ├─ Filter\n" +
-			"     │   │               │           │   ├─ (i7hcr.SWCQV = 0)\n" +
-			"     │   │               │           │   └─ TableAlias(i7hcr)\n" +
-			"     │   │               │           │       └─ Table\n" +
-			"     │   │               │           │           └─ name: EPZU6\n" +
-			"     │   │               │           └─ Project\n" +
-			"     │   │               │               ├─ columns: [flqlp.OCA7E, 1]\n" +
-			"     │   │               │               └─ Filter\n" +
-			"     │   │               │                   ├─ (NOT(flqlp.OCA7E IS NULL))\n" +
-			"     │   │               │                   └─ IndexedTableAccess(FLQLP)\n" +
-			"     │   │               │                       ├─ index: [FLQLP.OCA7E]\n" +
-			"     │   │               │                       ├─ columns: [oca7e]\n" +
-			"     │   │               │                       └─ keys: i7hcr.id\n" +
-			"     │   │               └─ TableAlias(uct)\n" +
-			"     │   │                   └─ IndexedTableAccess(OUBDL)\n" +
-			"     │   │                       ├─ index: [OUBDL.FTQLQ]\n" +
-			"     │   │                       └─ keys: i7hcr.TOFPN\n" +
+			"     │   │           └─ Project\n" +
+			"     │   │               ├─ columns: [EPZU6.id, EPZU6.TOFPN, EPZU6.SJYN2, EPZU6.BTXC5, EPZU6.FVUCX, EPZU6.SWCQV, EPZU6.YKSSU, EPZU6.FHCYT, OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.SFJ6L, OUBDL.V5DPX, OUBDL.LJLUM, OUBDL.IDPK7, OUBDL.NO52D, OUBDL.ZRV3B, OUBDL.VYO5E, OUBDL.YKSSU, OUBDL.FHCYT, OUBDL.QZ6VT]\n" +
+			"     │   │               └─ Filter\n" +
+			"     │   │                   ├─ 1 IS NULL\n" +
+			"     │   │                   └─ LeftOuterHashJoinExcludingNulls\n" +
+			"     │   │                       ├─ (i7hcr.id = flqlp.OCA7E)\n" +
+			"     │   │                       ├─ LookupJoin\n" +
+			"     │   │                       │   ├─ ((uct.ZH72S = i7hcr.SJYN2) AND (uct.LJLUM = i7hcr.BTXC5))\n" +
+			"     │   │                       │   ├─ Filter\n" +
+			"     │   │                       │   │   ├─ (i7hcr.SWCQV = 0)\n" +
+			"     │   │                       │   │   └─ TableAlias(i7hcr)\n" +
+			"     │   │                       │   │       └─ Table\n" +
+			"     │   │                       │   │           └─ name: EPZU6\n" +
+			"     │   │                       │   └─ TableAlias(uct)\n" +
+			"     │   │                       │       └─ IndexedTableAccess(OUBDL)\n" +
+			"     │   │                       │           ├─ index: [OUBDL.FTQLQ]\n" +
+			"     │   │                       │           └─ keys: i7hcr.TOFPN\n" +
+			"     │   │                       └─ HashLookup\n" +
+			"     │   │                           ├─ left-key: (i7hcr.id)\n" +
+			"     │   │                           ├─ right-key: (flqlp.OCA7E)\n" +
+			"     │   │                           └─ Project\n" +
+			"     │   │                               ├─ columns: [flqlp.OCA7E, 1]\n" +
+			"     │   │                               └─ IndexedTableAccess(FLQLP)\n" +
+			"     │   │                                   ├─ index: [FLQLP.OCA7E]\n" +
+			"     │   │                                   ├─ filters: [{(NULL, ∞)}]\n" +
+			"     │   │                                   └─ columns: [oca7e]\n" +
 			"     │   │  ))\n" +
 			"     │   ├─ MergeJoin (estimated cost=18957.040 rows=14781) (actual rows=0 loops=1)\n" +
 			"     │   │   ├─ cmp: (ct.LUEVY = nd.id)\n" +
@@ -1783,7 +1793,10 @@ WHERE
 			"     │               │   │   ├─ columns: [OUBDL.id:1!null, OUBDL.FTQLQ:2, OUBDL.ZH72S:3, OUBDL.LJLUM:4, E2I7U.ZH72S:0]\n" +
 			"     │               │   │   └─ Filter\n" +
 			"     │               │   │       ├─ 1:6 IS NULL\n" +
-			"     │               │   │       └─ LeftOuterLookupJoin\n" +
+			"     │               │   │       └─ LeftOuterHashJoinExcludingNulls\n" +
+			"     │               │   │           ├─ Eq\n" +
+			"     │               │   │           │   ├─ ylksy.id:1!null\n" +
+			"     │               │   │           │   └─ flqlp.NRURT:5\n" +
 			"     │               │   │           ├─ LookupJoin\n" +
 			"     │               │   │           │   ├─ TableAlias(nd)\n" +
 			"     │               │   │           │   │   └─ Table\n" +
@@ -1803,14 +1816,14 @@ WHERE
 			"     │               │   │           │               └─ Table\n" +
 			"     │               │   │           │                   ├─ name: OUBDL\n" +
 			"     │               │   │           │                   └─ columns: [id ftqlq zh72s ljlum]\n" +
-			"     │               │   │           └─ Project\n" +
-			"     │               │   │               ├─ columns: [flqlp.NRURT:0, 1 (bigint)]\n" +
-			"     │               │   │               └─ Filter\n" +
-			"     │               │   │                   ├─ NOT\n" +
-			"     │               │   │                   │   └─ flqlp.NRURT:0 IS NULL\n" +
+			"     │               │   │           └─ HashLookup\n" +
+			"     │               │   │               ├─ left-key: TUPLE(ylksy.id:1!null)\n" +
+			"     │               │   │               ├─ right-key: TUPLE(flqlp.NRURT:0)\n" +
+			"     │               │   │               └─ Project\n" +
+			"     │               │   │                   ├─ columns: [flqlp.NRURT:0, 1 (bigint)]\n" +
 			"     │               │   │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │   │                       ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │   │                       ├─ keys: [ylksy.id:1!null]\n" +
+			"     │               │   │                       ├─ static: [{(NULL, ∞)}]\n" +
 			"     │               │   │                       ├─ colSet: (39-50)\n" +
 			"     │               │   │                       ├─ tableId: 5\n" +
 			"     │               │   │                       └─ Table\n" +
@@ -1864,7 +1877,8 @@ WHERE
 			"     │               │   │   ├─ columns: [OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.LJLUM, E2I7U.ZH72S]\n" +
 			"     │               │   │   └─ Filter\n" +
 			"     │               │   │       ├─ 1 IS NULL\n" +
-			"     │               │   │       └─ LeftOuterLookupJoin (estimated cost=18627.300 rows=6002)\n" +
+			"     │               │   │       └─ LeftOuterHashJoinExcludingNulls (estimated cost=381887.820 rows=35486780)\n" +
+			"     │               │   │           ├─ (ylksy.id = flqlp.NRURT)\n" +
 			"     │               │   │           ├─ LookupJoin (estimated cost=14907.300 rows=4802)\n" +
 			"     │               │   │           │   ├─ TableAlias(nd)\n" +
 			"     │               │   │           │   │   └─ Table\n" +
@@ -1877,14 +1891,15 @@ WHERE
 			"     │               │   │           │               ├─ index: [OUBDL.ZH72S]\n" +
 			"     │               │   │           │               ├─ columns: [id ftqlq zh72s ljlum]\n" +
 			"     │               │   │           │               └─ keys: nd.ZH72S\n" +
-			"     │               │   │           └─ Project\n" +
-			"     │               │   │               ├─ columns: [flqlp.NRURT, 1]\n" +
-			"     │               │   │               └─ Filter\n" +
-			"     │               │   │                   ├─ (NOT(flqlp.NRURT IS NULL))\n" +
+			"     │               │   │           └─ HashLookup\n" +
+			"     │               │   │               ├─ left-key: (ylksy.id)\n" +
+			"     │               │   │               ├─ right-key: (flqlp.NRURT)\n" +
+			"     │               │   │               └─ Project\n" +
+			"     │               │   │                   ├─ columns: [flqlp.NRURT, 1]\n" +
 			"     │               │   │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │   │                       ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │   │                       ├─ columns: [nrurt]\n" +
-			"     │               │   │                       └─ keys: ylksy.id\n" +
+			"     │               │   │                       ├─ filters: [{(NULL, ∞)}]\n" +
+			"     │               │   │                       └─ columns: [nrurt]\n" +
 			"     │               │   └─ TableAlias(aac)\n" +
 			"     │               │       └─ IndexedTableAccess(TPXBU)\n" +
 			"     │               │           ├─ index: [TPXBU.BTXC5]\n" +
@@ -1923,7 +1938,8 @@ WHERE
 			"     │               │   │   ├─ columns: [OUBDL.id, OUBDL.FTQLQ, OUBDL.ZH72S, OUBDL.LJLUM, E2I7U.ZH72S]\n" +
 			"     │               │   │   └─ Filter\n" +
 			"     │               │   │       ├─ 1 IS NULL\n" +
-			"     │               │   │       └─ LeftOuterLookupJoin (estimated cost=18627.300 rows=6002) (actual rows=0 loops=1)\n" +
+			"     │               │   │       └─ LeftOuterHashJoinExcludingNulls (estimated cost=381887.820 rows=35486780) (actual rows=0 loops=1)\n" +
+			"     │               │   │           ├─ (ylksy.id = flqlp.NRURT)\n" +
 			"     │               │   │           ├─ LookupJoin (estimated cost=14907.300 rows=4802) (actual rows=0 loops=1)\n" +
 			"     │               │   │           │   ├─ TableAlias(nd)\n" +
 			"     │               │   │           │   │   └─ Table\n" +
@@ -1936,14 +1952,15 @@ WHERE
 			"     │               │   │           │               ├─ index: [OUBDL.ZH72S]\n" +
 			"     │               │   │           │               ├─ columns: [id ftqlq zh72s ljlum]\n" +
 			"     │               │   │           │               └─ keys: nd.ZH72S\n" +
-			"     │               │   │           └─ Project\n" +
-			"     │               │   │               ├─ columns: [flqlp.NRURT, 1]\n" +
-			"     │               │   │               └─ Filter\n" +
-			"     │               │   │                   ├─ (NOT(flqlp.NRURT IS NULL))\n" +
+			"     │               │   │           └─ HashLookup\n" +
+			"     │               │   │               ├─ left-key: (ylksy.id)\n" +
+			"     │               │   │               ├─ right-key: (flqlp.NRURT)\n" +
+			"     │               │   │               └─ Project\n" +
+			"     │               │   │                   ├─ columns: [flqlp.NRURT, 1]\n" +
 			"     │               │   │                   └─ IndexedTableAccess(FLQLP)\n" +
 			"     │               │   │                       ├─ index: [FLQLP.NRURT]\n" +
-			"     │               │   │                       ├─ columns: [nrurt]\n" +
-			"     │               │   │                       └─ keys: ylksy.id\n" +
+			"     │               │   │                       ├─ filters: [{(NULL, ∞)}]\n" +
+			"     │               │   │                       └─ columns: [nrurt]\n" +
 			"     │               │   └─ TableAlias(aac)\n" +
 			"     │               │       └─ IndexedTableAccess(TPXBU)\n" +
 			"     │               │           ├─ index: [TPXBU.BTXC5]\n" +
@@ -2162,12 +2179,19 @@ WHERE
 			" ├─ columns: [HU5A5.id:0!null, HU5A5.TOFPN:1!null, HU5A5.I3VTA:2!null, HU5A5.SFJ6L:3, HU5A5.V5DPX:4!null, HU5A5.LJLUM:5!null, HU5A5.IDPK7:6!null, HU5A5.NO52D:7!null, HU5A5.ZRV3B:8!null, HU5A5.VYO5E:9, HU5A5.SWCQV:10!null, HU5A5.YKSSU:11, HU5A5.FHCYT:12]\n" +
 			" └─ Filter\n" +
 			"     ├─ 1:14 IS NULL\n" +
-			"     └─ LeftOuterLookupJoin\n" +
+			"     └─ LeftOuterMergeJoin\n" +
+			"         ├─ cmp: Eq\n" +
+			"         │   ├─ hu5a5.id:0!null\n" +
+			"         │   └─ flqlp.XMM6Q:13\n" +
 			"         ├─ Filter\n" +
 			"         │   ├─ Eq\n" +
 			"         │   │   ├─ hu5a5.SWCQV:10!null\n" +
 			"         │   │   └─ 0 (int)\n" +
-			"         │   └─ ProcessTable\n" +
+			"         │   └─ IndexedTableAccess(HU5A5)\n" +
+			"         │       ├─ index: [HU5A5.id]\n" +
+			"         │       ├─ static: [{[NULL, ∞)}]\n" +
+			"         │       ├─ colSet: (1-13)\n" +
+			"         │       ├─ tableId: 1\n" +
 			"         │       └─ Table\n" +
 			"         │           ├─ name: HU5A5\n" +
 			"         │           └─ columns: [id tofpn i3vta sfj6l v5dpx ljlum idpk7 no52d zrv3b vyo5e swcqv ykssu fhcyt]\n" +
@@ -2180,7 +2204,7 @@ WHERE
 			"                     │   └─ flqlp.XMM6Q:7 IS NULL\n" +
 			"                     └─ IndexedTableAccess(FLQLP)\n" +
 			"                         ├─ index: [FLQLP.XMM6Q]\n" +
-			"                         ├─ keys: [hu5a5.id:0!null]\n" +
+			"                         ├─ static: [{[NULL, ∞)}]\n" +
 			"                         ├─ colSet: (14-25)\n" +
 			"                         ├─ tableId: 2\n" +
 			"                         └─ Table\n" +
@@ -2191,11 +2215,13 @@ WHERE
 			" ├─ columns: [HU5A5.id, HU5A5.TOFPN, HU5A5.I3VTA, HU5A5.SFJ6L, HU5A5.V5DPX, HU5A5.LJLUM, HU5A5.IDPK7, HU5A5.NO52D, HU5A5.ZRV3B, HU5A5.VYO5E, HU5A5.SWCQV, HU5A5.YKSSU, HU5A5.FHCYT]\n" +
 			" └─ Filter\n" +
 			"     ├─ 1 IS NULL\n" +
-			"     └─ LeftOuterLookupJoin (estimated cost=126.900 rows=34)\n" +
+			"     └─ LeftOuterMergeJoin (estimated cost=9561.410 rows=206920)\n" +
+			"         ├─ cmp: (hu5a5.id = flqlp.XMM6Q)\n" +
 			"         ├─ Filter\n" +
 			"         │   ├─ (hu5a5.SWCQV = 0)\n" +
-			"         │   └─ Table\n" +
-			"         │       └─ name: HU5A5\n" +
+			"         │   └─ IndexedTableAccess(HU5A5)\n" +
+			"         │       ├─ index: [HU5A5.id]\n" +
+			"         │       └─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [flqlp.XMM6Q, 1]\n" +
 			"             └─ Project\n" +
@@ -2204,17 +2230,19 @@ WHERE
 			"                     ├─ (NOT(flqlp.XMM6Q IS NULL))\n" +
 			"                     └─ IndexedTableAccess(FLQLP)\n" +
 			"                         ├─ index: [FLQLP.XMM6Q]\n" +
-			"                         └─ keys: hu5a5.id\n" +
+			"                         └─ filters: [{[NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [HU5A5.id, HU5A5.TOFPN, HU5A5.I3VTA, HU5A5.SFJ6L, HU5A5.V5DPX, HU5A5.LJLUM, HU5A5.IDPK7, HU5A5.NO52D, HU5A5.ZRV3B, HU5A5.VYO5E, HU5A5.SWCQV, HU5A5.YKSSU, HU5A5.FHCYT]\n" +
 			" └─ Filter\n" +
 			"     ├─ 1 IS NULL\n" +
-			"     └─ LeftOuterLookupJoin (estimated cost=126.900 rows=34) (actual rows=0 loops=1)\n" +
+			"     └─ LeftOuterMergeJoin (estimated cost=9561.410 rows=206920) (actual rows=0 loops=1)\n" +
+			"         ├─ cmp: (hu5a5.id = flqlp.XMM6Q)\n" +
 			"         ├─ Filter\n" +
 			"         │   ├─ (hu5a5.SWCQV = 0)\n" +
-			"         │   └─ Table\n" +
-			"         │       └─ name: HU5A5\n" +
+			"         │   └─ IndexedTableAccess(HU5A5)\n" +
+			"         │       ├─ index: [HU5A5.id]\n" +
+			"         │       └─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ Project\n" +
 			"             ├─ columns: [flqlp.XMM6Q, 1]\n" +
 			"             └─ Project\n" +
@@ -2223,7 +2251,7 @@ WHERE
 			"                     ├─ (NOT(flqlp.XMM6Q IS NULL))\n" +
 			"                     └─ IndexedTableAccess(FLQLP)\n" +
 			"                         ├─ index: [FLQLP.XMM6Q]\n" +
-			"                         └─ keys: hu5a5.id\n" +
+			"                         └─ filters: [{[NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -3118,15 +3146,15 @@ WHERE
 			"     │                                   │                       ├─ name: AMYXQ\n" +
 			"     │                                   │                       └─ columns: [luevy]\n" +
 			"     │                                   │  ->TJ66D:0]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ NOT\n" +
-			"     │                                       │   └─ nd.ZH72S:7 IS NULL\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           ├─ static: [{(NULL, ∞)}]\n" +
+			"     │                                           ├─ colSet: (1-17)\n" +
+			"     │                                           ├─ tableId: 1\n" +
 			"     │                                           └─ Table\n" +
 			"     │                                               ├─ name: E2I7U\n" +
-			"     │                                               ├─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"     │                                               ├─ colSet: (1-17)\n" +
-			"     │                                               └─ tableId: 1\n" +
+			"     │                                               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -3195,11 +3223,10 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as TJ66D]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -3264,11 +3291,10 @@ WHERE
 			"     │                                   │                   ├─ columns: [luevy]\n" +
 			"     │                                   │                   └─ keys: nd.id\n" +
 			"     │                                   │   as TJ66D]\n" +
-			"     │                                   └─ Filter\n" +
-			"     │                                       ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"     │                                       └─ TableAlias(nd)\n" +
-			"     │                                           └─ Table\n" +
-			"     │                                               └─ name: E2I7U\n" +
+			"     │                                   └─ TableAlias(nd)\n" +
+			"     │                                       └─ IndexedTableAccess(E2I7U)\n" +
+			"     │                                           ├─ index: [E2I7U.ZH72S]\n" +
+			"     │                                           └─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ TableAlias(pbmrx)\n" +
 			"         └─ IndexedTableAccess(E2I7U)\n" +
 			"             ├─ index: [E2I7U.ZH72S]\n" +
@@ -3300,119 +3326,137 @@ WHERE
 			"     ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ cla.FTQLQ:29!null\n" +
-			"         │   └─ ufc.T4IBQ:1\n" +
-			"         ├─ Project\n" +
-			"         │   ├─ columns: [SISUT.id:17!null, SISUT.T4IBQ:18, SISUT.ZH72S:19, SISUT.AMYXQ:20, SISUT.KTNZ2:21, SISUT.HIID2:22, SISUT.DN3OQ:23, SISUT.VVKNB:24, SISUT.SH7TP:25, SISUT.SRZZO:26, SISUT.QZ6VT:27, E2I7U.id:0!null, E2I7U.DKCAJ:1!null, E2I7U.KNG7T:2, E2I7U.TW55N:3!null, E2I7U.QRQXW:4!null, E2I7U.ECXAJ:5!null, E2I7U.FGG57:6, E2I7U.ZH72S:7, E2I7U.FSK67:8!null, E2I7U.XQDYT:9!null, E2I7U.TCE7A:10, E2I7U.IWV2H:11, E2I7U.HPCMS:12!null, E2I7U.N5CC2:13, E2I7U.FHCYT:14, E2I7U.ETAQ7:15, E2I7U.A75X7:16]\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ 1:29 IS NULL\n" +
-			"         │       └─ LeftOuterLookupJoin\n" +
-			"         │           ├─ LookupJoin\n" +
-			"         │           │   ├─ Filter\n" +
-			"         │           │   │   ├─ NOT\n" +
-			"         │           │   │   │   └─ nd.ZH72S:7 IS NULL\n" +
-			"         │           │   │   └─ TableAlias(nd)\n" +
-			"         │           │   │       └─ ProcessTable\n" +
-			"         │           │   │           └─ Table\n" +
-			"         │           │   │               ├─ name: E2I7U\n" +
-			"         │           │   │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"         │           │   └─ TableAlias(ufc)\n" +
-			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │           │           ├─ keys: [nd.ZH72S:7]\n" +
-			"         │           │           ├─ colSet: (1-11)\n" +
-			"         │           │           ├─ tableId: 1\n" +
-			"         │           │           └─ Table\n" +
-			"         │           │               ├─ name: SISUT\n" +
-			"         │           │               └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
-			"         │           └─ Project\n" +
-			"         │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
-			"         │               └─ Project\n" +
-			"         │                   ├─ columns: [amyxq.KKGN5:7]\n" +
-			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │                       ├─ keys: [ufc.id:17!null]\n" +
-			"         │                       ├─ colSet: (59-66)\n" +
-			"         │                       ├─ tableId: 4\n" +
-			"         │                       └─ Table\n" +
-			"         │                           ├─ name: AMYXQ\n" +
-			"         │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
+			"         │   ├─ nd.ZH72S:48\n" +
+			"         │   └─ ufc.ZH72S:2\n" +
+			"         ├─ HashJoin\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ cla.FTQLQ:12!null\n" +
+			"         │   │   └─ ufc.T4IBQ:1\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [SISUT.id:0!null, SISUT.T4IBQ:1, SISUT.ZH72S:2, SISUT.AMYXQ:3, SISUT.KTNZ2:4, SISUT.HIID2:5, SISUT.DN3OQ:6, SISUT.VVKNB:7, SISUT.SH7TP:8, SISUT.SRZZO:9, SISUT.QZ6VT:10]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ 1:12 IS NULL\n" +
+			"         │   │       └─ LeftOuterMergeJoin\n" +
+			"         │   │           ├─ cmp: Eq\n" +
+			"         │   │           │   ├─ ufc.id:0!null\n" +
+			"         │   │           │   └─ amyxq.KKGN5:11\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           │       ├─ index: [SISUT.id]\n" +
+			"         │   │           │       ├─ static: [{[NULL, ∞)}]\n" +
+			"         │   │           │       ├─ colSet: (1-11)\n" +
+			"         │   │           │       ├─ tableId: 1\n" +
+			"         │   │           │       └─ Table\n" +
+			"         │   │           │           ├─ name: SISUT\n" +
+			"         │   │           │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
+			"         │   │           └─ Project\n" +
+			"         │   │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [amyxq.KKGN5:7]\n" +
+			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │   │                       ├─ static: [{[NULL, ∞)}]\n" +
+			"         │   │                       ├─ colSet: (59-66)\n" +
+			"         │   │                       ├─ tableId: 4\n" +
+			"         │   │                       └─ Table\n" +
+			"         │   │                           ├─ name: AMYXQ\n" +
+			"         │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
+			"         │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ ProcessTable\n" +
+			"         │               └─ Table\n" +
+			"         │                   ├─ name: YK2GW\n" +
+			"         │                   └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
-			"             ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ ProcessTable\n" +
+			"             ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
+			"             ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     ├─ index: [E2I7U.ZH72S]\n" +
+			"                     ├─ static: [{(NULL, ∞)}]\n" +
+			"                     ├─ colSet: (12-28)\n" +
+			"                     ├─ tableId: 2\n" +
 			"                     └─ Table\n" +
-			"                         ├─ name: YK2GW\n" +
-			"                         └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"                         ├─ name: E2I7U\n" +
+			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 		ExpectedEstimates: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=11656.620 rows=4081)\n" +
-			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         ├─ Project\n" +
-			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ 1 IS NULL\n" +
-			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101)\n" +
-			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081)\n" +
-			"         │           │   ├─ Filter\n" +
-			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"         │           │   │   └─ TableAlias(nd)\n" +
-			"         │           │   │       └─ Table\n" +
-			"         │           │   │           └─ name: E2I7U\n" +
-			"         │           │   └─ TableAlias(ufc)\n" +
-			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │           │           └─ keys: nd.ZH72S\n" +
-			"         │           └─ Project\n" +
-			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │               └─ Project\n" +
-			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │                       └─ keys: ufc.id\n" +
+			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260)\n" +
+			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
+			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060)\n" +
+			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ 1 IS NULL\n" +
+			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130)\n" +
+			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           │       ├─ index: [SISUT.id]\n" +
+			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   │           └─ Project\n" +
+			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
+			"         │       ├─ right-key: (cla.FTQLQ)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ Table\n" +
+			"         │               └─ name: YK2GW\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.T4IBQ)\n" +
-			"             ├─ right-key: (cla.FTQLQ)\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: YK2GW\n" +
+			"             ├─ left-key: (ufc.ZH72S)\n" +
+			"             ├─ right-key: (nd.ZH72S)\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     ├─ index: [E2I7U.ZH72S]\n" +
+			"                     └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=11656.620 rows=4081) (actual rows=0 loops=1)\n" +
-			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         ├─ Project\n" +
-			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ 1 IS NULL\n" +
-			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101) (actual rows=0 loops=1)\n" +
-			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081) (actual rows=0 loops=1)\n" +
-			"         │           │   ├─ Filter\n" +
-			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"         │           │   │   └─ TableAlias(nd)\n" +
-			"         │           │   │       └─ Table\n" +
-			"         │           │   │           └─ name: E2I7U\n" +
-			"         │           │   └─ TableAlias(ufc)\n" +
-			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │           │           └─ keys: nd.ZH72S\n" +
-			"         │           └─ Project\n" +
-			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │               └─ Project\n" +
-			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │                       └─ keys: ufc.id\n" +
+			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260) (actual rows=0 loops=1)\n" +
+			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
+			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060) (actual rows=0 loops=1)\n" +
+			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ 1 IS NULL\n" +
+			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130) (actual rows=0 loops=1)\n" +
+			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           │       ├─ index: [SISUT.id]\n" +
+			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   │           └─ Project\n" +
+			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
+			"         │       ├─ right-key: (cla.FTQLQ)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ Table\n" +
+			"         │               └─ name: YK2GW\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.T4IBQ)\n" +
-			"             ├─ right-key: (cla.FTQLQ)\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: YK2GW\n" +
+			"             ├─ left-key: (ufc.ZH72S)\n" +
+			"             ├─ right-key: (nd.ZH72S)\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     ├─ index: [E2I7U.ZH72S]\n" +
+			"                     └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -3439,119 +3483,137 @@ WHERE
 			"     ├─ columns: [ufc.id:0!null, ufc.T4IBQ:1, ufc.ZH72S:2, ufc.AMYXQ:3, ufc.KTNZ2:4, ufc.HIID2:5, ufc.DN3OQ:6, ufc.VVKNB:7, ufc.SH7TP:8, ufc.SRZZO:9, ufc.QZ6VT:10]\n" +
 			"     └─ HashJoin\n" +
 			"         ├─ Eq\n" +
-			"         │   ├─ cla.FTQLQ:29!null\n" +
-			"         │   └─ ufc.T4IBQ:1\n" +
-			"         ├─ Project\n" +
-			"         │   ├─ columns: [SISUT.id:17!null, SISUT.T4IBQ:18, SISUT.ZH72S:19, SISUT.AMYXQ:20, SISUT.KTNZ2:21, SISUT.HIID2:22, SISUT.DN3OQ:23, SISUT.VVKNB:24, SISUT.SH7TP:25, SISUT.SRZZO:26, SISUT.QZ6VT:27, E2I7U.id:0!null, E2I7U.DKCAJ:1!null, E2I7U.KNG7T:2, E2I7U.TW55N:3!null, E2I7U.QRQXW:4!null, E2I7U.ECXAJ:5!null, E2I7U.FGG57:6, E2I7U.ZH72S:7, E2I7U.FSK67:8!null, E2I7U.XQDYT:9!null, E2I7U.TCE7A:10, E2I7U.IWV2H:11, E2I7U.HPCMS:12!null, E2I7U.N5CC2:13, E2I7U.FHCYT:14, E2I7U.ETAQ7:15, E2I7U.A75X7:16]\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ 1:29 IS NULL\n" +
-			"         │       └─ LeftOuterLookupJoin\n" +
-			"         │           ├─ LookupJoin\n" +
-			"         │           │   ├─ Filter\n" +
-			"         │           │   │   ├─ NOT\n" +
-			"         │           │   │   │   └─ nd.ZH72S:7 IS NULL\n" +
-			"         │           │   │   └─ TableAlias(nd)\n" +
-			"         │           │   │       └─ ProcessTable\n" +
-			"         │           │   │           └─ Table\n" +
-			"         │           │   │               ├─ name: E2I7U\n" +
-			"         │           │   │               └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
-			"         │           │   └─ TableAlias(ufc)\n" +
-			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │           │           ├─ keys: [nd.ZH72S:7]\n" +
-			"         │           │           ├─ colSet: (1-11)\n" +
-			"         │           │           ├─ tableId: 1\n" +
-			"         │           │           └─ Table\n" +
-			"         │           │               ├─ name: SISUT\n" +
-			"         │           │               └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
-			"         │           └─ Project\n" +
-			"         │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
-			"         │               └─ Project\n" +
-			"         │                   ├─ columns: [amyxq.KKGN5:7]\n" +
-			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │                       ├─ keys: [ufc.id:17!null]\n" +
-			"         │                       ├─ colSet: (59-66)\n" +
-			"         │                       ├─ tableId: 4\n" +
-			"         │                       └─ Table\n" +
-			"         │                           ├─ name: AMYXQ\n" +
-			"         │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
+			"         │   ├─ nd.ZH72S:48\n" +
+			"         │   └─ ufc.ZH72S:2\n" +
+			"         ├─ HashJoin\n" +
+			"         │   ├─ Eq\n" +
+			"         │   │   ├─ cla.FTQLQ:12!null\n" +
+			"         │   │   └─ ufc.T4IBQ:1\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [SISUT.id:0!null, SISUT.T4IBQ:1, SISUT.ZH72S:2, SISUT.AMYXQ:3, SISUT.KTNZ2:4, SISUT.HIID2:5, SISUT.DN3OQ:6, SISUT.VVKNB:7, SISUT.SH7TP:8, SISUT.SRZZO:9, SISUT.QZ6VT:10]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ 1:12 IS NULL\n" +
+			"         │   │       └─ LeftOuterMergeJoin\n" +
+			"         │   │           ├─ cmp: Eq\n" +
+			"         │   │           │   ├─ ufc.id:0!null\n" +
+			"         │   │           │   └─ amyxq.KKGN5:11\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           │       ├─ index: [SISUT.id]\n" +
+			"         │   │           │       ├─ static: [{[NULL, ∞)}]\n" +
+			"         │   │           │       ├─ colSet: (1-11)\n" +
+			"         │   │           │       ├─ tableId: 1\n" +
+			"         │   │           │       └─ Table\n" +
+			"         │   │           │           ├─ name: SISUT\n" +
+			"         │   │           │           └─ columns: [id t4ibq zh72s amyxq ktnz2 hiid2 dn3oq vvknb sh7tp srzzo qz6vt]\n" +
+			"         │   │           └─ Project\n" +
+			"         │   │               ├─ columns: [amyxq.KKGN5:0, 1 (bigint)]\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [amyxq.KKGN5:7]\n" +
+			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │   │                       ├─ static: [{[NULL, ∞)}]\n" +
+			"         │   │                       ├─ colSet: (59-66)\n" +
+			"         │   │                       ├─ tableId: 4\n" +
+			"         │   │                       └─ Table\n" +
+			"         │   │                           ├─ name: AMYXQ\n" +
+			"         │   │                           └─ columns: [id gxlub luevy xqdyt amyxq oztqf z35gy kkgn5]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
+			"         │       ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ ProcessTable\n" +
+			"         │               └─ Table\n" +
+			"         │                   ├─ name: YK2GW\n" +
+			"         │                   └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(ufc.T4IBQ:1)\n" +
-			"             ├─ right-key: TUPLE(cla.FTQLQ:1!null)\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ ProcessTable\n" +
+			"             ├─ left-key: TUPLE(ufc.ZH72S:2)\n" +
+			"             ├─ right-key: TUPLE(nd.ZH72S:7)\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     ├─ index: [E2I7U.ZH72S]\n" +
+			"                     ├─ static: [{(NULL, ∞)}]\n" +
+			"                     ├─ colSet: (12-28)\n" +
+			"                     ├─ tableId: 2\n" +
 			"                     └─ Table\n" +
-			"                         ├─ name: YK2GW\n" +
-			"                         └─ columns: [id ftqlq tuxml paef5 rucy4 tpnj6 lbl53 nb3qs eo7iv muhjf fm34l ty5rf zhtlh npb7w sx3hh isbnf ya7yb c5ykb qk7kt ffge6 fiigj sh3nc ntena m4aub x5air sab6m g5qi5 zvqvd ykssu fhcyt]\n" +
+			"                         ├─ name: E2I7U\n" +
+			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 		ExpectedEstimates: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=11656.620 rows=4081)\n" +
-			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         ├─ Project\n" +
-			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ 1 IS NULL\n" +
-			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101)\n" +
-			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081)\n" +
-			"         │           │   ├─ Filter\n" +
-			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"         │           │   │   └─ TableAlias(nd)\n" +
-			"         │           │   │       └─ Table\n" +
-			"         │           │   │           └─ name: E2I7U\n" +
-			"         │           │   └─ TableAlias(ufc)\n" +
-			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │           │           └─ keys: nd.ZH72S\n" +
-			"         │           └─ Project\n" +
-			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │               └─ Project\n" +
-			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │                       └─ keys: ufc.id\n" +
+			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260)\n" +
+			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
+			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060)\n" +
+			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ 1 IS NULL\n" +
+			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130)\n" +
+			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           │       ├─ index: [SISUT.id]\n" +
+			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   │           └─ Project\n" +
+			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
+			"         │       ├─ right-key: (cla.FTQLQ)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ Table\n" +
+			"         │               └─ name: YK2GW\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.T4IBQ)\n" +
-			"             ├─ right-key: (cla.FTQLQ)\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: YK2GW\n" +
+			"             ├─ left-key: (ufc.ZH72S)\n" +
+			"             ├─ right-key: (nd.ZH72S)\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     ├─ index: [E2I7U.ZH72S]\n" +
+			"                     └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [ufc.id, ufc.T4IBQ, ufc.ZH72S, ufc.AMYXQ, ufc.KTNZ2, ufc.HIID2, ufc.DN3OQ, ufc.VVKNB, ufc.SH7TP, ufc.SRZZO, ufc.QZ6VT]\n" +
-			"     └─ HashJoin (estimated cost=11656.620 rows=4081) (actual rows=0 loops=1)\n" +
-			"         ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
-			"         ├─ Project\n" +
-			"         │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT, E2I7U.id, E2I7U.DKCAJ, E2I7U.KNG7T, E2I7U.TW55N, E2I7U.QRQXW, E2I7U.ECXAJ, E2I7U.FGG57, E2I7U.ZH72S, E2I7U.FSK67, E2I7U.XQDYT, E2I7U.TCE7A, E2I7U.IWV2H, E2I7U.HPCMS, E2I7U.N5CC2, E2I7U.FHCYT, E2I7U.ETAQ7, E2I7U.A75X7]\n" +
-			"         │   └─ Filter\n" +
-			"         │       ├─ 1 IS NULL\n" +
-			"         │       └─ LeftOuterLookupJoin (estimated cost=15834.000 rows=5101) (actual rows=0 loops=1)\n" +
-			"         │           ├─ LookupJoin (estimated cost=12672.000 rows=4081) (actual rows=0 loops=1)\n" +
-			"         │           │   ├─ Filter\n" +
-			"         │           │   │   ├─ (NOT(nd.ZH72S IS NULL))\n" +
-			"         │           │   │   └─ TableAlias(nd)\n" +
-			"         │           │   │       └─ Table\n" +
-			"         │           │   │           └─ name: E2I7U\n" +
-			"         │           │   └─ TableAlias(ufc)\n" +
-			"         │           │       └─ IndexedTableAccess(SISUT)\n" +
-			"         │           │           ├─ index: [SISUT.ZH72S]\n" +
-			"         │           │           └─ keys: nd.ZH72S\n" +
-			"         │           └─ Project\n" +
-			"         │               ├─ columns: [amyxq.KKGN5, 1]\n" +
-			"         │               └─ Project\n" +
-			"         │                   ├─ columns: [amyxq.KKGN5]\n" +
-			"         │                   └─ IndexedTableAccess(AMYXQ)\n" +
-			"         │                       ├─ index: [AMYXQ.KKGN5]\n" +
-			"         │                       └─ keys: ufc.id\n" +
+			"     └─ HashJoin (estimated cost=1785857596.200 rows=169664756260) (actual rows=0 loops=1)\n" +
+			"         ├─ (nd.ZH72S = ufc.ZH72S)\n" +
+			"         ├─ HashJoin (estimated cost=90094975.200 rows=88321060) (actual rows=0 loops=1)\n" +
+			"         │   ├─ (cla.FTQLQ = ufc.T4IBQ)\n" +
+			"         │   ├─ Project\n" +
+			"         │   │   ├─ columns: [SISUT.id, SISUT.T4IBQ, SISUT.ZH72S, SISUT.AMYXQ, SISUT.KTNZ2, SISUT.HIID2, SISUT.DN3OQ, SISUT.VVKNB, SISUT.SH7TP, SISUT.SRZZO, SISUT.QZ6VT]\n" +
+			"         │   │   └─ Filter\n" +
+			"         │   │       ├─ 1 IS NULL\n" +
+			"         │   │       └─ LeftOuterMergeJoin (estimated cost=110819817.410 rows=103907130) (actual rows=0 loops=1)\n" +
+			"         │   │           ├─ cmp: (ufc.id = amyxq.KKGN5)\n" +
+			"         │   │           ├─ TableAlias(ufc)\n" +
+			"         │   │           │   └─ IndexedTableAccess(SISUT)\n" +
+			"         │   │           │       ├─ index: [SISUT.id]\n" +
+			"         │   │           │       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   │           └─ Project\n" +
+			"         │   │               ├─ columns: [amyxq.KKGN5, 1]\n" +
+			"         │   │               └─ Project\n" +
+			"         │   │                   ├─ columns: [amyxq.KKGN5]\n" +
+			"         │   │                   └─ IndexedTableAccess(AMYXQ)\n" +
+			"         │   │                       ├─ index: [AMYXQ.KKGN5]\n" +
+			"         │   │                       └─ filters: [{[NULL, ∞)}]\n" +
+			"         │   └─ HashLookup\n" +
+			"         │       ├─ left-key: (ufc.T4IBQ)\n" +
+			"         │       ├─ right-key: (cla.FTQLQ)\n" +
+			"         │       └─ TableAlias(cla)\n" +
+			"         │           └─ Table\n" +
+			"         │               └─ name: YK2GW\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (ufc.T4IBQ)\n" +
-			"             ├─ right-key: (cla.FTQLQ)\n" +
-			"             └─ TableAlias(cla)\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: YK2GW\n" +
+			"             ├─ left-key: (ufc.ZH72S)\n" +
+			"             ├─ right-key: (nd.ZH72S)\n" +
+			"             └─ TableAlias(nd)\n" +
+			"                 └─ IndexedTableAccess(E2I7U)\n" +
+			"                     ├─ index: [E2I7U.ZH72S]\n" +
+			"                     └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -4105,18 +4167,19 @@ WHERE
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: TUPLE(umf.FGG57:2)\n" +
 			"         ├─ right-key: TUPLE(nd.FGG57:6)\n" +
-			"         └─ Filter\n" +
-			"             ├─ NOT\n" +
-			"             │   └─ nd.FGG57:6 IS NULL\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ ProcessTable\n" +
-			"                     └─ Table\n" +
-			"                         ├─ name: E2I7U\n" +
-			"                         └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
+			"         └─ TableAlias(nd)\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 ├─ index: [E2I7U.FGG57]\n" +
+			"                 ├─ static: [{(NULL, ∞)}]\n" +
+			"                 ├─ colSet: (26-42)\n" +
+			"                 ├─ tableId: 2\n" +
+			"                 └─ Table\n" +
+			"                     ├─ name: E2I7U\n" +
+			"                     └─ columns: [id dkcaj kng7t tw55n qrqxw ecxaj fgg57 zh72s fsk67 xqdyt tce7a iwv2h hpcms n5cc2 fhcyt etaq7 a75x7]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [umf.id, umf.T4IBQ, umf.FGG57, umf.SSHPJ, umf.NLA6O, umf.SFJ6L, umf.TJPT7, umf.ARN5P, umf.SYPKF, umf.IVFMK, umf.IDE43, umf.AZ6SP, umf.FSDY2, umf.XOSD4, umf.HMW4H, umf.S76OM, umf.vaf, umf.ZROH6, umf.QCGTS, umf.LNFM6, umf.TVAWL, umf.HDLCL, umf.BHHW6, umf.FHCYT, umf.QZ6VT]\n" +
-			" └─ HashJoin (estimated cost=13849505.880 rows=13568344)\n" +
+			" └─ HashJoin (estimated cost=13845473.880 rows=13568344)\n" +
 			"     ├─ (nd.FGG57 = umf.FGG57)\n" +
 			"     ├─ HashJoin (estimated cost=13847204.880 rows=13568344)\n" +
 			"     │   ├─ (cla.FTQLQ = umf.T4IBQ)\n" +
@@ -4148,15 +4211,14 @@ WHERE
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: (umf.FGG57)\n" +
 			"         ├─ right-key: (nd.FGG57)\n" +
-			"         └─ Filter\n" +
-			"             ├─ (NOT(nd.FGG57 IS NULL))\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"         └─ TableAlias(nd)\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 ├─ index: [E2I7U.FGG57]\n" +
+			"                 └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [umf.id, umf.T4IBQ, umf.FGG57, umf.SSHPJ, umf.NLA6O, umf.SFJ6L, umf.TJPT7, umf.ARN5P, umf.SYPKF, umf.IVFMK, umf.IDE43, umf.AZ6SP, umf.FSDY2, umf.XOSD4, umf.HMW4H, umf.S76OM, umf.vaf, umf.ZROH6, umf.QCGTS, umf.LNFM6, umf.TVAWL, umf.HDLCL, umf.BHHW6, umf.FHCYT, umf.QZ6VT]\n" +
-			" └─ HashJoin (estimated cost=13849505.880 rows=13568344) (actual rows=0 loops=1)\n" +
+			" └─ HashJoin (estimated cost=13845473.880 rows=13568344) (actual rows=0 loops=1)\n" +
 			"     ├─ (nd.FGG57 = umf.FGG57)\n" +
 			"     ├─ HashJoin (estimated cost=13847204.880 rows=13568344) (actual rows=0 loops=1)\n" +
 			"     │   ├─ (cla.FTQLQ = umf.T4IBQ)\n" +
@@ -4188,11 +4250,10 @@ WHERE
 			"     └─ HashLookup\n" +
 			"         ├─ left-key: (umf.FGG57)\n" +
 			"         ├─ right-key: (nd.FGG57)\n" +
-			"         └─ Filter\n" +
-			"             ├─ (NOT(nd.FGG57 IS NULL))\n" +
-			"             └─ TableAlias(nd)\n" +
-			"                 └─ Table\n" +
-			"                     └─ name: E2I7U\n" +
+			"         └─ TableAlias(nd)\n" +
+			"             └─ IndexedTableAccess(E2I7U)\n" +
+			"                 ├─ index: [E2I7U.FGG57]\n" +
+			"                 └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -19649,14 +19710,14 @@ WHERE
 			"     │                       │   │   │       └─ right: Subquery\n" +
 			"     │                       │   │   │           ├─ cacheable: true\n" +
 			"     │                       │   │   │           ├─ alias-string: select BTXC5 from TPXBU where BTXC5 is not null\n" +
-			"     │                       │   │   │           └─ Filter\n" +
-			"     │                       │   │   │               ├─ NOT\n" +
-			"     │                       │   │   │               │   └─ tpxbu.BTXC5:25 IS NULL\n" +
+			"     │                       │   │   │           └─ IndexedTableAccess(TPXBU)\n" +
+			"     │                       │   │   │               ├─ index: [TPXBU.BTXC5]\n" +
+			"     │                       │   │   │               ├─ static: [{(NULL, ∞)}]\n" +
+			"     │                       │   │   │               ├─ colSet: (29-31)\n" +
+			"     │                       │   │   │               ├─ tableId: 3\n" +
 			"     │                       │   │   │               └─ Table\n" +
 			"     │                       │   │   │                   ├─ name: TPXBU\n" +
-			"     │                       │   │   │                   ├─ columns: [btxc5]\n" +
-			"     │                       │   │   │                   ├─ colSet: (29-31)\n" +
-			"     │                       │   │   │                   └─ tableId: 3\n" +
+			"     │                       │   │   │                   └─ columns: [btxc5]\n" +
 			"     │                       │   │   └─ NOT\n" +
 			"     │                       │   │       └─ umf.SYPKF:8 IS NULL\n" +
 			"     │                       │   └─ NOT\n" +
@@ -19831,16 +19892,13 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │       │   └─ Project\n" +
 			"     │       │       ├─ columns: [nd_for_id.id:84!null]\n" +
 			"     │       │       └─ Filter\n" +
-			"     │       │           ├─ AND\n" +
-			"     │       │           │   ├─ NOT\n" +
-			"     │       │           │   │   └─ nd_for_id.FGG57:85 IS NULL\n" +
-			"     │       │           │   └─ Eq\n" +
-			"     │       │           │       ├─ nd_for_id.FGG57:85\n" +
-			"     │       │           │       └─ umf.FGG57:2\n" +
+			"     │       │           ├─ Eq\n" +
+			"     │       │           │   ├─ nd_for_id.FGG57:85\n" +
+			"     │       │           │   └─ umf.FGG57:2\n" +
 			"     │       │           └─ TableAlias(nd_for_id)\n" +
 			"     │       │               └─ IndexedTableAccess(E2I7U)\n" +
 			"     │       │                   ├─ index: [E2I7U.FGG57]\n" +
-			"     │       │                   ├─ keys: [umf.FGG57:2]\n" +
+			"     │       │                   ├─ static: [{(NULL, ∞)}]\n" +
 			"     │       │                   ├─ colSet: (176-192)\n" +
 			"     │       │                   ├─ tableId: 10\n" +
 			"     │       │                   └─ Table\n" +
@@ -19932,16 +19990,13 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │           │   └─ Project\n" +
 			"     │           │       ├─ columns: [nd_for_id.id:67!null]\n" +
 			"     │           │       └─ Filter\n" +
-			"     │           │           ├─ AND\n" +
-			"     │           │           │   ├─ NOT\n" +
-			"     │           │           │   │   └─ nd_for_id.FGG57:68 IS NULL\n" +
-			"     │           │           │   └─ Eq\n" +
-			"     │           │           │       ├─ nd_for_id.FGG57:68\n" +
-			"     │           │           │       └─ umf.FGG57:2\n" +
+			"     │           │           ├─ Eq\n" +
+			"     │           │           │   ├─ nd_for_id.FGG57:68\n" +
+			"     │           │           │   └─ umf.FGG57:2\n" +
 			"     │           │           └─ TableAlias(nd_for_id)\n" +
 			"     │           │               └─ IndexedTableAccess(E2I7U)\n" +
 			"     │           │                   ├─ index: [E2I7U.FGG57]\n" +
-			"     │           │                   ├─ keys: [umf.FGG57:2]\n" +
+			"     │           │                   ├─ static: [{(NULL, ∞)}]\n" +
 			"     │           │                   ├─ colSet: (176-192)\n" +
 			"     │           │                   ├─ tableId: 10\n" +
 			"     │           │                   └─ Table\n" +
@@ -20049,14 +20104,14 @@ INNER JOIN THNTS bs ON cla.id = bs.IXUXU`,
 			"     │               │   │   │       │   │       └─ right: Subquery\n" +
 			"     │               │   │   │       │   │           ├─ cacheable: true\n" +
 			"     │               │   │   │       │   │           ├─ alias-string: select FGG57 from E2I7U where FGG57 is not null\n" +
-			"     │               │   │   │       │   │           └─ Filter\n" +
-			"     │               │   │   │       │   │               ├─ NOT\n" +
-			"     │               │   │   │       │   │               │   └─ e2i7u.FGG57:25 IS NULL\n" +
+			"     │               │   │   │       │   │           └─ IndexedTableAccess(E2I7U)\n" +
+			"     │               │   │   │       │   │               ├─ index: [E2I7U.FGG57]\n" +
+			"     │               │   │   │       │   │               ├─ static: [{(NULL, ∞)}]\n" +
+			"     │               │   │   │       │   │               ├─ colSet: (73-89)\n" +
+			"     │               │   │   │       │   │               ├─ tableId: 4\n" +
 			"     │               │   │   │       │   │               └─ Table\n" +
 			"     │               │   │   │       │   │                   ├─ name: E2I7U\n" +
-			"     │               │   │   │       │   │                   ├─ columns: [fgg57]\n" +
-			"     │               │   │   │       │   │                   ├─ colSet: (73-89)\n" +
-			"     │               │   │   │       │   │                   └─ tableId: 4\n" +
+			"     │               │   │   │       │   │                   └─ columns: [fgg57]\n" +
 			"     │               │   │   │       │   └─ NOT\n" +
 			"     │               │   │   │       │       └─ Eq\n" +
 			"     │               │   │   │       │           ├─ nzkpm.ARN5P:7\n" +
@@ -20883,14 +20938,14 @@ WHERE
 			"     │           │   │               ├─ cacheable: true\n" +
 			"     │           │   │               ├─ alias-string: select distinct NO52D, VYO5E, DKCAJ from SFEGG where VYO5E is not null\n" +
 			"     │           │   │               └─ Distinct\n" +
-			"     │           │   │                   └─ Filter\n" +
-			"     │           │   │                       ├─ NOT\n" +
-			"     │           │   │                       │   └─ sfegg.VYO5E:5 IS NULL\n" +
+			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
+			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"     │           │   │                       ├─ static: [{[NULL, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
+			"     │           │   │                       ├─ colSet: (60-65)\n" +
+			"     │           │   │                       ├─ tableId: 8\n" +
 			"     │           │   │                       └─ Table\n" +
 			"     │           │   │                           ├─ name: SFEGG\n" +
-			"     │           │   │                           ├─ columns: [no52d vyo5e dkcaj]\n" +
-			"     │           │   │                           ├─ colSet: (60-65)\n" +
-			"     │           │   │                           └─ tableId: 8\n" +
+			"     │           │   │                           └─ columns: [no52d vyo5e dkcaj]\n" +
 			"     │           │   └─ AND\n" +
 			"     │           │       ├─ rs.VYO5E:1 IS NULL\n" +
 			"     │           │       └─ NOT\n" +
@@ -21637,14 +21692,14 @@ WHERE
 			"     │           │   │               ├─ cacheable: true\n" +
 			"     │           │   │               ├─ alias-string: select distinct NO52D, VYO5E, DKCAJ from SFEGG where VYO5E is not null\n" +
 			"     │           │   │               └─ Distinct\n" +
-			"     │           │   │                   └─ Filter\n" +
-			"     │           │   │                       ├─ NOT\n" +
-			"     │           │   │                       │   └─ sfegg.VYO5E:5 IS NULL\n" +
+			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
+			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"     │           │   │                       ├─ static: [{[NULL, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
+			"     │           │   │                       ├─ colSet: (48-53)\n" +
+			"     │           │   │                       ├─ tableId: 6\n" +
 			"     │           │   │                       └─ Table\n" +
 			"     │           │   │                           ├─ name: SFEGG\n" +
-			"     │           │   │                           ├─ columns: [no52d vyo5e dkcaj]\n" +
-			"     │           │   │                           ├─ colSet: (48-53)\n" +
-			"     │           │   │                           └─ tableId: 6\n" +
+			"     │           │   │                           └─ columns: [no52d vyo5e dkcaj]\n" +
 			"     │           │   └─ AND\n" +
 			"     │           │       ├─ rs.VYO5E:1 IS NULL\n" +
 			"     │           │       └─ NOT\n" +

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -4266,7 +4266,7 @@ WHERE
 			" ├─ columns: [qywqd.HVHRZ:1!null]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-6)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -4277,14 +4277,14 @@ WHERE
 			" ├─ columns: [qywqd.HVHRZ]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id hvhrz]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [qywqd.HVHRZ]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id hvhrz]\n" +
 			"",
 	},
@@ -8886,7 +8886,7 @@ WHERE
 			" ├─ columns: [e2i7u.ECXAJ:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -8897,14 +8897,14 @@ WHERE
 			" ├─ columns: [e2i7u.ECXAJ]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecxaj]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.ECXAJ]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecxaj]\n" +
 			"",
 	},
@@ -9163,7 +9163,7 @@ WHERE
 			"     │   THEN 0 (tinyint) ELSE 3 (tinyint) END->SZ6KK:0]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-17)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -9210,7 +9210,7 @@ WHERE
 			"     │   THEN 1 WHEN (e2i7u.FSK67 = 'z') THEN 2 WHEN (e2i7u.FSK67 = 'CRZ2X') THEN 0 ELSE 3 END as SZ6KK]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         └─ filters: [{[NULL, ∞)}]\n" +
+			"         └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [CASE  WHEN e2i7u.FGG57 IS NULL THEN 0 WHEN InSubquery\n" +
@@ -9252,7 +9252,7 @@ WHERE
 			"     │   THEN 1 WHEN (e2i7u.FSK67 = 'z') THEN 2 WHEN (e2i7u.FSK67 = 'CRZ2X') THEN 0 ELSE 3 END as SZ6KK]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         └─ filters: [{[NULL, ∞)}]\n" +
+			"         └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -15967,7 +15967,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -15978,14 +15978,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.TW55N]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n]\n" +
 			"",
 	},
@@ -16000,7 +16000,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N:1!null, e2i7u.FGG57:2]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -16011,14 +16011,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N, e2i7u.FGG57]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.TW55N, e2i7u.FGG57]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 	},
@@ -16257,7 +16257,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id:0!null->XLFIA:0, noxn3.BRQP2:1!null]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ static: [{[NULL, ∞)}]\n" +
+			"         │           ├─ static: [{(NULL, ∞)}]\n" +
 			"         │           ├─ colSet: (1-10)\n" +
 			"         │           ├─ tableId: 1\n" +
 			"         │           └─ Table\n" +
@@ -16332,7 +16332,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"         │           ├─ filters: [{(NULL, ∞)}]\n" +
 			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
@@ -16390,7 +16390,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"         │           ├─ filters: [{(NULL, ∞)}]\n" +
 			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
@@ -17459,7 +17459,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.KBO7R:1!null]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17470,14 +17470,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.KBO7R]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id kbo7r]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [noxn3.KBO7R]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id kbo7r]\n" +
 			"",
 	},
@@ -17720,7 +17720,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.QRQXW:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17731,14 +17731,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.QRQXW]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id qrqxw]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.QRQXW]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id qrqxw]\n" +
 			"",
 	},
@@ -17832,7 +17832,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.id:0!null, noxn3.NUMK2:2!null, noxn3.ECDKM:1]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17843,14 +17843,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.id, noxn3.NUMK2, noxn3.ECDKM]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [noxn3.id, noxn3.NUMK2, noxn3.ECDKM]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
@@ -17870,7 +17870,7 @@ SELECT
 			" │   THEN noxn3.ECDKM:1 ELSE 0 (tinyint) END->RGXLL:0]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17881,14 +17881,14 @@ SELECT
 			" ├─ columns: [CASE  WHEN (noxn3.NUMK2 = 2) THEN noxn3.ECDKM ELSE 0 END as RGXLL]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [CASE  WHEN (noxn3.NUMK2 = 2) THEN noxn3.ECDKM ELSE 0 END as RGXLL]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
@@ -20940,7 +20940,7 @@ WHERE
 			"     │           │   │               └─ Distinct\n" +
 			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
 			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │   │                       ├─ static: [{[NULL, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
+			"     │           │   │                       ├─ static: [{(NULL, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			"     │           │   │                       ├─ colSet: (60-65)\n" +
 			"     │           │   │                       ├─ tableId: 8\n" +
 			"     │           │   │                       └─ Table\n" +
@@ -20959,7 +20959,7 @@ WHERE
 			"     │           │                           ├─ columns: [sfegg.NO52D:4!null, sfegg.DKCAJ:6!null]\n" +
 			"     │           │                           └─ IndexedTableAccess(SFEGG)\n" +
 			"     │           │                               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │                               ├─ static: [{[NULL, ∞), [NULL, NULL], [NULL, ∞)}]\n" +
+			"     │           │                               ├─ static: [{(NULL, ∞), [NULL, NULL], (NULL, ∞)}]\n" +
 			"     │           │                               ├─ colSet: (66-71)\n" +
 			"     │           │                               ├─ tableId: 9\n" +
 			"     │           │                               └─ Table\n" +
@@ -21694,7 +21694,7 @@ WHERE
 			"     │           │   │               └─ Distinct\n" +
 			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
 			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │   │                       ├─ static: [{[NULL, ∞), (NULL, ∞), [NULL, ∞)}]\n" +
+			"     │           │   │                       ├─ static: [{(NULL, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			"     │           │   │                       ├─ colSet: (48-53)\n" +
 			"     │           │   │                       ├─ tableId: 6\n" +
 			"     │           │   │                       └─ Table\n" +
@@ -21713,7 +21713,7 @@ WHERE
 			"     │           │                           ├─ columns: [sfegg.NO52D:4!null, sfegg.DKCAJ:6!null]\n" +
 			"     │           │                           └─ IndexedTableAccess(SFEGG)\n" +
 			"     │           │                               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
-			"     │           │                               ├─ static: [{[NULL, ∞), [NULL, NULL], [NULL, ∞)}]\n" +
+			"     │           │                               ├─ static: [{(NULL, ∞), [NULL, NULL], (NULL, ∞)}]\n" +
 			"     │           │                               ├─ colSet: (54-59)\n" +
 			"     │           │                               ├─ tableId: 7\n" +
 			"     │           │                               └─ Table\n" +

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -4266,7 +4266,7 @@ WHERE
 			" ├─ columns: [qywqd.HVHRZ:1!null]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-6)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -4277,14 +4277,14 @@ WHERE
 			" ├─ columns: [qywqd.HVHRZ]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id hvhrz]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [qywqd.HVHRZ]\n" +
 			" └─ IndexedTableAccess(QYWQD)\n" +
 			"     ├─ index: [QYWQD.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id hvhrz]\n" +
 			"",
 	},
@@ -8886,7 +8886,7 @@ WHERE
 			" ├─ columns: [e2i7u.ECXAJ:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -8897,14 +8897,14 @@ WHERE
 			" ├─ columns: [e2i7u.ECXAJ]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecxaj]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.ECXAJ]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecxaj]\n" +
 			"",
 	},
@@ -9163,7 +9163,7 @@ WHERE
 			"     │   THEN 0 (tinyint) ELSE 3 (tinyint) END->SZ6KK:0]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-17)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -9210,7 +9210,7 @@ WHERE
 			"     │   THEN 1 WHEN (e2i7u.FSK67 = 'z') THEN 2 WHEN (e2i7u.FSK67 = 'CRZ2X') THEN 0 ELSE 3 END as SZ6KK]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         └─ filters: [{[NULL, ∞)}]\n" +
+			"         └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [CASE  WHEN e2i7u.FGG57 IS NULL THEN 0 WHEN InSubquery\n" +
@@ -9252,7 +9252,7 @@ WHERE
 			"     │   THEN 1 WHEN (e2i7u.FSK67 = 'z') THEN 2 WHEN (e2i7u.FSK67 = 'CRZ2X') THEN 0 ELSE 3 END as SZ6KK]\n" +
 			"     └─ IndexedTableAccess(E2I7U)\n" +
 			"         ├─ index: [E2I7U.id]\n" +
-			"         └─ filters: [{[NULL, ∞)}]\n" +
+			"         └─ filters: [{(NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -15967,7 +15967,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -15978,14 +15978,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.TW55N]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n]\n" +
 			"",
 	},
@@ -16000,7 +16000,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N:1!null, e2i7u.FGG57:2]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -16011,14 +16011,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.TW55N, e2i7u.FGG57]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.TW55N, e2i7u.FGG57]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id tw55n fgg57]\n" +
 			"",
 	},
@@ -16257,7 +16257,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id:0!null->XLFIA:0, noxn3.BRQP2:1!null]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ static: [{[NULL, ∞)}]\n" +
+			"         │           ├─ static: [{(NULL, ∞)}]\n" +
 			"         │           ├─ colSet: (1-10)\n" +
 			"         │           ├─ tableId: 1\n" +
 			"         │           └─ Table\n" +
@@ -16332,7 +16332,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"         │           ├─ filters: [{(NULL, ∞)}]\n" +
 			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
@@ -16390,7 +16390,7 @@ ORDER BY sn.XLFIA ASC`,
 			"         │       ├─ columns: [noxn3.id as XLFIA, noxn3.BRQP2]\n" +
 			"         │       └─ IndexedTableAccess(NOXN3)\n" +
 			"         │           ├─ index: [NOXN3.id]\n" +
-			"         │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"         │           ├─ filters: [{(NULL, ∞)}]\n" +
 			"         │           └─ columns: [id brqp2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (sn.BRQP2)\n" +
@@ -17459,7 +17459,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.KBO7R:1!null]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17470,14 +17470,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.KBO7R]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id kbo7r]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [noxn3.KBO7R]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id kbo7r]\n" +
 			"",
 	},
@@ -17720,7 +17720,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.QRQXW:1!null]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-17)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17731,14 +17731,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [e2i7u.QRQXW]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id qrqxw]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [e2i7u.QRQXW]\n" +
 			" └─ IndexedTableAccess(E2I7U)\n" +
 			"     ├─ index: [E2I7U.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id qrqxw]\n" +
 			"",
 	},
@@ -17832,7 +17832,7 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.id:0!null, noxn3.NUMK2:2!null, noxn3.ECDKM:1]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17843,14 +17843,14 @@ ORDER BY id ASC`,
 			" ├─ columns: [noxn3.id, noxn3.NUMK2, noxn3.ECDKM]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [noxn3.id, noxn3.NUMK2, noxn3.ECDKM]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
@@ -17870,7 +17870,7 @@ SELECT
 			" │   THEN noxn3.ECDKM:1 ELSE 0 (tinyint) END->RGXLL:0]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -17881,14 +17881,14 @@ SELECT
 			" ├─ columns: [CASE  WHEN (noxn3.NUMK2 = 2) THEN noxn3.ECDKM ELSE 0 END as RGXLL]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [CASE  WHEN (noxn3.NUMK2 = 2) THEN noxn3.ECDKM ELSE 0 END as RGXLL]\n" +
 			" └─ IndexedTableAccess(NOXN3)\n" +
 			"     ├─ index: [NOXN3.id]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [id ecdkm numk2]\n" +
 			"",
 	},
@@ -20938,14 +20938,14 @@ WHERE
 			"     │           │   │               ├─ cacheable: true\n" +
 			"     │           │   │               ├─ alias-string: select distinct NO52D, VYO5E, DKCAJ from SFEGG where VYO5E is not null\n" +
 			"     │           │   │               └─ Distinct\n" +
-			"     │           │   │                   └─ Filter\n" +
-			"     │           │   │                       ├─ NOT\n" +
-			"     │           │   │                       │   └─ sfegg.VYO5E:5 IS NULL\n" +
+			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
+			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"     │           │   │                       ├─ static: [{(NULL, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
+			"     │           │   │                       ├─ colSet: (60-65)\n" +
+			"     │           │   │                       ├─ tableId: 8\n" +
 			"     │           │   │                       └─ Table\n" +
 			"     │           │   │                           ├─ name: SFEGG\n" +
-			"     │           │   │                           ├─ columns: [no52d vyo5e dkcaj]\n" +
-			"     │           │   │                           ├─ colSet: (60-65)\n" +
-			"     │           │   │                           └─ tableId: 8\n" +
+			"     │           │   │                           └─ columns: [no52d vyo5e dkcaj]\n" +
 			"     │           │   └─ AND\n" +
 			"     │           │       ├─ rs.VYO5E:1 IS NULL\n" +
 			"     │           │       └─ NOT\n" +
@@ -20957,13 +20957,14 @@ WHERE
 			"     │           │                   └─ Distinct\n" +
 			"     │           │                       └─ Project\n" +
 			"     │           │                           ├─ columns: [sfegg.NO52D:4!null, sfegg.DKCAJ:6!null]\n" +
-			"     │           │                           └─ Filter\n" +
-			"     │           │                               ├─ sfegg.VYO5E:5 IS NULL\n" +
+			"     │           │                           └─ IndexedTableAccess(SFEGG)\n" +
+			"     │           │                               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"     │           │                               ├─ static: [{(NULL, ∞), [NULL, NULL], (NULL, ∞)}]\n" +
+			"     │           │                               ├─ colSet: (66-71)\n" +
+			"     │           │                               ├─ tableId: 9\n" +
 			"     │           │                               └─ Table\n" +
 			"     │           │                                   ├─ name: SFEGG\n" +
-			"     │           │                                   ├─ columns: [no52d vyo5e dkcaj]\n" +
-			"     │           │                                   ├─ colSet: (66-71)\n" +
-			"     │           │                                   └─ tableId: 9\n" +
+			"     │           │                                   └─ columns: [no52d vyo5e dkcaj]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: rs\n" +
 			"     │               ├─ outerVisibility: false\n" +
@@ -21691,14 +21692,14 @@ WHERE
 			"     │           │   │               ├─ cacheable: true\n" +
 			"     │           │   │               ├─ alias-string: select distinct NO52D, VYO5E, DKCAJ from SFEGG where VYO5E is not null\n" +
 			"     │           │   │               └─ Distinct\n" +
-			"     │           │   │                   └─ Filter\n" +
-			"     │           │   │                       ├─ NOT\n" +
-			"     │           │   │                       │   └─ sfegg.VYO5E:5 IS NULL\n" +
+			"     │           │   │                   └─ IndexedTableAccess(SFEGG)\n" +
+			"     │           │   │                       ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"     │           │   │                       ├─ static: [{(NULL, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
+			"     │           │   │                       ├─ colSet: (48-53)\n" +
+			"     │           │   │                       ├─ tableId: 6\n" +
 			"     │           │   │                       └─ Table\n" +
 			"     │           │   │                           ├─ name: SFEGG\n" +
-			"     │           │   │                           ├─ columns: [no52d vyo5e dkcaj]\n" +
-			"     │           │   │                           ├─ colSet: (48-53)\n" +
-			"     │           │   │                           └─ tableId: 6\n" +
+			"     │           │   │                           └─ columns: [no52d vyo5e dkcaj]\n" +
 			"     │           │   └─ AND\n" +
 			"     │           │       ├─ rs.VYO5E:1 IS NULL\n" +
 			"     │           │       └─ NOT\n" +
@@ -21710,13 +21711,14 @@ WHERE
 			"     │           │                   └─ Distinct\n" +
 			"     │           │                       └─ Project\n" +
 			"     │           │                           ├─ columns: [sfegg.NO52D:4!null, sfegg.DKCAJ:6!null]\n" +
-			"     │           │                           └─ Filter\n" +
-			"     │           │                               ├─ sfegg.VYO5E:5 IS NULL\n" +
+			"     │           │                           └─ IndexedTableAccess(SFEGG)\n" +
+			"     │           │                               ├─ index: [SFEGG.NO52D,SFEGG.VYO5E,SFEGG.DKCAJ]\n" +
+			"     │           │                               ├─ static: [{(NULL, ∞), [NULL, NULL], (NULL, ∞)}]\n" +
+			"     │           │                               ├─ colSet: (54-59)\n" +
+			"     │           │                               ├─ tableId: 7\n" +
 			"     │           │                               └─ Table\n" +
 			"     │           │                                   ├─ name: SFEGG\n" +
-			"     │           │                                   ├─ columns: [no52d vyo5e dkcaj]\n" +
-			"     │           │                                   ├─ colSet: (54-59)\n" +
-			"     │           │                                   └─ tableId: 7\n" +
+			"     │           │                                   └─ columns: [no52d vyo5e dkcaj]\n" +
 			"     │           └─ SubqueryAlias\n" +
 			"     │               ├─ name: rs\n" +
 			"     │               ├─ outerVisibility: false\n" +

--- a/enginetest/queries/query_plan_script_tests.go
+++ b/enginetest/queries/query_plan_script_tests.go
@@ -637,7 +637,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -667,7 +667,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" └─ CrossJoin\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
 					"     │   ├─ index: [t2.j]\n" +
-					"     │   ├─ static: [{[NULL, ∞)}]\n" +
+					"     │   ├─ static: [{(NULL, ∞)}]\n" +
 					"     │   ├─ colSet: (2)\n" +
 					"     │   ├─ tableId: 2\n" +
 					"     │   └─ Table\n" +
@@ -695,7 +695,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞)}]\n" +
 					" │   ├─ reverse: true\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
@@ -741,7 +741,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
+					" │   ├─ static: [{[1, 1], (NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -749,7 +749,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ columns: [i j]\n" +
 					" └─ IndexedTableAccess(t4)\n" +
 					"     ├─ index: [t4.x,t4.y]\n" +
-					"     ├─ static: [{[3, 3], [NULL, ∞)}]\n" +
+					"     ├─ static: [{[3, 3], (NULL, ∞)}]\n" +
 					"     ├─ colSet: (3,4)\n" +
 					"     ├─ tableId: 2\n" +
 					"     └─ Table\n" +
@@ -764,22 +764,18 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{1, 2, 3, 3},
 				},
 				ExpectedPlan: "CrossJoin\n" +
-					" ├─ Filter\n" +
-					" │   ├─ Eq\n" +
-					" │   │   ├─ t3.j:1!null\n" +
-					" │   │   └─ 2 (int)\n" +
-					" │   └─ IndexedTableAccess(t3)\n" +
-					" │       ├─ index: [t3.i,t3.j]\n" +
-					" │       ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
-					" │       ├─ reverse: true\n" +
-					" │       ├─ colSet: (1,2)\n" +
-					" │       ├─ tableId: 1\n" +
-					" │       └─ Table\n" +
-					" │           ├─ name: t3\n" +
-					" │           └─ columns: [i j]\n" +
+					" ├─ IndexedTableAccess(t3)\n" +
+					" │   ├─ index: [t3.i,t3.j]\n" +
+					" │   ├─ static: [{(NULL, ∞), [2, 2]}]\n" +
+					" │   ├─ reverse: true\n" +
+					" │   ├─ colSet: (1,2)\n" +
+					" │   ├─ tableId: 1\n" +
+					" │   └─ Table\n" +
+					" │       ├─ name: t3\n" +
+					" │       └─ columns: [i j]\n" +
 					" └─ IndexedTableAccess(t4)\n" +
 					"     ├─ index: [t4.x,t4.y]\n" +
-					"     ├─ static: [{[3, 3], [NULL, ∞)}]\n" +
+					"     ├─ static: [{[3, 3], (NULL, ∞)}]\n" +
 					"     ├─ colSet: (3,4)\n" +
 					"     ├─ tableId: 2\n" +
 					"     └─ Table\n" +
@@ -803,7 +799,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │   └─ t2.j:1!null\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -833,7 +829,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					"     │   └─ t2.j:0!null\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
 					"     │   ├─ index: [t2.j]\n" +
-					"     │   ├─ static: [{[NULL, ∞)}]\n" +
+					"     │   ├─ static: [{(NULL, ∞)}]\n" +
 					"     │   ├─ reverse: true\n" +
 					"     │   ├─ colSet: (2)\n" +
 					"     │   ├─ tableId: 2\n" +
@@ -867,7 +863,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ t4.x:2!null\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +

--- a/enginetest/queries/query_plan_script_tests.go
+++ b/enginetest/queries/query_plan_script_tests.go
@@ -637,7 +637,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{(NULL, ∞)}]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -667,7 +667,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" └─ CrossJoin\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
 					"     │   ├─ index: [t2.j]\n" +
-					"     │   ├─ static: [{(NULL, ∞)}]\n" +
+					"     │   ├─ static: [{[NULL, ∞)}]\n" +
 					"     │   ├─ colSet: (2)\n" +
 					"     │   ├─ tableId: 2\n" +
 					"     │   └─ Table\n" +
@@ -695,7 +695,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{(NULL, ∞)}]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
 					" │   ├─ reverse: true\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
@@ -741,7 +741,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{[1, 1], (NULL, ∞)}]\n" +
+					" │   ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -749,7 +749,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ columns: [i j]\n" +
 					" └─ IndexedTableAccess(t4)\n" +
 					"     ├─ index: [t4.x,t4.y]\n" +
-					"     ├─ static: [{[3, 3], (NULL, ∞)}]\n" +
+					"     ├─ static: [{[3, 3], [NULL, ∞)}]\n" +
 					"     ├─ colSet: (3,4)\n" +
 					"     ├─ tableId: 2\n" +
 					"     └─ Table\n" +
@@ -766,7 +766,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{(NULL, ∞), [2, 2]}]\n" +
+					" │   ├─ static: [{[NULL, ∞), [2, 2]}]\n" +
 					" │   ├─ reverse: true\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
@@ -775,7 +775,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ columns: [i j]\n" +
 					" └─ IndexedTableAccess(t4)\n" +
 					"     ├─ index: [t4.x,t4.y]\n" +
-					"     ├─ static: [{[3, 3], (NULL, ∞)}]\n" +
+					"     ├─ static: [{[3, 3], [NULL, ∞)}]\n" +
 					"     ├─ colSet: (3,4)\n" +
 					"     ├─ tableId: 2\n" +
 					"     └─ Table\n" +
@@ -799,7 +799,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │   └─ t2.j:1!null\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{(NULL, ∞)}]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -829,7 +829,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					"     │   └─ t2.j:0!null\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
 					"     │   ├─ index: [t2.j]\n" +
-					"     │   ├─ static: [{(NULL, ∞)}]\n" +
+					"     │   ├─ static: [{[NULL, ∞)}]\n" +
 					"     │   ├─ reverse: true\n" +
 					"     │   ├─ colSet: (2)\n" +
 					"     │   ├─ tableId: 2\n" +
@@ -863,7 +863,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ t4.x:2!null\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+					" │   ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +

--- a/enginetest/queries/query_plan_script_tests.go
+++ b/enginetest/queries/query_plan_script_tests.go
@@ -637,7 +637,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -667,7 +667,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" └─ CrossJoin\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
 					"     │   ├─ index: [t2.j]\n" +
-					"     │   ├─ static: [{[NULL, ∞)}]\n" +
+					"     │   ├─ static: [{(NULL, ∞)}]\n" +
 					"     │   ├─ colSet: (2)\n" +
 					"     │   ├─ tableId: 2\n" +
 					"     │   └─ Table\n" +
@@ -695,7 +695,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞)}]\n" +
 					" │   ├─ reverse: true\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
@@ -741,7 +741,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
+					" │   ├─ static: [{[1, 1], (NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -749,7 +749,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ columns: [i j]\n" +
 					" └─ IndexedTableAccess(t4)\n" +
 					"     ├─ index: [t4.x,t4.y]\n" +
-					"     ├─ static: [{[3, 3], [NULL, ∞)}]\n" +
+					"     ├─ static: [{[3, 3], (NULL, ∞)}]\n" +
 					"     ├─ colSet: (3,4)\n" +
 					"     ├─ tableId: 2\n" +
 					"     └─ Table\n" +
@@ -766,7 +766,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{[NULL, ∞), [2, 2]}]\n" +
+					" │   ├─ static: [{(NULL, ∞), [2, 2]}]\n" +
 					" │   ├─ reverse: true\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
@@ -775,7 +775,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ columns: [i j]\n" +
 					" └─ IndexedTableAccess(t4)\n" +
 					"     ├─ index: [t4.x,t4.y]\n" +
-					"     ├─ static: [{[3, 3], [NULL, ∞)}]\n" +
+					"     ├─ static: [{[3, 3], (NULL, ∞)}]\n" +
 					"     ├─ colSet: (3,4)\n" +
 					"     ├─ tableId: 2\n" +
 					"     └─ Table\n" +
@@ -799,7 +799,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │   └─ t2.j:1!null\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
-					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +
@@ -829,7 +829,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					"     │   └─ t2.j:0!null\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
 					"     │   ├─ index: [t2.j]\n" +
-					"     │   ├─ static: [{[NULL, ∞)}]\n" +
+					"     │   ├─ static: [{(NULL, ∞)}]\n" +
 					"     │   ├─ reverse: true\n" +
 					"     │   ├─ colSet: (2)\n" +
 					"     │   ├─ tableId: 2\n" +
@@ -863,7 +863,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					" │       └─ t4.x:2!null\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
-					" │   ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+					" │   ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 					" │   ├─ colSet: (1,2)\n" +
 					" │   ├─ tableId: 1\n" +
 					" │   └─ Table\n" +

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -1131,7 +1131,7 @@ WHERE
 			"         │   └─ order_line1.ol_i_id:3\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
+			"         │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
 			"         │   ├─ colSet: (1-10)\n" +
 			"         │   ├─ tableId: 1\n" +
 			"         │   └─ Table\n" +
@@ -1146,7 +1146,7 @@ WHERE
 			"                 │   └─ 15 (smallint)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ static: [{[5, 5], [NULL, ∞)}]\n" +
+			"                     ├─ static: [{[5, 5], (NULL, ∞)}]\n" +
 			"                     ├─ colSet: (11-27)\n" +
 			"                     ├─ tableId: 2\n" +
 			"                     └─ Table\n" +
@@ -1162,7 +1162,7 @@ WHERE
 			"         ├─ (stock1.s_i_id = order_line1.ol_i_id)\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (order_line1.ol_i_id)\n" +
@@ -1171,7 +1171,7 @@ WHERE
 			"                 ├─ (stock1.s_quantity < 15)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ filters: [{[5, 5], [NULL, ∞)}]\n" +
+			"                     ├─ filters: [{[5, 5], (NULL, ∞)}]\n" +
 			"                     └─ columns: [s_i_id s_w_id s_quantity]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -1183,7 +1183,7 @@ WHERE
 			"         ├─ (stock1.s_i_id = order_line1.ol_i_id)\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (order_line1.ol_i_id)\n" +
@@ -1192,7 +1192,7 @@ WHERE
 			"                 ├─ (stock1.s_quantity < 15)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ filters: [{[5, 5], [NULL, ∞)}]\n" +
+			"                     ├─ filters: [{[5, 5], (NULL, ∞)}]\n" +
 			"                     └─ columns: [s_i_id s_w_id s_quantity]\n" +
 			"",
 	},
@@ -3617,7 +3617,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -3635,7 +3635,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -3649,7 +3649,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -3665,7 +3665,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -3682,7 +3682,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -3695,7 +3695,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -3722,7 +3722,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin:0!null->dst:0]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       ├─ static: [{[New York, New York], (NULL, ∞)}]\n" +
 			"             │       ├─ colSet: (1,2)\n" +
 			"             │       ├─ tableId: 1\n" +
 			"             │       └─ Table\n" +
@@ -3755,7 +3755,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       ├─ filters: [{[New York, New York], (NULL, ∞)}]\n" +
 			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
@@ -3780,7 +3780,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       ├─ filters: [{[New York, New York], (NULL, ∞)}]\n" +
 			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
@@ -6310,7 +6310,7 @@ inner join pq on true
 		Query: `SELECT * FROM one_pk ORDER BY pk`,
 		ExpectedPlan: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ static: [{[NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞)}]\n" +
 			" ├─ colSet: (1-6)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6319,12 +6319,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ filters: [{[NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞)}]\n" +
 			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ filters: [{[NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞)}]\n" +
 			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6332,7 +6332,7 @@ inner join pq on true
 		Query: `SELECT * FROM two_pk ORDER BY pk1, pk2`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6341,12 +6341,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6354,7 +6354,7 @@ inner join pq on true
 		Query: `SELECT * FROM two_pk ORDER BY pk1`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6363,12 +6363,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6378,7 +6378,7 @@ inner join pq on true
 			" ├─ columns: [two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -6389,14 +6389,14 @@ inner join pq on true
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -6408,7 +6408,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -6421,7 +6421,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -6430,7 +6430,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -8841,7 +8841,7 @@ inner join pq on true
 		ExpectedPlan: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1,2)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -8851,13 +8851,13 @@ inner join pq on true
 		ExpectedEstimates: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [i s]\n" +
 			"",
 	},
@@ -8877,7 +8877,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -8895,7 +8895,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -8909,7 +8909,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -8929,7 +8929,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -8947,7 +8947,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -8961,7 +8961,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -8981,7 +8981,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -8999,7 +8999,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -9013,7 +9013,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -15403,7 +15403,7 @@ inner join pq on true
 			"     │   └─ 0 (tinyint)\n" +
 			"     ├─ IndexedTableAccess(two_pk)\n" +
 			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │   ├─ static: [{[NULL, ∞), (NULL, 1)}]\n" +
+			"     │   ├─ static: [{(NULL, ∞), (NULL, 1)}]\n" +
 			"     │   ├─ colSet: (7-13)\n" +
 			"     │   ├─ tableId: 2\n" +
 			"     │   └─ Table\n" +
@@ -15420,7 +15420,7 @@ inner join pq on true
 			"     ├─ ((two_pk.pk1 - one_pk.pk) > 0)\n" +
 			"     ├─ IndexedTableAccess(two_pk)\n" +
 			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │   ├─ filters: [{[NULL, ∞), (NULL, 1)}]\n" +
+			"     │   ├─ filters: [{(NULL, ∞), (NULL, 1)}]\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: one_pk\n" +
@@ -15432,7 +15432,7 @@ inner join pq on true
 			"     ├─ ((two_pk.pk1 - one_pk.pk) > 0)\n" +
 			"     ├─ IndexedTableAccess(two_pk)\n" +
 			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │   ├─ filters: [{[NULL, ∞), (NULL, 1)}]\n" +
+			"     │   ├─ filters: [{(NULL, ∞), (NULL, 1)}]\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: one_pk\n" +
@@ -15942,7 +15942,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ static: [{[NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ static: [{(NULL, ∞), [1, 1]}]\n" +
 			"         │       ├─ colSet: (7-13)\n" +
 			"         │       ├─ tableId: 2\n" +
 			"         │       └─ Table\n" +
@@ -15965,7 +15965,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ filters: [{[NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ filters: [{(NULL, ∞), [1, 1]}]\n" +
 			"         │       └─ columns: [pk2]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
@@ -15980,7 +15980,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ filters: [{[NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ filters: [{(NULL, ∞), [1, 1]}]\n" +
 			"         │       └─ columns: [pk2]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
@@ -16200,7 +16200,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ static: [{[NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ static: [{(NULL, ∞), [1, 1]}]\n" +
 			"         │       ├─ colSet: (7-13)\n" +
 			"         │       ├─ tableId: 2\n" +
 			"         │       └─ Table\n" +
@@ -16230,7 +16230,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       └─ filters: [{[NULL, ∞), [1, 1]}]\n" +
+			"         │       └─ filters: [{(NULL, ∞), [1, 1]}]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16250,7 +16250,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       └─ filters: [{[NULL, ∞), [1, 1]}]\n" +
+			"         │       └─ filters: [{(NULL, ∞), [1, 1]}]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16707,7 +16707,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ static: [{[NULL, ∞), [2, 2], [NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
 			"             ├─ colSet: (1-3)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -16725,7 +16725,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ filters: [{[NULL, ∞), [2, 2], [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
 			"             └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -16739,7 +16739,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ filters: [{[NULL, ∞), [2, 2], [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
 			"             └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16747,7 +16747,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y = 0`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16756,12 +16756,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16769,7 +16769,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y >= 0`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16778,12 +16778,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16791,7 +16791,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y >= 0 AND z < 1`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
+			" ├─ static: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16800,12 +16800,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -21659,7 +21659,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ static: [{[NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -21679,7 +21679,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21695,7 +21695,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21716,7 +21716,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ static: [{[NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -21736,7 +21736,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21752,7 +21752,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -22408,7 +22408,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -22420,7 +22420,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -22428,7 +22428,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -22438,7 +22438,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s:1!null, mytable.i:0!null]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ reverse: true\n" +
 			"     ├─ colSet: (1,2)\n" +
 			"     ├─ tableId: 1\n" +
@@ -22450,7 +22450,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s, mytable.i]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     ├─ columns: [i s]\n" +
 			"     └─ reverse: true\n" +
 			"",
@@ -22458,7 +22458,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s, mytable.i]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     ├─ columns: [i s]\n" +
 			"     └─ reverse: true\n" +
 			"",
@@ -22467,7 +22467,7 @@ WHERE keyless.c0 IN (
 		Query: `SELECT pk1, pk2 FROM two_pk order by pk1 asc, pk2 asc;`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -22476,12 +22476,12 @@ WHERE keyless.c0 IN (
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -22508,7 +22508,7 @@ WHERE keyless.c0 IN (
 		Query: `SELECT pk1, pk2 FROM two_pk order by pk1 desc, pk2 desc;`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ reverse: true\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
@@ -22518,13 +22518,13 @@ WHERE keyless.c0 IN (
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ columns: [pk1 pk2]\n" +
 			" └─ reverse: true\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ columns: [pk1 pk2]\n" +
 			" └─ reverse: true\n" +
 			"",
@@ -22621,7 +22621,7 @@ WHERE keyless.c0 IN (
 		ExpectedPlan: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-6)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -22631,13 +22631,13 @@ WHERE keyless.c0 IN (
 		ExpectedEstimates: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -22647,21 +22647,21 @@ WHERE keyless.c0 IN (
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedEstimates: "Limit(10)\n" +
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Limit(10)\n" +
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -23192,7 +23192,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23205,7 +23205,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23214,7 +23214,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23226,7 +23226,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->min(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -23238,7 +23238,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as min(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [x]\n" +
 			"",
 		ExpectedAnalysis: "Limit(1)\n" +
@@ -23246,7 +23246,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as min(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [x]\n" +
 			"",
 	},
@@ -23288,7 +23288,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x:0!null + 100 (tinyint))->max(x)+100:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23301,7 +23301,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x + 100) as max(x)+100]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23310,7 +23310,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x + 100) as max(x)+100]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23322,7 +23322,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->xx:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23335,7 +23335,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as xx]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23344,7 +23344,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as xx]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23356,7 +23356,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1 (tinyint), 2.0 (decimal(2,1)), 3 (longtext), xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23369,7 +23369,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1, 2.0, '3', xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23378,7 +23378,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1, 2.0, '3', xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23536,7 +23536,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ static: [{[NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -23556,7 +23556,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x as max(x)]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [x]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -23572,7 +23572,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x as max(x)]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [x]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -23593,7 +23593,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ static: [{[NULL, ∞)}]\n" +
+			"                 ├─ static: [{(NULL, ∞)}]\n" +
 			"                 ├─ reverse: true\n" +
 			"                 ├─ colSet: (1,2)\n" +
 			"                 ├─ tableId: 1\n" +
@@ -23615,7 +23615,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x as max(x)]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 ├─ filters: [{(NULL, ∞)}]\n" +
 			"                 ├─ columns: [x]\n" +
 			"                 └─ reverse: true\n" +
 			"",
@@ -23633,7 +23633,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x as max(x)]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 ├─ filters: [{(NULL, ∞)}]\n" +
 			"                 ├─ columns: [x]\n" +
 			"                 └─ reverse: true\n" +
 			"",
@@ -24629,7 +24629,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24639,13 +24639,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1]\n" +
 			"",
 	},
@@ -24706,7 +24706,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2:1!null]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -24718,7 +24718,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
@@ -24726,7 +24726,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24735,7 +24735,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24745,13 +24745,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24782,7 +24782,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24792,13 +24792,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24831,7 +24831,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2:1!null, two_pk.pk1:0!null]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -24843,7 +24843,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2, two_pk.pk1]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
@@ -24851,7 +24851,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2, two_pk.pk1]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -1131,7 +1131,7 @@ WHERE
 			"         │   └─ order_line1.ol_i_id:3\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
+			"         │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
 			"         │   ├─ colSet: (1-10)\n" +
 			"         │   ├─ tableId: 1\n" +
 			"         │   └─ Table\n" +
@@ -1146,7 +1146,7 @@ WHERE
 			"                 │   └─ 15 (smallint)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ static: [{[5, 5], [NULL, ∞)}]\n" +
+			"                     ├─ static: [{[5, 5], (NULL, ∞)}]\n" +
 			"                     ├─ colSet: (11-27)\n" +
 			"                     ├─ tableId: 2\n" +
 			"                     └─ Table\n" +
@@ -1162,7 +1162,7 @@ WHERE
 			"         ├─ (stock1.s_i_id = order_line1.ol_i_id)\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (order_line1.ol_i_id)\n" +
@@ -1171,7 +1171,7 @@ WHERE
 			"                 ├─ (stock1.s_quantity < 15)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ filters: [{[5, 5], [NULL, ∞)}]\n" +
+			"                     ├─ filters: [{[5, 5], (NULL, ∞)}]\n" +
 			"                     └─ columns: [s_i_id s_w_id s_quantity]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -1183,7 +1183,7 @@ WHERE
 			"         ├─ (stock1.s_i_id = order_line1.ol_i_id)\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (order_line1.ol_i_id)\n" +
@@ -1192,7 +1192,7 @@ WHERE
 			"                 ├─ (stock1.s_quantity < 15)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ filters: [{[5, 5], [NULL, ∞)}]\n" +
+			"                     ├─ filters: [{[5, 5], (NULL, ∞)}]\n" +
 			"                     └─ columns: [s_i_id s_w_id s_quantity]\n" +
 			"",
 	},
@@ -3617,7 +3617,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -3635,7 +3635,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -3649,7 +3649,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -3665,7 +3665,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -3682,7 +3682,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -3695,7 +3695,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -3722,7 +3722,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin:0!null->dst:0]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       ├─ static: [{[New York, New York], (NULL, ∞)}]\n" +
 			"             │       ├─ colSet: (1,2)\n" +
 			"             │       ├─ tableId: 1\n" +
 			"             │       └─ Table\n" +
@@ -3755,7 +3755,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       ├─ filters: [{[New York, New York], (NULL, ∞)}]\n" +
 			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
@@ -3780,7 +3780,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
+			"             │       ├─ filters: [{[New York, New York], (NULL, ∞)}]\n" +
 			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
@@ -6310,7 +6310,7 @@ inner join pq on true
 		Query: `SELECT * FROM one_pk ORDER BY pk`,
 		ExpectedPlan: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ static: [{[NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞)}]\n" +
 			" ├─ colSet: (1-6)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6319,12 +6319,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ filters: [{[NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞)}]\n" +
 			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ filters: [{[NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞)}]\n" +
 			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6332,7 +6332,7 @@ inner join pq on true
 		Query: `SELECT * FROM two_pk ORDER BY pk1, pk2`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6341,12 +6341,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6354,7 +6354,7 @@ inner join pq on true
 		Query: `SELECT * FROM two_pk ORDER BY pk1`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6363,12 +6363,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6378,7 +6378,7 @@ inner join pq on true
 			" ├─ columns: [two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -6389,14 +6389,14 @@ inner join pq on true
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -6408,7 +6408,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -6421,7 +6421,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -6430,7 +6430,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -8841,7 +8841,7 @@ inner join pq on true
 		ExpectedPlan: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1,2)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -8851,13 +8851,13 @@ inner join pq on true
 		ExpectedEstimates: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "TableAlias(a)\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [i s]\n" +
 			"",
 	},
@@ -8877,7 +8877,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -8895,7 +8895,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -8909,7 +8909,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -8929,7 +8929,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -8947,7 +8947,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -8961,7 +8961,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -8981,7 +8981,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -8999,7 +8999,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -9013,7 +9013,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -15401,14 +15401,14 @@ inner join pq on true
 			"     ├─ GreaterThan\n" +
 			"     │   ├─ (two_pk.pk1:0!null - one_pk.pk:2!null)\n" +
 			"     │   └─ 0 (tinyint)\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ LessThan\n" +
-			"     │   │   ├─ two_pk.pk2:1!null\n" +
-			"     │   │   └─ 1 (tinyint)\n" +
-			"     │   └─ ProcessTable\n" +
-			"     │       └─ Table\n" +
-			"     │           ├─ name: two_pk\n" +
-			"     │           └─ columns: [pk1 pk2]\n" +
+			"     ├─ IndexedTableAccess(two_pk)\n" +
+			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"     │   ├─ static: [{(NULL, ∞), (NULL, 1)}]\n" +
+			"     │   ├─ colSet: (7-13)\n" +
+			"     │   ├─ tableId: 2\n" +
+			"     │   └─ Table\n" +
+			"     │       ├─ name: two_pk\n" +
+			"     │       └─ columns: [pk1 pk2]\n" +
 			"     └─ ProcessTable\n" +
 			"         └─ Table\n" +
 			"             ├─ name: one_pk\n" +
@@ -15416,26 +15416,24 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [one_pk.pk, two_pk.pk1, two_pk.pk2]\n" +
-			" └─ InnerJoin (estimated cost=13.120 rows=3)\n" +
+			" └─ InnerJoin (estimated cost=9.080 rows=4)\n" +
 			"     ├─ ((two_pk.pk1 - one_pk.pk) > 0)\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ (two_pk.pk2 < 1)\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: two_pk\n" +
-			"     │       └─ columns: [pk1 pk2]\n" +
+			"     ├─ IndexedTableAccess(two_pk)\n" +
+			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"     │   ├─ filters: [{(NULL, ∞), (NULL, 1)}]\n" +
+			"     │   └─ columns: [pk1 pk2]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: one_pk\n" +
 			"         └─ columns: [pk]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [one_pk.pk, two_pk.pk1, two_pk.pk2]\n" +
-			" └─ InnerJoin (estimated cost=13.120 rows=3) (actual rows=1 loops=1)\n" +
+			" └─ InnerJoin (estimated cost=9.080 rows=4) (actual rows=1 loops=1)\n" +
 			"     ├─ ((two_pk.pk1 - one_pk.pk) > 0)\n" +
-			"     ├─ Filter\n" +
-			"     │   ├─ (two_pk.pk2 < 1)\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: two_pk\n" +
-			"     │       └─ columns: [pk1 pk2]\n" +
+			"     ├─ IndexedTableAccess(two_pk)\n" +
+			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"     │   ├─ filters: [{(NULL, ∞), (NULL, 1)}]\n" +
+			"     │   └─ columns: [pk1 pk2]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: one_pk\n" +
 			"         └─ columns: [pk]\n" +
@@ -15941,15 +15939,15 @@ inner join pq on true
 			" ├─ columns: [t1.pk:1!null, t2.pk2:0!null]\n" +
 			" └─ Sort(t1.pk:1!null ASC nullsFirst, t2.pk2:0!null ASC nullsFirst)\n" +
 			"     └─ CrossJoin\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ t2.pk2:0!null\n" +
-			"         │   │   └─ 1 (tinyint)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ ProcessTable\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: two_pk\n" +
-			"         │               └─ columns: [pk2]\n" +
+			"         ├─ TableAlias(t2)\n" +
+			"         │   └─ IndexedTableAccess(two_pk)\n" +
+			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"         │       ├─ static: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ colSet: (7-13)\n" +
+			"         │       ├─ tableId: 2\n" +
+			"         │       └─ Table\n" +
+			"         │           ├─ name: two_pk\n" +
+			"         │           └─ columns: [pk2]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -15963,13 +15961,12 @@ inner join pq on true
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [t1.pk, t2.pk2]\n" +
 			" └─ Sort(t1.pk ASC, t2.pk2 ASC)\n" +
-			"     └─ CrossJoin (estimated cost=4.030 rows=3)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (t2.pk2 = 1)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: two_pk\n" +
-			"         │           └─ columns: [pk2]\n" +
+			"     └─ CrossJoin (estimated cost=3.020 rows=1)\n" +
+			"         ├─ TableAlias(t2)\n" +
+			"         │   └─ IndexedTableAccess(two_pk)\n" +
+			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"         │       ├─ filters: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       └─ columns: [pk2]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -15979,13 +15976,12 @@ inner join pq on true
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [t1.pk, t2.pk2]\n" +
 			" └─ Sort(t1.pk ASC, t2.pk2 ASC)\n" +
-			"     └─ CrossJoin (estimated cost=4.030 rows=3) (actual rows=2 loops=1)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (t2.pk2 = 1)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: two_pk\n" +
-			"         │           └─ columns: [pk2]\n" +
+			"     └─ CrossJoin (estimated cost=3.020 rows=1) (actual rows=2 loops=1)\n" +
+			"         ├─ TableAlias(t2)\n" +
+			"         │   └─ IndexedTableAccess(two_pk)\n" +
+			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"         │       ├─ filters: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       └─ columns: [pk2]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16201,15 +16197,15 @@ inner join pq on true
 			" │  ->(SELECT pk from one_pk where pk = 1 limit 1):0]\n" +
 			" └─ Sort(t1.pk:7!null ASC nullsFirst, t2.pk2:1!null ASC nullsFirst)\n" +
 			"     └─ CrossJoin\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ t2.pk2:1!null\n" +
-			"         │   │   └─ 1 (tinyint)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ ProcessTable\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: two_pk\n" +
-			"         │               └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
+			"         ├─ TableAlias(t2)\n" +
+			"         │   └─ IndexedTableAccess(two_pk)\n" +
+			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"         │       ├─ static: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ colSet: (7-13)\n" +
+			"         │       ├─ tableId: 2\n" +
+			"         │       └─ Table\n" +
+			"         │           ├─ name: two_pk\n" +
+			"         │           └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16230,12 +16226,11 @@ inner join pq on true
 			" │           └─ columns: [pk]\n" +
 			" │   as (SELECT pk from one_pk where pk = 1 limit 1)]\n" +
 			" └─ Sort(t1.pk ASC, t2.pk2 ASC)\n" +
-			"     └─ CrossJoin (estimated cost=4.030 rows=3)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (t2.pk2 = 1)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ Table\n" +
-			"         │           └─ name: two_pk\n" +
+			"     └─ CrossJoin (estimated cost=3.020 rows=1)\n" +
+			"         ├─ TableAlias(t2)\n" +
+			"         │   └─ IndexedTableAccess(two_pk)\n" +
+			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"         │       └─ filters: [{(NULL, ∞), [1, 1]}]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16251,12 +16246,11 @@ inner join pq on true
 			" │           └─ columns: [pk]\n" +
 			" │   as (SELECT pk from one_pk where pk = 1 limit 1)]\n" +
 			" └─ Sort(t1.pk ASC, t2.pk2 ASC)\n" +
-			"     └─ CrossJoin (estimated cost=4.030 rows=3) (actual rows=2 loops=1)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (t2.pk2 = 1)\n" +
-			"         │   └─ TableAlias(t2)\n" +
-			"         │       └─ Table\n" +
-			"         │           └─ name: two_pk\n" +
+			"     └─ CrossJoin (estimated cost=3.020 rows=1) (actual rows=2 loops=1)\n" +
+			"         ├─ TableAlias(t2)\n" +
+			"         │   └─ IndexedTableAccess(two_pk)\n" +
+			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
+			"         │       └─ filters: [{(NULL, ∞), [1, 1]}]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16710,53 +16704,50 @@ inner join pq on true
 			"     │       └─ Table\n" +
 			"     │           ├─ name: invert_pk\n" +
 			"     │           └─ columns: [z]\n" +
-			"     └─ Filter\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ a.z:2!null\n" +
-			"         │   └─ 2 (bigint)\n" +
-			"         └─ TableAlias(a)\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(invert_pk)\n" +
+			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
+			"             ├─ static: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
+			"             ├─ colSet: (1-3)\n" +
+			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: invert_pk\n" +
-			"                 ├─ columns: [x y z]\n" +
-			"                 ├─ colSet: (1-3)\n" +
-			"                 └─ tableId: 1\n" +
+			"                 └─ columns: [x y z]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [a.x, a.y, a.z]\n" +
-			" └─ InnerJoin (estimated cost=7.060 rows=2)\n" +
+			" └─ InnerJoin (estimated cost=4.030 rows=3)\n" +
 			"     ├─ (a.y = b.z)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: invert_pk\n" +
 			"     │       └─ columns: [z]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (a.z = 2)\n" +
-			"         └─ TableAlias(a)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: invert_pk\n" +
-			"                 └─ columns: [x y z]\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(invert_pk)\n" +
+			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
+			"             ├─ filters: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
+			"             └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [a.x, a.y, a.z]\n" +
-			" └─ InnerJoin (estimated cost=7.060 rows=2) (actual rows=1 loops=1)\n" +
+			" └─ InnerJoin (estimated cost=4.030 rows=3) (actual rows=1 loops=1)\n" +
 			"     ├─ (a.y = b.z)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: invert_pk\n" +
 			"     │       └─ columns: [z]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (a.z = 2)\n" +
-			"         └─ TableAlias(a)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: invert_pk\n" +
-			"                 └─ columns: [x y z]\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(invert_pk)\n" +
+			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
+			"             ├─ filters: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
+			"             └─ columns: [x y z]\n" +
 			"",
 	},
 	{
 		Query: `SELECT * FROM invert_pk WHERE y = 0`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16765,12 +16756,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16778,7 +16769,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y >= 0`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16787,12 +16778,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16800,7 +16791,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y >= 0 AND z < 1`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
+			" ├─ static: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16809,12 +16800,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -21683,7 +21674,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ static: [{[NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -21703,7 +21694,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21719,7 +21710,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21740,7 +21731,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ static: [{[NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -21760,7 +21751,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21776,7 +21767,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -22432,7 +22423,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -22444,7 +22435,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -22452,7 +22443,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -22462,7 +22453,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s:1!null, mytable.i:0!null]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ reverse: true\n" +
 			"     ├─ colSet: (1,2)\n" +
 			"     ├─ tableId: 1\n" +
@@ -22474,7 +22465,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s, mytable.i]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     ├─ columns: [i s]\n" +
 			"     └─ reverse: true\n" +
 			"",
@@ -22482,7 +22473,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s, mytable.i]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     ├─ columns: [i s]\n" +
 			"     └─ reverse: true\n" +
 			"",
@@ -22491,7 +22482,7 @@ WHERE keyless.c0 IN (
 		Query: `SELECT pk1, pk2 FROM two_pk order by pk1 asc, pk2 asc;`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -22500,12 +22491,12 @@ WHERE keyless.c0 IN (
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -22532,7 +22523,7 @@ WHERE keyless.c0 IN (
 		Query: `SELECT pk1, pk2 FROM two_pk order by pk1 desc, pk2 desc;`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ reverse: true\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
@@ -22542,13 +22533,13 @@ WHERE keyless.c0 IN (
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ columns: [pk1 pk2]\n" +
 			" └─ reverse: true\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			" ├─ columns: [pk1 pk2]\n" +
 			" └─ reverse: true\n" +
 			"",
@@ -22645,7 +22636,7 @@ WHERE keyless.c0 IN (
 		ExpectedPlan: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ static: [{[NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-6)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -22655,13 +22646,13 @@ WHERE keyless.c0 IN (
 		ExpectedEstimates: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ filters: [{[NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞)}]\n" +
 			"     └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -22671,21 +22662,21 @@ WHERE keyless.c0 IN (
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedEstimates: "Limit(10)\n" +
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Limit(10)\n" +
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -23216,7 +23207,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23229,7 +23220,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23238,7 +23229,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23250,7 +23241,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->min(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -23262,7 +23253,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as min(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [x]\n" +
 			"",
 		ExpectedAnalysis: "Limit(1)\n" +
@@ -23270,7 +23261,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as min(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         └─ columns: [x]\n" +
 			"",
 	},
@@ -23312,7 +23303,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x:0!null + 100 (tinyint))->max(x)+100:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23325,7 +23316,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x + 100) as max(x)+100]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23334,7 +23325,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x + 100) as max(x)+100]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23346,7 +23337,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->xx:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23359,7 +23350,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as xx]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23368,7 +23359,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as xx]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23377,10 +23368,10 @@ WHERE keyless.c0 IN (
 		Query: `select 1, 2.0, '3', max(x) from xy`,
 		ExpectedPlan: "Limit(1)\n" +
 			" └─ Project\n" +
-			"     ├─ columns: [1 (tinyint), 2 (decimal(2,1)), 3 (longtext), xy.x:0!null->max(x):0]\n" +
+			"     ├─ columns: [1 (tinyint), 2.0 (decimal(2,1)), 3 (longtext), xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{[NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23393,7 +23384,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1, 2.0, '3', xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23402,7 +23393,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1, 2.0, '3', xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{[NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23560,7 +23551,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ static: [{[NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -23580,7 +23571,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x as max(x)]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [x]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -23596,7 +23587,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x as max(x)]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ filters: [{[NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, ∞)}]\n" +
 			"             ├─ columns: [x]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -23617,7 +23608,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ static: [{[NULL, ∞)}]\n" +
+			"                 ├─ static: [{(NULL, ∞)}]\n" +
 			"                 ├─ reverse: true\n" +
 			"                 ├─ colSet: (1,2)\n" +
 			"                 ├─ tableId: 1\n" +
@@ -23639,7 +23630,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x as max(x)]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 ├─ filters: [{(NULL, ∞)}]\n" +
 			"                 ├─ columns: [x]\n" +
 			"                 └─ reverse: true\n" +
 			"",
@@ -23657,7 +23648,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x as max(x)]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 ├─ filters: [{(NULL, ∞)}]\n" +
 			"                 ├─ columns: [x]\n" +
 			"                 └─ reverse: true\n" +
 			"",
@@ -24653,7 +24644,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24663,13 +24654,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1]\n" +
 			"",
 	},
@@ -24730,7 +24721,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2:1!null]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -24742,7 +24733,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
@@ -24750,7 +24741,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24759,7 +24750,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24769,13 +24760,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24806,7 +24797,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24816,13 +24807,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24855,7 +24846,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2:1!null, two_pk.pk1:0!null]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -24867,7 +24858,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2, two_pk.pk1]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
@@ -24875,7 +24866,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2, two_pk.pk1]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
+			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -8838,28 +8838,27 @@ inner join pq on true
 	},
 	{
 		Query: `SELECT a.* FROM mytable a WHERE a.s is not null`,
-		ExpectedPlan: "Filter\n" +
-			" ├─ NOT\n" +
-			" │   └─ a.s:1!null IS NULL\n" +
-			" └─ TableAlias(a)\n" +
-			"     └─ ProcessTable\n" +
-			"         └─ Table\n" +
-			"             ├─ name: mytable\n" +
-			"             └─ columns: [i s]\n" +
-			"",
-		ExpectedEstimates: "Filter\n" +
-			" ├─ (NOT(a.s IS NULL))\n" +
-			" └─ TableAlias(a)\n" +
+		ExpectedPlan: "TableAlias(a)\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
+			"     ├─ index: [mytable.s,mytable.i]\n" +
+			"     ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     ├─ colSet: (1,2)\n" +
+			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
 			"         ├─ name: mytable\n" +
 			"         └─ columns: [i s]\n" +
 			"",
-		ExpectedAnalysis: "Filter\n" +
-			" ├─ (NOT(a.s IS NULL))\n" +
-			" └─ TableAlias(a)\n" +
-			"     └─ Table\n" +
-			"         ├─ name: mytable\n" +
-			"         └─ columns: [i s]\n" +
+		ExpectedEstimates: "TableAlias(a)\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
+			"     ├─ index: [mytable.s,mytable.i]\n" +
+			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     └─ columns: [i s]\n" +
+			"",
+		ExpectedAnalysis: "TableAlias(a)\n" +
+			" └─ IndexedTableAccess(mytable)\n" +
+			"     ├─ index: [mytable.s,mytable.i]\n" +
+			"     ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"     └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -8875,45 +8874,43 @@ inner join pq on true
 			"     │       └─ Table\n" +
 			"     │           ├─ name: mytable\n" +
 			"     │           └─ columns: [s]\n" +
-			"     └─ Filter\n" +
-			"         ├─ NOT\n" +
-			"         │   └─ a.s:1!null IS NULL\n" +
-			"         └─ TableAlias(a)\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ colSet: (1,2)\n" +
+			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: mytable\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 ├─ colSet: (1,2)\n" +
-			"                 └─ tableId: 1\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=7.060 rows=3)\n" +
+			" └─ InnerJoin (estimated cost=4.030 rows=3)\n" +
 			"     ├─ (a.i = b.s)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [s]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (NOT(a.s IS NULL))\n" +
-			"         └─ TableAlias(a)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ columns: [i s]\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=7.060 rows=3) (actual rows=0 loops=1)\n" +
+			" └─ InnerJoin (estimated cost=4.030 rows=3) (actual rows=0 loops=1)\n" +
 			"     ├─ (a.i = b.s)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [s]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (NOT(a.s IS NULL))\n" +
-			"         └─ TableAlias(a)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ columns: [i s]\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -8929,45 +8926,43 @@ inner join pq on true
 			"     │       └─ Table\n" +
 			"     │           ├─ name: mytable\n" +
 			"     │           └─ columns: [s]\n" +
-			"     └─ Filter\n" +
-			"         ├─ NOT\n" +
-			"         │   └─ a.s:1!null IS NULL\n" +
-			"         └─ TableAlias(a)\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ static: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             ├─ colSet: (1,2)\n" +
+			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: mytable\n" +
-			"                 ├─ columns: [i s]\n" +
-			"                 ├─ colSet: (1,2)\n" +
-			"                 └─ tableId: 1\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=7.060 rows=3)\n" +
+			" └─ InnerJoin (estimated cost=4.030 rows=3)\n" +
 			"     ├─ (a.i = b.s)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [s]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (NOT(a.s IS NULL))\n" +
-			"         └─ TableAlias(a)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ columns: [i s]\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=7.060 rows=3) (actual rows=0 loops=1)\n" +
+			" └─ InnerJoin (estimated cost=4.030 rows=3) (actual rows=0 loops=1)\n" +
 			"     ├─ (a.i = b.s)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [s]\n" +
-			"     └─ Filter\n" +
-			"         ├─ (NOT(a.s IS NULL))\n" +
-			"         └─ TableAlias(a)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: mytable\n" +
-			"                 └─ columns: [i s]\n" +
+			"     └─ TableAlias(a)\n" +
+			"         └─ IndexedTableAccess(mytable)\n" +
+			"             ├─ index: [mytable.s,mytable.i]\n" +
+			"             ├─ filters: [{(NULL, ∞), [NULL, ∞)}]\n" +
+			"             └─ columns: [i s]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -1131,7 +1131,7 @@ WHERE
 			"         │   └─ order_line1.ol_i_id:3\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
+			"         │   ├─ static: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
 			"         │   ├─ colSet: (1-10)\n" +
 			"         │   ├─ tableId: 1\n" +
 			"         │   └─ Table\n" +
@@ -1146,7 +1146,7 @@ WHERE
 			"                 │   └─ 15 (smallint)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ static: [{[5, 5], (NULL, ∞)}]\n" +
+			"                     ├─ static: [{[5, 5], [NULL, ∞)}]\n" +
 			"                     ├─ colSet: (11-27)\n" +
 			"                     ├─ tableId: 2\n" +
 			"                     └─ Table\n" +
@@ -1162,7 +1162,7 @@ WHERE
 			"         ├─ (stock1.s_i_id = order_line1.ol_i_id)\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (order_line1.ol_i_id)\n" +
@@ -1171,7 +1171,7 @@ WHERE
 			"                 ├─ (stock1.s_quantity < 15)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ filters: [{[5, 5], (NULL, ∞)}]\n" +
+			"                     ├─ filters: [{[5, 5], [NULL, ∞)}]\n" +
 			"                     └─ columns: [s_i_id s_w_id s_quantity]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -1183,7 +1183,7 @@ WHERE
 			"         ├─ (stock1.s_i_id = order_line1.ol_i_id)\n" +
 			"         ├─ IndexedTableAccess(order_line1)\n" +
 			"         │   ├─ index: [order_line1.ol_w_id,order_line1.ol_d_id,order_line1.ol_o_id,order_line1.ol_number]\n" +
-			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), (NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[5, 5], [2, 2], [2981, 3001), [NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (order_line1.ol_i_id)\n" +
@@ -1192,7 +1192,7 @@ WHERE
 			"                 ├─ (stock1.s_quantity < 15)\n" +
 			"                 └─ IndexedTableAccess(stock1)\n" +
 			"                     ├─ index: [stock1.s_w_id,stock1.s_i_id]\n" +
-			"                     ├─ filters: [{[5, 5], (NULL, ∞)}]\n" +
+			"                     ├─ filters: [{[5, 5], [NULL, ∞)}]\n" +
 			"                     └─ columns: [s_i_id s_w_id s_quantity]\n" +
 			"",
 	},
@@ -3617,7 +3617,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -3635,7 +3635,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -3649,7 +3649,7 @@ Select * from (
 			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -3665,7 +3665,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -3682,7 +3682,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "SubqueryAlias\n" +
@@ -3695,7 +3695,7 @@ Select * from (
 			" └─ TableAlias(t)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -3722,7 +3722,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin:0!null->dst:0]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ static: [{[New York, New York], (NULL, ∞)}]\n" +
+			"             │       ├─ static: [{[New York, New York], [NULL, ∞)}]\n" +
 			"             │       ├─ colSet: (1,2)\n" +
 			"             │       ├─ tableId: 1\n" +
 			"             │       └─ Table\n" +
@@ -3755,7 +3755,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ filters: [{[New York, New York], (NULL, ∞)}]\n" +
+			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
 			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
@@ -3780,7 +3780,7 @@ Select * from (
 			"             │   ├─ columns: [bus_routes.origin as dst]\n" +
 			"             │   └─ IndexedTableAccess(bus_routes)\n" +
 			"             │       ├─ index: [bus_routes.origin,bus_routes.dst]\n" +
-			"             │       ├─ filters: [{[New York, New York], (NULL, ∞)}]\n" +
+			"             │       ├─ filters: [{[New York, New York], [NULL, ∞)}]\n" +
 			"             │       └─ columns: [origin]\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [bus_routes.dst]\n" +
@@ -6310,7 +6310,7 @@ inner join pq on true
 		Query: `SELECT * FROM one_pk ORDER BY pk`,
 		ExpectedPlan: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ static: [{(NULL, ∞)}]\n" +
+			" ├─ static: [{[NULL, ∞)}]\n" +
 			" ├─ colSet: (1-6)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6319,12 +6319,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ filters: [{(NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞)}]\n" +
 			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(one_pk)\n" +
 			" ├─ index: [one_pk.pk]\n" +
-			" ├─ filters: [{(NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞)}]\n" +
 			" └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6332,7 +6332,7 @@ inner join pq on true
 		Query: `SELECT * FROM two_pk ORDER BY pk1, pk2`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6341,12 +6341,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6354,7 +6354,7 @@ inner join pq on true
 		Query: `SELECT * FROM two_pk ORDER BY pk1`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -6363,12 +6363,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -6378,7 +6378,7 @@ inner join pq on true
 			" ├─ columns: [two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -6389,14 +6389,14 @@ inner join pq on true
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -6408,7 +6408,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1:0!null, two_pk.pk2:1!null, two_pk.c1:2!null, two_pk.c2:3!null, two_pk.c3:4!null, two_pk.c4:5!null, two_pk.c5:6!null, two_pk.pk1:0!null->one:0, two_pk.pk2:1!null->two:0]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -6421,7 +6421,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -6430,7 +6430,7 @@ inner join pq on true
 			"     ├─ columns: [two_pk.pk1, two_pk.pk2, two_pk.c1, two_pk.c2, two_pk.c3, two_pk.c4, two_pk.c5, two_pk.pk1 as one, two_pk.pk2 as two]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2 c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -8838,27 +8838,28 @@ inner join pq on true
 	},
 	{
 		Query: `SELECT a.* FROM mytable a WHERE a.s is not null`,
-		ExpectedPlan: "TableAlias(a)\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"     ├─ colSet: (1,2)\n" +
-			"     ├─ tableId: 1\n" +
+		ExpectedPlan: "Filter\n" +
+			" ├─ NOT\n" +
+			" │   └─ a.s:1!null IS NULL\n" +
+			" └─ TableAlias(a)\n" +
+			"     └─ ProcessTable\n" +
+			"         └─ Table\n" +
+			"             ├─ name: mytable\n" +
+			"             └─ columns: [i s]\n" +
+			"",
+		ExpectedEstimates: "Filter\n" +
+			" ├─ (NOT(a.s IS NULL))\n" +
+			" └─ TableAlias(a)\n" +
 			"     └─ Table\n" +
 			"         ├─ name: mytable\n" +
 			"         └─ columns: [i s]\n" +
 			"",
-		ExpectedEstimates: "TableAlias(a)\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"     └─ columns: [i s]\n" +
-			"",
-		ExpectedAnalysis: "TableAlias(a)\n" +
-			" └─ IndexedTableAccess(mytable)\n" +
-			"     ├─ index: [mytable.s,mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"     └─ columns: [i s]\n" +
+		ExpectedAnalysis: "Filter\n" +
+			" ├─ (NOT(a.s IS NULL))\n" +
+			" └─ TableAlias(a)\n" +
+			"     └─ Table\n" +
+			"         ├─ name: mytable\n" +
+			"         └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -8874,43 +8875,45 @@ inner join pq on true
 			"     │       └─ Table\n" +
 			"     │           ├─ name: mytable\n" +
 			"     │           └─ columns: [s]\n" +
-			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"             ├─ colSet: (1,2)\n" +
-			"             ├─ tableId: 1\n" +
+			"     └─ Filter\n" +
+			"         ├─ NOT\n" +
+			"         │   └─ a.s:1!null IS NULL\n" +
+			"         └─ TableAlias(a)\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: mytable\n" +
+			"                 ├─ columns: [i s]\n" +
+			"                 ├─ colSet: (1,2)\n" +
+			"                 └─ tableId: 1\n" +
+			"",
+		ExpectedEstimates: "Project\n" +
+			" ├─ columns: [a.i, a.s]\n" +
+			" └─ InnerJoin (estimated cost=7.060 rows=3)\n" +
+			"     ├─ (a.i = b.s)\n" +
+			"     ├─ TableAlias(b)\n" +
+			"     │   └─ Table\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [s]\n" +
+			"     └─ Filter\n" +
+			"         ├─ (NOT(a.s IS NULL))\n" +
+			"         └─ TableAlias(a)\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: mytable\n" +
 			"                 └─ columns: [i s]\n" +
 			"",
-		ExpectedEstimates: "Project\n" +
-			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=4.030 rows=3)\n" +
-			"     ├─ (a.i = b.s)\n" +
-			"     ├─ TableAlias(b)\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: mytable\n" +
-			"     │       └─ columns: [s]\n" +
-			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"             └─ columns: [i s]\n" +
-			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=4.030 rows=3) (actual rows=0 loops=1)\n" +
+			" └─ InnerJoin (estimated cost=7.060 rows=3) (actual rows=0 loops=1)\n" +
 			"     ├─ (a.i = b.s)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [s]\n" +
-			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"             └─ columns: [i s]\n" +
+			"     └─ Filter\n" +
+			"         ├─ (NOT(a.s IS NULL))\n" +
+			"         └─ TableAlias(a)\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: mytable\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -8926,43 +8929,45 @@ inner join pq on true
 			"     │       └─ Table\n" +
 			"     │           ├─ name: mytable\n" +
 			"     │           └─ columns: [s]\n" +
-			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"             ├─ colSet: (1,2)\n" +
-			"             ├─ tableId: 1\n" +
+			"     └─ Filter\n" +
+			"         ├─ NOT\n" +
+			"         │   └─ a.s:1!null IS NULL\n" +
+			"         └─ TableAlias(a)\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: mytable\n" +
+			"                 ├─ columns: [i s]\n" +
+			"                 ├─ colSet: (1,2)\n" +
+			"                 └─ tableId: 1\n" +
+			"",
+		ExpectedEstimates: "Project\n" +
+			" ├─ columns: [a.i, a.s]\n" +
+			" └─ InnerJoin (estimated cost=7.060 rows=3)\n" +
+			"     ├─ (a.i = b.s)\n" +
+			"     ├─ TableAlias(b)\n" +
+			"     │   └─ Table\n" +
+			"     │       ├─ name: mytable\n" +
+			"     │       └─ columns: [s]\n" +
+			"     └─ Filter\n" +
+			"         ├─ (NOT(a.s IS NULL))\n" +
+			"         └─ TableAlias(a)\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: mytable\n" +
 			"                 └─ columns: [i s]\n" +
 			"",
-		ExpectedEstimates: "Project\n" +
-			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=4.030 rows=3)\n" +
-			"     ├─ (a.i = b.s)\n" +
-			"     ├─ TableAlias(b)\n" +
-			"     │   └─ Table\n" +
-			"     │       ├─ name: mytable\n" +
-			"     │       └─ columns: [s]\n" +
-			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"             └─ columns: [i s]\n" +
-			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [a.i, a.s]\n" +
-			" └─ InnerJoin (estimated cost=4.030 rows=3) (actual rows=0 loops=1)\n" +
+			" └─ InnerJoin (estimated cost=7.060 rows=3) (actual rows=0 loops=1)\n" +
 			"     ├─ (a.i = b.s)\n" +
 			"     ├─ TableAlias(b)\n" +
 			"     │   └─ Table\n" +
 			"     │       ├─ name: mytable\n" +
 			"     │       └─ columns: [s]\n" +
-			"     └─ TableAlias(a)\n" +
-			"         └─ IndexedTableAccess(mytable)\n" +
-			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
-			"             └─ columns: [i s]\n" +
+			"     └─ Filter\n" +
+			"         ├─ (NOT(a.s IS NULL))\n" +
+			"         └─ TableAlias(a)\n" +
+			"             └─ Table\n" +
+			"                 ├─ name: mytable\n" +
+			"                 └─ columns: [i s]\n" +
 			"",
 	},
 	{
@@ -8981,7 +8986,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ static: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
+			"             ├─ static: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -8999,7 +9004,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -9013,7 +9018,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.s,mytable.i]\n" +
-			"             ├─ filters: [{(NULL, 1), (NULL, ∞)}, {(1, 2), (NULL, ∞)}, {(2, 3), (NULL, ∞)}, {(3, 4), (NULL, ∞)}, {(4, ∞), (NULL, ∞)}]\n" +
+			"             ├─ filters: [{(NULL, 1), [NULL, ∞)}, {(1, 2), [NULL, ∞)}, {(2, 3), [NULL, ∞)}, {(3, 4), [NULL, ∞)}, {(4, ∞), [NULL, ∞)}]\n" +
 			"             └─ columns: [i s]\n" +
 			"",
 	},
@@ -15403,7 +15408,7 @@ inner join pq on true
 			"     │   └─ 0 (tinyint)\n" +
 			"     ├─ IndexedTableAccess(two_pk)\n" +
 			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │   ├─ static: [{(NULL, ∞), (NULL, 1)}]\n" +
+			"     │   ├─ static: [{[NULL, ∞), (NULL, 1)}]\n" +
 			"     │   ├─ colSet: (7-13)\n" +
 			"     │   ├─ tableId: 2\n" +
 			"     │   └─ Table\n" +
@@ -15420,7 +15425,7 @@ inner join pq on true
 			"     ├─ ((two_pk.pk1 - one_pk.pk) > 0)\n" +
 			"     ├─ IndexedTableAccess(two_pk)\n" +
 			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │   ├─ filters: [{(NULL, ∞), (NULL, 1)}]\n" +
+			"     │   ├─ filters: [{[NULL, ∞), (NULL, 1)}]\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: one_pk\n" +
@@ -15432,7 +15437,7 @@ inner join pq on true
 			"     ├─ ((two_pk.pk1 - one_pk.pk) > 0)\n" +
 			"     ├─ IndexedTableAccess(two_pk)\n" +
 			"     │   ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     │   ├─ filters: [{(NULL, ∞), (NULL, 1)}]\n" +
+			"     │   ├─ filters: [{[NULL, ∞), (NULL, 1)}]\n" +
 			"     │   └─ columns: [pk1 pk2]\n" +
 			"     └─ Table\n" +
 			"         ├─ name: one_pk\n" +
@@ -15942,7 +15947,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ static: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ static: [{[NULL, ∞), [1, 1]}]\n" +
 			"         │       ├─ colSet: (7-13)\n" +
 			"         │       ├─ tableId: 2\n" +
 			"         │       └─ Table\n" +
@@ -15965,7 +15970,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ filters: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ filters: [{[NULL, ∞), [1, 1]}]\n" +
 			"         │       └─ columns: [pk2]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
@@ -15980,7 +15985,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ filters: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ filters: [{[NULL, ∞), [1, 1]}]\n" +
 			"         │       └─ columns: [pk2]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
@@ -16200,7 +16205,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       ├─ static: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       ├─ static: [{[NULL, ∞), [1, 1]}]\n" +
 			"         │       ├─ colSet: (7-13)\n" +
 			"         │       ├─ tableId: 2\n" +
 			"         │       └─ Table\n" +
@@ -16230,7 +16235,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       └─ filters: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       └─ filters: [{[NULL, ∞), [1, 1]}]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16250,7 +16255,7 @@ inner join pq on true
 			"         ├─ TableAlias(t2)\n" +
 			"         │   └─ IndexedTableAccess(two_pk)\n" +
 			"         │       ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         │       └─ filters: [{(NULL, ∞), [1, 1]}]\n" +
+			"         │       └─ filters: [{[NULL, ∞), [1, 1]}]\n" +
 			"         └─ TableAlias(t1)\n" +
 			"             └─ IndexedTableAccess(one_pk)\n" +
 			"                 ├─ index: [one_pk.pk]\n" +
@@ -16707,7 +16712,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ static: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
+			"             ├─ static: [{[NULL, ∞), [2, 2], [NULL, ∞)}]\n" +
 			"             ├─ colSet: (1-3)\n" +
 			"             ├─ tableId: 1\n" +
 			"             └─ Table\n" +
@@ -16725,7 +16730,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ filters: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞), [2, 2], [NULL, ∞)}]\n" +
 			"             └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -16739,7 +16744,7 @@ inner join pq on true
 			"     └─ TableAlias(a)\n" +
 			"         └─ IndexedTableAccess(invert_pk)\n" +
 			"             ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			"             ├─ filters: [{(NULL, ∞), [2, 2], (NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞), [2, 2], [NULL, ∞)}]\n" +
 			"             └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16747,7 +16752,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y = 0`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ static: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16756,12 +16761,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, 0], (NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, 0], [NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16769,7 +16774,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y >= 0`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ static: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16778,12 +16783,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), [NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -16791,7 +16796,7 @@ inner join pq on true
 		Query: `SELECT * FROM invert_pk WHERE y >= 0 AND z < 1`,
 		ExpectedPlan: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ static: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
+			" ├─ static: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
 			" ├─ colSet: (1-3)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -16800,12 +16805,12 @@ inner join pq on true
 			"",
 		ExpectedEstimates: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(invert_pk)\n" +
 			" ├─ index: [invert_pk.y,invert_pk.z,invert_pk.x]\n" +
-			" ├─ filters: [{[0, ∞), (NULL, 1), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[0, ∞), (NULL, 1), [NULL, ∞)}]\n" +
 			" └─ columns: [x y z]\n" +
 			"",
 	},
@@ -17297,25 +17302,24 @@ inner join pq on true
 			"         ├─ Eq\n" +
 			"         │   ├─ b.pk:2!null\n" +
 			"         │   └─ c.v1:0\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ c.v2:1\n" +
-			"         │   │   └─ 0 (bigint)\n" +
-			"         │   └─ TableAlias(c)\n" +
-			"         │       └─ ProcessTable\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: one_pk_three_idx\n" +
-			"         │               └─ columns: [v1 v2]\n" +
+			"         ├─ TableAlias(c)\n" +
+			"         │   └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"         │       ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"         │       ├─ static: [{[NULL, ∞), [0, 0], [NULL, ∞)}]\n" +
+			"         │       ├─ colSet: (9-12)\n" +
+			"         │       ├─ tableId: 3\n" +
+			"         │       └─ Table\n" +
+			"         │           ├─ name: one_pk_three_idx\n" +
+			"         │           └─ columns: [v1 v2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: TUPLE(c.v1:0)\n" +
 			"             ├─ right-key: TUPLE(b.pk:0!null)\n" +
 			"             └─ CrossJoin\n" +
 			"                 ├─ TableAlias(b)\n" +
-			"                 │   └─ Table\n" +
-			"                 │       ├─ name: one_pk_three_idx\n" +
-			"                 │       ├─ columns: [pk]\n" +
-			"                 │       ├─ colSet: (5-8)\n" +
-			"                 │       └─ tableId: 2\n" +
+			"                 │   └─ ProcessTable\n" +
+			"                 │       └─ Table\n" +
+			"                 │           ├─ name: one_pk_three_idx\n" +
+			"                 │           └─ columns: [pk]\n" +
 			"                 └─ TableAlias(a)\n" +
 			"                     └─ Table\n" +
 			"                         ├─ name: one_pk_three_idx\n" +
@@ -17327,14 +17331,13 @@ inner join pq on true
 			" ├─ columns: [a.pk, c.v2]\n" +
 			" └─ Filter\n" +
 			"     ├─ (b.pk = 0)\n" +
-			"     └─ LeftOuterHashJoin (estimated cost=36.130 rows=7)\n" +
+			"     └─ LeftOuterHashJoin (estimated cost=34.170 rows=13)\n" +
 			"         ├─ (b.pk = c.v1)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (c.v2 = 0)\n" +
-			"         │   └─ TableAlias(c)\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: one_pk_three_idx\n" +
-			"         │           └─ columns: [v1 v2]\n" +
+			"         ├─ TableAlias(c)\n" +
+			"         │   └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"         │       ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"         │       ├─ filters: [{[NULL, ∞), [0, 0], [NULL, ∞)}]\n" +
+			"         │       └─ columns: [v1 v2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (c.v1)\n" +
 			"             ├─ right-key: (b.pk)\n" +
@@ -17352,14 +17355,13 @@ inner join pq on true
 			" ├─ columns: [a.pk, c.v2]\n" +
 			" └─ Filter\n" +
 			"     ├─ (b.pk = 0)\n" +
-			"     └─ LeftOuterHashJoin (estimated cost=36.130 rows=7) (actual rows=32 loops=1)\n" +
+			"     └─ LeftOuterHashJoin (estimated cost=34.170 rows=13) (actual rows=32 loops=1)\n" +
 			"         ├─ (b.pk = c.v1)\n" +
-			"         ├─ Filter\n" +
-			"         │   ├─ (c.v2 = 0)\n" +
-			"         │   └─ TableAlias(c)\n" +
-			"         │       └─ Table\n" +
-			"         │           ├─ name: one_pk_three_idx\n" +
-			"         │           └─ columns: [v1 v2]\n" +
+			"         ├─ TableAlias(c)\n" +
+			"         │   └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"         │       ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"         │       ├─ filters: [{[NULL, ∞), [0, 0], [NULL, ∞)}]\n" +
+			"         │       └─ columns: [v1 v2]\n" +
 			"         └─ HashLookup\n" +
 			"             ├─ left-key: (c.v1)\n" +
 			"             ├─ right-key: (b.pk)\n" +
@@ -17378,7 +17380,7 @@ inner join pq on true
 		Query: `select a.pk, c.v2 from one_pk_three_idx a cross join one_pk_three_idx b left join one_pk_three_idx c on b.pk = c.v1 where b.pk = 0 and a.v2 = 1;`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [a.pk:1!null, c.v2:4]\n" +
-			" └─ LeftOuterHashJoin\n" +
+			" └─ LeftOuterJoin\n" +
 			"     ├─ Eq\n" +
 			"     │   ├─ b.pk:0!null\n" +
 			"     │   └─ c.v1:3\n" +
@@ -17392,72 +17394,60 @@ inner join pq on true
 			"     │   │       └─ Table\n" +
 			"     │   │           ├─ name: one_pk_three_idx\n" +
 			"     │   │           └─ columns: [pk]\n" +
-			"     │   └─ Filter\n" +
-			"     │       ├─ Eq\n" +
-			"     │       │   ├─ a.v2:1\n" +
-			"     │       │   └─ 1 (bigint)\n" +
-			"     │       └─ TableAlias(a)\n" +
-			"     │           └─ ProcessTable\n" +
-			"     │               └─ Table\n" +
-			"     │                   ├─ name: one_pk_three_idx\n" +
-			"     │                   └─ columns: [pk v2]\n" +
-			"     └─ HashLookup\n" +
-			"         ├─ left-key: TUPLE(b.pk:0!null)\n" +
-			"         ├─ right-key: TUPLE(c.v1:0)\n" +
-			"         └─ TableAlias(c)\n" +
+			"     │   └─ TableAlias(a)\n" +
+			"     │       └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"     │           ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     │           ├─ static: [{[NULL, ∞), [1, 1], [NULL, ∞)}]\n" +
+			"     │           ├─ colSet: (1-4)\n" +
+			"     │           ├─ tableId: 1\n" +
+			"     │           └─ Table\n" +
+			"     │               ├─ name: one_pk_three_idx\n" +
+			"     │               └─ columns: [pk v2]\n" +
+			"     └─ TableAlias(c)\n" +
+			"         └─ ProcessTable\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: one_pk_three_idx\n" +
-			"                 ├─ columns: [v1 v2]\n" +
-			"                 ├─ colSet: (9-12)\n" +
-			"                 └─ tableId: 3\n" +
+			"                 └─ columns: [v1 v2]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [a.pk, c.v2]\n" +
-			" └─ LeftOuterHashJoin (estimated cost=30.130 rows=7)\n" +
+			" └─ LeftOuterJoin (estimated cost=7.080 rows=1)\n" +
 			"     ├─ (b.pk = c.v1)\n" +
-			"     ├─ CrossJoin (estimated cost=7.060 rows=6)\n" +
+			"     ├─ CrossJoin (estimated cost=5.040 rows=1)\n" +
 			"     │   ├─ TableAlias(b)\n" +
 			"     │   │   └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     │   │       ├─ index: [one_pk_three_idx.pk]\n" +
 			"     │   │       ├─ filters: [{[0, 0]}]\n" +
 			"     │   │       └─ columns: [pk]\n" +
-			"     │   └─ Filter\n" +
-			"     │       ├─ (a.v2 = 1)\n" +
-			"     │       └─ TableAlias(a)\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk_three_idx\n" +
-			"     │               └─ columns: [pk v2]\n" +
-			"     └─ HashLookup\n" +
-			"         ├─ left-key: (b.pk)\n" +
-			"         ├─ right-key: (c.v1)\n" +
-			"         └─ TableAlias(c)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_three_idx\n" +
-			"                 └─ columns: [v1 v2]\n" +
+			"     │   └─ TableAlias(a)\n" +
+			"     │       └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"     │           ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     │           ├─ filters: [{[NULL, ∞), [1, 1], [NULL, ∞)}]\n" +
+			"     │           └─ columns: [pk v2]\n" +
+			"     └─ TableAlias(c)\n" +
+			"         └─ Table\n" +
+			"             ├─ name: one_pk_three_idx\n" +
+			"             └─ columns: [v1 v2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [a.pk, c.v2]\n" +
-			" └─ LeftOuterHashJoin (estimated cost=30.130 rows=7) (actual rows=4 loops=1)\n" +
+			" └─ LeftOuterJoin (estimated cost=7.080 rows=1) (actual rows=4 loops=1)\n" +
 			"     ├─ (b.pk = c.v1)\n" +
-			"     ├─ CrossJoin (estimated cost=7.060 rows=6) (actual rows=1 loops=1)\n" +
+			"     ├─ CrossJoin (estimated cost=5.040 rows=1) (actual rows=1 loops=1)\n" +
 			"     │   ├─ TableAlias(b)\n" +
 			"     │   │   └─ IndexedTableAccess(one_pk_three_idx)\n" +
 			"     │   │       ├─ index: [one_pk_three_idx.pk]\n" +
 			"     │   │       ├─ filters: [{[0, 0]}]\n" +
 			"     │   │       └─ columns: [pk]\n" +
-			"     │   └─ Filter\n" +
-			"     │       ├─ (a.v2 = 1)\n" +
-			"     │       └─ TableAlias(a)\n" +
-			"     │           └─ Table\n" +
-			"     │               ├─ name: one_pk_three_idx\n" +
-			"     │               └─ columns: [pk v2]\n" +
-			"     └─ HashLookup\n" +
-			"         ├─ left-key: (b.pk)\n" +
-			"         ├─ right-key: (c.v1)\n" +
-			"         └─ TableAlias(c)\n" +
-			"             └─ Table\n" +
-			"                 ├─ name: one_pk_three_idx\n" +
-			"                 └─ columns: [v1 v2]\n" +
+			"     │   └─ TableAlias(a)\n" +
+			"     │       └─ IndexedTableAccess(one_pk_three_idx)\n" +
+			"     │           ├─ index: [one_pk_three_idx.v1,one_pk_three_idx.v2,one_pk_three_idx.v3]\n" +
+			"     │           ├─ filters: [{[NULL, ∞), [1, 1], [NULL, ∞)}]\n" +
+			"     │           └─ columns: [pk v2]\n" +
+			"     └─ TableAlias(c)\n" +
+			"         └─ Table\n" +
+			"             ├─ name: one_pk_three_idx\n" +
+			"             └─ columns: [v1 v2]\n" +
 			"",
 	},
 	{
@@ -21674,7 +21664,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞)}]\n" +
+			"             ├─ static: [{[NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -21694,7 +21684,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21710,7 +21700,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21731,7 +21721,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ static: [{(NULL, ∞)}]\n" +
+			"             ├─ static: [{[NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -21751,7 +21741,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -21767,7 +21757,7 @@ With c as (
 			"     └─ Limit(1)\n" +
 			"         └─ IndexedTableAccess(mytable)\n" +
 			"             ├─ index: [mytable.i]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞)}]\n" +
 			"             ├─ columns: [i]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -22423,7 +22413,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -22435,7 +22425,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -22443,7 +22433,7 @@ WHERE keyless.c0 IN (
 			" └─ TableAlias(a)\n" +
 			"     └─ IndexedTableAccess(mytable)\n" +
 			"         ├─ index: [mytable.i]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 	},
@@ -22453,7 +22443,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s:1!null, mytable.i:0!null]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ reverse: true\n" +
 			"     ├─ colSet: (1,2)\n" +
 			"     ├─ tableId: 1\n" +
@@ -22465,7 +22455,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s, mytable.i]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     ├─ columns: [i s]\n" +
 			"     └─ reverse: true\n" +
 			"",
@@ -22473,7 +22463,7 @@ WHERE keyless.c0 IN (
 			" ├─ columns: [mytable.s, mytable.i]\n" +
 			" └─ IndexedTableAccess(mytable)\n" +
 			"     ├─ index: [mytable.i]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     ├─ columns: [i s]\n" +
 			"     └─ reverse: true\n" +
 			"",
@@ -22482,7 +22472,7 @@ WHERE keyless.c0 IN (
 		Query: `SELECT pk1, pk2 FROM two_pk order by pk1 asc, pk2 asc;`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
 			" └─ Table\n" +
@@ -22491,12 +22481,12 @@ WHERE keyless.c0 IN (
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -22523,7 +22513,7 @@ WHERE keyless.c0 IN (
 		Query: `SELECT pk1, pk2 FROM two_pk order by pk1 desc, pk2 desc;`,
 		ExpectedPlan: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ reverse: true\n" +
 			" ├─ colSet: (1-7)\n" +
 			" ├─ tableId: 1\n" +
@@ -22533,13 +22523,13 @@ WHERE keyless.c0 IN (
 			"",
 		ExpectedEstimates: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ columns: [pk1 pk2]\n" +
 			" └─ reverse: true\n" +
 			"",
 		ExpectedAnalysis: "IndexedTableAccess(two_pk)\n" +
 			" ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			" ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			" ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			" ├─ columns: [pk1 pk2]\n" +
 			" └─ reverse: true\n" +
 			"",
@@ -22636,7 +22626,7 @@ WHERE keyless.c0 IN (
 		ExpectedPlan: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ static: [{(NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-6)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -22646,13 +22636,13 @@ WHERE keyless.c0 IN (
 		ExpectedEstimates: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Limit(10)\n" +
 			" └─ IndexedTableAccess(one_pk)\n" +
 			"     ├─ index: [one_pk.pk]\n" +
-			"     ├─ filters: [{(NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞)}]\n" +
 			"     └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -22662,21 +22652,21 @@ WHERE keyless.c0 IN (
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedEstimates: "Limit(10)\n" +
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 		ExpectedAnalysis: "Limit(10)\n" +
 			" └─ Offset(5)\n" +
 			"     └─ IndexedTableAccess(one_pk)\n" +
 			"         ├─ index: [one_pk.pk]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [pk c1 c2 c3 c4 c5]\n" +
 			"",
 	},
@@ -23207,7 +23197,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23220,7 +23210,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23229,7 +23219,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23241,7 +23231,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->min(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -23253,7 +23243,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as min(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [x]\n" +
 			"",
 		ExpectedAnalysis: "Limit(1)\n" +
@@ -23261,7 +23251,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as min(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         └─ columns: [x]\n" +
 			"",
 	},
@@ -23303,7 +23293,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x:0!null + 100 (tinyint))->max(x)+100:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23316,7 +23306,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x + 100) as max(x)+100]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23325,7 +23315,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [(xy.x + 100) as max(x)+100]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23337,7 +23327,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x:0!null->xx:0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23350,7 +23340,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as xx]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23359,7 +23349,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [xy.x as xx]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23371,7 +23361,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1 (tinyint), 2.0 (decimal(2,1)), 3 (longtext), xy.x:0!null->max(x):0]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ static: [{(NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞)}]\n" +
 			"         ├─ reverse: true\n" +
 			"         ├─ colSet: (1,2)\n" +
 			"         ├─ tableId: 1\n" +
@@ -23384,7 +23374,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1, 2.0, '3', xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23393,7 +23383,7 @@ WHERE keyless.c0 IN (
 			"     ├─ columns: [1, 2.0, '3', xy.x as max(x)]\n" +
 			"     └─ IndexedTableAccess(xy)\n" +
 			"         ├─ index: [xy.x]\n" +
-			"         ├─ filters: [{(NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞)}]\n" +
 			"         ├─ columns: [x]\n" +
 			"         └─ reverse: true\n" +
 			"",
@@ -23551,7 +23541,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ static: [{(NULL, ∞)}]\n" +
+			"             ├─ static: [{[NULL, ∞)}]\n" +
 			"             ├─ reverse: true\n" +
 			"             ├─ colSet: (1,2)\n" +
 			"             ├─ tableId: 1\n" +
@@ -23571,7 +23561,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x as max(x)]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞)}]\n" +
 			"             ├─ columns: [x]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -23587,7 +23577,7 @@ WHERE keyless.c0 IN (
 			"         ├─ columns: [xy.x as max(x)]\n" +
 			"         └─ IndexedTableAccess(xy)\n" +
 			"             ├─ index: [xy.x]\n" +
-			"             ├─ filters: [{(NULL, ∞)}]\n" +
+			"             ├─ filters: [{[NULL, ∞)}]\n" +
 			"             ├─ columns: [x]\n" +
 			"             └─ reverse: true\n" +
 			"",
@@ -23608,7 +23598,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x:0!null->max(x):0]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ static: [{(NULL, ∞)}]\n" +
+			"                 ├─ static: [{[NULL, ∞)}]\n" +
 			"                 ├─ reverse: true\n" +
 			"                 ├─ colSet: (1,2)\n" +
 			"                 ├─ tableId: 1\n" +
@@ -23630,7 +23620,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x as max(x)]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ filters: [{(NULL, ∞)}]\n" +
+			"                 ├─ filters: [{[NULL, ∞)}]\n" +
 			"                 ├─ columns: [x]\n" +
 			"                 └─ reverse: true\n" +
 			"",
@@ -23648,7 +23638,7 @@ WHERE keyless.c0 IN (
 			"             ├─ columns: [xy.x as max(x)]\n" +
 			"             └─ IndexedTableAccess(xy)\n" +
 			"                 ├─ index: [xy.x]\n" +
-			"                 ├─ filters: [{(NULL, ∞)}]\n" +
+			"                 ├─ filters: [{[NULL, ∞)}]\n" +
 			"                 ├─ columns: [x]\n" +
 			"                 └─ reverse: true\n" +
 			"",
@@ -24644,7 +24634,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24654,13 +24644,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1]\n" +
 			"",
 	},
@@ -24721,7 +24711,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2:1!null]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -24733,7 +24723,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
@@ -24741,7 +24731,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24750,7 +24740,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24760,13 +24750,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24797,7 +24787,7 @@ order by x, y;
 		ExpectedPlan: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-7)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -24807,13 +24797,13 @@ order by x, y;
 		ExpectedEstimates: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
 			" └─ IndexedTableAccess(two_pk)\n" +
 			"     ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"     ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"     └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24846,7 +24836,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2:1!null, two_pk.pk1:0!null]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ static: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ static: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-7)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -24858,7 +24848,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2, two_pk.pk1]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 		ExpectedAnalysis: "Distinct\n" +
@@ -24866,7 +24856,7 @@ order by x, y;
 			"     ├─ columns: [two_pk.pk2, two_pk.pk1]\n" +
 			"     └─ IndexedTableAccess(two_pk)\n" +
 			"         ├─ index: [two_pk.pk1,two_pk.pk2]\n" +
-			"         ├─ filters: [{(NULL, ∞), (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[NULL, ∞), [NULL, ∞)}]\n" +
 			"         └─ columns: [pk1 pk2]\n" +
 			"",
 	},
@@ -24958,7 +24948,10 @@ order by x, y;
 		Query: `select * from comp_index_t0 c join comp_index_t0 b join comp_index_t0 a on a.v2 = b.pk and b.v2 = c.pk and c.v2 = 1`,
 		ExpectedPlan: "Project\n" +
 			" ├─ columns: [c.pk:6!null, c.v1:7, c.v2:8, b.pk:3!null, b.v1:4, b.v2:5, a.pk:0!null, a.v1:1, a.v2:2]\n" +
-			" └─ LookupJoin\n" +
+			" └─ HashJoin\n" +
+			"     ├─ Eq\n" +
+			"     │   ├─ b.v2:5\n" +
+			"     │   └─ c.pk:6!null\n" +
 			"     ├─ LookupJoin\n" +
 			"     │   ├─ TableAlias(a)\n" +
 			"     │   │   └─ ProcessTable\n" +
@@ -24974,14 +24967,13 @@ order by x, y;
 			"     │           └─ Table\n" +
 			"     │               ├─ name: comp_index_t0\n" +
 			"     │               └─ columns: [pk v1 v2]\n" +
-			"     └─ Filter\n" +
-			"         ├─ Eq\n" +
-			"         │   ├─ c.v2:2\n" +
-			"         │   └─ 1 (bigint)\n" +
+			"     └─ HashLookup\n" +
+			"         ├─ left-key: TUPLE(b.v2:5)\n" +
+			"         ├─ right-key: TUPLE(c.pk:0!null)\n" +
 			"         └─ TableAlias(c)\n" +
 			"             └─ IndexedTableAccess(comp_index_t0)\n" +
-			"                 ├─ index: [comp_index_t0.pk]\n" +
-			"                 ├─ keys: [b.v2:5]\n" +
+			"                 ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"                 ├─ static: [{[NULL, ∞), [1, 1]}]\n" +
 			"                 ├─ colSet: (1-3)\n" +
 			"                 ├─ tableId: 1\n" +
 			"                 └─ Table\n" +
@@ -24990,7 +24982,8 @@ order by x, y;
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [c.pk, c.v1, c.v2, b.pk, b.v1, b.v2, a.pk, a.v1, a.v2]\n" +
-			" └─ LookupJoin (estimated cost=333.300 rows=101)\n" +
+			" └─ HashJoin (estimated cost=253.020 rows=101)\n" +
+			"     ├─ (b.v2 = c.pk)\n" +
 			"     ├─ LookupJoin (estimated cost=333.300 rows=101)\n" +
 			"     │   ├─ TableAlias(a)\n" +
 			"     │   │   └─ Table\n" +
@@ -25001,17 +24994,19 @@ order by x, y;
 			"     │           ├─ index: [comp_index_t0.pk]\n" +
 			"     │           ├─ columns: [pk v1 v2]\n" +
 			"     │           └─ keys: a.v2\n" +
-			"     └─ Filter\n" +
-			"         ├─ (c.v2 = 1)\n" +
+			"     └─ HashLookup\n" +
+			"         ├─ left-key: (b.v2)\n" +
+			"         ├─ right-key: (c.pk)\n" +
 			"         └─ TableAlias(c)\n" +
 			"             └─ IndexedTableAccess(comp_index_t0)\n" +
-			"                 ├─ index: [comp_index_t0.pk]\n" +
-			"                 ├─ columns: [pk v1 v2]\n" +
-			"                 └─ keys: b.v2\n" +
+			"                 ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"                 ├─ filters: [{[NULL, ∞), [1, 1]}]\n" +
+			"                 └─ columns: [pk v1 v2]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [c.pk, c.v1, c.v2, b.pk, b.v1, b.v2, a.pk, a.v1, a.v2]\n" +
-			" └─ LookupJoin (estimated cost=333.300 rows=101) (actual rows=0 loops=1)\n" +
+			" └─ HashJoin (estimated cost=253.020 rows=101) (actual rows=0 loops=1)\n" +
+			"     ├─ (b.v2 = c.pk)\n" +
 			"     ├─ LookupJoin (estimated cost=333.300 rows=101) (actual rows=101 loops=1)\n" +
 			"     │   ├─ TableAlias(a)\n" +
 			"     │   │   └─ Table\n" +
@@ -25022,18 +25017,22 @@ order by x, y;
 			"     │           ├─ index: [comp_index_t0.pk]\n" +
 			"     │           ├─ columns: [pk v1 v2]\n" +
 			"     │           └─ keys: a.v2\n" +
-			"     └─ Filter\n" +
-			"         ├─ (c.v2 = 1)\n" +
+			"     └─ HashLookup\n" +
+			"         ├─ left-key: (b.v2)\n" +
+			"         ├─ right-key: (c.pk)\n" +
 			"         └─ TableAlias(c)\n" +
 			"             └─ IndexedTableAccess(comp_index_t0)\n" +
-			"                 ├─ index: [comp_index_t0.pk]\n" +
-			"                 ├─ columns: [pk v1 v2]\n" +
-			"                 └─ keys: b.v2\n" +
+			"                 ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"                 ├─ filters: [{[NULL, ∞), [1, 1]}]\n" +
+			"                 └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{
 		Query: `select * from comp_index_t0 a join comp_index_t0 b join comp_index_t0 c on a.v2 = b.pk and b.v2 = c.pk and c.v2 = 5`,
-		ExpectedPlan: "LookupJoin\n" +
+		ExpectedPlan: "HashJoin\n" +
+			" ├─ Eq\n" +
+			" │   ├─ b.v2:5\n" +
+			" │   └─ c.pk:6!null\n" +
 			" ├─ LookupJoin\n" +
 			" │   ├─ TableAlias(a)\n" +
 			" │   │   └─ ProcessTable\n" +
@@ -25049,21 +25048,21 @@ order by x, y;
 			" │           └─ Table\n" +
 			" │               ├─ name: comp_index_t0\n" +
 			" │               └─ columns: [pk v1 v2]\n" +
-			" └─ Filter\n" +
-			"     ├─ Eq\n" +
-			"     │   ├─ c.v2:2\n" +
-			"     │   └─ 5 (bigint)\n" +
+			" └─ HashLookup\n" +
+			"     ├─ left-key: TUPLE(b.v2:5)\n" +
+			"     ├─ right-key: TUPLE(c.pk:0!null)\n" +
 			"     └─ TableAlias(c)\n" +
 			"         └─ IndexedTableAccess(comp_index_t0)\n" +
-			"             ├─ index: [comp_index_t0.pk]\n" +
-			"             ├─ keys: [b.v2:5]\n" +
+			"             ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"             ├─ static: [{[NULL, ∞), [5, 5]}]\n" +
 			"             ├─ colSet: (7-9)\n" +
 			"             ├─ tableId: 3\n" +
 			"             └─ Table\n" +
 			"                 ├─ name: comp_index_t0\n" +
 			"                 └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedEstimates: "LookupJoin (estimated cost=333.300 rows=101)\n" +
+		ExpectedEstimates: "HashJoin (estimated cost=253.020 rows=101)\n" +
+			" ├─ (b.v2 = c.pk)\n" +
 			" ├─ LookupJoin (estimated cost=333.300 rows=101)\n" +
 			" │   ├─ TableAlias(a)\n" +
 			" │   │   └─ Table\n" +
@@ -25074,15 +25073,17 @@ order by x, y;
 			" │           ├─ index: [comp_index_t0.pk]\n" +
 			" │           ├─ columns: [pk v1 v2]\n" +
 			" │           └─ keys: a.v2\n" +
-			" └─ Filter\n" +
-			"     ├─ (c.v2 = 5)\n" +
+			" └─ HashLookup\n" +
+			"     ├─ left-key: (b.v2)\n" +
+			"     ├─ right-key: (c.pk)\n" +
 			"     └─ TableAlias(c)\n" +
 			"         └─ IndexedTableAccess(comp_index_t0)\n" +
-			"             ├─ index: [comp_index_t0.pk]\n" +
-			"             ├─ columns: [pk v1 v2]\n" +
-			"             └─ keys: b.v2\n" +
+			"             ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"             ├─ filters: [{[NULL, ∞), [5, 5]}]\n" +
+			"             └─ columns: [pk v1 v2]\n" +
 			"",
-		ExpectedAnalysis: "LookupJoin (estimated cost=333.300 rows=101) (actual rows=0 loops=1)\n" +
+		ExpectedAnalysis: "HashJoin (estimated cost=253.020 rows=101) (actual rows=0 loops=1)\n" +
+			" ├─ (b.v2 = c.pk)\n" +
 			" ├─ LookupJoin (estimated cost=333.300 rows=101) (actual rows=101 loops=1)\n" +
 			" │   ├─ TableAlias(a)\n" +
 			" │   │   └─ Table\n" +
@@ -25093,13 +25094,14 @@ order by x, y;
 			" │           ├─ index: [comp_index_t0.pk]\n" +
 			" │           ├─ columns: [pk v1 v2]\n" +
 			" │           └─ keys: a.v2\n" +
-			" └─ Filter\n" +
-			"     ├─ (c.v2 = 5)\n" +
+			" └─ HashLookup\n" +
+			"     ├─ left-key: (b.v2)\n" +
+			"     ├─ right-key: (c.pk)\n" +
 			"     └─ TableAlias(c)\n" +
 			"         └─ IndexedTableAccess(comp_index_t0)\n" +
-			"             ├─ index: [comp_index_t0.pk]\n" +
-			"             ├─ columns: [pk v1 v2]\n" +
-			"             └─ keys: b.v2\n" +
+			"             ├─ index: [comp_index_t0.v1,comp_index_t0.v2]\n" +
+			"             ├─ filters: [{[NULL, ∞), [5, 5]}]\n" +
+			"             └─ columns: [pk v1 v2]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/tpcc_plans.go
+++ b/enginetest/queries/tpcc_plans.go
@@ -602,7 +602,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" └─ Sort(orders2.o_id:0!null DESC nullsFirst)\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ static: [{[1, 1], [1, 1], [355, 355], (NULL, ∞)}]\n" +
+			"         ├─ static: [{[1, 1], [1, 1], [355, 355], [NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-8)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -614,7 +614,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" └─ Sort(orders2.o_id DESC)\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], [NULL, ∞)}]\n" +
 			"         └─ columns: [o_id o_d_id o_w_id o_c_id o_entry_d o_carrier_id]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -622,7 +622,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" └─ Sort(orders2.o_id DESC)\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], (NULL, ∞)}]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], [NULL, ∞)}]\n" +
 			"         └─ columns: [o_id o_d_id o_w_id o_c_id o_entry_d o_carrier_id]\n" +
 			"",
 	},
@@ -632,7 +632,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" ├─ columns: [order_line2.ol_i_id:3, order_line2.ol_supply_w_id:4, order_line2.ol_quantity:6, order_line2.ol_amount:7, order_line2.ol_delivery_d:5]\n" +
 			" └─ IndexedTableAccess(order_line2)\n" +
 			"     ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"     ├─ static: [{[1, 1], [1, 1], [1, 1], (NULL, ∞)}]\n" +
+			"     ├─ static: [{[1, 1], [1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -643,14 +643,14 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" ├─ columns: [order_line2.ol_i_id, order_line2.ol_supply_w_id, order_line2.ol_quantity, order_line2.ol_amount, order_line2.ol_delivery_d]\n" +
 			" └─ IndexedTableAccess(order_line2)\n" +
 			"     ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id ol_supply_w_id ol_delivery_d ol_quantity ol_amount]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [order_line2.ol_i_id, order_line2.ol_supply_w_id, order_line2.ol_quantity, order_line2.ol_amount, order_line2.ol_delivery_d]\n" +
 			" └─ IndexedTableAccess(order_line2)\n" +
 			"     ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], (NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], [NULL, ∞)}]\n" +
 			"     └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id ol_supply_w_id ol_delivery_d ol_quantity ol_amount]\n" +
 			"",
 	},
@@ -694,7 +694,7 @@ SELECT d_next_o_id FROM district2 WHERE d_id = 5 AND d_w_id= 1`,
 			"     └─ LookupJoin\n" +
 			"         ├─ IndexedTableAccess(order_line2)\n" +
 			"         │   ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"         │   ├─ static: [{[1, 1], [5, 5], [2983, 3003), (NULL, ∞)}]\n" +
+			"         │   ├─ static: [{[1, 1], [5, 5], [2983, 3003), [NULL, ∞)}]\n" +
 			"         │   ├─ colSet: (1-10)\n" +
 			"         │   ├─ tableId: 1\n" +
 			"         │   └─ Table\n" +
@@ -725,7 +725,7 @@ SELECT d_next_o_id FROM district2 WHERE d_id = 5 AND d_w_id= 1`,
 			"     └─ LookupJoin (estimated cost=130201.500 rows=39455)\n" +
 			"         ├─ IndexedTableAccess(order_line2)\n" +
 			"         │   ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), (NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), [NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ Filter\n" +
 			"             ├─ ((stock2.s_w_id = 1) AND (stock2.s_quantity < 18))\n" +
@@ -742,7 +742,7 @@ SELECT d_next_o_id FROM district2 WHERE d_id = 5 AND d_w_id= 1`,
 			"     └─ LookupJoin (estimated cost=130201.500 rows=39455) (actual rows=0 loops=1)\n" +
 			"         ├─ IndexedTableAccess(order_line2)\n" +
 			"         │   ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), (NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), [NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ Filter\n" +
 			"             ├─ ((stock2.s_w_id = 1) AND (stock2.s_quantity < 18))\n" +
@@ -777,7 +777,7 @@ WHERE
 			"     │               ├─ group: \n" +
 			"     │               └─ IndexedTableAccess(orders2)\n" +
 			"     │                   ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"     │                   ├─ static: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
+			"     │                   ├─ static: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
 			"     │                   ├─ colSet: (9-16)\n" +
 			"     │                   ├─ tableId: 2\n" +
 			"     │                   └─ Table\n" +
@@ -785,7 +785,7 @@ WHERE
 			"     │                       └─ columns: [o_id o_d_id o_w_id o_c_id]\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ static: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
+			"         ├─ static: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-8)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -798,7 +798,7 @@ WHERE
 			"     ├─ (orders2.o_id = Subquery(select MAX(o_id) from orders2 where o_w_id = 1 and o_d_id = 3 and o_c_id = 20001))\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
+			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [orders2.o_id, orders2.o_entry_d, coalesce(orders2.o_carrier_id,0) as COALESCE(o_carrier_id,0)]\n" +
@@ -806,7 +806,7 @@ WHERE
 			"     ├─ (orders2.o_id = Subquery(select MAX(o_id) from orders2 where o_w_id = 1 and o_d_id = 3 and o_c_id = 20001))\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
+			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -850,7 +850,7 @@ from
 			"         │                   ├─ group: orders2.o_c_id:3, orders2.o_d_id:1!null, orders2.o_w_id:2!null\n" +
 			"         │                   └─ IndexedTableAccess(orders2)\n" +
 			"         │                       ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_id]\n" +
-			"         │                       ├─ static: [{[1, 1], (NULL, ∞), (2100, 11153)}]\n" +
+			"         │                       ├─ static: [{[1, 1], [NULL, ∞), (2100, 11153)}]\n" +
 			"         │                       ├─ colSet: (9-16)\n" +
 			"         │                       ├─ tableId: 2\n" +
 			"         │                       └─ Table\n" +
@@ -886,7 +886,7 @@ from
 			"         │                   ├─ group: orders2.o_c_id, orders2.o_d_id, orders2.o_w_id\n" +
 			"         │                   └─ IndexedTableAccess(orders2)\n" +
 			"         │                       ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_id]\n" +
-			"         │                       └─ filters: [{[1, 1], (NULL, ∞), (2100, 11153)}]\n" +
+			"         │                       └─ filters: [{[1, 1], [NULL, ∞), (2100, 11153)}]\n" +
 			"         └─ TableAlias(o)\n" +
 			"             └─ IndexedTableAccess(orders2)\n" +
 			"                 ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
@@ -913,7 +913,7 @@ from
 			"         │                   ├─ group: orders2.o_c_id, orders2.o_d_id, orders2.o_w_id\n" +
 			"         │                   └─ IndexedTableAccess(orders2)\n" +
 			"         │                       ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_id]\n" +
-			"         │                       └─ filters: [{[1, 1], (NULL, ∞), (2100, 11153)}]\n" +
+			"         │                       └─ filters: [{[1, 1], [NULL, ∞), (2100, 11153)}]\n" +
 			"         └─ TableAlias(o)\n" +
 			"             └─ IndexedTableAccess(orders2)\n" +
 			"                 ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +

--- a/enginetest/queries/tpcc_plans.go
+++ b/enginetest/queries/tpcc_plans.go
@@ -602,7 +602,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" └─ Sort(orders2.o_id:0!null DESC nullsFirst)\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ static: [{[1, 1], [1, 1], [355, 355], [NULL, ∞)}]\n" +
+			"         ├─ static: [{[1, 1], [1, 1], [355, 355], (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-8)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -614,7 +614,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" └─ Sort(orders2.o_id DESC)\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], [NULL, ∞)}]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], (NULL, ∞)}]\n" +
 			"         └─ columns: [o_id o_d_id o_w_id o_c_id o_entry_d o_carrier_id]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
@@ -622,7 +622,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" └─ Sort(orders2.o_id DESC)\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], [NULL, ∞)}]\n" +
+			"         ├─ filters: [{[1, 1], [1, 1], [355, 355], (NULL, ∞)}]\n" +
 			"         └─ columns: [o_id o_d_id o_w_id o_c_id o_entry_d o_carrier_id]\n" +
 			"",
 	},
@@ -632,7 +632,7 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" ├─ columns: [order_line2.ol_i_id:3, order_line2.ol_supply_w_id:4, order_line2.ol_quantity:6, order_line2.ol_amount:7, order_line2.ol_delivery_d:5]\n" +
 			" └─ IndexedTableAccess(order_line2)\n" +
 			"     ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"     ├─ static: [{[1, 1], [1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     ├─ static: [{[1, 1], [1, 1], [1, 1], (NULL, ∞)}]\n" +
 			"     ├─ colSet: (1-10)\n" +
 			"     ├─ tableId: 1\n" +
 			"     └─ Table\n" +
@@ -643,14 +643,14 @@ SELECT count(c_id) namecnt FROM customer2 WHERE c_w_id = 1 AND c_d_id= 1 AND c_l
 			" ├─ columns: [order_line2.ol_i_id, order_line2.ol_supply_w_id, order_line2.ol_quantity, order_line2.ol_amount, order_line2.ol_delivery_d]\n" +
 			" └─ IndexedTableAccess(order_line2)\n" +
 			"     ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], (NULL, ∞)}]\n" +
 			"     └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id ol_supply_w_id ol_delivery_d ol_quantity ol_amount]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [order_line2.ol_i_id, order_line2.ol_supply_w_id, order_line2.ol_quantity, order_line2.ol_amount, order_line2.ol_delivery_d]\n" +
 			" └─ IndexedTableAccess(order_line2)\n" +
 			"     ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], [NULL, ∞)}]\n" +
+			"     ├─ filters: [{[1, 1], [1, 1], [1, 1], (NULL, ∞)}]\n" +
 			"     └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id ol_supply_w_id ol_delivery_d ol_quantity ol_amount]\n" +
 			"",
 	},
@@ -694,7 +694,7 @@ SELECT d_next_o_id FROM district2 WHERE d_id = 5 AND d_w_id= 1`,
 			"     └─ LookupJoin\n" +
 			"         ├─ IndexedTableAccess(order_line2)\n" +
 			"         │   ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"         │   ├─ static: [{[1, 1], [5, 5], [2983, 3003), [NULL, ∞)}]\n" +
+			"         │   ├─ static: [{[1, 1], [5, 5], [2983, 3003), (NULL, ∞)}]\n" +
 			"         │   ├─ colSet: (1-10)\n" +
 			"         │   ├─ tableId: 1\n" +
 			"         │   └─ Table\n" +
@@ -725,7 +725,7 @@ SELECT d_next_o_id FROM district2 WHERE d_id = 5 AND d_w_id= 1`,
 			"     └─ LookupJoin (estimated cost=130201.500 rows=39455)\n" +
 			"         ├─ IndexedTableAccess(order_line2)\n" +
 			"         │   ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), [NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), (NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ Filter\n" +
 			"             ├─ ((stock2.s_w_id = 1) AND (stock2.s_quantity < 18))\n" +
@@ -742,7 +742,7 @@ SELECT d_next_o_id FROM district2 WHERE d_id = 5 AND d_w_id= 1`,
 			"     └─ LookupJoin (estimated cost=130201.500 rows=39455) (actual rows=0 loops=1)\n" +
 			"         ├─ IndexedTableAccess(order_line2)\n" +
 			"         │   ├─ index: [order_line2.ol_w_id,order_line2.ol_d_id,order_line2.ol_o_id,order_line2.ol_number]\n" +
-			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), [NULL, ∞)}]\n" +
+			"         │   ├─ filters: [{[1, 1], [5, 5], [2983, 3003), (NULL, ∞)}]\n" +
 			"         │   └─ columns: [ol_o_id ol_d_id ol_w_id ol_i_id]\n" +
 			"         └─ Filter\n" +
 			"             ├─ ((stock2.s_w_id = 1) AND (stock2.s_quantity < 18))\n" +
@@ -777,7 +777,7 @@ WHERE
 			"     │               ├─ group: \n" +
 			"     │               └─ IndexedTableAccess(orders2)\n" +
 			"     │                   ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"     │                   ├─ static: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
+			"     │                   ├─ static: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
 			"     │                   ├─ colSet: (9-16)\n" +
 			"     │                   ├─ tableId: 2\n" +
 			"     │                   └─ Table\n" +
@@ -785,7 +785,7 @@ WHERE
 			"     │                       └─ columns: [o_id o_d_id o_w_id o_c_id]\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         ├─ static: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
+			"         ├─ static: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
 			"         ├─ colSet: (1-8)\n" +
 			"         ├─ tableId: 1\n" +
 			"         └─ Table\n" +
@@ -798,7 +798,7 @@ WHERE
 			"     ├─ (orders2.o_id = Subquery(select MAX(o_id) from orders2 where o_w_id = 1 and o_d_id = 3 and o_c_id = 20001))\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
+			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [orders2.o_id, orders2.o_entry_d, coalesce(orders2.o_carrier_id,0) as COALESCE(o_carrier_id,0)]\n" +
@@ -806,7 +806,7 @@ WHERE
 			"     ├─ (orders2.o_id = Subquery(select MAX(o_id) from orders2 where o_w_id = 1 and o_d_id = 3 and o_c_id = 20001))\n" +
 			"     └─ IndexedTableAccess(orders2)\n" +
 			"         ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
-			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], [NULL, ∞)}]\n" +
+			"         └─ filters: [{[1, 1], [3, 3], [20001, 20001], (NULL, ∞)}]\n" +
 			"",
 	},
 	{
@@ -850,7 +850,7 @@ from
 			"         │                   ├─ group: orders2.o_c_id:3, orders2.o_d_id:1!null, orders2.o_w_id:2!null\n" +
 			"         │                   └─ IndexedTableAccess(orders2)\n" +
 			"         │                       ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_id]\n" +
-			"         │                       ├─ static: [{[1, 1], [NULL, ∞), (2100, 11153)}]\n" +
+			"         │                       ├─ static: [{[1, 1], (NULL, ∞), (2100, 11153)}]\n" +
 			"         │                       ├─ colSet: (9-16)\n" +
 			"         │                       ├─ tableId: 2\n" +
 			"         │                       └─ Table\n" +
@@ -886,7 +886,7 @@ from
 			"         │                   ├─ group: orders2.o_c_id, orders2.o_d_id, orders2.o_w_id\n" +
 			"         │                   └─ IndexedTableAccess(orders2)\n" +
 			"         │                       ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_id]\n" +
-			"         │                       └─ filters: [{[1, 1], [NULL, ∞), (2100, 11153)}]\n" +
+			"         │                       └─ filters: [{[1, 1], (NULL, ∞), (2100, 11153)}]\n" +
 			"         └─ TableAlias(o)\n" +
 			"             └─ IndexedTableAccess(orders2)\n" +
 			"                 ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +
@@ -913,7 +913,7 @@ from
 			"         │                   ├─ group: orders2.o_c_id, orders2.o_d_id, orders2.o_w_id\n" +
 			"         │                   └─ IndexedTableAccess(orders2)\n" +
 			"         │                       ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_id]\n" +
-			"         │                       └─ filters: [{[1, 1], [NULL, ∞), (2100, 11153)}]\n" +
+			"         │                       └─ filters: [{[1, 1], (NULL, ∞), (2100, 11153)}]\n" +
 			"         └─ TableAlias(o)\n" +
 			"             └─ IndexedTableAccess(orders2)\n" +
 			"                 ├─ index: [orders2.o_w_id,orders2.o_d_id,orders2.o_c_id,orders2.o_id]\n" +

--- a/memory/index.go
+++ b/memory/index.go
@@ -189,6 +189,7 @@ func (idx *Index) ColumnExpressionTypes(ctx *sql.Context) []sql.ColumnExpression
 		cets[i] = sql.ColumnExpressionType{
 			Expression: expr.String(),
 			Type:       expr.Type(ctx),
+			Nullable:   expr.IsNullable(ctx),
 		}
 	}
 	return cets

--- a/memory/index.go
+++ b/memory/index.go
@@ -189,7 +189,7 @@ func (idx *Index) ColumnExpressionTypes(ctx *sql.Context) []sql.ColumnExpression
 		cets[i] = sql.ColumnExpressionType{
 			Expression: expr.String(),
 			Type:       expr.Type(ctx),
-			Nullable:   expr.IsNullable(ctx),
+			Nullable:   true,
 		}
 	}
 	return cets

--- a/memory/index.go
+++ b/memory/index.go
@@ -189,7 +189,7 @@ func (idx *Index) ColumnExpressionTypes(ctx *sql.Context) []sql.ColumnExpression
 		cets[i] = sql.ColumnExpressionType{
 			Expression: expr.String(),
 			Type:       expr.Type(ctx),
-			Nullable:   true,
+			Nullable:   expr.IsNullable(ctx),
 		}
 	}
 	return cets

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -305,19 +305,19 @@ func getCostedIndexScan(
 	if len(ranges) == 0 {
 		emptyLookup = true
 	} else if len(ranges) == 1 {
+		// if every range is empty or everything don't use index
 		emptyLookup, err = ranges[0].IsEmpty(ctx)
 		if err != nil {
 			return nil, nil, nil, err
 		}
 		allRange := true
-		for i, r := range ranges[0] {
+		for _, r := range ranges[0] {
 			_, uok := r.UpperBound.(sql.AboveAll)
-			_, lok := r.LowerBound.(sql.BelowNull)
-			allRange = allRange && uok && lok
-			// TODO: why? what if we just want sorted results?
-			if i == 0 && allRange {
-				// no prefix restriction
-				return nil, nil, nil, err
+			_, lok1 := r.LowerBound.(sql.BelowNull)
+			_, lok2 := r.LowerBound.(sql.AboveNull)
+			if !uok || (!lok1 && !lok2) {
+				allRange = false
+				break
 			}
 		}
 		if allRange {

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -314,6 +314,7 @@ func getCostedIndexScan(
 			_, uok := r.UpperBound.(sql.AboveAll)
 			_, lok := r.LowerBound.(sql.BelowNull)
 			allRange = allRange && uok && lok
+			// TODO: why? what if we just want sorted results?
 			if i == 0 && allRange {
 				// no prefix restriction
 				return nil, nil, nil, err
@@ -889,6 +890,7 @@ func newIndexScanRangeBuilder(ctx *sql.Context, idx sql.Index, include, imprecis
 
 type indexScanRangeBuilder struct {
 	idx       sql.Index
+	sch       sql.Schema
 	ctx       *sql.Context
 	idToExpr  map[indexScanId]sql.Expression
 	conjIb    *sql.MySQLIndexBuilder

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -313,9 +313,8 @@ func getCostedIndexScan(
 		allRange := true
 		for _, r := range ranges[0] {
 			_, uok := r.UpperBound.(sql.AboveAll)
-			_, lok1 := r.LowerBound.(sql.BelowNull)
-			_, lok2 := r.LowerBound.(sql.AboveNull)
-			if !uok || (!lok1 && !lok2) {
+			_, lok := r.LowerBound.(sql.BelowNull)
+			if !uok || !lok {
 				allRange = false
 				break
 			}
@@ -325,12 +324,23 @@ func getCostedIndexScan(
 		}
 	}
 
-	if !idx.CanSupport(ctx, ranges.ToRanges()...) {
-		return nil, nil, nil, err
+	if idx.IsSpatial() {
+		// spatial indexes don't support disjunct ranges
+		if len(ranges) > 1 {
+			return nil, nil, nil, err
+		}
+		// spatial indexes require the ranges to have specified values
+		for _, r := range ranges[0] {
+			_, uok := r.UpperBound.(sql.AboveAll)
+			_, lok1 := r.LowerBound.(sql.BelowNull)
+			_, lok2 := r.LowerBound.(sql.AboveNull)
+			if uok || lok1 || lok2 {
+				return nil, nil, nil, err
+			}
+		}
 	}
 
-	if idx.IsSpatial() && len(ranges) > 1 {
-		// spatials don't support disjunct ranges
+	if !idx.CanSupport(ctx, ranges.ToRanges()...) {
 		return nil, nil, nil, err
 	}
 

--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -900,7 +900,6 @@ func newIndexScanRangeBuilder(ctx *sql.Context, idx sql.Index, include, imprecis
 
 type indexScanRangeBuilder struct {
 	idx       sql.Index
-	sch       sql.Schema
 	ctx       *sql.Context
 	idToExpr  map[indexScanId]sql.Expression
 	conjIb    *sql.MySQLIndexBuilder

--- a/sql/index.go
+++ b/sql/index.go
@@ -337,6 +337,7 @@ type OrderedIndex interface {
 type ColumnExpressionType struct {
 	Type       Type
 	Expression string
+	Nullable   bool
 }
 
 // ValidatePrimaryKeyDrop validates that a primary key may be dropped. If any validation error is returned, then it

--- a/sql/index_builder.go
+++ b/sql/index_builder.go
@@ -52,7 +52,11 @@ func NewMySQLIndexBuilder(ctx *Context, idx Index) *MySQLIndexBuilder {
 		}
 		expr := strings.ToLower(cet.Expression)
 		colExprTypes[expr] = typ
-		ranges[expr] = []MySQLRangeColumnExpr{AllRangeColumnExpr(typ)}
+		if cet.Nullable {
+			ranges[expr] = []MySQLRangeColumnExpr{AllRangeColumnExpr(typ)}
+		} else {
+			ranges[expr] = []MySQLRangeColumnExpr{NotNullRangeColumnExpr(typ)}
+		}
 	}
 	return &MySQLIndexBuilder{
 		idx:          idx,

--- a/sql/index_builder_test.go
+++ b/sql/index_builder_test.go
@@ -220,7 +220,11 @@ func (i testIndex) ColumnExpressionTypes(ctx *sql.Context) []sql.ColumnExpressio
 	es := i.Expressions()
 	res := make([]sql.ColumnExpressionType, len(es))
 	for i := range es {
-		res[i] = sql.ColumnExpressionType{Expression: es[i], Type: types.Int8}
+		res[i] = sql.ColumnExpressionType{
+			Expression: es[i],
+			Type:       types.Int8,
+			Nullable:   true,
+		}
 	}
 	return res
 }

--- a/sql/memo/coster.go
+++ b/sql/memo/coster.go
@@ -101,13 +101,12 @@ func (c *coster) costRel(ctx *sql.Context, n RelExpr, s sql.StatsProvider) (floa
 			return ((lBest*rBest)*seqIOCostFactor + (lBest*rBest)*cpuCostFactor) * degeneratePenalty, nil
 		case jp.Op.IsLateral():
 			return (lBest*rBest-1)*seqIOCostFactor + (lBest*rBest)*cpuCostFactor, nil
-
 		case jp.Op.IsMerge():
 			// TODO memory overhead when not injective
 			// TODO lose index scan benefits, need to read whole table
 
 			if !n.(*MergeJoin).Injective {
-				// Injective is guarenteed to never iterate over multiple rows in memory.
+				// Injective is guaranteed to never iterate over multiple rows in memory.
 				// Otherwise O(k) where k is the key with the highest number of matches.
 				// Each comparison reduces the expected number of collisions on the comparator.
 				// TODO: better cost estimate for memory overhead


### PR DESCRIPTION
When building ranges for IndexLookups, we can exclude NULLs if we know the column/expression is non-nullable.
Additionally, we should allow lookups to be AllRange for prefixed fields.

This was a performance issue in the analyzer where an index wasn't replacing a filter because it didn't constrain the first column.
```sql
create table t (i int, j int, primary key (i, j));
select * from t where j = 0; -- should still use index
```

TODO: 
This sort of breaks index costing based on "prefix" of the filter and index. 
Before, we would pick an index that had the longest prefix match with the expression, as it _should_ be much more selective than a different index. However, there is an assumption that the range over the prefix would never be `ALL`. We should account for this pick the best index.