### PR TITLE
fix groupby in subquery

### DIFF
--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -394,6 +394,7 @@ func (s *scope) push() *scope {
 		b:          s.b,
 		parent:     s,
 		schemaName: s.schemaName,
+		groupBy:    s.groupBy,
 	}
 	if s.procActive() {
 		new.initProc()


### PR DESCRIPTION
aggregations within subquery within having were getting skipped

TODO: write simplified repro of this
```
SELECT
  ps_partkey,
  SUM(ps_supplycost * ps_availqty) AS VALUE
FROM
  partsupp,
  supplier,
  nation
WHERE
  ps_suppkey = s_suppkey
  AND s_nationkey = n_nationkey
  AND n_name = 'ALGERIA'
GROUP BY
  ps_partkey
HAVING
  SUM(ps_supplycost * ps_availqty) > (
    SELECT
      SUM(ps_supplycost * ps_availqty) + 1
    FROM
      partsupp, supplier, nation
    WHERE
      ps_suppkey = s_suppkey
      AND s_nationkey = n_nationkey
      AND n_name = 'ALGERIA'
  )
  ORDER BY
    VALUE DESC
;
```