### PR TITLE
fix JSON control-character escaping and out-of-band text reads

### DIFF
--- a/internal/strings/quote_test.go
+++ b/internal/strings/quote_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuote(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		expected string
+	}{
+		{"plain", "hello", "\"hello\""},
+		{"double quote", "a\"b", "\"a\\\"b\""},
+		{"backslash", "a\\b", "\"a\\\\b\""},
+		{"short escape", "a\nb", "\"a\\nb\""},
+		{"vertical tab", "a\u000bb", "\"a\\u000bb\""},
+		{"nul", "\u0000", "\"\\u0000\""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, Quote(tc.in))
+		})
+	}
+}

--- a/internal/strings/unquote.go
+++ b/internal/strings/unquote.go
@@ -145,37 +145,44 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 	return
 }
 
+const hexDigits = "0123456789abcdef"
+
+const firstNonControlByte = 0x20
+
+// quoteEscape maps an ASCII byte to its JSON escape, or the empty string when
+// the byte is safe to write unchanged.
+var quoteEscape = func() (t [256]string) {
+	for c := 0; c < firstNonControlByte; c++ {
+		t[c] = `\u00` + string([]byte{hexDigits[c>>4], hexDigits[c&0xf]})
+	}
+	t['"'] = `\"`
+	t['\\'] = `\\`
+	t['\b'] = `\b`
+	t['\f'] = `\f`
+	t['\n'] = `\n`
+	t['\r'] = `\r`
+	t['\t'] = `\t`
+	return t
+}()
+
 // Quote returns a json quoted string with escape characters.
 // The implementation is taken from TiDB:
 // https://github.com/pingcap/tidb/blob/a594287e9f402037b06930026906547000006bb6/types/json/binary_functions.go#L155
 func Quote(s string) string {
-	var escapeByteMap = map[byte]string{
-		'\\': "\\\\",
-		'"':  "\\\"",
-		'\b': "\\b",
-		'\f': "\\f",
-		'\n': "\\n",
-		'\r': "\\r",
-		'\t': "\\t",
-	}
-
 	ret := new(bytes.Buffer)
 	ret.WriteByte('"')
 
 	start := 0
 	for i := 0; i < len(s); {
 		if b := s[i]; b < utf8.RuneSelf {
-			escaped, ok := escapeByteMap[b]
-			if ok {
+			if esc := quoteEscape[b]; esc != "" {
 				if start < i {
 					ret.WriteString(s[start:i])
 				}
-				ret.WriteString(escaped)
-				i++
-				start = i
-			} else {
-				i++
+				ret.WriteString(esc)
+				start = i + 1
 			}
+			i++
 		} else {
 			c, size := utf8.DecodeRune([]byte(s[i:]))
 			if c == utf8.RuneError && size == 1 { // refer to codes of `binary.marshalStringTo`

--- a/sql/expression/function/json/json_common.go
+++ b/sql/expression/function/json/json_common.go
@@ -61,6 +61,16 @@ func getJSONDocumentFromRow(ctx *sql.Context, row sql.Row, json sql.Expression) 
 		return nil, err
 	}
 
+	// A large text value can arrive as a lazily loaded StringWrapper. Unwrap it
+	// so it follows the string path below.
+	if sw, ok := js.(sql.StringWrapper); ok {
+		s, err := sw.Unwrap(ctx)
+		if err != nil {
+			return nil, err
+		}
+		js = s
+	}
+
 	var jsonData interface{}
 
 	switch jsType := js.(type) {

--- a/sql/types/json_encode.go
+++ b/sql/types/json_encode.go
@@ -14,26 +14,25 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
-var isEscaped = [256]bool{}
-var escapeSeq = [256][]byte{}
+const hexDigits = "0123456789abcdef"
 
-func init() {
-	isEscaped[uint8('\b')] = true
-	isEscaped[uint8('\f')] = true
-	isEscaped[uint8('\n')] = true
-	isEscaped[uint8('\r')] = true
-	isEscaped[uint8('\t')] = true
-	isEscaped[uint8('"')] = true
-	isEscaped[uint8('\\')] = true
+const firstNonControlByte = 0x20
 
-	escapeSeq[uint8('\b')] = []byte("\\b")
-	escapeSeq[uint8('\f')] = []byte("\\f")
-	escapeSeq[uint8('\n')] = []byte("\\n")
-	escapeSeq[uint8('\r')] = []byte("\\r")
-	escapeSeq[uint8('\t')] = []byte("\\t")
-	escapeSeq[uint8('"')] = []byte("\\\"")
-	escapeSeq[uint8('\\')] = []byte("\\\\")
-}
+// escapeSeq maps a byte to its JSON escape, or nil when the byte is safe to
+// write unchanged.
+var escapeSeq = func() (seq [256][]byte) {
+	for c := 0; c < firstNonControlByte; c++ {
+		seq[c] = []byte{'\\', 'u', '0', '0', hexDigits[c>>4], hexDigits[c&0xf]}
+	}
+	seq['\b'] = []byte(`\b`)
+	seq['\t'] = []byte(`\t`)
+	seq['\n'] = []byte(`\n`)
+	seq['\f'] = []byte(`\f`)
+	seq['\r'] = []byte(`\r`)
+	seq['"'] = []byte(`\"`)
+	seq['\\'] = []byte(`\\`)
+	return seq
+}()
 
 type NoCopyBuilder struct {
 	buffers   [][]byte
@@ -193,11 +192,13 @@ func writeMarshalledValue(writer io.Writer, val interface{}) error {
 
 		writer.Write([]byte{'{'})
 		for i, k := range keys {
-			writer.Write([]byte{'"'})
-			writer.Write([]byte(k))
-			writer.Write([]byte(`": "`))
-			writer.Write([]byte(val[k]))
-			writer.Write([]byte{'"'})
+			if err := writeMarshalledValue(writer, k); err != nil {
+				return err
+			}
+			writer.Write([]byte(`: `))
+			if err := writeMarshalledValue(writer, val[k]); err != nil {
+				return err
+			}
 
 			if i != len(keys)-1 {
 				writer.Write([]byte{',', ' '})
@@ -232,22 +233,19 @@ func writeMarshalledValue(writer io.Writer, val interface{}) error {
 
 	case string:
 		writer.Write([]byte{'"'})
-		// iterate over each rune in the string to escape any special characters
+		// Iterate by byte. Every byte that needs escaping is ASCII, so the bytes
+		// of a multi byte UTF-8 sequence are always copied through unchanged.
 		start := 0
-		for i, r := range val {
-			if r > '\\' {
+		for i := 0; i < len(val); i++ {
+			esc := escapeSeq[val[i]]
+			if esc == nil {
 				continue
 			}
-
-			b := uint8(r)
-			if isEscaped[b] {
-				if start != i {
-					writer.Write([]byte(val[start:i]))
-				}
-
-				writer.Write(escapeSeq[b])
-				start = i + 1
+			if start != i {
+				writer.Write([]byte(val[start:i]))
 			}
+			writer.Write(esc)
+			start = i + 1
 		}
 
 		if start != len(val) {

--- a/sql/types/json_encode_test.go
+++ b/sql/types/json_encode_test.go
@@ -114,6 +114,22 @@ newlines
 			},
 			expected: `{"foo\"": "bar\t", "baz\n\\n": "qux"}`,
 		},
+		{
+			// See https://dev.mysql.com/doc/refman/8.4/en/json.html
+			name:     "control characters",
+			val:      []string{"\x00\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x1f\x7f"},
+			expected: "[\"\\u0000\\u0007\\b\\t\\n\\u000b\\f\\r\\u000e\\u001f\x7f\"]",
+		},
+		{
+			name:     "map of strings with control characters",
+			val:      map[string]string{"a\x0bb": "c\x0bd"},
+			expected: "{\"a\\u000bb\": \"c\\u000bd\"}",
+		},
+		{
+			name:     "multibyte utf8 passes through",
+			val:      []string{"日本語"},
+			expected: `["日本語"]`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Escape every control character in JSON output and unwrap lazily loaded text so JSON functions read it correctly.
- escape `U+0000` to `U+001F` as `\uXXXX`, keeping the short forms for backspace, tab, newline, form feed, and carriage return.
- unwrap StringWrapper before evaluating `JSON` functions, fixing `JSON_VALID` and friends on large keyless `TEXT`
- add serializer, JSON_QUOTE, and function tests
Block dolthub/dolt#11215