### PR TITLE
bug fix: honor named window reference

### DIFF
--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -4007,6 +4007,16 @@ func TestNamedWindows(t *testing.T, harness Harness) {
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w) FROM a WINDOW w as (partition by z order by x rows 2 preceding) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(3)}, {float64(4)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT row_number() over (w3) FROM a WINDOW w3 as (w2), w2 as (w1), w1 as (partition by z order by x) order by x`, []sql.Row{{int64(1)}, {int64(2)}, {int64(3)}, {int64(4)}, {int64(5)}, {int64(6)}}, nil, nil, nil)
 
+	// A named window with only a PARTITION BY (no ORDER BY) gets a full-partition default frame
+	// baked in when it's built on its own. If a second window inherits from it and adds an ORDER
+	// BY -- either through another named window (w2 AS (w1 ORDER BY id)) or an inline override
+	// (OVER (w1 ORDER BY id)) -- that stale full-partition frame must not survive the merge; the
+	// running sum implied by the newly-added ORDER BY has to win.
+	RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE b (id INTEGER PRIMARY KEY, grp INTEGER, amt INTEGER)")
+	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO b VALUES (1,1,10), (2,1,20), (3,1,30), (4,2,5), (5,2,15)")
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(amt) over w2 FROM b WINDOW w1 as (partition by grp), w2 as (w1 order by id) order by id`, []sql.Row{{float64(10)}, {float64(30)}, {float64(60)}, {float64(5)}, {float64(20)}}, nil, nil, nil)
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(amt) over (w1 order by id) FROM b WINDOW w1 as (partition by grp) order by id`, []sql.Row{{float64(10)}, {float64(30)}, {float64(60)}, {float64(5)}, {float64(20)}}, nil, nil, nil)
+
 	// errors
 	AssertErr(t, e, harness, "SELECT sum(y) over (w1 partition by x) FROM a WINDOW w1 as (partition by z) order by x", nil, sql.ErrInvalidWindowInheritance)
 	AssertErr(t, e, harness, "SELECT sum(y) over (w1 order by x) FROM a WINDOW w1 as (order by z) order by x", nil, sql.ErrInvalidWindowInheritance)

--- a/enginetest/enginetests.go
+++ b/enginetest/enginetests.go
@@ -3992,8 +3992,16 @@ func TestNamedWindows(t *testing.T, harness Harness) {
 	RunQueryWithContext(t, e, harness, ctx, "CREATE TABLE a (x INTEGER PRIMARY KEY, y INTEGER, z INTEGER)")
 	RunQueryWithContext(t, e, harness, ctx, "INSERT INTO a VALUES (0,0,0), (1,1,0), (2,2,0), (3,0,0), (4,1,0), (5,3,0)")
 
-	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
+	// Expected values reflect this engine's DefaultFramer, which is ROWS UNBOUNDED PRECEDING TO
+	// CURRENT ROW (no RANGE peer-group tie handling), consistently applied whenever a window has
+	// an ORDER BY but no explicit frame -- whether inline or via a named window reference.
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (order by z) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(4)}, {float64(7)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w1) FROM a WINDOW w1 as (partition by z) order by x`, []sql.Row{{float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}, {float64(7)}}, nil, nil, nil)
+	// A named window with an ORDER BY but no explicit frame must default to a running (cumulative)
+	// frame, same as an equivalent inline OVER (...) clause -- not the full-partition frame. The
+	// default-frame inference has to run against the referenced window's merged ORDER BY, not the
+	// (possibly empty) ORDER BY on the OVER w reference itself.
+	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over w1 FROM a WINDOW w1 as (partition by z order by x) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(4)}, {float64(7)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over w FROM a WINDOW w as (partition by z order by x rows unbounded preceding) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(4)}, {float64(7)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over w FROM a WINDOW w as (partition by z order by x rows current row) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(2)}, {float64(0)}, {float64(1)}, {float64(3)}}, nil, nil, nil)
 	TestQueryWithContext(t, ctx, e, harness, `SELECT sum(y) over (w) FROM a WINDOW w as (partition by z order by x rows 2 preceding) order by x`, []sql.Row{{float64(0)}, {float64(1)}, {float64(3)}, {float64(3)}, {float64(3)}, {float64(4)}}, nil, nil, nil)

