### PR TITLE
Advertise binary charset for `BIT` result columns

### DIFF
--- a/enginetest/queries/charset_collation_wire.go
+++ b/enginetest/queries/charset_collation_wire.go
@@ -1034,6 +1034,20 @@ var CharsetCollationWireTests = []CharsetCollationWireTest{
 			},
 		},
 	},
+	{
+		Name: "BIT columns advertise the binary charset",
+		SetUpScript: []string{
+			"CREATE TABLE test (pk BIGINT PRIMARY KEY, v1 BIT(3));",
+			"INSERT INTO test VALUES (1, b'010');",
+		},
+		Queries: []CharsetCollationWireTestQuery{
+			{
+				Query:              "SELECT v1 FROM test;",
+				Expected:           []sql.Row{{"\x02"}},
+				ExpectedCollations: []sql.CollationID{sql.Collation_binary},
+			},
+		},
+	},
 }
 
 // DatabaseCollationWireTests are used to validate that CREATE DATABASE and ALTER DATABASE correctly handle having their

--- a/server/handler.go
+++ b/server/handler.go
@@ -1201,8 +1201,10 @@ func schemaToFields(ctx *sql.Context, s sql.Schema) []*querypb.Field {
 		}
 
 		// Binary types always use a binary collation, but non-binary types must
-		// respect character_set_results if it is set.
-		if types.IsBinaryType(c.Type) {
+		// respect character_set_results if it is set. BIT is not a string type,
+		// but MySQL advertises it with the binary charset so that clients render
+		// its values as binary data rather than text.
+		if types.IsBinaryType(c.Type) || types.IsBit(c.Type) {
 			charset = uint32(sql.Collation_binary)
 		} else if charSetResults != sql.CharacterSet_Unspecified {
 			charset = uint32(charSetResults)

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -1010,7 +1010,7 @@ func TestSchemaToFields(t *testing.T) {
 		{Name: "varbinary12345", OrgName: "varbinary12345", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_VARBINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 12345, Flags: uint32(query.MySqlFlag_NOT_NULL_FLAG)},
 		{Name: "binary123", OrgName: "binary123", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BINARY, Charset: mysql.CharacterSetBinary, ColumnLength: 123, Flags: uint32(query.MySqlFlag_NOT_NULL_FLAG)},
 		{Name: "char123", OrgName: "char123", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_CHAR, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 123 * 4, Flags: uint32(query.MySqlFlag_NOT_NULL_FLAG)},
-		{Name: "bit12", OrgName: "bit12", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BIT, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 12, Flags: uint32(query.MySqlFlag_NOT_NULL_FLAG)},
+		{Name: "bit12", OrgName: "bit12", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_BIT, Charset: mysql.CharacterSetBinary, ColumnLength: 12, Flags: uint32(query.MySqlFlag_NOT_NULL_FLAG)},
 
 		// Dates
 		{Name: "datetime", OrgName: "datetime", Table: "table1", OrgTable: "table1", Database: "db1", Type: query.Type_DATETIME, Charset: uint32(sql.CharacterSet_utf8mb4), ColumnLength: 26, Flags: uint32(query.MySqlFlag_NOT_NULL_FLAG)},


### PR DESCRIPTION
MySQL marks `BIT` result columns with the binary charset (63) in the wire protocol. We were sending `utf8mb4` (255), so clients like the `mysql` CLI printed `BIT` values as raw bytes instead of hex.
- `schemaToFields` now sets the binary charset for `BIT` columns
Block dolthub/dolt#11306