### PR TITLE
Create single override point for `SplitConjunction`

### DIFF
--- a/sql/analyzer/costed_index_scan.go
+++ b/sql/analyzer/costed_index_scan.go
@@ -76,7 +76,7 @@ func costedIndexScans(ctx *sql.Context, a *Analyzer, n sql.Node, qFlags *sql.Que
 		}
 
 		if is, ok := rt.UnderlyingTable().(sql.IndexSearchableTable); ok {
-			lookup, lookupFds, newFilter, ok, err := is.LookupForExpressions(ctx, SplitConjunction(ctx, filter.Expression)...)
+			lookup, lookupFds, newFilter, ok, err := is.LookupForExpressions(ctx, expression.SplitConjunction(ctx, filter.Expression)...)
 			if err != nil {
 				return n, transform.SameTree, err
 			}
@@ -128,8 +128,6 @@ func indexSearchableLookup(ctx *sql.Context, n sql.Node, rt sql.TableNode, looku
 	return ret, transform.NewTree, nil
 }
 
-var SplitConjunction func(ctx *sql.Context, expr sql.Expression) []sql.Expression = expression.SplitConjunction
-
 func costedIndexLookup(
 	ctx *sql.Context,
 	n sql.Node,
@@ -145,7 +143,7 @@ func costedIndexLookup(
 		return n, transform.SameTree, err
 	}
 
-	ita, stats, filters, err := getCostedIndexScan(ctx, a.Catalog, a.Catalog, rt, indexes, SplitConjunction(ctx, oldFilter), qFlags)
+	ita, stats, filters, err := getCostedIndexScan(ctx, a.Catalog, a.Catalog, rt, indexes, expression.SplitConjunction(ctx, oldFilter), qFlags)
 	if err != nil || ita == nil {
 		return n, transform.SameTree, err
 	}

--- a/sql/expression/logic.go
+++ b/sql/expression/logic.go
@@ -56,8 +56,11 @@ func JoinAnd(exprs ...sql.Expression) sql.Expression {
 	}
 }
 
-// SplitConjunction breaks AND expressions into their left and right parts, recursively
-func SplitConjunction(ctx *sql.Context, expr sql.Expression) []sql.Expression {
+// SplitConjunction as an exported variable allows integrators to replace its logic
+var SplitConjunction func(ctx *sql.Context, expr sql.Expression) []sql.Expression = splitConjunction
+
+// splitConjunction breaks AND expressions into their left and right parts, recursively
+func splitConjunction(ctx *sql.Context, expr sql.Expression) []sql.Expression {
 	if expr == nil {
 		return nil
 	}
@@ -67,14 +70,14 @@ func SplitConjunction(ctx *sql.Context, expr sql.Expression) []sql.Expression {
 	}
 
 	return append(
-		SplitConjunction(ctx, and.LeftChild),
-		SplitConjunction(ctx, and.RightChild)...,
+		splitConjunction(ctx, and.LeftChild),
+		splitConjunction(ctx, and.RightChild)...,
 	)
 }
 
 // SplitDisjunction breaks OR expressions into their left and right parts, recursively
 func SplitDisjunction(expr sql.Expression) []sql.Expression {
-	// TODO: This is function is nearly identical to SplitConjunction and clearly copy-pasted from it. Consider
+	// TODO: This is function is nearly identical to splitConjunction and clearly copy-pasted from it. Consider
 	//  refactoring out repeated code into another function.
 	if expr == nil {
 		return nil

--- a/sql/memo/join_order_builder.go
+++ b/sql/memo/join_order_builder.go
@@ -26,10 +26,6 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/plan"
 )
 
-// SplitConjunction is a pseudo-extension point of expression.SplitConjunction, used to alter the logic
-// for different integrators.
-var SplitConjunction func(ctx *sql.Context, expr sql.Expression) []sql.Expression = expression.SplitConjunction
-
 // joinOrderBuilder enumerates valid plans for a join tree.  We build the join
 // tree bottom up, first joining single nodes with join condition "edges", then
 // single nodes to hypernodes (1+n), and finally hyper nodes to
@@ -508,7 +504,7 @@ func (j *joinOrderBuilder) buildJoinOp(ctx *sql.Context, n *plan.JoinNode) *Expr
 		rightEdges:    rightE,
 	}
 
-	filters := SplitConjunction(ctx, n.JoinCond())
+	filters := expression.SplitConjunction(ctx, n.JoinCond())
 	j.m.Tracer.Log("Join filters: %v", filters)
 	union := leftV.union(rightV)
 	group, ok := j.plans[union]
@@ -536,7 +532,7 @@ func (j *joinOrderBuilder) buildFilter(ctx *sql.Context, child sql.Node, e sql.E
 	// memoize child
 	childV, childE, childGrp := j.populateSubgraph(ctx, child)
 
-	filterGrp := j.m.MemoizeFilter(ctx, nil, childGrp, SplitConjunction(ctx, e))
+	filterGrp := j.m.MemoizeFilter(ctx, nil, childGrp, expression.SplitConjunction(ctx, e))
 
 	// filter will absorb child relation for join reordering
 	j.plans[childV] = filterGrp


### PR DESCRIPTION
`SplitConjunction` works differently for Doltgres expressions. The integration with Doltgres relied on `analyzer.SplitConjunction` and `memo.SplitConjunction` being replaced and called instead of `expression.SplitConjunction`; however, `expression.SplitConjunction` was still being called in many places in the analyzer. Not calling the correct version of `SplitConjunction` was preventing filter expressions from being properly pushed down in Doltgres. Furthermore, `expression.SplitConjunction` was still being called in `rowexec` and calling `analyzer.SplitConjunction` from the `rowexec` package causes a cyclical import.

To avoid confusion between the various `SplitConjunction` instances, this PR replaces the various override variables with a single one in the `expression` package. This allows `SplitConjunction` to be consistently replaced throughout GMS without requiring GMS developers to have knowledge of `SplitConjunction` working differently in Doltgres.

This change is integrated into Dolgres in dolthub/doltgresql#2865.

This issue was originally encountered while working on #3591.