### PR TITLE
pushdown inequalities to merge joins

### DIFF
--- a/enginetest/queries/query_plan_script_tests.go
+++ b/enginetest/queries/query_plan_script_tests.go
@@ -40,8 +40,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2},
 					sql.Row{3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -69,8 +68,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2},
 					sql.Row{3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -98,8 +96,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3},
 					sql.Row{2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -129,8 +126,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3},
 					sql.Row{2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -159,8 +155,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				Expected: []sql.Row{
 					sql.Row{3},
 				},
-				ExpectedPlan: "" +
-					"Project\n" +
+				ExpectedPlan: "Project\n" +
 					" ├─ columns: [t1.i:0!null]\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
@@ -197,8 +192,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -226,8 +220,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -257,8 +250,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -286,8 +278,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -317,8 +308,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -346,8 +336,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -405,8 +394,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -436,8 +424,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
+				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -466,8 +453,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null DESC nullsFirst)\n" +
+				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null DESC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -496,8 +482,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
+				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -526,8 +511,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst, t4.y:3!null ASC nullsFirst)\n" +
+				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst, t4.y:3!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -556,8 +540,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"Sort(t3.j:1!null ASC nullsFirst)\n" +
+				ExpectedPlan: "Sort(t3.j:1!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -586,8 +569,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"Sort(t4.y:3!null ASC nullsFirst)\n" +
+				ExpectedPlan: "Sort(t4.y:3!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -616,8 +598,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null DESC nullsFirst)\n" +
+				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null DESC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -653,8 +634,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3},
 					sql.Row{3, 4},
 				},
-				ExpectedPlan: "" +
-					"CrossJoin\n" +
+				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
 					" │   ├─ static: [{[NULL, ∞)}]\n" +
@@ -682,8 +662,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 4},
 					sql.Row{3, 4},
 				},
-				ExpectedPlan: "" +
-					"Project\n" +
+				ExpectedPlan: "Project\n" +
 					" ├─ columns: [t1.i:1!null, t2.j:0!null]\n" +
 					" └─ CrossJoin\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
@@ -713,8 +692,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{1, 3},
 					sql.Row{1, 4},
 				},
-				ExpectedPlan: "" +
-					"CrossJoin\n" +
+				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
 					" │   ├─ static: [{[NULL, ∞)}]\n" +
@@ -735,8 +713,7 @@ var QueryPlanScriptTests = []ScriptTest{
 				Expected: []sql.Row{
 					sql.Row{2, 3},
 				},
-				ExpectedPlan: "" +
-					"CrossJoin\n" +
+				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
 					" │   ├─ static: [{(1, 3)}]\n" +
@@ -761,8 +738,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{1, 1, 3, 3},
 					sql.Row{1, 2, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"CrossJoin\n" +
+				ExpectedPlan: "CrossJoin\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
 					" │   ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
@@ -787,8 +763,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 3, 3},
 					sql.Row{1, 2, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"CrossJoin\n" +
+				ExpectedPlan: "CrossJoin\n" +
 					" ├─ Filter\n" +
 					" │   ├─ Eq\n" +
 					" │   │   ├─ t3.j:1!null\n" +
@@ -822,8 +797,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 4},
 					sql.Row{3, 4},
 				},
-				ExpectedPlan: "" +
-					"InnerJoin\n" +
+				ExpectedPlan: "InnerJoin\n" +
 					" ├─ LessThan\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -851,8 +825,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 3},
 					sql.Row{1, 2},
 				},
-				ExpectedPlan: "" +
-					"Project\n" +
+				ExpectedPlan: "Project\n" +
 					" ├─ columns: [t1.i:1!null, t2.j:0!null]\n" +
 					" └─ InnerJoin\n" +
 					"     ├─ LessThan\n" +
@@ -887,8 +860,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 2, 2},
 					sql.Row{3, 3, 4, 4},
 				},
-				ExpectedPlan: "" +
-					"InnerJoin\n" +
+				ExpectedPlan: "InnerJoin\n" +
 					" ├─ NOT\n" +
 					" │   └─ Eq\n" +
 					" │       ├─ t3.i:0!null\n" +
