### PR TITLE
Fix `JSON_LENGTH` and member-access lookups to match MySQL

### DIFF
--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -959,6 +959,20 @@ var JsonScripts = []ScriptTest{
 				Expected: []sql.Row{{true}},
 			},
 			{
+				Query:    `select json_extract('{"a":5}', '$.a.*') is null`,
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    `select json_extract('{"a":null}', '$.a.b') is null`,
+				Expected: []sql.Row{{true}},
+			},
+			{
+				// Assert the value directly: it must be SQL NULL, not the empty
+				// array this returned before the fix.
+				Query:    `select json_extract('{"a":[1,2]}', '$.a.b')`,
+				Expected: []sql.Row{{nil}},
+			},
+			{
 				Query:    `select json_extract('{"a":{"b":[1,2]}}', '$.a.b')`,
 				Expected: []sql.Row{{types.MustJSON("[1, 2]")}},
 			},

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -967,8 +967,6 @@ var JsonScripts = []ScriptTest{
 				Expected: []sql.Row{{true}},
 			},
 			{
-				// Assert the value directly: it must be SQL NULL, not the empty
-				// array this returned before the fix.
 				Query:    `select json_extract('{"a":[1,2]}', '$.a.b')`,
 				Expected: []sql.Row{{nil}},
 			},

--- a/enginetest/queries/json_scripts.go
+++ b/enginetest/queries/json_scripts.go
@@ -358,6 +358,31 @@ var JsonScripts = []ScriptTest{
 					{1},
 				},
 			},
+			// See https://github.com/dolthub/dolt/issues/11224
+			{
+				Query: `select json_length(cast('[]' as json))`,
+				Expected: []sql.Row{
+					{0},
+				},
+			},
+			{
+				Query: `select json_length(cast('{}' as json))`,
+				Expected: []sql.Row{
+					{0},
+				},
+			},
+			{
+				Query: `select json_length(cast('null' as json))`,
+				Expected: []sql.Row{
+					{1},
+				},
+			},
+			{
+				Query: `select json_length(cast('{"a": []}' as json), "$.a")`,
+				Expected: []sql.Row{
+					{0},
+				},
+			},
 		},
 	},
 	{
@@ -901,7 +926,9 @@ var JsonScripts = []ScriptTest{
 					{1, types.MustJSON("[1, 2]")},
 					{2, nil},
 					{3, nil},
-					{4, types.MustJSON("null")},
+					// The member wildcard matches only objects, so applying it to
+					// the JSON null stored at items returns SQL NULL.
+					{4, nil},
 					{5, nil},
 				},
 			},
@@ -912,6 +939,32 @@ var JsonScripts = []ScriptTest{
 			{
 				Query:    "select pk from t where json_extract(col1, '$.items') <> null;",
 				Expected: []sql.Row{},
+			},
+		},
+	},
+	{
+		// See https://github.com/dolthub/dolt/issues/11224
+		Name: "json_extract member access on a non-object yields SQL NULL",
+		Assertions: []ScriptTestAssertion{
+			{
+				Query:    `select json_extract('{"a":[1,2]}', '$.a.b') is null`,
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    `select json_extract('{"a":[1,2]}', '$.a.*') is null`,
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    `select json_extract('{"a":5}', '$.a.b') is null`,
+				Expected: []sql.Row{{true}},
+			},
+			{
+				Query:    `select json_extract('{"a":{"b":[1,2]}}', '$.a.b')`,
+				Expected: []sql.Row{{types.MustJSON("[1, 2]")}},
+			},
+			{
+				Query:    `select json_extract('{"a":[{"b":1}]}', '$.a[0].b')`,
+				Expected: []sql.Row{{types.MustJSON("1")}},
 			},
 		},
 	},

