### PR TITLE
[no-release-notes] Refactor: new `sorters` package

### DIFF
--- a/memory/table.go
+++ b/memory/table.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
 	"io"
 	"math"
 	"sort"
@@ -1756,16 +1757,16 @@ func (t *IndexedTable) PartitionRows(ctx *sql.Context, partition sql.Partition) 
 				// TODO: null ordering?
 			}
 		}
-		var sorter *expression.Sorter
+		var sorter *sort2.Sorter
 		if i, ok := iter.(*tableIter); ok {
-			sorter = &expression.Sorter{
+			sorter = &sort2.Sorter{
 				SortConditions: sc,
 				Rows:           i.rows,
 				LastError:      nil,
 				Ctx:            ctx,
 			}
 		} else if i, ok := iter.(*spatialTableIter); ok {
-			sorter = &expression.Sorter{
+			sorter = &sort2.Sorter{
 				SortConditions: sc,
 				Rows:           i.rows,
 				LastError:      nil,

--- a/memory/table.go
+++ b/memory/table.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"math"
 	"sort"
@@ -34,6 +33,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression/function/vector"
 	"github.com/dolthub/go-mysql-server/sql/fulltext"
 	"github.com/dolthub/go-mysql-server/sql/iters"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"github.com/dolthub/go-mysql-server/sql/transform"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )

--- a/memory/table.go
+++ b/memory/table.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"math"
 	"sort"
@@ -1757,16 +1757,16 @@ func (t *IndexedTable) PartitionRows(ctx *sql.Context, partition sql.Partition) 
 				// TODO: null ordering?
 			}
 		}
-		var sorter *sort2.Sorter
+		var sorter *sorters.Sorter
 		if i, ok := iter.(*tableIter); ok {
-			sorter = &sort2.Sorter{
+			sorter = &sorters.Sorter{
 				SortConditions: sc,
 				Rows:           i.rows,
 				LastError:      nil,
 				Ctx:            ctx,
 			}
 		} else if i, ok := iter.(*spatialTableIter); ok {
-			sorter = &sort2.Sorter{
+			sorter = &sorters.Sorter{
 				SortConditions: sc,
 				Rows:           i.rows,
 				LastError:      nil,

--- a/memory/table.go
+++ b/memory/table.go
@@ -1757,16 +1757,16 @@ func (t *IndexedTable) PartitionRows(ctx *sql.Context, partition sql.Partition) 
 				// TODO: null ordering?
 			}
 		}
-		var sorter *sorters.Sorter
+		var sorter *sorters.RowSorter
 		if i, ok := iter.(*tableIter); ok {
-			sorter = &sorters.Sorter{
+			sorter = &sorters.RowSorter{
 				SortConditions: sc,
 				Rows:           i.rows,
 				LastError:      nil,
 				Ctx:            ctx,
 			}
 		} else if i, ok := iter.(*spatialTableIter); ok {
-			sorter = &sorters.Sorter{
+			sorter = &sorters.RowSorter{
 				SortConditions: sc,
 				Rows:           i.rows,
 				LastError:      nil,

--- a/memory/table.go
+++ b/memory/table.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"fmt"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"math"
 	"sort"

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -16,13 +16,13 @@ package aggregation
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"sort"
 	"strings"
 
 	"github.com/dolthub/vitess/go/vt/proto/query"
 
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -16,7 +16,7 @@ package aggregation
 
 import (
 	"fmt"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"sort"
 	"strings"
 
@@ -338,7 +338,7 @@ func (g *groupConcatBuffer) Eval(ctx *sql.Context) (interface{}, error) {
 
 	// Execute the order operation if it exists.
 	if g.gc.sortConditions != nil {
-		sorter := &sort2.Sorter{
+		sorter := &sorters.Sorter{
 			SortConditions: g.gc.sortConditions,
 			Rows:           rows,
 			Ctx:            ctx,

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -338,7 +338,7 @@ func (g *groupConcatBuffer) Eval(ctx *sql.Context) (interface{}, error) {
 
 	// Execute the order operation if it exists.
 	if g.gc.sortConditions != nil {
-		sorter := &sorters.Sorter{
+		sorter := &sorters.RowSorter{
 			SortConditions: g.gc.sortConditions,
 			Rows:           rows,
 			Ctx:            ctx,

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -16,13 +16,13 @@ package aggregation
 
 import (
 	"fmt"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
 	"sort"
 	"strings"
 
 	"github.com/dolthub/vitess/go/vt/proto/query"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 
@@ -338,7 +338,7 @@ func (g *groupConcatBuffer) Eval(ctx *sql.Context) (interface{}, error) {
 
 	// Execute the order operation if it exists.
 	if g.gc.sortConditions != nil {
-		sorter := &expression.Sorter{
+		sorter := &sort2.Sorter{
 			SortConditions: g.gc.sortConditions,
 			Rows:           rows,
 			Ctx:            ctx,

--- a/sql/expression/function/aggregation/group_concat.go
+++ b/sql/expression/function/aggregation/group_concat.go
@@ -16,7 +16,7 @@ package aggregation
 
 import (
 	"fmt"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
 	"sort"
 	"strings"
 

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -15,6 +15,7 @@
 package aggregation
 
 import (
+	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
 	"math"
 	"sort"
 	"strings"
@@ -901,7 +902,7 @@ func (a *GroupConcatAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, 
 
 	// Execute the order operation if it exists.
 	if a.gc.sortConditions != nil {
-		sorter := &expression.Sorter{
+		sorter := &sort2.Sorter{
 			SortConditions: a.gc.sortConditions,
 			Rows:           rows,
 			Ctx:            ctx,

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -902,7 +902,7 @@ func (a *GroupConcatAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, 
 
 	// Execute the order operation if it exists.
 	if a.gc.sortConditions != nil {
-		sorter := &sorters.Sorter{
+		sorter := &sorters.RowSorter{
 			SortConditions: a.gc.sortConditions,
 			Rows:           rows,
 			Ctx:            ctx,

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -15,7 +15,7 @@
 package aggregation
 
 import (
-	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
 	"math"
 	"sort"
 	"strings"

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -19,10 +19,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dolthub/go-mysql-server/sql/sorters"
-
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"github.com/dolthub/go-mysql-server/sql/types"
 )
 

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -15,7 +15,7 @@
 package aggregation
 
 import (
-	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"math"
 	"sort"
 	"strings"
@@ -902,7 +902,7 @@ func (a *GroupConcatAgg) Compute(ctx *sql.Context, interval sql.WindowInterval, 
 
 	// Execute the order operation if it exists.
 	if a.gc.sortConditions != nil {
-		sorter := &sort2.Sorter{
+		sorter := &sorters.Sorter{
 			SortConditions: a.gc.sortConditions,
 			Rows:           rows,
 			Ctx:            ctx,

--- a/sql/expression/function/aggregation/window_functions.go
+++ b/sql/expression/function/aggregation/window_functions.go
@@ -15,10 +15,11 @@
 package aggregation
 
 import (
-	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"math"
 	"sort"
 	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression"

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -16,9 +16,10 @@ package aggregation
 
 import (
 	"errors"
-	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"sort"
+
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -16,7 +16,7 @@ package aggregation
 
 import (
 	"errors"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"sort"
 

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -169,6 +169,7 @@ func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuff
 			}
 			return nil, nil, err
 		}
+		// TODO: We should not be appending the row number to the end of the row!!! This causes indexing issues!!!
 		input = append(input, append(row, j))
 		j++
 	}
@@ -178,7 +179,7 @@ func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuff
 	}
 
 	// sort all rows by partition
-	sorter := &sorters.Sorter{
+	sorter := &sorters.RowSorter{
 		SortConditions: append(partitionsToSortConditions(i.w.PartitionBy), i.w.SortBy...),
 		Rows:           input,
 		Ctx:            ctx,

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -16,11 +16,11 @@ package aggregation
 
 import (
 	"errors"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
 	"io"
 	"sort"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 )
 
 var ErrNoPartitions = errors.New("no partitions")
@@ -178,7 +178,7 @@ func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuff
 	}
 
 	// sort all rows by partition
-	sorter := &expression.Sorter{
+	sorter := &sort2.Sorter{
 		SortConditions: append(partitionsToSortConditions(i.w.PartitionBy), i.w.SortBy...),
 		Rows:           input,
 		Ctx:            ctx,

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -16,7 +16,7 @@ package aggregation
 
 import (
 	"errors"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"sort"
 
@@ -178,7 +178,7 @@ func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuff
 	}
 
 	// sort all rows by partition
-	sorter := &sort2.Sorter{
+	sorter := &sorters.Sorter{
 		SortConditions: append(partitionsToSortConditions(i.w.PartitionBy), i.w.SortBy...),
 		Rows:           input,
 		Ctx:            ctx,

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -169,7 +169,8 @@ func (i *WindowPartitionIter) materializeInput(ctx *sql.Context) (sql.WindowBuff
 			}
 			return nil, nil, err
 		}
-		// TODO: We should not be appending the row number to the end of the row!!! This causes indexing issues!!!
+		// TODO: Appending the row number to the end of the row can likely cause indexing issues
+		//  https://github.com/dolthub/dolt/issues/11328
 		input = append(input, append(row, j))
 		j++
 	}

--- a/sql/expression/function/aggregation/window_partition.go
+++ b/sql/expression/function/aggregation/window_partition.go
@@ -19,9 +19,8 @@ import (
 	"io"
 	"sort"
 
-	"github.com/dolthub/go-mysql-server/sql/sorters"
-
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 )
 
 var ErrNoPartitions = errors.New("no partitions")

--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -16,7 +16,7 @@ package iters
 
 import (
 	"fmt"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"sort"
 
@@ -448,7 +448,7 @@ func (i *sortIter) computeSortedRows(ctx *sql.Context) error {
 	}
 
 	rows := cache.Get()
-	sorter := &sort2.Sorter{
+	sorter := &sorters.Sorter{
 		SortConditions: i.sortConditions,
 		Rows:           rows,
 		LastError:      nil,

--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -16,13 +16,13 @@ package iters
 
 import (
 	"fmt"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
 	"io"
 	"sort"
 
 	"github.com/dolthub/jsonpath"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 	"github.com/dolthub/go-mysql-server/sql/hash"
 )
 
@@ -448,7 +448,7 @@ func (i *sortIter) computeSortedRows(ctx *sql.Context) error {
 	}
 
 	rows := cache.Get()
-	sorter := &expression.Sorter{
+	sorter := &sort2.Sorter{
 		SortConditions: i.sortConditions,
 		Rows:           rows,
 		LastError:      nil,

--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -16,7 +16,7 @@ package iters
 
 import (
 	"fmt"
-	sort2 "github.com/dolthub/go-mysql-server/sql/sort"
+	sort2 "github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"sort"
 

--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -16,7 +16,6 @@ package iters
 
 import (
 	"fmt"
-	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 	"sort"
 
@@ -24,6 +23,7 @@ import (
 
 	"github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/hash"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 )
 
 // GetInt64Value returns the int64 literal value in the expression given, or an error with the errStr given if it

--- a/sql/iters/rel_iters.go
+++ b/sql/iters/rel_iters.go
@@ -448,7 +448,7 @@ func (i *sortIter) computeSortedRows(ctx *sql.Context) error {
 	}
 
 	rows := cache.Get()
-	sorter := &sorters.Sorter{
+	sorter := &sorters.RowSorter{
 		SortConditions: i.sortConditions,
 		Rows:           rows,
 		LastError:      nil,

--- a/sql/iters/top_rows_iters.go
+++ b/sql/iters/top_rows_iters.go
@@ -16,10 +16,10 @@ package iters
 
 import (
 	"container/heap"
+	"github.com/dolthub/go-mysql-server/sql/sort"
 	"io"
 
 	"github.com/dolthub/go-mysql-server/sql"
-	"github.com/dolthub/go-mysql-server/sql/expression"
 )
 
 // topRowsIter is defined by the topN node. It uses a heap to sort the rows of the child iterator and returns the top N
@@ -74,7 +74,7 @@ func (i *topRowsIter) Close(ctx *sql.Context) error {
 // computeTopRows uses a Top-N Heap Sort to find the top N rows. It relies on topRowsHeap being a max-heap.
 func (i *topRowsIter) computeTopRows(ctx *sql.Context) error {
 	rowsHeap := &topRowsHeap{
-		Sorter: expression.Sorter{
+		Sorter: sort.Sorter{
 			SortConditions: i.sortConditions,
 			Rows:           make([]sql.Row, 0, i.limit+1),
 			LastError:      nil,
@@ -125,7 +125,7 @@ func getTopRows(h *topRowsHeap) []sql.Row {
 // topRowsHeap implements heap.Interface. Since heap.Interface assumes a min-heap, topRowsHeap inverts Less to implement
 // a max-heap. This is so that topRowsHeap can be used for a Top-N Heap Sort.
 type topRowsHeap struct {
-	expression.Sorter
+	sort.Sorter
 	order []int64
 }
 
@@ -191,7 +191,7 @@ func (i *topRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	sorter := expression.Sorter{
+	sorter := sort.Sorter{
 		Ctx:            ctx,
 		SortConditions: i.sortConditions,
 	}

--- a/sql/iters/top_rows_iters.go
+++ b/sql/iters/top_rows_iters.go
@@ -16,7 +16,7 @@ package iters
 
 import (
 	"container/heap"
-	"github.com/dolthub/go-mysql-server/sql/sort"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
 
 	"github.com/dolthub/go-mysql-server/sql"
@@ -74,7 +74,7 @@ func (i *topRowsIter) Close(ctx *sql.Context) error {
 // computeTopRows uses a Top-N Heap Sort to find the top N rows. It relies on topRowsHeap being a max-heap.
 func (i *topRowsIter) computeTopRows(ctx *sql.Context) error {
 	rowsHeap := &topRowsHeap{
-		Sorter: sort.Sorter{
+		Sorter: sorters.Sorter{
 			SortConditions: i.sortConditions,
 			Rows:           make([]sql.Row, 0, i.limit+1),
 			LastError:      nil,
@@ -125,7 +125,7 @@ func getTopRows(h *topRowsHeap) []sql.Row {
 // topRowsHeap implements heap.Interface. Since heap.Interface assumes a min-heap, topRowsHeap inverts Less to implement
 // a max-heap. This is so that topRowsHeap can be used for a Top-N Heap Sort.
 type topRowsHeap struct {
-	sort.Sorter
+	sorters.Sorter
 	order []int64
 }
 
@@ -191,7 +191,7 @@ func (i *topRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	sorter := sort.Sorter{
+	sorter := sorters.Sorter{
 		Ctx:            ctx,
 		SortConditions: i.sortConditions,
 	}

--- a/sql/iters/top_rows_iters.go
+++ b/sql/iters/top_rows_iters.go
@@ -18,9 +18,8 @@ import (
 	"container/heap"
 	"io"
 
-	"github.com/dolthub/go-mysql-server/sql/sorters"
-
 	"github.com/dolthub/go-mysql-server/sql"
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 )
 
 // topRowsIter is defined by the topN node. It uses a heap to sort the rows of the child iterator and returns the top N

--- a/sql/iters/top_rows_iters.go
+++ b/sql/iters/top_rows_iters.go
@@ -16,8 +16,9 @@ package iters
 
 import (
 	"container/heap"
-	"github.com/dolthub/go-mysql-server/sql/sorters"
 	"io"
+
+	"github.com/dolthub/go-mysql-server/sql/sorters"
 
 	"github.com/dolthub/go-mysql-server/sql"
 )

--- a/sql/iters/top_rows_iters.go
+++ b/sql/iters/top_rows_iters.go
@@ -74,7 +74,7 @@ func (i *topRowsIter) Close(ctx *sql.Context) error {
 // computeTopRows uses a Top-N Heap Sort to find the top N rows. It relies on topRowsHeap being a max-heap.
 func (i *topRowsIter) computeTopRows(ctx *sql.Context) error {
 	rowsHeap := &topRowsHeap{
-		Sorter: sorters.Sorter{
+		RowSorter: sorters.RowSorter{
 			SortConditions: i.sortConditions,
 			Rows:           make([]sql.Row, 0, i.limit+1),
 			LastError:      nil,
@@ -125,13 +125,13 @@ func getTopRows(h *topRowsHeap) []sql.Row {
 // topRowsHeap implements heap.Interface. Since heap.Interface assumes a min-heap, topRowsHeap inverts Less to implement
 // a max-heap. This is so that topRowsHeap can be used for a Top-N Heap Sort.
 type topRowsHeap struct {
-	sorters.Sorter
+	sorters.RowSorter
 	order []int64
 }
 
 // Less implements heap.Interface. It is inverted to implement a max-heap.
 func (h *topRowsHeap) Less(i, j int) bool {
-	cmp := h.Sorter.CompareRows(h.Sorter.Rows[i], h.Sorter.Rows[j])
+	cmp := h.RowSorter.CompareRows(h.RowSorter.Rows[i], h.RowSorter.Rows[j])
 	if cmp == 0 {
 		return h.order[i] > h.order[j]
 	}
@@ -140,22 +140,22 @@ func (h *topRowsHeap) Less(i, j int) bool {
 
 // Swap implements heap.Interface
 func (h *topRowsHeap) Swap(i, j int) {
-	h.Sorter.Swap(i, j)
+	h.RowSorter.Swap(i, j)
 	h.order[i], h.order[j] = h.order[j], h.order[i]
 }
 
 // Push implements heap.Interface. x is expected to be a rowWithOrder.
 func (h *topRowsHeap) Push(x interface{}) {
 	e := x.(rowWithOrder)
-	h.Sorter.Rows = append(h.Sorter.Rows, e.row)
+	h.RowSorter.Rows = append(h.RowSorter.Rows, e.row)
 	h.order = append(h.order, e.order)
 }
 
 // Pop implements heap.Interface. The return type is a sql.Row.
 func (h *topRowsHeap) Pop() interface{} {
-	n := len(h.Sorter.Rows)
-	row := h.Sorter.Rows[n-1]
-	h.Sorter.Rows = h.Sorter.Rows[:n-1]
+	n := len(h.RowSorter.Rows)
+	row := h.RowSorter.Rows[n-1]
+	h.RowSorter.Rows = h.RowSorter.Rows[:n-1]
 	h.order = h.order[:n-1]
 	return row
 }
@@ -191,7 +191,7 @@ func (i *topRowIter) Next(ctx *sql.Context) (sql.Row, error) {
 	if err != nil {
 		return nil, err
 	}
-	sorter := sorters.Sorter{
+	sorter := sorters.RowSorter{
 		Ctx:            ctx,
 		SortConditions: i.sortConditions,
 	}

--- a/sql/sort/row_sorter.go
+++ b/sql/sort/row_sorter.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Dolthub, Inc.
+// Copyright 2026 Dolthub, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package expression
+package sort
 
 import (
 	"github.com/dolthub/go-mysql-server/sql"

--- a/sql/sorters/row_sorter.go
+++ b/sql/sorters/row_sorter.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package sort
+package sorters
 
 import (
 	"github.com/dolthub/go-mysql-server/sql"

--- a/sql/sorters/row_sorter.go
+++ b/sql/sorters/row_sorter.go
@@ -18,9 +18,8 @@ import (
 	"github.com/dolthub/go-mysql-server/sql"
 )
 
-// Sorter is a sorter implementation for Row slices using SortFields for the comparison
-// TODO: Rename to RowSorter since this is used specifically for sorting Rows and is not a generic sorter.
-type Sorter struct {
+// RowSorter is a sorter implementation for Row slices using SortFields for the comparison
+type RowSorter struct {
 	LastError      error
 	Ctx            *sql.Context
 	SortConditions sql.SortConditions
@@ -28,17 +27,17 @@ type Sorter struct {
 }
 
 // Len implements sort.Interface
-func (s *Sorter) Len() int {
+func (s *RowSorter) Len() int {
 	return len(s.Rows)
 }
 
 // Swap implements sort.Interface
-func (s *Sorter) Swap(i, j int) {
+func (s *RowSorter) Swap(i, j int) {
 	s.Rows[i], s.Rows[j] = s.Rows[j], s.Rows[i]
 }
 
 // CompareRows compares rows a and b based on s.SortFields
-func (s *Sorter) CompareRows(a, b sql.Row) int {
+func (s *RowSorter) CompareRows(a, b sql.Row) int {
 	for _, sc := range s.SortConditions {
 		typ := sc.Expr.Type(s.Ctx)
 		// TODO: For complex SortFields, like Subqueries, recalculating the value may be costly. We should find some way
@@ -84,12 +83,12 @@ func (s *Sorter) CompareRows(a, b sql.Row) int {
 }
 
 // IsLesserRow determines if sql.Row `a` is less than sql.Row `b` based off s.SortFields
-func (s *Sorter) IsLesserRow(a, b sql.Row) bool {
+func (s *RowSorter) IsLesserRow(a, b sql.Row) bool {
 	return s.CompareRows(a, b) < 0
 }
 
 // Less implements sort.Interface interface.
-func (s *Sorter) Less(i, j int) bool {
+func (s *RowSorter) Less(i, j int) bool {
 	if s.LastError != nil {
 		return false
 	}


### PR DESCRIPTION
Fixes #3622

This PR
- creates new `sorters` package
- moves `expression.Sorter` into `sorters` package and renames it to `sorters.RowSorter`

Doltgres updated in dolthub/doltgresql#2958