### PR TITLE
Use `TableId`s instead of names when mapping filters to tables

### DIFF
--- a/enginetest/queries/index_query_plans.go
+++ b/enginetest/queries/index_query_plans.go
@@ -16499,7 +16499,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (4-6)\n" +
-			" ├─ tableId: 3\n" +
+			" ├─ tableId: 2\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"     ├─ static: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
@@ -16515,7 +16515,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (4-6)\n" +
-			" ├─ tableId: 3\n" +
+			" ├─ tableId: 2\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
@@ -16527,7 +16527,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (4-6)\n" +
-			" ├─ tableId: 3\n" +
+			" ├─ tableId: 2\n" +
 			" └─ IndexedTableAccess(three_pks)\n" +
 			"     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"     ├─ filters: [{[1, 1], [1, 1], [NULL, ∞)}]\n" +
@@ -16542,14 +16542,14 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (7-9)\n" +
-			" ├─ tableId: 5\n" +
+			" ├─ tableId: 3\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: three_pks_view\n" +
 			"     ├─ outerVisibility: false\n" +
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     ├─ colSet: (4-6)\n" +
-			"     ├─ tableId: 3\n" +
+			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(three_pks)\n" +
 			"         ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"         ├─ static: [{[1, 1], [1, 1], [1, 1]}]\n" +
@@ -16565,14 +16565,14 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (7-9)\n" +
-			" ├─ tableId: 5\n" +
+			" ├─ tableId: 3\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: three_pks_view\n" +
 			"     ├─ outerVisibility: false\n" +
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     ├─ colSet: (4-6)\n" +
-			"     ├─ tableId: 3\n" +
+			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(three_pks)\n" +
 			"         ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"         ├─ filters: [{[1, 1], [1, 1], [1, 1]}]\n" +
@@ -16584,14 +16584,14 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (7-9)\n" +
-			" ├─ tableId: 5\n" +
+			" ├─ tableId: 3\n" +
 			" └─ SubqueryAlias\n" +
 			"     ├─ name: three_pks_view\n" +
 			"     ├─ outerVisibility: false\n" +
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     ├─ colSet: (4-6)\n" +
-			"     ├─ tableId: 3\n" +
+			"     ├─ tableId: 2\n" +
 			"     └─ IndexedTableAccess(three_pks)\n" +
 			"         ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"         ├─ filters: [{[1, 1], [1, 1], [1, 1]}]\n" +
@@ -16608,7 +16608,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     ├─ colSet: (9)\n" +
-			"     ├─ tableId: 5\n" +
+			"     ├─ tableId: 3\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [three_pks_projection_view.pk2:1!null->pk:0]\n" +
 			"         └─ SubqueryAlias\n" +
@@ -16617,7 +16617,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ isLateral: false\n" +
 			"             ├─ cacheable: true\n" +
 			"             ├─ colSet: (6,7)\n" +
-			"             ├─ tableId: 3\n" +
+			"             ├─ tableId: 2\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [three_pks.pk2:1!null->pk1:0, three_pks.pk3:2!null->pk2:0]\n" +
 			"                 └─ IndexedTableAccess(three_pks)\n" +
@@ -16637,7 +16637,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     ├─ colSet: (9)\n" +
-			"     ├─ tableId: 5\n" +
+			"     ├─ tableId: 3\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [three_pks_projection_view.pk2 as pk]\n" +
 			"         └─ SubqueryAlias\n" +
@@ -16646,7 +16646,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ isLateral: false\n" +
 			"             ├─ cacheable: true\n" +
 			"             ├─ colSet: (6,7)\n" +
-			"             ├─ tableId: 3\n" +
+			"             ├─ tableId: 2\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [three_pks.pk2 as pk1, three_pks.pk3 as pk2]\n" +
 			"                 └─ IndexedTableAccess(three_pks)\n" +
@@ -16662,7 +16662,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"     ├─ isLateral: false\n" +
 			"     ├─ cacheable: true\n" +
 			"     ├─ colSet: (9)\n" +
-			"     ├─ tableId: 5\n" +
+			"     ├─ tableId: 3\n" +
 			"     └─ Project\n" +
 			"         ├─ columns: [three_pks_projection_view.pk2 as pk]\n" +
 			"         └─ SubqueryAlias\n" +
@@ -16671,7 +16671,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"             ├─ isLateral: false\n" +
 			"             ├─ cacheable: true\n" +
 			"             ├─ colSet: (6,7)\n" +
-			"             ├─ tableId: 3\n" +
+			"             ├─ tableId: 2\n" +
 			"             └─ Project\n" +
 			"                 ├─ columns: [three_pks.pk2 as pk1, three_pks.pk3 as pk2]\n" +
 			"                 └─ IndexedTableAccess(three_pks)\n" +
@@ -16762,7 +16762,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (25-28)\n" +
-			" ├─ tableId: 9\n" +
+			" ├─ tableId: 7\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [l.left_pk:0!null->left_left:0, l.right_pk:1!null->left_right:0, r.left_pk:2!null->right_left:0, r.right_pk:3!null->right_right:0]\n" +
 			"     └─ CrossHashJoin\n" +
@@ -16772,7 +16772,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │   ├─ isLateral: false\n" +
 			"         │   ├─ cacheable: true\n" +
 			"         │   ├─ colSet: (9,10)\n" +
-			"         │   ├─ tableId: 4\n" +
+			"         │   ├─ tableId: 3\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [l.pk1:2!null->left_pk:0, r.pk1:0!null->right_pk:0]\n" +
 			"         │       └─ InnerJoin\n" +
@@ -16807,7 +16807,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"                     ├─ isLateral: false\n" +
 			"                     ├─ cacheable: true\n" +
 			"                     ├─ colSet: (19,20)\n" +
-			"                     ├─ tableId: 8\n" +
+			"                     ├─ tableId: 6\n" +
 			"                     └─ Project\n" +
 			"                         ├─ columns: [l.pk1:2!null->left_pk:0, r.pk1:0!null->right_pk:0]\n" +
 			"                         └─ InnerJoin\n" +
