### PR TITLE
cache `GeneralizeTypes` output and avoid `fmt.Sprintf` in `HashOfSimple`

### DIFF
--- a/enginetest/queries/indexed_expressions_queries.go
+++ b/enginetest/queries/indexed_expressions_queries.go
@@ -1150,8 +1150,7 @@ var IndexedExpressionsScriptTests = []ScriptTest{
 		},
 	},
 	{
-		Name:    "composite indexes are used during tuple expression filters",
-		Dialect: "mysql",
+		Name: "composite indexes are used during tuple expression filters",
 		SetUpScript: []string{
 			"create table t (i int, j int, k int, primary key(i, j, k));",
 			"insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4), (5, 5, 5), (6, 6, 6), (7, 7, 7), (8, 8, 8), (9, 9, 9), (10, 10, 10);",

--- a/sql/expression/case.go
+++ b/sql/expression/case.go
@@ -33,6 +33,7 @@ type Case struct {
 	Expr     sql.Expression
 	Else     sql.Expression
 	Branches []CaseBranch
+	typ      sql.Type
 }
 
 var _ sql.Expression = (*Case)(nil)
@@ -45,15 +46,17 @@ func NewCase(expr sql.Expression, branches []CaseBranch, elseExpr sql.Expression
 
 // Type implements the sql.Expression interface.
 func (c *Case) Type(ctx *sql.Context) sql.Type {
-	var curr sql.Type
-	curr = types.Null
+	if c.typ != nil {
+		return c.typ
+	}
+	c.typ = types.Null
 	for _, b := range c.Branches {
-		curr = types.GeneralizeTypes(curr, b.Value.Type(ctx))
+		c.typ = types.GeneralizeTypes(c.typ, b.Value.Type(ctx))
 	}
 	if c.Else != nil {
-		curr = types.GeneralizeTypes(curr, c.Else.Type(ctx))
+		c.typ = types.GeneralizeTypes(c.typ, c.Else.Type(ctx))
 	}
-	return curr
+	return c.typ
 }
 
 // CollationCoercibility implements the interface sql.CollationCoercible.

--- a/sql/hash/hash.go
+++ b/sql/hash/hash.go
@@ -151,22 +151,9 @@ func HashOfSimple(ctx *sql.Context, i any, t sql.Type) (uint64, sql.ConvertInRan
 
 	var str string
 	var inRange sql.ConvertInRange
-	coll := sql.Collation_Default
-	if types.IsTuple(t) {
-		tup := i.([]any)
-		tupType := t.(types.TupleType)
-		hashes := make([]uint64, len(tup))
-		for idx, v := range tup {
-			// TODO: handle out of range conversions here?
-			h, _, err := HashOfSimple(ctx, v, tupType[idx])
-			if err != nil {
-				return 0, sql.InRange, err
-			}
-			hashes[idx] = h
-		}
-		str = fmt.Sprintf("%v", hashes)
-	} else if types.IsTextOnly(t) {
-		coll = t.(sql.StringType).Collation()
+	if types.IsTextOnly(t) {
+		// Collated strings that are equivalent may have different runes, so we must make them hash to the same value
+		coll := t.(sql.StringType).Collation()
 		if s, ok := i.(string); ok {
 			str = s
 		} else {
@@ -179,64 +166,92 @@ func HashOfSimple(ctx *sql.Context, i any, t sql.Type) (uint64, sql.ConvertInRan
 				return 0, sql.InRange, err
 			}
 		}
-	} else {
-		var val any
-		var err error
-		val, inRange, err = types.ConvertOrTruncate(ctx, i, t.Promote())
+		h, err := coll.HashToUint(str)
 		if err != nil {
 			return 0, sql.InRange, err
 		}
-
-		// Remove trailing 0s from floats
-		switch v := val.(type) {
-		case int:
-			str = strconv.FormatInt(int64(v), 10)
-		case int8:
-			str = strconv.FormatInt(int64(v), 10)
-		case int16:
-			str = strconv.FormatInt(int64(v), 10)
-		case int32:
-			str = strconv.FormatInt(int64(v), 10)
-		case int64:
-			str = strconv.FormatInt(v, 10)
-		case uint:
-			str = strconv.FormatUint(uint64(v), 10)
-		case uint8:
-			str = strconv.FormatUint(uint64(v), 10)
-		case uint16:
-			str = strconv.FormatUint(uint64(v), 10)
-		case uint32:
-			str = strconv.FormatUint(uint64(v), 10)
-		case uint64:
-			str = strconv.FormatUint(v, 10)
-		case float32:
-			str = strconv.FormatFloat(float64(v), 'f', -1, 32)
-			if str == "-0" {
-				str = "0"
-			}
-		case float64:
-			str = strconv.FormatFloat(v, 'f', -1, 64)
-			if str == "-0" {
-				str = "0"
-			}
-		case *apd.Decimal:
-			str = v.Text('f')
-			if strings.IndexByte(str, '.') != -1 {
-				// remove trailing 0s after '.'
-				str = strings.TrimRightFunc(str, func(r rune) bool {
-					return r == '0'
-				})
-				str = strings.TrimRight(str, ".")
-			}
-		default:
-			str = fmt.Sprintf("%v", v)
-		}
+		return h, inRange, nil
 	}
 
-	// Collated strings that are equivalent may have different runes, so we must make them hash to the same value
-	h, err := coll.HashToUint(str)
+	hash := digestPool.Get().(*xxhash.Digest)
+	hash.Reset()
+	defer digestPool.Put(hash)
+
+	if types.IsTuple(t) {
+		tup := i.([]any)
+		tupType := t.(types.TupleType)
+		hashes := make([]uint64, len(tup))
+		for idx, v := range tup {
+			// TODO: handle out of range conversions here?
+			h, _, err := HashOfSimple(ctx, v, tupType[idx])
+			if err != nil {
+				return 0, sql.InRange, err
+			}
+			hashes[idx] = h
+		}
+		str = fmt.Sprintf("%v", hashes) // TODO: avoid Sprintf for performance
+		_, err := hash.WriteString(str)
+		if err != nil {
+			return 0, sql.InRange, err
+		}
+		return hash.Sum64(), inRange, nil
+	}
+
+	var val any
+	var err error
+	val, inRange, err = types.ConvertOrTruncate(ctx, i, t.Promote())
 	if err != nil {
 		return 0, sql.InRange, err
 	}
-	return h, inRange, nil
+
+	// TODO: use strconv.Append...() and a byte buffer
+	switch v := val.(type) {
+	case int:
+		str = strconv.FormatInt(int64(v), 10)
+	case int8:
+		str = strconv.FormatInt(int64(v), 10)
+	case int16:
+		str = strconv.FormatInt(int64(v), 10)
+	case int32:
+		str = strconv.FormatInt(int64(v), 10)
+	case int64:
+		str = strconv.FormatInt(v, 10)
+	case uint:
+		str = strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		str = strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		str = strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		str = strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		str = strconv.FormatUint(v, 10)
+	case float32:
+		str = strconv.FormatFloat(float64(v), 'f', -1, 32)
+		if str == "-0" {
+			str = "0"
+		}
+	case float64:
+		str = strconv.FormatFloat(v, 'f', -1, 64)
+		if str == "-0" {
+			str = "0"
+		}
+	case *apd.Decimal:
+		str = v.Text('f')
+		if strings.IndexByte(str, '.') != -1 {
+			// remove trailing 0s after '.'
+			str = strings.TrimRightFunc(str, func(r rune) bool {
+				return r == '0'
+			})
+			str = strings.TrimRight(str, ".")
+		}
+	default:
+		str = fmt.Sprintf("%v", v) // TODO: avoid Sprintf for performance
+	}
+
+	_, err = hash.WriteString(str)
+	if err != nil {
+		return 0, sql.InRange, err
+	}
+	return hash.Sum64(), inRange, nil
 }

--- a/sql/hash/hash.go
+++ b/sql/hash/hash.go
@@ -189,6 +189,26 @@ func HashOfSimple(ctx *sql.Context, i any, t sql.Type) (uint64, sql.ConvertInRan
 
 		// Remove trailing 0s from floats
 		switch v := val.(type) {
+		case int:
+			str = strconv.FormatInt(int64(v), 10)
+		case int8:
+			str = strconv.FormatInt(int64(v), 10)
+		case int16:
+			str = strconv.FormatInt(int64(v), 10)
+		case int32:
+			str = strconv.FormatInt(int64(v), 10)
+		case int64:
+			str = strconv.FormatInt(v, 10)
+		case uint:
+			str = strconv.FormatUint(uint64(v), 10)
+		case uint8:
+			str = strconv.FormatUint(uint64(v), 10)
+		case uint16:
+			str = strconv.FormatUint(uint64(v), 10)
+		case uint32:
+			str = strconv.FormatUint(uint64(v), 10)
+		case uint64:
+			str = strconv.FormatUint(v, 10)
 		case float32:
 			str = strconv.FormatFloat(float64(v), 'f', -1, 32)
 			if str == "-0" {

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -227,8 +227,9 @@ func (b *BaseBuilder) buildJSONTable(ctx *sql.Context, n *plan.JSONTable, row sq
 }
 
 func (b *BaseBuilder) buildHashLookup(ctx *sql.Context, n *plan.HashLookup, row sql.Row) (sql.RowIter, error) {
-	//n.Mutex.Lock()
-	//defer n.Mutex.Unlock()
+	// TODO: pretty sure this Mutex is useless, but keep it for now
+	n.Mutex.Lock()
+	defer n.Mutex.Unlock()
 	if n.Lookup == nil {
 		childIter, err := b.buildNodeExec(ctx, n.Child, row)
 		if err != nil {

--- a/sql/rowexec/rel.go
+++ b/sql/rowexec/rel.go
@@ -227,8 +227,8 @@ func (b *BaseBuilder) buildJSONTable(ctx *sql.Context, n *plan.JSONTable, row sq
 }
 
 func (b *BaseBuilder) buildHashLookup(ctx *sql.Context, n *plan.HashLookup, row sql.Row) (sql.RowIter, error) {
-	n.Mutex.Lock()
-	defer n.Mutex.Unlock()
+	//n.Mutex.Lock()
+	//defer n.Mutex.Unlock()
 	if n.Lookup == nil {
 		childIter, err := b.buildNodeExec(ctx, n.Child, row)
 		if err != nil {


### PR DESCRIPTION
This PR adds some optimizations to CASE statements and HashLookups