### PR TITLE
sql: Fix ALTER USER to allow the Identity field of the User record to be updated.

### DIFF
--- a/enginetest/queries/priv_auth_queries.go
+++ b/enginetest/queries/priv_auth_queries.go
@@ -797,6 +797,26 @@ var UserPrivTests = []UserPrivilegeTest{
 		},
 	},
 	{
+		Name: "ALTER USER can update the identity",
+		SetUpScript: []string{
+			"CREATE USER testuser1@`127.0.0.1` IDENTIFIED WITH mysql_native_password AS 'initial_identity';",
+		},
+		Assertions: []UserPrivilegeTestAssertion{
+			{
+				Query:    "select user, host, plugin, identity from mysql.user where user='testuser1';",
+				Expected: []sql.Row{{"testuser1", "127.0.0.1", "mysql_native_password", "initial_identity"}},
+			},
+			{
+				Query:    "ALTER USER testuser1@`127.0.0.1` IDENTIFIED WITH mysql_native_password AS 'updated_identity';",
+				Expected: []sql.Row{{types.NewOkResult(0)}},
+			},
+			{
+				Query:    "select user, host, plugin, identity from mysql.user where user='testuser1';",
+				Expected: []sql.Row{{"testuser1", "127.0.0.1", "mysql_native_password", "updated_identity"}},
+			},
+		},
+	},
+	{
 		Name: "User creation with SSL/TLS requirements",
 		SetUpScript: []string{
 			"CREATE USER testuser1@`127.0.0.1` REQUIRE NONE;",

--- a/sql/rowexec/ddl.go
+++ b/sql/rowexec/ddl.go
@@ -630,6 +630,7 @@ func (b *BaseBuilder) buildAlterUser(ctx *sql.Context, a *plan.AlterUser, _ sql.
 	// have a plaintext password to process into an authorization string for the auth plugin.
 	plugin := previousUserEntry.Plugin
 	authString := previousUserEntry.AuthString
+	identity := previousUserEntry.Identity
 	if user.Auth1 != nil {
 		plugin = user.Auth1.Plugin()
 		var err error
@@ -637,6 +638,7 @@ func (b *BaseBuilder) buildAlterUser(ctx *sql.Context, a *plan.AlterUser, _ sql.
 		if err != nil {
 			return nil, err
 		}
+		identity = user.Identity
 	}
 	if plugin != string(mysql.MysqlNativePassword) && plugin != string(mysql.CachingSha2Password) {
 		if err := mysqlDb.VerifyPlugin(plugin); err != nil {
@@ -646,6 +648,7 @@ func (b *BaseBuilder) buildAlterUser(ctx *sql.Context, a *plan.AlterUser, _ sql.
 
 	previousUserEntry.Plugin = plugin
 	previousUserEntry.AuthString = authString
+	previousUserEntry.Identity = identity
 	previousUserEntry.PasswordLastChanged = time.Now().UTC()
 	editor.PutUser(previousUserEntry)
 


### PR DESCRIPTION
`CREATE USER ... IDENTITY WITH <plugin> AS '<identity>'` correctly parsed and persisted the Identity field. `ALTER USER` correctly parsed the Identity field but failed to persist the changes. The end result is that GMS had a bug where attempt to alter the identity field on an existing user seemed to succeed but was not reflected in the data going forward.

Fix the bug so that updates to Identity are reflected and persisted going forward.