@@ -910,22 +882,20 @@ var QueryPlanScriptTests = []ScriptTest{
 		},
 	},
 	{
-		// TODO: We should be able to drop the Filter node over IndexedTableAccess for many of these plans
-		Name: "merge join properly pushes down static filters",
+		Name: "merge join properly pushes down static filters (TODO: DROP FILTER NODES ABOVE INDEXEDTABLEACCESS)",
 		SetUpScript: []string{
-			"create table t1 (i int primary key, j int, k int);",
-			"create table t2 (x int primary key, y int, z int);",
-			"insert into t1 values (1, 1, 1), (2, 2, 2), (3, 3, 3);",
-			"insert into t2 values (1, 1, 1), (2, 2, 2), (3, 3, 3);",
+			`create table t1 (i int primary key, j int, k int);`,
+			`create table t2 (x int primary key, y int, z int);`,
+			`insert into t1 values (1, 1, 1), (2, 2, 2), (3, 3, 3);`,
+			`insert into t2 values (1, 1, 1), (2, 2, 2), (3, 3, 3);`,
 		},
 		Assertions: []ScriptTestAssertion{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i = 2;`,
 				Expected: []sql.Row{
-					{2, 2, 2, 2, 2, 2},
+					sql.Row{2, 2, 2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"Project\n" +
+				ExpectedPlan: "Project\n" +
 					" ├─ columns: [t1.i:3!null, t1.j:4, t1.k:5, t2.x:0!null, t2.y:1, t2.z:2]\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
@@ -956,10 +926,9 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x = 2;`,
 				Expected: []sql.Row{
-					{2, 2, 2, 2, 2, 2},
+					sql.Row{2, 2, 2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -988,11 +957,10 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i > 1;`,
 				Expected: []sql.Row{
-					{2, 2, 2, 2, 2, 2},
-					{3, 3, 3, 3, 3, 3},
+					sql.Row{2, 2, 2, 2, 2, 2},
+					sql.Row{3, 3, 3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -1021,11 +989,10 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x > 1;`,
 				Expected: []sql.Row{
-					{2, 2, 2, 2, 2, 2},
-					{3, 3, 3, 3, 3, 3},
+					sql.Row{2, 2, 2, 2, 2, 2},
+					sql.Row{3, 3, 3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -1054,8 +1021,8 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i < 3;`,
 				Expected: []sql.Row{
-					{1, 1, 1, 1, 1, 1},
-					{2, 2, 2, 2, 2, 2},
+					sql.Row{1, 1, 1, 1, 1, 1},
+					sql.Row{2, 2, 2, 2, 2, 2},
 				},
 				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
@@ -1086,8 +1053,8 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x < 3;`,
 				Expected: []sql.Row{
-					{1, 1, 1, 1, 1, 1},
-					{2, 2, 2, 2, 2, 2},
+					sql.Row{1, 1, 1, 1, 1, 1},
+					sql.Row{2, 2, 2, 2, 2, 2},
 				},
 				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
@@ -1118,11 +1085,10 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i >= 2;`,
 				Expected: []sql.Row{
-					{2, 2, 2, 2, 2, 2},
-					{3, 3, 3, 3, 3, 3},
+					sql.Row{2, 2, 2, 2, 2, 2},
+					sql.Row{3, 3, 3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -1151,11 +1117,10 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x >= 2;`,
 				Expected: []sql.Row{
-					{2, 2, 2, 2, 2, 2},
-					{3, 3, 3, 3, 3, 3},
+					sql.Row{2, 2, 2, 2, 2, 2},
+					sql.Row{3, 3, 3, 3, 3, 3},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -1184,11 +1149,10 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i <= 2;`,
 				Expected: []sql.Row{
-					{1, 1, 1, 1, 1, 1},
-					{2, 2, 2, 2, 2, 2},
+					sql.Row{1, 1, 1, 1, 1, 1},
+					sql.Row{2, 2, 2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -1217,11 +1181,10 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x <= 2;`,
 				Expected: []sql.Row{
-					{1, 1, 1, 1, 1, 1},
-					{2, 2, 2, 2, 2, 2},
+					sql.Row{1, 1, 1, 1, 1, 1},
+					sql.Row{2, 2, 2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -1250,10 +1213,9 @@ var QueryPlanScriptTests = []ScriptTest{
 			{
 				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i = 2 or x = 2;`,
 				Expected: []sql.Row{
-					{2, 2, 2, 2, 2, 2},
+					sql.Row{2, 2, 2, 2, 2, 2},
 				},
-				ExpectedPlan: "" +
-					"MergeJoin\n" +
+				ExpectedPlan: "MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.x:3!null\n" +
@@ -1276,7 +1238,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					"     ├─ index: [t2.x]\n" +
 					"     ├─ static: [{[NULL, ∞)}]\n" +
 					"     ├─ colSet: (4-6)\n" +
-					"     ├─ tableId: 2\n     └─ Table\n" +
+					"     ├─ tableId: 2\n" +
+					"     └─ Table\n" +
 					"         ├─ name: t2\n" +
 					"         └─ columns: [x y z]\n" +
 					"",

--- a/enginetest/queries/query_plan_script_tests.go
+++ b/enginetest/queries/query_plan_script_tests.go
@@ -40,7 +40,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2},
 					sql.Row{3, 3},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -68,7 +69,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2},
 					sql.Row{3, 3},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -96,7 +98,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3},
 					sql.Row{2, 2},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -126,7 +129,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3},
 					sql.Row{2, 2},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -155,7 +159,8 @@ var QueryPlanScriptTests = []ScriptTest{
 				Expected: []sql.Row{
 					sql.Row{3},
 				},
-				ExpectedPlan: "Project\n" +
+				ExpectedPlan: "" +
+					"Project\n" +
 					" ├─ columns: [t1.i:0!null]\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
@@ -177,7 +182,7 @@ var QueryPlanScriptTests = []ScriptTest{
 					"             │   └─ 2 (int)\n" +
 					"             └─ IndexedTableAccess(t2)\n" +
 					"                 ├─ index: [t2.j]\n" +
-					"                 ├─ static: [{[NULL, ∞)}]\n" +
+					"                 ├─ static: [{(2, ∞)}]\n" +
 					"                 ├─ reverse: true\n" +
 					"                 ├─ colSet: (2)\n" +
 					"                 ├─ tableId: 2\n" +
@@ -192,7 +197,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -220,7 +226,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -250,7 +257,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -278,7 +286,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -308,7 +317,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -336,7 +346,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -394,7 +405,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 3, 3},
 					sql.Row{2, 2, 2, 2},
 				},
-				ExpectedPlan: "MergeJoin\n" +
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
 					" ├─ cmp: Eq\n" +
 					" │   ├─ t3.i:0!null\n" +
 					" │   └─ t4.x:2!null\n" +
@@ -424,7 +436,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
+				ExpectedPlan: "" +
+					"Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -453,7 +466,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null DESC nullsFirst)\n" +
+				ExpectedPlan: "" +
+					"Sort(t3.i:0!null ASC nullsFirst, t4.x:2!null DESC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -482,7 +496,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
+				ExpectedPlan: "" +
+					"Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -511,7 +526,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst, t4.y:3!null ASC nullsFirst)\n" +
+				ExpectedPlan: "" +
+					"Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null ASC nullsFirst, t4.x:2!null ASC nullsFirst, t4.y:3!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -540,7 +556,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "Sort(t3.j:1!null ASC nullsFirst)\n" +
+				ExpectedPlan: "" +
+					"Sort(t3.j:1!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -569,7 +586,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "Sort(t4.y:3!null ASC nullsFirst)\n" +
+				ExpectedPlan: "" +
+					"Sort(t4.y:3!null ASC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -598,7 +616,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 2, 2},
 					sql.Row{3, 3, 3, 3},
 				},
-				ExpectedPlan: "Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null DESC nullsFirst)\n" +
+				ExpectedPlan: "" +
+					"Sort(t3.i:0!null ASC nullsFirst, t3.j:1!null DESC nullsFirst)\n" +
 					" └─ MergeJoin\n" +
 					"     ├─ cmp: Eq\n" +
 					"     │   ├─ t3.i:0!null\n" +
@@ -634,7 +653,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3},
 					sql.Row{3, 4},
 				},
-				ExpectedPlan: "CrossJoin\n" +
+				ExpectedPlan: "" +
+					"CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
 					" │   ├─ static: [{[NULL, ∞)}]\n" +
@@ -662,7 +682,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 4},
 					sql.Row{3, 4},
 				},
-				ExpectedPlan: "Project\n" +
+				ExpectedPlan: "" +
+					"Project\n" +
 					" ├─ columns: [t1.i:1!null, t2.j:0!null]\n" +
 					" └─ CrossJoin\n" +
 					"     ├─ IndexedTableAccess(t2)\n" +
@@ -692,7 +713,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{1, 3},
 					sql.Row{1, 4},
 				},
-				ExpectedPlan: "CrossJoin\n" +
+				ExpectedPlan: "" +
+					"CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
 					" │   ├─ static: [{[NULL, ∞)}]\n" +
@@ -713,7 +735,8 @@ var QueryPlanScriptTests = []ScriptTest{
 				Expected: []sql.Row{
 					sql.Row{2, 3},
 				},
-				ExpectedPlan: "CrossJoin\n" +
+				ExpectedPlan: "" +
+					"CrossJoin\n" +
 					" ├─ IndexedTableAccess(t1)\n" +
 					" │   ├─ index: [t1.i]\n" +
 					" │   ├─ static: [{(1, 3)}]\n" +
@@ -738,7 +761,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{1, 1, 3, 3},
 					sql.Row{1, 2, 3, 3},
 				},
-				ExpectedPlan: "CrossJoin\n" +
+				ExpectedPlan: "" +
+					"CrossJoin\n" +
 					" ├─ IndexedTableAccess(t3)\n" +
 					" │   ├─ index: [t3.i,t3.j]\n" +
 					" │   ├─ static: [{[1, 1], [NULL, ∞)}]\n" +
@@ -763,7 +787,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 2, 3, 3},
 					sql.Row{1, 2, 3, 3},
 				},
-				ExpectedPlan: "CrossJoin\n" +
+				ExpectedPlan: "" +
+					"CrossJoin\n" +
 					" ├─ Filter\n" +
 					" │   ├─ Eq\n" +
 					" │   │   ├─ t3.j:1!null\n" +
@@ -797,7 +822,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 4},
 					sql.Row{3, 4},
 				},
-				ExpectedPlan: "InnerJoin\n" +
+				ExpectedPlan: "" +
+					"InnerJoin\n" +
 					" ├─ LessThan\n" +
 					" │   ├─ t1.i:0!null\n" +
 					" │   └─ t2.j:1!null\n" +
@@ -825,7 +851,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{2, 3},
 					sql.Row{1, 2},
 				},
-				ExpectedPlan: "Project\n" +
+				ExpectedPlan: "" +
+					"Project\n" +
 					" ├─ columns: [t1.i:1!null, t2.j:0!null]\n" +
 					" └─ InnerJoin\n" +
 					"     ├─ LessThan\n" +
@@ -860,7 +887,8 @@ var QueryPlanScriptTests = []ScriptTest{
 					sql.Row{3, 3, 2, 2},
 					sql.Row{3, 3, 4, 4},
 				},
-				ExpectedPlan: "InnerJoin\n" +
+				ExpectedPlan: "" +
+					"InnerJoin\n" +
 					" ├─ NOT\n" +
 					" │   └─ Eq\n" +
 					" │       ├─ t3.i:0!null\n" +
@@ -877,6 +905,380 @@ var QueryPlanScriptTests = []ScriptTest{
 					"     └─ Table\n" +
 					"         ├─ name: t4\n" +
 					"         └─ columns: [x y]\n" +
+					"",
+			},
+		},
+	},
+	{
+		// TODO: We should be able to drop the Filter node over IndexedTableAccess for many of these plans
+		Name: "merge join properly pushes down static filters",
+		SetUpScript: []string{
+			"create table t1 (i int primary key, j int, k int);",
+			"create table t2 (x int primary key, y int, z int);",
+			"insert into t1 values (1, 1, 1), (2, 2, 2), (3, 3, 3);",
+			"insert into t2 values (1, 1, 1), (2, 2, 2), (3, 3, 3);",
+		},
+		Assertions: []ScriptTestAssertion{
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i = 2;`,
+				Expected: []sql.Row{
+					{2, 2, 2, 2, 2, 2},
+				},
+				ExpectedPlan: "" +
+					"Project\n" +
+					" ├─ columns: [t1.i:3!null, t1.j:4, t1.k:5, t2.x:0!null, t2.y:1, t2.z:2]\n" +
+					" └─ MergeJoin\n" +
+					"     ├─ cmp: Eq\n" +
+					"     │   ├─ t2.x:0!null\n" +
+					"     │   └─ t1.i:3!null\n" +
+					"     ├─ IndexedTableAccess(t2)\n" +
+					"     │   ├─ index: [t2.x]\n" +
+					"     │   ├─ static: [{[NULL, ∞)}]\n" +
+					"     │   ├─ colSet: (4-6)\n" +
+					"     │   ├─ tableId: 2\n" +
+					"     │   └─ Table\n" +
+					"     │       ├─ name: t2\n" +
+					"     │       └─ columns: [x y z]\n" +
+					"     └─ Filter\n" +
+					"         ├─ Eq\n" +
+					"         │   ├─ t1.i:0!null\n" +
+					"         │   └─ 2 (int)\n" +
+					"         └─ IndexedTableAccess(t1)\n" +
+					"             ├─ index: [t1.i]\n" +
+					"             ├─ static: [{[2, 2]}]\n" +
+					"             ├─ colSet: (1-3)\n" +
+					"             ├─ tableId: 1\n" +
+					"             └─ Table\n" +
+					"                 ├─ name: t1\n" +
+					"                 └─ columns: [i j k]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x = 2;`,
+				Expected: []sql.Row{
+					{2, 2, 2, 2, 2, 2},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ IndexedTableAccess(t1)\n" +
+					" │   ├─ index: [t1.i]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ colSet: (1-3)\n" +
+					" │   ├─ tableId: 1\n" +
+					" │   └─ Table\n" +
+					" │       ├─ name: t1\n" +
+					" │       └─ columns: [i j k]\n" +
+					" └─ Filter\n" +
+					"     ├─ Eq\n" +
+					"     │   ├─ t2.x:0!null\n" +
+					"     │   └─ 2 (int)\n" +
+					"     └─ IndexedTableAccess(t2)\n" +
+					"         ├─ index: [t2.x]\n" +
+					"         ├─ static: [{[2, 2]}]\n" +
+					"         ├─ colSet: (4-6)\n" +
+					"         ├─ tableId: 2\n" +
+					"         └─ Table\n" +
+					"             ├─ name: t2\n" +
+					"             └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i > 1;`,
+				Expected: []sql.Row{
+					{2, 2, 2, 2, 2, 2},
+					{3, 3, 3, 3, 3, 3},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ Filter\n" +
+					" │   ├─ GreaterThan\n" +
+					" │   │   ├─ t1.i:0!null\n" +
+					" │   │   └─ 1 (int)\n" +
+					" │   └─ IndexedTableAccess(t1)\n" +
+					" │       ├─ index: [t1.i]\n" +
+					" │       ├─ static: [{(1, ∞)}]\n" +
+					" │       ├─ colSet: (1-3)\n" +
+					" │       ├─ tableId: 1\n" +
+					" │       └─ Table\n" +
+					" │           ├─ name: t1\n" +
+					" │           └─ columns: [i j k]\n" +
+					" └─ IndexedTableAccess(t2)\n" +
+					"     ├─ index: [t2.x]\n" +
+					"     ├─ static: [{[NULL, ∞)}]\n" +
+					"     ├─ colSet: (4-6)\n" +
+					"     ├─ tableId: 2\n" +
+					"     └─ Table\n" +
+					"         ├─ name: t2\n" +
+					"         └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x > 1;`,
+				Expected: []sql.Row{
+					{2, 2, 2, 2, 2, 2},
+					{3, 3, 3, 3, 3, 3},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ IndexedTableAccess(t1)\n" +
+					" │   ├─ index: [t1.i]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ colSet: (1-3)\n" +
+					" │   ├─ tableId: 1\n" +
+					" │   └─ Table\n" +
+					" │       ├─ name: t1\n" +
+					" │       └─ columns: [i j k]\n" +
+					" └─ Filter\n" +
+					"     ├─ GreaterThan\n" +
+					"     │   ├─ t2.x:0!null\n" +
+					"     │   └─ 1 (int)\n" +
+					"     └─ IndexedTableAccess(t2)\n" +
+					"         ├─ index: [t2.x]\n" +
+					"         ├─ static: [{(1, ∞)}]\n" +
+					"         ├─ colSet: (4-6)\n" +
+					"         ├─ tableId: 2\n" +
+					"         └─ Table\n" +
+					"             ├─ name: t2\n" +
+					"             └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i < 3;`,
+				Expected: []sql.Row{
+					{1, 1, 1, 1, 1, 1},
+					{2, 2, 2, 2, 2, 2},
+				},
+				ExpectedPlan: "MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ Filter\n" +
+					" │   ├─ LessThan\n" +
+					" │   │   ├─ t1.i:0!null\n" +
+					" │   │   └─ 3 (int)\n" +
+					" │   └─ IndexedTableAccess(t1)\n" +
+					" │       ├─ index: [t1.i]\n" +
+					" │       ├─ static: [{(NULL, 3)}]\n" +
+					" │       ├─ colSet: (1-3)\n" +
+					" │       ├─ tableId: 1\n" +
+					" │       └─ Table\n" +
+					" │           ├─ name: t1\n" +
+					" │           └─ columns: [i j k]\n" +
+					" └─ IndexedTableAccess(t2)\n" +
+					"     ├─ index: [t2.x]\n" +
+					"     ├─ static: [{[NULL, ∞)}]\n" +
+					"     ├─ colSet: (4-6)\n" +
+					"     ├─ tableId: 2\n" +
+					"     └─ Table\n" +
+					"         ├─ name: t2\n" +
+					"         └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x < 3;`,
+				Expected: []sql.Row{
+					{1, 1, 1, 1, 1, 1},
+					{2, 2, 2, 2, 2, 2},
+				},
+				ExpectedPlan: "MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ IndexedTableAccess(t1)\n" +
+					" │   ├─ index: [t1.i]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ colSet: (1-3)\n" +
+					" │   ├─ tableId: 1\n" +
+					" │   └─ Table\n" +
+					" │       ├─ name: t1\n" +
+					" │       └─ columns: [i j k]\n" +
+					" └─ Filter\n" +
+					"     ├─ LessThan\n" +
+					"     │   ├─ t2.x:0!null\n" +
+					"     │   └─ 3 (int)\n" +
+					"     └─ IndexedTableAccess(t2)\n" +
+					"         ├─ index: [t2.x]\n" +
+					"         ├─ static: [{(NULL, 3)}]\n" +
+					"         ├─ colSet: (4-6)\n" +
+					"         ├─ tableId: 2\n" +
+					"         └─ Table\n" +
+					"             ├─ name: t2\n" +
+					"             └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i >= 2;`,
+				Expected: []sql.Row{
+					{2, 2, 2, 2, 2, 2},
+					{3, 3, 3, 3, 3, 3},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ Filter\n" +
+					" │   ├─ GreaterThanOrEqual\n" +
+					" │   │   ├─ t1.i:0!null\n" +
+					" │   │   └─ 2 (int)\n" +
+					" │   └─ IndexedTableAccess(t1)\n" +
+					" │       ├─ index: [t1.i]\n" +
+					" │       ├─ static: [{[2, ∞)}]\n" +
+					" │       ├─ colSet: (1-3)\n" +
+					" │       ├─ tableId: 1\n" +
+					" │       └─ Table\n" +
+					" │           ├─ name: t1\n" +
+					" │           └─ columns: [i j k]\n" +
+					" └─ IndexedTableAccess(t2)\n" +
+					"     ├─ index: [t2.x]\n" +
+					"     ├─ static: [{[NULL, ∞)}]\n" +
+					"     ├─ colSet: (4-6)\n" +
+					"     ├─ tableId: 2\n" +
+					"     └─ Table\n" +
+					"         ├─ name: t2\n" +
+					"         └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x >= 2;`,
+				Expected: []sql.Row{
+					{2, 2, 2, 2, 2, 2},
+					{3, 3, 3, 3, 3, 3},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ IndexedTableAccess(t1)\n" +
+					" │   ├─ index: [t1.i]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ colSet: (1-3)\n" +
+					" │   ├─ tableId: 1\n" +
+					" │   └─ Table\n" +
+					" │       ├─ name: t1\n" +
+					" │       └─ columns: [i j k]\n" +
+					" └─ Filter\n" +
+					"     ├─ GreaterThanOrEqual\n" +
+					"     │   ├─ t2.x:0!null\n" +
+					"     │   └─ 2 (int)\n" +
+					"     └─ IndexedTableAccess(t2)\n" +
+					"         ├─ index: [t2.x]\n" +
+					"         ├─ static: [{[2, ∞)}]\n" +
+					"         ├─ colSet: (4-6)\n" +
+					"         ├─ tableId: 2\n" +
+					"         └─ Table\n" +
+					"             ├─ name: t2\n" +
+					"             └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i <= 2;`,
+				Expected: []sql.Row{
+					{1, 1, 1, 1, 1, 1},
+					{2, 2, 2, 2, 2, 2},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ Filter\n" +
+					" │   ├─ LessThanOrEqual\n" +
+					" │   │   ├─ t1.i:0!null\n" +
+					" │   │   └─ 2 (int)\n" +
+					" │   └─ IndexedTableAccess(t1)\n" +
+					" │       ├─ index: [t1.i]\n" +
+					" │       ├─ static: [{(NULL, 2]}]\n" +
+					" │       ├─ colSet: (1-3)\n" +
+					" │       ├─ tableId: 1\n" +
+					" │       └─ Table\n" +
+					" │           ├─ name: t1\n" +
+					" │           └─ columns: [i j k]\n" +
+					" └─ IndexedTableAccess(t2)\n" +
+					"     ├─ index: [t2.x]\n" +
+					"     ├─ static: [{[NULL, ∞)}]\n" +
+					"     ├─ colSet: (4-6)\n" +
+					"     ├─ tableId: 2\n" +
+					"     └─ Table\n" +
+					"         ├─ name: t2\n" +
+					"         └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where x <= 2;`,
+				Expected: []sql.Row{
+					{1, 1, 1, 1, 1, 1},
+					{2, 2, 2, 2, 2, 2},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ IndexedTableAccess(t1)\n" +
+					" │   ├─ index: [t1.i]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ colSet: (1-3)\n" +
+					" │   ├─ tableId: 1\n" +
+					" │   └─ Table\n" +
+					" │       ├─ name: t1\n" +
+					" │       └─ columns: [i j k]\n" +
+					" └─ Filter\n" +
+					"     ├─ LessThanOrEqual\n" +
+					"     │   ├─ t2.x:0!null\n" +
+					"     │   └─ 2 (int)\n" +
+					"     └─ IndexedTableAccess(t2)\n" +
+					"         ├─ index: [t2.x]\n" +
+					"         ├─ static: [{(NULL, 2]}]\n" +
+					"         ├─ colSet: (4-6)\n" +
+					"         ├─ tableId: 2\n" +
+					"         └─ Table\n" +
+					"             ├─ name: t2\n" +
+					"             └─ columns: [x y z]\n" +
+					"",
+			},
+			{
+				Query: `select /*+ MERGE_JOIN(t1, t2) */ * from t1 join t2 on i = x where i = 2 or x = 2;`,
+				Expected: []sql.Row{
+					{2, 2, 2, 2, 2, 2},
+				},
+				ExpectedPlan: "" +
+					"MergeJoin\n" +
+					" ├─ cmp: Eq\n" +
+					" │   ├─ t1.i:0!null\n" +
+					" │   └─ t2.x:3!null\n" +
+					" ├─ sel: Or\n" +
+					" │   ├─ Eq\n" +
+					" │   │   ├─ t1.i:0!null\n" +
+					" │   │   └─ 2 (int)\n" +
+					" │   └─ Eq\n" +
+					" │       ├─ t2.x:3!null\n" +
+					" │       └─ 2 (int)\n" +
+					" ├─ IndexedTableAccess(t1)\n" +
+					" │   ├─ index: [t1.i]\n" +
+					" │   ├─ static: [{[NULL, ∞)}]\n" +
+					" │   ├─ colSet: (1-3)\n" +
+					" │   ├─ tableId: 1\n" +
+					" │   └─ Table\n" +
+					" │       ├─ name: t1\n" +
+					" │       └─ columns: [i j k]\n" +
+					" └─ IndexedTableAccess(t2)\n" +
+					"     ├─ index: [t2.x]\n" +
+					"     ├─ static: [{[NULL, ∞)}]\n" +
+					"     ├─ colSet: (4-6)\n" +
+					"     ├─ tableId: 2\n     └─ Table\n" +
+					"         ├─ name: t2\n" +
+					"         └─ columns: [x y z]\n" +
 					"",
 			},
 		},

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -1442,7 +1442,7 @@ func sortedIndexScansForTableCol(ctx *sql.Context, statsProv sql.StatsProvider, 
 }
 
 func filterExprToMySQLRangeExpr(filter sql.Expression, colId sql.ColumnId, colTyp sql.Type) (res sql.MySQLRangeColumnExpr, ok bool) {
-	// TODO: this is very similar range builder
+	// TODO: Could use RangeTree from gms/sql/range_tree.go?
 	switch f := filter.(type) {
 	case expression.Equality:
 		if !f.RepresentsEquality() {

--- a/sql/analyzer/indexed_joins.go
+++ b/sql/analyzer/indexed_joins.go
@@ -424,12 +424,15 @@ func keyForExpr(
 	targetCol sql.ColumnId,
 	tableId sql.TableId,
 	filters []sql.Expression,
-	columnIdToIndexedExprMap map[sql.ColumnId]indexedExprEntry) (key sql.Expression, filter sql.Expression, nullable bool) {
+	colIdToIdxExpr map[sql.ColumnId]indexedExprEntry) (key sql.Expression, filter sql.Expression, nullable bool) {
 	for _, f := range filters {
 		var left sql.Expression
 		var right sql.Expression
 		switch e := f.(type) {
-		case *expression.Equals:
+		case expression.Equality:
+			if !e.RepresentsEquality() {
+				continue
+			}
 			left = e.Left()
 			right = e.Right()
 		case *expression.NullSafeEquals:
@@ -437,21 +440,19 @@ func keyForExpr(
 			left = e.Left()
 			right = e.Right()
 		default:
-			if e, ok := e.(expression.Equality); ok && e.RepresentsEquality() {
-				left = e.Left()
-				right = e.Right()
-			}
+			continue
 		}
+
 		if ref, ok := left.(*expression.GetField); ok && ref.Id() == targetCol &&
 			sql.IsConvertibleKeyType(left.Type(ctx), right.Type(ctx)) {
 			key = right
-		} else if ref, ok := right.(*expression.GetField); ok && ref.Id() == targetCol &&
+		} else if ref, ok = right.(*expression.GetField); ok && ref.Id() == targetCol &&
 			sql.IsConvertibleKeyType(right.Type(ctx), left.Type(ctx)) {
 			key = left
 		} else if left != nil && right != nil {
 			// Check if targetCol is an indexed functional expression and if
 			// either side of the filter matches the generated expression.
-			if entry, ok := columnIdToIndexedExprMap[targetCol]; ok {
+			if entry, ok := colIdToIdxExpr[targetCol]; ok {
 				if entry.matches(left) {
 					key = right
 				} else if entry.matches(right) {
@@ -1440,51 +1441,128 @@ func sortedIndexScansForTableCol(ctx *sql.Context, statsProv sql.StatsProvider, 
 	return ret, nil
 }
 
-func makeIndexScan(ctx *sql.Context, statsProv sql.StatsProvider, tab plan.TableIdNode, idx *memo.Index, matchedIdx sql.ColumnId, filters []sql.Expression) (*memo.IndexScan, bool, error) {
-	rang := make(sql.MySQLRange, len(idx.Cols()))
-	var j int
-	for {
-		found := idx.Cols()[j] == matchedIdx
+func filterExprToMySQLRangeExpr(filter sql.Expression, colId sql.ColumnId, colTyp sql.Type) (res sql.MySQLRangeColumnExpr, ok bool) {
+	// TODO: this is very similar range builder
+	switch f := filter.(type) {
+	case expression.Equality:
+		if !f.RepresentsEquality() {
+			return
+		}
 		var lit *expression.Literal
-		for _, f := range filters {
-			if eq, ok := f.(expression.Equality); ok && eq.RepresentsEquality() {
-				if l, ok := eq.Left().(*expression.GetField); ok && l.Id() == idx.Cols()[j] {
-					lit, _ = eq.Right().(*expression.Literal)
-				}
-				if r, ok := eq.Right().(*expression.GetField); ok && r.Id() == idx.Cols()[j] {
-					lit, _ = eq.Left().(*expression.Literal)
-				}
-				if lit != nil {
-					break
-				}
+		lExpr, rExpr := f.Left(), f.Right()
+		if lGf, ok := lExpr.(*expression.GetField); ok && lGf.Id() == colId {
+			lit = rExpr.(*expression.Literal)
+		}
+		if rGf, ok := rExpr.(*expression.GetField); ok && rGf.Id() == colId {
+			lit = lExpr.(*expression.Literal)
+		}
+		if lit == nil {
+			return
+		}
+		return sql.ClosedRangeColumnExpr(lit.Val, lit.Val, colTyp), true
+	case *expression.LessThan:
+		lExpr, rExpr := f.Left(), f.Right()
+		if lGf, isGf := lExpr.(*expression.GetField); isGf && lGf.Id() == colId {
+			if rLit, isLit := rExpr.(*expression.Literal); isLit {
+				return sql.LessThanRangeColumnExpr(rLit.Val, colTyp), true
 			}
 		}
-		if found && lit == nil {
-			break
+		if rGf, isGf := rExpr.(*expression.GetField); isGf && rGf.Id() == colId {
+			if lLit, isLit := lExpr.(*expression.Literal); isLit {
+				return sql.GreaterThanRangeColumnExpr(lLit.Val, colTyp), true
+			}
 		}
-		rang[j] = sql.ClosedRangeColumnExpr(lit.Value(), lit.Value(), idx.SqlIdx().ColumnExpressionTypes(ctx)[j].Type)
-		j++
+		return
+	case *expression.LessThanOrEqual:
+		lExpr, rExpr := f.Left(), f.Right()
+		if lGf, isGf := lExpr.(*expression.GetField); isGf && lGf.Id() == colId {
+			if rLit, isLit := rExpr.(*expression.Literal); isLit {
+				return sql.LessOrEqualRangeColumnExpr(rLit.Val, colTyp), true
+			}
+		}
+		if rGf, isGf := rExpr.(*expression.GetField); isGf && rGf.Id() == colId {
+			if lLit, isLit := lExpr.(*expression.Literal); isLit {
+				return sql.GreaterOrEqualRangeColumnExpr(lLit.Val, colTyp), true
+			}
+		}
+		return
+	case *expression.GreaterThan:
+		lExpr, rExpr := f.Left(), f.Right()
+		if lGf, isGf := lExpr.(*expression.GetField); isGf && lGf.Id() == colId {
+			if rLit, isLit := rExpr.(*expression.Literal); isLit {
+				return sql.GreaterThanRangeColumnExpr(rLit.Val, colTyp), true
+			}
+		}
+		if rGf, isGf := rExpr.(*expression.GetField); isGf && rGf.Id() == colId {
+			if lLit, isLit := lExpr.(*expression.Literal); isLit {
+				return sql.LessThanRangeColumnExpr(lLit.Val, colTyp), true
+			}
+		}
+		return
+	case *expression.GreaterThanOrEqual:
+		lExpr, rExpr := f.Left(), f.Right()
+		if lGf, isGf := lExpr.(*expression.GetField); isGf && lGf.Id() == colId {
+			if rLit, isLit := rExpr.(*expression.Literal); isLit {
+				return sql.GreaterOrEqualRangeColumnExpr(rLit.Val, colTyp), true
+			}
+		}
+		if rGf, isGf := rExpr.(*expression.GetField); isGf && rGf.Id() == colId {
+			if lLit, isLit := lExpr.(*expression.Literal); isLit {
+				return sql.LessOrEqualRangeColumnExpr(lLit.Val, colTyp), true
+			}
+		}
+		return
+	default:
+		return
+	}
+}
+
+// makeIndexScan pushes any static filters in |filters| preceeding and possible including |matchedIdx| into an
+// IndexLookup. The result is a series of MySQLRanges that prefixes the index upto |matchedIdx|.
+func makeIndexScan(ctx *sql.Context, statsProv sql.StatsProvider, tab plan.TableIdNode, idx *memo.Index, matchedIdx sql.ColumnId, filters []sql.Expression) (*memo.IndexScan, bool, error) {
+	// TODO: This should build a proper range tree to handle all filters.
+	// TODO: We should be able to push all static expressions, even the ones past |matchedIdx|.
+	var i int
+	idxCols := idx.Cols()
+	rang := make(sql.MySQLRange, len(idxCols))
+	// Create MySQL Range prefix for this index
+	idxColExprTypes := idx.SqlIdx().ColumnExpressionTypes(ctx)
+	for i = 0; i < len(idxCols); {
+		// TODO: It seems like it's possible for no filter to be found for a column before |matchedIdx|, but it is
+		//  ignored. Appears to be impossible to reproduce due to functional dependency logic beforehand.
+		found := matchedIdx == idxCols[i]
+		for _, filter := range filters {
+			if r, ok := filterExprToMySQLRangeExpr(filter, idxCols[i], idxColExprTypes[i].Type); ok {
+				rang[i] = r
+				i++
+				break
+			}
+		}
 		if found {
 			break
 		}
 	}
-	for j < len(idx.Cols()) {
+
+	// Fill remaining ranges with AllRange
+	for ; i < len(idxCols); i++ {
 		// all range bound Compare() is type insensitive
-		rang[j] = sql.AllRangeColumnExpr(types.Null)
-		j++
+		rang[i] = sql.AllRangeColumnExpr(types.Null)
 	}
 
 	if !idx.SqlIdx().CanSupport(ctx, rang) {
 		return nil, false, nil
 	}
 
-	for i, typ := range idx.SqlIdx().ColumnExpressionTypes(ctx) {
+	for i, typ := range idxColExprTypes {
 		if !types.Null.Equals(rang[i].Typ) && !typ.Type.Equals(rang[i].Typ) {
 			return nil, false, nil
 		}
 	}
 
-	l := sql.IndexLookup{Index: idx.SqlIdx(), Ranges: sql.MySQLRangeCollection{rang}}
+	l := sql.IndexLookup{
+		Index:  idx.SqlIdx(),
+		Ranges: sql.MySQLRangeCollection{rang},
+	}
 
 	var tn sql.TableNode
 	var alias string
@@ -1509,7 +1587,7 @@ func makeIndexScan(ctx *sql.Context, statsProv sql.StatsProvider, tab plan.Table
 	}
 
 	var cols []string
-	tablePrefix := fmt.Sprintf("%s.", tn.Name())
+	tablePrefix := tn.Name() + "."
 	for _, e := range idx.SqlIdx().Expressions() {
 		cols = append(cols, strings.TrimPrefix(e, tablePrefix))
 	}

--- a/sql/memo/coster.go
+++ b/sql/memo/coster.go
@@ -68,6 +68,7 @@ func (c *coster) costRel(ctx *sql.Context, n RelExpr, s sql.StatsProvider) (floa
 		lBest := math.Max(1, float64(jp.Left.RelProps.GetStats().RowCount()))
 		rBest := math.Max(1, float64(jp.Right.RelProps.GetStats().RowCount()))
 
+		// TODO: this is not necessarily correct, since we push down filters into that index scan
 		// if a child is an index scan, the table scan will be more expensive
 		var err error
 		lTableScan := uint64(lBest)

--- a/sql/memo/expr_group.go
+++ b/sql/memo/expr_group.go
@@ -166,7 +166,7 @@ func (e *ExprGroup) fixTableScanPath() bool {
 	for n != nil {
 		src, ok := n.(SourceRel)
 		if !ok {
-			// not a source, try to find path through children
+			// not a source, try to find a path through children
 			for _, c := range n.Children() {
 				if c.fixTableScanPath() {
 					// found path, update best


### PR DESCRIPTION
Before, only equality filters would be pushed down into the IndexedTableAccess for MergeJoins.
This PR makes it so all static comparisons are pushed down.

TODO:
 - The Filter over these IndexedTableAccess nodes are useless and we should drop them
 - The coster needs to properly account for the pushed down filters.
 - We should be able to push down more than just one expression over a column
 - We should be able to push more than just the prefix into the index