--- a/enginetest/queries/query_plans.go
+++ b/enginetest/queries/query_plans.go
@@ -16525,9 +16525,9 @@ inner join pq on true
 	{
 		Query: `select i, row_number() over (w1 partition by s) from mytable window w1 as (order by i asc)`,
 		ExpectedPlan: "Project\n" +
-			" ├─ columns: [mytable.i:1!null, row_number() over ( partition by mytable.s order by mytable.i asc rows between unbounded preceding and unbounded following):0!null->row_number() over (w1 partition by s):0]\n" +
+			" ├─ columns: [mytable.i:1!null, row_number() over ( partition by mytable.s order by mytable.i asc):0!null->row_number() over (w1 partition by s):0]\n" +
 			" └─ Window\n" +
-			"     ├─ row_number() over ( partition by mytable.s order by mytable.i ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)\n" +
+			"     ├─ row_number() over ( partition by mytable.s order by mytable.i ASC)\n" +
 			"     ├─ mytable.i:0!null\n" +
 			"     └─ ProcessTable\n" +
 			"         └─ Table\n" +
@@ -16535,15 +16535,15 @@ inner join pq on true
 			"             └─ columns: [i s]\n" +
 			"",
 		ExpectedEstimates: "Project\n" +
-			" ├─ columns: [mytable.i, row_number() over ( partition by mytable.s order by mytable.i asc rows between unbounded preceding and unbounded following) as row_number() over (w1 partition by s)]\n" +
-			" └─ Window(row_number() over ( partition by mytable.s order by mytable.i ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), mytable.i)\n" +
+			" ├─ columns: [mytable.i, row_number() over ( partition by mytable.s order by mytable.i asc) as row_number() over (w1 partition by s)]\n" +
+			" └─ Window(row_number() over ( partition by mytable.s order by mytable.i ASC), mytable.i)\n" +
 			"     └─ Table\n" +
 			"         ├─ name: mytable\n" +
 			"         └─ columns: [i s]\n" +
 			"",
 		ExpectedAnalysis: "Project\n" +
-			" ├─ columns: [mytable.i, row_number() over ( partition by mytable.s order by mytable.i asc rows between unbounded preceding and unbounded following) as row_number() over (w1 partition by s)]\n" +
-			" └─ Window(row_number() over ( partition by mytable.s order by mytable.i ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), mytable.i)\n" +
+			" ├─ columns: [mytable.i, row_number() over ( partition by mytable.s order by mytable.i asc) as row_number() over (w1 partition by s)]\n" +
+			" └─ Window(row_number() over ( partition by mytable.s order by mytable.i ASC), mytable.i)\n" +
 			"     └─ Table\n" +
 			"         ├─ name: mytable\n" +
 			"         └─ columns: [i s]\n" +

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -838,12 +838,12 @@ func (b *Builder) mergeWindowDefs(def, ref *sql.WindowDefinition) *sql.WindowDef
 		partitionBy = []sql.Expression{}
 	}
 
+	_, isDefDefaultFrame := def.Frame.(*plan.RowsUnboundedPrecedingToUnboundedFollowingFrame)
+	_, isRefDefaultFrame := ref.Frame.(*plan.RowsUnboundedPrecedingToUnboundedFollowingFrame)
+
 	var frame sql.WindowFrame
 	switch {
 	case def.Frame != nil && ref.Frame != nil:
-		_, isDefDefaultFrame := def.Frame.(*plan.RowsUnboundedPrecedingToUnboundedFollowingFrame)
-		_, isRefDefaultFrame := ref.Frame.(*plan.RowsUnboundedPrecedingToUnboundedFollowingFrame)
-
 		// if both frames are set and one is RowsUnboundedPrecedingToUnboundedFollowingFrame (default),
 		// we should use the other frame
 		if isDefDefaultFrame {
@@ -860,6 +860,11 @@ func (b *Builder) mergeWindowDefs(def, ref *sql.WindowDefinition) *sql.WindowDef
 			}
 			frame = def.Frame
 		}