--- a/sql/expression/function/json/json_length.go
+++ b/sql/expression/function/json/json_length.go
@@ -111,11 +111,9 @@ func (j *JsonLength) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 
 	switch v := val.(type) {
 	case nil:
-		return nil, nil
+		// A JSON null is a scalar, so its length is one.
+		return 1, nil
 	case []interface{}:
-		if len(v) == 0 {
-			return nil, nil
-		}
 		return len(v), nil
 	case map[string]interface{}:
 		return len(v), nil

--- a/sql/expression/function/json/jsontests/json_length_test.go
+++ b/sql/expression/function/json/jsontests/json_length_test.go
@@ -39,10 +39,12 @@ func TestJsonLength(t *testing.T) {
 		exp interface{}
 		err error
 	}{
+		// See https://github.com/dolthub/dolt/issues/11224
 		{
+			// A JSON null is a scalar, so its length is one.
 			f:   f1,
 			row: sql.Row{`null`},
-			exp: nil,
+			exp: 1,
 		},
 		{
 			f:   f1,
@@ -53,6 +55,16 @@ func TestJsonLength(t *testing.T) {
 			f:   f1,
 			row: sql.Row{`[1]`},
 			exp: 1,
+		},
+		{
+			f:   f1,
+			row: sql.Row{`[]`},
+			exp: 0,
+		},
+		{
+			f:   f1,
+			row: sql.Row{`{}`},
+			exp: 0,
 		},
 		{
 			f:   f1,
@@ -93,6 +105,21 @@ func TestJsonLength(t *testing.T) {
 			f:   f2,
 			row: sql.Row{`{"a": [1, false]}`, "$.a"},
 			exp: 2,
+		},
+		{
+			f:   f2,
+			row: sql.Row{`{"a": []}`, "$.a"},
+			exp: 0,
+		},
+		{
+			f:   f2,
+			row: sql.Row{`[[], []]`, "$[0]"},
+			exp: 0,
+		},
+		{
+			f:   f2,
+			row: sql.Row{`null`, "$"},
+			exp: 1,
 		},
 		{
 			f:   f2,

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -267,7 +267,7 @@ func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 
 	// The jsonpath library treats a member access against an array as a search
 	// of its elements, but MySQL treats it as no match and returns SQL NULL.
-	if memberAccessYieldsNoMatch(j, path) {
+	if memberAccessOnNonObject(j, path) {
 		return nil, nil
 	}
 
@@ -297,7 +297,7 @@ func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 	return JSONDocument{Val: val}, nil
 }
 
-// memberAccessYieldsNoMatch reports whether evaluating |path| against |document|
+// memberAccessOnNonObject reports whether evaluating |path| against |document|
 // would apply a member access, .key or .*, to a value that is not an object.
 // MySQL matches a member access only against objects and returns SQL NULL
 // otherwise, while the jsonpath library would instead search the elements of an
@@ -314,7 +314,7 @@ func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 //
 // [Allocating on the Stack]: https://go.dev/blog/allocation-optimizations
 // [MySQL JSON path syntax]: https://dev.mysql.com/doc/refman/8.4/en/json.html#json-path-syntax
-func memberAccessYieldsNoMatch(document interface{}, path string) bool {
+func memberAccessOnNonObject(document interface{}, path string) bool {
 	if !strings.HasPrefix(path, "$") {
 		return false
 	}

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"math"
 	"regexp"
 	"slices"
 	"strconv"
@@ -236,148 +237,6 @@ func LookupJSONValue(ctx context.Context, j sql.JSONWrapper, path string) (sql.J
 	return lookupJson(r, path)
 }
 
-// memberAccessYieldsNoMatch reports whether evaluating |path| against |j| would
-// apply a member access, .key or .*, to a value that is not an object. MySQL
-// matches a member access only against objects and returns SQL NULL otherwise,
-// while the jsonpath library would instead search the elements of an array.
-//
-// It reads only the part of |path| whose result is a single value reached by
-// following one branch, namely member accesses, the member wildcard, and
-// non-negative array indices, and reports true only when it is certain a member
-// access lands on a non-object, so it never reports true for a path that does
-// locate a value. Any other leg, such as an array wildcard, a range, [last], or
-// the ** ellipsis, makes it stop and report false so the caller falls back to
-// the jsonpath library.
-//
-// It scans |path| in a single pass and keeps no per-leg state on the heap, which
-// matters because lookups happen once per row. See [Allocating on the Stack] for
-// why the absence of an escaping slice lets the scan stay on the stack.
-//
-// For the path syntax itself see
-// https://dev.mysql.com/doc/refman/8.4/en/json.html#json-path-syntax.
-//
-// [Allocating on the Stack]: https://go.dev/blog/allocation-optimizations
-func memberAccessYieldsNoMatch(j interface{}, path string) bool {
-	if len(path) == 0 || path[0] != '$' {
-		return false
-	}
-	cur := j
-	for i := 1; i < len(path); {
-		switch path[i] {
-		case '.':
-			i++
-			if i >= len(path) {
-				return false
-			}
-			obj, isObject := cur.(JsonObject)
-			if path[i] == '*' {
-				i++
-				return !isObject
-			}
-			name, ok := readJSONMemberName(path, &i)
-			if !ok {
-				return false
-			}
-			if !isObject {
-				return true
-			}
-			child, exists := obj[name]
-			if !exists {
-				return false
-			}
-			cur = child
-		case '[':
-			end := strings.IndexByte(path[i:], ']')
-			if end < 0 {
-				return false
-			}
-			// Parse the index without strconv.Atoi, whose error value would
-			// escape and allocate for every wildcard or range leg this rejects.
-			n, ok := parseNonNegativeInt(strings.TrimSpace(path[i+1 : i+end]))
-			if !ok {
-				return false
-			}
-			i += end + 1
-			arr, isArray := cur.(JsonArray)
-			if !isArray {
-				// MySQL treats a non-array as a single element array, so only
-				// the index 0 selects the value and any other index misses.
-				if n != 0 {
-					return false
-				}
-				continue
-			}
-			if n >= len(arr) {
-				return false
-			}
-			cur = arr[n]
-		default:
-			return false
-		}
-	}
-	return false
-}
-
-// parseNonNegativeInt reports the integer value of |s| when |s| is a non-empty
-// run of ASCII digits, and false otherwise.
-func parseNonNegativeInt(s string) (int, bool) {
-	if len(s) == 0 {
-		return 0, false
-	}
-	n := 0
-	for k := 0; k < len(s); k++ {
-		if s[k] < '0' || s[k] > '9' {
-			return 0, false
-		}
-		n = n*10 + int(s[k]-'0')
-	}
-	return n, true
-}
-
-// readJSONMemberName reads the member name that follows a "." leg in a JSON path,
-// advancing |i| past it. A quoted name without escapes and an unquoted name are
-// returned as substrings of |path| so the common case allocates nothing. It
-// returns false if a quoted name is never closed or an unquoted name is empty.
-func readJSONMemberName(path string, i *int) (string, bool) {
-	if path[*i] != '"' {
-		start := *i
-		for *i < len(path) && path[*i] != '.' && path[*i] != '[' {
-			*i++
-		}
-		if *i == start {
-			return "", false
-		}
-		return path[start:*i], true
-	}
-	*i++
-	start := *i
-	escaped := false
-	for *i < len(path) && path[*i] != '"' {
-		if path[*i] == '\\' {
-			escaped = true
-			*i++
-		}
-		*i++
-	}
-	if *i >= len(path) {
-		return "", false
-	}
-	raw := path[start:*i]
-	*i++
-	if !escaped {
-		return raw, true
-	}
-	var b strings.Builder
-	b.Grow(len(raw))
-	for k := 0; k < len(raw); k++ {
-		if raw[k] == '\\' && k+1 < len(raw) {
-			k++
-		}
-		b.WriteByte(raw[k])
-	}
-	return b.String(), true
-}
-
 func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 	// Lookup(obj) throws an error if obj is nil. We want lookups on a json null
 	// to always result in sql NULL, except in the case of the identity lookup
@@ -436,6 +295,217 @@ func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 	}
 
 	return JSONDocument{Val: val}, nil
+}
+
+// memberAccessYieldsNoMatch reports whether evaluating |path| against |document|
+// would apply a member access, .key or .*, to a value that is not an object.
+// MySQL matches a member access only against objects and returns SQL NULL
+// otherwise, while the jsonpath library would instead search the elements of an
+// array.
+//
+// It walks only the legs whose result is a single value, namely member accesses,
+// the member wildcard, and non-negative array indices, and reports true only
+// when it is certain a member access lands on a non-object. Any other leg, such
+// as an array-cell wildcard, a range, or the ** ellipsis, stops the walk and
+// reports false so the caller falls back to the jsonpath library.
+//
+// The walk keeps no per-leg state on the heap because lookups happen once per
+// row. See [Allocating on the Stack] and the [MySQL JSON path syntax].
+//
+// [Allocating on the Stack]: https://go.dev/blog/allocation-optimizations
+// [MySQL JSON path syntax]: https://dev.mysql.com/doc/refman/8.4/en/json.html#json-path-syntax
+func memberAccessYieldsNoMatch(document interface{}, path string) bool {
+	if !strings.HasPrefix(path, "$") {
+		return false
+	}
+	scanner := jsonPathScanner{path: path, position: 1}
+	current := document
+	for {
+		switch leg := scanner.next(); leg.kind {
+		case legMember, legMemberWildcard:
+			object, isObject := current.(JsonObject)
+			if !isObject {
+				// A member access matches only objects in MySQL.
+				return true
+			}
+			if leg.kind == legMemberWildcard {
+				// .* selects every member, a multi-valued result we leave to the
+				// jsonpath library.
+				return false
+			}
+			child, exists := object[leg.member]
+			if !exists {
+				return false
+			}
+			current = child
+		case legIndex:
+			array, isArray := current.(JsonArray)
+			if !isArray {
+				// MySQL auto-wraps a non-array as a single-element array, so only
+				// index 0 selects the value and any other index misses.
+				if leg.index != 0 {
+					return false
+				}
+				continue
+			}
+			if leg.index >= len(array) {
+				return false
+			}
+			current = array[leg.index]
+		default:
+			// legEnd or legUnsupported: there is nothing more to follow, so leave
+			// the remaining path to the jsonpath library.
+			return false
+		}
+	}
+}
+
+// jsonPathLegKind classifies one leg of a JSON path. See [jsonPathScanner].
+type jsonPathLegKind int
+
+const (
+	legEnd            jsonPathLegKind = iota // the path has been fully consumed
+	legUnsupported                           // a leg the scanner does not model
+	legMember                                // a named member, such as .key
+	legMemberWildcard                        // the member wildcard, .*
+	legIndex                                 // a non-negative array index, such as [3]
+)
+
+// jsonPathLeg is one leg of a JSON path, produced by [jsonPathScanner.next]. It
+// is returned by value so that walking a path allocates nothing.
+type jsonPathLeg struct {
+	kind   jsonPathLegKind
+	member string // the member name, set when kind is legMember
+	index  int    // the array index, set when kind is legIndex
+}
+
+// jsonPathScanner reads the legs of a MySQL JSON path one at a time.
+type jsonPathScanner struct {
+	path     string
+	position int
+}
+
+// next returns the leg beginning at the current position and advances past it.
+// It returns kind [legEnd] once the path is consumed and [legUnsupported] for
+// any syntax the scanner does not model.
+func (scanner *jsonPathScanner) next() jsonPathLeg {
+	if scanner.position >= len(scanner.path) {
+		return jsonPathLeg{kind: legEnd}
+	}
+	switch scanner.path[scanner.position] {
+	case '.':
+		return scanner.scanMember()
+	case '[':
+		return scanner.scanIndex()
+	default:
+		return jsonPathLeg{kind: legUnsupported}
+	}
+}
+
+// scanMember reads a "." leg, which is either a member name or the member
+// wildcard .*.
+func (scanner *jsonPathScanner) scanMember() jsonPathLeg {
+	scanner.position++ // consume the '.'
+	if scanner.position >= len(scanner.path) {
+		return jsonPathLeg{kind: legUnsupported}
+	}
+	if scanner.path[scanner.position] == '*' {
+		scanner.position++
+		return jsonPathLeg{kind: legMemberWildcard}
+	}
+	member, ok := scanner.scanMemberName()
+	if !ok {
+		return jsonPathLeg{kind: legUnsupported}
+	}
+	return jsonPathLeg{kind: legMember, member: member}
+}
+
+// scanIndex reads a "[...]" leg. Only a non-negative integer index is modelled,
+// so array-cell wildcards and ranges report [legUnsupported].
+func (scanner *jsonPathScanner) scanIndex() jsonPathLeg {
+	closeBracket := strings.IndexByte(scanner.path[scanner.position:], ']')
+	if closeBracket < 0 {
+		return jsonPathLeg{kind: legUnsupported}
+	}
+	contents := scanner.path[scanner.position+1 : scanner.position+closeBracket]
+	index, ok := parseNonNegativeInt(strings.TrimSpace(contents))
+	if !ok {
+		return jsonPathLeg{kind: legUnsupported}
+	}
+	scanner.position += closeBracket + 1
+	return jsonPathLeg{kind: legIndex, index: index}
+}
+
+// scanMemberName reads the member name after a ".". It returns a substring of
+// the path so the common case allocates nothing, unescaping into a new string
+// only when a quoted name actually contains a backslash. It returns false for an
+// empty unquoted name or an unterminated quoted name.
+func (scanner *jsonPathScanner) scanMemberName() (string, bool) {
+	if scanner.path[scanner.position] != '"' {
+		start := scanner.position
+		for scanner.position < len(scanner.path) &&
+			scanner.path[scanner.position] != '.' &&
+			scanner.path[scanner.position] != '[' {
+			scanner.position++
+		}
+		return scanner.path[start:scanner.position], scanner.position > start
+	}
+	scanner.position++ // consume the opening quote
+	start := scanner.position
+	escaped := false
+	for scanner.position < len(scanner.path) && scanner.path[scanner.position] != '"' {
+		if scanner.path[scanner.position] == '\\' {
+			escaped = true
+			scanner.position++ // skip the escaped character
+		}
+		scanner.position++
+	}
+	if scanner.position >= len(scanner.path) {
+		return "", false
+	}
+	member := scanner.path[start:scanner.position]
+	scanner.position++ // consume the closing quote
+	if !escaped {
+		return member, true
+	}
+	return unescapeJSONMemberName(member), true
+}
+
+// unescapeJSONMemberName drops the backslash escapes from a quoted member name.
+func unescapeJSONMemberName(member string) string {
+	var builder strings.Builder
+	builder.Grow(len(member))
+	for position := 0; position < len(member); position++ {
+		if member[position] == '\\' && position+1 < len(member) {
+			position++ // drop the backslash and keep the byte it escaped
+		}
+		builder.WriteByte(member[position])
+	}
+	return builder.String()
+}
+
+// parseNonNegativeInt reports the integer value of |text| when |text| is a
+// non-empty run of ASCII digits no greater than [math.MaxInt32], and false
+// otherwise. It avoids strconv.Atoi, whose error value would escape and allocate
+// for every array-cell wildcard or range leg it rejects. MySQL caps array
+// indices well below MaxInt32, so rejecting larger values also keeps the
+// accumulator from overflowing into a negative index that could panic a caller.
+func parseNonNegativeInt(text string) (int, bool) {
+	if len(text) == 0 {
+		return 0, false
+	}
+	value := 0
+	for position := 0; position < len(text); position++ {
+		digit := text[position]
+		if digit < '0' || digit > '9' {
+			return 0, false
+		}
+		value = value*10 + int(digit-'0')
+		if value > math.MaxInt32 {
+			return 0, false
+		}
+	}
+	return value, true
 }
 
 var _ driver.Valuer = JSONDocument{}

--- a/sql/types/json_value.go
+++ b/sql/types/json_value.go
@@ -236,6 +236,148 @@ func LookupJSONValue(ctx context.Context, j sql.JSONWrapper, path string) (sql.J
 	return lookupJson(r, path)
 }
 
+// memberAccessYieldsNoMatch reports whether evaluating |path| against |j| would
+// apply a member access, .key or .*, to a value that is not an object. MySQL
+// matches a member access only against objects and returns SQL NULL otherwise,
+// while the jsonpath library would instead search the elements of an array.
+//
+// It reads only the part of |path| whose result is a single value reached by
+// following one branch, namely member accesses, the member wildcard, and
+// non-negative array indices, and reports true only when it is certain a member
+// access lands on a non-object, so it never reports true for a path that does
+// locate a value. Any other leg, such as an array wildcard, a range, [last], or
+// the ** ellipsis, makes it stop and report false so the caller falls back to
+// the jsonpath library.
+//
+// It scans |path| in a single pass and keeps no per-leg state on the heap, which
+// matters because lookups happen once per row. See [Allocating on the Stack] for
+// why the absence of an escaping slice lets the scan stay on the stack.
+//
+// For the path syntax itself see
+// https://dev.mysql.com/doc/refman/8.4/en/json.html#json-path-syntax.
+//
+// [Allocating on the Stack]: https://go.dev/blog/allocation-optimizations
+func memberAccessYieldsNoMatch(j interface{}, path string) bool {
+	if len(path) == 0 || path[0] != '$' {
+		return false
+	}
+	cur := j
+	for i := 1; i < len(path); {
+		switch path[i] {
+		case '.':
+			i++
+			if i >= len(path) {
+				return false
+			}
+			obj, isObject := cur.(JsonObject)
+			if path[i] == '*' {
+				i++
+				return !isObject
+			}
+			name, ok := readJSONMemberName(path, &i)
+			if !ok {
+				return false
+			}
+			if !isObject {
+				return true
+			}
+			child, exists := obj[name]
+			if !exists {
+				return false
+			}
+			cur = child
+		case '[':
+			end := strings.IndexByte(path[i:], ']')
+			if end < 0 {
+				return false
+			}
+			// Parse the index without strconv.Atoi, whose error value would
+			// escape and allocate for every wildcard or range leg this rejects.
+			n, ok := parseNonNegativeInt(strings.TrimSpace(path[i+1 : i+end]))
+			if !ok {
+				return false
+			}
+			i += end + 1
+			arr, isArray := cur.(JsonArray)
+			if !isArray {
+				// MySQL treats a non-array as a single element array, so only
+				// the index 0 selects the value and any other index misses.
+				if n != 0 {
+					return false
+				}
+				continue
+			}
+			if n >= len(arr) {
+				return false
+			}
+			cur = arr[n]
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// parseNonNegativeInt reports the integer value of |s| when |s| is a non-empty
+// run of ASCII digits, and false otherwise.
+func parseNonNegativeInt(s string) (int, bool) {
+	if len(s) == 0 {
+		return 0, false
+	}
+	n := 0
+	for k := 0; k < len(s); k++ {
+		if s[k] < '0' || s[k] > '9' {
+			return 0, false
+		}
+		n = n*10 + int(s[k]-'0')
+	}
+	return n, true
+}
+
+// readJSONMemberName reads the member name that follows a "." leg in a JSON path,
+// advancing |i| past it. A quoted name without escapes and an unquoted name are
+// returned as substrings of |path| so the common case allocates nothing. It
+// returns false if a quoted name is never closed or an unquoted name is empty.
+func readJSONMemberName(path string, i *int) (string, bool) {
+	if path[*i] != '"' {
+		start := *i
+		for *i < len(path) && path[*i] != '.' && path[*i] != '[' {
+			*i++
+		}
+		if *i == start {
+			return "", false
+		}
+		return path[start:*i], true
+	}
+	*i++
+	start := *i
+	escaped := false
+	for *i < len(path) && path[*i] != '"' {
+		if path[*i] == '\\' {
+			escaped = true
+			*i++
+		}
+		*i++
+	}
+	if *i >= len(path) {
+		return "", false
+	}
+	raw := path[start:*i]
+	*i++
+	if !escaped {
+		return raw, true
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	for k := 0; k < len(raw); k++ {
+		if raw[k] == '\\' && k+1 < len(raw) {
+			k++
+		}
+		b.WriteByte(raw[k])
+	}
+	return b.String(), true
+}
+
 func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 	// Lookup(obj) throws an error if obj is nil. We want lookups on a json null
 	// to always result in sql NULL, except in the case of the identity lookup
@@ -261,6 +403,12 @@ func lookupJson(j interface{}, path string) (SearchableJSON, error) {
 	_, isObject := j.(JsonObject)
 	_, isArray := j.(JsonArray)
 	if !isObject && !isArray {
+		return nil, nil
+	}
+
+	// The jsonpath library treats a member access against an array as a search
+	// of its elements, but MySQL treats it as no match and returns SQL NULL.
+	if memberAccessYieldsNoMatch(j, path) {
 		return nil, nil
 	}
 

--- a/sql/types/json_value_test.go
+++ b/sql/types/json_value_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Dolthub, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemberAccessYieldsNoMatch(t *testing.T) {
+	array := JsonArray{1.0, 2.0, 3.0}
+	objectWithArray := JsonObject{"a": JsonArray{1.0, 2.0}}
+	objectWithScalar := JsonObject{"a": 5.0}
+	objectWithObject := JsonObject{"a": JsonObject{"b": 9.0}}
+
+	tests := []struct {
+		name     string
+		document interface{}
+		path     string
+		want     bool
+	}{
+		// A member access lands on a non-object, so the result is certainly empty.
+		{"member on array", array, "$.a", true},
+		{"member wildcard on array", array, "$.*", true},
+		{"nested member on array", objectWithArray, "$.a.b", true},
+		{"nested wildcard on array", objectWithArray, "$.a.*", true},
+		{"member on scalar", objectWithScalar, "$.a.b", true},
+		{"member after index on array", objectWithArray, "$.a[0].b", true},
+
+		// The path locates a value, so we must defer to the jsonpath library.
+		{"value is array", objectWithArray, "$.a", false},
+		{"member on object", objectWithObject, "$.a.b", false},
+		{"index into array", array, "$[0]", false},
+		{"index auto-wraps non-array", objectWithScalar, "$.a[0]", false},
+
+		// Malformed or unmodelled paths must fall back without panicking.
+		{"empty path", array, "", false},
+		{"root only", array, "$", false},
+		{"trailing dot", array, "$.", false},
+		{"trailing dot after member", objectWithArray, "$.a.", false},
+		{"unterminated bracket", array, "$[5", false},
+		{"empty bracket", array, "$[]", false},
+		{"open bracket only", array, "$[", false},
+		{"unterminated quote", objectWithObject, `$."a`, false},
+		{"array cell wildcard", array, "$[*].a", false},
+		{"ellipsis", objectWithObject, "$**.a", false},
+		{"index overflows int32", array, "$[99999999999999999999]", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, memberAccessYieldsNoMatch(test.document, test.path))
+		})
+	}
+}

--- a/sql/types/json_value_test.go
+++ b/sql/types/json_value_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMemberAccessYieldsNoMatch(t *testing.T) {
+func TestMemberAccessOnNonObject(t *testing.T) {
 	array := JsonArray{1.0, 2.0, 3.0}
 	objectWithArray := JsonObject{"a": JsonArray{1.0, 2.0}}
 	objectWithScalar := JsonObject{"a": 5.0}
@@ -62,7 +62,7 @@ func TestMemberAccessYieldsNoMatch(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.want, memberAccessYieldsNoMatch(test.document, test.path))
+			require.Equal(t, test.want, memberAccessOnNonObject(test.document, test.path))
 		})
 	}
 }


### PR DESCRIPTION
 `JSON_LENGTH` returned `NULL` for empty arrays and the JSON null literal, and member-access paths (`.key`/`.*`) on an array returned `[]` instead of `NULL`.
- Empty array now has length 0, JSON null has length 1
- Member access on a non object yields `SQL NULL`, at any depth
- New allocation free path scanner for the pre check
Fix dolthub/dolt#11224
Close dolthub/dolt#11235