### PR TITLE
Add LockSubsystem.TryLock for non-blocking lock acquisition

### DIFF
--- a/enginetest/queries/queries.go
+++ b/enginetest/queries/queries.go
@@ -7285,6 +7285,22 @@ SELECT * FROM cte WHERE  d = 2;`,
 		Expected: []sql.Row{{0}},
 	},
 	{
+		Query:    "select GET_LOCK('try_lock', 0)",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "Select IS_FREE_LOCK('try_lock')",
+		Expected: []sql.Row{{0}},
+	},
+	{
+		Query:    "Select RELEASE_LOCK('try_lock')",
+		Expected: []sql.Row{{1}},
+	},
+	{
+		Query:    "Select IS_FREE_LOCK('try_lock')",
+		Expected: []sql.Row{{1}},
+	},
+	{
 		Query:    "SELECT CONV('a',16,2)",
 		Expected: []sql.Row{{"1010"}},
 	},

--- a/sql/expression/function/locks.go
+++ b/sql/expression/function/locks.go
@@ -339,6 +339,19 @@ func (gl *GetLock) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 		return nil, fmt.Errorf("illegal value for timeout %v", timeout)
 	}
 
+	if timeout.(int64) == 0 {
+		acquired, err := gl.ls.TryLock(ctx, lockName)
+		if err != nil {
+			return nil, err
+		}
+
+		if !acquired {
+			return int8(0), nil
+		}
+
+		return int8(1), nil
+	}
+
 	err = gl.ls.Lock(ctx, lockName, time.Second*time.Duration(timeout.(int64)))
 
 	if err != nil {

--- a/sql/lock_subsystem.go
+++ b/sql/lock_subsystem.go
@@ -70,17 +70,19 @@ func (ls *LockSubsystem) createLock(name string) **ownedLock {
 	return nl
 }
 
-// Lock attempts to acquire a lock with a given name for the Id associated with the given ctx.Session within the given
-// timeout
-func (ls *LockSubsystem) Lock(ctx *Context, name string, timeout time.Duration) error {
+func (ls *LockSubsystem) getOrCreateLock(name string) **ownedLock {
 	nl := ls.getNamedLock(name)
-
 	if nl == nil {
 		nl = ls.createLock(name)
 	}
+	return nl
+}
 
+// tryLock makes a single non-blocking attempt to acquire the given resolved lock for the ID associated with the given
+// ctx.Session, retrying only on CAS contention. It returns false if the lock is owned by another session.
+func (ls *LockSubsystem) tryLock(ctx *Context, nl **ownedLock, name string) (bool, error) {
 	userId := int64(ctx.Session.ID())
-	for i, start := 0, time.Now(); i == 0 || timeout < 0 || time.Since(start) < timeout; i++ {
+	for {
 		dest := (*unsafe.Pointer)(unsafe.Pointer(nl))
 		curr := atomic.LoadPointer(dest)
 		currLock := *(*ownedLock)(curr)
@@ -88,19 +90,42 @@ func (ls *LockSubsystem) Lock(ctx *Context, name string, timeout time.Duration) 
 		if currLock.Owner == 0 {
 			newVal := &ownedLock{userId, 1}
 			if atomic.CompareAndSwapPointer(dest, curr, unsafe.Pointer(newVal)) {
-				return ctx.Session.AddLock(name)
+				return true, ctx.Session.AddLock(name)
 			}
 		} else if currLock.Owner == userId {
 			newVal := &ownedLock{userId, currLock.Count + 1}
 			if atomic.CompareAndSwapPointer(dest, curr, unsafe.Pointer(newVal)) {
-				return nil
+				return true, nil
 			}
+		} else {
+			return false, nil
+		}
+	}
+}
+
+// Lock attempts to acquire a lock with a given name for the Id associated with the given ctx.Session within the given
+// timeout
+func (ls *LockSubsystem) Lock(ctx *Context, name string, timeout time.Duration) error {
+	nl := ls.getOrCreateLock(name)
+
+	for i, start := 0, time.Now(); i == 0 || timeout < 0 || time.Since(start) < timeout; i++ {
+		acquired, err := ls.tryLock(ctx, nl, name)
+		if acquired || err != nil {
+			return err
 		}
 
 		time.Sleep(100 * time.Microsecond)
 	}
 
 	return ErrLockTimeout.New(name)
+}
+
+// TryLock attempts to acquire a lock with a given name for the Id associated with the given ctx.Session without
+// waiting. It returns true if the lock was acquired, and false if the lock is currently owned by another session.
+// Like Lock, it is reentrant; acquiring a lock that is already owned by the session increments its lock count.
+func (ls *LockSubsystem) TryLock(ctx *Context, name string) (bool, error) {
+	nl := ls.getOrCreateLock(name)
+	return ls.tryLock(ctx, nl, name)
 }
 
 // Unlock releases a lock with a given name for the ID associated with the given ctx.Session

--- a/sql/lock_subsystem_test.go
+++ b/sql/lock_subsystem_test.go
@@ -100,6 +100,50 @@ func TestLock(t *testing.T) {
 	assert.Nil(t, getLockDiffs(user2Ctx))
 }
 
+func TestTryLock(t *testing.T) {
+	ls := NewLockSubsystem()
+	user1Ctx := NewEmptyContext()
+	user2Ctx := NewEmptyContext()
+
+	acquired, err := ls.TryLock(user1Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+	assert.Nil(t, getLockDiffs(user1Ctx, testLockName))
+
+	acquired, err = ls.TryLock(user1Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+	assert.Nil(t, getLockDiffs(user1Ctx, testLockName))
+
+	acquired, err = ls.TryLock(user2Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.False(t, acquired)
+	assert.Nil(t, getLockDiffs(user2Ctx))
+
+	err = ls.Unlock(user1Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.Nil(t, getLockDiffs(user1Ctx, testLockName))
+
+	acquired, err = ls.TryLock(user2Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.False(t, acquired)
+	assert.Nil(t, getLockDiffs(user2Ctx))
+
+	err = ls.Unlock(user1Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.Nil(t, getLockDiffs(user1Ctx))
+
+	acquired, err = ls.TryLock(user2Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+	assert.Nil(t, getLockDiffs(user2Ctx, testLockName))
+
+	acquired, err = ls.TryLock(user1Ctx, testLockName)
+	assert.NoError(t, err)
+	assert.False(t, acquired)
+	assert.Nil(t, getLockDiffs(user1Ctx))
+}
+
 func TestRace(t *testing.T) {
 	const numGoRoutines = 8
 


### PR DESCRIPTION
Extract the single CAS attempt from Lock into a private tryLock helper and expose it as a public TryLock method that returns immediately if the lock is held by another session.

Callers no longer need to pass a short timeout to Lock and treat ErrLockTimeout as a false return. Referenced by a TODO in [dolthub/doltgresql](https://github.com/dolthub/doltgresql/blob/82e2d2eba2ddba80f03338800730e424bcd2d9fe/server/functions/advisory_locks.go#L77).