@@ -16819,7 +16819,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"                             │       ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"                             │       ├─ static: [{[4, 4], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                             │       ├─ colSet: (14-16)\n" +
-			"                             │       ├─ tableId: 6\n" +
+			"                             │       ├─ tableId: 5\n" +
 			"                             │       └─ Table\n" +
 			"                             │           ├─ name: three_pks\n" +
 			"                             │           └─ columns: [pk1 pk2]\n" +
@@ -16828,7 +16828,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"                                     ├─ index: [three_pks.pk1,three_pks.pk2,three_pks.pk3]\n" +
 			"                                     ├─ static: [{[3, 3], [NULL, ∞), [NULL, ∞)}]\n" +
 			"                                     ├─ colSet: (11-13)\n" +
-			"                                     ├─ tableId: 5\n" +
+			"                                     ├─ tableId: 4\n" +
 			"                                     └─ Table\n" +
 			"                                         ├─ name: three_pks\n" +
 			"                                         └─ columns: [pk1 pk2]\n" +
@@ -16839,7 +16839,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (25-28)\n" +
-			" ├─ tableId: 9\n" +
+			" ├─ tableId: 7\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [l.left_pk as left_left, l.right_pk as left_right, r.left_pk as right_left, r.right_pk as right_right]\n" +
 			"     └─ CrossHashJoin (estimated cost=402.250 rows=125)\n" +
@@ -16849,7 +16849,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │   ├─ isLateral: false\n" +
 			"         │   ├─ cacheable: true\n" +
 			"         │   ├─ colSet: (9,10)\n" +
-			"         │   ├─ tableId: 4\n" +
+			"         │   ├─ tableId: 3\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [l.pk1 as left_pk, r.pk1 as right_pk]\n" +
 			"         │       └─ InnerJoin (estimated cost=2.010 rows=1)\n" +
@@ -16894,7 +16894,7 @@ var IndexPlanTests = []QueryPlanTest{
 			" ├─ isLateral: false\n" +
 			" ├─ cacheable: true\n" +
 			" ├─ colSet: (25-28)\n" +
-			" ├─ tableId: 9\n" +
+			" ├─ tableId: 7\n" +
 			" └─ Project\n" +
 			"     ├─ columns: [l.left_pk as left_left, l.right_pk as left_right, r.left_pk as right_left, r.right_pk as right_right]\n" +
 			"     └─ CrossHashJoin (estimated cost=402.250 rows=125) (actual rows=0 loops=1)\n" +
@@ -16904,7 +16904,7 @@ var IndexPlanTests = []QueryPlanTest{
 			"         │   ├─ isLateral: false\n" +
 			"         │   ├─ cacheable: true\n" +
 			"         │   ├─ colSet: (9,10)\n" +
-			"         │   ├─ tableId: 4\n" +
+			"         │   ├─ tableId: 3\n" +
 			"         │   └─ Project\n" +
 			"         │       ├─ columns: [l.pk1 as left_pk, r.pk1 as right_pk]\n" +
 			"         │       └─ InnerJoin (estimated cost=2.010 rows=1) (actual rows=0 loops=1)\n" +

--- a/enginetest/queries/integration_plans.go
+++ b/enginetest/queries/integration_plans.go
@@ -10564,533 +10564,536 @@ WHERE
 			"     │                               └─ columns: [id]\n" +
 			"     │   END->M6T2N:0, mjr3d.GE5EL:7->GE5EL:0, mjr3d.F7A4Q:8->F7A4Q:0, mjr3d.CC4AX:10->CC4AX:0, mjr3d.SL76B:11!null->SL76B:0, aac.BTXC5:1->YEBDJ:0]\n" +
 			"     └─ HashJoin\n" +
-			"         ├─ AND\n" +
-			"         │   ├─ Eq\n" +
-			"         │   │   ├─ mf.LUEVY:25!null\n" +
-			"         │   │   └─ sn.BRQP2:15!null\n" +
-			"         │   └─ Eq\n" +
-			"         │       ├─ mf.M22QN:26!null\n" +
-			"         │       └─ mjr3d.M22QN:6!null\n" +
-			"         ├─ LeftOuterJoin\n" +
-			"         │   ├─ Or\n" +
-			"         │   │   ├─ Or\n" +
-			"         │   │   │   ├─ Or\n" +
-			"         │   │   │   │   ├─ AND\n" +
-			"         │   │   │   │   │   ├─ AND\n" +
-			"         │   │   │   │   │   │   ├─ NOT\n" +
-			"         │   │   │   │   │   │   │   └─ mjr3d.QNI57:12 IS NULL\n" +
-			"         │   │   │   │   │   │   └─ Eq\n" +
-			"         │   │   │   │   │   │       ├─ sn.id:14!null\n" +
-			"         │   │   │   │   │   │       └─ mjr3d.QNI57:12\n" +
-			"         │   │   │   │   │   └─ mjr3d.BJUF2:4!null IS NULL\n" +
-			"         │   │   │   │   └─ AND\n" +
-			"         │   │   │   │       ├─ AND\n" +
-			"         │   │   │   │       │   ├─ NOT\n" +
-			"         │   │   │   │       │   │   └─ mjr3d.QNI57:12 IS NULL\n" +
-			"         │   │   │   │       │   └─ NOT\n" +
-			"         │   │   │   │       │       └─ mjr3d.BJUF2:4!null IS NULL\n" +
-			"         │   │   │   │       └─ InSubquery\n" +
-			"         │   │   │   │           ├─ left: sn.id:14!null\n" +
-			"         │   │   │   │           └─ right: Subquery\n" +
-			"         │   │   │   │               ├─ cacheable: false\n" +
-			"         │   │   │   │               ├─ alias-string: select JTEHG.id from NOXN3 as JTEHG where BRQP2 = MJR3D.BJUF2\n" +
-			"         │   │   │   │               └─ Project\n" +
-			"         │   │   │   │                   ├─ columns: [jtehg.id:24!null]\n" +
-			"         │   │   │   │                   └─ Filter\n" +
-			"         │   │   │   │                       ├─ Eq\n" +
-			"         │   │   │   │                       │   ├─ jtehg.BRQP2:25!null\n" +
-			"         │   │   │   │                       │   └─ mjr3d.BJUF2:4!null\n" +
-			"         │   │   │   │                       └─ TableAlias(jtehg)\n" +
-			"         │   │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │   │   │                               ├─ keys: [mjr3d.BJUF2:4!null]\n" +
-			"         │   │   │   │                               ├─ colSet: (165-174)\n" +
-			"         │   │   │   │                               ├─ tableId: 18\n" +
-			"         │   │   │   │                               └─ Table\n" +
-			"         │   │   │   │                                   ├─ name: NOXN3\n" +
-			"         │   │   │   │                                   └─ columns: [id brqp2]\n" +
-			"         │   │   │   └─ AND\n" +
-			"         │   │   │       ├─ AND\n" +
-			"         │   │   │       │   ├─ NOT\n" +
-			"         │   │   │       │   │   └─ mjr3d.TDEIU:13 IS NULL\n" +
-			"         │   │   │       │   └─ mjr3d.BJUF2:4!null IS NULL\n" +
-			"         │   │   │       └─ InSubquery\n" +
-			"         │   │   │           ├─ left: sn.id:14!null\n" +
-			"         │   │   │           └─ right: Subquery\n" +
-			"         │   │   │               ├─ cacheable: false\n" +
-			"         │   │   │               ├─ alias-string: select XMAFZ.id from NOXN3 as XMAFZ where BRQP2 = MJR3D.FJDP5\n" +
-			"         │   │   │               └─ Project\n" +
-			"         │   │   │                   ├─ columns: [xmafz.id:24!null]\n" +
-			"         │   │   │                   └─ Filter\n" +
-			"         │   │   │                       ├─ Eq\n" +
-			"         │   │   │                       │   ├─ xmafz.BRQP2:25!null\n" +
-			"         │   │   │                       │   └─ mjr3d.FJDP5:3!null\n" +
-			"         │   │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │   │                               ├─ keys: [mjr3d.FJDP5:3!null]\n" +
-			"         │   │   │                               ├─ colSet: (175-184)\n" +
-			"         │   │   │                               ├─ tableId: 19\n" +
-			"         │   │   │                               └─ Table\n" +
-			"         │   │   │                                   ├─ name: NOXN3\n" +
-			"         │   │   │                                   └─ columns: [id brqp2]\n" +
-			"         │   │   └─ AND\n" +
-			"         │   │       ├─ AND\n" +
-			"         │   │       │   ├─ NOT\n" +
-			"         │   │       │   │   └─ mjr3d.TDEIU:13 IS NULL\n" +
-			"         │   │       │   └─ NOT\n" +
-			"         │   │       │       └─ mjr3d.BJUF2:4!null IS NULL\n" +
-			"         │   │       └─ InSubquery\n" +
-			"         │   │           ├─ left: sn.id:14!null\n" +
-			"         │   │           └─ right: Subquery\n" +
-			"         │   │               ├─ cacheable: false\n" +
-			"         │   │               ├─ alias-string: select XMAFZ.id from NOXN3 as XMAFZ where BRQP2 = MJR3D.BJUF2\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [xmafz.id:24!null]\n" +
-			"         │   │                   └─ Filter\n" +
-			"         │   │                       ├─ Eq\n" +
-			"         │   │                       │   ├─ xmafz.BRQP2:25!null\n" +
-			"         │   │                       │   └─ mjr3d.BJUF2:4!null\n" +
-			"         │   │                       └─ TableAlias(xmafz)\n" +
-			"         │   │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                               ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │                               ├─ keys: [mjr3d.BJUF2:4!null]\n" +
-			"         │   │                               ├─ colSet: (185-194)\n" +
-			"         │   │                               ├─ tableId: 20\n" +
-			"         │   │                               └─ Table\n" +
-			"         │   │                                   ├─ name: NOXN3\n" +
-			"         │   │                                   └─ columns: [id brqp2]\n" +
-			"         │   ├─ InnerJoin\n" +
-			"         │   │   ├─ Eq\n" +
-			"         │   │   │   ├─ aac.id:0!null\n" +
-			"         │   │   │   └─ mjr3d.M22QN:6!null\n" +
-			"         │   │   ├─ TableAlias(aac)\n" +
-			"         │   │   │   └─ ProcessTable\n" +
-			"         │   │   │       └─ Table\n" +
-			"         │   │   │           ├─ name: TPXBU\n" +
-			"         │   │   │           └─ columns: [id btxc5 fhcyt]\n" +
-			"         │   │   └─ CachedResults\n" +
-			"         │   │       └─ SubqueryAlias\n" +
-			"         │   │           ├─ name: mjr3d\n" +
-			"         │   │           ├─ outerVisibility: false\n" +
-			"         │   │           ├─ isLateral: false\n" +
-			"         │   │           ├─ cacheable: true\n" +
-			"         │   │           ├─ colSet: (144-154)\n" +
-			"         │   │           ├─ tableId: 16\n" +
-			"         │   │           └─ Union distinct\n" +
-			"         │   │               ├─ Project\n" +
-			"         │   │               │   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, convert\n" +
-			"         │   │               │   │   ├─ type: char\n" +
-			"         │   │               │   │   └─ jchir.QNI57:9!null\n" +
-			"         │   │               │   │  ->QNI57:0, TDEIU:10->TDEIU:0]\n" +
-			"         │   │               │   └─ Union distinct\n" +
-			"         │   │               │       ├─ Project\n" +
-			"         │   │               │       │   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, convert\n" +
-			"         │   │               │       │   │   ├─ type: char\n" +
-			"         │   │               │       │   │   └─ jchir.TDEIU:10!null\n" +
-			"         │   │               │       │   │  ->TDEIU:0]\n" +
-			"         │   │               │       │   └─ SubqueryAlias\n" +
-			"         │   │               │       │       ├─ name: jchir\n" +
-			"         │   │               │       │       ├─ outerVisibility: false\n" +
-			"         │   │               │       │       ├─ isLateral: false\n" +
-			"         │   │               │       │       ├─ cacheable: true\n" +
-			"         │   │               │       │       ├─ colSet: (98-108)\n" +
-			"         │   │               │       │       ├─ tableId: 11\n" +
-			"         │   │               │       │       └─ Filter\n" +
-			"         │   │               │       │           ├─ Or\n" +
-			"         │   │               │       │           │   ├─ AND\n" +
-			"         │   │               │       │           │   │   ├─ NOT\n" +
-			"         │   │               │       │           │   │   │   └─ QNI57:9!null IS NULL\n" +
-			"         │   │               │       │           │   │   └─ TDEIU:10!null IS NULL\n" +
-			"         │   │               │       │           │   └─ AND\n" +
-			"         │   │               │       │           │       ├─ QNI57:9!null IS NULL\n" +
-			"         │   │               │       │           │       └─ NOT\n" +
-			"         │   │               │       │           │           └─ TDEIU:10!null IS NULL\n" +
-			"         │   │               │       │           └─ Project\n" +
-			"         │   │               │       │               ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
-			"         │   │               │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │       │               │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
-			"         │   │               │       │               │   THEN 0 (tinyint) WHEN IN\n" +
-			"         │   │               │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │       │               │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
-			"         │   │               │       │               │   THEN 1 (tinyint) WHEN IN\n" +
-			"         │   │               │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │       │               │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
-			"         │   │               │       │               │   THEN 2 (tinyint) WHEN IN\n" +
-			"         │   │               │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │       │               │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"         │   │               │       │               │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
-			"         │   │               │       │               └─ Filter\n" +
-			"         │   │               │       │                   ├─ Or\n" +
-			"         │   │               │       │                   │   ├─ NOT\n" +
-			"         │   │               │       │                   │   │   └─ yqif4.id:15!null IS NULL\n" +
-			"         │   │               │       │                   │   └─ NOT\n" +
-			"         │   │               │       │                   │       └─ yvhjz.id:18!null IS NULL\n" +
-			"         │   │               │       │                   └─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       ├─ Eq\n" +
-			"         │   │               │       │                       │   ├─ yvhjz.BRQP2:19!null\n" +
-			"         │   │               │       │                       │   └─ ism.UJ6XY:1!null\n" +
-			"         │   │               │       │                       ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       │   ├─ Eq\n" +
-			"         │   │               │       │                       │   │   ├─ yqif4.BRQP2:16!null\n" +
-			"         │   │               │       │                       │   │   └─ ism.FV24E:0!null\n" +
-			"         │   │               │       │                       │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       │   │   ├─ NOT\n" +
-			"         │   │               │       │                       │   │   │   └─ Eq\n" +
-			"         │   │               │       │                       │   │   │       ├─ cpmfe.id:12!null\n" +
-			"         │   │               │       │                       │   │   │       └─ ism.FV24E:0!null\n" +
-			"         │   │               │       │                       │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │               │       │                       │   │   │   ├─ Eq\n" +
-			"         │   │               │       │                       │   │   │   │   ├─ nhmxw.id:10!null\n" +
-			"         │   │               │       │                       │   │   │   │   └─ ism.PRUV2:4\n" +
-			"         │   │               │       │                       │   │   │   ├─ MergeJoin\n" +
-			"         │   │               │       │                       │   │   │   │   ├─ cmp: Eq\n" +
-			"         │   │               │       │                       │   │   │   │   │   ├─ ism.NZ4MQ:3!null\n" +
-			"         │   │               │       │                       │   │   │   │   │   └─ g3yxs.id:5!null\n" +
-			"         │   │               │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │               │       │                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ colSet: (15-23)\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ tableId: 4\n" +
-			"         │   │               │       │                       │   │   │   │   │       └─ Table\n" +
-			"         │   │               │       │                       │   │   │   │   │           ├─ name: HDDVB\n" +
-			"         │   │               │       │                       │   │   │   │   │           └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │               │       │                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │               │       │                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ colSet: (24-31)\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ tableId: 5\n" +
-			"         │   │               │       │                       │   │   │   │           └─ Table\n" +
-			"         │   │               │       │                       │   │   │   │               ├─ name: YYBCX\n" +
-			"         │   │               │       │                       │   │   │   │               └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │               │       │                       │   │   │   └─ HashLookup\n" +
-			"         │   │               │       │                       │   │   │       ├─ left-key: TUPLE(ism.PRUV2:4)\n" +
-			"         │   │               │       │                       │   │   │       ├─ right-key: TUPLE(nhmxw.id:0!null)\n" +
-			"         │   │               │       │                       │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │               │       │                       │   │   │           └─ Table\n" +
-			"         │   │               │       │                       │   │   │               ├─ name: WGSDC\n" +
-			"         │   │               │       │                       │   │   │               ├─ columns: [id nohhr]\n" +
-			"         │   │               │       │                       │   │   │               ├─ colSet: (32-41)\n" +
-			"         │   │               │       │                       │   │   │               └─ tableId: 6\n" +
-			"         │   │               │       │                       │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │               │       │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │               │       │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │               │       │                       │   │           ├─ keys: [nhmxw.NOHHR:11!null]\n" +
-			"         │   │               │       │                       │   │           ├─ colSet: (42-58)\n" +
-			"         │   │               │       │                       │   │           ├─ tableId: 7\n" +
-			"         │   │               │       │                       │   │           └─ Table\n" +
-			"         │   │               │       │                       │   │               ├─ name: E2I7U\n" +
-			"         │   │               │       │                       │   │               └─ columns: [id tw55n zh72s]\n" +
-			"         │   │               │       │                       │   └─ TableAlias(yqif4)\n" +
-			"         │   │               │       │                       │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │       │                       │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │       │                       │           ├─ keys: [ism.UJ6XY:1!null]\n" +
-			"         │   │               │       │                       │           ├─ colSet: (59-68)\n" +
-			"         │   │               │       │                       │           ├─ tableId: 8\n" +
-			"         │   │               │       │                       │           └─ Table\n" +
-			"         │   │               │       │                       │               ├─ name: NOXN3\n" +
-			"         │   │               │       │                       │               └─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │       │                       └─ TableAlias(yvhjz)\n" +
-			"         │   │               │       │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │       │                               ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │       │                               ├─ keys: [ism.FV24E:0!null]\n" +
-			"         │   │               │       │                               ├─ colSet: (69-78)\n" +
-			"         │   │               │       │                               ├─ tableId: 9\n" +
-			"         │   │               │       │                               └─ Table\n" +
-			"         │   │               │       │                                   ├─ name: NOXN3\n" +
-			"         │   │               │       │                                   └─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │       └─ Project\n" +
-			"         │   │               │           ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, convert\n" +
-			"         │   │               │           │   ├─ type: char\n" +
-			"         │   │               │           │   └─ TDEIU:10\n" +
-			"         │   │               │           │  ->TDEIU:0]\n" +
-			"         │   │               │           └─ Project\n" +
-			"         │   │               │               ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, NULL (null)->TDEIU:120]\n" +
-			"         │   │               │               └─ SubqueryAlias\n" +
-			"         │   │               │                   ├─ name: jchir\n" +
-			"         │   │               │                   ├─ outerVisibility: false\n" +
-			"         │   │               │                   ├─ isLateral: false\n" +
-			"         │   │               │                   ├─ cacheable: true\n" +
-			"         │   │               │                   ├─ colSet: (109-119)\n" +
-			"         │   │               │                   ├─ tableId: 12\n" +
-			"         │   │               │                   └─ Filter\n" +
-			"         │   │               │                       ├─ AND\n" +
-			"         │   │               │                       │   ├─ NOT\n" +
-			"         │   │               │                       │   │   └─ QNI57:9!null IS NULL\n" +
-			"         │   │               │                       │   └─ NOT\n" +
-			"         │   │               │                       │       └─ TDEIU:10!null IS NULL\n" +
-			"         │   │               │                       └─ Project\n" +
-			"         │   │               │                           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
-			"         │   │               │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
-			"         │   │               │                           │   THEN 0 (tinyint) WHEN IN\n" +
-			"         │   │               │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │                           │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
-			"         │   │               │                           │   THEN 1 (tinyint) WHEN IN\n" +
-			"         │   │               │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │                           │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
-			"         │   │               │                           │   THEN 2 (tinyint) WHEN IN\n" +
-			"         │   │               │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │               │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"         │   │               │                           │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
-			"         │   │               │                           └─ Filter\n" +
-			"         │   │               │                               ├─ Or\n" +
-			"         │   │               │                               │   ├─ NOT\n" +
-			"         │   │               │                               │   │   └─ yqif4.id:15!null IS NULL\n" +
-			"         │   │               │                               │   └─ NOT\n" +
-			"         │   │               │                               │       └─ yvhjz.id:18!null IS NULL\n" +
-			"         │   │               │                               └─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   ├─ Eq\n" +
-			"         │   │               │                                   │   ├─ yvhjz.BRQP2:19!null\n" +
-			"         │   │               │                                   │   └─ ism.UJ6XY:1!null\n" +
-			"         │   │               │                                   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   │   ├─ Eq\n" +
-			"         │   │               │                                   │   │   ├─ yqif4.BRQP2:16!null\n" +
-			"         │   │               │                                   │   │   └─ ism.FV24E:0!null\n" +
-			"         │   │               │                                   │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   │   │   ├─ NOT\n" +
-			"         │   │               │                                   │   │   │   └─ Eq\n" +
-			"         │   │               │                                   │   │   │       ├─ cpmfe.id:12!null\n" +
-			"         │   │               │                                   │   │   │       └─ ism.FV24E:0!null\n" +
-			"         │   │               │                                   │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │               │                                   │   │   │   ├─ Eq\n" +
-			"         │   │               │                                   │   │   │   │   ├─ nhmxw.id:10!null\n" +
-			"         │   │               │                                   │   │   │   │   └─ ism.PRUV2:4\n" +
-			"         │   │               │                                   │   │   │   ├─ MergeJoin\n" +
-			"         │   │               │                                   │   │   │   │   ├─ cmp: Eq\n" +
-			"         │   │               │                                   │   │   │   │   │   ├─ ism.NZ4MQ:3!null\n" +
-			"         │   │               │                                   │   │   │   │   │   └─ g3yxs.id:5!null\n" +
-			"         │   │               │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │               │                                   │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ colSet: (15-23)\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ tableId: 4\n" +
-			"         │   │               │                                   │   │   │   │   │       └─ Table\n" +
-			"         │   │               │                                   │   │   │   │   │           ├─ name: HDDVB\n" +
-			"         │   │               │                                   │   │   │   │   │           └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │               │                                   │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │               │                                   │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │               │                                   │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │               │                                   │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │               │                                   │   │   │   │           ├─ colSet: (24-31)\n" +
-			"         │   │               │                                   │   │   │   │           ├─ tableId: 5\n" +
-			"         │   │               │                                   │   │   │   │           └─ Table\n" +
-			"         │   │               │                                   │   │   │   │               ├─ name: YYBCX\n" +
-			"         │   │               │                                   │   │   │   │               └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │               │                                   │   │   │   └─ HashLookup\n" +
-			"         │   │               │                                   │   │   │       ├─ left-key: TUPLE(ism.PRUV2:4)\n" +
-			"         │   │               │                                   │   │   │       ├─ right-key: TUPLE(nhmxw.id:0!null)\n" +
-			"         │   │               │                                   │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │               │                                   │   │   │           └─ Table\n" +
-			"         │   │               │                                   │   │   │               ├─ name: WGSDC\n" +
-			"         │   │               │                                   │   │   │               ├─ columns: [id nohhr]\n" +
-			"         │   │               │                                   │   │   │               ├─ colSet: (32-41)\n" +
-			"         │   │               │                                   │   │   │               └─ tableId: 6\n" +
-			"         │   │               │                                   │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │               │                                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │               │                                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │               │                                   │   │           ├─ keys: [nhmxw.NOHHR:11!null]\n" +
-			"         │   │               │                                   │   │           ├─ colSet: (42-58)\n" +
-			"         │   │               │                                   │   │           ├─ tableId: 7\n" +
-			"         │   │               │                                   │   │           └─ Table\n" +
-			"         │   │               │                                   │   │               ├─ name: E2I7U\n" +
-			"         │   │               │                                   │   │               └─ columns: [id tw55n zh72s]\n" +
-			"         │   │               │                                   │   └─ TableAlias(yqif4)\n" +
-			"         │   │               │                                   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │                                   │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │                                   │           ├─ keys: [ism.UJ6XY:1!null]\n" +
-			"         │   │               │                                   │           ├─ colSet: (59-68)\n" +
-			"         │   │               │                                   │           ├─ tableId: 8\n" +
-			"         │   │               │                                   │           └─ Table\n" +
-			"         │   │               │                                   │               ├─ name: NOXN3\n" +
-			"         │   │               │                                   │               └─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │                                   └─ TableAlias(yvhjz)\n" +
-			"         │   │               │                                       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │                                           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │                                           ├─ keys: [ism.FV24E:0!null]\n" +
-			"         │   │               │                                           ├─ colSet: (69-78)\n" +
-			"         │   │               │                                           ├─ tableId: 9\n" +
-			"         │   │               │                                           └─ Table\n" +
-			"         │   │               │                                               ├─ name: NOXN3\n" +
-			"         │   │               │                                               └─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, convert\n" +
-			"         │   │                   │   ├─ type: char\n" +
-			"         │   │                   │   └─ QNI57:9\n" +
-			"         │   │                   │  ->QNI57:0, convert\n" +
-			"         │   │                   │   ├─ type: char\n" +
-			"         │   │                   │   └─ jchir.TDEIU:10!null\n" +
-			"         │   │                   │  ->TDEIU:0]\n" +
-			"         │   │                   └─ Project\n" +
-			"         │   │                       ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, NULL (null)->QNI57:132, jchir.TDEIU:10!null]\n" +
-			"         │   │                       └─ SubqueryAlias\n" +
-			"         │   │                           ├─ name: jchir\n" +
-			"         │   │                           ├─ outerVisibility: false\n" +
-			"         │   │                           ├─ isLateral: false\n" +
-			"         │   │                           ├─ cacheable: true\n" +
-			"         │   │                           ├─ colSet: (121-131)\n" +
-			"         │   │                           ├─ tableId: 13\n" +
-			"         │   │                           └─ Filter\n" +
-			"         │   │                               ├─ AND\n" +
-			"         │   │                               │   ├─ NOT\n" +
-			"         │   │                               │   │   └─ QNI57:9!null IS NULL\n" +
-			"         │   │                               │   └─ NOT\n" +
-			"         │   │                               │       └─ TDEIU:10!null IS NULL\n" +
-			"         │   │                               └─ Project\n" +
-			"         │   │                                   ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
-			"         │   │                                   │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │                                   │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
-			"         │   │                                   │   THEN 0 (tinyint) WHEN IN\n" +
-			"         │   │                                   │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │                                   │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
-			"         │   │                                   │   THEN 1 (tinyint) WHEN IN\n" +
-			"         │   │                                   │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │                                   │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
-			"         │   │                                   │   THEN 2 (tinyint) WHEN IN\n" +
-			"         │   │                                   │   ├─ left: g3yxs.SL76B:7!null\n" +
-			"         │   │                                   │   └─ right: TUPLE(Y62X7 (longtext))\n" +
-			"         │   │                                   │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
-			"         │   │                                   └─ Filter\n" +
-			"         │   │                                       ├─ Or\n" +
-			"         │   │                                       │   ├─ NOT\n" +
-			"         │   │                                       │   │   └─ yqif4.id:15!null IS NULL\n" +
-			"         │   │                                       │   └─ NOT\n" +
-			"         │   │                                       │       └─ yvhjz.id:18!null IS NULL\n" +
-			"         │   │                                       └─ LeftOuterLookupJoin\n" +
-			"         │   │                                           ├─ Eq\n" +
-			"         │   │                                           │   ├─ yvhjz.BRQP2:19!null\n" +
-			"         │   │                                           │   └─ ism.UJ6XY:1!null\n" +
-			"         │   │                                           ├─ LeftOuterLookupJoin\n" +
-			"         │   │                                           │   ├─ Eq\n" +
-			"         │   │                                           │   │   ├─ yqif4.BRQP2:16!null\n" +
-			"         │   │                                           │   │   └─ ism.FV24E:0!null\n" +
-			"         │   │                                           │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │                                           │   │   ├─ NOT\n" +
-			"         │   │                                           │   │   │   └─ Eq\n" +
-			"         │   │                                           │   │   │       ├─ cpmfe.id:12!null\n" +
-			"         │   │                                           │   │   │       └─ ism.FV24E:0!null\n" +
-			"         │   │                                           │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │                                           │   │   │   ├─ Eq\n" +
-			"         │   │                                           │   │   │   │   ├─ nhmxw.id:10!null\n" +
-			"         │   │                                           │   │   │   │   └─ ism.PRUV2:4\n" +
-			"         │   │                                           │   │   │   ├─ MergeJoin\n" +
-			"         │   │                                           │   │   │   │   ├─ cmp: Eq\n" +
-			"         │   │                                           │   │   │   │   │   ├─ ism.NZ4MQ:3!null\n" +
-			"         │   │                                           │   │   │   │   │   └─ g3yxs.id:5!null\n" +
-			"         │   │                                           │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │                                           │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │                                           │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │                                           │   │   │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │                                           │   │   │   │   │       ├─ colSet: (15-23)\n" +
-			"         │   │                                           │   │   │   │   │       ├─ tableId: 4\n" +
-			"         │   │                                           │   │   │   │   │       └─ Table\n" +
-			"         │   │                                           │   │   │   │   │           ├─ name: HDDVB\n" +
-			"         │   │                                           │   │   │   │   │           └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │                                           │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │                                           │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │                                           │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │                                           │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
-			"         │   │                                           │   │   │   │           ├─ colSet: (24-31)\n" +
-			"         │   │                                           │   │   │   │           ├─ tableId: 5\n" +
-			"         │   │                                           │   │   │   │           └─ Table\n" +
-			"         │   │                                           │   │   │   │               ├─ name: YYBCX\n" +
-			"         │   │                                           │   │   │   │               └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │                                           │   │   │   └─ HashLookup\n" +
-			"         │   │                                           │   │   │       ├─ left-key: TUPLE(ism.PRUV2:4)\n" +
-			"         │   │                                           │   │   │       ├─ right-key: TUPLE(nhmxw.id:0!null)\n" +
-			"         │   │                                           │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │                                           │   │   │           └─ Table\n" +
-			"         │   │                                           │   │   │               ├─ name: WGSDC\n" +
-			"         │   │                                           │   │   │               ├─ columns: [id nohhr]\n" +
-			"         │   │                                           │   │   │               ├─ colSet: (32-41)\n" +
-			"         │   │                                           │   │   │               └─ tableId: 6\n" +
-			"         │   │                                           │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │                                           │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │                                           │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │                                           │   │           ├─ keys: [nhmxw.NOHHR:11!null]\n" +
-			"         │   │                                           │   │           ├─ colSet: (42-58)\n" +
-			"         │   │                                           │   │           ├─ tableId: 7\n" +
-			"         │   │                                           │   │           └─ Table\n" +
-			"         │   │                                           │   │               ├─ name: E2I7U\n" +
-			"         │   │                                           │   │               └─ columns: [id tw55n zh72s]\n" +
-			"         │   │                                           │   └─ TableAlias(yqif4)\n" +
-			"         │   │                                           │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                                           │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │                                           │           ├─ keys: [ism.UJ6XY:1!null]\n" +
-			"         │   │                                           │           ├─ colSet: (59-68)\n" +
-			"         │   │                                           │           ├─ tableId: 8\n" +
-			"         │   │                                           │           └─ Table\n" +
-			"         │   │                                           │               ├─ name: NOXN3\n" +
-			"         │   │                                           │               └─ columns: [id brqp2 fftbj]\n" +
-			"         │   │                                           └─ TableAlias(yvhjz)\n" +
-			"         │   │                                               └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                                                   ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │                                                   ├─ keys: [ism.FV24E:0!null]\n" +
-			"         │   │                                                   ├─ colSet: (69-78)\n" +
-			"         │   │                                                   ├─ tableId: 9\n" +
-			"         │   │                                                   └─ Table\n" +
-			"         │   │                                                       ├─ name: NOXN3\n" +
-			"         │   │                                                       └─ columns: [id brqp2 fftbj]\n" +
-			"         │   └─ TableAlias(sn)\n" +
-			"         │       └─ ProcessTable\n" +
-			"         │           └─ Table\n" +
-			"         │               ├─ name: NOXN3\n" +
-			"         │               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			"         ├─ Eq\n" +
+			"         │   ├─ aac.id:0!null\n" +
+			"         │   └─ mjr3d.M22QN:6!null\n" +
+			"         ├─ TableAlias(aac)\n" +
+			"         │   └─ ProcessTable\n" +
+			"         │       └─ Table\n" +
+			"         │           ├─ name: TPXBU\n" +
+			"         │           └─ columns: [id btxc5 fhcyt]\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: TUPLE(sn.BRQP2:15!null, mjr3d.M22QN:6!null)\n" +
-			"             ├─ right-key: TUPLE(mf.LUEVY:1!null, mf.M22QN:2!null)\n" +
-			"             └─ CachedResults\n" +
-			"                 └─ SubqueryAlias\n" +
-			"                     ├─ name: mf\n" +
-			"                     ├─ outerVisibility: false\n" +
-			"                     ├─ isLateral: false\n" +
-			"                     ├─ cacheable: true\n" +
-			"                     ├─ colSet: (246-248)\n" +
-			"                     ├─ tableId: 24\n" +
-			"                     └─ Project\n" +
-			"                         ├─ columns: [cla.FTQLQ:4!null, mf.LUEVY:1!null, mf.M22QN:2!null]\n" +
-			"                         └─ HashJoin\n" +
-			"                             ├─ Eq\n" +
-			"                             │   ├─ bs.id:5!null\n" +
-			"                             │   └─ mf.GXLUB:0!null\n" +
-			"                             ├─ TableAlias(mf)\n" +
-			"                             │   └─ Table\n" +
-			"                             │       ├─ name: HGMQ6\n" +
-			"                             │       ├─ columns: [gxlub luevy m22qn]\n" +
-			"                             │       ├─ colSet: (229-245)\n" +
-			"                             │       └─ tableId: 23\n" +
-			"                             └─ HashLookup\n" +
-			"                                 ├─ left-key: TUPLE(mf.GXLUB:0!null)\n" +
-			"                                 ├─ right-key: TUPLE(bs.id:2!null)\n" +
-			"                                 └─ MergeJoin\n" +
-			"                                     ├─ cmp: Eq\n" +
-			"                                     │   ├─ cla.id:3!null\n" +
-			"                                     │   └─ bs.IXUXU:6\n" +
-			"                                     ├─ Filter\n" +
-			"                                     │   ├─ HashIn\n" +
-			"                                     │   │   ├─ cla.FTQLQ:1!null\n" +
-			"                                     │   │   └─ TUPLE(SQ1 (longtext))\n" +
-			"                                     │   └─ TableAlias(cla)\n" +
-			"                                     │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                                     │           ├─ index: [YK2GW.id]\n" +
-			"                                     │           ├─ static: [{[NULL, ∞)}]\n" +
-			"                                     │           ├─ colSet: (195-224)\n" +
-			"                                     │           ├─ tableId: 21\n" +
-			"                                     │           └─ Table\n" +
-			"                                     │               ├─ name: YK2GW\n" +
-			"                                     │               └─ columns: [id ftqlq]\n" +
-			"                                     └─ TableAlias(bs)\n" +
-			"                                         └─ IndexedTableAccess(THNTS)\n" +
-			"                                             ├─ index: [THNTS.IXUXU]\n" +
-			"                                             ├─ static: [{[NULL, ∞)}]\n" +
-			"                                             ├─ colSet: (225-228)\n" +
-			"                                             ├─ tableId: 22\n" +
-			"                                             └─ Table\n" +
-			"                                                 ├─ name: THNTS\n" +
-			"                                                 └─ columns: [id ixuxu]\n" +
+			"             ├─ left-key: TUPLE(aac.id:0!null)\n" +
+			"             ├─ right-key: TUPLE(mjr3d.M22QN:3!null)\n" +
+			"             └─ HashJoin\n" +
+			"                 ├─ AND\n" +
+			"                 │   ├─ Eq\n" +
+			"                 │   │   ├─ mf.LUEVY:25!null\n" +
+			"                 │   │   └─ sn.BRQP2:15!null\n" +
+			"                 │   └─ Eq\n" +
+			"                 │       ├─ mf.M22QN:26!null\n" +
+			"                 │       └─ mjr3d.M22QN:6!null\n" +
+			"                 ├─ LeftOuterJoin\n" +
+			"                 │   ├─ Or\n" +
+			"                 │   │   ├─ Or\n" +
+			"                 │   │   │   ├─ Or\n" +
+			"                 │   │   │   │   ├─ AND\n" +
+			"                 │   │   │   │   │   ├─ AND\n" +
+			"                 │   │   │   │   │   │   ├─ NOT\n" +
+			"                 │   │   │   │   │   │   │   └─ mjr3d.QNI57:12 IS NULL\n" +
+			"                 │   │   │   │   │   │   └─ Eq\n" +
+			"                 │   │   │   │   │   │       ├─ sn.id:14!null\n" +
+			"                 │   │   │   │   │   │       └─ mjr3d.QNI57:12\n" +
+			"                 │   │   │   │   │   └─ mjr3d.BJUF2:4!null IS NULL\n" +
+			"                 │   │   │   │   └─ AND\n" +
+			"                 │   │   │   │       ├─ AND\n" +
+			"                 │   │   │   │       │   ├─ NOT\n" +
+			"                 │   │   │   │       │   │   └─ mjr3d.QNI57:12 IS NULL\n" +
+			"                 │   │   │   │       │   └─ NOT\n" +
+			"                 │   │   │   │       │       └─ mjr3d.BJUF2:4!null IS NULL\n" +
+			"                 │   │   │   │       └─ InSubquery\n" +
+			"                 │   │   │   │           ├─ left: sn.id:14!null\n" +
+			"                 │   │   │   │           └─ right: Subquery\n" +
+			"                 │   │   │   │               ├─ cacheable: false\n" +
+			"                 │   │   │   │               ├─ alias-string: select JTEHG.id from NOXN3 as JTEHG where BRQP2 = MJR3D.BJUF2\n" +
+			"                 │   │   │   │               └─ Project\n" +
+			"                 │   │   │   │                   ├─ columns: [jtehg.id:24!null]\n" +
+			"                 │   │   │   │                   └─ Filter\n" +
+			"                 │   │   │   │                       ├─ Eq\n" +
+			"                 │   │   │   │                       │   ├─ jtehg.BRQP2:25!null\n" +
+			"                 │   │   │   │                       │   └─ mjr3d.BJUF2:4!null\n" +
+			"                 │   │   │   │                       └─ TableAlias(jtehg)\n" +
+			"                 │   │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │   │   │                               ├─ keys: [mjr3d.BJUF2:4!null]\n" +
+			"                 │   │   │   │                               ├─ colSet: (165-174)\n" +
+			"                 │   │   │   │                               ├─ tableId: 18\n" +
+			"                 │   │   │   │                               └─ Table\n" +
+			"                 │   │   │   │                                   ├─ name: NOXN3\n" +
+			"                 │   │   │   │                                   └─ columns: [id brqp2]\n" +
+			"                 │   │   │   └─ AND\n" +
+			"                 │   │   │       ├─ AND\n" +
+			"                 │   │   │       │   ├─ NOT\n" +
+			"                 │   │   │       │   │   └─ mjr3d.TDEIU:13 IS NULL\n" +
+			"                 │   │   │       │   └─ mjr3d.BJUF2:4!null IS NULL\n" +
+			"                 │   │   │       └─ InSubquery\n" +
+			"                 │   │   │           ├─ left: sn.id:14!null\n" +
+			"                 │   │   │           └─ right: Subquery\n" +
+			"                 │   │   │               ├─ cacheable: false\n" +
+			"                 │   │   │               ├─ alias-string: select XMAFZ.id from NOXN3 as XMAFZ where BRQP2 = MJR3D.FJDP5\n" +
+			"                 │   │   │               └─ Project\n" +
+			"                 │   │   │                   ├─ columns: [xmafz.id:24!null]\n" +
+			"                 │   │   │                   └─ Filter\n" +
+			"                 │   │   │                       ├─ Eq\n" +
+			"                 │   │   │                       │   ├─ xmafz.BRQP2:25!null\n" +
+			"                 │   │   │                       │   └─ mjr3d.FJDP5:3!null\n" +
+			"                 │   │   │                       └─ TableAlias(xmafz)\n" +
+			"                 │   │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │   │                               ├─ keys: [mjr3d.FJDP5:3!null]\n" +
+			"                 │   │   │                               ├─ colSet: (175-184)\n" +
+			"                 │   │   │                               ├─ tableId: 19\n" +
+			"                 │   │   │                               └─ Table\n" +
+			"                 │   │   │                                   ├─ name: NOXN3\n" +
+			"                 │   │   │                                   └─ columns: [id brqp2]\n" +
+			"                 │   │   └─ AND\n" +
+			"                 │   │       ├─ AND\n" +
+			"                 │   │       │   ├─ NOT\n" +
+			"                 │   │       │   │   └─ mjr3d.TDEIU:13 IS NULL\n" +
+			"                 │   │       │   └─ NOT\n" +
+			"                 │   │       │       └─ mjr3d.BJUF2:4!null IS NULL\n" +
+			"                 │   │       └─ InSubquery\n" +
+			"                 │   │           ├─ left: sn.id:14!null\n" +
+			"                 │   │           └─ right: Subquery\n" +
+			"                 │   │               ├─ cacheable: false\n" +
+			"                 │   │               ├─ alias-string: select XMAFZ.id from NOXN3 as XMAFZ where BRQP2 = MJR3D.BJUF2\n" +
+			"                 │   │               └─ Project\n" +
+			"                 │   │                   ├─ columns: [xmafz.id:24!null]\n" +
+			"                 │   │                   └─ Filter\n" +
+			"                 │   │                       ├─ Eq\n" +
+			"                 │   │                       │   ├─ xmafz.BRQP2:25!null\n" +
+			"                 │   │                       │   └─ mjr3d.BJUF2:4!null\n" +
+			"                 │   │                       └─ TableAlias(xmafz)\n" +
+			"                 │   │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                               ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │                               ├─ keys: [mjr3d.BJUF2:4!null]\n" +
+			"                 │   │                               ├─ colSet: (185-194)\n" +
+			"                 │   │                               ├─ tableId: 20\n" +
+			"                 │   │                               └─ Table\n" +
+			"                 │   │                                   ├─ name: NOXN3\n" +
+			"                 │   │                                   └─ columns: [id brqp2]\n" +
+			"                 │   ├─ CachedResults\n" +
+			"                 │   │   └─ SubqueryAlias\n" +
+			"                 │   │       ├─ name: mjr3d\n" +
+			"                 │   │       ├─ outerVisibility: false\n" +
+			"                 │   │       ├─ isLateral: false\n" +
+			"                 │   │       ├─ cacheable: true\n" +
+			"                 │   │       ├─ colSet: (144-154)\n" +
+			"                 │   │       ├─ tableId: 16\n" +
+			"                 │   │       └─ Union distinct\n" +
+			"                 │   │           ├─ Project\n" +
+			"                 │   │           │   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, convert\n" +
+			"                 │   │           │   │   ├─ type: char\n" +
+			"                 │   │           │   │   └─ jchir.QNI57:9!null\n" +
+			"                 │   │           │   │  ->QNI57:0, TDEIU:10->TDEIU:0]\n" +
+			"                 │   │           │   └─ Union distinct\n" +
+			"                 │   │           │       ├─ Project\n" +
+			"                 │   │           │       │   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, convert\n" +
+			"                 │   │           │       │   │   ├─ type: char\n" +
+			"                 │   │           │       │   │   └─ jchir.TDEIU:10!null\n" +
+			"                 │   │           │       │   │  ->TDEIU:0]\n" +
+			"                 │   │           │       │   └─ SubqueryAlias\n" +
+			"                 │   │           │       │       ├─ name: jchir\n" +
+			"                 │   │           │       │       ├─ outerVisibility: false\n" +
+			"                 │   │           │       │       ├─ isLateral: false\n" +
+			"                 │   │           │       │       ├─ cacheable: true\n" +
+			"                 │   │           │       │       ├─ colSet: (98-108)\n" +
+			"                 │   │           │       │       ├─ tableId: 11\n" +
+			"                 │   │           │       │       └─ Filter\n" +
+			"                 │   │           │       │           ├─ Or\n" +
+			"                 │   │           │       │           │   ├─ AND\n" +
+			"                 │   │           │       │           │   │   ├─ NOT\n" +
+			"                 │   │           │       │           │   │   │   └─ QNI57:9!null IS NULL\n" +
+			"                 │   │           │       │           │   │   └─ TDEIU:10!null IS NULL\n" +
+			"                 │   │           │       │           │   └─ AND\n" +
+			"                 │   │           │       │           │       ├─ QNI57:9!null IS NULL\n" +
+			"                 │   │           │       │           │       └─ NOT\n" +
+			"                 │   │           │       │           │           └─ TDEIU:10!null IS NULL\n" +
+			"                 │   │           │       │           └─ Project\n" +
+			"                 │   │           │       │               ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
+			"                 │   │           │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │       │               │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
+			"                 │   │           │       │               │   THEN 0 (tinyint) WHEN IN\n" +
+			"                 │   │           │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │       │               │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
+			"                 │   │           │       │               │   THEN 1 (tinyint) WHEN IN\n" +
+			"                 │   │           │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │       │               │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
+			"                 │   │           │       │               │   THEN 2 (tinyint) WHEN IN\n" +
+			"                 │   │           │       │               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │       │               │   └─ right: TUPLE(Y62X7 (longtext))\n" +
+			"                 │   │           │       │               │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
+			"                 │   │           │       │               └─ Filter\n" +
+			"                 │   │           │       │                   ├─ Or\n" +
+			"                 │   │           │       │                   │   ├─ NOT\n" +
+			"                 │   │           │       │                   │   │   └─ yqif4.id:15!null IS NULL\n" +
+			"                 │   │           │       │                   │   └─ NOT\n" +
+			"                 │   │           │       │                   │       └─ yvhjz.id:18!null IS NULL\n" +
+			"                 │   │           │       │                   └─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       ├─ Eq\n" +
+			"                 │   │           │       │                       │   ├─ yvhjz.BRQP2:19!null\n" +
+			"                 │   │           │       │                       │   └─ ism.UJ6XY:1!null\n" +
+			"                 │   │           │       │                       ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       │   ├─ Eq\n" +
+			"                 │   │           │       │                       │   │   ├─ yqif4.BRQP2:16!null\n" +
+			"                 │   │           │       │                       │   │   └─ ism.FV24E:0!null\n" +
+			"                 │   │           │       │                       │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       │   │   ├─ NOT\n" +
+			"                 │   │           │       │                       │   │   │   └─ Eq\n" +
+			"                 │   │           │       │                       │   │   │       ├─ cpmfe.id:12!null\n" +
+			"                 │   │           │       │                       │   │   │       └─ ism.FV24E:0!null\n" +
+			"                 │   │           │       │                       │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │           │       │                       │   │   │   ├─ Eq\n" +
+			"                 │   │           │       │                       │   │   │   │   ├─ nhmxw.id:10!null\n" +
+			"                 │   │           │       │                       │   │   │   │   └─ ism.PRUV2:4\n" +
+			"                 │   │           │       │                       │   │   │   ├─ MergeJoin\n" +
+			"                 │   │           │       │                       │   │   │   │   ├─ cmp: Eq\n" +
+			"                 │   │           │       │                       │   │   │   │   │   ├─ ism.NZ4MQ:3!null\n" +
+			"                 │   │           │       │                       │   │   │   │   │   └─ g3yxs.id:5!null\n" +
+			"                 │   │           │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │           │       │                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ colSet: (15-23)\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ tableId: 4\n" +
+			"                 │   │           │       │                       │   │   │   │   │       └─ Table\n" +
+			"                 │   │           │       │                       │   │   │   │   │           ├─ name: HDDVB\n" +
+			"                 │   │           │       │                       │   │   │   │   │           └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │           │       │                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │           │       │                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ colSet: (24-31)\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ tableId: 5\n" +
+			"                 │   │           │       │                       │   │   │   │           └─ Table\n" +
+			"                 │   │           │       │                       │   │   │   │               ├─ name: YYBCX\n" +
+			"                 │   │           │       │                       │   │   │   │               └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │           │       │                       │   │   │   └─ HashLookup\n" +
+			"                 │   │           │       │                       │   │   │       ├─ left-key: TUPLE(ism.PRUV2:4)\n" +
+			"                 │   │           │       │                       │   │   │       ├─ right-key: TUPLE(nhmxw.id:0!null)\n" +
+			"                 │   │           │       │                       │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │           │       │                       │   │   │           └─ Table\n" +
+			"                 │   │           │       │                       │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │           │       │                       │   │   │               ├─ columns: [id nohhr]\n" +
+			"                 │   │           │       │                       │   │   │               ├─ colSet: (32-41)\n" +
+			"                 │   │           │       │                       │   │   │               └─ tableId: 6\n" +
+			"                 │   │           │       │                       │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │           │       │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │           │       │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │           │       │                       │   │           ├─ keys: [nhmxw.NOHHR:11!null]\n" +
+			"                 │   │           │       │                       │   │           ├─ colSet: (42-58)\n" +
+			"                 │   │           │       │                       │   │           ├─ tableId: 7\n" +
+			"                 │   │           │       │                       │   │           └─ Table\n" +
+			"                 │   │           │       │                       │   │               ├─ name: E2I7U\n" +
+			"                 │   │           │       │                       │   │               └─ columns: [id tw55n zh72s]\n" +
+			"                 │   │           │       │                       │   └─ TableAlias(yqif4)\n" +
+			"                 │   │           │       │                       │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │       │                       │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │       │                       │           ├─ keys: [ism.UJ6XY:1!null]\n" +
+			"                 │   │           │       │                       │           ├─ colSet: (59-68)\n" +
+			"                 │   │           │       │                       │           ├─ tableId: 8\n" +
+			"                 │   │           │       │                       │           └─ Table\n" +
+			"                 │   │           │       │                       │               ├─ name: NOXN3\n" +
+			"                 │   │           │       │                       │               └─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │       │                       └─ TableAlias(yvhjz)\n" +
+			"                 │   │           │       │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │       │                               ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │       │                               ├─ keys: [ism.FV24E:0!null]\n" +
+			"                 │   │           │       │                               ├─ colSet: (69-78)\n" +
+			"                 │   │           │       │                               ├─ tableId: 9\n" +
+			"                 │   │           │       │                               └─ Table\n" +
+			"                 │   │           │       │                                   ├─ name: NOXN3\n" +
+			"                 │   │           │       │                                   └─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │       └─ Project\n" +
+			"                 │   │           │           ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, convert\n" +
+			"                 │   │           │           │   ├─ type: char\n" +
+			"                 │   │           │           │   └─ TDEIU:10\n" +
+			"                 │   │           │           │  ->TDEIU:0]\n" +
+			"                 │   │           │           └─ Project\n" +
+			"                 │   │           │               ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, jchir.QNI57:9!null, NULL (null)->TDEIU:120]\n" +
+			"                 │   │           │               └─ SubqueryAlias\n" +
+			"                 │   │           │                   ├─ name: jchir\n" +
+			"                 │   │           │                   ├─ outerVisibility: false\n" +
+			"                 │   │           │                   ├─ isLateral: false\n" +
+			"                 │   │           │                   ├─ cacheable: true\n" +
+			"                 │   │           │                   ├─ colSet: (109-119)\n" +
+			"                 │   │           │                   ├─ tableId: 12\n" +
+			"                 │   │           │                   └─ Filter\n" +
+			"                 │   │           │                       ├─ AND\n" +
+			"                 │   │           │                       │   ├─ NOT\n" +
+			"                 │   │           │                       │   │   └─ QNI57:9!null IS NULL\n" +
+			"                 │   │           │                       │   └─ NOT\n" +
+			"                 │   │           │                       │       └─ TDEIU:10!null IS NULL\n" +
+			"                 │   │           │                       └─ Project\n" +
+			"                 │   │           │                           ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
+			"                 │   │           │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │                           │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
+			"                 │   │           │                           │   THEN 0 (tinyint) WHEN IN\n" +
+			"                 │   │           │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │                           │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
+			"                 │   │           │                           │   THEN 1 (tinyint) WHEN IN\n" +
+			"                 │   │           │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │                           │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
+			"                 │   │           │                           │   THEN 2 (tinyint) WHEN IN\n" +
+			"                 │   │           │                           │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │           │                           │   └─ right: TUPLE(Y62X7 (longtext))\n" +
+			"                 │   │           │                           │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
+			"                 │   │           │                           └─ Filter\n" +
+			"                 │   │           │                               ├─ Or\n" +
+			"                 │   │           │                               │   ├─ NOT\n" +
+			"                 │   │           │                               │   │   └─ yqif4.id:15!null IS NULL\n" +
+			"                 │   │           │                               │   └─ NOT\n" +
+			"                 │   │           │                               │       └─ yvhjz.id:18!null IS NULL\n" +
+			"                 │   │           │                               └─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   ├─ Eq\n" +
+			"                 │   │           │                                   │   ├─ yvhjz.BRQP2:19!null\n" +
+			"                 │   │           │                                   │   └─ ism.UJ6XY:1!null\n" +
+			"                 │   │           │                                   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   │   ├─ Eq\n" +
+			"                 │   │           │                                   │   │   ├─ yqif4.BRQP2:16!null\n" +
+			"                 │   │           │                                   │   │   └─ ism.FV24E:0!null\n" +
+			"                 │   │           │                                   │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   │   │   ├─ NOT\n" +
+			"                 │   │           │                                   │   │   │   └─ Eq\n" +
+			"                 │   │           │                                   │   │   │       ├─ cpmfe.id:12!null\n" +
+			"                 │   │           │                                   │   │   │       └─ ism.FV24E:0!null\n" +
+			"                 │   │           │                                   │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │           │                                   │   │   │   ├─ Eq\n" +
+			"                 │   │           │                                   │   │   │   │   ├─ nhmxw.id:10!null\n" +
+			"                 │   │           │                                   │   │   │   │   └─ ism.PRUV2:4\n" +
+			"                 │   │           │                                   │   │   │   ├─ MergeJoin\n" +
+			"                 │   │           │                                   │   │   │   │   ├─ cmp: Eq\n" +
+			"                 │   │           │                                   │   │   │   │   │   ├─ ism.NZ4MQ:3!null\n" +
+			"                 │   │           │                                   │   │   │   │   │   └─ g3yxs.id:5!null\n" +
+			"                 │   │           │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │           │                                   │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ colSet: (15-23)\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ tableId: 4\n" +
+			"                 │   │           │                                   │   │   │   │   │       └─ Table\n" +
+			"                 │   │           │                                   │   │   │   │   │           ├─ name: HDDVB\n" +
+			"                 │   │           │                                   │   │   │   │   │           └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │           │                                   │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │           │                                   │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ colSet: (24-31)\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ tableId: 5\n" +
+			"                 │   │           │                                   │   │   │   │           └─ Table\n" +
+			"                 │   │           │                                   │   │   │   │               ├─ name: YYBCX\n" +
+			"                 │   │           │                                   │   │   │   │               └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │           │                                   │   │   │   └─ HashLookup\n" +
+			"                 │   │           │                                   │   │   │       ├─ left-key: TUPLE(ism.PRUV2:4)\n" +
+			"                 │   │           │                                   │   │   │       ├─ right-key: TUPLE(nhmxw.id:0!null)\n" +
+			"                 │   │           │                                   │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │           │                                   │   │   │           └─ Table\n" +
+			"                 │   │           │                                   │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │           │                                   │   │   │               ├─ columns: [id nohhr]\n" +
+			"                 │   │           │                                   │   │   │               ├─ colSet: (32-41)\n" +
+			"                 │   │           │                                   │   │   │               └─ tableId: 6\n" +
+			"                 │   │           │                                   │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │           │                                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │           │                                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │           │                                   │   │           ├─ keys: [nhmxw.NOHHR:11!null]\n" +
+			"                 │   │           │                                   │   │           ├─ colSet: (42-58)\n" +
+			"                 │   │           │                                   │   │           ├─ tableId: 7\n" +
+			"                 │   │           │                                   │   │           └─ Table\n" +
+			"                 │   │           │                                   │   │               ├─ name: E2I7U\n" +
+			"                 │   │           │                                   │   │               └─ columns: [id tw55n zh72s]\n" +
+			"                 │   │           │                                   │   └─ TableAlias(yqif4)\n" +
+			"                 │   │           │                                   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │                                   │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │                                   │           ├─ keys: [ism.UJ6XY:1!null]\n" +
+			"                 │   │           │                                   │           ├─ colSet: (59-68)\n" +
+			"                 │   │           │                                   │           ├─ tableId: 8\n" +
+			"                 │   │           │                                   │           └─ Table\n" +
+			"                 │   │           │                                   │               ├─ name: NOXN3\n" +
+			"                 │   │           │                                   │               └─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │                                   └─ TableAlias(yvhjz)\n" +
+			"                 │   │           │                                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │                                           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │                                           ├─ keys: [ism.FV24E:0!null]\n" +
+			"                 │   │           │                                           ├─ colSet: (69-78)\n" +
+			"                 │   │           │                                           ├─ tableId: 9\n" +
+			"                 │   │           │                                           └─ Table\n" +
+			"                 │   │           │                                               ├─ name: NOXN3\n" +
+			"                 │   │           │                                               └─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           └─ Project\n" +
+			"                 │   │               ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, convert\n" +
+			"                 │   │               │   ├─ type: char\n" +
+			"                 │   │               │   └─ QNI57:9\n" +
+			"                 │   │               │  ->QNI57:0, convert\n" +
+			"                 │   │               │   ├─ type: char\n" +
+			"                 │   │               │   └─ jchir.TDEIU:10!null\n" +
+			"                 │   │               │  ->TDEIU:0]\n" +
+			"                 │   │               └─ Project\n" +
+			"                 │   │                   ├─ columns: [jchir.FJDP5:0!null, jchir.BJUF2:1!null, jchir.PSMU6:2!null, jchir.M22QN:3!null, jchir.GE5EL:4, jchir.F7A4Q:5, jchir.ESFVY:6!null, jchir.CC4AX:7, jchir.SL76B:8!null, NULL (null)->QNI57:132, jchir.TDEIU:10!null]\n" +
+			"                 │   │                   └─ SubqueryAlias\n" +
+			"                 │   │                       ├─ name: jchir\n" +
+			"                 │   │                       ├─ outerVisibility: false\n" +
+			"                 │   │                       ├─ isLateral: false\n" +
+			"                 │   │                       ├─ cacheable: true\n" +
+			"                 │   │                       ├─ colSet: (121-131)\n" +
+			"                 │   │                       ├─ tableId: 13\n" +
+			"                 │   │                       └─ Filter\n" +
+			"                 │   │                           ├─ AND\n" +
+			"                 │   │                           │   ├─ NOT\n" +
+			"                 │   │                           │   │   └─ QNI57:9!null IS NULL\n" +
+			"                 │   │                           │   └─ NOT\n" +
+			"                 │   │                           │       └─ TDEIU:10!null IS NULL\n" +
+			"                 │   │                           └─ Project\n" +
+			"                 │   │                               ├─ columns: [ism.FV24E:0!null->FJDP5:0, cpmfe.id:12!null->BJUF2:0, cpmfe.TW55N:13!null->PSMU6:0, ism.M22QN:2!null->M22QN:0, g3yxs.GE5EL:8, g3yxs.F7A4Q:9, g3yxs.ESFVY:6!null, CASE  WHEN IN\n" +
+			"                 │   │                               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │                               │   └─ right: TUPLE(FO422 (longtext), SJ53H (longtext))\n" +
+			"                 │   │                               │   THEN 0 (tinyint) WHEN IN\n" +
+			"                 │   │                               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │                               │   └─ right: TUPLE(DCV4Z (longtext), UOSM4 (longtext), FUGIP (longtext), H5MCC (longtext), YKEQE (longtext), D3AKL (longtext))\n" +
+			"                 │   │                               │   THEN 1 (tinyint) WHEN IN\n" +
+			"                 │   │                               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │                               │   └─ right: TUPLE(QJEXM (longtext), J6S7P (longtext), VT7FI (longtext))\n" +
+			"                 │   │                               │   THEN 2 (tinyint) WHEN IN\n" +
+			"                 │   │                               │   ├─ left: g3yxs.SL76B:7!null\n" +
+			"                 │   │                               │   └─ right: TUPLE(Y62X7 (longtext))\n" +
+			"                 │   │                               │   THEN 3 (tinyint) END->CC4AX:0, g3yxs.SL76B:7!null->SL76B:0, yqif4.id:15!null->QNI57:0, yvhjz.id:18!null->TDEIU:0]\n" +
+			"                 │   │                               └─ Filter\n" +
+			"                 │   │                                   ├─ Or\n" +
+			"                 │   │                                   │   ├─ NOT\n" +
+			"                 │   │                                   │   │   └─ yqif4.id:15!null IS NULL\n" +
+			"                 │   │                                   │   └─ NOT\n" +
+			"                 │   │                                   │       └─ yvhjz.id:18!null IS NULL\n" +
+			"                 │   │                                   └─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       ├─ Eq\n" +
+			"                 │   │                                       │   ├─ yvhjz.BRQP2:19!null\n" +
+			"                 │   │                                       │   └─ ism.UJ6XY:1!null\n" +
+			"                 │   │                                       ├─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       │   ├─ Eq\n" +
+			"                 │   │                                       │   │   ├─ yqif4.BRQP2:16!null\n" +
+			"                 │   │                                       │   │   └─ ism.FV24E:0!null\n" +
+			"                 │   │                                       │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       │   │   ├─ NOT\n" +
+			"                 │   │                                       │   │   │   └─ Eq\n" +
+			"                 │   │                                       │   │   │       ├─ cpmfe.id:12!null\n" +
+			"                 │   │                                       │   │   │       └─ ism.FV24E:0!null\n" +
+			"                 │   │                                       │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │                                       │   │   │   ├─ Eq\n" +
+			"                 │   │                                       │   │   │   │   ├─ nhmxw.id:10!null\n" +
+			"                 │   │                                       │   │   │   │   └─ ism.PRUV2:4\n" +
+			"                 │   │                                       │   │   │   ├─ MergeJoin\n" +
+			"                 │   │                                       │   │   │   │   ├─ cmp: Eq\n" +
+			"                 │   │                                       │   │   │   │   │   ├─ ism.NZ4MQ:3!null\n" +
+			"                 │   │                                       │   │   │   │   │   └─ g3yxs.id:5!null\n" +
+			"                 │   │                                       │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │                                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ colSet: (15-23)\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ tableId: 4\n" +
+			"                 │   │                                       │   │   │   │   │       └─ Table\n" +
+			"                 │   │                                       │   │   │   │   │           ├─ name: HDDVB\n" +
+			"                 │   │                                       │   │   │   │   │           └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │                                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │                                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │                                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │                                       │   │   │   │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                 │   │                                       │   │   │   │           ├─ colSet: (24-31)\n" +
+			"                 │   │                                       │   │   │   │           ├─ tableId: 5\n" +
+			"                 │   │                                       │   │   │   │           └─ Table\n" +
+			"                 │   │                                       │   │   │   │               ├─ name: YYBCX\n" +
+			"                 │   │                                       │   │   │   │               └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │                                       │   │   │   └─ HashLookup\n" +
+			"                 │   │                                       │   │   │       ├─ left-key: TUPLE(ism.PRUV2:4)\n" +
+			"                 │   │                                       │   │   │       ├─ right-key: TUPLE(nhmxw.id:0!null)\n" +
+			"                 │   │                                       │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │                                       │   │   │           └─ Table\n" +
+			"                 │   │                                       │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │                                       │   │   │               ├─ columns: [id nohhr]\n" +
+			"                 │   │                                       │   │   │               ├─ colSet: (32-41)\n" +
+			"                 │   │                                       │   │   │               └─ tableId: 6\n" +
+			"                 │   │                                       │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │                                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │                                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │                                       │   │           ├─ keys: [nhmxw.NOHHR:11!null]\n" +
+			"                 │   │                                       │   │           ├─ colSet: (42-58)\n" +
+			"                 │   │                                       │   │           ├─ tableId: 7\n" +
+			"                 │   │                                       │   │           └─ Table\n" +
+			"                 │   │                                       │   │               ├─ name: E2I7U\n" +
+			"                 │   │                                       │   │               └─ columns: [id tw55n zh72s]\n" +
+			"                 │   │                                       │   └─ TableAlias(yqif4)\n" +
+			"                 │   │                                       │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                                       │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │                                       │           ├─ keys: [ism.UJ6XY:1!null]\n" +
+			"                 │   │                                       │           ├─ colSet: (59-68)\n" +
+			"                 │   │                                       │           ├─ tableId: 8\n" +
+			"                 │   │                                       │           └─ Table\n" +
+			"                 │   │                                       │               ├─ name: NOXN3\n" +
+			"                 │   │                                       │               └─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │                                       └─ TableAlias(yvhjz)\n" +
+			"                 │   │                                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                                               ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │                                               ├─ keys: [ism.FV24E:0!null]\n" +
+			"                 │   │                                               ├─ colSet: (69-78)\n" +
+			"                 │   │                                               ├─ tableId: 9\n" +
+			"                 │   │                                               └─ Table\n" +
+			"                 │   │                                                   ├─ name: NOXN3\n" +
+			"                 │   │                                                   └─ columns: [id brqp2 fftbj]\n" +
+			"                 │   └─ TableAlias(sn)\n" +
+			"                 │       └─ ProcessTable\n" +
+			"                 │           └─ Table\n" +
+			"                 │               ├─ name: NOXN3\n" +
+			"                 │               └─ columns: [id brqp2 fftbj a7xo2 kbo7r ecdkm numk2 letoe ykssu fhcyt]\n" +
+			"                 └─ HashLookup\n" +
+			"                     ├─ left-key: TUPLE(sn.BRQP2:15!null, mjr3d.M22QN:6!null)\n" +
+			"                     ├─ right-key: TUPLE(mf.LUEVY:1!null, mf.M22QN:2!null)\n" +
+			"                     └─ CachedResults\n" +
+			"                         └─ SubqueryAlias\n" +
+			"                             ├─ name: mf\n" +
+			"                             ├─ outerVisibility: false\n" +
+			"                             ├─ isLateral: false\n" +
+			"                             ├─ cacheable: true\n" +
+			"                             ├─ colSet: (246-248)\n" +
+			"                             ├─ tableId: 24\n" +
+			"                             └─ Project\n" +
+			"                                 ├─ columns: [cla.FTQLQ:4!null, mf.LUEVY:1!null, mf.M22QN:2!null]\n" +
+			"                                 └─ HashJoin\n" +
+			"                                     ├─ Eq\n" +
+			"                                     │   ├─ bs.id:5!null\n" +
+			"                                     │   └─ mf.GXLUB:0!null\n" +
+			"                                     ├─ TableAlias(mf)\n" +
+			"                                     │   └─ Table\n" +
+			"                                     │       ├─ name: HGMQ6\n" +
+			"                                     │       ├─ columns: [gxlub luevy m22qn]\n" +
+			"                                     │       ├─ colSet: (229-245)\n" +
+			"                                     │       └─ tableId: 23\n" +
+			"                                     └─ HashLookup\n" +
+			"                                         ├─ left-key: TUPLE(mf.GXLUB:0!null)\n" +
+			"                                         ├─ right-key: TUPLE(bs.id:2!null)\n" +
+			"                                         └─ MergeJoin\n" +
+			"                                             ├─ cmp: Eq\n" +
+			"                                             │   ├─ cla.id:3!null\n" +
+			"                                             │   └─ bs.IXUXU:6\n" +
+			"                                             ├─ Filter\n" +
+			"                                             │   ├─ HashIn\n" +
+			"                                             │   │   ├─ cla.FTQLQ:1!null\n" +
+			"                                             │   │   └─ TUPLE(SQ1 (longtext))\n" +
+			"                                             │   └─ TableAlias(cla)\n" +
+			"                                             │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                                             │           ├─ index: [YK2GW.id]\n" +
+			"                                             │           ├─ static: [{[NULL, ∞)}]\n" +
+			"                                             │           ├─ colSet: (195-224)\n" +
+			"                                             │           ├─ tableId: 21\n" +
+			"                                             │           └─ Table\n" +
+			"                                             │               ├─ name: YK2GW\n" +
+			"                                             │               └─ columns: [id ftqlq]\n" +
+			"                                             └─ TableAlias(bs)\n" +
+			"                                                 └─ IndexedTableAccess(THNTS)\n" +
+			"                                                     ├─ index: [THNTS.IXUXU]\n" +
+			"                                                     ├─ static: [{[NULL, ∞)}]\n" +
+			"                                                     ├─ colSet: (225-228)\n" +
+			"                                                     ├─ tableId: 22\n" +
+			"                                                     └─ Table\n" +
+			"                                                         ├─ name: THNTS\n" +
+			"                                                         └─ columns: [id ixuxu]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
 			" ├─ columns: [mf.FTQLQ as T4IBQ, CASE  WHEN (NOT(mjr3d.QNI57 IS NULL)) THEN Subquery\n" +
@@ -11176,276 +11179,279 @@ WHERE
 			"     │                           ├─ columns: [id]\n" +
 			"     │                           └─ keys: mjr3d.TDEIU\n" +
 			"     │   END as M6T2N, mjr3d.GE5EL as GE5EL, mjr3d.F7A4Q as F7A4Q, mjr3d.CC4AX as CC4AX, mjr3d.SL76B as SL76B, aac.BTXC5 as YEBDJ]\n" +
-			"     └─ HashJoin (estimated cost=459.120 rows=156)\n" +
-			"         ├─ ((mf.LUEVY = sn.BRQP2) AND (mf.M22QN = mjr3d.M22QN))\n" +
-			"         ├─ LeftOuterJoin (estimated cost=1479459.120 rows=156)\n" +
-			"         │   ├─ ((((((NOT(mjr3d.QNI57 IS NULL)) AND (sn.id = mjr3d.QNI57)) AND mjr3d.BJUF2 IS NULL) OR (((NOT(mjr3d.QNI57 IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
-			"         │   │   ├─ left: sn.id\n" +
-			"         │   │   └─ right: Subquery\n" +
-			"         │   │       ├─ cacheable: false\n" +
-			"         │   │       └─ Project\n" +
-			"         │   │           ├─ columns: [jtehg.id]\n" +
-			"         │   │           └─ Filter\n" +
-			"         │   │               ├─ (jtehg.BRQP2 = mjr3d.BJUF2)\n" +
-			"         │   │               └─ TableAlias(jtehg)\n" +
-			"         │   │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │                       ├─ columns: [id brqp2]\n" +
-			"         │   │                       └─ keys: mjr3d.BJUF2\n" +
-			"         │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND mjr3d.BJUF2 IS NULL) AND InSubquery\n" +
-			"         │   │   ├─ left: sn.id\n" +
-			"         │   │   └─ right: Subquery\n" +
-			"         │   │       ├─ cacheable: false\n" +
-			"         │   │       └─ Project\n" +
-			"         │   │           ├─ columns: [xmafz.id]\n" +
-			"         │   │           └─ Filter\n" +
-			"         │   │               ├─ (xmafz.BRQP2 = mjr3d.FJDP5)\n" +
-			"         │   │               └─ TableAlias(xmafz)\n" +
-			"         │   │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │                       ├─ columns: [id brqp2]\n" +
-			"         │   │                       └─ keys: mjr3d.FJDP5\n" +
-			"         │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
-			"         │   │   ├─ left: sn.id\n" +
-			"         │   │   └─ right: Subquery\n" +
-			"         │   │       ├─ cacheable: false\n" +
-			"         │   │       └─ Project\n" +
-			"         │   │           ├─ columns: [xmafz.id]\n" +
-			"         │   │           └─ Filter\n" +
-			"         │   │               ├─ (xmafz.BRQP2 = mjr3d.BJUF2)\n" +
-			"         │   │               └─ TableAlias(xmafz)\n" +
-			"         │   │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │                       ├─ columns: [id brqp2]\n" +
-			"         │   │                       └─ keys: mjr3d.BJUF2\n" +
-			"         │   │  ))\n" +
-			"         │   ├─ InnerJoin (estimated cost=12510568.000 rows=124)\n" +
-			"         │   │   ├─ (aac.id = mjr3d.M22QN)\n" +
-			"         │   │   ├─ TableAlias(aac)\n" +
-			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: TPXBU\n" +
-			"         │   │   └─ CachedResults\n" +
-			"         │   │       └─ SubqueryAlias\n" +
-			"         │   │           ├─ name: mjr3d\n" +
-			"         │   │           ├─ outerVisibility: false\n" +
-			"         │   │           ├─ isLateral: false\n" +
-			"         │   │           ├─ cacheable: true\n" +
-			"         │   │           └─ Union distinct\n" +
-			"         │   │               ├─ Project\n" +
-			"         │   │               │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(jchir.QNI57, char) as QNI57, TDEIU as TDEIU]\n" +
-			"         │   │               │   └─ Union distinct\n" +
-			"         │   │               │       ├─ Project\n" +
-			"         │   │               │       │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
-			"         │   │               │       │   └─ SubqueryAlias\n" +
-			"         │   │               │       │       ├─ name: jchir\n" +
-			"         │   │               │       │       ├─ outerVisibility: false\n" +
-			"         │   │               │       │       ├─ isLateral: false\n" +
-			"         │   │               │       │       ├─ cacheable: true\n" +
-			"         │   │               │       │       ├─ colSet: (98-108)\n" +
-			"         │   │               │       │       ├─ tableId: 11\n" +
-			"         │   │               │       │       └─ Filter\n" +
-			"         │   │               │       │           ├─ (((NOT(QNI57 IS NULL)) AND TDEIU IS NULL) OR (QNI57 IS NULL AND (NOT(TDEIU IS NULL))))\n" +
-			"         │   │               │       │           └─ Project\n" +
-			"         │   │               │       │               ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
-			"         │   │               │       │               └─ Filter\n" +
-			"         │   │               │       │                   ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
-			"         │   │               │       │                   └─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
-			"         │   │               │       │                       ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
-			"         │   │               │       │                       │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
-			"         │   │               │       │                       │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │               │       │                       │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
-			"         │   │               │       │                       │   │   │   ├─ MergeJoin\n" +
-			"         │   │               │       │                       │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
-			"         │   │               │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │               │       │                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │       │                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │               │       │                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │               │       │                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │       │                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │               │       │                       │   │   │   └─ HashLookup\n" +
-			"         │   │               │       │                       │   │   │       ├─ left-key: (ism.PRUV2)\n" +
-			"         │   │               │       │                       │   │   │       ├─ right-key: (nhmxw.id)\n" +
-			"         │   │               │       │                       │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │               │       │                       │   │   │           └─ Table\n" +
-			"         │   │               │       │                       │   │   │               ├─ name: WGSDC\n" +
-			"         │   │               │       │                       │   │   │               └─ columns: [id nohhr]\n" +
-			"         │   │               │       │                       │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │               │       │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │               │       │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │               │       │                       │   │           ├─ columns: [id tw55n zh72s]\n" +
-			"         │   │               │       │                       │   │           └─ keys: nhmxw.NOHHR\n" +
-			"         │   │               │       │                       │   └─ TableAlias(yqif4)\n" +
-			"         │   │               │       │                       │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │       │                       │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │       │                       │           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │       │                       │           └─ keys: ism.UJ6XY\n" +
-			"         │   │               │       │                       └─ TableAlias(yvhjz)\n" +
-			"         │   │               │       │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │       │                               ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │       │                               ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │       │                               └─ keys: ism.FV24E\n" +
-			"         │   │               │       └─ Project\n" +
-			"         │   │               │           ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(TDEIU, char) as TDEIU]\n" +
-			"         │   │               │           └─ Project\n" +
-			"         │   │               │               ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, NULL as TDEIU]\n" +
-			"         │   │               │               └─ SubqueryAlias\n" +
-			"         │   │               │                   ├─ name: jchir\n" +
-			"         │   │               │                   ├─ outerVisibility: false\n" +
-			"         │   │               │                   ├─ isLateral: false\n" +
-			"         │   │               │                   ├─ cacheable: true\n" +
-			"         │   │               │                   ├─ colSet: (109-119)\n" +
-			"         │   │               │                   ├─ tableId: 12\n" +
-			"         │   │               │                   └─ Filter\n" +
-			"         │   │               │                       ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
-			"         │   │               │                       └─ Project\n" +
-			"         │   │               │                           ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
-			"         │   │               │                           └─ Filter\n" +
-			"         │   │               │                               ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
-			"         │   │               │                               └─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
-			"         │   │               │                                   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
-			"         │   │               │                                   │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
-			"         │   │               │                                   │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │               │                                   │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
-			"         │   │               │                                   │   │   │   ├─ MergeJoin\n" +
-			"         │   │               │                                   │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
-			"         │   │               │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │               │                                   │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │               │                                   │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │               │                                   │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │               │                                   │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │               │                                   │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │               │                                   │   │   │   └─ HashLookup\n" +
-			"         │   │               │                                   │   │   │       ├─ left-key: (ism.PRUV2)\n" +
-			"         │   │               │                                   │   │   │       ├─ right-key: (nhmxw.id)\n" +
-			"         │   │               │                                   │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │               │                                   │   │   │           └─ Table\n" +
-			"         │   │               │                                   │   │   │               ├─ name: WGSDC\n" +
-			"         │   │               │                                   │   │   │               └─ columns: [id nohhr]\n" +
-			"         │   │               │                                   │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │               │                                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │               │                                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │               │                                   │   │           ├─ columns: [id tw55n zh72s]\n" +
-			"         │   │               │                                   │   │           └─ keys: nhmxw.NOHHR\n" +
-			"         │   │               │                                   │   └─ TableAlias(yqif4)\n" +
-			"         │   │               │                                   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │                                   │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │                                   │           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │                                   │           └─ keys: ism.UJ6XY\n" +
-			"         │   │               │                                   └─ TableAlias(yvhjz)\n" +
-			"         │   │               │                                       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │                                           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │                                           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │                                           └─ keys: ism.FV24E\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(QNI57, char) as QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
-			"         │   │                   └─ Project\n" +
-			"         │   │                       ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, NULL as QNI57, jchir.TDEIU]\n" +
-			"         │   │                       └─ SubqueryAlias\n" +
-			"         │   │                           ├─ name: jchir\n" +
-			"         │   │                           ├─ outerVisibility: false\n" +
-			"         │   │                           ├─ isLateral: false\n" +
-			"         │   │                           ├─ cacheable: true\n" +
-			"         │   │                           ├─ colSet: (121-131)\n" +
-			"         │   │                           ├─ tableId: 13\n" +
-			"         │   │                           └─ Filter\n" +
-			"         │   │                               ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
-			"         │   │                               └─ Project\n" +
-			"         │   │                                   ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
-			"         │   │                                   └─ Filter\n" +
-			"         │   │                                       ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
-			"         │   │                                       └─ LeftOuterLookupJoin\n" +
-			"         │   │                                           ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
-			"         │   │                                           ├─ LeftOuterLookupJoin\n" +
-			"         │   │                                           │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
-			"         │   │                                           │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │                                           │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
-			"         │   │                                           │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │                                           │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
-			"         │   │                                           │   │   │   ├─ MergeJoin\n" +
-			"         │   │                                           │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
-			"         │   │                                           │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │                                           │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │                                           │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │                                           │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │                                           │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │                                           │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │                                           │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │                                           │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │                                           │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │                                           │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │                                           │   │   │   └─ HashLookup\n" +
-			"         │   │                                           │   │   │       ├─ left-key: (ism.PRUV2)\n" +
-			"         │   │                                           │   │   │       ├─ right-key: (nhmxw.id)\n" +
-			"         │   │                                           │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │                                           │   │   │           └─ Table\n" +
-			"         │   │                                           │   │   │               ├─ name: WGSDC\n" +
-			"         │   │                                           │   │   │               └─ columns: [id nohhr]\n" +
-			"         │   │                                           │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │                                           │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │                                           │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │                                           │   │           ├─ columns: [id tw55n zh72s]\n" +
-			"         │   │                                           │   │           └─ keys: nhmxw.NOHHR\n" +
-			"         │   │                                           │   └─ TableAlias(yqif4)\n" +
-			"         │   │                                           │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                                           │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │                                           │           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │                                           │           └─ keys: ism.UJ6XY\n" +
-			"         │   │                                           └─ TableAlias(yvhjz)\n" +
-			"         │   │                                               └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                                                   ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │                                                   ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │                                                   └─ keys: ism.FV24E\n" +
-			"         │   └─ TableAlias(sn)\n" +
-			"         │       └─ Table\n" +
-			"         │           └─ name: NOXN3\n" +
+			"     └─ HashJoin (estimated cost=125482.230 rows=156)\n" +
+			"         ├─ (aac.id = mjr3d.M22QN)\n" +
+			"         ├─ TableAlias(aac)\n" +
+			"         │   └─ Table\n" +
+			"         │       └─ name: TPXBU\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (sn.BRQP2, mjr3d.M22QN)\n" +
-			"             ├─ right-key: (mf.LUEVY, mf.M22QN)\n" +
-			"             └─ CachedResults\n" +
-			"                 └─ SubqueryAlias\n" +
-			"                     ├─ name: mf\n" +
-			"                     ├─ outerVisibility: false\n" +
-			"                     ├─ isLateral: false\n" +
-			"                     ├─ cacheable: true\n" +
-			"                     └─ Project\n" +
-			"                         ├─ columns: [cla.FTQLQ, mf.LUEVY, mf.M22QN]\n" +
-			"                         └─ HashJoin\n" +
-			"                             ├─ (bs.id = mf.GXLUB)\n" +
-			"                             ├─ TableAlias(mf)\n" +
-			"                             │   └─ Table\n" +
-			"                             │       ├─ name: HGMQ6\n" +
-			"                             │       └─ columns: [gxlub luevy m22qn]\n" +
-			"                             └─ HashLookup\n" +
-			"                                 ├─ left-key: (mf.GXLUB)\n" +
-			"                                 ├─ right-key: (bs.id)\n" +
-			"                                 └─ MergeJoin\n" +
-			"                                     ├─ cmp: (cla.id = bs.IXUXU)\n" +
-			"                                     ├─ Filter\n" +
-			"                                     │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
-			"                                     │   └─ TableAlias(cla)\n" +
-			"                                     │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                                     │           ├─ index: [YK2GW.id]\n" +
-			"                                     │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"                                     │           └─ columns: [id ftqlq]\n" +
-			"                                     └─ TableAlias(bs)\n" +
-			"                                         └─ IndexedTableAccess(THNTS)\n" +
-			"                                             ├─ index: [THNTS.IXUXU]\n" +
-			"                                             ├─ filters: [{[NULL, ∞)}]\n" +
-			"                                             └─ columns: [id ixuxu]\n" +
+			"             ├─ left-key: (aac.id)\n" +
+			"             ├─ right-key: (mjr3d.M22QN)\n" +
+			"             └─ HashJoin (estimated cost=427.500 rows=125)\n" +
+			"                 ├─ ((mf.LUEVY = sn.BRQP2) AND (mf.M22QN = mjr3d.M22QN))\n" +
+			"                 ├─ LeftOuterJoin (estimated cost=1193112.000 rows=125)\n" +
+			"                 │   ├─ ((((((NOT(mjr3d.QNI57 IS NULL)) AND (sn.id = mjr3d.QNI57)) AND mjr3d.BJUF2 IS NULL) OR (((NOT(mjr3d.QNI57 IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
+			"                 │   │   ├─ left: sn.id\n" +
+			"                 │   │   └─ right: Subquery\n" +
+			"                 │   │       ├─ cacheable: false\n" +
+			"                 │   │       └─ Project\n" +
+			"                 │   │           ├─ columns: [jtehg.id]\n" +
+			"                 │   │           └─ Filter\n" +
+			"                 │   │               ├─ (jtehg.BRQP2 = mjr3d.BJUF2)\n" +
+			"                 │   │               └─ TableAlias(jtehg)\n" +
+			"                 │   │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │                       ├─ columns: [id brqp2]\n" +
+			"                 │   │                       └─ keys: mjr3d.BJUF2\n" +
+			"                 │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND mjr3d.BJUF2 IS NULL) AND InSubquery\n" +
+			"                 │   │   ├─ left: sn.id\n" +
+			"                 │   │   └─ right: Subquery\n" +
+			"                 │   │       ├─ cacheable: false\n" +
+			"                 │   │       └─ Project\n" +
+			"                 │   │           ├─ columns: [xmafz.id]\n" +
+			"                 │   │           └─ Filter\n" +
+			"                 │   │               ├─ (xmafz.BRQP2 = mjr3d.FJDP5)\n" +
+			"                 │   │               └─ TableAlias(xmafz)\n" +
+			"                 │   │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │                       ├─ columns: [id brqp2]\n" +
+			"                 │   │                       └─ keys: mjr3d.FJDP5\n" +
+			"                 │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
+			"                 │   │   ├─ left: sn.id\n" +
+			"                 │   │   └─ right: Subquery\n" +
+			"                 │   │       ├─ cacheable: false\n" +
+			"                 │   │       └─ Project\n" +
+			"                 │   │           ├─ columns: [xmafz.id]\n" +
+			"                 │   │           └─ Filter\n" +
+			"                 │   │               ├─ (xmafz.BRQP2 = mjr3d.BJUF2)\n" +
+			"                 │   │               └─ TableAlias(xmafz)\n" +
+			"                 │   │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │                       ├─ columns: [id brqp2]\n" +
+			"                 │   │                       └─ keys: mjr3d.BJUF2\n" +
+			"                 │   │  ))\n" +
+			"                 │   ├─ CachedResults\n" +
+			"                 │   │   └─ SubqueryAlias\n" +
+			"                 │   │       ├─ name: mjr3d\n" +
+			"                 │   │       ├─ outerVisibility: false\n" +
+			"                 │   │       ├─ isLateral: false\n" +
+			"                 │   │       ├─ cacheable: true\n" +
+			"                 │   │       └─ Union distinct\n" +
+			"                 │   │           ├─ Project\n" +
+			"                 │   │           │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(jchir.QNI57, char) as QNI57, TDEIU as TDEIU]\n" +
+			"                 │   │           │   └─ Union distinct\n" +
+			"                 │   │           │       ├─ Project\n" +
+			"                 │   │           │       │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
+			"                 │   │           │       │   └─ SubqueryAlias\n" +
+			"                 │   │           │       │       ├─ name: jchir\n" +
+			"                 │   │           │       │       ├─ outerVisibility: false\n" +
+			"                 │   │           │       │       ├─ isLateral: false\n" +
+			"                 │   │           │       │       ├─ cacheable: true\n" +
+			"                 │   │           │       │       ├─ colSet: (98-108)\n" +
+			"                 │   │           │       │       ├─ tableId: 11\n" +
+			"                 │   │           │       │       └─ Filter\n" +
+			"                 │   │           │       │           ├─ (((NOT(QNI57 IS NULL)) AND TDEIU IS NULL) OR (QNI57 IS NULL AND (NOT(TDEIU IS NULL))))\n" +
+			"                 │   │           │       │           └─ Project\n" +
+			"                 │   │           │       │               ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
+			"                 │   │           │       │               └─ Filter\n" +
+			"                 │   │           │       │                   ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
+			"                 │   │           │       │                   └─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
+			"                 │   │           │       │                       ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
+			"                 │   │           │       │                       │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
+			"                 │   │           │       │                       │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │           │       │                       │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
+			"                 │   │           │       │                       │   │   │   ├─ MergeJoin\n" +
+			"                 │   │           │       │                       │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
+			"                 │   │           │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │           │       │                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │       │                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │           │       │                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │           │       │                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │       │                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │           │       │                       │   │   │   └─ HashLookup\n" +
+			"                 │   │           │       │                       │   │   │       ├─ left-key: (ism.PRUV2)\n" +
+			"                 │   │           │       │                       │   │   │       ├─ right-key: (nhmxw.id)\n" +
+			"                 │   │           │       │                       │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │           │       │                       │   │   │           └─ Table\n" +
+			"                 │   │           │       │                       │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │           │       │                       │   │   │               └─ columns: [id nohhr]\n" +
+			"                 │   │           │       │                       │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │           │       │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │           │       │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │           │       │                       │   │           ├─ columns: [id tw55n zh72s]\n" +
+			"                 │   │           │       │                       │   │           └─ keys: nhmxw.NOHHR\n" +
+			"                 │   │           │       │                       │   └─ TableAlias(yqif4)\n" +
+			"                 │   │           │       │                       │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │       │                       │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │       │                       │           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │       │                       │           └─ keys: ism.UJ6XY\n" +
+			"                 │   │           │       │                       └─ TableAlias(yvhjz)\n" +
+			"                 │   │           │       │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │       │                               ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │       │                               ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │       │                               └─ keys: ism.FV24E\n" +
+			"                 │   │           │       └─ Project\n" +
+			"                 │   │           │           ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(TDEIU, char) as TDEIU]\n" +
+			"                 │   │           │           └─ Project\n" +
+			"                 │   │           │               ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, NULL as TDEIU]\n" +
+			"                 │   │           │               └─ SubqueryAlias\n" +
+			"                 │   │           │                   ├─ name: jchir\n" +
+			"                 │   │           │                   ├─ outerVisibility: false\n" +
+			"                 │   │           │                   ├─ isLateral: false\n" +
+			"                 │   │           │                   ├─ cacheable: true\n" +
+			"                 │   │           │                   ├─ colSet: (109-119)\n" +
+			"                 │   │           │                   ├─ tableId: 12\n" +
+			"                 │   │           │                   └─ Filter\n" +
+			"                 │   │           │                       ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
+			"                 │   │           │                       └─ Project\n" +
+			"                 │   │           │                           ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
+			"                 │   │           │                           └─ Filter\n" +
+			"                 │   │           │                               ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
+			"                 │   │           │                               └─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
+			"                 │   │           │                                   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
+			"                 │   │           │                                   │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
+			"                 │   │           │                                   │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │           │                                   │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
+			"                 │   │           │                                   │   │   │   ├─ MergeJoin\n" +
+			"                 │   │           │                                   │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
+			"                 │   │           │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │           │                                   │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │           │                                   │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │           │                                   │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │           │                                   │   │   │   └─ HashLookup\n" +
+			"                 │   │           │                                   │   │   │       ├─ left-key: (ism.PRUV2)\n" +
+			"                 │   │           │                                   │   │   │       ├─ right-key: (nhmxw.id)\n" +
+			"                 │   │           │                                   │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │           │                                   │   │   │           └─ Table\n" +
+			"                 │   │           │                                   │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │           │                                   │   │   │               └─ columns: [id nohhr]\n" +
+			"                 │   │           │                                   │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │           │                                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │           │                                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │           │                                   │   │           ├─ columns: [id tw55n zh72s]\n" +
+			"                 │   │           │                                   │   │           └─ keys: nhmxw.NOHHR\n" +
+			"                 │   │           │                                   │   └─ TableAlias(yqif4)\n" +
+			"                 │   │           │                                   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │                                   │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │                                   │           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │                                   │           └─ keys: ism.UJ6XY\n" +
+			"                 │   │           │                                   └─ TableAlias(yvhjz)\n" +
+			"                 │   │           │                                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │                                           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │                                           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │                                           └─ keys: ism.FV24E\n" +
+			"                 │   │           └─ Project\n" +
+			"                 │   │               ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(QNI57, char) as QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
+			"                 │   │               └─ Project\n" +
+			"                 │   │                   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, NULL as QNI57, jchir.TDEIU]\n" +
+			"                 │   │                   └─ SubqueryAlias\n" +
+			"                 │   │                       ├─ name: jchir\n" +
+			"                 │   │                       ├─ outerVisibility: false\n" +
+			"                 │   │                       ├─ isLateral: false\n" +
+			"                 │   │                       ├─ cacheable: true\n" +
+			"                 │   │                       ├─ colSet: (121-131)\n" +
+			"                 │   │                       ├─ tableId: 13\n" +
+			"                 │   │                       └─ Filter\n" +
+			"                 │   │                           ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
+			"                 │   │                           └─ Project\n" +
+			"                 │   │                               ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
+			"                 │   │                               └─ Filter\n" +
+			"                 │   │                                   ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
+			"                 │   │                                   └─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
+			"                 │   │                                       ├─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
+			"                 │   │                                       │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
+			"                 │   │                                       │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │                                       │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
+			"                 │   │                                       │   │   │   ├─ MergeJoin\n" +
+			"                 │   │                                       │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
+			"                 │   │                                       │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │                                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │                                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │                                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │                                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │                                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │                                       │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │                                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │                                       │   │   │   └─ HashLookup\n" +
+			"                 │   │                                       │   │   │       ├─ left-key: (ism.PRUV2)\n" +
+			"                 │   │                                       │   │   │       ├─ right-key: (nhmxw.id)\n" +
+			"                 │   │                                       │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │                                       │   │   │           └─ Table\n" +
+			"                 │   │                                       │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │                                       │   │   │               └─ columns: [id nohhr]\n" +
+			"                 │   │                                       │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │                                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │                                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │                                       │   │           ├─ columns: [id tw55n zh72s]\n" +
+			"                 │   │                                       │   │           └─ keys: nhmxw.NOHHR\n" +
+			"                 │   │                                       │   └─ TableAlias(yqif4)\n" +
+			"                 │   │                                       │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                                       │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │                                       │           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │                                       │           └─ keys: ism.UJ6XY\n" +
+			"                 │   │                                       └─ TableAlias(yvhjz)\n" +
+			"                 │   │                                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                                               ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │                                               ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │                                               └─ keys: ism.FV24E\n" +
+			"                 │   └─ TableAlias(sn)\n" +
+			"                 │       └─ Table\n" +
+			"                 │           └─ name: NOXN3\n" +
+			"                 └─ HashLookup\n" +
+			"                     ├─ left-key: (sn.BRQP2, mjr3d.M22QN)\n" +
+			"                     ├─ right-key: (mf.LUEVY, mf.M22QN)\n" +
+			"                     └─ CachedResults\n" +
+			"                         └─ SubqueryAlias\n" +
+			"                             ├─ name: mf\n" +
+			"                             ├─ outerVisibility: false\n" +
+			"                             ├─ isLateral: false\n" +
+			"                             ├─ cacheable: true\n" +
+			"                             └─ Project\n" +
+			"                                 ├─ columns: [cla.FTQLQ, mf.LUEVY, mf.M22QN]\n" +
+			"                                 └─ HashJoin\n" +
+			"                                     ├─ (bs.id = mf.GXLUB)\n" +
+			"                                     ├─ TableAlias(mf)\n" +
+			"                                     │   └─ Table\n" +
+			"                                     │       ├─ name: HGMQ6\n" +
+			"                                     │       └─ columns: [gxlub luevy m22qn]\n" +
+			"                                     └─ HashLookup\n" +
+			"                                         ├─ left-key: (mf.GXLUB)\n" +
+			"                                         ├─ right-key: (bs.id)\n" +
+			"                                         └─ MergeJoin\n" +
+			"                                             ├─ cmp: (cla.id = bs.IXUXU)\n" +
+			"                                             ├─ Filter\n" +
+			"                                             │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
+			"                                             │   └─ TableAlias(cla)\n" +
+			"                                             │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                                             │           ├─ index: [YK2GW.id]\n" +
+			"                                             │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                                             │           └─ columns: [id ftqlq]\n" +
+			"                                             └─ TableAlias(bs)\n" +
+			"                                                 └─ IndexedTableAccess(THNTS)\n" +
+			"                                                     ├─ index: [THNTS.IXUXU]\n" +
+			"                                                     ├─ filters: [{[NULL, ∞)}]\n" +
+			"                                                     └─ columns: [id ixuxu]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
 			" ├─ columns: [mf.FTQLQ as T4IBQ, CASE  WHEN (NOT(mjr3d.QNI57 IS NULL)) THEN Subquery\n" +
@@ -11531,276 +11537,279 @@ WHERE
 			"     │                           ├─ columns: [id]\n" +
 			"     │                           └─ keys: mjr3d.TDEIU\n" +
 			"     │   END as M6T2N, mjr3d.GE5EL as GE5EL, mjr3d.F7A4Q as F7A4Q, mjr3d.CC4AX as CC4AX, mjr3d.SL76B as SL76B, aac.BTXC5 as YEBDJ]\n" +
-			"     └─ HashJoin (estimated cost=459.120 rows=156) (actual rows=0 loops=1)\n" +
-			"         ├─ ((mf.LUEVY = sn.BRQP2) AND (mf.M22QN = mjr3d.M22QN))\n" +
-			"         ├─ LeftOuterJoin (estimated cost=1479459.120 rows=156) (actual rows=0 loops=1)\n" +
-			"         │   ├─ ((((((NOT(mjr3d.QNI57 IS NULL)) AND (sn.id = mjr3d.QNI57)) AND mjr3d.BJUF2 IS NULL) OR (((NOT(mjr3d.QNI57 IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
-			"         │   │   ├─ left: sn.id\n" +
-			"         │   │   └─ right: Subquery\n" +
-			"         │   │       ├─ cacheable: false\n" +
-			"         │   │       └─ Project\n" +
-			"         │   │           ├─ columns: [jtehg.id]\n" +
-			"         │   │           └─ Filter\n" +
-			"         │   │               ├─ (jtehg.BRQP2 = mjr3d.BJUF2)\n" +
-			"         │   │               └─ TableAlias(jtehg)\n" +
-			"         │   │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │                       ├─ columns: [id brqp2]\n" +
-			"         │   │                       └─ keys: mjr3d.BJUF2\n" +
-			"         │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND mjr3d.BJUF2 IS NULL) AND InSubquery\n" +
-			"         │   │   ├─ left: sn.id\n" +
-			"         │   │   └─ right: Subquery\n" +
-			"         │   │       ├─ cacheable: false\n" +
-			"         │   │       └─ Project\n" +
-			"         │   │           ├─ columns: [xmafz.id]\n" +
-			"         │   │           └─ Filter\n" +
-			"         │   │               ├─ (xmafz.BRQP2 = mjr3d.FJDP5)\n" +
-			"         │   │               └─ TableAlias(xmafz)\n" +
-			"         │   │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │                       ├─ columns: [id brqp2]\n" +
-			"         │   │                       └─ keys: mjr3d.FJDP5\n" +
-			"         │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
-			"         │   │   ├─ left: sn.id\n" +
-			"         │   │   └─ right: Subquery\n" +
-			"         │   │       ├─ cacheable: false\n" +
-			"         │   │       └─ Project\n" +
-			"         │   │           ├─ columns: [xmafz.id]\n" +
-			"         │   │           └─ Filter\n" +
-			"         │   │               ├─ (xmafz.BRQP2 = mjr3d.BJUF2)\n" +
-			"         │   │               └─ TableAlias(xmafz)\n" +
-			"         │   │                   └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                       ├─ index: [NOXN3.BRQP2]\n" +
-			"         │   │                       ├─ columns: [id brqp2]\n" +
-			"         │   │                       └─ keys: mjr3d.BJUF2\n" +
-			"         │   │  ))\n" +
-			"         │   ├─ InnerJoin (estimated cost=12510568.000 rows=124) (actual rows=0 loops=1)\n" +
-			"         │   │   ├─ (aac.id = mjr3d.M22QN)\n" +
-			"         │   │   ├─ TableAlias(aac)\n" +
-			"         │   │   │   └─ Table\n" +
-			"         │   │   │       └─ name: TPXBU\n" +
-			"         │   │   └─ CachedResults\n" +
-			"         │   │       └─ SubqueryAlias\n" +
-			"         │   │           ├─ name: mjr3d\n" +
-			"         │   │           ├─ outerVisibility: false\n" +
-			"         │   │           ├─ isLateral: false\n" +
-			"         │   │           ├─ cacheable: true\n" +
-			"         │   │           └─ Union distinct\n" +
-			"         │   │               ├─ Project\n" +
-			"         │   │               │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(jchir.QNI57, char) as QNI57, TDEIU as TDEIU]\n" +
-			"         │   │               │   └─ Union distinct\n" +
-			"         │   │               │       ├─ Project\n" +
-			"         │   │               │       │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
-			"         │   │               │       │   └─ SubqueryAlias\n" +
-			"         │   │               │       │       ├─ name: jchir\n" +
-			"         │   │               │       │       ├─ outerVisibility: false\n" +
-			"         │   │               │       │       ├─ isLateral: false\n" +
-			"         │   │               │       │       ├─ cacheable: true\n" +
-			"         │   │               │       │       ├─ colSet: (98-108)\n" +
-			"         │   │               │       │       ├─ tableId: 11\n" +
-			"         │   │               │       │       └─ Filter\n" +
-			"         │   │               │       │           ├─ (((NOT(QNI57 IS NULL)) AND TDEIU IS NULL) OR (QNI57 IS NULL AND (NOT(TDEIU IS NULL))))\n" +
-			"         │   │               │       │           └─ Project\n" +
-			"         │   │               │       │               ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
-			"         │   │               │       │               └─ Filter\n" +
-			"         │   │               │       │                   ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
-			"         │   │               │       │                   └─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
-			"         │   │               │       │                       ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
-			"         │   │               │       │                       │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │       │                       │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
-			"         │   │               │       │                       │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │               │       │                       │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
-			"         │   │               │       │                       │   │   │   ├─ MergeJoin\n" +
-			"         │   │               │       │                       │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
-			"         │   │               │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │               │       │                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │               │       │                       │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │       │                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │               │       │                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │               │       │                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │               │       │                       │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │       │                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │               │       │                       │   │   │   └─ HashLookup\n" +
-			"         │   │               │       │                       │   │   │       ├─ left-key: (ism.PRUV2)\n" +
-			"         │   │               │       │                       │   │   │       ├─ right-key: (nhmxw.id)\n" +
-			"         │   │               │       │                       │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │               │       │                       │   │   │           └─ Table\n" +
-			"         │   │               │       │                       │   │   │               ├─ name: WGSDC\n" +
-			"         │   │               │       │                       │   │   │               └─ columns: [id nohhr]\n" +
-			"         │   │               │       │                       │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │               │       │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │               │       │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │               │       │                       │   │           ├─ columns: [id tw55n zh72s]\n" +
-			"         │   │               │       │                       │   │           └─ keys: nhmxw.NOHHR\n" +
-			"         │   │               │       │                       │   └─ TableAlias(yqif4)\n" +
-			"         │   │               │       │                       │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │       │                       │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │       │                       │           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │       │                       │           └─ keys: ism.UJ6XY\n" +
-			"         │   │               │       │                       └─ TableAlias(yvhjz)\n" +
-			"         │   │               │       │                           └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │       │                               ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │       │                               ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │       │                               └─ keys: ism.FV24E\n" +
-			"         │   │               │       └─ Project\n" +
-			"         │   │               │           ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(TDEIU, char) as TDEIU]\n" +
-			"         │   │               │           └─ Project\n" +
-			"         │   │               │               ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, NULL as TDEIU]\n" +
-			"         │   │               │               └─ SubqueryAlias\n" +
-			"         │   │               │                   ├─ name: jchir\n" +
-			"         │   │               │                   ├─ outerVisibility: false\n" +
-			"         │   │               │                   ├─ isLateral: false\n" +
-			"         │   │               │                   ├─ cacheable: true\n" +
-			"         │   │               │                   ├─ colSet: (109-119)\n" +
-			"         │   │               │                   ├─ tableId: 12\n" +
-			"         │   │               │                   └─ Filter\n" +
-			"         │   │               │                       ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
-			"         │   │               │                       └─ Project\n" +
-			"         │   │               │                           ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
-			"         │   │               │                           └─ Filter\n" +
-			"         │   │               │                               ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
-			"         │   │               │                               └─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
-			"         │   │               │                                   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
-			"         │   │               │                                   │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │               │                                   │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
-			"         │   │               │                                   │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │               │                                   │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
-			"         │   │               │                                   │   │   │   ├─ MergeJoin\n" +
-			"         │   │               │                                   │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
-			"         │   │               │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │               │                                   │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │               │                                   │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │               │                                   │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │               │                                   │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │               │                                   │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │               │                                   │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │               │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │               │                                   │   │   │   └─ HashLookup\n" +
-			"         │   │               │                                   │   │   │       ├─ left-key: (ism.PRUV2)\n" +
-			"         │   │               │                                   │   │   │       ├─ right-key: (nhmxw.id)\n" +
-			"         │   │               │                                   │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │               │                                   │   │   │           └─ Table\n" +
-			"         │   │               │                                   │   │   │               ├─ name: WGSDC\n" +
-			"         │   │               │                                   │   │   │               └─ columns: [id nohhr]\n" +
-			"         │   │               │                                   │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │               │                                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │               │                                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │               │                                   │   │           ├─ columns: [id tw55n zh72s]\n" +
-			"         │   │               │                                   │   │           └─ keys: nhmxw.NOHHR\n" +
-			"         │   │               │                                   │   └─ TableAlias(yqif4)\n" +
-			"         │   │               │                                   │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │                                   │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │                                   │           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │                                   │           └─ keys: ism.UJ6XY\n" +
-			"         │   │               │                                   └─ TableAlias(yvhjz)\n" +
-			"         │   │               │                                       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │               │                                           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │               │                                           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │               │                                           └─ keys: ism.FV24E\n" +
-			"         │   │               └─ Project\n" +
-			"         │   │                   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(QNI57, char) as QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
-			"         │   │                   └─ Project\n" +
-			"         │   │                       ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, NULL as QNI57, jchir.TDEIU]\n" +
-			"         │   │                       └─ SubqueryAlias\n" +
-			"         │   │                           ├─ name: jchir\n" +
-			"         │   │                           ├─ outerVisibility: false\n" +
-			"         │   │                           ├─ isLateral: false\n" +
-			"         │   │                           ├─ cacheable: true\n" +
-			"         │   │                           ├─ colSet: (121-131)\n" +
-			"         │   │                           ├─ tableId: 13\n" +
-			"         │   │                           └─ Filter\n" +
-			"         │   │                               ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
-			"         │   │                               └─ Project\n" +
-			"         │   │                                   ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
-			"         │   │                                   └─ Filter\n" +
-			"         │   │                                       ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
-			"         │   │                                       └─ LeftOuterLookupJoin\n" +
-			"         │   │                                           ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
-			"         │   │                                           ├─ LeftOuterLookupJoin\n" +
-			"         │   │                                           │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
-			"         │   │                                           │   ├─ LeftOuterLookupJoin\n" +
-			"         │   │                                           │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
-			"         │   │                                           │   │   ├─ LeftOuterHashJoin\n" +
-			"         │   │                                           │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
-			"         │   │                                           │   │   │   ├─ MergeJoin\n" +
-			"         │   │                                           │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
-			"         │   │                                           │   │   │   │   ├─ TableAlias(ism)\n" +
-			"         │   │                                           │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
-			"         │   │                                           │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
-			"         │   │                                           │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │                                           │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
-			"         │   │                                           │   │   │   │   └─ TableAlias(g3yxs)\n" +
-			"         │   │                                           │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
-			"         │   │                                           │   │   │   │           ├─ index: [YYBCX.id]\n" +
-			"         │   │                                           │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"         │   │                                           │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
-			"         │   │                                           │   │   │   └─ HashLookup\n" +
-			"         │   │                                           │   │   │       ├─ left-key: (ism.PRUV2)\n" +
-			"         │   │                                           │   │   │       ├─ right-key: (nhmxw.id)\n" +
-			"         │   │                                           │   │   │       └─ TableAlias(nhmxw)\n" +
-			"         │   │                                           │   │   │           └─ Table\n" +
-			"         │   │                                           │   │   │               ├─ name: WGSDC\n" +
-			"         │   │                                           │   │   │               └─ columns: [id nohhr]\n" +
-			"         │   │                                           │   │   └─ TableAlias(cpmfe)\n" +
-			"         │   │                                           │   │       └─ IndexedTableAccess(E2I7U)\n" +
-			"         │   │                                           │   │           ├─ index: [E2I7U.ZH72S]\n" +
-			"         │   │                                           │   │           ├─ columns: [id tw55n zh72s]\n" +
-			"         │   │                                           │   │           └─ keys: nhmxw.NOHHR\n" +
-			"         │   │                                           │   └─ TableAlias(yqif4)\n" +
-			"         │   │                                           │       └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                                           │           ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │                                           │           ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │                                           │           └─ keys: ism.UJ6XY\n" +
-			"         │   │                                           └─ TableAlias(yvhjz)\n" +
-			"         │   │                                               └─ IndexedTableAccess(NOXN3)\n" +
-			"         │   │                                                   ├─ index: [NOXN3.FFTBJ]\n" +
-			"         │   │                                                   ├─ columns: [id brqp2 fftbj]\n" +
-			"         │   │                                                   └─ keys: ism.FV24E\n" +
-			"         │   └─ TableAlias(sn)\n" +
-			"         │       └─ Table\n" +
-			"         │           └─ name: NOXN3\n" +
+			"     └─ HashJoin (estimated cost=125482.230 rows=156) (actual rows=0 loops=1)\n" +
+			"         ├─ (aac.id = mjr3d.M22QN)\n" +
+			"         ├─ TableAlias(aac)\n" +
+			"         │   └─ Table\n" +
+			"         │       └─ name: TPXBU\n" +
 			"         └─ HashLookup\n" +
-			"             ├─ left-key: (sn.BRQP2, mjr3d.M22QN)\n" +
-			"             ├─ right-key: (mf.LUEVY, mf.M22QN)\n" +
-			"             └─ CachedResults\n" +
-			"                 └─ SubqueryAlias\n" +
-			"                     ├─ name: mf\n" +
-			"                     ├─ outerVisibility: false\n" +
-			"                     ├─ isLateral: false\n" +
-			"                     ├─ cacheable: true\n" +
-			"                     └─ Project\n" +
-			"                         ├─ columns: [cla.FTQLQ, mf.LUEVY, mf.M22QN]\n" +
-			"                         └─ HashJoin\n" +
-			"                             ├─ (bs.id = mf.GXLUB)\n" +
-			"                             ├─ TableAlias(mf)\n" +
-			"                             │   └─ Table\n" +
-			"                             │       ├─ name: HGMQ6\n" +
-			"                             │       └─ columns: [gxlub luevy m22qn]\n" +
-			"                             └─ HashLookup\n" +
-			"                                 ├─ left-key: (mf.GXLUB)\n" +
-			"                                 ├─ right-key: (bs.id)\n" +
-			"                                 └─ MergeJoin\n" +
-			"                                     ├─ cmp: (cla.id = bs.IXUXU)\n" +
-			"                                     ├─ Filter\n" +
-			"                                     │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
-			"                                     │   └─ TableAlias(cla)\n" +
-			"                                     │       └─ IndexedTableAccess(YK2GW)\n" +
-			"                                     │           ├─ index: [YK2GW.id]\n" +
-			"                                     │           ├─ filters: [{[NULL, ∞)}]\n" +
-			"                                     │           └─ columns: [id ftqlq]\n" +
-			"                                     └─ TableAlias(bs)\n" +
-			"                                         └─ IndexedTableAccess(THNTS)\n" +
-			"                                             ├─ index: [THNTS.IXUXU]\n" +
-			"                                             ├─ filters: [{[NULL, ∞)}]\n" +
-			"                                             └─ columns: [id ixuxu]\n" +
+			"             ├─ left-key: (aac.id)\n" +
+			"             ├─ right-key: (mjr3d.M22QN)\n" +
+			"             └─ HashJoin (estimated cost=427.500 rows=125)\n" +
+			"                 ├─ ((mf.LUEVY = sn.BRQP2) AND (mf.M22QN = mjr3d.M22QN))\n" +
+			"                 ├─ LeftOuterJoin (estimated cost=1193112.000 rows=125)\n" +
+			"                 │   ├─ ((((((NOT(mjr3d.QNI57 IS NULL)) AND (sn.id = mjr3d.QNI57)) AND mjr3d.BJUF2 IS NULL) OR (((NOT(mjr3d.QNI57 IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
+			"                 │   │   ├─ left: sn.id\n" +
+			"                 │   │   └─ right: Subquery\n" +
+			"                 │   │       ├─ cacheable: false\n" +
+			"                 │   │       └─ Project\n" +
+			"                 │   │           ├─ columns: [jtehg.id]\n" +
+			"                 │   │           └─ Filter\n" +
+			"                 │   │               ├─ (jtehg.BRQP2 = mjr3d.BJUF2)\n" +
+			"                 │   │               └─ TableAlias(jtehg)\n" +
+			"                 │   │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │                       ├─ columns: [id brqp2]\n" +
+			"                 │   │                       └─ keys: mjr3d.BJUF2\n" +
+			"                 │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND mjr3d.BJUF2 IS NULL) AND InSubquery\n" +
+			"                 │   │   ├─ left: sn.id\n" +
+			"                 │   │   └─ right: Subquery\n" +
+			"                 │   │       ├─ cacheable: false\n" +
+			"                 │   │       └─ Project\n" +
+			"                 │   │           ├─ columns: [xmafz.id]\n" +
+			"                 │   │           └─ Filter\n" +
+			"                 │   │               ├─ (xmafz.BRQP2 = mjr3d.FJDP5)\n" +
+			"                 │   │               └─ TableAlias(xmafz)\n" +
+			"                 │   │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │                       ├─ columns: [id brqp2]\n" +
+			"                 │   │                       └─ keys: mjr3d.FJDP5\n" +
+			"                 │   │  )) OR (((NOT(mjr3d.TDEIU IS NULL)) AND (NOT(mjr3d.BJUF2 IS NULL))) AND InSubquery\n" +
+			"                 │   │   ├─ left: sn.id\n" +
+			"                 │   │   └─ right: Subquery\n" +
+			"                 │   │       ├─ cacheable: false\n" +
+			"                 │   │       └─ Project\n" +
+			"                 │   │           ├─ columns: [xmafz.id]\n" +
+			"                 │   │           └─ Filter\n" +
+			"                 │   │               ├─ (xmafz.BRQP2 = mjr3d.BJUF2)\n" +
+			"                 │   │               └─ TableAlias(xmafz)\n" +
+			"                 │   │                   └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                       ├─ index: [NOXN3.BRQP2]\n" +
+			"                 │   │                       ├─ columns: [id brqp2]\n" +
+			"                 │   │                       └─ keys: mjr3d.BJUF2\n" +
+			"                 │   │  ))\n" +
+			"                 │   ├─ CachedResults\n" +
+			"                 │   │   └─ SubqueryAlias\n" +
+			"                 │   │       ├─ name: mjr3d\n" +
+			"                 │   │       ├─ outerVisibility: false\n" +
+			"                 │   │       ├─ isLateral: false\n" +
+			"                 │   │       ├─ cacheable: true\n" +
+			"                 │   │       └─ Union distinct\n" +
+			"                 │   │           ├─ Project\n" +
+			"                 │   │           │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(jchir.QNI57, char) as QNI57, TDEIU as TDEIU]\n" +
+			"                 │   │           │   └─ Union distinct\n" +
+			"                 │   │           │       ├─ Project\n" +
+			"                 │   │           │       │   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
+			"                 │   │           │       │   └─ SubqueryAlias\n" +
+			"                 │   │           │       │       ├─ name: jchir\n" +
+			"                 │   │           │       │       ├─ outerVisibility: false\n" +
+			"                 │   │           │       │       ├─ isLateral: false\n" +
+			"                 │   │           │       │       ├─ cacheable: true\n" +
+			"                 │   │           │       │       ├─ colSet: (98-108)\n" +
+			"                 │   │           │       │       ├─ tableId: 11\n" +
+			"                 │   │           │       │       └─ Filter\n" +
+			"                 │   │           │       │           ├─ (((NOT(QNI57 IS NULL)) AND TDEIU IS NULL) OR (QNI57 IS NULL AND (NOT(TDEIU IS NULL))))\n" +
+			"                 │   │           │       │           └─ Project\n" +
+			"                 │   │           │       │               ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
+			"                 │   │           │       │               └─ Filter\n" +
+			"                 │   │           │       │                   ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
+			"                 │   │           │       │                   └─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
+			"                 │   │           │       │                       ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
+			"                 │   │           │       │                       │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │       │                       │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
+			"                 │   │           │       │                       │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │           │       │                       │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
+			"                 │   │           │       │                       │   │   │   ├─ MergeJoin\n" +
+			"                 │   │           │       │                       │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
+			"                 │   │           │       │                       │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │           │       │                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │           │       │                       │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │       │                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │           │       │                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │           │       │                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │           │       │                       │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │       │                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │           │       │                       │   │   │   └─ HashLookup\n" +
+			"                 │   │           │       │                       │   │   │       ├─ left-key: (ism.PRUV2)\n" +
+			"                 │   │           │       │                       │   │   │       ├─ right-key: (nhmxw.id)\n" +
+			"                 │   │           │       │                       │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │           │       │                       │   │   │           └─ Table\n" +
+			"                 │   │           │       │                       │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │           │       │                       │   │   │               └─ columns: [id nohhr]\n" +
+			"                 │   │           │       │                       │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │           │       │                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │           │       │                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │           │       │                       │   │           ├─ columns: [id tw55n zh72s]\n" +
+			"                 │   │           │       │                       │   │           └─ keys: nhmxw.NOHHR\n" +
+			"                 │   │           │       │                       │   └─ TableAlias(yqif4)\n" +
+			"                 │   │           │       │                       │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │       │                       │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │       │                       │           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │       │                       │           └─ keys: ism.UJ6XY\n" +
+			"                 │   │           │       │                       └─ TableAlias(yvhjz)\n" +
+			"                 │   │           │       │                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │       │                               ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │       │                               ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │       │                               └─ keys: ism.FV24E\n" +
+			"                 │   │           │       └─ Project\n" +
+			"                 │   │           │           ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, convert(TDEIU, char) as TDEIU]\n" +
+			"                 │   │           │           └─ Project\n" +
+			"                 │   │           │               ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, jchir.QNI57, NULL as TDEIU]\n" +
+			"                 │   │           │               └─ SubqueryAlias\n" +
+			"                 │   │           │                   ├─ name: jchir\n" +
+			"                 │   │           │                   ├─ outerVisibility: false\n" +
+			"                 │   │           │                   ├─ isLateral: false\n" +
+			"                 │   │           │                   ├─ cacheable: true\n" +
+			"                 │   │           │                   ├─ colSet: (109-119)\n" +
+			"                 │   │           │                   ├─ tableId: 12\n" +
+			"                 │   │           │                   └─ Filter\n" +
+			"                 │   │           │                       ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
+			"                 │   │           │                       └─ Project\n" +
+			"                 │   │           │                           ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
+			"                 │   │           │                           └─ Filter\n" +
+			"                 │   │           │                               ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
+			"                 │   │           │                               └─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
+			"                 │   │           │                                   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
+			"                 │   │           │                                   │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │           │                                   │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
+			"                 │   │           │                                   │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │           │                                   │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
+			"                 │   │           │                                   │   │   │   ├─ MergeJoin\n" +
+			"                 │   │           │                                   │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
+			"                 │   │           │                                   │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │           │                                   │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │           │                                   │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                                   │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │           │                                   │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │           │                                   │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │           │                                   │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │           │                                   │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │           │                                   │   │   │   └─ HashLookup\n" +
+			"                 │   │           │                                   │   │   │       ├─ left-key: (ism.PRUV2)\n" +
+			"                 │   │           │                                   │   │   │       ├─ right-key: (nhmxw.id)\n" +
+			"                 │   │           │                                   │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │           │                                   │   │   │           └─ Table\n" +
+			"                 │   │           │                                   │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │           │                                   │   │   │               └─ columns: [id nohhr]\n" +
+			"                 │   │           │                                   │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │           │                                   │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │           │                                   │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │           │                                   │   │           ├─ columns: [id tw55n zh72s]\n" +
+			"                 │   │           │                                   │   │           └─ keys: nhmxw.NOHHR\n" +
+			"                 │   │           │                                   │   └─ TableAlias(yqif4)\n" +
+			"                 │   │           │                                   │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │                                   │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │                                   │           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │                                   │           └─ keys: ism.UJ6XY\n" +
+			"                 │   │           │                                   └─ TableAlias(yvhjz)\n" +
+			"                 │   │           │                                       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │           │                                           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │           │                                           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │           │                                           └─ keys: ism.FV24E\n" +
+			"                 │   │           └─ Project\n" +
+			"                 │   │               ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, convert(QNI57, char) as QNI57, convert(jchir.TDEIU, char) as TDEIU]\n" +
+			"                 │   │               └─ Project\n" +
+			"                 │   │                   ├─ columns: [jchir.FJDP5, jchir.BJUF2, jchir.PSMU6, jchir.M22QN, jchir.GE5EL, jchir.F7A4Q, jchir.ESFVY, jchir.CC4AX, jchir.SL76B, NULL as QNI57, jchir.TDEIU]\n" +
+			"                 │   │                   └─ SubqueryAlias\n" +
+			"                 │   │                       ├─ name: jchir\n" +
+			"                 │   │                       ├─ outerVisibility: false\n" +
+			"                 │   │                       ├─ isLateral: false\n" +
+			"                 │   │                       ├─ cacheable: true\n" +
+			"                 │   │                       ├─ colSet: (121-131)\n" +
+			"                 │   │                       ├─ tableId: 13\n" +
+			"                 │   │                       └─ Filter\n" +
+			"                 │   │                           ├─ ((NOT(QNI57 IS NULL)) AND (NOT(TDEIU IS NULL)))\n" +
+			"                 │   │                           └─ Project\n" +
+			"                 │   │                               ├─ columns: [ism.FV24E as FJDP5, cpmfe.id as BJUF2, cpmfe.TW55N as PSMU6, ism.M22QN as M22QN, g3yxs.GE5EL, g3yxs.F7A4Q, g3yxs.ESFVY, CASE  WHEN (g3yxs.SL76B IN ('FO422', 'SJ53H')) THEN 0 WHEN (g3yxs.SL76B IN ('DCV4Z', 'UOSM4', 'FUGIP', 'H5MCC', 'YKEQE', 'D3AKL')) THEN 1 WHEN (g3yxs.SL76B IN ('QJEXM', 'J6S7P', 'VT7FI')) THEN 2 WHEN (g3yxs.SL76B IN ('Y62X7')) THEN 3 END as CC4AX, g3yxs.SL76B as SL76B, yqif4.id as QNI57, yvhjz.id as TDEIU]\n" +
+			"                 │   │                               └─ Filter\n" +
+			"                 │   │                                   ├─ ((NOT(yqif4.id IS NULL)) OR (NOT(yvhjz.id IS NULL)))\n" +
+			"                 │   │                                   └─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       ├─ (yvhjz.BRQP2 = ism.UJ6XY)\n" +
+			"                 │   │                                       ├─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       │   ├─ (yqif4.BRQP2 = ism.FV24E)\n" +
+			"                 │   │                                       │   ├─ LeftOuterLookupJoin\n" +
+			"                 │   │                                       │   │   ├─ (NOT((cpmfe.id = ism.FV24E)))\n" +
+			"                 │   │                                       │   │   ├─ LeftOuterHashJoin\n" +
+			"                 │   │                                       │   │   │   ├─ (nhmxw.id = ism.PRUV2)\n" +
+			"                 │   │                                       │   │   │   ├─ MergeJoin\n" +
+			"                 │   │                                       │   │   │   │   ├─ cmp: (ism.NZ4MQ = g3yxs.id)\n" +
+			"                 │   │                                       │   │   │   │   ├─ TableAlias(ism)\n" +
+			"                 │   │                                       │   │   │   │   │   └─ IndexedTableAccess(HDDVB)\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ index: [HDDVB.NZ4MQ]\n" +
+			"                 │   │                                       │   │   │   │   │       ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │                                       │   │   │   │   │       └─ columns: [fv24e uj6xy m22qn nz4mq pruv2]\n" +
+			"                 │   │                                       │   │   │   │   └─ TableAlias(g3yxs)\n" +
+			"                 │   │                                       │   │   │   │       └─ IndexedTableAccess(YYBCX)\n" +
+			"                 │   │                                       │   │   │   │           ├─ index: [YYBCX.id]\n" +
+			"                 │   │                                       │   │   │   │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                 │   │                                       │   │   │   │           └─ columns: [id esfvy sl76b ge5el f7a4q]\n" +
+			"                 │   │                                       │   │   │   └─ HashLookup\n" +
+			"                 │   │                                       │   │   │       ├─ left-key: (ism.PRUV2)\n" +
+			"                 │   │                                       │   │   │       ├─ right-key: (nhmxw.id)\n" +
+			"                 │   │                                       │   │   │       └─ TableAlias(nhmxw)\n" +
+			"                 │   │                                       │   │   │           └─ Table\n" +
+			"                 │   │                                       │   │   │               ├─ name: WGSDC\n" +
+			"                 │   │                                       │   │   │               └─ columns: [id nohhr]\n" +
+			"                 │   │                                       │   │   └─ TableAlias(cpmfe)\n" +
+			"                 │   │                                       │   │       └─ IndexedTableAccess(E2I7U)\n" +
+			"                 │   │                                       │   │           ├─ index: [E2I7U.ZH72S]\n" +
+			"                 │   │                                       │   │           ├─ columns: [id tw55n zh72s]\n" +
+			"                 │   │                                       │   │           └─ keys: nhmxw.NOHHR\n" +
+			"                 │   │                                       │   └─ TableAlias(yqif4)\n" +
+			"                 │   │                                       │       └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                                       │           ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │                                       │           ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │                                       │           └─ keys: ism.UJ6XY\n" +
+			"                 │   │                                       └─ TableAlias(yvhjz)\n" +
+			"                 │   │                                           └─ IndexedTableAccess(NOXN3)\n" +
+			"                 │   │                                               ├─ index: [NOXN3.FFTBJ]\n" +
+			"                 │   │                                               ├─ columns: [id brqp2 fftbj]\n" +
+			"                 │   │                                               └─ keys: ism.FV24E\n" +
+			"                 │   └─ TableAlias(sn)\n" +
+			"                 │       └─ Table\n" +
+			"                 │           └─ name: NOXN3\n" +
+			"                 └─ HashLookup\n" +
+			"                     ├─ left-key: (sn.BRQP2, mjr3d.M22QN)\n" +
+			"                     ├─ right-key: (mf.LUEVY, mf.M22QN)\n" +
+			"                     └─ CachedResults\n" +
+			"                         └─ SubqueryAlias\n" +
+			"                             ├─ name: mf\n" +
+			"                             ├─ outerVisibility: false\n" +
+			"                             ├─ isLateral: false\n" +
+			"                             ├─ cacheable: true\n" +
+			"                             └─ Project\n" +
+			"                                 ├─ columns: [cla.FTQLQ, mf.LUEVY, mf.M22QN]\n" +
+			"                                 └─ HashJoin\n" +
+			"                                     ├─ (bs.id = mf.GXLUB)\n" +
+			"                                     ├─ TableAlias(mf)\n" +
+			"                                     │   └─ Table\n" +
+			"                                     │       ├─ name: HGMQ6\n" +
+			"                                     │       └─ columns: [gxlub luevy m22qn]\n" +
+			"                                     └─ HashLookup\n" +
+			"                                         ├─ left-key: (mf.GXLUB)\n" +
+			"                                         ├─ right-key: (bs.id)\n" +
+			"                                         └─ MergeJoin\n" +
+			"                                             ├─ cmp: (cla.id = bs.IXUXU)\n" +
+			"                                             ├─ Filter\n" +
+			"                                             │   ├─ (cla.FTQLQ HASH IN ('SQ1'))\n" +
+			"                                             │   └─ TableAlias(cla)\n" +
+			"                                             │       └─ IndexedTableAccess(YK2GW)\n" +
+			"                                             │           ├─ index: [YK2GW.id]\n" +
+			"                                             │           ├─ filters: [{[NULL, ∞)}]\n" +
+			"                                             │           └─ columns: [id ftqlq]\n" +
+			"                                             └─ TableAlias(bs)\n" +
+			"                                                 └─ IndexedTableAccess(THNTS)\n" +
+			"                                                     ├─ index: [THNTS.IXUXU]\n" +
+			"                                                     ├─ filters: [{[NULL, ∞)}]\n" +
+			"                                                     └─ columns: [id ixuxu]\n" +
 			"",
 	},
 	{

--- a/enginetest/queries/join_queries.go
+++ b/enginetest/queries/join_queries.go
@@ -746,6 +746,10 @@ on w = 0;`,
 		Expected: []sql.Row{{"third", 1, "a", 4}, {"third", 1, "b", 2}, {"third", 1, "c", 0}},
 	},
 	{
+		Query:    "select * from othertable join foo.othertable where othertable.s2 = 'third'",
+		Expected: []sql.Row{{"third", 1, "a", 4}, {"third", 1, "b", 2}, {"third", 1, "c", 0}},
+	},
+	{
 		Query:    "select * from othertable join foo.othertable on mydb.othertable.s2 = 'third'",
 		Expected: []sql.Row{{"third", 1, "a", 4}, {"third", 1, "b", 2}, {"third", 1, "c", 0}},
 	},

--- a/sql/analyzer/filters.go
+++ b/sql/analyzer/filters.go
@@ -15,11 +15,12 @@
 package analyzer
 
 import (
+	"reflect"
+
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
-	"reflect"
 )
 
 type filtersByTable map[sql.TableId][]sql.Expression

--- a/sql/analyzer/filters.go
+++ b/sql/analyzer/filters.go
@@ -94,6 +94,8 @@ func exprToTableFilters(ctx *sql.Context, expr sql.Expression, scope *plan.Scope
 		}
 		sql.Inspect(ctx, expr, findGetFields)
 
+		// A TableId equaling 0 means it was never assigned. We don't want to match these filters because there may be
+		// multiple tables with unassigned TableIds.
 		if lastTable != 0 && len(seenTables) == 1 && !hasSubquery {
 			filters[lastTable] = append(filters[lastTable], expr)
 		}

--- a/sql/analyzer/filters.go
+++ b/sql/analyzer/filters.go
@@ -15,16 +15,14 @@
 package analyzer
 
 import (
-	"reflect"
-	"strings"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/plan"
 	"github.com/dolthub/go-mysql-server/sql/transform"
+	"reflect"
 )
 
-type filtersByTable map[string][]sql.Expression
+type filtersByTable map[sql.TableId][]sql.Expression
 
 func newFiltersByTable() filtersByTable {
 	return make(filtersByTable)
@@ -62,8 +60,8 @@ func getFiltersByTable(ctx *sql.Context, n sql.Node, scope *plan.Scope, projecte
 func exprToTableFilters(ctx *sql.Context, expr sql.Expression, scope *plan.Scope, projectionExpressions map[sql.ColumnId]sql.Expression) filtersByTable {
 	filters := newFiltersByTable()
 	for _, expr := range expression.SplitConjunction(ctx, expr) {
-		var seenTables = make(map[string]bool)
-		var lastTable string
+		var seenTables = make(map[sql.TableId]bool)
+		var lastTable sql.TableId
 		hasSubquery := false
 		var findGetFields func(*sql.Context, sql.Expression) bool
 		findGetFields = func(ctx *sql.Context, e sql.Expression) bool {
@@ -81,7 +79,7 @@ func exprToTableFilters(ctx *sql.Context, expr sql.Expression, scope *plan.Scope
 					sql.Inspect(ctx, projectionExpression, findGetFields)
 					return true
 				}
-				table := f.Table()
+				table := f.TableId()
 				if !seenTables[table] {
 					seenTables[table] = true
 					lastTable = table
@@ -95,7 +93,7 @@ func exprToTableFilters(ctx *sql.Context, expr sql.Expression, scope *plan.Scope
 		}
 		sql.Inspect(ctx, expr, findGetFields)
 
-		if len(seenTables) == 1 && !hasSubquery {
+		if lastTable != 0 && len(seenTables) == 1 && !hasSubquery {
 			filters[lastTable] = append(filters[lastTable], expr)
 		}
 	}
@@ -129,8 +127,8 @@ func newFilterSet(
 
 // availableFiltersForTable returns the filters that are still available for the table given (not previously marked
 // handled)
-func (fs *filterSet) availableFiltersForTable(ctx *sql.Context, table string) []sql.Expression {
-	filters, ok := fs.filtersByTable[strings.ToLower(table)]
+func (fs *filterSet) availableFiltersForTable(ctx *sql.Context, table sql.TableId) []sql.Expression {
+	filters, ok := fs.filtersByTable[table]
 	if !ok {
 		return nil
 	}

--- a/sql/analyzer/filters_test.go
+++ b/sql/analyzer/filters_test.go
@@ -28,19 +28,19 @@ import (
 
 func TestFiltersMerge(t *testing.T) {
 	f1 := filtersByTable{
-		"1": []sql.Expression{
+		1: []sql.Expression{
 			expression.NewLiteral("1", types.LongText),
 		},
-		"2": []sql.Expression{
+		2: []sql.Expression{
 			expression.NewLiteral("2", types.LongText),
 		},
 	}
 
 	f2 := filtersByTable{
-		"2": []sql.Expression{
+		2: []sql.Expression{
 			expression.NewLiteral("2.2", types.LongText),
 		},
-		"3": []sql.Expression{
+		3: []sql.Expression{
 			expression.NewLiteral("3", types.LongText),
 		},
 	}
@@ -49,14 +49,14 @@ func TestFiltersMerge(t *testing.T) {
 
 	require.Equal(t,
 		filtersByTable{
-			"1": []sql.Expression{
+			1: []sql.Expression{
 				expression.NewLiteral("1", types.LongText),
 			},
-			"2": []sql.Expression{
+			2: []sql.Expression{
 				expression.NewLiteral("2", types.LongText),
 				expression.NewLiteral("2.2", types.LongText),
 			},
-			"3": []sql.Expression{
+			3: []sql.Expression{
 				expression.NewLiteral("3", types.LongText),
 			},
 		},
@@ -129,54 +129,54 @@ func TestExprToTableFilters(t *testing.T) {
 			expression.NewAnd(
 				expression.NewAnd(
 					expression.NewEquals(
-						expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+						expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 						expression.NewLiteral(3.14, types.Float64),
 					),
 					expression.NewGreaterThan(
-						expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+						expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 						expression.NewLiteral(3., types.Float64),
 					),
 				),
 				expression.NewIsNull(
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable2", "i2", false),
+					expression.NewGetFieldWithTable(0, 2, types.Int64, "db", "mytable2", "i2", false),
 				),
 			),
 			expression.NewOr(
 				expression.NewEquals(
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+					expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 					expression.NewLiteral(3.14, types.Float64),
 				),
 				expression.NewGreaterThan(
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+					expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 					expression.NewLiteral(3., types.Float64),
 				),
 			),
 		)
 
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
+			1: []sql.Expression{
 				expression.NewEquals(
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+					expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 					expression.NewLiteral(3.14, types.Float64),
 				),
 				expression.NewGreaterThan(
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+					expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 					expression.NewLiteral(3., types.Float64),
 				),
 				expression.NewOr(
 					expression.NewEquals(
-						expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+						expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 						expression.NewLiteral(3.14, types.Float64),
 					),
 					expression.NewGreaterThan(
-						expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+						expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 						expression.NewLiteral(3., types.Float64),
 					),
 				),
 			},
-			"mytable2": []sql.Expression{
+			2: []sql.Expression{
 				expression.NewIsNull(
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable2", "i2", false),
+					expression.NewGetFieldWithTable(0, 2, types.Int64, "db", "mytable2", "i2", false),
 				),
 			},
 		}
@@ -189,11 +189,11 @@ func TestExprToTableFilters(t *testing.T) {
 
 		filters := exprToTableFilters(ctx, expression.NewAnd(
 			lit(0),
-			expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+			expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 		), nil, nil)
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
-				expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+			1: []sql.Expression{
+				expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 			},
 		}
 		assert.Equal(t, expected, filters)
@@ -202,11 +202,11 @@ func TestExprToTableFilters(t *testing.T) {
 	t.Run("NULL literal", func(t *testing.T) {
 		filters := exprToTableFilters(ctx, expression.NewAnd(
 			expression.NewLiteral(nil, types.Null),
-			expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+			expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 		), nil, nil)
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
-				expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+			1: []sql.Expression{
+				expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 			},
 		}
 		assert.Equal(t, expected, filters)
@@ -215,11 +215,11 @@ func TestExprToTableFilters(t *testing.T) {
 	t.Run("random expression", func(t *testing.T) {
 		filters := exprToTableFilters(ctx, expression.NewAnd(
 			expression.NewEquals(lit(1), mustExpr(function.NewRand(ctx))),
-			expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+			expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 		), nil, nil)
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
-				expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+			1: []sql.Expression{
+				expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 			},
 		}
 		assert.Equal(t, expected, filters)
@@ -228,13 +228,13 @@ func TestExprToTableFilters(t *testing.T) {
 	t.Run("or expression", func(t *testing.T) {
 		filters := exprToTableFilters(ctx, expression.NewOr(
 			expression.NewLiteral(nil, types.Null),
-			expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+			expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 		), nil, nil)
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
+			1: []sql.Expression{
 				expression.NewOr(
 					expression.NewLiteral(nil, types.Null),
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
+					expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
 				),
 			},
 		}
@@ -244,18 +244,18 @@ func TestExprToTableFilters(t *testing.T) {
 	t.Run("comparing multiple tables", func(t *testing.T) {
 		filters := exprToTableFilters(ctx, expression.NewAnd(
 			eq(
-				expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "a", false),
+				expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "a", false),
 				lit(1),
 			),
 			eq(
-				expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "f", false),
-				expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable2", "i", false),
+				expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "f", false),
+				expression.NewGetFieldWithTable(0, 2, types.Int64, "db", "mytable2", "i", false),
 			),
 		), nil, nil)
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
+			1: []sql.Expression{
 				eq(
-					expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "a", false),
+					expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "a", false),
 					lit(1),
 				),
 			},
@@ -265,15 +265,15 @@ func TestExprToTableFilters(t *testing.T) {
 
 	t.Run("project expressions", func(t *testing.T) {
 		projections := map[sql.ColumnId]sql.Expression{
-			1: expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "a", false),
+			1: expression.NewGetFieldWithTable(0, 1, types.Int64, "db", "mytable", "a", false),
 		}
 		filters := exprToTableFilters(
 			ctx,
-			expression.NewGetFieldWithTable(1, 0, types.Int64, "db", "", "a", false),
+			expression.NewGetFieldWithTable(1, 2, types.Int64, "db", "", "a", false),
 			nil, projections)
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
-				expression.NewGetFieldWithTable(1, 0, types.Int64, "db", "", "a", false),
+			1: []sql.Expression{
+				expression.NewGetFieldWithTable(1, 2, types.Int64, "db", "", "a", false),
 			},
 		}
 		assert.Equal(t, expected, filters)
@@ -281,16 +281,16 @@ func TestExprToTableFilters(t *testing.T) {
 
 	t.Run("nested project expressions", func(t *testing.T) {
 		projections := map[sql.ColumnId]sql.Expression{
-			1: expression.NewGetFieldWithTable(2, 0, types.Int64, "db", "", "a", false),
-			2: expression.NewGetFieldWithTable(0, 0, types.Int64, "db", "mytable", "a", false),
+			1: expression.NewGetFieldWithTable(2, 1, types.Int64, "db", "", "a", false),
+			2: expression.NewGetFieldWithTable(0, 2, types.Int64, "db", "mytable", "a", false),
 		}
 		filters := exprToTableFilters(
 			ctx,
-			expression.NewGetFieldWithTable(1, 0, types.Int64, "db", "", "a", false),
+			expression.NewGetFieldWithTable(1, 1, types.Int64, "db", "", "a", false),
 			nil, projections)
 		expected := filtersByTable{
-			"mytable": []sql.Expression{
-				expression.NewGetFieldWithTable(1, 0, types.Int64, "db", "", "a", false),
+			2: []sql.Expression{
+				expression.NewGetFieldWithTable(1, 1, types.Int64, "db", "", "a", false),
 			},
 		}
 		assert.Equal(t, expected, filters)

--- a/sql/analyzer/pushdown.go
+++ b/sql/analyzer/pushdown.go
@@ -49,8 +49,8 @@ func pushFilters(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Scope, s
 					return plan.NewFilter(ctx, expression.JoinAnd(node.Expression, f.Expression), f.Child), transform.NewTree, nil
 				}
 				return node, transform.SameTree, nil
-			case *plan.TableAlias, *plan.ResolvedTable, *plan.ValueDerivedTable, sql.TableFunction:
-				table, same, err := pushdownFiltersToAboveTable(ctx, a, node.(sql.NameableNode), scope, filters)
+			case *plan.TableAlias, *plan.ResolvedTable, *plan.ValueDerivedTable:
+				table, same, err := pushdownFiltersToAboveTable(ctx, a, node.(plan.TableIdNode), filters)
 				if err != nil {
 					return nil, transform.SameTree, err
 				}
@@ -220,8 +220,7 @@ func transformPushdownSubqueryAliasFilters(ctx *sql.Context, a *Analyzer, n sql.
 func pushdownFiltersToAboveTable(
 	ctx *sql.Context,
 	a *Analyzer,
-	tableNode sql.NameableNode,
-	scope *plan.Scope,
+	tableNode plan.TableIdNode,
 	filters *filterSet,
 ) (sql.Node, transform.TreeIdentity, error) {
 	table := getTable(ctx, tableNode)
@@ -231,7 +230,7 @@ func pushdownFiltersToAboveTable(
 
 	// Move any remaining filters for the table directly above the table itself
 	var pushedDownFilterExpression sql.Expression
-	if tableFilters := filters.availableFiltersForTable(ctx, tableNode.Name()); len(tableFilters) > 0 {
+	if tableFilters := filters.availableFiltersForTable(ctx, tableNode.Id()); len(tableFilters) > 0 {
 		filters.markFiltersHandled(tableFilters...)
 		for i, filter := range tableFilters {
 			// If a filter contains a reference to a projection alias, pushing the filter will move it below the
@@ -277,7 +276,7 @@ func pushdownFiltersUnderSubqueryAlias(ctx *sql.Context, a *Analyzer, sa *plan.S
 	if sa.ScopeMapping == nil {
 		return sa, transform.SameTree, nil
 	}
-	handled := filters.availableFiltersForTable(ctx, sa.Name())
+	handled := filters.availableFiltersForTable(ctx, sa.Id())
 	if len(handled) == 0 {
 		return sa, transform.SameTree, nil
 	}

--- a/sql/analyzer/replace_subqueries.go
+++ b/sql/analyzer/replace_subqueries.go
@@ -39,13 +39,13 @@ func replaceSubqueries(ctx *sql.Context, a *Analyzer, n sql.Node, scope *plan.Sc
 			case *plan.Project:
 				if len(sqa.ColumnNames) == 0 {
 					if table, ok := child.Child.(*plan.ResolvedTable); ok && child.Schema(ctx).Equals(table.Schema(ctx)) {
-						return plan.NewTableAlias(sqa.Name(), table), transform.NewTree, nil
+						return plan.NewTableAlias(sqa.Name(), table).WithId(sqa.Id()), transform.NewTree, nil
 
 					}
 				}
 			case *plan.TableAlias:
 				if len(sqa.ColumnNames) == 0 {
-					return plan.NewTableAlias(sqa.Name(), getResolvedTable(ctx, child)), transform.NewTree, nil
+					return plan.NewTableAlias(sqa.Name(), getResolvedTable(ctx, child)).WithId(sqa.Id()), transform.NewTree, nil
 				}
 			case *plan.SubqueryAlias:
 				if sqa.Columns().Len() == child.Columns().Len() {

--- a/sql/plan/tablealias.go
+++ b/sql/plan/tablealias.go
@@ -31,6 +31,7 @@ type TableAlias struct {
 var _ sql.RenameableNode = (*TableAlias)(nil)
 var _ sql.CommentedNode = (*TableAlias)(nil)
 var _ sql.CollationCoercible = (*TableAlias)(nil)
+var _ TableIdNode = (*TableAlias)(nil)
 
 // NewTableAlias returns a new Table alias node.
 func NewTableAlias(name string, node sql.Node) *TableAlias {

--- a/sql/planbuilder/from.go
+++ b/sql/planbuilder/from.go
@@ -802,9 +802,8 @@ func (b *Builder) buildResolvedTable(inScope *scope, db, schema, name string, as
 
 func resolvedViewScope(ctx *sql.Context, outScope *scope, view sql.Node, db string, name string) (*scope, bool) {
 	outScope.node = view
-	tabId := outScope.addTable(strings.ToLower(view.Schema(ctx)[0].Name))
+	tabId := outScope.addTable(name)
 	if tin, ok := view.(plan.TableIdNode); ok {
-		// TODO should *sql.View implement TableIdNode?
 		outScope.node = tin.WithId(tabId)
 	}
 	return outScope, true

--- a/sql/planbuilder/scope.go
+++ b/sql/planbuilder/scope.go
@@ -649,10 +649,8 @@ func (s *scope) handleErr(err error) {
 	panic(parseErr{err})
 }
 
-// tableId and columnId are temporary ways to track expression
-// and name uniqueness.
+// columnId is a temporary way to track expression and name uniqueness.
 // todo: the plan format should track these
-type tableId uint16
 type columnId uint16
 
 type scopeColumn struct {


### PR DESCRIPTION
Split off from #3591

Using table names prevented us from being able to distinguish between tables from different databases with the same unqualified name.

This PR also updates places where we were not using the correct `TableId`
- when condensing a `SubqueryAlias` into a `TableAlias`, the new `TableAlias` should have the same `TableId` as the `SubqueryAlias`
- A view should be getting its `TableId` from the scope via its name, not the name of its first column