### PR TITLE
sql/expression/function: cache compiled DATE_FORMAT formatters (fixes strftime read-lock leak deadlock)

### DIFF
--- a/enginetest/queries/script_queries.go
+++ b/enginetest/queries/script_queries.go
@@ -123,6 +123,29 @@ type ScriptTestAssertion struct {
 // the tests.
 var ScriptTests = []ScriptTest{
 	{
+		Name: "DATE_FORMAT over multiple rows and formats",
+		SetUpScript: []string{
+			"create table dfcache (id int primary key, ts datetime)",
+			"insert into dfcache values (1, '2020-02-03 04:05:06'), (2, '2021-12-25 13:14:15')",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: "select date_format(ts, '%Y-%m-%d %H:%i:%s') from dfcache order by id",
+				Expected: []sql.Row{
+					{"2020-02-03 04:05:06"},
+					{"2021-12-25 13:14:15"},
+				},
+			},
+			{
+				Query: "select date_format(ts, '%W %M %Y') from dfcache order by id",
+				Expected: []sql.Row{
+					{"Monday February 2020"},
+					{"Saturday December 2021"},
+				},
+			},
+		},
+	},
+	{
 		// https://github.com/dolthub/dolt/issues/10113
 		Name: "DELETE with NOT EXISTS subquery",
 		SetUpScript: []string{

--- a/sql/expression/function/date_format.go
+++ b/sql/expression/function/date_format.go
@@ -17,6 +17,7 @@ package function
 import (
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/lestrrat-go/strftime"
@@ -239,14 +240,22 @@ func init() {
 	}
 }
 
-func formatDate(format string, t time.Time) (string, error) {
-	formatter, err := strftime.New(format, strftime.WithSpecificationSet(mysqlDateFormatSpec))
+// formatterCache memoizes compiled formatters by format string; recompiling per
+// call also leaks a read-lock in strftime's Lookup on the shared spec set.
+var formatterCache sync.Map // map[string]*strftime.Strftime
 
+func formatDate(format string, t time.Time) (string, error) {
+	if cached, ok := formatterCache.Load(format); ok {
+		return cached.(*strftime.Strftime).FormatString(t), nil
+	}
+
+	formatter, err := strftime.New(format, strftime.WithSpecificationSet(mysqlDateFormatSpec))
 	if err != nil {
 		return "", err
 	}
 
-	return formatter.FormatString(t), nil
+	cached, _ := formatterCache.LoadOrStore(format, formatter)
+	return cached.(*strftime.Strftime).FormatString(t), nil
 }
 
 // DateFormat function returns a string representation of the date specified in the format specified

--- a/sql/expression/function/date_format_test.go
+++ b/sql/expression/function/date_format_test.go
@@ -16,6 +16,7 @@ package function
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -190,4 +191,43 @@ func TestDateFormatEval(t *testing.T) {
 	res, err = dateFormat.Eval(nil, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, res)
+}
+
+// TestDateFormatCachesCompiledFormatter fails if formatDate recompiles a format
+// instead of reusing the cached formatter.
+func TestDateFormatCachesCompiledFormatter(t *testing.T) {
+	const format = "%Y-%m-%d %H:%i:%s"
+	formatterCache.Delete(format)
+	tm := time.Date(2020, 2, 3, 4, 5, 6, 0, time.UTC)
+
+	out, err := formatDate(format, tm)
+	require.NoError(t, err)
+	require.Equal(t, "2020-02-03 04:05:06", out)
+
+	first, ok := formatterCache.Load(format)
+	require.True(t, ok, "first formatDate call must populate the formatter cache")
+
+	out, err = formatDate(format, tm)
+	require.NoError(t, err)
+	require.Equal(t, "2020-02-03 04:05:06", out)
+
+	second, ok := formatterCache.Load(format)
+	require.True(t, ok)
+	require.Same(t, first, second, "the compiled formatter must be reused, not recompiled per call")
+}
+
+func TestDateFormatConcurrent(t *testing.T) {
+	const format = "%Y-%m-%d"
+	tm := time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC)
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := formatDate(format, tm)
+			require.NoError(t, err)
+			require.Equal(t, "2026-06-12", out)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem

Under sustained concurrent `DATE_FORMAT` load, a server eventually **deadlocks every `DATE_FORMAT` query** and hangs. We hit this in production (root incident: dolthub/dolt#11196 — a connection pool ratcheting to `max_connections` with thousands of sessions stuck in `DATE_FORMAT` aggregation queries).

## Root cause

`formatDate` recompiles the strftime formatter on every call:

```go
formatter, err := strftime.New(format, strftime.WithSpecificationSet(mysqlDateFormatSpec))
```

Compilation calls `(*specificationSet).Lookup` on the shared, mutable `mysqlDateFormatSpec`. In `github.com/lestrrat-go/strftime`, `Lookup` leaks a read-lock on that set's `RWMutex` on **every** call — it does `defer ds.lock.RLock()` instead of `RUnlock()` (`specifications.go`, present through at least v1.0.6):

```go
func (ds *specificationSet) Lookup(b byte) (Appender, error) {
	if ds.mutable {
		ds.lock.RLock()
		defer ds.lock.RLock()   // should be RUnlock()
	}
	...
}
```

Because `mysqlDateFormatSpec` is mutable (it's built with `Set`), the buggy path is taken on every `DATE_FORMAT`. There is **no writer**, so the leaked read-count is never reset — it climbs monotonically until it overflows the `int32` `readerCount` and wraps negative. At that point `RLock`'s `readerCount.Add(1) < 0` check misreads the overflow as a pending writer and blocks on a semaphore that nobody will ever signal. Every subsequent `DATE_FORMAT` compile then hangs forever.

We reproduced the exact mechanism deterministically (no writer): a tight `Lookup` loop deadlocks at ~2³⁰ iterations on the leaking version and runs unbounded once the leak is removed.

## Fix

Cache the compiled formatter by format string. `Lookup` (and therefore the leak) now happens at most once per distinct format string instead of once per call, which keeps the leaked count many orders of magnitude below the overflow point. It also removes a per-call recompile cost on a hot path.

This is a complete, in-repo fix that does not require a release of `lestrrat-go/strftime` (whose bug is still present in v1.0.6). Making `mysqlDateFormatSpec` immutable would also avoid the buggy path, but strftime exposes no public immutable constructor.

## Tests

- `TestDateFormatCachesCompiledFormatter` — fails before this change (the formatter would be recompiled, not reused).
- `TestDateFormatConcurrent` — exercises the cache under `-race`.
- An `enginetest` `ScriptTest` covering `DATE_FORMAT` over multiple rows and formats.

A companion dolt PR carries an interim `replace` to a fixed strftime so dolt is unblocked before this lands; that workaround can be dropped once this merges.
