### PR TITLE
Error on SELECT @@SESSION.<global-only-var>, matching MySQL

### DIFF
--- a/enginetest/queries/variable_queries.go
+++ b/enginetest/queries/variable_queries.go
@@ -383,7 +383,6 @@ var VariableQueries = []ScriptTest{
 				},
 			},
 			{
-				Skip:        true,
 				Query:       `select @@session.innodb_autoinc_lock_mode;`,
 				ExpectedErr: sql.ErrSystemVariableGlobalOnly,
 			},

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -228,7 +228,7 @@ func (b *Builder) buildSysVar(colName *ast.ColName, scopeHint ast.SetScope) (sql
 			}
 			// specifiedScope is only non-empty when the scope was explicitly given (e.g. @@SESSION.foo,
 			// @@LOCAL.foo), as opposed to being inferred for a bare @@foo reference. MySQL allows the bare
-			// form to fall back to the global value for GLOBAL-only variables, but errors when SESSION scope
+			// form to fall back to the global value for GLOBAL-only variables but errors when SESSION scope
 			// is explicitly requested for one.
 			if specifiedScope != "" && sysVar.IsGlobalOnly() {
 				b.handleErr(sql.ErrSystemVariableGlobalOnly.New(varName))

--- a/sql/planbuilder/set.go
+++ b/sql/planbuilder/set.go
@@ -226,6 +226,13 @@ func (b *Builder) buildSysVar(colName *ast.ColName, scopeHint ast.SetScope) (sql
 			if !ok {
 				return nil, scope, false
 			}
+			// specifiedScope is only non-empty when the scope was explicitly given (e.g. @@SESSION.foo,
+			// @@LOCAL.foo), as opposed to being inferred for a bare @@foo reference. MySQL allows the bare
+			// form to fall back to the global value for GLOBAL-only variables, but errors when SESSION scope
+			// is explicitly requested for one.
+			if specifiedScope != "" && sysVar.IsGlobalOnly() {
+				b.handleErr(sql.ErrSystemVariableGlobalOnly.New(varName))
+			}
 			return expression.NewSystemVar(varName, sysVar.GetSessionScope(), specifiedScope), scope, true
 		}
 	case ast.SetScope_User:


### PR DESCRIPTION
GMS silently returned the global value when a GLOBAL-only system variable was read with an explicitly-qualified SESSION/LOCAL scope (e.g. `SELECT @@SESSION.innodb_autoinc_lock_mode`), instead of raising MySQL's ERROR 1238 (`ErrSystemVariableGlobalOnly`).

`buildSysVar`'s case for `SetScope_None`/`SetScope_Session` already carries `specifiedScope`, which is empty for a bare `@@foo` reference and non-empty (`"session"`/`"local"`) only when the scope was explicitly written in the query. This change uses that existing signal to raise `ErrSystemVariableGlobalOnly` when a global-only variable's scope is explicitly specified as session/local, while leaving the bare `@@foo` fallback-to-global behavior untouched (MySQL allows that case).

Also un-skips a pre-existing enginetest case in `variable_queries.go` that already asserted this exact error — the test was written in anticipation of this fix (`Skip: true`) and now passes.

Fixes dolthub/dolt#6722