+	case isDefDefaultFrame, isRefDefaultFrame:
+		// The default frame was only correct in the context of the (partial) window definition
+		// that computed it, which may not have known about an ORDER BY contributed by the other
+		// side of this merge. Leave frame unset so the caller re-derives the correct default from
+		// the fully merged ORDER BY, rather than blindly propagating a stale sentinel value.
 	case def.Frame != nil:
 		frame = def.Frame
 	case ref.Frame != nil:

--- a/sql/planbuilder/aggregates.go
+++ b/sql/planbuilder/aggregates.go
@@ -785,12 +785,6 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 
 	frame := b.NewFrame(fromScope, def.Frame)
 
-	// According to MySQL documentation at https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html
-	// "If OVER() is empty, the window consists of all query rows and the window function computes a result using all rows."
-	if def.OrderBy == nil && frame == nil {
-		frame = plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame()
-	}
-
 	windowDef := sql.NewWindowDefinition(partitions, sortFields, frame, def.NameRef.Lowered(), def.Name.Lowered())
 	if ref, ok := fromScope.windowDefs[def.NameRef.Lowered()]; ok {
 		// this is only safe if windows are built in topo order
@@ -798,6 +792,15 @@ func (b *Builder) buildWindowDef(fromScope *scope, def *ast.WindowDef) *sql.Wind
 		// collapse dependencies if any reference this window
 		fromScope.windowDefs[windowDef.Name] = windowDef
 	}
+
+	// According to MySQL documentation at https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html
+	// "If OVER() is empty, the window consists of all query rows and the window function computes a result using all rows."
+	// This must be evaluated after merging with any referenced named window (OVER w), since the
+	// referenced window's ORDER BY determines the correct default frame, not this def's own (possibly empty) ORDER BY.
+	if windowDef.OrderBy == nil && windowDef.Frame == nil {
+		windowDef.Frame = plan.NewRowsUnboundedPrecedingToUnboundedFollowingFrame()
+	}
+
 	return windowDef
 }
 

--- a/sql/planbuilder/parse_test.go
+++ b/sql/planbuilder/parse_test.go
@@ -1435,11 +1435,11 @@ Project
 			WINDOW w AS (PARTITION BY y ORDER BY x);`,
 			ExpectedPlan: `
 Project
- ├─ columns: [xy.x:1!null, row_number() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):4!null->row_number:5, rank() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):6!null->rank:7, dense_rank() over ( partition by xy.y order by xy.x asc rows between unbounded preceding and unbounded following):8!null->dense_rank:9]
+ ├─ columns: [xy.x:1!null, row_number() over ( partition by xy.y order by xy.x asc):4!null->row_number:5, rank() over ( partition by xy.y order by xy.x asc):6!null->rank:7, dense_rank() over ( partition by xy.y order by xy.x asc):8!null->dense_rank:9]
  └─ Window
-     ├─ row_number() over ( partition by xy.y order by xy.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-     ├─ rank() over ( partition by xy.y order by xy.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
-     ├─ dense_rank() over ( partition by xy.y order by xy.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+     ├─ row_number() over ( partition by xy.y order by xy.x ASC)
+     ├─ rank() over ( partition by xy.y order by xy.x ASC)
+     ├─ dense_rank() over ( partition by xy.y order by xy.x ASC)
      ├─ xy.x:1!null
      └─ Table
          ├─ name: xy


### PR DESCRIPTION
An existing bug in GMS was not properly applying a named window reference. We had enginetests for named window references, but they weren't sufficient to catch this because the aggregate function they used produced identical values in both cases. New enginetest cases are added to prevent a regression. 

These two issues were identified by Ito automated review, in https://github.com/dolthub/doltgresql/pull/2913